### PR TITLE
Prime Progress before tab presentation

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -165,6 +165,8 @@ struct FlashcardsApp: App {
             }
         }
 
+        store.prepareVisibleTabForPresentation(tab: selectedTab, now: Date())
+
         _store = State(initialValue: store)
         _navigation = State(
             initialValue: AppNavigationModel(

--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -5,6 +5,15 @@ struct RootTabView: View {
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
 
     @MainActor
+    private func prepareTabForPresentationIfNeeded(nextTab: AppTab) {
+        guard self.store.currentVisibleTab != nextTab else {
+            return
+        }
+
+        self.store.prepareVisibleTabForPresentation(tab: nextTab, now: Date())
+    }
+
+    @MainActor
     private func refreshSelectedTabIfNeeded(nextTab: AppTab) async {
         switch nextTab {
         case .review:
@@ -18,8 +27,17 @@ struct RootTabView: View {
 
     var body: some View {
         @Bindable var navigation = self.navigation
+        let selectedTabBinding = Binding(
+            get: {
+                navigation.selectedTab
+            },
+            set: { nextTab in
+                self.store.prepareVisibleTabForPresentation(tab: nextTab, now: Date())
+                navigation.selectedTab = nextTab
+            }
+        )
 
-        return TabView(selection: $navigation.selectedTab) {
+        return TabView(selection: selectedTabBinding) {
             NavigationStack {
                 ReviewView()
             }
@@ -147,7 +165,7 @@ struct RootTabView: View {
         }
         .tabBarMinimizeBehavior(.never)
         .task {
-            store.updateCurrentVisibleTab(tab: navigation.selectedTab)
+            store.prepareVisibleTabForPresentation(tab: navigation.selectedTab, now: Date())
         }
         .overlay {
             ZStack {
@@ -160,7 +178,7 @@ struct RootTabView: View {
             }
         }
         .onChange(of: navigation.selectedTab) { _, nextTab in
-            store.updateCurrentVisibleTab(tab: nextTab)
+            self.prepareTabForPresentationIfNeeded(nextTab: nextTab)
             Task { @MainActor in
                 await self.refreshSelectedTabIfNeeded(nextTab: nextTab)
             }

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+Progress.swift
@@ -27,6 +27,19 @@ private let progressSeriesServerBaseCacheUserDefaultsKeyPrefix: String = "progre
 /// then refresh summary and series independently and re-render whenever the latest response still matches the latest token.
 @MainActor
 extension FlashcardsStore {
+    func prepareVisibleTabForPresentation(
+        tab: AppTab,
+        now: Date
+    ) {
+        self.updateCurrentVisibleTab(tab: tab)
+
+        guard isProgressConsumerTab(tab: tab) else {
+            return
+        }
+
+        self.applyProgressContextChange(now: now, refreshVisibleProgress: false)
+    }
+
     func refreshReviewProgressBadgeIfNeeded() async {
         await self.refreshReviewProgressBadgeIfNeeded(now: Date())
     }

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -19,21 +19,6 @@ struct ProgressScreen: View {
                         .modifier(ProgressCardModifier())
                 }
 
-                if self.store.isProgressRefreshing && self.store.progressSnapshot == nil {
-                    VStack(alignment: .leading, spacing: 0) {
-                        ProgressView(
-                            String(
-                                localized: "progress.screen.loading",
-                                defaultValue: "Loading progress...",
-                                table: progressStringsTableName,
-                                comment: "Progress loading state"
-                            )
-                        )
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .modifier(ProgressCardModifier())
-                }
-
                 if let progressSnapshot = self.store.progressSnapshot {
                     let presentationCalendar = requiredProgressPresentationCalendar(
                         timeZoneIdentifier: progressSnapshot.scopeKey.timeZone
@@ -42,21 +27,6 @@ struct ProgressScreen: View {
                         progressSnapshot: progressSnapshot,
                         calendar: presentationCalendar
                     )
-                    if self.store.isProgressRefreshing {
-                        VStack(alignment: .leading, spacing: 0) {
-                            ProgressView(
-                                String(
-                                    localized: "progress.screen.loading",
-                                    defaultValue: "Loading progress...",
-                                    table: progressStringsTableName,
-                                    comment: "Progress loading state"
-                                )
-                            )
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .modifier(ProgressCardModifier())
-                    }
-
                     VStack(alignment: .leading, spacing: 12) {
                         Text(
                             String(

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewView.swift
@@ -542,6 +542,7 @@ struct ReviewView: View {
         let badgeState = self.store.reviewProgressBadgeState
 
         return Button {
+            self.store.prepareVisibleTabForPresentation(tab: .progress, now: Date())
             self.navigation.selectTab(.progress)
         } label: {
             reviewProgressBadgeLabel(badgeState: badgeState)


### PR DESCRIPTION
## Summary\n- remove the visible Progress loading card on iOS\n- synchronously prepare Progress state before presentation for launch, tab taps, and review badge navigation\n- keep the existing background refresh flow intact\n\n## Testing\n- xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'generic/platform=iOS Simulator' -quiet build CODE_SIGNING_ALLOWED=NO COMPILER_INDEX_STORE_ENABLE=NO