### PR TITLE
[codex] Align progress flame icon

### DIFF
--- a/apps/web/src/screens/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/ProgressScreen.render.test.tsx
@@ -260,7 +260,7 @@ describe("ProgressScreen", () => {
       throw new Error("Progress summary badge SVG icon was not found");
     }
 
-    const streakMarkerIcons = [...container.querySelectorAll(".progress-streak-marker .review-progress-badge-icon")];
+    const streakMarkerIcons = [...container.querySelectorAll(".progress-streak-marker-flame .review-progress-badge-icon")];
     expect(streakMarkerIcons.length).toBeGreaterThan(0);
     expect(streakMarkerIcons.every((icon) => icon instanceof SVGSVGElement)).toBe(true);
   });

--- a/apps/web/src/screens/ProgressScreen.tsx
+++ b/apps/web/src/screens/ProgressScreen.tsx
@@ -370,7 +370,7 @@ export function ProgressScreen(): ReactElement {
                     <p className="progress-streak-summary-status">{reviewProgressBadgeTodayStatus}</p>
                   </div>
                   <span
-                    className={`badge review-progress-badge${reviewProgressBadge.hasReviewedToday ? " review-progress-badge-active" : ""}`}
+                    className={`badge review-progress-badge progress-streak-summary-badge${reviewProgressBadge.hasReviewedToday ? " review-progress-badge-active" : ""}`}
                     aria-label={reviewProgressBadgeAriaLabel}
                     title={reviewProgressBadgeAriaLabel}
                   >
@@ -408,7 +408,13 @@ export function ProgressScreen(): ReactElement {
                             aria-hidden="true"
                             style={day.isFuture ? futureStreakMarkerStyle : undefined}
                           >
-                            {day.reviewCount > 0 ? <ReviewProgressBadgeIcon /> : day.isFuture ? "" : day.dayLabel}
+                            {day.reviewCount > 0 ? (
+                              <span className="progress-streak-marker-flame">
+                                <ReviewProgressBadgeIcon />
+                              </span>
+                            ) : day.isFuture ? null : (
+                              <span className="progress-streak-marker-day-value">{day.dayLabel}</span>
+                            )}
                           </span>
                         </div>
                       );

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -38,6 +38,10 @@
   flex-wrap: wrap;
 }
 
+.progress-streak-summary-badge {
+  min-height: 34px;
+}
+
 .progress-streak-summary-copy {
   display: grid;
   gap: 4px;
@@ -114,30 +118,48 @@
   justify-content: center;
   width: 34px;
   height: 34px;
+  border: 1px solid transparent;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.08);
   color: var(--text);
   font-size: 14px;
   line-height: 1;
   font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
 }
 
 .progress-streak-day-complete .progress-streak-marker {
-  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.12);
   color: #fff5f2;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
-  font-size: 16px;
 }
 
 .progress-streak-day-today .progress-streak-marker {
+  border-color: rgba(196, 75, 45, 0.2);
+  background: rgba(196, 75, 45, 0.08);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.18),
     0 0 0 3px var(--accent-soft);
 }
 
-.progress-streak-marker .review-progress-badge-icon {
-  width: 18px;
-  height: 18px;
+.progress-streak-marker-flame,
+.progress-streak-marker-day-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.progress-streak-marker-flame .review-progress-badge-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.progress-streak-marker-day-value {
+  min-width: 1ch;
 }
 
 .progress-chart-shell {

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -17,6 +17,7 @@
   width: fit-content;
   justify-self: start;
   gap: 6px;
+  flex-shrink: 0;
   padding-inline: 10px 12px;
   color: var(--text-secondary);
   text-decoration: none;
@@ -48,12 +49,15 @@
 }
 
 .review-progress-badge-icon {
+  display: block;
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
 }
 
 .review-progress-badge-value {
+  display: inline-flex;
+  align-items: center;
   font-variant-numeric: tabular-nums;
 }
 


### PR DESCRIPTION
## Summary
- align the web progress streak badge with the shared review flame treatment
- add progress-specific flame and day-value wrappers so the streak grid can style completed days cleanly
- tighten shared badge alignment so the flame SVG and value stay centered without baseline drift

## Why
The web progress surface needed to match the same flame icon treatment already used on the review screen and in iOS progress instead of relying on looser progress-only styling.

## Impact
The change is web-only and visual. It does not change progress calculations, routes, accessibility copy, or API behavior.

## Root Cause
The progress screen already used the shared flame SVG, but its grid marker styling was still generic enough to make the flame fit feel inconsistent compared with the review badge and iOS treatment.

## Validation
- `npm exec vitest run src/screens/ReviewScreen.test.tsx src/screens/ProgressScreen.render.test.tsx`
- `npm run build`
- manual browser check with a local harness using the built web CSS and shared flame SVG because the full local app route could not bootstrap without `/me`
