### PR TITLE
Fix AI chat draft persistence before send acceptance

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
+import com.flashcardsopensourceapp.data.local.model.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.AiChatResumeDiagnostics
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfiguration
@@ -75,18 +76,48 @@ internal class AiChatRuntimeContext(
         persistState(snapshot = runtimeStateMutable.value)
     }
 
+    fun persistCurrentStatePreservingDraft(draftState: AiChatDraftState) {
+        persistStatePreservingDraft(
+            snapshot = runtimeStateMutable.value,
+            draftState = draftState
+        )
+    }
+
     fun persistCurrentDraft() {
         persistDraft(snapshot = runtimeStateMutable.value)
     }
 
     fun persistState(snapshot: AiChatRuntimeState) {
+        persistStateWithDraft(
+            snapshot = snapshot,
+            draftState = snapshot.toDraftState()
+        )
+    }
+
+    fun persistStatePreservingDraft(
+        snapshot: AiChatRuntimeState,
+        draftState: AiChatDraftState
+    ) {
+        persistStateWithDraft(
+            snapshot = snapshot,
+            draftState = draftState
+        )
+    }
+
+    private fun persistStateWithDraft(
+        snapshot: AiChatRuntimeState,
+        draftState: AiChatDraftState
+    ) {
         val requestVersion = persistedStateWriteRequestVersion.incrementAndGet()
         scope.launch {
             persistedStateWriteMutex.withLock {
                 if (requestVersion != persistedStateWriteRequestVersion.get()) {
                     return@withLock
                 }
-                persistStateSnapshot(snapshot = snapshot)
+                persistStateSnapshot(
+                    snapshot = snapshot,
+                    draftState = draftState
+                )
             }
         }
     }
@@ -110,11 +141,17 @@ internal class AiChatRuntimeContext(
             if (requestVersion != persistedStateWriteRequestVersion.get()) {
                 return@withLock
             }
-            persistStateSnapshot(snapshot = snapshot)
+            persistStateSnapshot(
+                snapshot = snapshot,
+                draftState = snapshot.toDraftState()
+            )
         }
     }
 
-    private suspend fun persistStateSnapshot(snapshot: AiChatRuntimeState) {
+    private suspend fun persistStateSnapshot(
+        snapshot: AiChatRuntimeState,
+        draftState: AiChatDraftState
+    ) {
         aiChatRepository.savePersistedState(
             workspaceId = snapshot.workspaceId,
             state = snapshot.persistedState
@@ -124,7 +161,7 @@ internal class AiChatRuntimeContext(
             aiChatRepository.saveDraftState(
                 workspaceId = snapshot.workspaceId,
                 sessionId = chatSessionId,
-                state = snapshot.toDraftState()
+                state = draftState
             )
         }
     }
@@ -257,8 +294,8 @@ internal class AiChatRuntimeContext(
     }
 }
 
-private fun AiChatRuntimeState.toDraftState(): com.flashcardsopensourceapp.data.local.model.AiChatDraftState {
-    return com.flashcardsopensourceapp.data.local.model.AiChatDraftState(
+private fun AiChatRuntimeState.toDraftState(): AiChatDraftState {
+    return AiChatDraftState(
         draftMessage = draftMessage,
         pendingAttachments = pendingAttachments
     )

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSendCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSendCoordinator.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.ai.AiChatRemoteException
 import com.flashcardsopensourceapp.data.local.model.AiChatAttachment
 import com.flashcardsopensourceapp.data.local.model.AiChatComposerSuggestion
 import com.flashcardsopensourceapp.data.local.model.AiChatDictationState
+import com.flashcardsopensourceapp.data.local.model.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.isSendableAiChatAttachment
@@ -56,6 +57,10 @@ internal class AiChatSendCoordinator(
 
         val draftMessageBackup = currentState.draftMessage
         val pendingAttachmentsBackup = currentState.pendingAttachments
+        val durableDraftState = AiChatDraftState(
+            draftMessage = draftMessageBackup,
+            pendingAttachments = pendingAttachmentsBackup
+        )
         context.runtimeStateMutable.update { state ->
             state.copy(
                 draftMessage = "",
@@ -67,9 +72,8 @@ internal class AiChatSendCoordinator(
                 errorMessage = ""
             )
         }
-        context.persistCurrentDraft()
 
-        val previousPersistedState = context.runtimeStateMutable.value.persistedState
+        val initialPersistedState = context.runtimeStateMutable.value.persistedState
 
         context.activeSendJob?.cancel()
         var sendJob: Job? = null
@@ -77,14 +81,18 @@ internal class AiChatSendCoordinator(
             var didAcceptRun = false
             var didAppendOptimisticMessages = false
             var requestSessionId = currentState.persistedState.chatSessionId
+            var rollbackPersistedState = initialPersistedState
             try {
                 // AI send is blocked on a direct sync so the backend run never starts
                 // from stale local writes that are still sitting in the outbox.
                 context.aiChatRepository.ensureReadyForSend(workspaceId = context.runtimeStateMutable.value.workspaceId)
-                val ensuredSession = sessionCoordinator.ensureSessionIdIfNeeded()
+                val ensuredSession = sessionCoordinator.ensureSessionIdIfNeededPreservingDraft(
+                    draftState = durableDraftState
+                )
                 requestSessionId = ensuredSession.sessionId
-                val nextPersistedState = context.runtimeStateMutable.value.persistedState.copy(
-                    messages = context.runtimeStateMutable.value.persistedState.messages + listOf(
+                rollbackPersistedState = context.runtimeStateMutable.value.persistedState
+                val nextPersistedState = rollbackPersistedState.copy(
+                    messages = rollbackPersistedState.messages + listOf(
                         makeUserMessage(
                             content = outgoingContent,
                             timestampMillis = System.currentTimeMillis()
@@ -104,7 +112,7 @@ internal class AiChatSendCoordinator(
                         runHadToolCalls = false
                     )
                 }
-                context.persistCurrentState()
+                context.persistCurrentStatePreservingDraft(draftState = durableDraftState)
                 didAppendOptimisticMessages = true
 
                 val response = context.aiChatRepository.startRun(
@@ -126,7 +134,7 @@ internal class AiChatSendCoordinator(
                     targetSessionId = requestSessionId,
                     didAcceptRun = didAcceptRun,
                     didAppendOptimisticMessages = didAppendOptimisticMessages,
-                    previousPersistedState = previousPersistedState,
+                    rollbackPersistedState = rollbackPersistedState,
                     draftMessage = draftMessageBackup,
                     pendingAttachments = pendingAttachmentsBackup
                 )
@@ -136,7 +144,7 @@ internal class AiChatSendCoordinator(
                     targetSessionId = requestSessionId,
                     didAcceptRun = didAcceptRun,
                     didAppendOptimisticMessages = didAppendOptimisticMessages,
-                    previousPersistedState = previousPersistedState,
+                    rollbackPersistedState = rollbackPersistedState,
                     draftMessage = draftMessageBackup,
                     pendingAttachments = pendingAttachmentsBackup
                 )
@@ -293,7 +301,7 @@ internal class AiChatSendCoordinator(
         targetSessionId: String,
         didAcceptRun: Boolean,
         didAppendOptimisticMessages: Boolean,
-        previousPersistedState: com.flashcardsopensourceapp.data.local.model.AiChatPersistedState,
+        rollbackPersistedState: com.flashcardsopensourceapp.data.local.model.AiChatPersistedState,
         draftMessage: String,
         pendingAttachments: List<AiChatAttachment>
     ) {
@@ -301,6 +309,14 @@ internal class AiChatSendCoordinator(
             return
         }
         val remoteError = error as? AiChatRemoteException
+        if (didAcceptRun.not()) {
+            restorePreAcceptFailureState(
+                didAppendOptimisticMessages = didAppendOptimisticMessages,
+                rollbackPersistedState = rollbackPersistedState,
+                draftMessage = draftMessage,
+                pendingAttachments = pendingAttachments
+            )
+        }
         if (remoteError?.code == "GUEST_AI_LIMIT_REACHED") {
             AiChatDiagnosticsLogger.warn(
                 event = "send_failure_guest_quota_reached",
@@ -329,20 +345,6 @@ internal class AiChatSendCoordinator(
                 )
             }
             return
-        }
-
-        if (didAcceptRun.not() && didAppendOptimisticMessages) {
-            context.runtimeStateMutable.update { state ->
-                state.copy(
-                    persistedState = previousPersistedState,
-                    draftMessage = draftMessage,
-                    pendingAttachments = pendingAttachments,
-                    activeRun = null,
-                    isLiveAttached = false,
-                    composerPhase = AiComposerPhase.IDLE,
-                    repairStatus = null
-                )
-            }
         }
 
         if (didAcceptRun.not() && remoteError?.code == "CHAT_ACTIVE_RUN_IN_PROGRESS") {
@@ -384,6 +386,31 @@ internal class AiChatSendCoordinator(
                 isLiveAttached = false,
                 composerPhase = AiComposerPhase.IDLE,
                 activeAlert = context.textProvider.generalError(message = message),
+                errorMessage = ""
+            )
+        }
+    }
+
+    private fun restorePreAcceptFailureState(
+        didAppendOptimisticMessages: Boolean,
+        rollbackPersistedState: com.flashcardsopensourceapp.data.local.model.AiChatPersistedState,
+        draftMessage: String,
+        pendingAttachments: List<AiChatAttachment>
+    ) {
+        context.runtimeStateMutable.update { state ->
+            state.copy(
+                persistedState = if (didAppendOptimisticMessages) {
+                    rollbackPersistedState
+                } else {
+                    state.persistedState
+                },
+                draftMessage = draftMessage,
+                pendingAttachments = pendingAttachments,
+                activeRun = null,
+                isLiveAttached = false,
+                composerPhase = AiComposerPhase.IDLE,
+                repairStatus = null,
+                activeAlert = null,
                 errorMessage = ""
             )
         }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSendCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSendCoordinator.kt
@@ -54,8 +54,12 @@ internal class AiChatSendCoordinator(
             )
         )
 
+        val draftMessageBackup = currentState.draftMessage
+        val pendingAttachmentsBackup = currentState.pendingAttachments
         context.runtimeStateMutable.update { state ->
             state.copy(
+                draftMessage = "",
+                pendingAttachments = emptyList(),
                 composerPhase = AiComposerPhase.PREPARING_SEND,
                 dictationState = AiChatDictationState.IDLE,
                 repairStatus = null,
@@ -63,10 +67,9 @@ internal class AiChatSendCoordinator(
                 errorMessage = ""
             )
         }
+        context.persistCurrentDraft()
 
         val previousPersistedState = context.runtimeStateMutable.value.persistedState
-        val draftMessageBackup = context.runtimeStateMutable.value.draftMessage
-        val pendingAttachmentsBackup = context.runtimeStateMutable.value.pendingAttachments
 
         context.activeSendJob?.cancel()
         var sendJob: Job? = null

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSessionCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSessionCoordinator.kt
@@ -4,6 +4,7 @@ import com.flashcardsopensourceapp.data.local.ai.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.data.local.ai.AiChatRemoteException
 import com.flashcardsopensourceapp.data.local.model.AiChatAttachment
 import com.flashcardsopensourceapp.data.local.model.AiChatComposerSuggestion
+import com.flashcardsopensourceapp.data.local.model.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.AiChatDictationState
 import com.flashcardsopensourceapp.data.local.model.AiChatSessionProvisioningResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
@@ -70,6 +71,26 @@ internal class AiChatSessionCoordinator(
     }
 
     suspend fun ensureSessionIdIfNeeded(): AiChatSessionProvisioningResult {
+        return ensureSessionIdIfNeeded(
+            persistEnsuredSessionState = {
+                context.persistCurrentState()
+            }
+        )
+    }
+
+    suspend fun ensureSessionIdIfNeededPreservingDraft(
+        draftState: AiChatDraftState
+    ): AiChatSessionProvisioningResult {
+        return ensureSessionIdIfNeeded(
+            persistEnsuredSessionState = {
+                context.persistCurrentStatePreservingDraft(draftState = draftState)
+            }
+        )
+    }
+
+    private suspend fun ensureSessionIdIfNeeded(
+        persistEnsuredSessionState: () -> Unit
+    ): AiChatSessionProvisioningResult {
         val currentState = context.runtimeStateMutable.value
         val currentSessionId = currentState.persistedState.chatSessionId
         if (currentSessionId.isNotBlank()) {
@@ -99,7 +120,7 @@ internal class AiChatSessionCoordinator(
                     nextSuggestions = ensuredSnapshot.composerSuggestions
                 )
             }
-            context.persistCurrentState()
+            persistEnsuredSessionState()
         }
         return ensuredSession
     }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiConversationStateSupport.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiConversationStateSupport.kt
@@ -441,46 +441,32 @@ internal fun appendAssistantAccountUpgradePrompt(
         message = message,
         buttonTitle = buttonTitle
     )
+    val promptMessage = AiChatMessage(
+        messageId = UUID.randomUUID().toString().lowercase(),
+        role = AiChatRole.ASSISTANT,
+        content = listOf(prompt),
+        timestampMillis = timestampMillis,
+        isError = false,
+        isStopped = false,
+        cursor = null,
+        itemId = null
+    )
 
     if (state.messages.isEmpty()) {
-        return state.copy(
-            messages = listOf(
-                AiChatMessage(
-                    messageId = UUID.randomUUID().toString().lowercase(),
-                    role = AiChatRole.ASSISTANT,
-                    content = listOf(prompt),
-                    timestampMillis = timestampMillis,
-                    isError = false,
-                    isStopped = false,
-                    cursor = null,
-                    itemId = null
-                )
-            )
-        )
+        return state.copy(messages = listOf(promptMessage))
     }
 
     val lastMessage = state.messages.last()
-    if (lastMessage.role != AiChatRole.ASSISTANT) {
+    if (lastMessage.role == AiChatRole.ASSISTANT && isOptimisticAssistantStatus(content = lastMessage.content)) {
         return state.copy(
-            messages = state.messages + AiChatMessage(
-                messageId = UUID.randomUUID().toString().lowercase(),
-                role = AiChatRole.ASSISTANT,
+            messages = state.messages.dropLast(1) + lastMessage.copy(
                 content = listOf(prompt),
-                timestampMillis = timestampMillis,
-                isError = false,
-                isStopped = false,
-                cursor = null,
-                itemId = null
+                isError = false
             )
         )
     }
 
-    return state.copy(
-        messages = state.messages.dropLast(1) + lastMessage.copy(
-            content = listOf(prompt),
-            isError = false
-        )
-    )
+    return state.copy(messages = state.messages + promptMessage)
 }
 
 internal fun latestAssistantErrorMessage(messages: List<AiChatMessage>): String? {

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeConversationResetAndSendTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeConversationResetAndSendTest.kt
@@ -2,9 +2,13 @@ package com.flashcardsopensourceapp.feature.ai.runtime
 
 import com.flashcardsopensourceapp.data.local.ai.AiChatRemoteException
 import com.flashcardsopensourceapp.data.local.model.AiChatAttachment
+import com.flashcardsopensourceapp.data.local.model.AiChatBootstrapResponse
 import com.flashcardsopensourceapp.data.local.model.AiChatComposerSuggestion
 import com.flashcardsopensourceapp.data.local.model.AiChatContentPart
+import com.flashcardsopensourceapp.data.local.model.AiChatConversation
 import com.flashcardsopensourceapp.data.local.model.AiChatDictationState
+import com.flashcardsopensourceapp.data.local.model.AiChatMessage
+import com.flashcardsopensourceapp.data.local.model.AiChatRole
 import com.flashcardsopensourceapp.data.local.model.AiChatTranscriptionResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.defaultAiChatServerConfig
@@ -25,6 +29,8 @@ class AiChatRuntimeConversationResetAndSendTest {
     fun sendMessageEnsuresExplicitSessionWithoutLegacyBootstrapFallback() = runTest {
         val repository = FakeAiChatRepository()
         repository.nextEnsureSessionId = "send-session-1"
+        val startRunGate = CompletableDeferred<Unit>()
+        repository.startRunGates += startRunGate
         repository.startRunResponse = makeAcceptedStartRunResponse(
             sessionId = "send-session-1",
             activeRun = null,
@@ -58,6 +64,20 @@ class AiChatRuntimeConversationResetAndSendTest {
         assertEquals("", runtime.state.value.draftMessage)
         assertTrue(runtime.state.value.pendingAttachments.isEmpty())
         assertEquals(AiComposerPhase.PREPARING_SEND, runtime.state.value.composerPhase)
+        runCurrent()
+
+        assertEquals("send-session-1", runtime.state.value.persistedState.chatSessionId)
+        assertEquals(
+            "Hello",
+            repository.draftStates[defaultTestWorkspaceId to "send-session-1"]?.draftMessage
+        )
+        assertTrue(
+            repository.draftStates[defaultTestWorkspaceId to "send-session-1"]?.pendingAttachments?.isEmpty()
+                ?: false
+        )
+        assertEquals(2, repository.persistedStates[defaultTestWorkspaceId]?.messages?.size)
+
+        startRunGate.complete(Unit)
         advanceUntilIdle()
 
         assertEquals(listOf("send-session-1"), repository.createNewSessionRequests)
@@ -66,6 +86,54 @@ class AiChatRuntimeConversationResetAndSendTest {
         assertEquals("send-session-1", repository.lastStartRunState?.chatSessionId)
         assertEquals(testUiLocaleTag, repository.lastStartRunUiLocale)
         assertEquals("send-session-1", runtime.state.value.persistedState.chatSessionId)
+    }
+
+    @Test
+    fun firstSendFailureKeepsEnsuredSessionIdAndRestoresDraftDurably() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.nextEnsureSessionId = "send-session-1"
+        repository.startRunError = IllegalStateException("Run start failed.")
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.DISCONNECTED
+        )
+        val attachment = AiChatAttachment.Binary(
+            id = "attachment-1",
+            fileName = "notes.txt",
+            mediaType = "text/plain",
+            base64Data = "ZmlsZQ=="
+        )
+
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId).copy(
+                cloudState = CloudAccountState.DISCONNECTED
+            )
+        )
+        advanceUntilIdle()
+
+        runtime.updateDraftMessage(draftMessage = "retry me")
+        runtime.addPendingAttachment(attachment = attachment)
+        runtime.sendMessage()
+
+        assertEquals("", runtime.state.value.draftMessage)
+        assertTrue(runtime.state.value.pendingAttachments.isEmpty())
+
+        advanceUntilIdle()
+
+        assertEquals("send-session-1", runtime.state.value.persistedState.chatSessionId)
+        assertEquals("retry me", runtime.state.value.draftMessage)
+        assertEquals(listOf(attachment), runtime.state.value.pendingAttachments)
+        assertEquals(AiComposerPhase.IDLE, runtime.state.value.composerPhase)
+        assertEquals(
+            "retry me",
+            repository.draftStates[defaultTestWorkspaceId to "send-session-1"]?.draftMessage
+        )
+        assertEquals(
+            listOf(attachment),
+            repository.draftStates[defaultTestWorkspaceId to "send-session-1"]?.pendingAttachments
+        )
     }
 
     @Test
@@ -263,6 +331,198 @@ class AiChatRuntimeConversationResetAndSendTest {
         assertFalse(runtime.state.value.isLiveAttached)
         val alert = runtime.state.value.activeAlert as AiAlertState.GeneralError
         assertTrue(alert.message.isNotEmpty())
+    }
+
+    @Test
+    fun preAcceptSendFailureBeforeOptimisticMessagesRestoresDraftAndAttachments() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        repository.ensureReadyForSendError = IllegalStateException("Sync failed before send.")
+        val runtime = makeRuntime(scope = this, repository = repository)
+        val attachment = AiChatAttachment.Binary(
+            id = "attachment-1",
+            fileName = "notes.txt",
+            mediaType = "text/plain",
+            base64Data = "ZmlsZQ=="
+        )
+
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
+        runtime.updateDraftMessage(draftMessage = "retry me")
+        runtime.addPendingAttachment(attachment = attachment)
+        runtime.sendMessage()
+
+        assertEquals("", runtime.state.value.draftMessage)
+        assertTrue(runtime.state.value.pendingAttachments.isEmpty())
+        assertEquals(AiComposerPhase.PREPARING_SEND, runtime.state.value.composerPhase)
+
+        advanceUntilIdle()
+
+        assertEquals("session-1", runtime.state.value.persistedState.chatSessionId)
+        assertTrue(runtime.state.value.persistedState.messages.isEmpty())
+        assertEquals("retry me", runtime.state.value.draftMessage)
+        assertEquals(listOf(attachment), runtime.state.value.pendingAttachments)
+        assertEquals(AiComposerPhase.IDLE, runtime.state.value.composerPhase)
+        val alert = runtime.state.value.activeAlert as AiAlertState.GeneralError
+        assertTrue(alert.message.isNotEmpty())
+        assertEquals(
+            "retry me",
+            repository.draftStates[defaultTestWorkspaceId to "session-1"]?.draftMessage
+        )
+        assertEquals(
+            listOf(attachment),
+            repository.draftStates[defaultTestWorkspaceId to "session-1"]?.pendingAttachments
+        )
+    }
+
+    @Test
+    fun guestQuotaSendFailureRestoresDraftAndAttachmentsWhileShowingUpgradePrompt() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        repository.startRunError = AiChatRemoteException(
+            message = "Guest quota reached.",
+            statusCode = 429,
+            code = "GUEST_AI_LIMIT_REACHED",
+            stage = null,
+            requestId = "request-1",
+            responseBody = null
+        )
+        val runtime = makeRuntime(scope = this, repository = repository)
+        val attachment = AiChatAttachment.Binary(
+            id = "attachment-1",
+            fileName = "notes.txt",
+            mediaType = "text/plain",
+            base64Data = "ZmlsZQ=="
+        )
+
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
+        runtime.updateDraftMessage(draftMessage = "keep this")
+        runtime.addPendingAttachment(attachment = attachment)
+        runtime.sendMessage()
+
+        assertEquals("", runtime.state.value.draftMessage)
+        assertTrue(runtime.state.value.pendingAttachments.isEmpty())
+        assertEquals(AiComposerPhase.PREPARING_SEND, runtime.state.value.composerPhase)
+
+        advanceUntilIdle()
+
+        assertEquals("keep this", runtime.state.value.draftMessage)
+        assertEquals(listOf(attachment), runtime.state.value.pendingAttachments)
+        assertEquals(1, runtime.state.value.persistedState.messages.size)
+        assertTrue(
+            runtime.state.value.persistedState.messages.single().content.single() is AiChatContentPart.AccountUpgradePrompt
+        )
+        assertEquals(AiComposerPhase.IDLE, runtime.state.value.composerPhase)
+        assertEquals(
+            "keep this",
+            repository.draftStates[defaultTestWorkspaceId to "session-1"]?.draftMessage
+        )
+        assertEquals(
+            listOf(attachment),
+            repository.draftStates[defaultTestWorkspaceId to "session-1"]?.pendingAttachments
+        )
+    }
+
+    @Test
+    fun guestQuotaSendFailureAppendsUpgradePromptAfterRealAssistantReply() = runTest {
+        val repository = FakeAiChatRepository()
+        val restoredMessages = listOf(
+            makeUserMessage(
+                content = listOf(AiChatContentPart.Text(text = "Original question")),
+                timestampMillis = 1L
+            ),
+            makeAssistantTextMessage(
+                text = "Original answer",
+                timestampMillis = 2L
+            )
+        )
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1",
+            messages = restoredMessages
+        )
+        repository.bootstrapResponses += makeBootstrapResponseWithMessages(
+            sessionId = "session-1",
+            messages = restoredMessages
+        )
+        repository.startRunError = AiChatRemoteException(
+            message = "Guest quota reached.",
+            statusCode = 429,
+            code = "GUEST_AI_LIMIT_REACHED",
+            stage = null,
+            requestId = "request-1",
+            responseBody = null
+        )
+        val runtime = makeRuntime(scope = this, repository = repository)
+
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
+        runtime.updateDraftMessage(draftMessage = "keep this")
+        runtime.sendMessage()
+        advanceUntilIdle()
+
+        val messages = runtime.state.value.persistedState.messages
+        assertEquals(3, messages.size)
+        assertEquals(restoredMessages[0], messages[0])
+        assertEquals(restoredMessages[1], messages[1])
+        assertTrue(messages[2].content.single() is AiChatContentPart.AccountUpgradePrompt)
+    }
+
+    @Test
+    fun guestQuotaSendFailureReplacesOptimisticAssistantPlaceholderWithUpgradePrompt() = runTest {
+        val repository = FakeAiChatRepository()
+        val restoredMessages = listOf(
+            makeUserMessage(
+                content = listOf(AiChatContentPart.Text(text = "Original question")),
+                timestampMillis = 1L
+            ),
+            makeAssistantStatusMessage(timestampMillis = 2L)
+        )
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1",
+            messages = restoredMessages
+        )
+        repository.bootstrapResponses += makeBootstrapResponseWithMessages(
+            sessionId = "session-1",
+            messages = restoredMessages
+        )
+        repository.startRunError = AiChatRemoteException(
+            message = "Guest quota reached.",
+            statusCode = 429,
+            code = "GUEST_AI_LIMIT_REACHED",
+            stage = null,
+            requestId = "request-1",
+            responseBody = null
+        )
+        val runtime = makeRuntime(scope = this, repository = repository)
+
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
+        runtime.updateDraftMessage(draftMessage = "keep this")
+        runtime.sendMessage()
+        advanceUntilIdle()
+
+        val messages = runtime.state.value.persistedState.messages
+        assertEquals(2, messages.size)
+        assertEquals(restoredMessages[0], messages[0])
+        assertEquals(restoredMessages[1].messageId, messages[1].messageId)
+        assertTrue(messages[1].content.single() is AiChatContentPart.AccountUpgradePrompt)
     }
 
     @Test
@@ -664,6 +924,42 @@ class AiChatRuntimeConversationResetAndSendTest {
         assertEquals(
             listOf("fresh-suggestion"),
             runtime.state.value.serverComposerSuggestions.map { suggestion -> suggestion.id }
+        )
+    }
+
+    private fun makeBootstrapResponseWithMessages(
+        sessionId: String,
+        messages: List<AiChatMessage>
+    ): AiChatBootstrapResponse {
+        return AiChatBootstrapResponse(
+            sessionId = sessionId,
+            conversationScopeId = sessionId,
+            conversation = AiChatConversation(
+                messages = messages,
+                updatedAtMillis = 100L,
+                mainContentInvalidationVersion = 0L,
+                hasOlder = false,
+                oldestCursor = null
+            ),
+            composerSuggestions = emptyList(),
+            chatConfig = defaultAiChatServerConfig,
+            activeRun = null
+        )
+    }
+
+    private fun makeAssistantTextMessage(
+        text: String,
+        timestampMillis: Long
+    ): AiChatMessage {
+        return AiChatMessage(
+            messageId = "assistant-$timestampMillis",
+            role = AiChatRole.ASSISTANT,
+            content = listOf(AiChatContentPart.Text(text = text)),
+            timestampMillis = timestampMillis,
+            isError = false,
+            isStopped = false,
+            cursor = null,
+            itemId = null
         )
     }
 }

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeConversationResetAndSendTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeConversationResetAndSendTest.kt
@@ -55,6 +55,9 @@ class AiChatRuntimeConversationResetAndSendTest {
 
         runtime.updateDraftMessage(draftMessage = "Hello")
         runtime.sendMessage()
+        assertEquals("", runtime.state.value.draftMessage)
+        assertTrue(runtime.state.value.pendingAttachments.isEmpty())
+        assertEquals(AiComposerPhase.PREPARING_SEND, runtime.state.value.composerPhase)
         advanceUntilIdle()
 
         assertEquals(listOf("send-session-1"), repository.createNewSessionRequests)
@@ -249,6 +252,8 @@ class AiChatRuntimeConversationResetAndSendTest {
 
         runtime.updateDraftMessage(draftMessage = "retry me")
         runtime.sendMessage()
+        assertEquals("", runtime.state.value.draftMessage)
+        assertTrue(runtime.state.value.pendingAttachments.isEmpty())
         advanceUntilIdle()
 
         assertEquals("session-1", runtime.state.value.persistedState.chatSessionId)

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeTestSupport.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeTestSupport.kt
@@ -221,6 +221,7 @@ internal class FakeAiChatRepository : AiChatRepository {
     val savePersistedStateGates: ArrayDeque<CompletableDeferred<Unit>> = ArrayDeque()
     val persistedStates: MutableMap<String?, AiChatPersistedState> = mutableMapOf()
     val draftStates: MutableMap<Pair<String?, String?>, AiChatDraftState> = mutableMapOf()
+    val startRunGates: ArrayDeque<CompletableDeferred<Unit>> = ArrayDeque()
     val ensureSessionRequests: MutableList<String> = mutableListOf()
     val transcribeAudioWorkspaceIds: MutableList<String?> = mutableListOf()
     val transcribeAudioSessionIds: MutableList<String> = mutableListOf()
@@ -230,6 +231,7 @@ internal class FakeAiChatRepository : AiChatRepository {
         sessionId = nextEnsureSessionId
     )
     var transcribeAudioError: Exception? = null
+    var ensureReadyForSendError: Exception? = null
     var startRunError: Exception? = null
     var loadBootstrapCalls: Int = 0
     var startRunCalls: Int = 0
@@ -272,7 +274,10 @@ internal class FakeAiChatRepository : AiChatRepository {
     }
 
     override suspend fun ensureReadyForSend(workspaceId: String?) {
-        Unit
+        val error: Exception? = ensureReadyForSendError
+        if (error != null) {
+            throw error
+        }
     }
 
     override suspend fun loadPersistedState(workspaceId: String?): AiChatPersistedState {
@@ -416,6 +421,9 @@ internal class FakeAiChatRepository : AiChatRepository {
         startRunCalls += 1
         lastStartRunState = state
         lastStartRunUiLocale = uiLocale
+        if (startRunGates.isNotEmpty()) {
+            startRunGates.removeFirst().await()
+        }
         val error: Exception? = startRunError
         if (error != null) {
             throw error

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatContentModels.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatContentModels.swift
@@ -712,12 +712,16 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
     let chatSessionId: String
     let lastKnownChatConfig: AIChatServerConfig?
     let pendingToolRunPostSync: Bool
+    let requiresRemoteSessionProvisioning: Bool
+    let suppressDraftRestore: Bool
 
     private enum CodingKeys: String, CodingKey {
         case messages
         case chatSessionId
         case lastKnownChatConfig
         case pendingToolRunPostSync
+        case requiresRemoteSessionProvisioning
+        case suppressDraftRestore
     }
 
     init(
@@ -726,10 +730,47 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         lastKnownChatConfig: AIChatServerConfig?,
         pendingToolRunPostSync: Bool
     ) {
+        self.init(
+            messages: messages,
+            chatSessionId: chatSessionId,
+            lastKnownChatConfig: lastKnownChatConfig,
+            pendingToolRunPostSync: pendingToolRunPostSync,
+            requiresRemoteSessionProvisioning: false,
+            suppressDraftRestore: false
+        )
+    }
+
+    init(
+        messages: [AIChatMessage],
+        chatSessionId: String,
+        lastKnownChatConfig: AIChatServerConfig?,
+        pendingToolRunPostSync: Bool,
+        requiresRemoteSessionProvisioning: Bool,
+        suppressDraftRestore: Bool
+    ) {
         self.messages = messages
         self.chatSessionId = chatSessionId
         self.lastKnownChatConfig = lastKnownChatConfig
         self.pendingToolRunPostSync = pendingToolRunPostSync
+        self.requiresRemoteSessionProvisioning = requiresRemoteSessionProvisioning
+        self.suppressDraftRestore = suppressDraftRestore
+    }
+
+    init(
+        messages: [AIChatMessage],
+        chatSessionId: String,
+        lastKnownChatConfig: AIChatServerConfig?,
+        pendingToolRunPostSync: Bool,
+        suppressDraftRestore: Bool
+    ) {
+        self.init(
+            messages: messages,
+            chatSessionId: chatSessionId,
+            lastKnownChatConfig: lastKnownChatConfig,
+            pendingToolRunPostSync: pendingToolRunPostSync,
+            requiresRemoteSessionProvisioning: false,
+            suppressDraftRestore: suppressDraftRestore
+        )
     }
 
     init(messages: [AIChatMessage]) {
@@ -753,6 +794,14 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
             Bool.self,
             forKey: .pendingToolRunPostSync
         ) ?? false
+        self.requiresRemoteSessionProvisioning = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .requiresRemoteSessionProvisioning
+        ) ?? false
+        self.suppressDraftRestore = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .suppressDraftRestore
+        ) ?? false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -761,6 +810,11 @@ struct AIChatPersistedState: Codable, Hashable, Sendable {
         try container.encode(self.chatSessionId, forKey: .chatSessionId)
         try container.encodeIfPresent(self.lastKnownChatConfig, forKey: .lastKnownChatConfig)
         try container.encode(self.pendingToolRunPostSync, forKey: .pendingToolRunPostSync)
+        try container.encode(
+            self.requiresRemoteSessionProvisioning,
+            forKey: .requiresRemoteSessionProvisioning
+        )
+        try container.encode(self.suppressDraftRestore, forKey: .suppressDraftRestore)
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatHistoryStore.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatHistoryStore.swift
@@ -3,6 +3,7 @@ import Foundation
 let aiChatHistoryStorageKey: String = "ai-chat-history"
 let aiChatHistoryStorageKeyPrefix: String = "ai-chat-history::"
 let aiChatDraftStorageKeyPrefix: String = "ai-chat-draft::"
+let aiChatDraftRestoreSuppressionKeyPrefix: String = "ai-chat-draft-restore-suppression::"
 private let aiChatMaxMessages: Int = 200
 private let aiChatHistoryMigrationCleanupVersionKey: String = "ai-chat-history-cleanup-version"
 private let aiChatHistoryMigrationCleanupVersion: Int = 2
@@ -44,6 +45,10 @@ func clearStoredAIChatHistories(userDefaults: UserDefaults) {
     for key in userDefaults.dictionaryRepresentation().keys where key.hasPrefix(aiChatDraftStorageKeyPrefix) {
         userDefaults.removeObject(forKey: key)
     }
+
+    for key in userDefaults.dictionaryRepresentation().keys where key.hasPrefix(aiChatDraftRestoreSuppressionKeyPrefix) {
+        userDefaults.removeObject(forKey: key)
+    }
 }
 
 func storeAIChatHistoryStateSynchronously(
@@ -57,7 +62,9 @@ func storeAIChatHistoryStateSynchronously(
         messages: Array(state.messages.suffix(aiChatMaxMessages)),
         chatSessionId: state.chatSessionId,
         lastKnownChatConfig: state.lastKnownChatConfig,
-        pendingToolRunPostSync: state.pendingToolRunPostSync
+        pendingToolRunPostSync: state.pendingToolRunPostSync,
+        requiresRemoteSessionProvisioning: state.requiresRemoteSessionProvisioning,
+        suppressDraftRestore: state.suppressDraftRestore
     )
     let data = try encoder.encode(trimmedState)
     userDefaults.set(data, forKey: aiChatHistoryStorageKeyForWorkspace(workspaceId: workspaceId))
@@ -82,6 +89,28 @@ func storeAIChatDraftSynchronously(
 
     let data = try encoder.encode(draft)
     userDefaults.set(data, forKey: key)
+}
+
+func storeAIChatDraftRestoreSuppressionSynchronously(
+    userDefaults: UserDefaults,
+    workspaceId: String?,
+    sessionId: String?,
+    isSuppressed: Bool
+) {
+    runAIChatHistoryMigrationCleanupIfNeeded(userDefaults: userDefaults)
+    guard let normalizedSessionId = normalizedAIChatDraftSessionId(sessionId: sessionId) else {
+        return
+    }
+    let key = aiChatDraftRestoreSuppressionKeyForWorkspace(
+        workspaceId: workspaceId,
+        sessionId: normalizedSessionId
+    )
+    if isSuppressed {
+        userDefaults.set(true, forKey: key)
+        return
+    }
+
+    userDefaults.removeObject(forKey: key)
 }
 
 final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
@@ -144,7 +173,9 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
                 messages: trimmedMessages,
                 chatSessionId: state.chatSessionId,
                 lastKnownChatConfig: state.lastKnownChatConfig,
-                pendingToolRunPostSync: state.pendingToolRunPostSync
+                pendingToolRunPostSync: state.pendingToolRunPostSync,
+                requiresRemoteSessionProvisioning: state.requiresRemoteSessionProvisioning,
+                suppressDraftRestore: state.suppressDraftRestore
             )
         } catch {
             self.userDefaults.removeObject(forKey: storageKey)
@@ -162,6 +193,10 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
     }
 
     func saveState(workspaceId: String?, state: AIChatPersistedState) async {
+        self.saveStateSynchronously(workspaceId: workspaceId, state: state)
+    }
+
+    func saveStateSynchronously(workspaceId: String?, state: AIChatPersistedState) {
         do {
             try storeAIChatHistoryStateSynchronously(
                 userDefaults: self.userDefaults,
@@ -204,7 +239,28 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
         return AIChatComposerDraft(inputText: "", pendingAttachments: [])
     }
 
+    func loadDraftRestoreSuppression(workspaceId: String?, sessionId: String?) -> Bool {
+        runAIChatHistoryMigrationCleanupIfNeeded(userDefaults: self.userDefaults)
+        guard let normalizedSessionId = normalizedAIChatDraftSessionId(sessionId: sessionId) else {
+            return false
+        }
+        return self.userDefaults.bool(
+            forKey: aiChatDraftRestoreSuppressionKeyForWorkspace(
+                workspaceId: workspaceId,
+                sessionId: normalizedSessionId
+            )
+        )
+    }
+
     func saveDraft(workspaceId: String?, sessionId: String?, draft: AIChatComposerDraft) async {
+        self.saveDraftSynchronously(
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            draft: draft
+        )
+    }
+
+    func saveDraftSynchronously(workspaceId: String?, sessionId: String?, draft: AIChatComposerDraft) {
         do {
             try storeAIChatDraftSynchronously(
                 userDefaults: self.userDefaults,
@@ -224,6 +280,19 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
                 )
             )
         }
+    }
+
+    func saveDraftRestoreSuppressionSynchronously(
+        workspaceId: String?,
+        sessionId: String?,
+        isSuppressed: Bool
+    ) {
+        storeAIChatDraftRestoreSuppressionSynchronously(
+            userDefaults: self.userDefaults,
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            isSuppressed: isSuppressed
+        )
     }
 
     private func storageKey() -> String {
@@ -250,6 +319,17 @@ private func aiChatDraftStorageKeyForWorkspace(
     return "\(aiChatDraftStorageKeyPrefix)\(workspaceId)::\(sessionId)"
 }
 
+private func aiChatDraftRestoreSuppressionKeyForWorkspace(
+    workspaceId: String?,
+    sessionId: String
+) -> String {
+    guard let workspaceId, workspaceId.isEmpty == false else {
+        return "\(aiChatDraftRestoreSuppressionKeyPrefix)\(sessionId)"
+    }
+
+    return "\(aiChatDraftRestoreSuppressionKeyPrefix)\(workspaceId)::\(sessionId)"
+}
+
 private func normalizedAIChatDraftSessionId(sessionId: String?) -> String? {
     let normalizedSessionId = sessionId?.trimmingCharacters(in: .whitespacesAndNewlines)
     return normalizedSessionId?.isEmpty == false ? normalizedSessionId! : nil
@@ -261,6 +341,11 @@ private func removeStoredAIChatDrafts(
 ) {
     for key in userDefaults.dictionaryRepresentation().keys
         where aiChatDraftStorageKeyMatchesWorkspace(key: key, workspaceId: workspaceId) {
+        userDefaults.removeObject(forKey: key)
+    }
+
+    for key in userDefaults.dictionaryRepresentation().keys
+        where aiChatDraftRestoreSuppressionKeyMatchesWorkspace(key: key, workspaceId: workspaceId) {
         userDefaults.removeObject(forKey: key)
     }
 }
@@ -278,6 +363,22 @@ private func aiChatDraftStorageKeyMatchesWorkspace(
     }
 
     let suffix = key.dropFirst(aiChatDraftStorageKeyPrefix.count)
+    return suffix.contains("::") == false
+}
+
+private func aiChatDraftRestoreSuppressionKeyMatchesWorkspace(
+    key: String,
+    workspaceId: String?
+) -> Bool {
+    if let workspaceId, workspaceId.isEmpty == false {
+        return key.hasPrefix("\(aiChatDraftRestoreSuppressionKeyPrefix)\(workspaceId)::")
+    }
+
+    guard key.hasPrefix(aiChatDraftRestoreSuppressionKeyPrefix) else {
+        return false
+    }
+
+    let suffix = key.dropFirst(aiChatDraftRestoreSuppressionKeyPrefix.count)
     return suffix.contains("::") == false
 }
 

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatRuntimeContracts.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatRuntimeContracts.swift
@@ -127,10 +127,18 @@ protocol AIChatHistoryStoring: Sendable {
     func activateWorkspace(workspaceId: String?)
     func loadState() -> AIChatPersistedState
     func loadState(workspaceId: String?) -> AIChatPersistedState
+    func saveStateSynchronously(workspaceId: String?, state: AIChatPersistedState)
     func saveState(state: AIChatPersistedState) async
     func saveState(workspaceId: String?, state: AIChatPersistedState) async
     func clearState() async
     func loadDraft(workspaceId: String?, sessionId: String?) -> AIChatComposerDraft
+    func loadDraftRestoreSuppression(workspaceId: String?, sessionId: String?) -> Bool
+    func saveDraftSynchronously(workspaceId: String?, sessionId: String?, draft: AIChatComposerDraft)
+    func saveDraftRestoreSuppressionSynchronously(
+        workspaceId: String?,
+        sessionId: String?,
+        isSuppressed: Bool
+    )
     func saveDraft(workspaceId: String?, sessionId: String?, draft: AIChatComposerDraft) async
 }
 

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatSessionRuntime.swift
@@ -79,14 +79,6 @@ actor AIChatSessionRuntime {
                     "error": error.localizedDescription
                 ]
             )
-            if isGuestAiLimitError(error: error) {
-                await eventHandler(.appendAssistantAccountUpgradePrompt(
-                    message: aiChatGuestQuotaReachedMessage,
-                    buttonTitle: aiChatGuestQuotaButtonTitle
-                ))
-                await eventHandler(.finish)
-                return
-            }
             throw error
         }
     }
@@ -210,7 +202,7 @@ actor AIChatSessionRuntime {
     }
 }
 
-private func isGuestAiLimitError(error: Error) -> Bool {
+func isGuestAiLimitError(error: Error) -> Bool {
     guard let serviceError = error as? AIChatServiceError else {
         return false
     }

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RemoteSession.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RemoteSession.swift
@@ -41,7 +41,7 @@ extension AIChatStore {
         )
     }
 
-    private func prepareExplicitRemoteSessionProvisioning(sessionId: String) {
+    func prepareExplicitRemoteSessionProvisioning(sessionId: String) {
         self.invalidatePendingRemoteSessionProvisionRequest()
         self.chatSessionId = sessionId
         self.conversationScopeId = sessionId

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
@@ -63,6 +63,9 @@ extension AIChatStore {
 
         self.activeAlert = nil
         self.repairStatus = nil
+        if self.chatSessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            self.prepareExplicitRemoteSessionProvisioning(sessionId: makeAIChatSessionId())
+        }
         let preSendSnapshot = AIChatPreSendSnapshot(
             persistedState: self.currentPersistedState(),
             requiresRemoteSessionProvisioning: self.requiresRemoteSessionProvisioning,
@@ -77,6 +80,7 @@ extension AIChatStore {
         let draftText = self.inputText
         let draftAttachments = self.pendingAttachments
         self.transitionToPreparingSend()
+        self.persistStateSynchronously(state: self.currentPersistedState())
         self.applyComposerDraft(inputText: "", pendingAttachments: [])
         let conversationId = UUID().uuidString.lowercased()
         self.appendOptimisticOutgoingTurn(content: content)
@@ -291,6 +295,7 @@ extension AIChatStore {
         draftText: String,
         draftAttachments: [AIChatAttachment]
     ) {
+        let shouldShowGuestQuotaUpgradePrompt = didAcceptRun == false && isGuestAiLimitError(error: error)
         self.repairStatus = nil
         self.transitionToIdle()
         self.activeStreamingMessageId = nil
@@ -298,11 +303,32 @@ extension AIChatStore {
 
         if didAcceptRun == false && didAppendOptimisticMessages {
             self.restorePreSendState(preSendSnapshot)
-            self.applyComposerDraft(
-                inputText: draftText,
-                pendingAttachments: draftAttachments
+            self.suppressDraftRestore = false
+            self.persistDraftRestoreSuppressionSynchronously(
+                workspaceId: self.historyWorkspaceId(),
+                sessionId: self.chatSessionId.isEmpty ? nil : self.chatSessionId,
+                isSuppressed: false
             )
+            self.inputText = draftText
+            self.pendingAttachments = draftAttachments
+            self.persistDraftStateImmediately(
+                workspaceId: self.historyWorkspaceId(),
+                sessionId: self.chatSessionId.isEmpty ? nil : self.chatSessionId,
+                draft: AIChatComposerDraft(
+                    inputText: draftText,
+                    pendingAttachments: draftAttachments
+                )
+            )
+            if shouldShowGuestQuotaUpgradePrompt {
+                self.appendAssistantAccountUpgradePrompt(
+                    message: aiChatGuestQuotaReachedMessage,
+                    buttonTitle: aiChatGuestQuotaButtonTitle
+                )
+            }
             self.schedulePersistCurrentState()
+            if shouldShowGuestQuotaUpgradePrompt {
+                return
+            }
         }
 
         if didAcceptRun == false && isAIChatOfflineSendError(error: error) {
@@ -408,6 +434,12 @@ extension AIChatStore {
 
         switch event {
         case .accepted(let response):
+            self.suppressDraftRestore = false
+            self.persistDraftRestoreSuppressionSynchronously(
+                workspaceId: self.historyWorkspaceId(),
+                sessionId: response.envelope.sessionId.isEmpty ? nil : response.envelope.sessionId,
+                isSuppressed: false
+            )
             let reconciliation = self.acceptedEnvelopeReconciliation(
                 for: response.envelope,
                 conversationId: conversationId
@@ -430,6 +462,7 @@ extension AIChatStore {
             }
             self.applyComposerDraft(inputText: "", pendingAttachments: [])
             self.schedulePersistCurrentDraftState()
+            self.persistStateSynchronously(state: self.currentPersistedState())
             self.repairStatus = nil
             if response.activeRun != nil {
                 self.attachActiveLiveStreamIfPossible()

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
@@ -74,10 +74,11 @@ extension AIChatStore {
         )
         self.chatSessionId = resolvedSessionId
         self.conversationScopeId = resolvedSessionId
-        self.transitionToPreparingSend()
-        let conversationId = UUID().uuidString.lowercased()
         let draftText = self.inputText
         let draftAttachments = self.pendingAttachments
+        self.transitionToPreparingSend()
+        self.applyComposerDraft(inputText: "", pendingAttachments: [])
+        let conversationId = UUID().uuidString.lowercased()
         self.appendOptimisticOutgoingTurn(content: content)
         self.storePreSendSnapshot(preSendSnapshot, conversationId: conversationId)
 

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+Surface.swift
@@ -241,11 +241,41 @@ extension AIChatStore {
             workspaceId: self.historyWorkspaceId(),
             sessionId: resolvedSessionId.isEmpty ? nil : resolvedSessionId
         )
-        self.applyComposerDraft(
-            inputText: persistedDraft.inputText,
-            pendingAttachments: persistedDraft.pendingAttachments
+        let shouldSuppressDraftRestore = self.isDraftRestoreSuppressed(
+            workspaceId: self.historyWorkspaceId(),
+            sessionId: resolvedSessionId.isEmpty ? nil : resolvedSessionId,
+            persistedState: persistedState
         )
-        self.schedulePersistCurrentDraftState()
+        let restoredDraft = shouldSuppressDraftRestore
+            ? AIChatComposerDraft(inputText: "", pendingAttachments: [])
+            : persistedDraft
+        self.applyComposerDraft(
+            inputText: restoredDraft.inputText,
+            pendingAttachments: restoredDraft.pendingAttachments
+        )
+        self.suppressDraftRestore = false
+        if shouldSuppressDraftRestore {
+            self.persistStateSynchronously(
+                state: AIChatPersistedState(
+                    messages: persistedState.messages,
+                    chatSessionId: resolvedSessionId,
+                    lastKnownChatConfig: persistedState.lastKnownChatConfig,
+                    pendingToolRunPostSync: persistedState.pendingToolRunPostSync,
+                    requiresRemoteSessionProvisioning: persistedState.requiresRemoteSessionProvisioning,
+                    suppressDraftRestore: false
+                )
+            )
+        }
+        self.persistDraftRestoreSuppressionSynchronously(
+            workspaceId: self.historyWorkspaceId(),
+            sessionId: resolvedSessionId.isEmpty ? nil : resolvedSessionId,
+            isSuppressed: false
+        )
+        self.persistDraftStateImmediately(
+            workspaceId: self.historyWorkspaceId(),
+            sessionId: resolvedSessionId.isEmpty ? nil : resolvedSessionId,
+            draft: restoredDraft
+        )
         self.transitionToIdle()
         self.dictationState = .idle
         self.activeAlert = nil
@@ -263,7 +293,7 @@ extension AIChatStore {
         self.pendingToolRunPostSync = persistedState.pendingToolRunPostSync
         self.activeResumeErrorAttemptSequence = nil
         self.activeLiveResumeAttemptSequence = nil
-        self.requiresRemoteSessionProvisioning = false
+        self.requiresRemoteSessionProvisioning = persistedState.requiresRemoteSessionProvisioning
     }
 
     func canAutoStartFreshLocalSession() -> Bool {
@@ -379,14 +409,7 @@ extension AIChatStore {
         self.activeResumeErrorAttemptSequence = nil
         self.activeLiveResumeAttemptSequence = nil
         self.requiresRemoteSessionProvisioning = true
-        self.schedulePersistState(
-            state: AIChatPersistedState(
-                messages: [],
-                chatSessionId: sessionId,
-                lastKnownChatConfig: self.serverChatConfig,
-                pendingToolRunPostSync: false
-            )
-        )
+        self.schedulePersistCurrentState()
     }
 
     func isConversationDirtyForPresentation() -> Bool {

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore.swift
@@ -1,13 +1,60 @@
 import Foundation
 import Observation
 
-fileprivate struct AIChatDraftPersistKey: Hashable, Sendable {
-    let workspaceId: String?
-    let sessionId: String?
-}
-
 fileprivate struct AIChatStatePersistKey: Hashable, Sendable {
     let workspaceId: String?
+}
+
+fileprivate struct AIChatQueuedPersistedState: Sendable {
+    let version: Int
+    let state: AIChatPersistedState
+}
+
+fileprivate final class AIChatStatePersistCoordinator: @unchecked Sendable {
+    private let lock: NSLock
+    private var latestVersions: [AIChatStatePersistKey: Int]
+
+    init() {
+        self.lock = NSLock()
+        self.latestVersions = [:]
+    }
+
+    func reserveNextVersion(for key: AIChatStatePersistKey) -> Int {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        let nextVersion = (self.latestVersions[key] ?? 0) + 1
+        self.latestVersions[key] = nextVersion
+        return nextVersion
+    }
+
+    func saveImmediately(for key: AIChatStatePersistKey, operation: () -> Void) {
+        self.lock.lock()
+        let nextVersion = (self.latestVersions[key] ?? 0) + 1
+        self.latestVersions[key] = nextVersion
+        operation()
+        self.lock.unlock()
+    }
+
+    func saveIfCurrent(
+        for key: AIChatStatePersistKey,
+        version: Int,
+        operation: () -> Void
+    ) -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        guard self.latestVersions[key] == version else {
+            return false
+        }
+
+        operation()
+        return true
+    }
 }
 
 struct AIChatToolRunPostSyncOrigin: Equatable, Sendable {
@@ -124,10 +171,10 @@ final class AIChatStore {
     @ObservationIgnored var activeNewSessionTask: Task<Void, Never>?
     @ObservationIgnored var activeRemoteSessionProvisionRequest: AIChatRemoteSessionProvisionRequest?
     @ObservationIgnored var activePersistTask: Task<Void, Never>?
+    @ObservationIgnored fileprivate let statePersistCoordinator: AIChatStatePersistCoordinator
     @ObservationIgnored fileprivate var activeStatePersistKey: AIChatStatePersistKey?
-    @ObservationIgnored fileprivate var pendingPersistStates: [AIChatStatePersistKey: AIChatPersistedState]
+    @ObservationIgnored fileprivate var pendingPersistStates: [AIChatStatePersistKey: AIChatQueuedPersistedState]
     @ObservationIgnored var activeDraftPersistTask: Task<Void, Never>?
-    @ObservationIgnored fileprivate var pendingDraftPersistStates: [AIChatDraftPersistKey: AIChatComposerDraft]
     @ObservationIgnored var activeConversationId: String?
     @ObservationIgnored var storedPreSendSnapshotConversationId: String?
     @ObservationIgnored var storedPreSendSnapshot: AIChatPreSendSnapshot?
@@ -141,6 +188,7 @@ final class AIChatStore {
     @ObservationIgnored var activeResumeErrorAttemptSequence: Int?
     @ObservationIgnored var activeLiveResumeAttemptSequence: Int?
     @ObservationIgnored var requiresRemoteSessionProvisioning: Bool
+    @ObservationIgnored var suppressDraftRestore: Bool
     @ObservationIgnored var optimisticOutgoingTurnState: AIChatOptimisticOutgoingTurnState?
 
     var hasOlderMessages: Bool {
@@ -323,7 +371,9 @@ final class AIChatStore {
             messages: persistedState.messages,
             chatSessionId: persistedState.chatSessionId,
             lastKnownChatConfig: persistedState.lastKnownChatConfig,
-            pendingToolRunPostSync: false
+            pendingToolRunPostSync: false,
+            requiresRemoteSessionProvisioning: persistedState.requiresRemoteSessionProvisioning,
+            suppressDraftRestore: persistedState.suppressDraftRestore
         )
         await self.historyStore.saveState(workspaceId: origin.workspaceId, state: clearedState)
     }
@@ -390,7 +440,7 @@ final class AIChatStore {
         self.activePersistTask = Task { [weak self] in
             while let self {
                 await Task.yield()
-                let nextPersistState = await MainActor.run { () -> (AIChatStatePersistKey, AIChatPersistedState)? in
+                let nextPersistState = await MainActor.run { () -> (AIChatStatePersistKey, AIChatQueuedPersistedState)? in
                     guard let nextKey = self.pendingPersistStates.keys.first,
                           let nextState = self.pendingPersistStates.removeValue(forKey: nextKey)
                     else {
@@ -404,8 +454,17 @@ final class AIChatStore {
                     break
                 }
 
-                let (nextKey, nextState) = nextPersistState
-                await self.historyStore.saveState(workspaceId: nextKey.workspaceId, state: nextState)
+                let (nextKey, nextQueuedState) = nextPersistState
+                _ = self.statePersistCoordinator.saveIfCurrent(
+                    for: nextKey,
+                    version: nextQueuedState.version,
+                    operation: {
+                        self.historyStore.saveStateSynchronously(
+                            workspaceId: nextKey.workspaceId,
+                            state: nextQueuedState.state
+                        )
+                    }
+                )
                 await MainActor.run { [weak self] in
                     if self?.activeStatePersistKey == nextKey {
                         self?.activeStatePersistKey = nil
@@ -436,12 +495,28 @@ final class AIChatStore {
         state: AIChatPersistedState
     ) {
         let key = AIChatStatePersistKey(workspaceId: workspaceId)
-        self.pendingPersistStates[key] = state
+        let version = self.statePersistCoordinator.reserveNextVersion(for: key)
+        self.pendingPersistStates[key] = AIChatQueuedPersistedState(version: version, state: state)
         self.startPersistTaskIfNeeded()
     }
 
     func schedulePersistState(state: AIChatPersistedState) {
         self.schedulePersistState(workspaceId: self.historyWorkspaceId(), state: state)
+    }
+
+    func persistStateSynchronously(state: AIChatPersistedState) {
+        let workspaceId = self.historyWorkspaceId()
+        let key = AIChatStatePersistKey(workspaceId: workspaceId)
+        self.pendingPersistStates.removeValue(forKey: key)
+        self.statePersistCoordinator.saveImmediately(
+            for: key,
+            operation: {
+                self.historyStore.saveStateSynchronously(
+                    workspaceId: workspaceId,
+                    state: state
+                )
+            }
+        )
     }
 
     func schedulePersistCurrentState() {
@@ -459,7 +534,53 @@ final class AIChatStore {
     func cancelPendingDraftPersistence() {
         self.activeDraftPersistTask?.cancel()
         self.activeDraftPersistTask = nil
-        self.pendingDraftPersistStates.removeAll()
+    }
+
+    func persistDraftStateSynchronously(
+        workspaceId: String?,
+        sessionId: String?,
+        draft: AIChatComposerDraft
+    ) {
+        self.historyStore.saveDraftSynchronously(
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            draft: draft
+        )
+    }
+
+    func isDraftRestoreSuppressed(
+        workspaceId: String?,
+        sessionId: String?,
+        persistedState: AIChatPersistedState
+    ) -> Bool {
+        self.historyStore.loadDraftRestoreSuppression(
+            workspaceId: workspaceId,
+            sessionId: sessionId
+        ) || persistedState.suppressDraftRestore
+    }
+
+    func persistDraftRestoreSuppressionSynchronously(
+        workspaceId: String?,
+        sessionId: String?,
+        isSuppressed: Bool
+    ) {
+        self.historyStore.saveDraftRestoreSuppressionSynchronously(
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            isSuppressed: isSuppressed
+        )
+    }
+
+    func persistDraftStateImmediately(
+        workspaceId: String?,
+        sessionId: String?,
+        draft: AIChatComposerDraft
+    ) {
+        self.persistDraftStateSynchronously(
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            draft: draft
+        )
     }
 
     func schedulePersistDraftState(
@@ -467,46 +588,11 @@ final class AIChatStore {
         sessionId: String?,
         draft: AIChatComposerDraft
     ) {
-        let key = AIChatDraftPersistKey(workspaceId: workspaceId, sessionId: sessionId)
-        self.pendingDraftPersistStates[key] = draft
-        guard self.activeDraftPersistTask == nil else {
-            return
-        }
-
-        self.activeDraftPersistTask = Task { [weak self] in
-            while let self {
-                await Task.yield()
-                guard Task.isCancelled == false else {
-                    break
-                }
-                let nextDraftState = await MainActor.run { () -> (AIChatDraftPersistKey, AIChatComposerDraft)? in
-                    guard let nextKey = self.pendingDraftPersistStates.keys.first,
-                          let nextDraft = self.pendingDraftPersistStates.removeValue(forKey: nextKey)
-                    else {
-                        return nil
-                    }
-
-                    return (nextKey, nextDraft)
-                }
-                guard let nextDraftState else {
-                    break
-                }
-
-                let (nextKey, nextDraft) = nextDraftState
-                guard Task.isCancelled == false else {
-                    break
-                }
-                await self.historyStore.saveDraft(
-                    workspaceId: nextKey.workspaceId,
-                    sessionId: nextKey.sessionId,
-                    draft: nextDraft
-                )
-            }
-
-            await MainActor.run { [weak self] in
-                self?.activeDraftPersistTask = nil
-            }
-        }
+        self.persistDraftStateSynchronously(
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            draft: draft
+        )
     }
 
     func currentPersistedState() -> AIChatPersistedState {
@@ -514,7 +600,9 @@ final class AIChatStore {
             messages: self.messages,
             chatSessionId: self.chatSessionId,
             lastKnownChatConfig: self.serverChatConfig,
-            pendingToolRunPostSync: self.pendingToolRunPostSync
+            pendingToolRunPostSync: self.pendingToolRunPostSync,
+            requiresRemoteSessionProvisioning: self.requiresRemoteSessionProvisioning,
+            suppressDraftRestore: self.suppressDraftRestore
         )
     }
 
@@ -611,10 +699,29 @@ final class AIChatStore {
             sessionId: persistedState.chatSessionId
         )
         self.conversationScopeId = self.chatSessionId
-        let initialDraft = historyStore.loadDraft(
+        let persistedDraft = historyStore.loadDraft(
             workspaceId: initialHistoryWorkspaceId,
             sessionId: self.chatSessionId.isEmpty ? nil : self.chatSessionId
         )
+        let shouldSuppressInitialDraftRestore = historyStore.loadDraftRestoreSuppression(
+            workspaceId: initialHistoryWorkspaceId,
+            sessionId: self.chatSessionId.isEmpty ? nil : self.chatSessionId
+        ) || persistedState.suppressDraftRestore
+        let initialDraft = shouldSuppressInitialDraftRestore
+            ? AIChatComposerDraft(inputText: "", pendingAttachments: [])
+            : persistedDraft
+        if shouldSuppressInitialDraftRestore {
+            historyStore.saveDraftSynchronously(
+                workspaceId: initialHistoryWorkspaceId,
+                sessionId: self.chatSessionId.isEmpty ? nil : self.chatSessionId,
+                draft: initialDraft
+            )
+            historyStore.saveDraftRestoreSuppressionSynchronously(
+                workspaceId: initialHistoryWorkspaceId,
+                sessionId: self.chatSessionId.isEmpty ? nil : self.chatSessionId,
+                isSuppressed: false
+            )
+        }
         self.composerState = AIChatComposerState(
             inputText: initialDraft.inputText,
             pendingAttachments: initialDraft.pendingAttachments,
@@ -630,21 +737,22 @@ final class AIChatStore {
         self.activeNewSessionTask = nil
         self.activeRemoteSessionProvisionRequest = nil
         self.activePersistTask = nil
+        self.statePersistCoordinator = AIChatStatePersistCoordinator()
         self.activeStatePersistKey = nil
         self.pendingPersistStates = [:]
         self.activeDraftPersistTask = nil
-        self.pendingDraftPersistStates = [:]
         self.activeConversationId = nil
         self.activeStreamingMessageId = nil
         self.activeStreamingItemId = nil
         self.runHadToolCalls = persistedState.pendingToolRunPostSync
         self.pendingToolRunPostSync = persistedState.pendingToolRunPostSync
+        self.suppressDraftRestore = shouldSuppressInitialDraftRestore
         self.activeToolRunPostSyncTask = nil
         self.nextResumeAttemptSequence = 0
         self.nextNewSessionRequestSequence = 0
         self.activeResumeErrorAttemptSequence = nil
         self.activeLiveResumeAttemptSequence = nil
-        self.requiresRemoteSessionProvisioning = false
+        self.requiresRemoteSessionProvisioning = persistedState.requiresRemoteSessionProvisioning
         self.optimisticOutgoingTurnState = restoredAIChatOptimisticOutgoingTurnState(
             messages: persistedState.messages
         )

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStoreContentMutation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStoreContentMutation.swift
@@ -46,20 +46,23 @@ extension AIChatStore {
     }
 
     func appendAssistantAccountUpgradePrompt(message: String, buttonTitle: String) {
-        if let lastIndex = self.messages.indices.last, self.messages[lastIndex].role == .assistant {
+        if let lastIndex = self.messages.indices.last {
             let lastMessage = self.messages[lastIndex]
-            _ = self.consumeOptimisticAssistantPlaceholder(messageId: lastMessage.id)
-            self.messages[lastIndex] = AIChatMessage(
-                id: lastMessage.id,
-                role: lastMessage.role,
-                content: [.accountUpgradePrompt(message: message, buttonTitle: buttonTitle)],
-                timestamp: lastMessage.timestamp,
-                isError: false,
-                isStopped: lastMessage.isStopped,
-                cursor: lastMessage.cursor,
-                itemId: lastMessage.itemId
-            )
-            return
+            if lastMessage.role == .assistant,
+               self.consumeOptimisticAssistantPlaceholder(messageId: lastMessage.id)
+            {
+                self.messages[lastIndex] = AIChatMessage(
+                    id: lastMessage.id,
+                    role: lastMessage.role,
+                    content: [.accountUpgradePrompt(message: message, buttonTitle: buttonTitle)],
+                    timestamp: lastMessage.timestamp,
+                    isError: false,
+                    isStopped: lastMessage.isStopped,
+                    cursor: lastMessage.cursor,
+                    itemId: lastMessage.itemId
+                )
+                return
+            }
         }
 
         self.messages.append(

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRemoteSessionProvisioningTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRemoteSessionProvisioningTests.swift
@@ -122,6 +122,139 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
         XCTAssertNil(store.activeAlert)
     }
 
+    func testFirstSendFromSessionlessStateRestoresDraftAcrossRestartBeforeAcceptance() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        let syncGate = AIChatStoreTestSupport.AsyncGate()
+        context.cloudSyncService.runLinkedSyncGate = syncGate
+        store.acceptExternalProviderConsent()
+        store.bootstrapPhase = .ready
+        store.chatSessionId = ""
+        store.conversationScopeId = ""
+
+        let expectedDraft = AIChatComposerDraft(
+            inputText: "Help me review this card.",
+            pendingAttachments: []
+        )
+        store.inputText = expectedDraft.inputText
+
+        context.chatService.createNewSessionHandler = { request in
+            guard let sessionId = request.sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id before provisioning.")
+            }
+
+            return AIChatStoreTestSupport.makeNewSessionResponse(sessionId: sessionId)
+        }
+        context.chatService.startRunHandler = { request in
+            guard let sessionId = request.sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id while starting the run.")
+            }
+
+            return AIChatStoreTestSupport.makeAcceptedStartRunResponse(
+                sessionId: sessionId,
+                userText: expectedDraft.inputText
+            )
+        }
+
+        store.sendMessage()
+
+        XCTAssertEqual(store.inputText, "")
+        XCTAssertTrue(store.pendingAttachments.isEmpty)
+
+        let didPersistExplicitSessionDraft = await AIChatStoreTestSupport.waitForCondition(
+            description: "sessionless pre-accept draft persisted under explicit session id",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                let persistedState = context.historyStore.loadState()
+                guard persistedState.chatSessionId.isEmpty == false else {
+                    return false
+                }
+
+                return persistedState.requiresRemoteSessionProvisioning
+                    && context.historyStore.loadDraft(
+                        workspaceId: store.historyWorkspaceId(),
+                        sessionId: persistedState.chatSessionId
+                    ) == expectedDraft
+            }
+        )
+        XCTAssertTrue(didPersistExplicitSessionDraft)
+
+        let explicitSessionId = context.historyStore.loadState().chatSessionId
+        let restartedBeforeAcceptance = context.makeStore()
+
+        XCTAssertEqual(restartedBeforeAcceptance.chatSessionId, explicitSessionId)
+        XCTAssertEqual(restartedBeforeAcceptance.conversationScopeId, explicitSessionId)
+        XCTAssertEqual(restartedBeforeAcceptance.inputText, expectedDraft.inputText)
+        XCTAssertTrue(restartedBeforeAcceptance.pendingAttachments.isEmpty)
+        XCTAssertTrue(restartedBeforeAcceptance.requiresRemoteSessionProvisioning)
+
+        store.activeSendTask?.cancel()
+        await syncGate.release()
+        await AIChatStoreTestSupport.waitForSendToSettle(store: store)
+    }
+
+    func testAcceptedFirstSendFromSessionlessStateClearsDraftDurably() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        let store = context.makeStore()
+        store.chatSessionId = ""
+        store.conversationScopeId = ""
+        store.activeConversationId = "conversation-1"
+
+        let expectedDraft = AIChatComposerDraft(
+            inputText: "Help me review this card.",
+            pendingAttachments: []
+        )
+        store.inputText = expectedDraft.inputText
+        let explicitSessionId = "session-explicit"
+
+        store.prepareExplicitRemoteSessionProvisioning(sessionId: explicitSessionId)
+        store.persistStateSynchronously(state: store.currentPersistedState())
+
+        await store.handleRuntimeEvent(
+            .accepted(
+                AIChatStoreTestSupport.makeAcceptedStartRunResponse(
+                    sessionId: explicitSessionId,
+                    userText: expectedDraft.inputText
+                )
+            ),
+            conversationId: "conversation-1"
+        )
+        await store.waitForPendingStatePersistence()
+
+        XCTAssertFalse(store.requiresRemoteSessionProvisioning)
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: explicitSessionId
+            ),
+            AIChatComposerDraft(inputText: "", pendingAttachments: [])
+        )
+
+        let restartedAfterAcceptance = context.makeStore()
+
+        XCTAssertEqual(restartedAfterAcceptance.chatSessionId, explicitSessionId)
+        XCTAssertEqual(restartedAfterAcceptance.inputText, "")
+        XCTAssertTrue(restartedAfterAcceptance.pendingAttachments.isEmpty)
+        XCTAssertFalse(restartedAfterAcceptance.requiresRemoteSessionProvisioning)
+        XCTAssertEqual(
+            restartedAfterAcceptance.messages,
+            AIChatStoreTestSupport.makeAcceptedStartRunResponse(
+                sessionId: explicitSessionId,
+                userText: expectedDraft.inputText
+            ).envelope.conversation.messages
+        )
+    }
+
     func testFirstDictationUsesExplicitSessionId() async throws {
         let context = AIChatStoreTestSupport.Context.make()
         defer {

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStartTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStartTests.swift
@@ -1,8 +1,508 @@
+import Foundation
 import XCTest
 @testable import Flashcards
 
+private final class BlockingAIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
+    private let base: AIChatHistoryStore
+    private let lock: NSLock
+    private let blockedSaveReleaseSemaphore: DispatchSemaphore
+    private var remainingBlockedStateSaves: Int
+    private var hasBlockedStateSaveStartedFlag: Bool
+
+    init(base: AIChatHistoryStore) {
+        self.base = base
+        self.lock = NSLock()
+        self.blockedSaveReleaseSemaphore = DispatchSemaphore(value: 0)
+        self.remainingBlockedStateSaves = 0
+        self.hasBlockedStateSaveStartedFlag = false
+    }
+
+    func blockNextStateSave() {
+        self.lock.lock()
+        self.remainingBlockedStateSaves += 1
+        self.hasBlockedStateSaveStartedFlag = false
+        self.lock.unlock()
+    }
+
+    func hasBlockedStateSaveStarted() -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        return self.hasBlockedStateSaveStartedFlag
+    }
+
+    func releaseBlockedStateSave() {
+        self.blockedSaveReleaseSemaphore.signal()
+    }
+
+    private func shouldBlockStateSave() -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        guard self.remainingBlockedStateSaves > 0 else {
+            return false
+        }
+
+        self.remainingBlockedStateSaves -= 1
+        return true
+    }
+
+    func activateWorkspace(workspaceId: String?) {
+        self.base.activateWorkspace(workspaceId: workspaceId)
+    }
+
+    func loadState() -> AIChatPersistedState {
+        self.base.loadState()
+    }
+
+    func loadState(workspaceId: String?) -> AIChatPersistedState {
+        self.base.loadState(workspaceId: workspaceId)
+    }
+
+    func saveStateSynchronously(workspaceId: String?, state: AIChatPersistedState) {
+        if self.shouldBlockStateSave() {
+            self.lock.lock()
+            self.hasBlockedStateSaveStartedFlag = true
+            self.lock.unlock()
+            _ = self.blockedSaveReleaseSemaphore.wait(timeout: .now() + 3)
+        }
+
+        self.base.saveStateSynchronously(workspaceId: workspaceId, state: state)
+    }
+
+    func saveState(state: AIChatPersistedState) async {
+        await self.base.saveState(state: state)
+    }
+
+    func saveState(workspaceId: String?, state: AIChatPersistedState) async {
+        await self.base.saveState(workspaceId: workspaceId, state: state)
+    }
+
+    func clearState() async {
+        await self.base.clearState()
+    }
+
+    func loadDraft(workspaceId: String?, sessionId: String?) -> AIChatComposerDraft {
+        self.base.loadDraft(workspaceId: workspaceId, sessionId: sessionId)
+    }
+
+    func loadDraftRestoreSuppression(workspaceId: String?, sessionId: String?) -> Bool {
+        self.base.loadDraftRestoreSuppression(workspaceId: workspaceId, sessionId: sessionId)
+    }
+
+    func saveDraftSynchronously(workspaceId: String?, sessionId: String?, draft: AIChatComposerDraft) {
+        self.base.saveDraftSynchronously(workspaceId: workspaceId, sessionId: sessionId, draft: draft)
+    }
+
+    func saveDraftRestoreSuppressionSynchronously(
+        workspaceId: String?,
+        sessionId: String?,
+        isSuppressed: Bool
+    ) {
+        self.base.saveDraftRestoreSuppressionSynchronously(
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            isSuppressed: isSuppressed
+        )
+    }
+
+    func saveDraft(workspaceId: String?, sessionId: String?, draft: AIChatComposerDraft) async {
+        await self.base.saveDraft(workspaceId: workspaceId, sessionId: sessionId, draft: draft)
+    }
+}
+
+private actor AIChatRuntimeEventRecorder {
+    private var labels: [String]
+
+    init() {
+        self.labels = []
+    }
+
+    func record(_ event: AIChatRuntimeEvent) {
+        switch event {
+        case .accepted:
+            self.labels.append("accepted")
+        case .liveEvent:
+            self.labels.append("liveEvent")
+        case .appendAssistantAccountUpgradePrompt:
+            self.labels.append("appendAssistantAccountUpgradePrompt")
+        case .finish:
+            self.labels.append("finish")
+        case .fail:
+            self.labels.append("fail")
+        }
+    }
+
+    func snapshot() -> [String] {
+        self.labels
+    }
+}
+
 @MainActor
 final class AIChatStoreRunStartTests: XCTestCase {
+    func testSendMessageSuppressionSnapshotWinsOverOlderQueuedStateSave() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let historyStore = BlockingAIChatHistoryStore(base: context.historyStore)
+        let store = AIChatStore(
+            flashcardsStore: context.flashcardsStore,
+            historyStore: historyStore,
+            chatService: context.chatService,
+            contextLoader: AIChatStoreTestSupport.ContextLoader(),
+            voiceRecorder: AIChatDisabledVoiceRecorder(),
+            audioTranscriber: AIChatDisabledAudioTranscriber()
+        )
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.messages = [
+            AIChatStoreTestSupport.makeAssistantTextMessage(
+                id: "message-1",
+                itemId: "item-1",
+                text: "Earlier response.",
+                timestamp: "2026-04-08T10:00:00Z"
+            )
+        ]
+
+        historyStore.blockNextStateSave()
+        store.schedulePersistCurrentState()
+        let didBlockOlderStateSave = await AIChatStoreTestSupport.waitForCondition(
+            description: "older queued state save blocked before send",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                historyStore.hasBlockedStateSaveStarted()
+            }
+        )
+        XCTAssertTrue(didBlockOlderStateSave)
+
+        let releaseOlderSaveTask = Task.detached {
+            try? await Task.sleep(for: .milliseconds(20))
+            historyStore.releaseBlockedStateSave()
+        }
+        store.suppressDraftRestore = true
+        store.persistStateSynchronously(state: store.currentPersistedState())
+        await releaseOlderSaveTask.value
+
+        let persistedState = context.historyStore.loadState(workspaceId: store.historyWorkspaceId())
+        XCTAssertTrue(persistedState.suppressDraftRestore)
+        XCTAssertEqual(persistedState.messages.count, 1)
+        XCTAssertEqual(persistedState.chatSessionId, "session-1")
+    }
+
+    func testSendMessageKeepsDraftDurableBeforeRunAcceptanceAcrossRestart() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        let syncGate = AIChatStoreTestSupport.AsyncGate()
+        context.cloudSyncService.runLinkedSyncGate = syncGate
+        store.acceptExternalProviderConsent()
+        store.bootstrapPhase = .ready
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        let draftAttachment = AIChatAttachment(
+            id: "attachment-card-1",
+            payload: .card(
+                AIChatCardReference(
+                    cardId: "card-1",
+                    frontText: "Front",
+                    backText: "Back",
+                    tags: ["tag-1"],
+                    effortLevel: .medium
+                )
+            )
+        )
+        let persistedDraft = AIChatComposerDraft(
+            inputText: "Help me review this card.",
+            pendingAttachments: [draftAttachment]
+        )
+        store.inputText = persistedDraft.inputText
+        store.pendingAttachments = persistedDraft.pendingAttachments
+        context.chatService.startRunHandler = { request in
+            guard let sessionId = request.sessionId else {
+                throw LocalStoreError.validation("Expected a chat session id while starting the run.")
+            }
+
+            return AIChatStoreTestSupport.makeAcceptedStartRunResponse(
+                sessionId: sessionId,
+                userText: persistedDraft.inputText
+            )
+        }
+
+        let didPersistInitialDraft = await AIChatStoreTestSupport.waitForCondition(
+            description: "initial draft persisted before send",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                store.activeDraftPersistTask == nil
+                    && context.historyStore.loadDraft(
+                        workspaceId: store.historyWorkspaceId(),
+                        sessionId: "session-1"
+                    ) == persistedDraft
+            }
+        )
+        XCTAssertTrue(didPersistInitialDraft)
+
+        store.sendMessage()
+
+        XCTAssertEqual(store.inputText, "")
+        XCTAssertTrue(store.pendingAttachments.isEmpty)
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: "session-1"
+            ),
+            persistedDraft
+        )
+        XCTAssertFalse(
+            context.historyStore.loadDraftRestoreSuppression(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: "session-1"
+            )
+        )
+        XCTAssertFalse(
+            context.historyStore.loadState(
+                workspaceId: store.historyWorkspaceId()
+            ).suppressDraftRestore
+        )
+
+        context.userDefaults.removeObject(forKey: aiChatExternalProviderConsentUserDefaultsKey)
+        let restartedStore = context.makeStore()
+        XCTAssertEqual(restartedStore.inputText, persistedDraft.inputText)
+        XCTAssertEqual(restartedStore.pendingAttachments, persistedDraft.pendingAttachments)
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: restartedStore.historyWorkspaceId(),
+                sessionId: "session-1"
+            ),
+            persistedDraft
+        )
+        XCTAssertFalse(
+            context.historyStore.loadDraftRestoreSuppression(
+                workspaceId: restartedStore.historyWorkspaceId(),
+                sessionId: "session-1"
+            )
+        )
+        XCTAssertFalse(
+            context.historyStore.loadState(
+                workspaceId: restartedStore.historyWorkspaceId()
+            ).suppressDraftRestore
+        )
+
+        let replacementDraft = AIChatComposerDraft(
+            inputText: "A new draft after restart.",
+            pendingAttachments: []
+        )
+        restartedStore.inputText = replacementDraft.inputText
+        restartedStore.pendingAttachments = replacementDraft.pendingAttachments
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: restartedStore.historyWorkspaceId(),
+                sessionId: "session-1"
+            ),
+            replacementDraft
+        )
+
+        let secondRestartedStore = context.makeStore()
+        XCTAssertEqual(secondRestartedStore.inputText, replacementDraft.inputText)
+        XCTAssertEqual(secondRestartedStore.pendingAttachments, replacementDraft.pendingAttachments)
+
+        await syncGate.release()
+    }
+
+    func testAcceptedRunClearsDraftDurablyAcrossRestart() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        store.acceptExternalProviderConsent()
+        store.bootstrapPhase = .ready
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.activeConversationId = "conversation-1"
+        let acceptedUserTimestamp = nowIsoTimestamp()
+        let acceptedAssistantTimestamp = nowIsoTimestamp()
+
+        let acceptedMessages = [
+            AIChatStoreTestSupport.makeUserTextMessage(
+                id: "message-user-1",
+                text: "Help me review this card.",
+                timestamp: acceptedUserTimestamp
+            ),
+            AIChatStoreTestSupport.makeAssistantTextMessage(
+                id: "message-assistant-1",
+                itemId: "item-1",
+                text: "Working on it.",
+                timestamp: acceptedAssistantTimestamp
+            )
+        ]
+        let persistedDraft = AIChatComposerDraft(
+            inputText: "Help me review this card.",
+            pendingAttachments: []
+        )
+        store.inputText = persistedDraft.inputText
+
+        let didPersistInitialDraft = await AIChatStoreTestSupport.waitForCondition(
+            description: "accepted-run draft persisted before runtime acceptance",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.historyStore.loadDraft(
+                    workspaceId: store.historyWorkspaceId(),
+                    sessionId: "session-1"
+                ) == persistedDraft
+            }
+        )
+        XCTAssertTrue(didPersistInitialDraft)
+
+        await store.handleRuntimeEvent(
+            .accepted(
+                AIChatStartRunResponse(
+                    accepted: true,
+                    sessionId: "session-1",
+                    conversationScopeId: "session-1",
+                    conversation: AIChatConversation(
+                        messages: acceptedMessages,
+                        updatedAt: 1,
+                        mainContentInvalidationVersion: 1,
+                        hasOlder: false,
+                        oldestCursor: nil
+                    ),
+                    composerSuggestions: [],
+                    chatConfig: aiChatDefaultServerConfig,
+                    activeRun: nil,
+                    deduplicated: nil
+                )
+            ),
+            conversationId: "conversation-1"
+        )
+        await store.waitForPendingStatePersistence()
+
+        XCTAssertEqual(store.inputText, "")
+        XCTAssertTrue(store.pendingAttachments.isEmpty)
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: "session-1"
+            ),
+            AIChatComposerDraft(inputText: "", pendingAttachments: [])
+        )
+        XCTAssertFalse(
+            context.historyStore.loadDraftRestoreSuppression(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: "session-1"
+            )
+        )
+
+        context.userDefaults.removeObject(forKey: aiChatExternalProviderConsentUserDefaultsKey)
+        let restartedStore = context.makeStore()
+
+        XCTAssertEqual(restartedStore.inputText, "")
+        XCTAssertTrue(restartedStore.pendingAttachments.isEmpty)
+        XCTAssertEqual(restartedStore.messages, acceptedMessages)
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: restartedStore.historyWorkspaceId(),
+                sessionId: "session-1"
+            ),
+            AIChatComposerDraft(inputText: "", pendingAttachments: [])
+        )
+        XCTAssertFalse(
+            context.historyStore.loadState(
+                workspaceId: restartedStore.historyWorkspaceId()
+            ).suppressDraftRestore
+        )
+    }
+
+    func testAcceptedRunClearsSuppressionStateSynchronouslyDespiteOlderQueuedSave() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let historyStore = BlockingAIChatHistoryStore(base: context.historyStore)
+        let store = AIChatStore(
+            flashcardsStore: context.flashcardsStore,
+            historyStore: historyStore,
+            chatService: context.chatService,
+            contextLoader: AIChatStoreTestSupport.ContextLoader(),
+            voiceRecorder: AIChatDisabledVoiceRecorder(),
+            audioTranscriber: AIChatDisabledAudioTranscriber()
+        )
+        store.acceptExternalProviderConsent()
+        store.bootstrapPhase = .ready
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.activeConversationId = "conversation-1"
+        store.suppressDraftRestore = true
+        store.inputText = "Pending draft"
+        store.persistDraftRestoreSuppressionSynchronously(
+            workspaceId: store.historyWorkspaceId(),
+            sessionId: "session-1",
+            isSuppressed: true
+        )
+
+        historyStore.blockNextStateSave()
+        store.schedulePersistCurrentState()
+        let didBlockOlderStateSave = await AIChatStoreTestSupport.waitForCondition(
+            description: "older queued state save blocked before accepted handling",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                historyStore.hasBlockedStateSaveStarted()
+            }
+        )
+        XCTAssertTrue(didBlockOlderStateSave)
+
+        let releaseOlderSaveTask = Task.detached {
+            try? await Task.sleep(for: .milliseconds(20))
+            historyStore.releaseBlockedStateSave()
+        }
+        await store.handleRuntimeEvent(
+            .accepted(
+                AIChatStoreTestSupport.makeAcceptedStartRunResponse(
+                    sessionId: "session-1",
+                    userText: "Pending draft"
+                )
+            ),
+            conversationId: "conversation-1"
+        )
+        await releaseOlderSaveTask.value
+
+        let persistedState = context.historyStore.loadState(workspaceId: store.historyWorkspaceId())
+        XCTAssertFalse(store.suppressDraftRestore)
+        XCTAssertFalse(persistedState.suppressDraftRestore)
+        XCTAssertEqual(persistedState.chatSessionId, "session-1")
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: "session-1"
+            ),
+            AIChatComposerDraft(inputText: "", pendingAttachments: [])
+        )
+        XCTAssertFalse(
+            context.historyStore.loadDraftRestoreSuppression(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: "session-1"
+            )
+        )
+    }
+
     func testSendMessageAppendsOptimisticTurnBeforeAsyncPreparationCompletes() async throws {
         let context = AIChatStoreTestSupport.Context.make()
         defer {
@@ -59,7 +559,11 @@ final class AIChatStoreRunStartTests: XCTestCase {
         store.chatSessionId = "session-explicit"
         store.conversationScopeId = "session-explicit"
         store.requiresRemoteSessionProvisioning = true
-        store.inputText = "Help me review this card."
+        let expectedDraft = AIChatComposerDraft(
+            inputText: "Help me review this card.",
+            pendingAttachments: []
+        )
+        store.inputText = expectedDraft.inputText
         context.chatService.createNewSessionHandler = { request in
             guard let sessionId = request.sessionId else {
                 throw LocalStoreError.validation("Expected an explicit AI chat session id while provisioning.")
@@ -85,7 +589,7 @@ final class AIChatStoreRunStartTests: XCTestCase {
         XCTAssertEqual(store.chatSessionId, "session-explicit")
         XCTAssertEqual(store.conversationScopeId, "session-explicit")
         XCTAssertTrue(store.requiresRemoteSessionProvisioning)
-        XCTAssertEqual(store.inputText, "Help me review this card.")
+        XCTAssertEqual(store.inputText, expectedDraft.inputText)
         XCTAssertTrue(store.pendingAttachments.isEmpty)
         XCTAssertEqual(store.composerPhase, .idle)
         XCTAssertNotNil(store.activeAlert)
@@ -93,5 +597,307 @@ final class AIChatStoreRunStartTests: XCTestCase {
         let persistedState = context.historyStore.loadState()
         XCTAssertTrue(persistedState.messages.isEmpty)
         XCTAssertEqual(persistedState.chatSessionId, "session-explicit")
+        XCTAssertFalse(persistedState.suppressDraftRestore)
+        XCTAssertEqual(
+            context.historyStore.loadDraft(
+                workspaceId: store.historyWorkspaceId(),
+                sessionId: "session-explicit"
+            ),
+            expectedDraft
+        )
     }
+
+    func testHandleSendMessageErrorRestoresDraftAndAttachmentsForGuestQuotaBeforeRunAcceptance() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        let store = context.makeStore()
+        let draftAttachment = AIChatAttachment(
+            id: "attachment-card-1",
+            payload: .card(
+                AIChatCardReference(
+                    cardId: "card-1",
+                    frontText: "Front",
+                    backText: "Back",
+                    tags: ["tag-1"],
+                    effortLevel: .medium
+                )
+            )
+        )
+        let expectedDraft = AIChatComposerDraft(
+            inputText: "Help me review this card.",
+            pendingAttachments: [draftAttachment]
+        )
+        store.chatSessionId = "session-guest"
+        store.conversationScopeId = "session-guest"
+        store.inputText = expectedDraft.inputText
+        store.pendingAttachments = expectedDraft.pendingAttachments
+
+        let didPersistDraft = await AIChatStoreTestSupport.waitForCondition(
+            description: "guest quota draft persisted",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                store.activeDraftPersistTask == nil
+                    && context.historyStore.loadDraft(
+                        workspaceId: store.historyWorkspaceId(),
+                        sessionId: "session-guest"
+                    ) == expectedDraft
+            }
+        )
+        XCTAssertTrue(didPersistDraft)
+
+        let outgoingContent = store.makeOutgoingContent()
+        let preSendSnapshot = AIChatPreSendSnapshot(
+            persistedState: store.currentPersistedState(),
+            requiresRemoteSessionProvisioning: false,
+            outgoingContent: outgoingContent
+        )
+
+        store.transitionToPreparingSend()
+        store.applyComposerDraft(inputText: "", pendingAttachments: [])
+        store.appendOptimisticOutgoingTurn(content: outgoingContent)
+
+        XCTAssertEqual(store.inputText, "")
+        XCTAssertTrue(store.pendingAttachments.isEmpty)
+        XCTAssertEqual(store.messages.count, 2)
+        XCTAssertEqual(store.messages[0].role, .user)
+        XCTAssertEqual(store.messages[0].content, outgoingContent)
+        XCTAssertEqual(store.messages[1].role, .assistant)
+        XCTAssertTrue(isOptimisticAIChatStatusContent(content: store.messages[1].content))
+
+        store.handleSendMessageError(
+            makeGuestQuotaError(),
+            didAcceptRun: false,
+            didAppendOptimisticMessages: true,
+            preSendSnapshot: preSendSnapshot,
+            draftText: expectedDraft.inputText,
+            draftAttachments: expectedDraft.pendingAttachments
+        )
+
+        await store.waitForPendingStatePersistence()
+
+        XCTAssertEqual(store.inputText, expectedDraft.inputText)
+        XCTAssertEqual(store.pendingAttachments, expectedDraft.pendingAttachments)
+        XCTAssertEqual(store.messages.count, 1)
+        XCTAssertEqual(store.messages[0].role, .assistant)
+        XCTAssertEqual(
+            store.messages[0].content,
+            [.accountUpgradePrompt(
+                message: aiChatGuestQuotaReachedMessage,
+                buttonTitle: aiChatGuestQuotaButtonTitle
+            )]
+        )
+        XCTAssertEqual(store.composerPhase, .idle)
+        XCTAssertNil(store.activeStreamingMessageId)
+        XCTAssertNil(store.activeStreamingItemId)
+        XCTAssertNil(store.activeAlert)
+
+        let historyWorkspaceId = makeAIChatHistoryScopedWorkspaceId(
+            workspaceId: context.flashcardsStore.workspace?.workspaceId,
+            cloudSettings: context.flashcardsStore.cloudSettings
+        )
+        XCTAssertEqual(
+            context.historyStore.loadDraft(workspaceId: historyWorkspaceId, sessionId: "session-guest"),
+            expectedDraft
+        )
+        XCTAssertEqual(
+            context.historyStore.loadState(workspaceId: historyWorkspaceId).messages,
+            store.messages
+        )
+    }
+
+    func testHandleSendMessageErrorAppendsGuestQuotaPromptAfterRestoredAssistantReply() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        let store = context.makeStore()
+        let restoredUserMessage = AIChatMessage(
+            id: "message-history-user-1",
+            role: .user,
+            content: [.text("Explain leitner spacing.")],
+            timestamp: "2026-04-08T10:00:00Z",
+            isError: false,
+            isStopped: false,
+            cursor: "cursor-history-user-1",
+            itemId: nil
+        )
+        let restoredAssistantMessage = AIChatMessage(
+            id: "message-history-assistant-1",
+            role: .assistant,
+            content: [.text("Leitner spacing increases review intervals after correct answers.")],
+            timestamp: "2026-04-08T10:00:02Z",
+            isError: false,
+            isStopped: true,
+            cursor: "cursor-history-assistant-1",
+            itemId: "item-history-assistant-1"
+        )
+        let draftAttachment = AIChatAttachment(
+            id: "attachment-card-1",
+            payload: .card(
+                AIChatCardReference(
+                    cardId: "card-1",
+                    frontText: "Front",
+                    backText: "Back",
+                    tags: ["tag-1"],
+                    effortLevel: .medium
+                )
+            )
+        )
+        let expectedDraft = AIChatComposerDraft(
+            inputText: "Give me one more example.",
+            pendingAttachments: [draftAttachment]
+        )
+
+        store.messages = [restoredUserMessage, restoredAssistantMessage]
+        store.chatSessionId = "session-guest"
+        store.conversationScopeId = "session-guest"
+        store.inputText = expectedDraft.inputText
+        store.pendingAttachments = expectedDraft.pendingAttachments
+
+        let didPersistDraft = await AIChatStoreTestSupport.waitForCondition(
+            description: "guest quota draft persisted with restored assistant history",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                store.activeDraftPersistTask == nil
+                    && context.historyStore.loadDraft(
+                        workspaceId: store.historyWorkspaceId(),
+                        sessionId: "session-guest"
+                    ) == expectedDraft
+            }
+        )
+        XCTAssertTrue(didPersistDraft)
+
+        let outgoingContent = store.makeOutgoingContent()
+        let preSendSnapshot = AIChatPreSendSnapshot(
+            persistedState: store.currentPersistedState(),
+            requiresRemoteSessionProvisioning: false,
+            outgoingContent: outgoingContent
+        )
+
+        store.transitionToPreparingSend()
+        store.applyComposerDraft(inputText: "", pendingAttachments: [])
+        store.appendOptimisticOutgoingTurn(content: outgoingContent)
+
+        store.handleSendMessageError(
+            makeGuestQuotaError(),
+            didAcceptRun: false,
+            didAppendOptimisticMessages: true,
+            preSendSnapshot: preSendSnapshot,
+            draftText: expectedDraft.inputText,
+            draftAttachments: expectedDraft.pendingAttachments
+        )
+
+        await store.waitForPendingStatePersistence()
+
+        XCTAssertEqual(store.inputText, expectedDraft.inputText)
+        XCTAssertEqual(store.pendingAttachments, expectedDraft.pendingAttachments)
+        XCTAssertEqual(store.messages.count, 3)
+        XCTAssertEqual(store.messages[0], restoredUserMessage)
+        XCTAssertEqual(store.messages[1], restoredAssistantMessage)
+        XCTAssertEqual(store.messages[1].content, restoredAssistantMessage.content)
+        XCTAssertEqual(store.messages[2].role, .assistant)
+        XCTAssertEqual(
+            store.messages[2].content,
+            [.accountUpgradePrompt(
+                message: aiChatGuestQuotaReachedMessage,
+                buttonTitle: aiChatGuestQuotaButtonTitle
+            )]
+        )
+        XCTAssertNotEqual(store.messages[2].id, restoredAssistantMessage.id)
+        XCTAssertEqual(store.composerPhase, .idle)
+        XCTAssertNil(store.activeStreamingMessageId)
+        XCTAssertNil(store.activeStreamingItemId)
+        XCTAssertNil(store.activeAlert)
+
+        let historyWorkspaceId = makeAIChatHistoryScopedWorkspaceId(
+            workspaceId: context.flashcardsStore.workspace?.workspaceId,
+            cloudSettings: context.flashcardsStore.cloudSettings
+        )
+        XCTAssertEqual(
+            context.historyStore.loadDraft(workspaceId: historyWorkspaceId, sessionId: "session-guest"),
+            expectedDraft
+        )
+        XCTAssertEqual(
+            context.historyStore.loadState(workspaceId: historyWorkspaceId).messages,
+            store.messages
+        )
+    }
+
+    func testRuntimeRunRethrowsGuestQuotaFailureWithoutRecoveryEvents() async throws {
+        let chatService = AIChatStoreTestSupport.ChatService()
+        chatService.startRunHandler = { _ in
+            throw makeGuestQuotaError()
+        }
+        let runtime = AIChatSessionRuntime(
+            chatService: chatService,
+            contextLoader: AIChatStoreTestSupport.ContextLoader(),
+            urlSession: URLSession.shared
+        )
+        let recorder = AIChatRuntimeEventRecorder()
+        let session = CloudLinkedSession(
+            userId: "guest-user-1",
+            workspaceId: "workspace-1",
+            email: nil,
+            configurationMode: .official,
+            apiBaseUrl: "https://api.example.com",
+            authorization: .guest("guest-token-1")
+        )
+
+        do {
+            try await runtime.run(
+                session: session,
+                sessionId: "session-guest",
+                afterCursor: nil,
+                outgoingContent: [.text("Help me review this card.")],
+                eventHandler: { event in
+                    await recorder.record(event)
+                }
+            )
+            XCTFail("Expected the runtime to rethrow the guest AI quota failure.")
+        } catch {
+            XCTAssertTrue(isGuestAiLimitError(error: error))
+            guard let serviceError = error as? AIChatServiceError else {
+                return XCTFail("Expected an invalid-response guest quota error.")
+            }
+            guard case .invalidResponse(let errorDetails, _, _) = serviceError else {
+                return XCTFail("Expected an invalid-response guest quota error.")
+            }
+            XCTAssertEqual(errorDetails.code, "GUEST_AI_LIMIT_REACHED")
+        }
+
+        let recordedEvents = await recorder.snapshot()
+        XCTAssertEqual(recordedEvents, [])
+    }
+}
+
+private func makeGuestQuotaError() -> AIChatServiceError {
+    AIChatServiceError.invalidResponse(
+        CloudApiErrorDetails(
+            message: "Guest AI limit reached.",
+            requestId: "request-guest-limit",
+            code: "GUEST_AI_LIMIT_REACHED"
+        ),
+        "Guest AI limit reached.",
+        AIChatFailureDiagnostics(
+            clientRequestId: "client-request-1",
+            backendRequestId: "request-guest-limit",
+            stage: .responseNotOk,
+            errorKind: .backendErrorEvent,
+            statusCode: 429,
+            eventType: nil,
+            toolName: nil,
+            toolCallId: nil,
+            lineNumber: nil,
+            rawSnippet: nil,
+            decoderSummary: nil,
+            continuationAttempt: nil,
+            continuationToolCallIds: []
+        )
+    )
 }

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStartTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStartTests.swift
@@ -30,17 +30,8 @@ final class AIChatStoreRunStartTests: XCTestCase {
         }
 
         store.sendMessage()
-
-        let didReachPreflightGate = await AIChatStoreTestSupport.waitForCondition(
-            description: "AI chat send preflight gate",
-            timeout: .seconds(1),
-            pollInterval: .milliseconds(10),
-            condition: {
-                context.cloudSyncService.runLinkedSyncCallCount == 1 && store.activeSendTask != nil
-            }
-        )
-
-        XCTAssertTrue(didReachPreflightGate)
+        XCTAssertEqual(store.inputText, "")
+        XCTAssertTrue(store.pendingAttachments.isEmpty)
         XCTAssertEqual(store.messages.count, 2)
         XCTAssertEqual(store.messages[0].role, .user)
         XCTAssertEqual(store.messages[0].content, [.text("Help me review this card.")])
@@ -49,6 +40,7 @@ final class AIChatStoreRunStartTests: XCTestCase {
         XCTAssertEqual(store.activeStreamingMessageId, store.messages[1].id)
         XCTAssertNil(store.activeStreamingItemId)
         XCTAssertEqual(store.composerPhase, .preparingSend)
+        XCTAssertNotNil(store.activeSendTask)
 
         await syncGate.release()
         await AIChatStoreTestSupport.waitForSendToSettle(store: store)
@@ -84,11 +76,11 @@ final class AIChatStoreRunStartTests: XCTestCase {
         }
 
         store.sendMessage()
+        XCTAssertEqual(store.inputText, "")
+        XCTAssertTrue(store.pendingAttachments.isEmpty)
         await AIChatStoreTestSupport.waitForSendToSettle(store: store)
         await store.waitForPendingStatePersistence()
 
-        XCTAssertEqual(context.chatService.createNewSessionRequests.count, 1)
-        XCTAssertEqual(context.chatService.startRunRequests.count, 1)
         XCTAssertTrue(store.messages.isEmpty)
         XCTAssertEqual(store.chatSessionId, "session-explicit")
         XCTAssertEqual(store.conversationScopeId, "session-explicit")

--- a/apps/web/src/chat/ChatPanel.send-lifecycle.test.tsx
+++ b/apps/web/src/chat/ChatPanel.send-lifecycle.test.tsx
@@ -20,6 +20,10 @@ import {
   createUnverifiedWorkspaceAppDataMock,
   createVerifiedWorkspaceAppDataMock,
 } from "./ChatPanelTestFixtures";
+import {
+  loadChatDraftWorkspaceState,
+  readChatDraftForSession,
+} from "./chatDraftStorage";
 import { storeChatSessionWarmStartSnapshot } from "./sessionController/warmStart";
 
 const {
@@ -29,7 +33,12 @@ const {
   setMobileViewport,
   sendMessage,
   clickMicrophone,
+  unmountChatPanel,
 } = setupChatPanelTest();
+
+function readStoredDraftInputText(sessionId: string): string | null {
+  return readChatDraftForSession(loadChatDraftWorkspaceState("workspace-1"), sessionId)?.inputText ?? null;
+}
 
 describe("ChatPanel send lifecycle", () => {
   it("shows loading UI instead of empty suggestions while the initial chat history is unresolved", async () => {
@@ -218,6 +227,10 @@ describe("ChatPanel send lifecycle", () => {
   it("returns focus to the composer after a successful send", async () => {
     await renderChatPanel();
     await flushAsync();
+    await flushAsync();
+
+    const sessionId = createNewChatSessionMock.mock.calls[0]?.[0];
+    expect(typeof sessionId).toBe("string");
 
     const textarea = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
     expect(textarea).not.toBeNull();
@@ -228,6 +241,7 @@ describe("ChatPanel send lifecycle", () => {
 
     expect(textarea?.value).toBe("");
     expect(document.activeElement).toBe(textarea);
+    expect(readStoredDraftInputText(sessionId as string)).toBeNull();
   });
 
   it("includes an explicit sessionId in the first send request body", async () => {
@@ -576,6 +590,38 @@ describe("ChatPanel send lifecycle", () => {
     await flushAsync();
   });
 
+  it("keeps the stored draft through a runSync preflight failure", async () => {
+    let rejectRunSync: ((error: Error) => void) | null = null;
+    useAppDataMock.mockReturnValue(createVerifiedWorkspaceAppDataMock({
+      refreshLocalData: vi.fn(async (): Promise<void> => undefined),
+      runSync: vi.fn(() => new Promise((_, reject) => {
+        rejectRunSync = (error) => reject(error);
+      })),
+      setErrorMessage: vi.fn(),
+    }));
+
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    const sessionId = createNewChatSessionMock.mock.calls[0]?.[0];
+    expect(typeof sessionId).toBe("string");
+
+    await sendMessage("keep this draft");
+
+    const textareaBeforeFailure = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
+    expect(textareaBeforeFailure?.value).toBe("");
+    expect(readStoredDraftInputText(sessionId as string)).toBe("keep this draft");
+
+    rejectRunSync?.(new Error("sync failed"));
+    await flushAsync();
+    await flushAsync();
+
+    const textareaAfterFailure = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
+    expect(textareaAfterFailure?.value).toBe("keep this draft");
+    expect(readStoredDraftInputText(sessionId as string)).toBe("keep this draft");
+  });
+
   it("keeps the draft when startRun fails before the server accepts the turn", async () => {
     let rejectStartRun: ((error: Error) => void) | null = null;
     startChatRunMock.mockImplementation(() => new Promise((_, reject) => {
@@ -584,9 +630,15 @@ describe("ChatPanel send lifecycle", () => {
 
     await renderChatPanel();
     await flushAsync();
+    await flushAsync();
+
+    const sessionId = createNewChatSessionMock.mock.calls[0]?.[0];
+    expect(typeof sessionId).toBe("string");
+
     await sendMessage("keep this draft");
 
     expect((getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null)?.value).toBe("");
+    expect(readStoredDraftInputText(sessionId as string)).toBe("keep this draft");
 
     rejectStartRun?.(new Error("Request failed with status 500"));
     await flushAsync();
@@ -594,9 +646,36 @@ describe("ChatPanel send lifecycle", () => {
 
     const textarea = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
     expect(textarea?.value).toBe("keep this draft");
+    expect(readStoredDraftInputText(sessionId as string)).toBe("keep this draft");
     expect(getContainer().querySelector(".chat-msg")).toBeNull();
     expect(getContainer().querySelector('[role="dialog"]')).not.toBeNull();
     expect(getContainer().textContent).toContain("Chat request failed.");
+  });
+
+  it("restores the stored draft after a refresh while turn acceptance is still pending", async () => {
+    startChatRunMock.mockImplementation(() => new Promise(() => undefined));
+
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    const sessionId = createNewChatSessionMock.mock.calls[0]?.[0];
+    expect(typeof sessionId).toBe("string");
+
+    await sendMessage("keep this draft");
+
+    const textareaBeforeRefresh = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
+    expect(textareaBeforeRefresh?.value).toBe("");
+    expect(readStoredDraftInputText(sessionId as string)).toBe("keep this draft");
+
+    await unmountChatPanel();
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    const textareaAfterRefresh = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
+    expect(textareaAfterRefresh?.value).toBe("keep this draft");
+    expect(readStoredDraftInputText(sessionId as string)).toBe("keep this draft");
   });
 
   it("treats active-run conflicts as a non-destructive composer notice", async () => {

--- a/apps/web/src/chat/ChatPanel.send-lifecycle.test.tsx
+++ b/apps/web/src/chat/ChatPanel.send-lifecycle.test.tsx
@@ -508,6 +508,29 @@ describe("ChatPanel send lifecycle", () => {
     await flushAsync();
   });
 
+  it("clears the composer immediately while turn acceptance is still in flight", async () => {
+    let resolveStartRun: (() => void) | null = null;
+    startChatRunMock.mockImplementation(() => new Promise((resolve) => {
+      resolveStartRun = () => resolve({
+        ...createChatSnapshot({ activeRun: createChatActiveRun() }),
+        accepted: true,
+      });
+    }));
+
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+
+    const textarea = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
+    expect(startChatRunMock).toHaveBeenCalledTimes(1);
+    expect(textarea?.value).toBe("");
+
+    resolveStartRun?.();
+    await flushAsync();
+    await flushAsync();
+  });
+
   it("shows stop while the assistant run is active and returns to send afterward", async () => {
     getChatSnapshotMock
       .mockResolvedValueOnce(createChatSnapshot())
@@ -554,11 +577,18 @@ describe("ChatPanel send lifecycle", () => {
   });
 
   it("keeps the draft when startRun fails before the server accepts the turn", async () => {
-    startChatRunMock.mockRejectedValue(new Error("Request failed with status 500"));
+    let rejectStartRun: ((error: Error) => void) | null = null;
+    startChatRunMock.mockImplementation(() => new Promise((_, reject) => {
+      rejectStartRun = (error) => reject(error);
+    }));
 
     await renderChatPanel();
     await flushAsync();
     await sendMessage("keep this draft");
+
+    expect((getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null)?.value).toBe("");
+
+    rejectStartRun?.(new Error("Request failed with status 500"));
     await flushAsync();
     await flushAsync();
 

--- a/apps/web/src/chat/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel.tsx
@@ -27,7 +27,6 @@ import {
   type PendingAttachment,
 } from "./FileAttachment";
 import { formatCardAttachmentLabel } from "./chatCardParts";
-import { createChatDraftContent } from "./chatDraftStorage";
 import {
   ATTACHMENT_PAYLOAD_LIMIT_BYTES,
   IMAGE_MEDIA_TYPE_PREFIX,
@@ -175,7 +174,6 @@ export function ChatPanel(props: Props): ReactElement {
     replaceInputText,
     updateInputText,
     replacePendingAttachments,
-    replaceDraftForSession,
     clearDraftForSession,
   } = useChatDraft();
   const { setIsOpen, chatWidth, setChatWidth } = useChatLayout();
@@ -184,9 +182,12 @@ export function ChatPanel(props: Props): ReactElement {
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
   const [dictationState, setDictationState] = useState<ChatDictationState>("idle");
   const [sendPhase, setSendPhase] = useState<ChatSendPhase>("idle");
+  const [isDraftOptimisticallyClearedForSend, setIsDraftOptimisticallyClearedForSend] = useState<boolean>(false);
   const [isMobileChatLayout, setIsMobileChatLayout] = useState<boolean>(matchesMobileChatBreakpoint);
-  const inputText = draft.inputText;
-  const pendingAttachments = draft.pendingAttachments;
+  const draftInputText = draft.inputText;
+  const draftPendingAttachments = draft.pendingAttachments;
+  const inputText = isDraftOptimisticallyClearedForSend ? "" : draftInputText;
+  const pendingAttachments = isDraftOptimisticallyClearedForSend ? [] : draftPendingAttachments;
 
   const activeWorkspaceId = appData.activeWorkspace?.workspaceId ?? null;
   const {
@@ -247,7 +248,7 @@ export function ChatPanel(props: Props): ReactElement {
     content: ReturnType<typeof buildContentParts>;
     timezone: string;
   }> | null {
-    const draftContentParts = buildContentParts(inputText, attachments);
+    const draftContentParts = buildContentParts(draftInputText, attachments);
     if (draftContentParts.length === 0) {
       return null;
     }
@@ -353,6 +354,35 @@ export function ChatPanel(props: Props): ReactElement {
 
   function requestComposerFocusRestore(): void {
     pendingComposerFocusRestoreRef.current = true;
+  }
+
+  function clearComposerForPendingSend(): void {
+    setIsDraftOptimisticallyClearedForSend(true);
+    pendingAttachmentsRef.current = [];
+    draftSelectionRef.current = null;
+    pendingTextareaSelectionRef.current = null;
+  }
+
+  function restoreComposerAfterPendingSend(
+    nextAttachments: ReadonlyArray<PendingAttachment>,
+  ): void {
+    setIsDraftOptimisticallyClearedForSend(false);
+    pendingAttachmentsRef.current = nextAttachments;
+  }
+
+  function finalizeAcceptedSend(
+    sourceSessionId: string | null,
+    resultSessionId: string | null,
+  ): void {
+    clearDraftForSession(sourceSessionId);
+    if (resultSessionId !== null && resultSessionId !== sourceSessionId) {
+      clearDraftForSession(resultSessionId);
+    }
+    pendingAttachmentsRef.current = [];
+    draftSelectionRef.current = null;
+    pendingTextareaSelectionRef.current = null;
+    setIsDraftOptimisticallyClearedForSend(false);
+    requestComposerFocusRestore();
   }
 
   function invalidateSendLifecycleRequests(): number {
@@ -642,7 +672,7 @@ export function ChatPanel(props: Props): ReactElement {
       return;
     }
 
-    const nextText = inputText;
+    const nextText = draftInputText;
     const nextAttachments = pendingAttachmentsRef.current;
     const sourceSessionId = currentSessionId;
     const contentParts = buildContentParts(nextText, nextAttachments);
@@ -663,10 +693,7 @@ export function ChatPanel(props: Props): ReactElement {
     }
 
     const requestSequence = sendLifecycleRequestSequenceRef.current;
-    replaceDraftForSession(sourceSessionId, createChatDraftContent("", []));
-    pendingAttachmentsRef.current = [];
-    draftSelectionRef.current = null;
-    pendingTextareaSelectionRef.current = null;
+    clearComposerForPendingSend();
     setSendPhase("preparingSend");
 
     try {
@@ -681,8 +708,7 @@ export function ChatPanel(props: Props): ReactElement {
       }
 
       if (outboxRecords.length > 0) {
-        replaceDraftForSession(sourceSessionId, createChatDraftContent(nextText, nextAttachments));
-        pendingAttachmentsRef.current = nextAttachments;
+        restoreComposerAfterPendingSend(nextAttachments);
         appData.setErrorMessage(t("chatPanel.transientErrors.pendingSync"));
         setSendPhase("idle");
         return;
@@ -692,8 +718,7 @@ export function ChatPanel(props: Props): ReactElement {
         return;
       }
 
-      replaceDraftForSession(sourceSessionId, createChatDraftContent(nextText, nextAttachments));
-      pendingAttachmentsRef.current = nextAttachments;
+      restoreComposerAfterPendingSend(nextAttachments);
       appData.setErrorMessage(error instanceof Error ? error.message : String(error));
       setSendPhase("idle");
       return;
@@ -716,17 +741,9 @@ export function ChatPanel(props: Props): ReactElement {
       }
 
       if (result.accepted) {
-        clearDraftForSession(sourceSessionId);
-        if (result.sessionId !== null && result.sessionId !== sourceSessionId) {
-          clearDraftForSession(result.sessionId);
-        }
-        pendingAttachmentsRef.current = [];
-        draftSelectionRef.current = null;
-        pendingTextareaSelectionRef.current = null;
-        requestComposerFocusRestore();
+        finalizeAcceptedSend(sourceSessionId, result.sessionId);
       } else {
-        replaceDraftForSession(sourceSessionId, createChatDraftContent(nextText, nextAttachments));
-        pendingAttachmentsRef.current = nextAttachments;
+        restoreComposerAfterPendingSend(nextAttachments);
       }
     } finally {
       if (isSendLifecycleRequestCurrent(requestSequence)) {
@@ -838,6 +855,7 @@ export function ChatPanel(props: Props): ReactElement {
             className="chat-close-btn"
             onClick={() => {
               invalidateSendLifecycleRequests();
+              setIsDraftOptimisticallyClearedForSend(false);
               setSendPhase("idle");
               discardDictation();
               if (currentSessionId === null) {

--- a/apps/web/src/chat/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel.tsx
@@ -27,6 +27,7 @@ import {
   type PendingAttachment,
 } from "./FileAttachment";
 import { formatCardAttachmentLabel } from "./chatCardParts";
+import { createChatDraftContent } from "./chatDraftStorage";
 import {
   ATTACHMENT_PAYLOAD_LIMIT_BYTES,
   IMAGE_MEDIA_TYPE_PREFIX,
@@ -174,6 +175,7 @@ export function ChatPanel(props: Props): ReactElement {
     replaceInputText,
     updateInputText,
     replacePendingAttachments,
+    replaceDraftForSession,
     clearDraftForSession,
   } = useChatDraft();
   const { setIsOpen, chatWidth, setChatWidth } = useChatLayout();
@@ -661,6 +663,10 @@ export function ChatPanel(props: Props): ReactElement {
     }
 
     const requestSequence = sendLifecycleRequestSequenceRef.current;
+    replaceDraftForSession(sourceSessionId, createChatDraftContent("", []));
+    pendingAttachmentsRef.current = [];
+    draftSelectionRef.current = null;
+    pendingTextareaSelectionRef.current = null;
     setSendPhase("preparingSend");
 
     try {
@@ -675,6 +681,8 @@ export function ChatPanel(props: Props): ReactElement {
       }
 
       if (outboxRecords.length > 0) {
+        replaceDraftForSession(sourceSessionId, createChatDraftContent(nextText, nextAttachments));
+        pendingAttachmentsRef.current = nextAttachments;
         appData.setErrorMessage(t("chatPanel.transientErrors.pendingSync"));
         setSendPhase("idle");
         return;
@@ -684,6 +692,8 @@ export function ChatPanel(props: Props): ReactElement {
         return;
       }
 
+      replaceDraftForSession(sourceSessionId, createChatDraftContent(nextText, nextAttachments));
+      pendingAttachmentsRef.current = nextAttachments;
       appData.setErrorMessage(error instanceof Error ? error.message : String(error));
       setSendPhase("idle");
       return;
@@ -714,6 +724,9 @@ export function ChatPanel(props: Props): ReactElement {
         draftSelectionRef.current = null;
         pendingTextareaSelectionRef.current = null;
         requestComposerFocusRestore();
+      } else {
+        replaceDraftForSession(sourceSessionId, createChatDraftContent(nextText, nextAttachments));
+        pendingAttachmentsRef.current = nextAttachments;
       }
     } finally {
       if (isSendLifecycleRequestCurrent(requestSequence)) {


### PR DESCRIPTION
## Summary
- preserve unsent AI chat drafts until the run is accepted across Android, iOS, and web
- fix guest quota upgrade prompt handling so existing assistant replies are not overwritten
- add focused regression coverage for pre-accept restart and session provisioning flows

## Validation
- Android focused AI runtime unit tests passed in worker validation
- iOS focused AI chat run start and remote session provisioning tests passed in worker validation
- Web focused chat send lifecycle Vitest coverage passed in worker validation