### PR TITLE
[codex] Refactor local progress repository

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepository.kt
@@ -1,6 +1,5 @@
 package com.flashcardsopensourceapp.data.local.repository
 
-import android.util.Log
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.database.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.OutboxEntryEntity
@@ -12,14 +11,8 @@ import com.flashcardsopensourceapp.data.local.database.ProgressSummaryCacheEntit
 import com.flashcardsopensourceapp.data.local.database.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.database.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
-import com.flashcardsopensourceapp.data.local.model.CloudDailyReviewPoint
-import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
-import com.flashcardsopensourceapp.data.local.model.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
-import com.flashcardsopensourceapp.data.local.model.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.ProgressSeriesSnapshot
-import com.flashcardsopensourceapp.data.local.model.ProgressSnapshotSource
-import com.flashcardsopensourceapp.data.local.model.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.model.SyncStatusSnapshot
 import kotlinx.coroutines.CancellationException
@@ -30,18 +23,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import org.json.JSONArray
-import org.json.JSONObject
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.format.DateTimeParseException
-
-const val progressHistoryDayCount: Long = 140L
-private const val progressRepositoryLogTag: String = "ProgressRepository"
-private const val progressRepositoryLogMaxValueLength: Int = 240
 
 private enum class ProgressRefreshReason {
     MISSING_SERVER_BASE,
@@ -74,86 +55,28 @@ private data class ProgressObservedBaseInputs(
     val syncStatus: SyncStatusSnapshot
 )
 
-internal data class ProgressSummaryStoreState(
-    val scopeKey: ProgressSummaryScopeKey,
-    val cloudState: CloudAccountState,
-    val snapshot: ProgressSummarySnapshot?,
-    val isLocalCacheReady: Boolean,
-    val reviewHistoryFingerprint: String,
+private data class ProgressLocalCacheObservedInputs(
+    val localDayCounts: List<ProgressLocalDayCountEntity>,
+    val reviewHistoryStates: List<ProgressReviewHistoryStateEntity>,
+    val localCacheStates: List<ProgressLocalCacheStateEntity>
+)
+
+private data class ProgressPrimaryObservedInputs(
+    val cloudSettings: CloudSettings,
+    val workspaces: List<WorkspaceEntity>,
+    val localCacheInputs: ProgressLocalCacheObservedInputs
+)
+
+private data class ProgressSyncObservedInputs(
+    val pendingReviewOutboxEntries: List<OutboxEntryEntity>,
+    val syncStates: List<SyncStateEntity>,
     val syncStatus: SyncStatusSnapshot
 )
 
-internal data class ProgressSeriesStoreState(
-    val scopeKey: ProgressSeriesScopeKey,
-    val cloudState: CloudAccountState,
-    val snapshot: ProgressSeriesSnapshot?,
-    val isLocalCacheReady: Boolean,
-    val reviewHistoryFingerprint: String,
-    val syncStatus: SyncStatusSnapshot
+private data class ProgressObservedSummaryInputs(
+    val baseInputs: ProgressObservedBaseInputs,
+    val summaryCaches: List<ProgressSummaryCacheEntity>
 )
-
-interface ProgressTimeProvider {
-    fun currentZoneId(): ZoneId
-    fun currentTimeMillis(): Long
-}
-
-object SystemProgressTimeProvider : ProgressTimeProvider {
-    override fun currentZoneId(): ZoneId {
-        return ZoneId.systemDefault()
-    }
-
-    override fun currentTimeMillis(): Long {
-        return System.currentTimeMillis()
-    }
-}
-
-private fun logProgressRepositoryWarning(
-    event: String,
-    fields: List<Pair<String, String?>>,
-    error: Throwable
-) {
-    val message = buildProgressRepositoryLogMessage(
-        event = event,
-        fields = fields
-    )
-    val didLog = runCatching {
-        Log.w(progressRepositoryLogTag, message, error)
-    }.isSuccess
-    if (didLog.not()) {
-        println("$progressRepositoryLogTag W $message")
-        println(error.stackTraceToString())
-    }
-}
-
-private fun buildProgressRepositoryLogMessage(
-    event: String,
-    fields: List<Pair<String, String?>>
-): String {
-    val renderedFields = fields.map { (key, value) ->
-        "$key=${sanitizeProgressRepositoryLogValue(value = value)}"
-    }
-
-    return if (renderedFields.isEmpty()) {
-        "event=$event"
-    } else {
-        "event=$event ${renderedFields.joinToString(separator = " ")}"
-    }
-}
-
-private fun sanitizeProgressRepositoryLogValue(
-    value: String?
-): String {
-    if (value == null) {
-        return "null"
-    }
-
-    val normalized = value.replace(oldValue = "\n", newValue = "\\n")
-    return if (normalized.length <= progressRepositoryLogMaxValueLength) {
-        normalized
-    } else {
-        normalized.take(progressRepositoryLogMaxValueLength) + "..."
-    }
-}
 
 class LocalProgressRepository(
     private val appScope: CoroutineScope,
@@ -175,113 +98,8 @@ class LocalProgressRepository(
 
     init {
         appScope.launch {
-            combine(
-                combine(
-                    preferencesStore.observeCloudSettings(),
-                    database.workspaceDao().observeWorkspaces(),
-                    combine(
-                        database.progressLocalCacheDao().observeProgressLocalDayCounts(),
-                        database.progressLocalCacheDao().observeProgressReviewHistoryStates(),
-                        database.progressLocalCacheDao().observeProgressLocalCacheStates()
-                    ) { localDayCounts, reviewHistoryStates, localCacheStates ->
-                        Triple(localDayCounts, reviewHistoryStates, localCacheStates)
-                    }
-                ) { cloudSettings, workspaces, progressInputs ->
-                    Triple(cloudSettings, workspaces, progressInputs)
-                },
-                combine(
-                    database.outboxDao().observePendingReviewEventOutboxEntries(),
-                    database.syncStateDao().observeSyncStates(),
-                    syncRepository.observeSyncStatus()
-                ) { pendingReviewOutboxEntries, syncStates, syncStatus ->
-                    Triple(pendingReviewOutboxEntries, syncStates, syncStatus)
-                }
-            ) { primaryInputs, syncInputs ->
-                ProgressObservedBaseInputs(
-                    cloudSettings = primaryInputs.first,
-                    workspaces = primaryInputs.second,
-                    localDayCounts = primaryInputs.third.first,
-                    reviewHistoryStates = primaryInputs.third.second,
-                    localCacheStates = primaryInputs.third.third,
-                    pendingReviewOutboxEntries = syncInputs.first,
-                    syncStates = syncInputs.second,
-                    syncStatus = syncInputs.third
-                )
-            }.combine(
-                database.progressRemoteCacheDao().observeProgressSummaryCaches()
-            ) { baseInputs, summaryCaches ->
-                Pair(baseInputs, summaryCaches)
-            }.combine(
-                database.progressRemoteCacheDao().observeProgressSeriesCaches()
-            ) { summaryInputs, seriesCaches ->
-                ProgressObservedInputs(
-                    cloudSettings = summaryInputs.first.cloudSettings,
-                    workspaces = summaryInputs.first.workspaces,
-                    localDayCounts = summaryInputs.first.localDayCounts,
-                    reviewHistoryStates = summaryInputs.first.reviewHistoryStates,
-                    localCacheStates = summaryInputs.first.localCacheStates,
-                    pendingReviewOutboxEntries = summaryInputs.first.pendingReviewOutboxEntries,
-                    syncStates = summaryInputs.first.syncStates,
-                    syncStatus = summaryInputs.first.syncStatus,
-                    summaryCaches = summaryInputs.second,
-                    seriesCaches = seriesCaches
-                )
-            }.collect { inputs ->
-                latestInputsMutable.value = inputs
-
-                val previousSummaryStoreState = latestSummaryStoreStateMutable.value
-                val currentSummaryStoreState = createProgressSummaryStoreState(
-                    inputs = inputs,
-                    timeProvider = timeProvider
-                )
-                latestSummaryStoreStateMutable.value = currentSummaryStoreState
-                publishSummarySnapshotIfChanged(snapshot = currentSummaryStoreState.snapshot)
-
-                val previousSeriesStoreState = latestSeriesStoreStateMutable.value
-                val currentSeriesStoreState = createProgressSeriesStoreState(
-                    inputs = inputs,
-                    timeProvider = timeProvider
-                )
-                latestSeriesStoreStateMutable.value = currentSeriesStoreState
-                publishSeriesSnapshotIfChanged(snapshot = currentSeriesStoreState.snapshot)
-
-                if (currentSummaryStoreState.isLocalCacheReady.not() || currentSeriesStoreState.isLocalCacheReady.not()) {
-                    appScope.launch {
-                        ensureLocalCacheReady(timeZone = currentSummaryStoreState.scopeKey.timeZone)
-                    }
-                }
-
-                if (
-                    didSyncCompleteWithReviewHistoryChange(
-                        previousSuccessfulSyncAtMillis = previousSummaryStoreState?.syncStatus?.lastSuccessfulSyncAtMillis,
-                        currentSuccessfulSyncAtMillis = currentSummaryStoreState.syncStatus.lastSuccessfulSyncAtMillis,
-                        previousReviewHistoryFingerprint = previousSummaryStoreState?.reviewHistoryFingerprint,
-                        currentReviewHistoryFingerprint = currentSummaryStoreState.reviewHistoryFingerprint
-                    )
-                ) {
-                    appScope.launch {
-                        refreshSummaryFromStoreState(
-                            storeState = currentSummaryStoreState,
-                            refreshReason = ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
-                        )
-                    }
-                }
-
-                if (
-                    didSyncCompleteWithReviewHistoryChange(
-                        previousSuccessfulSyncAtMillis = previousSeriesStoreState?.syncStatus?.lastSuccessfulSyncAtMillis,
-                        currentSuccessfulSyncAtMillis = currentSeriesStoreState.syncStatus.lastSuccessfulSyncAtMillis,
-                        previousReviewHistoryFingerprint = previousSeriesStoreState?.reviewHistoryFingerprint,
-                        currentReviewHistoryFingerprint = currentSeriesStoreState.reviewHistoryFingerprint
-                    )
-                ) {
-                    appScope.launch {
-                        refreshSeriesFromStoreState(
-                            storeState = currentSeriesStoreState,
-                            refreshReason = ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
-                        )
-                    }
-                }
+            observeProgressInputs().collect { inputs ->
+                handleProgressInputs(inputs = inputs)
             }
         }
     }
@@ -416,6 +234,147 @@ class LocalProgressRepository(
         )
     }
 
+    private fun observeProgressInputs(): Flow<ProgressObservedInputs> {
+        val localCacheDao = database.progressLocalCacheDao()
+        val remoteCacheDao = database.progressRemoteCacheDao()
+        val localCacheInputsFlow = combine(
+            localCacheDao.observeProgressLocalDayCounts(),
+            localCacheDao.observeProgressReviewHistoryStates(),
+            localCacheDao.observeProgressLocalCacheStates()
+        ) { localDayCounts, reviewHistoryStates, localCacheStates ->
+            ProgressLocalCacheObservedInputs(
+                localDayCounts = localDayCounts,
+                reviewHistoryStates = reviewHistoryStates,
+                localCacheStates = localCacheStates
+            )
+        }
+        val primaryInputsFlow = combine(
+            preferencesStore.observeCloudSettings(),
+            database.workspaceDao().observeWorkspaces(),
+            localCacheInputsFlow
+        ) { cloudSettings, workspaces, localCacheInputs ->
+            ProgressPrimaryObservedInputs(
+                cloudSettings = cloudSettings,
+                workspaces = workspaces,
+                localCacheInputs = localCacheInputs
+            )
+        }
+        val syncInputsFlow = combine(
+            database.outboxDao().observePendingReviewEventOutboxEntries(),
+            database.syncStateDao().observeSyncStates(),
+            syncRepository.observeSyncStatus()
+        ) { pendingReviewOutboxEntries, syncStates, syncStatus ->
+            ProgressSyncObservedInputs(
+                pendingReviewOutboxEntries = pendingReviewOutboxEntries,
+                syncStates = syncStates,
+                syncStatus = syncStatus
+            )
+        }
+        val baseInputsFlow = combine(
+            primaryInputsFlow,
+            syncInputsFlow
+        ) { primaryInputs, syncInputs ->
+            ProgressObservedBaseInputs(
+                cloudSettings = primaryInputs.cloudSettings,
+                workspaces = primaryInputs.workspaces,
+                localDayCounts = primaryInputs.localCacheInputs.localDayCounts,
+                reviewHistoryStates = primaryInputs.localCacheInputs.reviewHistoryStates,
+                localCacheStates = primaryInputs.localCacheInputs.localCacheStates,
+                pendingReviewOutboxEntries = syncInputs.pendingReviewOutboxEntries,
+                syncStates = syncInputs.syncStates,
+                syncStatus = syncInputs.syncStatus
+            )
+        }
+        val summaryInputsFlow = baseInputsFlow.combine(
+            remoteCacheDao.observeProgressSummaryCaches()
+        ) { baseInputs, summaryCaches ->
+            ProgressObservedSummaryInputs(
+                baseInputs = baseInputs,
+                summaryCaches = summaryCaches
+            )
+        }
+
+        return summaryInputsFlow.combine(
+            remoteCacheDao.observeProgressSeriesCaches()
+        ) { summaryInputs, seriesCaches ->
+            ProgressObservedInputs(
+                cloudSettings = summaryInputs.baseInputs.cloudSettings,
+                workspaces = summaryInputs.baseInputs.workspaces,
+                localDayCounts = summaryInputs.baseInputs.localDayCounts,
+                reviewHistoryStates = summaryInputs.baseInputs.reviewHistoryStates,
+                localCacheStates = summaryInputs.baseInputs.localCacheStates,
+                pendingReviewOutboxEntries = summaryInputs.baseInputs.pendingReviewOutboxEntries,
+                syncStates = summaryInputs.baseInputs.syncStates,
+                syncStatus = summaryInputs.baseInputs.syncStatus,
+                summaryCaches = summaryInputs.summaryCaches,
+                seriesCaches = seriesCaches
+            )
+        }
+    }
+
+    private fun handleProgressInputs(inputs: ProgressObservedInputs) {
+        latestInputsMutable.value = inputs
+
+        val clockSnapshot = createProgressClockSnapshot(timeProvider = timeProvider)
+        val previousSummaryStoreState = latestSummaryStoreStateMutable.value
+        val currentSummaryStoreState = createProgressSummaryStoreState(
+            inputs = createProgressSummaryStoreInputs(
+                inputs = inputs,
+                clockSnapshot = clockSnapshot
+            )
+        )
+        latestSummaryStoreStateMutable.value = currentSummaryStoreState
+        publishSummarySnapshotIfChanged(snapshot = currentSummaryStoreState.snapshot)
+
+        val previousSeriesStoreState = latestSeriesStoreStateMutable.value
+        val currentSeriesStoreState = createProgressSeriesStoreState(
+            inputs = createProgressSeriesStoreInputs(
+                inputs = inputs,
+                clockSnapshot = clockSnapshot
+            )
+        )
+        latestSeriesStoreStateMutable.value = currentSeriesStoreState
+        publishSeriesSnapshotIfChanged(snapshot = currentSeriesStoreState.snapshot)
+
+        if (currentSummaryStoreState.isLocalCacheReady.not() || currentSeriesStoreState.isLocalCacheReady.not()) {
+            appScope.launch {
+                ensureLocalCacheReady(timeZone = currentSummaryStoreState.scopeKey.timeZone)
+            }
+        }
+
+        if (
+            didSyncCompleteWithReviewHistoryChange(
+                previousSuccessfulSyncAtMillis = previousSummaryStoreState?.syncStatus?.lastSuccessfulSyncAtMillis,
+                currentSuccessfulSyncAtMillis = currentSummaryStoreState.syncStatus.lastSuccessfulSyncAtMillis,
+                previousReviewHistoryFingerprint = previousSummaryStoreState?.reviewHistoryFingerprint,
+                currentReviewHistoryFingerprint = currentSummaryStoreState.reviewHistoryFingerprint
+            )
+        ) {
+            appScope.launch {
+                refreshSummaryFromStoreState(
+                    storeState = currentSummaryStoreState,
+                    refreshReason = ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
+                )
+            }
+        }
+
+        if (
+            didSyncCompleteWithReviewHistoryChange(
+                previousSuccessfulSyncAtMillis = previousSeriesStoreState?.syncStatus?.lastSuccessfulSyncAtMillis,
+                currentSuccessfulSyncAtMillis = currentSeriesStoreState.syncStatus.lastSuccessfulSyncAtMillis,
+                previousReviewHistoryFingerprint = previousSeriesStoreState?.reviewHistoryFingerprint,
+                currentReviewHistoryFingerprint = currentSeriesStoreState.reviewHistoryFingerprint
+            )
+        ) {
+            appScope.launch {
+                refreshSeriesFromStoreState(
+                    storeState = currentSeriesStoreState,
+                    refreshReason = ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
+                )
+            }
+        }
+    }
+
     private suspend fun refreshSummaryFromStoreState(
         storeState: ProgressSummaryStoreState,
         refreshReason: ProgressRefreshReason
@@ -425,11 +384,11 @@ class LocalProgressRepository(
         }
 
         val serializedScopeKey = serializeProgressSummaryScopeKey(scopeKey = storeState.scopeKey)
-        var requiresSyncBeforeRemoteLoad = requiresSyncBeforeRemoteLoad(refreshReason = refreshReason)
+        var syncMode = createProgressRemoteRefreshSyncMode(refreshReason = refreshReason)
         if (
             summaryRefreshCoordinator.beginRefresh(
                 scopeKey = serializedScopeKey,
-                requiresSyncBeforeRemoteLoad = requiresSyncBeforeRemoteLoad
+                syncMode = syncMode
             ).not()
         ) {
             return
@@ -441,14 +400,17 @@ class LocalProgressRepository(
                 performSummaryRefresh(
                     refreshStoreState = refreshStoreState,
                     initialStoreState = storeState,
-                    requiresSyncBeforeRemoteLoad = requiresSyncBeforeRemoteLoad
+                    syncMode = syncMode
                 )
             } catch (error: CancellationException) {
                 summaryRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
                 throw error
+            } catch (error: Exception) {
+                summaryRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
+                throw error
             }
 
-            val queuedRequiresSyncBeforeRemoteLoad = summaryRefreshCoordinator.completeRefreshIteration(
+            val queuedSyncMode = summaryRefreshCoordinator.completeRefreshIteration(
                 scopeKey = serializedScopeKey
             ) ?: return
             val latestStoreState = currentSummaryStoreState()
@@ -465,7 +427,7 @@ class LocalProgressRepository(
                 return
             }
             refreshStoreState = latestStoreState
-            requiresSyncBeforeRemoteLoad = queuedRequiresSyncBeforeRemoteLoad
+            syncMode = queuedSyncMode
         }
     }
 
@@ -478,11 +440,11 @@ class LocalProgressRepository(
         }
 
         val serializedScopeKey = serializeProgressSeriesScopeKey(scopeKey = storeState.scopeKey)
-        var requiresSyncBeforeRemoteLoad = requiresSyncBeforeRemoteLoad(refreshReason = refreshReason)
+        var syncMode = createProgressRemoteRefreshSyncMode(refreshReason = refreshReason)
         if (
             seriesRefreshCoordinator.beginRefresh(
                 scopeKey = serializedScopeKey,
-                requiresSyncBeforeRemoteLoad = requiresSyncBeforeRemoteLoad
+                syncMode = syncMode
             ).not()
         ) {
             return
@@ -494,14 +456,17 @@ class LocalProgressRepository(
                 performSeriesRefresh(
                     refreshStoreState = refreshStoreState,
                     initialStoreState = storeState,
-                    requiresSyncBeforeRemoteLoad = requiresSyncBeforeRemoteLoad
+                    syncMode = syncMode
                 )
             } catch (error: CancellationException) {
                 seriesRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
                 throw error
+            } catch (error: Exception) {
+                seriesRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
+                throw error
             }
 
-            val queuedRequiresSyncBeforeRemoteLoad = seriesRefreshCoordinator.completeRefreshIteration(
+            val queuedSyncMode = seriesRefreshCoordinator.completeRefreshIteration(
                 scopeKey = serializedScopeKey
             ) ?: return
             val latestStoreState = currentSeriesStoreState()
@@ -518,25 +483,33 @@ class LocalProgressRepository(
                 return
             }
             refreshStoreState = latestStoreState
-            requiresSyncBeforeRemoteLoad = queuedRequiresSyncBeforeRemoteLoad
+            syncMode = queuedSyncMode
         }
     }
 
     private suspend fun performSummaryRefresh(
         refreshStoreState: ProgressSummaryStoreState,
         initialStoreState: ProgressSummaryStoreState,
-        requiresSyncBeforeRemoteLoad: Boolean
+        syncMode: ProgressRemoteRefreshSyncMode
     ) {
         var resolvedRefreshStoreState = refreshStoreState
         if (resolvedRefreshStoreState.isLocalCacheReady.not()) {
             return
         }
-        if (requiresSyncBeforeRemoteLoad) {
+        if (syncMode == ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD) {
             try {
                 syncRepository.syncNow()
             } catch (error: CancellationException) {
                 throw error
-            } catch (_: Exception) {
+            } catch (error: Exception) {
+                logProgressRepositoryWarning(
+                    event = "progress_summary_sync_before_remote_load_failed",
+                    fields = listOf(
+                        "scopeKey" to serializeProgressSummaryScopeKey(scopeKey = resolvedRefreshStoreState.scopeKey),
+                        "timeZone" to resolvedRefreshStoreState.scopeKey.timeZone
+                    ),
+                    error = error
+                )
                 return
             }
             resolvedRefreshStoreState = currentSummaryStoreState() ?: return
@@ -557,7 +530,15 @@ class LocalProgressRepository(
             )
         } catch (error: CancellationException) {
             throw error
-        } catch (_: Exception) {
+        } catch (error: Exception) {
+            logProgressRepositoryWarning(
+                event = "progress_summary_remote_load_failed",
+                fields = listOf(
+                    "scopeKey" to serializeProgressSummaryScopeKey(scopeKey = resolvedRefreshStoreState.scopeKey),
+                    "timeZone" to resolvedRefreshStoreState.scopeKey.timeZone
+                ),
+                error = error
+            )
             return
         }
 
@@ -577,18 +558,28 @@ class LocalProgressRepository(
     private suspend fun performSeriesRefresh(
         refreshStoreState: ProgressSeriesStoreState,
         initialStoreState: ProgressSeriesStoreState,
-        requiresSyncBeforeRemoteLoad: Boolean
+        syncMode: ProgressRemoteRefreshSyncMode
     ) {
         var resolvedRefreshStoreState = refreshStoreState
         if (resolvedRefreshStoreState.isLocalCacheReady.not()) {
             return
         }
-        if (requiresSyncBeforeRemoteLoad) {
+        if (syncMode == ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD) {
             try {
                 syncRepository.syncNow()
             } catch (error: CancellationException) {
                 throw error
-            } catch (_: Exception) {
+            } catch (error: Exception) {
+                logProgressRepositoryWarning(
+                    event = "progress_series_sync_before_remote_load_failed",
+                    fields = listOf(
+                        "scopeKey" to serializeProgressSeriesScopeKey(scopeKey = resolvedRefreshStoreState.scopeKey),
+                        "timeZone" to resolvedRefreshStoreState.scopeKey.timeZone,
+                        "from" to resolvedRefreshStoreState.scopeKey.from,
+                        "to" to resolvedRefreshStoreState.scopeKey.to
+                    ),
+                    error = error
+                )
                 return
             }
             resolvedRefreshStoreState = currentSeriesStoreState() ?: return
@@ -611,7 +602,17 @@ class LocalProgressRepository(
             )
         } catch (error: CancellationException) {
             throw error
-        } catch (_: Exception) {
+        } catch (error: Exception) {
+            logProgressRepositoryWarning(
+                event = "progress_series_remote_load_failed",
+                fields = listOf(
+                    "scopeKey" to serializeProgressSeriesScopeKey(scopeKey = resolvedRefreshStoreState.scopeKey),
+                    "timeZone" to resolvedRefreshStoreState.scopeKey.timeZone,
+                    "from" to resolvedRefreshStoreState.scopeKey.from,
+                    "to" to resolvedRefreshStoreState.scopeKey.to
+                ),
+                error = error
+            )
             return
         }
 
@@ -666,552 +667,110 @@ class LocalProgressRepository(
     private fun currentSummaryStoreState(): ProgressSummaryStoreState? {
         val latestInputs = latestInputsMutable.value ?: return null
         return createProgressSummaryStoreState(
-            inputs = latestInputs,
-            timeProvider = timeProvider
+            inputs = createProgressSummaryStoreInputs(
+                inputs = latestInputs,
+                clockSnapshot = createProgressClockSnapshot(timeProvider = timeProvider)
+            )
         )
     }
 
     private fun currentSeriesStoreState(): ProgressSeriesStoreState? {
         val latestInputs = latestInputsMutable.value ?: return null
         return createProgressSeriesStoreState(
-            inputs = latestInputs,
-            timeProvider = timeProvider
+            inputs = createProgressSeriesStoreInputs(
+                inputs = latestInputs,
+                clockSnapshot = createProgressClockSnapshot(timeProvider = timeProvider)
+            )
         )
     }
-}
 
-internal class ProgressRefreshCoordinator {
-    private val refreshScopesMutex = Mutex()
-    private val refreshingScopeKeys = mutableSetOf<String>()
-    private val queuedRefreshSyncRequirements = mutableMapOf<String, Boolean>()
-
-    suspend fun beginRefresh(
-        scopeKey: String,
-        requiresSyncBeforeRemoteLoad: Boolean
-    ): Boolean {
-        return refreshScopesMutex.withLock {
-            if (refreshingScopeKeys.add(scopeKey)) {
-                return@withLock true
-            }
-
-            val queuedRequiresSyncBeforeRemoteLoad = queuedRefreshSyncRequirements[scopeKey] ?: false
-            queuedRefreshSyncRequirements[scopeKey] =
-                queuedRequiresSyncBeforeRemoteLoad || requiresSyncBeforeRemoteLoad
-            false
-        }
-    }
-
-    suspend fun completeRefreshIteration(
-        scopeKey: String
-    ): Boolean? {
-        return refreshScopesMutex.withLock {
-            val queuedRequiresSyncBeforeRemoteLoad = queuedRefreshSyncRequirements.remove(scopeKey)
-            if (queuedRequiresSyncBeforeRemoteLoad != null) {
-                return@withLock queuedRequiresSyncBeforeRemoteLoad
-            }
-
-            refreshingScopeKeys.remove(scopeKey)
-            null
-        }
-    }
-
-    suspend fun endRefresh(
-        scopeKey: String
-    ) {
-        refreshScopesMutex.withLock {
-            refreshingScopeKeys.remove(scopeKey)
-            queuedRefreshSyncRequirements.remove(scopeKey)
-        }
-    }
-}
-
-internal class ProgressLocalCacheRebuildCoordinator {
-    private val rebuildMutex = Mutex()
-    private val rebuildingTimeZones = mutableSetOf<String>()
-
-    suspend fun beginRebuild(timeZone: String): Boolean {
-        return rebuildMutex.withLock {
-            rebuildingTimeZones.add(timeZone)
-        }
-    }
-
-    suspend fun endRebuild(timeZone: String) {
-        rebuildMutex.withLock {
-            rebuildingTimeZones.remove(timeZone)
-        }
-    }
-}
-
-private fun createProgressSummaryStoreState(
-    inputs: ProgressObservedInputs,
-    timeProvider: ProgressTimeProvider
-): ProgressSummaryStoreState {
-    val zoneId = timeProvider.currentZoneId()
-    val today = Instant.ofEpochMilli(timeProvider.currentTimeMillis())
-        .atZone(zoneId)
-        .toLocalDate()
-    val scopeKey = createProgressSummaryScopeKey(
-        cloudSettings = inputs.cloudSettings,
-        today = today,
-        zoneId = zoneId
-    )
-    val workspaceIds = inputs.workspaces.map(WorkspaceEntity::workspaceId)
-    val isLocalCacheReady = isProgressLocalCacheReady(
-        reviewHistoryStates = inputs.reviewHistoryStates,
-        localCacheStates = inputs.localCacheStates,
-        workspaceIds = workspaceIds,
-        timeZone = scopeKey.timeZone
-    )
-    val serverBase = inputs.summaryCaches.firstOrNull { entry ->
-        entry.scopeKey == serializeProgressSummaryScopeKey(scopeKey = scopeKey)
-    }?.toCloudProgressSummaryOrNull()
-    val localFallback = if (isLocalCacheReady) {
-        createLocalFallbackSummary(
-            scopeKey = scopeKey,
-            localDayCounts = inputs.localDayCounts,
+    private fun createProgressSummaryStoreInputs(
+        inputs: ProgressObservedInputs,
+        clockSnapshot: ProgressClockSnapshot
+    ): ProgressSummaryStoreInputs {
+        val scopeKey = createProgressSummaryScopeKey(
+            cloudSettings = inputs.cloudSettings,
+            today = clockSnapshot.today,
+            zoneId = clockSnapshot.zoneId
+        )
+        val workspaceIds = inputs.workspaces.map(WorkspaceEntity::workspaceId)
+        val pendingReviewFingerprintEntries = createProgressPendingReviewFingerprintEntries(
+            pendingReviewOutboxEntries = inputs.pendingReviewOutboxEntries,
+            workspaceIds = workspaceIds
+        )
+        val isLocalCacheReady = isProgressLocalCacheReady(
+            reviewHistoryStates = inputs.reviewHistoryStates,
+            localCacheStates = inputs.localCacheStates,
             workspaceIds = workspaceIds,
-            today = today
+            timeZone = scopeKey.timeZone
         )
-    } else {
-        createEmptyProgressSummary()
-    }
-    return ProgressSummaryStoreState(
-        scopeKey = scopeKey,
-        cloudState = inputs.cloudSettings.cloudState,
-        snapshot = if (isLocalCacheReady) {
-            createProgressSummarySnapshot(
-                scopeKey = scopeKey,
-                localFallback = localFallback,
-                serverBase = serverBase,
-                cloudState = inputs.cloudSettings.cloudState
-            )
-        } else {
-            null
-        },
-        isLocalCacheReady = isLocalCacheReady,
-        reviewHistoryFingerprint = createReviewHistoryFingerprint(
-            reviewHistoryStates = inputs.reviewHistoryStates,
-            pendingReviewOutboxEntries = inputs.pendingReviewOutboxEntries,
-            syncStates = inputs.syncStates,
-            workspaceIds = workspaceIds
-        ),
-        syncStatus = inputs.syncStatus
-    )
-}
-
-private fun createProgressSeriesStoreState(
-    inputs: ProgressObservedInputs,
-    timeProvider: ProgressTimeProvider
-): ProgressSeriesStoreState {
-    val zoneId = timeProvider.currentZoneId()
-    val today = Instant.ofEpochMilli(timeProvider.currentTimeMillis())
-        .atZone(zoneId)
-        .toLocalDate()
-    val scopeKey = createProgressSeriesScopeKey(
-        cloudSettings = inputs.cloudSettings,
-        today = today,
-        zoneId = zoneId
-    )
-    val workspaceIds = inputs.workspaces.map(WorkspaceEntity::workspaceId)
-    val isLocalCacheReady = isProgressLocalCacheReady(
-        reviewHistoryStates = inputs.reviewHistoryStates,
-        localCacheStates = inputs.localCacheStates,
-        workspaceIds = workspaceIds,
-        timeZone = scopeKey.timeZone
-    )
-    val serverBase = inputs.seriesCaches.firstOrNull { entry ->
-        entry.scopeKey == serializeProgressSeriesScopeKey(scopeKey = scopeKey)
-    }?.toCloudProgressSeriesOrNull()
-    val localFallback = if (isLocalCacheReady) {
-        createLocalFallbackSeries(
+        return ProgressSummaryStoreInputs(
             scopeKey = scopeKey,
+            cloudState = inputs.cloudSettings.cloudState,
+            workspaceIds = workspaceIds,
             localDayCounts = inputs.localDayCounts,
-            workspaceIds = workspaceIds
+            isLocalCacheReady = isLocalCacheReady,
+            serverBase = inputs.summaryCaches.firstOrNull { entry ->
+                entry.scopeKey == serializeProgressSummaryScopeKey(scopeKey = scopeKey)
+            }?.toCloudProgressSummaryOrNull(),
+            reviewHistoryFingerprint = createReviewHistoryFingerprint(
+                reviewHistoryStates = inputs.reviewHistoryStates,
+                pendingReviewEntries = pendingReviewFingerprintEntries,
+                syncStates = inputs.syncStates,
+                workspaceIds = workspaceIds
+            ),
+            syncStatus = inputs.syncStatus,
+            today = clockSnapshot.today
         )
-    } else {
-        createEmptyProgressSeries(scopeKey = scopeKey)
     }
-    val pendingLocalOverlay = if (isLocalCacheReady) {
-        createPendingLocalOverlaySeries(
-            scopeKey = scopeKey,
+
+    private fun createProgressSeriesStoreInputs(
+        inputs: ProgressObservedInputs,
+        clockSnapshot: ProgressClockSnapshot
+    ): ProgressSeriesStoreInputs {
+        val scopeKey = createProgressSeriesScopeKey(
+            cloudSettings = inputs.cloudSettings,
+            today = clockSnapshot.today,
+            zoneId = clockSnapshot.zoneId
+        )
+        val workspaceIds = inputs.workspaces.map(WorkspaceEntity::workspaceId)
+        val pendingReviewFingerprintEntries = createProgressPendingReviewFingerprintEntries(
             pendingReviewOutboxEntries = inputs.pendingReviewOutboxEntries,
             workspaceIds = workspaceIds
         )
-    } else {
-        createEmptyProgressSeries(scopeKey = scopeKey)
-    }
-    return ProgressSeriesStoreState(
-        scopeKey = scopeKey,
-        cloudState = inputs.cloudSettings.cloudState,
-        snapshot = if (isLocalCacheReady) {
-            createProgressSeriesSnapshot(
-                scopeKey = scopeKey,
-                localFallback = localFallback,
-                serverBase = serverBase,
-                pendingLocalOverlay = pendingLocalOverlay,
-                cloudState = inputs.cloudSettings.cloudState
-            )
-        } else {
-            null
-        },
-        isLocalCacheReady = isLocalCacheReady,
-        reviewHistoryFingerprint = createReviewHistoryFingerprint(
+        val isLocalCacheReady = isProgressLocalCacheReady(
             reviewHistoryStates = inputs.reviewHistoryStates,
-            pendingReviewOutboxEntries = inputs.pendingReviewOutboxEntries,
-            syncStates = inputs.syncStates,
-            workspaceIds = workspaceIds
-        ),
-        syncStatus = inputs.syncStatus
-    )
-}
-
-internal fun createProgressSummaryScopeKey(
-    cloudSettings: CloudSettings,
-    today: LocalDate,
-    zoneId: ZoneId
-): ProgressSummaryScopeKey {
-    return ProgressSummaryScopeKey(
-        scopeId = createProgressScopeId(cloudSettings = cloudSettings),
-        timeZone = zoneId.id,
-        referenceLocalDate = today.toString()
-    )
-}
-
-internal fun createProgressSeriesScopeKey(
-    cloudSettings: CloudSettings,
-    today: LocalDate,
-    zoneId: ZoneId
-): ProgressSeriesScopeKey {
-    val from = today.minusDays(progressHistoryDayCount - 1L)
-    return ProgressSeriesScopeKey(
-        scopeId = createProgressScopeId(cloudSettings = cloudSettings),
-        timeZone = zoneId.id,
-        from = from.toString(),
-        to = today.toString()
-    )
-}
-
-internal fun createProgressScopeId(
-    cloudSettings: CloudSettings
-): String {
-    return when (cloudSettings.cloudState) {
-        CloudAccountState.LINKED -> "linked:${cloudSettings.linkedUserId ?: cloudSettings.installationId}"
-        CloudAccountState.GUEST -> "guest:${cloudSettings.activeWorkspaceId ?: cloudSettings.installationId}"
-        CloudAccountState.DISCONNECTED -> "local:${cloudSettings.installationId}"
-        CloudAccountState.LINKING_READY -> "linking:${cloudSettings.installationId}"
-    }
-}
-
-internal fun isProgressLocalCacheReady(
-    reviewHistoryStates: List<ProgressReviewHistoryStateEntity>,
-    localCacheStates: List<ProgressLocalCacheStateEntity>,
-    workspaceIds: List<String>,
-    timeZone: String
-): Boolean {
-    val historyStatesByWorkspaceId = reviewHistoryStates.associateBy(ProgressReviewHistoryStateEntity::workspaceId)
-    val cacheStatesByWorkspaceId = localCacheStates.filter { cacheState ->
-        cacheState.timeZone == timeZone
-    }.associateBy(ProgressLocalCacheStateEntity::workspaceId)
-
-    return workspaceIds.all { workspaceId ->
-        val historyVersion = historyStatesByWorkspaceId[workspaceId]?.historyVersion ?: 0L
-        if (historyVersion == 0L) {
-            return@all true
-        }
-
-        cacheStatesByWorkspaceId[workspaceId]?.historyVersion == historyVersion
-    }
-}
-
-internal fun createLocalFallbackSummary(
-    scopeKey: ProgressSummaryScopeKey,
-    localDayCounts: List<ProgressLocalDayCountEntity>,
-    workspaceIds: List<String>,
-    today: LocalDate
-): CloudProgressSummary {
-    val workspaceIdSet = workspaceIds.toSet()
-    val activeReviewDates = localDayCounts.filter { dayCount ->
-        dayCount.timeZone == scopeKey.timeZone &&
-            workspaceIdSet.contains(dayCount.workspaceId) &&
-            dayCount.reviewCount > 0
-    }.map(ProgressLocalDayCountEntity::localDate)
-        .distinct()
-        .sorted()
-    val activeReviewDateSet = activeReviewDates.toSet()
-    val lastReviewedOn = activeReviewDates.lastOrNull()
-    val currentStreakDays = computeCurrentStreakDays(
-        activeReviewDateSet = activeReviewDateSet,
-        today = today
-    )
-    return CloudProgressSummary(
-        currentStreakDays = currentStreakDays,
-        hasReviewedToday = activeReviewDateSet.contains(today.toString()),
-        lastReviewedOn = lastReviewedOn,
-        activeReviewDays = activeReviewDates.size
-    )
-}
-
-internal fun createLocalFallbackSeries(
-    scopeKey: ProgressSeriesScopeKey,
-    localDayCounts: List<ProgressLocalDayCountEntity>,
-    workspaceIds: List<String>
-): CloudProgressSeries {
-    val workspaceIdSet = workspaceIds.toSet()
-    val dateRange = createInclusiveLocalDateRange(
-        from = scopeKey.from,
-        to = scopeKey.to
-    )
-    val reviewCountsByDate = linkedMapOf<String, Int>()
-    dateRange.forEach { date ->
-        reviewCountsByDate[date] = 0
-    }
-    localDayCounts.forEach { dayCount ->
-        if (dayCount.timeZone != scopeKey.timeZone) {
-            return@forEach
-        }
-        if (workspaceIdSet.contains(dayCount.workspaceId).not()) {
-            return@forEach
-        }
-        if (reviewCountsByDate.containsKey(dayCount.localDate).not()) {
-            return@forEach
-        }
-        reviewCountsByDate[dayCount.localDate] = (reviewCountsByDate[dayCount.localDate] ?: 0) + dayCount.reviewCount
-    }
-
-    return CloudProgressSeries(
-        timeZone = scopeKey.timeZone,
-        from = scopeKey.from,
-        to = scopeKey.to,
-        dailyReviews = reviewCountsByDate.map { (date, reviewCount) ->
-            CloudDailyReviewPoint(
-                date = date,
-                reviewCount = reviewCount
-            )
-        },
-        generatedAt = null,
-        summary = null
-    )
-}
-
-internal fun createPendingLocalOverlaySeries(
-    scopeKey: ProgressSeriesScopeKey,
-    pendingReviewOutboxEntries: List<OutboxEntryEntity>,
-    workspaceIds: List<String>
-): CloudProgressSeries {
-    val workspaceIdSet = workspaceIds.toSet()
-    val zoneId = ZoneId.of(scopeKey.timeZone)
-    val reviewCountsByDate = createInclusiveLocalDateRange(
-        from = scopeKey.from,
-        to = scopeKey.to
-    ).associateWith { 0 }.toMutableMap()
-
-    pendingReviewOutboxEntries.forEach { entry ->
-        if (workspaceIdSet.contains(entry.workspaceId).not()) {
-            return@forEach
-        }
-
-        val localDate = try {
-            entry.toPendingReviewLocalDate(zoneId = zoneId)
-        } catch (error: IllegalArgumentException) {
-            logProgressRepositoryWarning(
-                event = "progress_pending_overlay_entry_skipped",
-                fields = listOf(
-                    "outboxEntryId" to entry.outboxEntryId,
-                    "workspaceId" to entry.workspaceId,
-                    "timeZone" to scopeKey.timeZone
-                ),
-                error = error
-            )
-            return@forEach
-        }
-        if (reviewCountsByDate.containsKey(localDate).not()) {
-            return@forEach
-        }
-
-        reviewCountsByDate[localDate] = (reviewCountsByDate[localDate] ?: 0) + 1
-    }
-
-    return CloudProgressSeries(
-        timeZone = scopeKey.timeZone,
-        from = scopeKey.from,
-        to = scopeKey.to,
-        dailyReviews = reviewCountsByDate.map { (date, reviewCount) ->
-            CloudDailyReviewPoint(
-                date = date,
-                reviewCount = reviewCount
-            )
-        },
-        generatedAt = null,
-        summary = null
-    )
-}
-
-internal fun createProgressSummarySnapshot(
-    scopeKey: ProgressSummaryScopeKey,
-    localFallback: CloudProgressSummary,
-    serverBase: CloudProgressSummary?,
-    cloudState: CloudAccountState
-): ProgressSummarySnapshot {
-    val hasPendingLocalOverlay = serverBase?.let { base ->
-        hasProgressSummaryOverlay(
-            localFallback = localFallback,
-            serverBase = base
+            localCacheStates = inputs.localCacheStates,
+            workspaceIds = workspaceIds,
+            timeZone = scopeKey.timeZone
         )
-    } ?: false
-    val renderedSummary = when {
-        serverBase == null -> localFallback
-        hasPendingLocalOverlay -> mergeProgressSummary(
-            base = serverBase,
-            localFallback = localFallback
-        )
-        else -> serverBase
-    }
-    val source = when {
-        serverBase == null -> ProgressSnapshotSource.LOCAL_ONLY
-        hasPendingLocalOverlay -> ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY
-        else -> ProgressSnapshotSource.SERVER_BASE
-    }
-    return ProgressSummarySnapshot(
-        scopeKey = scopeKey,
-        renderedSummary = renderedSummary,
-        localFallback = localFallback,
-        serverBase = serverBase,
-        source = source,
-        isApproximate = source == ProgressSnapshotSource.LOCAL_ONLY ||
-            hasPendingLocalOverlay ||
-            cloudState == CloudAccountState.DISCONNECTED ||
-            cloudState == CloudAccountState.LINKING_READY
-    )
-}
-
-internal fun createProgressSeriesSnapshot(
-    scopeKey: ProgressSeriesScopeKey,
-    localFallback: CloudProgressSeries,
-    serverBase: CloudProgressSeries?,
-    pendingLocalOverlay: CloudProgressSeries,
-    cloudState: CloudAccountState
-): ProgressSeriesSnapshot {
-    val hasPendingLocalOverlay = pendingLocalOverlay.dailyReviews.any { point ->
-        point.reviewCount > 0
-    }
-    val renderedSeries = if (serverBase == null) {
-        localFallback
-    } else {
-        mergeProgressSeries(
-            base = serverBase,
-            overlay = pendingLocalOverlay
+        return ProgressSeriesStoreInputs(
+            scopeKey = scopeKey,
+            cloudState = inputs.cloudSettings.cloudState,
+            workspaceIds = workspaceIds,
+            localDayCounts = inputs.localDayCounts,
+            isLocalCacheReady = isLocalCacheReady,
+            serverBase = inputs.seriesCaches.firstOrNull { entry ->
+                entry.scopeKey == serializeProgressSeriesScopeKey(scopeKey = scopeKey)
+            }?.toCloudProgressSeriesOrNull(),
+            pendingReviewLocalDates = if (isLocalCacheReady) {
+                createProgressPendingReviewLocalDates(
+                    pendingReviewOutboxEntries = inputs.pendingReviewOutboxEntries,
+                    workspaceIds = workspaceIds,
+                    timeZone = scopeKey.timeZone
+                )
+            } else {
+                emptyList()
+            },
+            reviewHistoryFingerprint = createReviewHistoryFingerprint(
+                reviewHistoryStates = inputs.reviewHistoryStates,
+                pendingReviewEntries = pendingReviewFingerprintEntries,
+                syncStates = inputs.syncStates,
+                workspaceIds = workspaceIds
+            ),
+            syncStatus = inputs.syncStatus
         )
     }
-    val source = when {
-        serverBase == null -> ProgressSnapshotSource.LOCAL_ONLY
-        hasPendingLocalOverlay -> ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY
-        else -> ProgressSnapshotSource.SERVER_BASE
-    }
-    return ProgressSeriesSnapshot(
-        scopeKey = scopeKey,
-        renderedSeries = renderedSeries,
-        localFallback = localFallback,
-        serverBase = serverBase,
-        pendingLocalOverlay = pendingLocalOverlay,
-        source = source,
-        isApproximate = source == ProgressSnapshotSource.LOCAL_ONLY ||
-            hasPendingLocalOverlay ||
-            cloudState == CloudAccountState.DISCONNECTED ||
-            cloudState == CloudAccountState.LINKING_READY
-    )
-}
-
-internal fun mergeProgressSummary(
-    base: CloudProgressSummary,
-    localFallback: CloudProgressSummary
-): CloudProgressSummary {
-    return CloudProgressSummary(
-        currentStreakDays = maxOf(base.currentStreakDays, localFallback.currentStreakDays),
-        hasReviewedToday = base.hasReviewedToday || localFallback.hasReviewedToday,
-        lastReviewedOn = maxLocalDate(
-            first = base.lastReviewedOn,
-            second = localFallback.lastReviewedOn
-        ),
-        activeReviewDays = maxOf(base.activeReviewDays, localFallback.activeReviewDays)
-    )
-}
-
-internal fun mergeProgressSeries(
-    base: CloudProgressSeries,
-    overlay: CloudProgressSeries
-): CloudProgressSeries {
-    val overlayCountsByDate = overlay.dailyReviews.associate { point ->
-        point.date to point.reviewCount
-    }
-    val mergedDailyReviews = base.dailyReviews.map { point ->
-        CloudDailyReviewPoint(
-            date = point.date,
-            reviewCount = point.reviewCount + (overlayCountsByDate[point.date] ?: 0)
-        )
-    }
-    return CloudProgressSeries(
-        timeZone = base.timeZone,
-        from = base.from,
-        to = base.to,
-        dailyReviews = mergedDailyReviews,
-        generatedAt = base.generatedAt,
-        summary = null
-    )
-}
-
-internal fun createReviewHistoryFingerprint(
-    reviewHistoryStates: List<ProgressReviewHistoryStateEntity>,
-    pendingReviewOutboxEntries: List<OutboxEntryEntity>,
-    syncStates: List<SyncStateEntity>,
-    workspaceIds: List<String>
-): String {
-    val workspaceIdSet = workspaceIds.toSet()
-    val relevantHistoryStates = reviewHistoryStates.filter { historyState ->
-        workspaceIdSet.contains(historyState.workspaceId)
-    }.sortedBy(ProgressReviewHistoryStateEntity::workspaceId)
-    val relevantPendingReviewEntries = pendingReviewOutboxEntries.filter { entry ->
-        workspaceIdSet.contains(entry.workspaceId)
-    }
-    val relevantSyncStates = syncStates.filter { syncState ->
-        workspaceIdSet.contains(syncState.workspaceId)
-    }.sortedBy(SyncStateEntity::workspaceId)
-
-    val historyFingerprint = relevantHistoryStates.joinToString(separator = "|") { historyState ->
-        "${historyState.workspaceId}:${historyState.historyVersion}"
-    }
-    val pendingReviewIds = relevantPendingReviewEntries.map(OutboxEntryEntity::outboxEntryId).sorted()
-    val reviewSequenceFingerprint = relevantSyncStates.joinToString(separator = "|") { syncState ->
-        "${syncState.workspaceId}:${syncState.lastReviewSequenceId}"
-    }
-    return "$historyFingerprint:${pendingReviewIds.joinToString(separator = ",")}:$reviewSequenceFingerprint"
-}
-
-internal fun didSyncCompleteWithReviewHistoryChange(
-    previousSuccessfulSyncAtMillis: Long?,
-    currentSuccessfulSyncAtMillis: Long?,
-    previousReviewHistoryFingerprint: String?,
-    currentReviewHistoryFingerprint: String
-): Boolean {
-    if (previousReviewHistoryFingerprint == null) {
-        return false
-    }
-    if (currentSuccessfulSyncAtMillis == null || currentSuccessfulSyncAtMillis == previousSuccessfulSyncAtMillis) {
-        return false
-    }
-
-    return previousReviewHistoryFingerprint != currentReviewHistoryFingerprint
-}
-
-internal fun serializeProgressSummaryScopeKey(
-    scopeKey: ProgressSummaryScopeKey
-): String {
-    return "${scopeKey.scopeId}::${scopeKey.timeZone}::${scopeKey.referenceLocalDate}"
-}
-
-internal fun serializeProgressSeriesScopeKey(
-    scopeKey: ProgressSeriesScopeKey
-): String {
-    return "${scopeKey.scopeId}::${scopeKey.timeZone}::${scopeKey.from}::${scopeKey.to}"
 }
 
 private fun supportsServerRefresh(
@@ -1220,262 +779,12 @@ private fun supportsServerRefresh(
     return cloudState == CloudAccountState.GUEST || cloudState == CloudAccountState.LINKED
 }
 
-private fun requiresSyncBeforeRemoteLoad(
+private fun createProgressRemoteRefreshSyncMode(
     refreshReason: ProgressRefreshReason
-): Boolean {
-    return refreshReason != ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
-}
-
-private fun createInclusiveLocalDateRange(
-    from: String,
-    to: String
-): List<String> {
-    val startDate = parseLocalDate(rawDate = from)
-    val endDate = parseLocalDate(rawDate = to)
-    val dates = mutableListOf<String>()
-    var currentDate = startDate
-
-    while (currentDate <= endDate) {
-        dates.add(currentDate.toString())
-        currentDate = currentDate.plusDays(1L)
-    }
-
-    return dates
-}
-
-private fun parseLocalDate(
-    rawDate: String
-): LocalDate {
-    return try {
-        LocalDate.parse(rawDate)
-    } catch (error: DateTimeParseException) {
-        throw IllegalArgumentException("Invalid local date '$rawDate'.", error)
-    }
-}
-
-private fun computeCurrentStreakDays(
-    activeReviewDateSet: Set<String>,
-    today: LocalDate
-): Int {
-    val anchorDate: LocalDate = when {
-        activeReviewDateSet.contains(today.toString()) -> today
-        activeReviewDateSet.contains(today.minusDays(1L).toString()) -> today.minusDays(1L)
-        else -> return 0
-    }
-
-    var streakDays = 0
-    var currentDate = anchorDate
-    while (activeReviewDateSet.contains(currentDate.toString())) {
-        streakDays += 1
-        currentDate = currentDate.minusDays(1L)
-    }
-    return streakDays
-}
-
-private fun OutboxEntryEntity.toPendingReviewLocalDate(
-    zoneId: ZoneId
-): String {
-    val payloadJsonObject = try {
-        JSONObject(payloadJson)
-    } catch (error: Exception) {
-        throw IllegalArgumentException(
-            "Invalid pending review-event payload JSON for outbox entry '$outboxEntryId': $payloadJson",
-            error
-        )
-    }
-    val reviewedAtClient = try {
-        payloadJsonObject.getString("reviewedAtClient")
-    } catch (error: Exception) {
-        throw IllegalArgumentException(
-            "Missing reviewedAtClient in pending review-event payload for outbox entry '$outboxEntryId': $payloadJson",
-            error
-        )
-    }
-    val reviewedAtInstant = try {
-        Instant.parse(reviewedAtClient)
-    } catch (error: Exception) {
-        throw IllegalArgumentException(
-            "Invalid reviewedAtClient '$reviewedAtClient' in pending review-event payload for outbox entry '$outboxEntryId'.",
-            error
-        )
-    }
-    return reviewedAtInstant.atZone(zoneId).toLocalDate().toString()
-}
-
-private fun hasProgressSummaryOverlay(
-    localFallback: CloudProgressSummary,
-    serverBase: CloudProgressSummary
-): Boolean {
-    return localFallback.currentStreakDays > serverBase.currentStreakDays ||
-        (localFallback.hasReviewedToday && serverBase.hasReviewedToday.not()) ||
-        isLocalDateAfter(
-            first = localFallback.lastReviewedOn,
-            second = serverBase.lastReviewedOn
-        ) ||
-        localFallback.activeReviewDays > serverBase.activeReviewDays
-}
-
-private fun isLocalDateAfter(
-    first: String?,
-    second: String?
-): Boolean {
-    return when {
-        first == null -> false
-        second == null -> true
-        else -> parseLocalDate(rawDate = first).isAfter(parseLocalDate(rawDate = second))
-    }
-}
-
-private fun maxLocalDate(
-    first: String?,
-    second: String?
-): String? {
-    return when {
-        first == null -> second
-        second == null -> first
-        parseLocalDate(rawDate = first).isAfter(parseLocalDate(rawDate = second)) -> first
-        else -> second
-    }
-}
-
-private fun createEmptyProgressSummary(): CloudProgressSummary {
-    return CloudProgressSummary(
-        currentStreakDays = 0,
-        hasReviewedToday = false,
-        lastReviewedOn = null,
-        activeReviewDays = 0
-    )
-}
-
-private fun createEmptyProgressSeries(
-    scopeKey: ProgressSeriesScopeKey
-): CloudProgressSeries {
-    return CloudProgressSeries(
-        timeZone = scopeKey.timeZone,
-        from = scopeKey.from,
-        to = scopeKey.to,
-        dailyReviews = createInclusiveLocalDateRange(
-            from = scopeKey.from,
-            to = scopeKey.to
-        ).map { date ->
-            CloudDailyReviewPoint(
-                date = date,
-                reviewCount = 0
-            )
-        },
-        generatedAt = null,
-        summary = null
-    )
-}
-
-private fun CloudProgressSummary.toCacheEntity(
-    scopeKey: ProgressSummaryScopeKey,
-    updatedAtMillis: Long
-): ProgressSummaryCacheEntity {
-    return ProgressSummaryCacheEntity(
-        scopeKey = serializeProgressSummaryScopeKey(scopeKey = scopeKey),
-        scopeId = scopeKey.scopeId,
-        timeZone = scopeKey.timeZone,
-        generatedAt = null,
-        currentStreakDays = currentStreakDays,
-        hasReviewedToday = hasReviewedToday,
-        lastReviewedOn = lastReviewedOn,
-        activeReviewDays = activeReviewDays,
-        updatedAtMillis = updatedAtMillis
-    )
-}
-
-private fun CloudProgressSeries.toCacheEntity(
-    scopeKey: ProgressSeriesScopeKey,
-    updatedAtMillis: Long
-): ProgressSeriesCacheEntity {
-    return ProgressSeriesCacheEntity(
-        scopeKey = serializeProgressSeriesScopeKey(scopeKey = scopeKey),
-        scopeId = scopeKey.scopeId,
-        timeZone = timeZone,
-        fromLocalDate = from,
-        toLocalDate = to,
-        generatedAt = generatedAt,
-        dailyReviewsJson = JSONArray().apply {
-            dailyReviews.forEach { point ->
-                put(
-                    JSONObject()
-                        .put("date", point.date)
-                        .put("reviewCount", point.reviewCount)
-                )
-            }
-        }.toString(),
-        updatedAtMillis = updatedAtMillis
-    )
-}
-
-internal fun ProgressSummaryCacheEntity.toCloudProgressSummaryOrNull(): CloudProgressSummary? {
-    return runCatching {
-        lastReviewedOn?.let { cachedLastReviewedOn ->
-            parseLocalDate(rawDate = cachedLastReviewedOn)
-        }
-        CloudProgressSummary(
-            currentStreakDays = currentStreakDays,
-            hasReviewedToday = hasReviewedToday,
-            lastReviewedOn = lastReviewedOn,
-            activeReviewDays = activeReviewDays
-        )
-    }.getOrElse { error ->
-        logProgressRepositoryWarning(
-            event = "progress_summary_cache_skipped",
-            fields = listOf(
-                "scopeKey" to scopeKey,
-                "timeZone" to timeZone,
-                "lastReviewedOn" to lastReviewedOn
-            ),
-            error = error
-        )
-        null
-    }
-}
-
-internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgressSeries? {
-    return runCatching {
-        val parsedFrom = parseLocalDate(rawDate = fromLocalDate)
-        val parsedTo = parseLocalDate(rawDate = toLocalDate)
-        if (parsedFrom.isAfter(parsedTo)) {
-            throw IllegalArgumentException(
-                "Invalid progress series cache range '$fromLocalDate' > '$toLocalDate'."
-            )
-        }
-
-        val dailyReviewsArray = JSONArray(dailyReviewsJson)
-        CloudProgressSeries(
-            timeZone = timeZone,
-            from = fromLocalDate,
-            to = toLocalDate,
-            dailyReviews = buildList {
-                for (index in 0 until dailyReviewsArray.length()) {
-                    val point = dailyReviewsArray.getJSONObject(index)
-                    val date = point.getString("date")
-                    parseLocalDate(rawDate = date)
-                    add(
-                        CloudDailyReviewPoint(
-                            date = date,
-                            reviewCount = point.getInt("reviewCount")
-                        )
-                    )
-                }
-            },
-            generatedAt = generatedAt,
-            summary = null
-        )
-    }.getOrElse { error ->
-        logProgressRepositoryWarning(
-            event = "progress_series_cache_skipped",
-            fields = listOf(
-                "scopeKey" to scopeKey,
-                "timeZone" to timeZone,
-                "fromLocalDate" to fromLocalDate,
-                "toLocalDate" to toLocalDate
-            ),
-            error = error
-        )
-        null
+): ProgressRemoteRefreshSyncMode {
+    return if (refreshReason == ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE) {
+        ProgressRemoteRefreshSyncMode.SKIP_SYNC
+    } else {
+        ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressCacheSerialization.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressCacheSerialization.kt
@@ -1,0 +1,123 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import com.flashcardsopensourceapp.data.local.database.ProgressSeriesCacheEntity
+import com.flashcardsopensourceapp.data.local.database.ProgressSummaryCacheEntity
+import com.flashcardsopensourceapp.data.local.model.CloudDailyReviewPoint
+import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.ProgressSeriesScopeKey
+import com.flashcardsopensourceapp.data.local.model.ProgressSummaryScopeKey
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal fun CloudProgressSummary.toCacheEntity(
+    scopeKey: ProgressSummaryScopeKey,
+    updatedAtMillis: Long
+): ProgressSummaryCacheEntity {
+    return ProgressSummaryCacheEntity(
+        scopeKey = serializeProgressSummaryScopeKey(scopeKey = scopeKey),
+        scopeId = scopeKey.scopeId,
+        timeZone = scopeKey.timeZone,
+        generatedAt = null,
+        currentStreakDays = currentStreakDays,
+        hasReviewedToday = hasReviewedToday,
+        lastReviewedOn = lastReviewedOn,
+        activeReviewDays = activeReviewDays,
+        updatedAtMillis = updatedAtMillis
+    )
+}
+
+internal fun CloudProgressSeries.toCacheEntity(
+    scopeKey: ProgressSeriesScopeKey,
+    updatedAtMillis: Long
+): ProgressSeriesCacheEntity {
+    return ProgressSeriesCacheEntity(
+        scopeKey = serializeProgressSeriesScopeKey(scopeKey = scopeKey),
+        scopeId = scopeKey.scopeId,
+        timeZone = timeZone,
+        fromLocalDate = from,
+        toLocalDate = to,
+        generatedAt = generatedAt,
+        dailyReviewsJson = JSONArray().apply {
+            dailyReviews.forEach { point ->
+                put(
+                    JSONObject()
+                        .put("date", point.date)
+                        .put("reviewCount", point.reviewCount)
+                )
+            }
+        }.toString(),
+        updatedAtMillis = updatedAtMillis
+    )
+}
+
+internal fun ProgressSummaryCacheEntity.toCloudProgressSummaryOrNull(): CloudProgressSummary? {
+    return runCatching {
+        lastReviewedOn?.let { cachedLastReviewedOn ->
+            parseLocalDate(rawDate = cachedLastReviewedOn)
+        }
+        CloudProgressSummary(
+            currentStreakDays = currentStreakDays,
+            hasReviewedToday = hasReviewedToday,
+            lastReviewedOn = lastReviewedOn,
+            activeReviewDays = activeReviewDays
+        )
+    }.getOrElse { error ->
+        logProgressRepositoryWarning(
+            event = "progress_summary_cache_skipped",
+            fields = listOf(
+                "scopeKey" to scopeKey,
+                "timeZone" to timeZone,
+                "lastReviewedOn" to lastReviewedOn
+            ),
+            error = error
+        )
+        null
+    }
+}
+
+internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgressSeries? {
+    return runCatching {
+        val parsedFrom = parseLocalDate(rawDate = fromLocalDate)
+        val parsedTo = parseLocalDate(rawDate = toLocalDate)
+        if (parsedFrom.isAfter(parsedTo)) {
+            throw IllegalArgumentException(
+                "Invalid progress series cache range '$fromLocalDate' > '$toLocalDate'."
+            )
+        }
+
+        val dailyReviewsArray = JSONArray(dailyReviewsJson)
+        CloudProgressSeries(
+            timeZone = timeZone,
+            from = fromLocalDate,
+            to = toLocalDate,
+            dailyReviews = buildList {
+                for (index in 0 until dailyReviewsArray.length()) {
+                    val point = dailyReviewsArray.getJSONObject(index)
+                    val date = point.getString("date")
+                    parseLocalDate(rawDate = date)
+                    add(
+                        CloudDailyReviewPoint(
+                            date = date,
+                            reviewCount = point.getInt("reviewCount")
+                        )
+                    )
+                }
+            },
+            generatedAt = generatedAt,
+            summary = null
+        )
+    }.getOrElse { error ->
+        logProgressRepositoryWarning(
+            event = "progress_series_cache_skipped",
+            fields = listOf(
+                "scopeKey" to scopeKey,
+                "timeZone" to timeZone,
+                "fromLocalDate" to fromLocalDate,
+                "toLocalDate" to toLocalDate
+            ),
+            error = error
+        )
+        null
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressPendingReviewInputs.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressPendingReviewInputs.kt
@@ -1,0 +1,98 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import com.flashcardsopensourceapp.data.local.database.OutboxEntryEntity
+import org.json.JSONObject
+import java.time.Instant
+import java.time.ZoneId
+
+internal data class ProgressPendingReviewLocalDate(
+    val workspaceId: String,
+    val localDate: String
+)
+
+internal data class ProgressPendingReviewFingerprintEntry(
+    val workspaceId: String,
+    val outboxEntryId: String
+)
+
+internal fun createProgressPendingReviewFingerprintEntries(
+    pendingReviewOutboxEntries: List<OutboxEntryEntity>,
+    workspaceIds: List<String>
+): List<ProgressPendingReviewFingerprintEntry> {
+    val workspaceIdSet = workspaceIds.toSet()
+    return pendingReviewOutboxEntries.filter { entry ->
+        workspaceIdSet.contains(entry.workspaceId)
+    }.map { entry ->
+        ProgressPendingReviewFingerprintEntry(
+            workspaceId = entry.workspaceId,
+            outboxEntryId = entry.outboxEntryId
+        )
+    }
+}
+
+internal fun createProgressPendingReviewLocalDates(
+    pendingReviewOutboxEntries: List<OutboxEntryEntity>,
+    workspaceIds: List<String>,
+    timeZone: String
+): List<ProgressPendingReviewLocalDate> {
+    val workspaceIdSet = workspaceIds.toSet()
+    val zoneId = ZoneId.of(timeZone)
+    return buildList {
+        pendingReviewOutboxEntries.forEach { entry ->
+            if (workspaceIdSet.contains(entry.workspaceId).not()) {
+                return@forEach
+            }
+
+            val localDate = try {
+                entry.toPendingReviewLocalDate(zoneId = zoneId)
+            } catch (error: IllegalArgumentException) {
+                logProgressRepositoryWarning(
+                    event = "progress_pending_overlay_entry_skipped",
+                    fields = listOf(
+                        "outboxEntryId" to entry.outboxEntryId,
+                        "workspaceId" to entry.workspaceId,
+                        "timeZone" to timeZone
+                    ),
+                    error = error
+                )
+                return@forEach
+            }
+            add(
+                ProgressPendingReviewLocalDate(
+                    workspaceId = entry.workspaceId,
+                    localDate = localDate
+                )
+            )
+        }
+    }
+}
+
+private fun OutboxEntryEntity.toPendingReviewLocalDate(
+    zoneId: ZoneId
+): String {
+    val payloadJsonObject = try {
+        JSONObject(payloadJson)
+    } catch (error: Exception) {
+        throw IllegalArgumentException(
+            "Invalid pending review-event payload JSON for outbox entry '$outboxEntryId': $payloadJson",
+            error
+        )
+    }
+    val reviewedAtClient = try {
+        payloadJsonObject.getString("reviewedAtClient")
+    } catch (error: Exception) {
+        throw IllegalArgumentException(
+            "Missing reviewedAtClient in pending review-event payload for outbox entry '$outboxEntryId': $payloadJson",
+            error
+        )
+    }
+    val reviewedAtInstant = try {
+        Instant.parse(reviewedAtClient)
+    } catch (error: Exception) {
+        throw IllegalArgumentException(
+            "Invalid reviewedAtClient '$reviewedAtClient' in pending review-event payload for outbox entry '$outboxEntryId'.",
+            error
+        )
+    }
+    return reviewedAtInstant.atZone(zoneId).toLocalDate().toString()
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressRefreshCoordination.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressRefreshCoordination.kt
@@ -1,0 +1,87 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal enum class ProgressRemoteRefreshSyncMode {
+    SKIP_SYNC,
+    SYNC_BEFORE_REMOTE_LOAD
+}
+
+internal class ProgressRefreshCoordinator {
+    private val refreshScopesMutex = Mutex()
+    private val refreshingScopeKeys = mutableSetOf<String>()
+    private val queuedRefreshSyncModes = mutableMapOf<String, ProgressRemoteRefreshSyncMode>()
+
+    suspend fun beginRefresh(
+        scopeKey: String,
+        syncMode: ProgressRemoteRefreshSyncMode
+    ): Boolean {
+        return refreshScopesMutex.withLock {
+            if (refreshingScopeKeys.add(scopeKey)) {
+                return@withLock true
+            }
+
+            val queuedSyncMode = queuedRefreshSyncModes[scopeKey] ?: ProgressRemoteRefreshSyncMode.SKIP_SYNC
+            queuedRefreshSyncModes[scopeKey] = mergeProgressRemoteRefreshSyncMode(
+                first = queuedSyncMode,
+                second = syncMode
+            )
+            false
+        }
+    }
+
+    suspend fun completeRefreshIteration(
+        scopeKey: String
+    ): ProgressRemoteRefreshSyncMode? {
+        return refreshScopesMutex.withLock {
+            val queuedSyncMode = queuedRefreshSyncModes.remove(scopeKey)
+            if (queuedSyncMode != null) {
+                return@withLock queuedSyncMode
+            }
+
+            refreshingScopeKeys.remove(scopeKey)
+            null
+        }
+    }
+
+    suspend fun endRefresh(
+        scopeKey: String
+    ) {
+        refreshScopesMutex.withLock {
+            refreshingScopeKeys.remove(scopeKey)
+            queuedRefreshSyncModes.remove(scopeKey)
+        }
+    }
+}
+
+internal class ProgressLocalCacheRebuildCoordinator {
+    private val rebuildMutex = Mutex()
+    private val rebuildingTimeZones = mutableSetOf<String>()
+
+    suspend fun beginRebuild(timeZone: String): Boolean {
+        return rebuildMutex.withLock {
+            rebuildingTimeZones.add(timeZone)
+        }
+    }
+
+    suspend fun endRebuild(timeZone: String) {
+        rebuildMutex.withLock {
+            rebuildingTimeZones.remove(timeZone)
+        }
+    }
+}
+
+private fun mergeProgressRemoteRefreshSyncMode(
+    first: ProgressRemoteRefreshSyncMode,
+    second: ProgressRemoteRefreshSyncMode
+): ProgressRemoteRefreshSyncMode {
+    return if (
+        first == ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD ||
+        second == ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD
+    ) {
+        ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD
+    } else {
+        ProgressRemoteRefreshSyncMode.SKIP_SYNC
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressRepositoryLogging.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressRepositoryLogging.kt
@@ -1,0 +1,54 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import android.util.Log
+
+private const val progressRepositoryLogTag: String = "ProgressRepository"
+private const val progressRepositoryLogMaxValueLength: Int = 240
+
+internal fun logProgressRepositoryWarning(
+    event: String,
+    fields: List<Pair<String, String?>>,
+    error: Throwable
+) {
+    val message = buildProgressRepositoryLogMessage(
+        event = event,
+        fields = fields
+    )
+    val didLog = runCatching {
+        Log.w(progressRepositoryLogTag, message, error)
+    }.isSuccess
+    if (didLog.not()) {
+        println("$progressRepositoryLogTag W $message")
+        println(error.stackTraceToString())
+    }
+}
+
+private fun buildProgressRepositoryLogMessage(
+    event: String,
+    fields: List<Pair<String, String?>>
+): String {
+    val renderedFields = fields.map { (key, value) ->
+        "$key=${sanitizeProgressRepositoryLogValue(value = value)}"
+    }
+
+    return if (renderedFields.isEmpty()) {
+        "event=$event"
+    } else {
+        "event=$event ${renderedFields.joinToString(separator = " ")}"
+    }
+}
+
+private fun sanitizeProgressRepositoryLogValue(
+    value: String?
+): String {
+    if (value == null) {
+        return "null"
+    }
+
+    val normalized = value.replace(oldValue = "\n", newValue = "\\n")
+    return if (normalized.length <= progressRepositoryLogMaxValueLength) {
+        normalized
+    } else {
+        normalized.take(progressRepositoryLogMaxValueLength) + "..."
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressSnapshotCalculations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressSnapshotCalculations.kt
@@ -1,0 +1,466 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import com.flashcardsopensourceapp.data.local.database.ProgressLocalCacheStateEntity
+import com.flashcardsopensourceapp.data.local.database.ProgressLocalDayCountEntity
+import com.flashcardsopensourceapp.data.local.database.ProgressReviewHistoryStateEntity
+import com.flashcardsopensourceapp.data.local.database.SyncStateEntity
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudDailyReviewPoint
+import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.ProgressSeriesScopeKey
+import com.flashcardsopensourceapp.data.local.model.ProgressSeriesSnapshot
+import com.flashcardsopensourceapp.data.local.model.ProgressSnapshotSource
+import com.flashcardsopensourceapp.data.local.model.ProgressSummaryScopeKey
+import com.flashcardsopensourceapp.data.local.model.ProgressSummarySnapshot
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+
+const val progressHistoryDayCount: Long = 140L
+
+internal fun createProgressSummaryScopeKey(
+    cloudSettings: CloudSettings,
+    today: LocalDate,
+    zoneId: ZoneId
+): ProgressSummaryScopeKey {
+    return ProgressSummaryScopeKey(
+        scopeId = createProgressScopeId(cloudSettings = cloudSettings),
+        timeZone = zoneId.id,
+        referenceLocalDate = today.toString()
+    )
+}
+
+internal fun createProgressSeriesScopeKey(
+    cloudSettings: CloudSettings,
+    today: LocalDate,
+    zoneId: ZoneId
+): ProgressSeriesScopeKey {
+    val from = today.minusDays(progressHistoryDayCount - 1L)
+    return ProgressSeriesScopeKey(
+        scopeId = createProgressScopeId(cloudSettings = cloudSettings),
+        timeZone = zoneId.id,
+        from = from.toString(),
+        to = today.toString()
+    )
+}
+
+internal fun createProgressScopeId(
+    cloudSettings: CloudSettings
+): String {
+    return when (cloudSettings.cloudState) {
+        CloudAccountState.LINKED -> "linked:${cloudSettings.linkedUserId ?: cloudSettings.installationId}"
+        CloudAccountState.GUEST -> "guest:${cloudSettings.activeWorkspaceId ?: cloudSettings.installationId}"
+        CloudAccountState.DISCONNECTED -> "local:${cloudSettings.installationId}"
+        CloudAccountState.LINKING_READY -> "linking:${cloudSettings.installationId}"
+    }
+}
+
+internal fun isProgressLocalCacheReady(
+    reviewHistoryStates: List<ProgressReviewHistoryStateEntity>,
+    localCacheStates: List<ProgressLocalCacheStateEntity>,
+    workspaceIds: List<String>,
+    timeZone: String
+): Boolean {
+    val historyStatesByWorkspaceId = reviewHistoryStates.associateBy(ProgressReviewHistoryStateEntity::workspaceId)
+    val cacheStatesByWorkspaceId = localCacheStates.filter { cacheState ->
+        cacheState.timeZone == timeZone
+    }.associateBy(ProgressLocalCacheStateEntity::workspaceId)
+
+    return workspaceIds.all { workspaceId ->
+        val historyVersion = historyStatesByWorkspaceId[workspaceId]?.historyVersion ?: 0L
+        if (historyVersion == 0L) {
+            return@all true
+        }
+
+        cacheStatesByWorkspaceId[workspaceId]?.historyVersion == historyVersion
+    }
+}
+
+internal fun createLocalFallbackSummary(
+    scopeKey: ProgressSummaryScopeKey,
+    localDayCounts: List<ProgressLocalDayCountEntity>,
+    workspaceIds: List<String>,
+    today: LocalDate
+): CloudProgressSummary {
+    val workspaceIdSet = workspaceIds.toSet()
+    val activeReviewDates = localDayCounts.filter { dayCount ->
+        dayCount.timeZone == scopeKey.timeZone &&
+            workspaceIdSet.contains(dayCount.workspaceId) &&
+            dayCount.reviewCount > 0
+    }.map(ProgressLocalDayCountEntity::localDate)
+        .distinct()
+        .sorted()
+    val activeReviewDateSet = activeReviewDates.toSet()
+    val lastReviewedOn = activeReviewDates.lastOrNull()
+    val currentStreakDays = computeCurrentStreakDays(
+        activeReviewDateSet = activeReviewDateSet,
+        today = today
+    )
+    return CloudProgressSummary(
+        currentStreakDays = currentStreakDays,
+        hasReviewedToday = activeReviewDateSet.contains(today.toString()),
+        lastReviewedOn = lastReviewedOn,
+        activeReviewDays = activeReviewDates.size
+    )
+}
+
+internal fun createLocalFallbackSeries(
+    scopeKey: ProgressSeriesScopeKey,
+    localDayCounts: List<ProgressLocalDayCountEntity>,
+    workspaceIds: List<String>
+): CloudProgressSeries {
+    val workspaceIdSet = workspaceIds.toSet()
+    val dateRange = createInclusiveLocalDateRange(
+        from = scopeKey.from,
+        to = scopeKey.to
+    )
+    val reviewCountsByDate = linkedMapOf<String, Int>()
+    dateRange.forEach { date ->
+        reviewCountsByDate[date] = 0
+    }
+    localDayCounts.forEach { dayCount ->
+        if (dayCount.timeZone != scopeKey.timeZone) {
+            return@forEach
+        }
+        if (workspaceIdSet.contains(dayCount.workspaceId).not()) {
+            return@forEach
+        }
+        if (reviewCountsByDate.containsKey(dayCount.localDate).not()) {
+            return@forEach
+        }
+        reviewCountsByDate[dayCount.localDate] = (reviewCountsByDate[dayCount.localDate] ?: 0) + dayCount.reviewCount
+    }
+
+    return CloudProgressSeries(
+        timeZone = scopeKey.timeZone,
+        from = scopeKey.from,
+        to = scopeKey.to,
+        dailyReviews = reviewCountsByDate.map { (date, reviewCount) ->
+            CloudDailyReviewPoint(
+                date = date,
+                reviewCount = reviewCount
+            )
+        },
+        generatedAt = null,
+        summary = null
+    )
+}
+
+internal fun createPendingLocalOverlaySeries(
+    scopeKey: ProgressSeriesScopeKey,
+    pendingReviewLocalDates: List<ProgressPendingReviewLocalDate>,
+    workspaceIds: List<String>
+): CloudProgressSeries {
+    val workspaceIdSet = workspaceIds.toSet()
+    val reviewCountsByDate = createInclusiveLocalDateRange(
+        from = scopeKey.from,
+        to = scopeKey.to
+    ).associateWith { 0 }.toMutableMap()
+
+    pendingReviewLocalDates.forEach { pendingReview ->
+        if (workspaceIdSet.contains(pendingReview.workspaceId).not()) {
+            return@forEach
+        }
+        if (reviewCountsByDate.containsKey(pendingReview.localDate).not()) {
+            return@forEach
+        }
+
+        reviewCountsByDate[pendingReview.localDate] = (reviewCountsByDate[pendingReview.localDate] ?: 0) + 1
+    }
+
+    return CloudProgressSeries(
+        timeZone = scopeKey.timeZone,
+        from = scopeKey.from,
+        to = scopeKey.to,
+        dailyReviews = reviewCountsByDate.map { (date, reviewCount) ->
+            CloudDailyReviewPoint(
+                date = date,
+                reviewCount = reviewCount
+            )
+        },
+        generatedAt = null,
+        summary = null
+    )
+}
+
+internal fun createProgressSummarySnapshot(
+    scopeKey: ProgressSummaryScopeKey,
+    localFallback: CloudProgressSummary,
+    serverBase: CloudProgressSummary?,
+    cloudState: CloudAccountState
+): ProgressSummarySnapshot {
+    val hasPendingLocalOverlay = serverBase?.let { base ->
+        hasProgressSummaryOverlay(
+            localFallback = localFallback,
+            serverBase = base
+        )
+    } ?: false
+    val renderedSummary = when {
+        serverBase == null -> localFallback
+        hasPendingLocalOverlay -> mergeProgressSummary(
+            base = serverBase,
+            localFallback = localFallback
+        )
+        else -> serverBase
+    }
+    val source = when {
+        serverBase == null -> ProgressSnapshotSource.LOCAL_ONLY
+        hasPendingLocalOverlay -> ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY
+        else -> ProgressSnapshotSource.SERVER_BASE
+    }
+    return ProgressSummarySnapshot(
+        scopeKey = scopeKey,
+        renderedSummary = renderedSummary,
+        localFallback = localFallback,
+        serverBase = serverBase,
+        source = source,
+        isApproximate = source == ProgressSnapshotSource.LOCAL_ONLY ||
+            hasPendingLocalOverlay ||
+            cloudState == CloudAccountState.DISCONNECTED ||
+            cloudState == CloudAccountState.LINKING_READY
+    )
+}
+
+internal fun createProgressSeriesSnapshot(
+    scopeKey: ProgressSeriesScopeKey,
+    localFallback: CloudProgressSeries,
+    serverBase: CloudProgressSeries?,
+    pendingLocalOverlay: CloudProgressSeries,
+    cloudState: CloudAccountState
+): ProgressSeriesSnapshot {
+    val hasPendingLocalOverlay = pendingLocalOverlay.dailyReviews.any { point ->
+        point.reviewCount > 0
+    }
+    val renderedSeries = if (serverBase == null) {
+        localFallback
+    } else {
+        mergeProgressSeries(
+            base = serverBase,
+            overlay = pendingLocalOverlay
+        )
+    }
+    val source = when {
+        serverBase == null -> ProgressSnapshotSource.LOCAL_ONLY
+        hasPendingLocalOverlay -> ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY
+        else -> ProgressSnapshotSource.SERVER_BASE
+    }
+    return ProgressSeriesSnapshot(
+        scopeKey = scopeKey,
+        renderedSeries = renderedSeries,
+        localFallback = localFallback,
+        serverBase = serverBase,
+        pendingLocalOverlay = pendingLocalOverlay,
+        source = source,
+        isApproximate = source == ProgressSnapshotSource.LOCAL_ONLY ||
+            hasPendingLocalOverlay ||
+            cloudState == CloudAccountState.DISCONNECTED ||
+            cloudState == CloudAccountState.LINKING_READY
+    )
+}
+
+internal fun mergeProgressSummary(
+    base: CloudProgressSummary,
+    localFallback: CloudProgressSummary
+): CloudProgressSummary {
+    return CloudProgressSummary(
+        currentStreakDays = maxOf(base.currentStreakDays, localFallback.currentStreakDays),
+        hasReviewedToday = base.hasReviewedToday || localFallback.hasReviewedToday,
+        lastReviewedOn = maxLocalDate(
+            first = base.lastReviewedOn,
+            second = localFallback.lastReviewedOn
+        ),
+        activeReviewDays = maxOf(base.activeReviewDays, localFallback.activeReviewDays)
+    )
+}
+
+internal fun mergeProgressSeries(
+    base: CloudProgressSeries,
+    overlay: CloudProgressSeries
+): CloudProgressSeries {
+    val overlayCountsByDate = overlay.dailyReviews.associate { point ->
+        point.date to point.reviewCount
+    }
+    val mergedDailyReviews = base.dailyReviews.map { point ->
+        CloudDailyReviewPoint(
+            date = point.date,
+            reviewCount = point.reviewCount + (overlayCountsByDate[point.date] ?: 0)
+        )
+    }
+    return CloudProgressSeries(
+        timeZone = base.timeZone,
+        from = base.from,
+        to = base.to,
+        dailyReviews = mergedDailyReviews,
+        generatedAt = base.generatedAt,
+        summary = null
+    )
+}
+
+internal fun createReviewHistoryFingerprint(
+    reviewHistoryStates: List<ProgressReviewHistoryStateEntity>,
+    pendingReviewEntries: List<ProgressPendingReviewFingerprintEntry>,
+    syncStates: List<SyncStateEntity>,
+    workspaceIds: List<String>
+): String {
+    val workspaceIdSet = workspaceIds.toSet()
+    val relevantHistoryStates = reviewHistoryStates.filter { historyState ->
+        workspaceIdSet.contains(historyState.workspaceId)
+    }.sortedBy(ProgressReviewHistoryStateEntity::workspaceId)
+    val relevantPendingReviewEntries = pendingReviewEntries.filter { entry ->
+        workspaceIdSet.contains(entry.workspaceId)
+    }
+    val relevantSyncStates = syncStates.filter { syncState ->
+        workspaceIdSet.contains(syncState.workspaceId)
+    }.sortedBy(SyncStateEntity::workspaceId)
+
+    val historyFingerprint = relevantHistoryStates.joinToString(separator = "|") { historyState ->
+        "${historyState.workspaceId}:${historyState.historyVersion}"
+    }
+    val pendingReviewIds = relevantPendingReviewEntries.map(ProgressPendingReviewFingerprintEntry::outboxEntryId).sorted()
+    val reviewSequenceFingerprint = relevantSyncStates.joinToString(separator = "|") { syncState ->
+        "${syncState.workspaceId}:${syncState.lastReviewSequenceId}"
+    }
+    return "$historyFingerprint:${pendingReviewIds.joinToString(separator = ",")}:$reviewSequenceFingerprint"
+}
+
+internal fun didSyncCompleteWithReviewHistoryChange(
+    previousSuccessfulSyncAtMillis: Long?,
+    currentSuccessfulSyncAtMillis: Long?,
+    previousReviewHistoryFingerprint: String?,
+    currentReviewHistoryFingerprint: String
+): Boolean {
+    if (previousReviewHistoryFingerprint == null) {
+        return false
+    }
+    if (currentSuccessfulSyncAtMillis == null || currentSuccessfulSyncAtMillis == previousSuccessfulSyncAtMillis) {
+        return false
+    }
+
+    return previousReviewHistoryFingerprint != currentReviewHistoryFingerprint
+}
+
+internal fun serializeProgressSummaryScopeKey(
+    scopeKey: ProgressSummaryScopeKey
+): String {
+    return "${scopeKey.scopeId}::${scopeKey.timeZone}::${scopeKey.referenceLocalDate}"
+}
+
+internal fun serializeProgressSeriesScopeKey(
+    scopeKey: ProgressSeriesScopeKey
+): String {
+    return "${scopeKey.scopeId}::${scopeKey.timeZone}::${scopeKey.from}::${scopeKey.to}"
+}
+
+internal fun parseLocalDate(
+    rawDate: String
+): LocalDate {
+    return try {
+        LocalDate.parse(rawDate)
+    } catch (error: DateTimeParseException) {
+        throw IllegalArgumentException("Invalid local date '$rawDate'.", error)
+    }
+}
+
+internal fun createEmptyProgressSummary(): CloudProgressSummary {
+    return CloudProgressSummary(
+        currentStreakDays = 0,
+        hasReviewedToday = false,
+        lastReviewedOn = null,
+        activeReviewDays = 0
+    )
+}
+
+internal fun createEmptyProgressSeries(
+    scopeKey: ProgressSeriesScopeKey
+): CloudProgressSeries {
+    return CloudProgressSeries(
+        timeZone = scopeKey.timeZone,
+        from = scopeKey.from,
+        to = scopeKey.to,
+        dailyReviews = createInclusiveLocalDateRange(
+            from = scopeKey.from,
+            to = scopeKey.to
+        ).map { date ->
+            CloudDailyReviewPoint(
+                date = date,
+                reviewCount = 0
+            )
+        },
+        generatedAt = null,
+        summary = null
+    )
+}
+
+private fun createInclusiveLocalDateRange(
+    from: String,
+    to: String
+): List<String> {
+    val startDate = parseLocalDate(rawDate = from)
+    val endDate = parseLocalDate(rawDate = to)
+    val dates = mutableListOf<String>()
+    var currentDate = startDate
+
+    while (currentDate <= endDate) {
+        dates.add(currentDate.toString())
+        currentDate = currentDate.plusDays(1L)
+    }
+
+    return dates
+}
+
+private fun computeCurrentStreakDays(
+    activeReviewDateSet: Set<String>,
+    today: LocalDate
+): Int {
+    val anchorDate: LocalDate = when {
+        activeReviewDateSet.contains(today.toString()) -> today
+        activeReviewDateSet.contains(today.minusDays(1L).toString()) -> today.minusDays(1L)
+        else -> return 0
+    }
+
+    var streakDays = 0
+    var currentDate = anchorDate
+    while (activeReviewDateSet.contains(currentDate.toString())) {
+        streakDays += 1
+        currentDate = currentDate.minusDays(1L)
+    }
+    return streakDays
+}
+
+private fun hasProgressSummaryOverlay(
+    localFallback: CloudProgressSummary,
+    serverBase: CloudProgressSummary
+): Boolean {
+    return localFallback.currentStreakDays > serverBase.currentStreakDays ||
+        (localFallback.hasReviewedToday && serverBase.hasReviewedToday.not()) ||
+        isLocalDateAfter(
+            first = localFallback.lastReviewedOn,
+            second = serverBase.lastReviewedOn
+        ) ||
+        localFallback.activeReviewDays > serverBase.activeReviewDays
+}
+
+private fun isLocalDateAfter(
+    first: String?,
+    second: String?
+): Boolean {
+    return when {
+        first == null -> false
+        second == null -> true
+        else -> parseLocalDate(rawDate = first).isAfter(parseLocalDate(rawDate = second))
+    }
+}
+
+private fun maxLocalDate(
+    first: String?,
+    second: String?
+): String? {
+    return when {
+        first == null -> second
+        second == null -> first
+        parseLocalDate(rawDate = first).isAfter(parseLocalDate(rawDate = second)) -> first
+        else -> second
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressStoreState.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressStoreState.kt
@@ -1,0 +1,127 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import com.flashcardsopensourceapp.data.local.database.ProgressLocalDayCountEntity
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.ProgressSeriesScopeKey
+import com.flashcardsopensourceapp.data.local.model.ProgressSeriesSnapshot
+import com.flashcardsopensourceapp.data.local.model.ProgressSummaryScopeKey
+import com.flashcardsopensourceapp.data.local.model.ProgressSummarySnapshot
+import com.flashcardsopensourceapp.data.local.model.SyncStatusSnapshot
+import java.time.LocalDate
+
+internal data class ProgressSummaryStoreInputs(
+    val scopeKey: ProgressSummaryScopeKey,
+    val cloudState: CloudAccountState,
+    val workspaceIds: List<String>,
+    val localDayCounts: List<ProgressLocalDayCountEntity>,
+    val isLocalCacheReady: Boolean,
+    val serverBase: CloudProgressSummary?,
+    val reviewHistoryFingerprint: String,
+    val syncStatus: SyncStatusSnapshot,
+    val today: LocalDate
+)
+
+internal data class ProgressSeriesStoreInputs(
+    val scopeKey: ProgressSeriesScopeKey,
+    val cloudState: CloudAccountState,
+    val workspaceIds: List<String>,
+    val localDayCounts: List<ProgressLocalDayCountEntity>,
+    val isLocalCacheReady: Boolean,
+    val serverBase: CloudProgressSeries?,
+    val pendingReviewLocalDates: List<ProgressPendingReviewLocalDate>,
+    val reviewHistoryFingerprint: String,
+    val syncStatus: SyncStatusSnapshot
+)
+
+internal data class ProgressSummaryStoreState(
+    val scopeKey: ProgressSummaryScopeKey,
+    val cloudState: CloudAccountState,
+    val snapshot: ProgressSummarySnapshot?,
+    val isLocalCacheReady: Boolean,
+    val reviewHistoryFingerprint: String,
+    val syncStatus: SyncStatusSnapshot
+)
+
+internal data class ProgressSeriesStoreState(
+    val scopeKey: ProgressSeriesScopeKey,
+    val cloudState: CloudAccountState,
+    val snapshot: ProgressSeriesSnapshot?,
+    val isLocalCacheReady: Boolean,
+    val reviewHistoryFingerprint: String,
+    val syncStatus: SyncStatusSnapshot
+)
+
+internal fun createProgressSummaryStoreState(
+    inputs: ProgressSummaryStoreInputs
+): ProgressSummaryStoreState {
+    val localFallback = if (inputs.isLocalCacheReady) {
+        createLocalFallbackSummary(
+            scopeKey = inputs.scopeKey,
+            localDayCounts = inputs.localDayCounts,
+            workspaceIds = inputs.workspaceIds,
+            today = inputs.today
+        )
+    } else {
+        createEmptyProgressSummary()
+    }
+    return ProgressSummaryStoreState(
+        scopeKey = inputs.scopeKey,
+        cloudState = inputs.cloudState,
+        snapshot = if (inputs.isLocalCacheReady) {
+            createProgressSummarySnapshot(
+                scopeKey = inputs.scopeKey,
+                localFallback = localFallback,
+                serverBase = inputs.serverBase,
+                cloudState = inputs.cloudState
+            )
+        } else {
+            null
+        },
+        isLocalCacheReady = inputs.isLocalCacheReady,
+        reviewHistoryFingerprint = inputs.reviewHistoryFingerprint,
+        syncStatus = inputs.syncStatus
+    )
+}
+
+internal fun createProgressSeriesStoreState(
+    inputs: ProgressSeriesStoreInputs
+): ProgressSeriesStoreState {
+    val localFallback = if (inputs.isLocalCacheReady) {
+        createLocalFallbackSeries(
+            scopeKey = inputs.scopeKey,
+            localDayCounts = inputs.localDayCounts,
+            workspaceIds = inputs.workspaceIds
+        )
+    } else {
+        createEmptyProgressSeries(scopeKey = inputs.scopeKey)
+    }
+    val pendingLocalOverlay = if (inputs.isLocalCacheReady) {
+        createPendingLocalOverlaySeries(
+            scopeKey = inputs.scopeKey,
+            pendingReviewLocalDates = inputs.pendingReviewLocalDates,
+            workspaceIds = inputs.workspaceIds
+        )
+    } else {
+        createEmptyProgressSeries(scopeKey = inputs.scopeKey)
+    }
+    return ProgressSeriesStoreState(
+        scopeKey = inputs.scopeKey,
+        cloudState = inputs.cloudState,
+        snapshot = if (inputs.isLocalCacheReady) {
+            createProgressSeriesSnapshot(
+                scopeKey = inputs.scopeKey,
+                localFallback = localFallback,
+                serverBase = inputs.serverBase,
+                pendingLocalOverlay = pendingLocalOverlay,
+                cloudState = inputs.cloudState
+            )
+        } else {
+            null
+        },
+        isLocalCacheReady = inputs.isLocalCacheReady,
+        reviewHistoryFingerprint = inputs.reviewHistoryFingerprint,
+        syncStatus = inputs.syncStatus
+    )
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressTimeProvider.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressTimeProvider.kt
@@ -1,0 +1,40 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+interface ProgressTimeProvider {
+    fun currentZoneId(): ZoneId
+    fun currentTimeMillis(): Long
+}
+
+object SystemProgressTimeProvider : ProgressTimeProvider {
+    override fun currentZoneId(): ZoneId {
+        return ZoneId.systemDefault()
+    }
+
+    override fun currentTimeMillis(): Long {
+        return System.currentTimeMillis()
+    }
+}
+
+internal data class ProgressClockSnapshot(
+    val zoneId: ZoneId,
+    val currentTimeMillis: Long,
+    val today: LocalDate
+)
+
+internal fun createProgressClockSnapshot(
+    timeProvider: ProgressTimeProvider
+): ProgressClockSnapshot {
+    val zoneId = timeProvider.currentZoneId()
+    val currentTimeMillis = timeProvider.currentTimeMillis()
+    return ProgressClockSnapshot(
+        zoneId = zoneId,
+        currentTimeMillis = currentTimeMillis,
+        today = Instant.ofEpochMilli(currentTimeMillis)
+            .atZone(zoneId)
+            .toLocalDate()
+    )
+}

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepositoryTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepositoryTest.kt
@@ -157,7 +157,7 @@ class LocalProgressRepositoryTest {
             serverBase = null,
             pendingLocalOverlay = createPendingLocalOverlaySeries(
                 scopeKey = scopeKey,
-                pendingReviewOutboxEntries = emptyList(),
+                pendingReviewLocalDates = emptyList(),
                 workspaceIds = listOf("workspace-1")
             ),
             cloudState = CloudAccountState.DISCONNECTED
@@ -212,12 +212,16 @@ class LocalProgressRepositoryTest {
 
         val overlay = createPendingLocalOverlaySeries(
             scopeKey = scopeKey,
-            pendingReviewOutboxEntries = listOf(
-                createPendingReviewOutboxEntry(
-                    workspaceId = "workspace-1",
-                    outboxEntryId = "outbox-1",
-                    reviewedAtClient = "2026-04-18T10:00:00Z"
-                )
+            pendingReviewLocalDates = createProgressPendingReviewLocalDates(
+                pendingReviewOutboxEntries = listOf(
+                    createPendingReviewOutboxEntry(
+                        workspaceId = "workspace-1",
+                        outboxEntryId = "outbox-1",
+                        reviewedAtClient = "2026-04-18T10:00:00Z"
+                    )
+                ),
+                workspaceIds = listOf("workspace-1"),
+                timeZone = scopeKey.timeZone
             ),
             workspaceIds = listOf("workspace-1")
         )
@@ -267,8 +271,11 @@ class LocalProgressRepositoryTest {
                     historyVersion = 3L
                 )
             ),
-            pendingReviewOutboxEntries = listOf(
-                createPendingReviewOutboxEntry(workspaceId = "workspace-1", outboxEntryId = "outbox-1")
+            pendingReviewEntries = listOf(
+                ProgressPendingReviewFingerprintEntry(
+                    workspaceId = "workspace-1",
+                    outboxEntryId = "outbox-1"
+                )
             ),
             syncStates = listOf(
                 SyncStateEntity(
@@ -340,29 +347,29 @@ class LocalProgressRepositoryTest {
 
         val initialRefreshStarted = coordinator.beginRefresh(
             scopeKey = "scope-1",
-            requiresSyncBeforeRemoteLoad = false
+            syncMode = ProgressRemoteRefreshSyncMode.SKIP_SYNC
         )
         val overlappingRefreshStarted = coordinator.beginRefresh(
             scopeKey = "scope-1",
-            requiresSyncBeforeRemoteLoad = false
+            syncMode = ProgressRemoteRefreshSyncMode.SKIP_SYNC
         )
-        val queuedRequiresSyncBeforeRemoteLoad = coordinator.completeRefreshIteration(scopeKey = "scope-1")
+        val queuedSyncMode = coordinator.completeRefreshIteration(scopeKey = "scope-1")
         val thirdRefreshStarted = coordinator.beginRefresh(
             scopeKey = "scope-1",
-            requiresSyncBeforeRemoteLoad = false
+            syncMode = ProgressRemoteRefreshSyncMode.SKIP_SYNC
         )
         val queuedRetryFromThirdRequest = coordinator.completeRefreshIteration(scopeKey = "scope-1")
         val noFurtherRetryQueued = coordinator.completeRefreshIteration(scopeKey = "scope-1")
         val nextIndependentRefreshStarted = coordinator.beginRefresh(
             scopeKey = "scope-1",
-            requiresSyncBeforeRemoteLoad = false
+            syncMode = ProgressRemoteRefreshSyncMode.SKIP_SYNC
         )
 
         assertTrue(initialRefreshStarted)
         assertFalse(overlappingRefreshStarted)
-        assertEquals(false, queuedRequiresSyncBeforeRemoteLoad)
+        assertEquals(ProgressRemoteRefreshSyncMode.SKIP_SYNC, queuedSyncMode)
         assertFalse(thirdRefreshStarted)
-        assertEquals(false, queuedRetryFromThirdRequest)
+        assertEquals(ProgressRemoteRefreshSyncMode.SKIP_SYNC, queuedRetryFromThirdRequest)
         assertEquals(null, noFurtherRetryQueued)
         assertTrue(nextIndependentRefreshStarted)
     }
@@ -373,23 +380,23 @@ class LocalProgressRepositoryTest {
 
         val initialRefreshStarted = coordinator.beginRefresh(
             scopeKey = "scope-1",
-            requiresSyncBeforeRemoteLoad = false
+            syncMode = ProgressRemoteRefreshSyncMode.SKIP_SYNC
         )
         val syncCompletedRefreshStarted = coordinator.beginRefresh(
             scopeKey = "scope-1",
-            requiresSyncBeforeRemoteLoad = false
+            syncMode = ProgressRemoteRefreshSyncMode.SKIP_SYNC
         )
         val manualRefreshStarted = coordinator.beginRefresh(
             scopeKey = "scope-1",
-            requiresSyncBeforeRemoteLoad = true
+            syncMode = ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD
         )
-        val queuedRequiresSyncBeforeRemoteLoad = coordinator.completeRefreshIteration(scopeKey = "scope-1")
+        val queuedSyncMode = coordinator.completeRefreshIteration(scopeKey = "scope-1")
         val finalQueuedRefresh = coordinator.completeRefreshIteration(scopeKey = "scope-1")
 
         assertTrue(initialRefreshStarted)
         assertFalse(syncCompletedRefreshStarted)
         assertFalse(manualRefreshStarted)
-        assertEquals(true, queuedRequiresSyncBeforeRemoteLoad)
+        assertEquals(ProgressRemoteRefreshSyncMode.SYNC_BEFORE_REMOTE_LOAD, queuedSyncMode)
         assertEquals(null, finalQueuedRefresh)
     }
 
@@ -436,17 +443,21 @@ class LocalProgressRepositoryTest {
 
         val overlay = createPendingLocalOverlaySeries(
             scopeKey = scopeKey,
-            pendingReviewOutboxEntries = listOf(
-                createPendingReviewOutboxEntry(
-                    workspaceId = "workspace-1",
-                    outboxEntryId = "outbox-valid",
-                    reviewedAtClient = "2026-04-18T10:00:00Z"
+            pendingReviewLocalDates = createProgressPendingReviewLocalDates(
+                pendingReviewOutboxEntries = listOf(
+                    createPendingReviewOutboxEntry(
+                        workspaceId = "workspace-1",
+                        outboxEntryId = "outbox-valid",
+                        reviewedAtClient = "2026-04-18T10:00:00Z"
+                    ),
+                    createPendingReviewOutboxEntry(
+                        workspaceId = "workspace-1",
+                        outboxEntryId = "outbox-invalid",
+                        reviewedAtClient = "not-an-instant"
+                    )
                 ),
-                createPendingReviewOutboxEntry(
-                    workspaceId = "workspace-1",
-                    outboxEntryId = "outbox-invalid",
-                    reviewedAtClient = "not-an-instant"
-                )
+                workspaceIds = listOf("workspace-1"),
+                timeZone = scopeKey.timeZone
             ),
             workspaceIds = listOf("workspace-1")
         )


### PR DESCRIPTION
## Summary
- split LocalProgressRepository into orchestration plus focused progress helpers
- keep progress flow DTOs private to repository orchestration
- keep snapshot calculations pure by decoding pending outbox review dates before calculation

## Validation
- ./gradlew :data:local:testDebugUnitTest --tests com.flashcardsopensourceapp.data.local.repository.LocalProgressRepositoryTest
- ./gradlew :feature:progress:testDebugUnitTest
- ./gradlew :app:testDebugUnitTest --tests com.flashcardsopensourceapp.app.ProgressContextRefreshControllerTest
- git --no-pager diff --check
- git --no-pager diff --cached --check

## Notes
- behavior-preserving structural refactor
- no public API, Room schema, DAO, entity, ViewModel, or UI contract changes