### PR TITLE
[codex] Refine web progress bar corners

### DIFF
--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -276,7 +276,7 @@
 .progress-chart-bar {
   width: 100%;
   height: 0;
-  border-radius: 999px 999px 8px 8px;
+  border-radius: var(--radius-sm) var(--radius-sm) 4px 4px;
   background: rgba(255, 255, 255, 0.12);
   transition: height 180ms ease;
 }


### PR DESCRIPTION
## Summary
- Reduce the web Progress chart bar corner radius so bars stay rounded without looking pill-shaped.
- Keep chart layout, colors, labels, data logic, and non-web clients unchanged.

## Validation
- npm run build in apps/web passed after installing local dependencies.
- Subagent review approved web progress changes with targeted Vitest: npx vitest run src/appData/progressSource.test.tsx src/screens/ProgressScreen.render.test.tsx, 18 tests passed.
- Browser CSS check confirmed computed chart bar radius is 10px 10px 4px 4px at desktop and mobile widths.
