### PR TITLE
[codex] Fix settings switcher stretch

### DIFF
--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -5,11 +5,13 @@
 
 .settings-panel {
   max-width: 980px;
+  align-content: start;
 }
 
 .settings-switcher {
   display: flex;
   gap: 8px;
+  align-items: center;
   max-width: 100%;
   margin-bottom: 20px;
   padding: 6px;


### PR DESCRIPTION
## Summary
Fix the web Settings panel layout so extra min-height space is not distributed into the tab switcher rows.

## Root cause
The settings panel inherits grid layout from `.panel`; when the chat layout gives the panel a minimum height, CSS Grid can distribute extra height across auto rows and stretch the settings switcher.

## Changes
- Keep settings panel content aligned to the top with `align-content: start`.
- Center settings switcher flex items vertically with `align-items: center` so active pills do not stretch.

## Validation
- `npm run build` in `apps/web` passed after `npm ci`.
- Subagent review approved the change with no findings.
- `git diff --check` passed in subagent review.