### PR TITLE
Update marketing screenshot generators

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -70,8 +70,9 @@ If Google already provides a supported solution, use it unless there is a concre
 The Android app should mirror the current top-level product structure:
 
 - Review
-- Cards
+- Progress
 - AI
+- Cards
 - Settings
 
 The goal is a working Android app that can run in an emulator and on-device while staying aligned with the shared product contract.
@@ -90,10 +91,10 @@ Run commands from `apps/android/`.
 
 - Add a new app language safely: [`docs/add-language-checklist.md`](docs/add-language-checklist.md)
 - Run Android marketing screenshot captures reliably: [`docs/marketing-screenshot-runbook.md`](docs/marketing-screenshot-runbook.md)
-- Track current Android marketing screenshot inventory: [`docs/marketing-screenshots.md`](docs/marketing-screenshots.md)
+- Track Android marketing screenshot generator inventory: [`docs/marketing-screenshots.md`](docs/marketing-screenshots.md)
 
 The marketing screenshot docs cover locale-prefixed runs as well.
-The current wrapper layout is one combined review-chain flow for screenshots 1, 2, and 4, plus a separate cards flow for screenshot 3.
+The current wrapper layout is one combined review-chain flow for screenshots 1, 2, and 4, plus separate Progress and Cards flows for screenshots 3 and 5.
 Use them when adding or validating multi-language Play screenshot content.
 
 ## Localization Rule

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingCardsScreenshotScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingCardsScreenshotScript.kt
@@ -32,7 +32,7 @@ class MarketingCardsScreenshotScript {
         )
         val cardsScreenshotFileName = marketingScreenshotFileName(
             localeConfig = localeConfig,
-            screenshotIndex = 3,
+            screenshotIndex = 5,
             screenshotSlug = cardsScreenshotSlug
         )
 

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingProgressScreenshotScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingProgressScreenshotScript.kt
@@ -1,0 +1,46 @@
+package com.flashcardsopensourceapp.app
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+
+private const val progressScreenshotSlug: String = "progress-google-play-study-history"
+
+@ManualOnlyAndroidTest
+@RunWith(AndroidJUnit4::class)
+class MarketingProgressScreenshotScript {
+    private val appStateResetRule = AppStateResetRule()
+    private val composeRule = createMarketingScreenshotComposeRule()
+
+    @get:Rule
+    val ruleChain: TestRule = RuleChain
+        .outerRule(appStateResetRule)
+        .around(composeRule)
+
+    @Test
+    fun generateStudyHistoryProgressScreenshot() {
+        val localeConfig = activeMarketingScreenshotLocaleConfig()
+        val robot = MarketingScreenshotRobot(
+            composeRule = composeRule,
+            localeConfig = localeConfig
+        )
+        val progressScreenshotFileName = marketingScreenshotFileName(
+            localeConfig = localeConfig,
+            screenshotIndex = 3,
+            screenshotSlug = progressScreenshotSlug
+        )
+
+        robot.prepareStudyHistoryProgressScreen()
+
+        val screenshotPath = robot.saveScreenshot(fileName = progressScreenshotFileName)
+        val screenshotListing = robot.runShellCommand(command = "ls $screenshotPath")
+        assertTrue(
+            "Expected screenshot file at $screenshotPath.",
+            screenshotListing.contains(progressScreenshotFileName)
+        )
+    }
+}

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt
@@ -30,13 +30,14 @@ import androidx.test.uiautomator.UiDevice
 import com.flashcardsopensourceapp.app.livesmoke.dismissBlockingSystemDialogIfPresent
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
+import com.flashcardsopensourceapp.app.navigation.ProgressDestination
 import com.flashcardsopensourceapp.app.navigation.ReviewDestination
+import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.feature.ai.R as AiFeatureR
 import com.flashcardsopensourceapp.feature.ai.aiComposerMessageFieldTag
 import com.flashcardsopensourceapp.feature.ai.aiComposerPendingAttachmentTag
 import com.flashcardsopensourceapp.feature.ai.aiComposerSendButtonTag
 import com.flashcardsopensourceapp.feature.ai.aiConversationSurfaceTag
-import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.feature.cards.cardEditorBackSummaryCardTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorBackTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorEffortLevelTag
@@ -49,6 +50,10 @@ import com.flashcardsopensourceapp.feature.cards.cardTagsInputFieldTag
 import com.flashcardsopensourceapp.feature.cards.cardsAddCardButtonTag
 import com.flashcardsopensourceapp.feature.cards.cardsEmptyStateTag
 import com.flashcardsopensourceapp.feature.cards.cardsSearchFieldTag
+import com.flashcardsopensourceapp.feature.progress.progressReviewsActivityChartTag
+import com.flashcardsopensourceapp.feature.progress.progressReviewsSectionTag
+import com.flashcardsopensourceapp.feature.progress.progressStreakSectionTag
+import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag
 import com.flashcardsopensourceapp.feature.review.reviewRateAgainButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateEasyButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateGoodButtonTag
@@ -65,6 +70,7 @@ import org.junit.runners.model.Statement
 private const val screenshotUiTimeoutMillis: Long = 10_000L
 private const val aiScreenshotUiTimeoutMillis: Long = 30_000L
 private const val aiAttachmentUiTimeoutMillis: Long = 60_000L
+private const val progressScreenshotUiTimeoutMillis: Long = 30_000L
 private const val marketingScreenshotDirectoryPath: String = "/sdcard/Download/flashcards-marketing-screenshots"
 
 internal typealias MainActivityComposeRule =
@@ -225,6 +231,14 @@ internal class MarketingScreenshotRobot(
         composeRule.onNodeWithTag(reviewRateGoodButtonTag).fetchSemanticsNode()
     }
 
+    fun prepareStudyHistoryProgressScreen() {
+        prepareOpportunityCostReviewCardForReview()
+        revealAnswerAndWaitForRatings()
+        rateGoodAndWaitForReviewCompletion()
+        openProgressTab()
+        waitForLoadedProgressWithReviewActivity()
+    }
+
     fun openAiFromRevealedOpportunityCostCardAndPrepareDraft(draftText: String) {
         ensureLocaleApplied()
         val consentTitle = composeRule.activity.getString(AiFeatureR.string.ai_consent_title)
@@ -280,6 +294,10 @@ internal class MarketingScreenshotRobot(
 
     private fun openAiTab() {
         clickTag(tag = AiDestination.testTag)
+    }
+
+    private fun openProgressTab() {
+        clickTag(tag = ProgressDestination.testTag)
     }
 
     private fun ensureLocaleApplied() {
@@ -350,6 +368,21 @@ internal class MarketingScreenshotRobot(
         waitUntilWithSystemDialogMitigation {
             composeRule.onAllNodesWithText(frontText).fetchSemanticsNodes().isNotEmpty() &&
                 composeRule.onAllNodesWithTag(reviewShowAnswerButtonTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun rateGoodAndWaitForReviewCompletion() {
+        clickTag(tag = reviewRateGoodButtonTag)
+        waitUntilWithSystemDialogMitigation {
+            composeRule.onAllNodesWithTag(reviewEmptyStateTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun waitForLoadedProgressWithReviewActivity() {
+        waitUntilWithSystemDialogMitigation(timeoutMillis = progressScreenshotUiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(progressStreakSectionTag).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(progressReviewsSectionTag).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(progressReviewsActivityChartTag).fetchSemanticsNodes().isNotEmpty()
         }
     }
 

--- a/apps/android/app/src/marketingScreenshot/res/values-ar/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ar/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">المراجعة</string>
+    <string name="top_level_progress">التقدم</string>
     <string name="top_level_cards">البطاقات</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">الإعدادات</string>
+
+    <string name="progress_title">التقدم</string>
+    <string name="progress_streak_title">السلسلة</string>
+    <string name="progress_streak_subtitle">آخر 5 أسابيع</string>
+    <string name="progress_reviews_title">المراجعات</string>
 
     <string name="cards_title">البطاقات</string>
     <string name="cards_add_card_content_description">إضافة بطاقة</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-b+es+419/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-b+es+419/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">Repasar</string>
+    <string name="top_level_progress">Progreso</string>
     <string name="top_level_cards">Tarjetas</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">Ajustes</string>
+
+    <string name="progress_title">Progreso</string>
+    <string name="progress_streak_title">Racha</string>
+    <string name="progress_streak_subtitle">Últimas 5 semanas</string>
+    <string name="progress_reviews_title">Repasos</string>
 
     <string name="cards_title">Tarjetas</string>
     <string name="cards_add_card_content_description">Agregar tarjeta</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-de-rDE/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-de-rDE/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">Wiederholen</string>
+    <string name="top_level_progress">Fortschritt</string>
     <string name="top_level_cards">Karten</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">Einstellungen</string>
+
+    <string name="progress_title">Fortschritt</string>
+    <string name="progress_streak_title">Serie</string>
+    <string name="progress_streak_subtitle">Letzte 5 Wochen</string>
+    <string name="progress_reviews_title">Wiederholungen</string>
 
     <string name="cards_title">Karten</string>
     <string name="cards_add_card_content_description">Karte hinzufügen</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-es-rES/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-es-rES/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">Repasar</string>
+    <string name="top_level_progress">Progreso</string>
     <string name="top_level_cards">Tarjetas</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">Ajustes</string>
+
+    <string name="progress_title">Progreso</string>
+    <string name="progress_streak_title">Racha</string>
+    <string name="progress_streak_subtitle">Últimas 5 semanas</string>
+    <string name="progress_reviews_title">Repasos</string>
 
     <string name="cards_title">Tarjetas</string>
     <string name="cards_add_card_content_description">Añadir tarjeta</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-es-rUS/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-es-rUS/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">Repasar</string>
+    <string name="top_level_progress">Progreso</string>
     <string name="top_level_cards">Tarjetas</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">Ajustes</string>
+
+    <string name="progress_title">Progreso</string>
+    <string name="progress_streak_title">Racha</string>
+    <string name="progress_streak_subtitle">Últimas 5 semanas</string>
+    <string name="progress_reviews_title">Repasos</string>
 
     <string name="cards_title">Tarjetas</string>
     <string name="cards_add_card_content_description">Agregar tarjeta</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-hi-rIN/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-hi-rIN/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">पुनरावलोकन</string>
+    <string name="top_level_progress">प्रगति</string>
     <string name="top_level_cards">कार्ड</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">सेटिंग्स</string>
+
+    <string name="progress_title">प्रगति</string>
+    <string name="progress_streak_title">सिलसिला</string>
+    <string name="progress_streak_subtitle">पिछले 5 सप्ताह</string>
+    <string name="progress_reviews_title">पुनरावलोकन</string>
 
     <string name="cards_title">कार्ड</string>
     <string name="cards_add_card_content_description">कार्ड जोड़ें</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-ja-rJP/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ja-rJP/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">復習</string>
+    <string name="top_level_progress">進捗</string>
     <string name="top_level_cards">カード</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">設定</string>
+
+    <string name="progress_title">進捗</string>
+    <string name="progress_streak_title">継続記録</string>
+    <string name="progress_streak_subtitle">過去5週間</string>
+    <string name="progress_reviews_title">復習</string>
 
     <string name="cards_title">カード</string>
     <string name="cards_add_card_content_description">カードを追加</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-ru-rRU/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ru-rRU/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">Повторение</string>
+    <string name="top_level_progress">Прогресс</string>
     <string name="top_level_cards">Карточки</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">Настройки</string>
+
+    <string name="progress_title">Прогресс</string>
+    <string name="progress_streak_title">Серия</string>
+    <string name="progress_streak_subtitle">Последние 5 недель</string>
+    <string name="progress_reviews_title">Повторения</string>
 
     <string name="cards_title">Карточки</string>
     <string name="cards_add_card_content_description">Добавить карточку</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-zh-rCN/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">复习</string>
+    <string name="top_level_progress">进度</string>
     <string name="top_level_cards">卡片</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">设置</string>
+
+    <string name="progress_title">进度</string>
+    <string name="progress_streak_title">连续记录</string>
+    <string name="progress_streak_subtitle">最近 5 周</string>
+    <string name="progress_reviews_title">复习</string>
 
     <string name="cards_title">卡片</string>
     <string name="cards_add_card_content_description">添加卡片</string>

--- a/apps/android/app/src/marketingScreenshot/res/values/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values/strings.xml
@@ -1,8 +1,14 @@
 <resources>
     <string name="top_level_review">Review</string>
+    <string name="top_level_progress">Progress</string>
     <string name="top_level_cards">Cards</string>
     <string name="top_level_ai">AI</string>
     <string name="top_level_settings">Settings</string>
+
+    <string name="progress_title">Progress</string>
+    <string name="progress_streak_title">Streak</string>
+    <string name="progress_streak_subtitle">Last 5 weeks</string>
+    <string name="progress_reviews_title">Reviews</string>
 
     <string name="cards_title">Cards</string>
     <string name="cards_add_card_content_description">Add card</string>

--- a/apps/android/docs/marketing-screenshot-runbook.md
+++ b/apps/android/docs/marketing-screenshot-runbook.md
@@ -2,7 +2,7 @@
 
 This document explains how to run the manual Android marketing screenshot flows reliably on a local machine.
 
-Use this runbook when you want to regenerate one or more committed Play Store screenshots from the Android app.
+Use this runbook when you want to regenerate one or more Play Store screenshots from the Android app and then review them before committing the resulting PNGs.
 
 ## Goal
 
@@ -18,6 +18,7 @@ Run these commands from the repository root:
 
 ```bash
 bash scripts/capture-android-review-screenshot.sh
+bash scripts/capture-android-progress-screenshot.sh
 bash scripts/capture-android-cards-screenshot.sh
 ```
 
@@ -45,12 +46,15 @@ The currently configured screenshot locale prefixes are:
 
 Today the default remains `en`.
 
-The current output files are:
+After the wrapper scripts run, the expected generated output files are:
 
 - `apps/android/docs/media/play-store-screenshots/en-1_review-card-front-google-play-opportunity-cost.png`
 - `apps/android/docs/media/play-store-screenshots/en-2_review-card-result-google-play-opportunity-cost.png`
-- `apps/android/docs/media/play-store-screenshots/en-3_cards-list-google-play-vocabulary.png`
+- `apps/android/docs/media/play-store-screenshots/en-3_progress-google-play-study-history.png`
 - `apps/android/docs/media/play-store-screenshots/en-4_review-card-ai-draft-google-play-opportunity-cost.png`
+- `apps/android/docs/media/play-store-screenshots/en-5_cards-list-google-play-vocabulary.png`
+
+Existing repository media can still contain the previous four-shot assets until these generators are run and the new output PNGs are reviewed.
 
 ## Reliable local process
 
@@ -133,7 +137,9 @@ The screenshot capture step now explicitly collapses the Android status bar befo
 That prevents an already-open notification shade from being captured on top of an otherwise-correct app screen.
 
 The review wrapper runs one combined review-chain entrypoint and pulls screenshots 1, 2, and 4 from the same instrumentation run.
-The cards wrapper remains separate because screenshot 3 uses a different app setup flow.
+The progress wrapper runs a separate Progress entrypoint and pulls screenshot 3.
+The cards wrapper remains separate because screenshot 5 uses a different app setup flow.
+Run these wrappers sequentially; do not start the next wrapper until the previous one has exited and pulled its PNG files.
 
 The locale-specific card texts, AI draft texts, file-name prefixes, and UI labels used by these screenshot flows are defined in `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotCatalog.kt`.
 

--- a/apps/android/docs/marketing-screenshots.md
+++ b/apps/android/docs/marketing-screenshots.md
@@ -9,7 +9,8 @@ Screenshot-only translated app resources belong in `apps/android/app/src/marketi
 
 ## Current inventory
 
-There are currently two Android manual capture flows and four tracked output PNG targets.
+There are currently three Android manual capture flows and five expected generated output PNG targets.
+Existing repository media can still contain the previous four-shot assets until the flows are run and the generated PNGs are reviewed.
 
 The screenshot catalog currently defines these locale prefixes:
 
@@ -34,17 +35,24 @@ The review screenshot chain captures an exam-prep concept card about opportunity
 - Manual screenshot entrypoint: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingReviewScreenshotScript.kt`
 - Shared screenshot helpers: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt`
 - Manual wrapper script: `scripts/capture-android-review-screenshot.sh`
-- Output PNG targets:
+- Expected generated output PNG targets:
   - `apps/android/docs/media/play-store-screenshots/en-1_review-card-front-google-play-opportunity-cost.png`
   - `apps/android/docs/media/play-store-screenshots/en-2_review-card-result-google-play-opportunity-cost.png`
   - `apps/android/docs/media/play-store-screenshots/en-4_review-card-ai-draft-google-play-opportunity-cost.png`
+
+The progress screenshot flow captures the `Progress` tab with deterministic study-history data.
+
+- Manual screenshot entrypoint: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingProgressScreenshotScript.kt`
+- Shared screenshot helpers: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt`
+- Manual wrapper script: `scripts/capture-android-progress-screenshot.sh`
+- Expected generated output PNG target: `apps/android/docs/media/play-store-screenshots/en-3_progress-google-play-study-history.png`
 
 The cards screenshot flow captures the `Cards` tab filled with exam-prep concept cards across multiple subjects.
 
 - Manual screenshot entrypoint: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingCardsScreenshotScript.kt`
 - Shared screenshot helpers: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt`
 - Manual wrapper script: `scripts/capture-android-cards-screenshot.sh`
-- Output PNG target: `apps/android/docs/media/play-store-screenshots/en-3_cards-list-google-play-vocabulary.png`
+- Expected generated output PNG target: `apps/android/docs/media/play-store-screenshots/en-5_cards-list-google-play-vocabulary.png`
 
 ## Run the flows
 
@@ -57,6 +65,7 @@ Command:
 
 ```bash
 bash scripts/capture-android-review-screenshot.sh
+bash scripts/capture-android-progress-screenshot.sh
 bash scripts/capture-android-cards-screenshot.sh
 ```
 
@@ -72,7 +81,11 @@ They run `:app:connectedMarketingScreenshotAndroidTest`, not the normal debug in
 
 The review wrapper script runs the combined manual-only review-chain entrypoint, saves screenshots 1, 2, and 4 into `/sdcard/Download/flashcards-marketing-screenshots/`, and then pulls those files into the committed marketing media directory.
 
-The cards wrapper script runs the manual-only cards screenshot entrypoint, saves screenshot 3 into the same device directory, and then pulls that file into the committed marketing media directory.
+The progress wrapper script runs the manual-only Progress screenshot entrypoint, saves screenshot 3 into the same device directory, and then pulls that file into the committed marketing media directory.
+
+The cards wrapper script runs the manual-only cards screenshot entrypoint, saves screenshot 5 into the same device directory, and then pulls that file into the committed marketing media directory.
+
+Run the wrappers sequentially. Do not start the Progress or Cards wrapper until the previous wrapper has exited.
 
 ## Pattern for future flows
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -77,6 +78,9 @@ private val reviewChartBarAreaHeight = reviewChartHeight - reviewChartVerticalPa
 private val reviewChartAxisWidth = 28.dp
 private val reviewChartLabelHeight = 20.dp
 private const val progressStreakOverflowThreshold: Int = 99
+const val progressStreakSectionTag: String = "progress_streak_section"
+const val progressReviewsSectionTag: String = "progress_reviews_section"
+const val progressReviewsActivityChartTag: String = "progress_reviews_activity_chart"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -285,7 +289,9 @@ private fun StreakSectionCard(
     uiState: ProgressStreakSectionUiState
 ) {
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(progressStreakSectionTag),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer
         ),
@@ -523,7 +529,9 @@ private fun ReviewsSectionCard(
     val visiblePage = uiState.pages.getOrNull(selectedPageIndex)
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(progressReviewsSectionTag),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer
         ),
@@ -623,6 +631,7 @@ private fun ReviewsSectionCard(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height(reviewChartHeight)
+                                    .testTag(progressReviewsActivityChartTag)
                                     .clip(RoundedCornerShape(22.dp))
                                     .background(MaterialTheme.colorScheme.surfaceContainerHighest)
                                     .drawBehind {

--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -17,6 +17,8 @@ enum UITestIdentifier {
     static let reviewScreen: String = "review.screen"
     static let aiScreen: String = "ai.screen"
     static let progressScreen: String = "progress.screen"
+    static let progressStreakSection: String = "progress.streakSection"
+    static let progressReviewsSection: String = "progress.reviewsSection"
     static let cardsScreen: String = "cards.screen"
     static let settingsScreen: String = "settings.screen"
     static let settingsCurrentWorkspaceRow: String = "settings.currentWorkspaceRow"

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudUITest.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudUITest.swift
@@ -8,6 +8,7 @@ enum FlashcardsUITestResetState: String {
     case localGuestSeededAIReviewCard = "local_guest_seeded_ai_review_card"
     case marketingOpportunityCostReviewCard = "marketing_opportunity_cost_review_card"
     case marketingConceptCards = "marketing_concept_cards"
+    case marketingProgress = "marketing_progress"
 }
 
 private struct FlashcardsUITestSeedCard {
@@ -22,6 +23,12 @@ private struct FlashcardsUITestMarketingLocaleFixture {
     let conceptCards: [FlashcardsUITestSeedCard]
 }
 
+private struct FlashcardsUITestMarketingProgressReviewSeed {
+    let card: FlashcardsUITestSeedCard
+    let reviewedAtDayOffset: Int
+    let rating: ReviewRating
+}
+
 private enum FlashcardsUITestSeedData {
     static let manualReviewCard: FlashcardsUITestSeedCard = FlashcardsUITestSeedCard(
         frontText: "Smoke seeded manual review question",
@@ -33,6 +40,17 @@ private enum FlashcardsUITestSeedData {
         backText: "Smoke seeded AI review answer",
         tags: ["smoke-seeded-ai-review"]
     )
+}
+
+private enum FlashcardsUITestMarketingProgressSeedError: LocalizedError {
+    case reviewedAtDateCreationFailed(dayOffset: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .reviewedAtDateCreationFailed(let dayOffset):
+            return "Failed to create marketing progress review timestamp for day offset \(dayOffset)."
+        }
+    }
 }
 
 private enum FlashcardsUITestMarketingFixtureError: LocalizedError {
@@ -572,6 +590,9 @@ extension FlashcardsStore {
         case .marketingConceptCards:
             let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: ProcessInfo.processInfo)
             try self.seedUITestCards(cards: localeFixture.conceptCards)
+        case .marketingProgress:
+            let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: ProcessInfo.processInfo)
+            try self.seedUITestProgress(cards: localeFixture.conceptCards)
         }
     }
 
@@ -583,13 +604,91 @@ extension FlashcardsStore {
 
     private func seedUITestCard(card: FlashcardsUITestSeedCard) throws {
         try self.saveCard(
-            input: CardEditorInput(
-                frontText: card.frontText,
-                backText: card.backText,
-                tags: card.tags,
-                effortLevel: .medium
-            ),
+            input: self.cardEditorInput(card: card),
             editingCardId: nil
+        )
+    }
+
+    private func seedUITestProgress(cards: [FlashcardsUITestSeedCard]) throws {
+        let context: LocalMutationContext = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let reviewSeeds: [FlashcardsUITestMarketingProgressReviewSeed] = try self.marketingProgressReviewSeeds(cards: cards)
+        let now: Date = Date()
+        let calendar: Calendar = Calendar.current
+
+        for reviewSeed in reviewSeeds {
+            let card: Card = try context.database.saveCard(
+                workspaceId: context.workspaceId,
+                input: self.cardEditorInput(card: reviewSeed.card),
+                cardId: nil
+            )
+            let reviewedAtClient: String = try self.marketingProgressReviewedAtClient(
+                dayOffset: reviewSeed.reviewedAtDayOffset,
+                now: now,
+                calendar: calendar
+            )
+            _ = try context.database.submitReview(
+                workspaceId: context.workspaceId,
+                reviewSubmission: ReviewSubmission(
+                    cardId: card.cardId,
+                    rating: reviewSeed.rating,
+                    reviewedAtClient: reviewedAtClient
+                )
+            )
+        }
+
+        try self.reload(now: now, refreshVisibleProgress: false)
+    }
+
+    private func marketingProgressReviewSeeds(
+        cards: [FlashcardsUITestSeedCard]
+    ) throws -> [FlashcardsUITestMarketingProgressReviewSeed] {
+        guard cards.count >= 7 else {
+            throw LocalStoreError.validation("Marketing progress screenshots require at least 7 fixture cards.")
+        }
+
+        return [
+            FlashcardsUITestMarketingProgressReviewSeed(card: cards[0], reviewedAtDayOffset: 0, rating: .easy),
+            FlashcardsUITestMarketingProgressReviewSeed(card: cards[1], reviewedAtDayOffset: 0, rating: .good),
+            FlashcardsUITestMarketingProgressReviewSeed(card: cards[2], reviewedAtDayOffset: -1, rating: .good),
+            FlashcardsUITestMarketingProgressReviewSeed(card: cards[3], reviewedAtDayOffset: -2, rating: .hard),
+            FlashcardsUITestMarketingProgressReviewSeed(card: cards[4], reviewedAtDayOffset: -2, rating: .good),
+            FlashcardsUITestMarketingProgressReviewSeed(card: cards[5], reviewedAtDayOffset: -4, rating: .easy),
+            FlashcardsUITestMarketingProgressReviewSeed(card: cards[6], reviewedAtDayOffset: -6, rating: .good)
+        ]
+    }
+
+    private func marketingProgressReviewedAtClient(
+        dayOffset: Int,
+        now: Date,
+        calendar: Calendar
+    ) throws -> String {
+        guard let todayNoon: Date = calendar.date(
+            bySettingHour: 12,
+            minute: 0,
+            second: 0,
+            of: now,
+            matchingPolicy: .nextTime,
+            repeatedTimePolicy: .first,
+            direction: .forward
+        ),
+            let reviewedAt: Date = calendar.date(
+                byAdding: .day,
+                value: dayOffset,
+                to: todayNoon,
+                wrappingComponents: false
+            ) else {
+            throw FlashcardsUITestMarketingProgressSeedError.reviewedAtDateCreationFailed(dayOffset: dayOffset)
+        }
+
+        return formatIsoTimestamp(date: reviewedAt)
+    }
+
+    private func cardEditorInput(card: FlashcardsUITestSeedCard) -> CardEditorInput {
+        CardEditorInput(
+            frontText: card.frontText,
+            backText: card.backText,
+            tags: card.tags,
+            effortLevel: .medium
         )
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -44,6 +44,8 @@ struct ProgressScreen: View {
                             calendar: presentationCalendar
                         )
                     }
+                    .accessibilityIdentifier(UITestIdentifier.progressStreakSection)
+                    .accessibilityValue(progressSummaryUITestValue(summary: progressSnapshot.summary))
                     .modifier(ProgressCardModifier())
 
                     VStack(alignment: .leading, spacing: 0) {
@@ -53,6 +55,7 @@ struct ProgressScreen: View {
                             selectionResetKey: progressSnapshot.scopeKey.storageKey
                         )
                     }
+                    .accessibilityIdentifier(UITestIdentifier.progressReviewsSection)
                     .modifier(ProgressCardModifier())
                 } else if self.store.isProgressRefreshing == false {
                     VStack(alignment: .leading, spacing: 0) {
@@ -95,6 +98,15 @@ struct ProgressScreen: View {
             await self.store.refreshProgressManually()
         }
     }
+}
+
+private func progressSummaryUITestValue(summary: ProgressSummary) -> String {
+    let components: [String] = [
+        "currentStreakDays=\(summary.currentStreakDays)",
+        "hasReviewedToday=\(summary.hasReviewedToday ? "true" : "false")",
+        "activeReviewDays=\(summary.activeReviewDays)"
+    ]
+    return components.joined(separator: ";")
 }
 
 private struct ProgressCardModifier: ViewModifier {

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeIdentifiers.swift
@@ -18,6 +18,8 @@ enum LiveSmokeIdentifier {
     static let reviewScreen: String = "review.screen"
     static let aiScreen: String = "ai.screen"
     static let progressScreen: String = "progress.screen"
+    static let progressStreakSection: String = "progress.streakSection"
+    static let progressReviewsSection: String = "progress.reviewsSection"
     static let cardsScreen: String = "cards.screen"
     static let settingsScreen: String = "settings.screen"
     static let settingsCurrentWorkspaceRow: String = "settings.currentWorkspaceRow"
@@ -95,6 +97,7 @@ enum LiveSmokeLaunchResetState: String {
     case localGuestSeededAIReviewCard = "local_guest_seeded_ai_review_card"
     case marketingOpportunityCostReviewCard = "marketing_opportunity_cost_review_card"
     case marketingConceptCards = "marketing_concept_cards"
+    case marketingProgress = "marketing_progress"
 }
 
 struct LiveSmokeTabBarItemLookup {

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
@@ -35,6 +35,12 @@ enum MarketingScreenshotEnvironment {
     static let aiHandoffCardKey: String = "FLASHCARDS_UI_TEST_AI_HANDOFF_CARD"
 }
 
+private let marketingProgressExpectedSummaryValue: String = [
+    "currentStreakDays=3",
+    "hasReviewedToday=true",
+    "activeReviewDays=5"
+].joined(separator: ";")
+
 private enum MarketingScreenshotRuntimeConfigurationStorage {
     static let filePath: String = "/tmp/flashcards-open-source-app-ios-marketing-screenshot-config.json"
 }
@@ -147,6 +153,51 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
             selectedTab: .ai,
             aiHandoffCard: "first_card"
         )
+    }
+
+    @MainActor
+    func launchMarketingProgress() throws -> MarketingScreenshotLocaleFixture {
+        let localeFixture: MarketingScreenshotLocaleFixture = try self.marketingLocaleFixture()
+
+        try self.launchMarketingApplication(
+            resetState: .marketingProgress,
+            selectedTab: .progress,
+            aiHandoffCard: nil
+        )
+        try self.waitForLoadedProgressScreen()
+
+        return localeFixture
+    }
+
+    @MainActor
+    func waitForLoadedProgressScreen() throws {
+        try self.assertScreenVisible(screen: .progress, timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.progressStreakSection,
+            timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
+        )
+        try self.assertElementExists(
+            identifier: LiveSmokeIdentifier.progressReviewsSection,
+            timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
+        )
+        let progressStreakSection = self.app.descendants(matching: .any)
+            .matching(identifier: LiveSmokeIdentifier.progressStreakSection)
+            .firstMatch
+        if try self.waitForElementValueContaining(
+            progressStreakSection,
+            identifier: LiveSmokeIdentifier.progressStreakSection,
+            expectedValue: marketingProgressExpectedSummaryValue,
+            timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
+        ) == false {
+            throw LiveSmokeFailure.unexpectedElementValue(
+                identifier: LiveSmokeIdentifier.progressStreakSection,
+                expectedValue: marketingProgressExpectedSummaryValue,
+                actualValue: self.elementValue(element: progressStreakSection),
+                timeoutSeconds: LiveSmokeConfiguration.longUiTimeoutSeconds,
+                screen: self.currentScreenSummary(),
+                step: self.currentStepTitle
+            )
+        }
     }
 
     @MainActor

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingProgressScreenshotTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingProgressScreenshotTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import XCTest
+
+final class MarketingProgressScreenshotTests: MarketingManualScreenshotTestCase {
+    @MainActor
+    func testGenerateStudyHistoryProgressScreenshot() throws {
+        let localeFixture: MarketingScreenshotLocaleFixture = try self.launchMarketingProgress()
+
+        try self.step("capture progress screenshot") {
+            try self.captureMarketingScreenshotAndAssertWritten(
+                fileName: localeFixture.progressFileName
+            )
+        }
+    }
+}

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingScreenshotFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingScreenshotFixtures.swift
@@ -49,8 +49,15 @@ struct MarketingScreenshotLocaleFixture {
 
     var cardsFileName: String {
         self.screenshotFileName(
-            screenshotIndex: 3,
+            screenshotIndex: 5,
             screenshotSlug: MarketingScreenshotFixture.cardsScreenshotSlug
+        )
+    }
+
+    var progressFileName: String {
+        self.screenshotFileName(
+            screenshotIndex: 3,
+            screenshotSlug: MarketingScreenshotFixture.progressScreenshotSlug
         )
     }
 
@@ -580,6 +587,7 @@ enum MarketingScreenshotFixture {
     static let defaultLocalizationCode: String = "en-US"
     static let reviewFrontScreenshotSlug: String = "review-card-front-app-store-opportunity-cost"
     static let reviewResultScreenshotSlug: String = "review-card-result-app-store-opportunity-cost"
+    static let progressScreenshotSlug: String = "progress-app-store-study-history"
     static let cardsScreenshotSlug: String = "cards-list-app-store-vocabulary"
     static let reviewAiDraftScreenshotSlug: String = "review-card-ai-draft-app-store-opportunity-cost"
     static let supportedLocalizationCodes: [String] = MarketingScreenshotLocaleCatalog.supportedLocalizationCodes

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -18,7 +18,7 @@ On iOS, the UI and interaction design should stay maximally native to iOS.
 - Current deployment target: iOS 26.0
 - Default visual direction: dark appearance with the existing orange accent color
 - Primary local storage: SQLite on device
-- Product scope should stay aligned with the supported top-level flows: Review, Cards, AI, Settings
+- Product scope should stay aligned with the supported top-level flows: Review, Progress, AI, Cards, Settings
 
 We intentionally optimize for the latest supported iOS release instead of spending time on older system behavior.
 
@@ -126,7 +126,7 @@ The grouped smoke suite still maps to the same top-level live-smoke contract as 
 
 The iOS App Store screenshot generator and the derived iOS marketing-material builder are documented in [`docs/marketing-screenshots.md`](docs/marketing-screenshots.md).
 
-Use that document when you need to regenerate localized App Store screenshots or build the derived horizontal marketing materials from screenshots 1, 2, 3, and 4. It explains the manual XCUITest entrypoints, wrapper scripts, locale selection, the requirement to use `iPhone 14 Plus` for the committed iPhone screenshot set, simulator-family-to-output-folder behavior, and the expected output paths under `apps/ios/docs/media/app-store-screenshots/` and `apps/ios/docs/media/marketing-materials/`.
+Use that document when you need to regenerate localized App Store screenshots or build the derived horizontal marketing materials from screenshots 1, 2, 3, 4, and 5. It explains the manual XCUITest entrypoints, sequential wrapper scripts for Review, Progress, and Cards, locale selection, the requirement to use `iPhone 14 Plus` for the committed iPhone screenshot set, simulator-family-to-output-folder behavior, and the expected generated output paths under `apps/ios/docs/media/app-store-screenshots/` and `apps/ios/docs/media/marketing-materials/`.
 
 ## CI/CD
 

--- a/apps/ios/docs/marketing-screenshots.md
+++ b/apps/ios/docs/marketing-screenshots.md
@@ -6,31 +6,34 @@ The generator is a small manual pipeline built from:
 
 - manual-only XCUITest entrypoints in `apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/`
 - one shared wrapper script, `scripts/capture-ios-marketing-screenshot.sh`
-- one combined review wrapper and one cards wrapper in `scripts/`
+- one combined review wrapper, one progress wrapper, and one cards wrapper in `scripts/`
 - one marketing-material wrapper in `scripts/`
 - deterministic localized fixture data used by both the UI tests and app-side UI-test seeding
 
-It is meant for committed App Store marketing PNG assets and derived marketing compositions, not for CI or release-gate validation.
+It writes into the directories used for committed App Store marketing PNG assets and derived marketing compositions, but it is not part of CI or release-gate validation.
+The generator configuration now targets five-shot outputs. Existing repository media can still contain the previous four-shot assets until the screenshot flows and derived-material builder are run and the generated PNGs are reviewed.
 
 ## What is included
 
-The current inventory is four screenshot outputs per locale:
+The expected generated inventory is five screenshot outputs per locale:
 
 1. Review front state
 2. Review revealed-answer state
-3. Cards list state
+3. Progress tab state
 4. Review AI draft state
+5. Cards list state
 
-One combined review scenario seeds the opportunity-cost card once, then captures screenshot 1, screenshot 2, and screenshot 4 sequentially. The cards screenshot remains a separate localized concept-card list scenario.
+One combined review scenario seeds the opportunity-cost card once, then captures screenshot 1, screenshot 2, and screenshot 4 sequentially. The Progress screenshot uses a separate deterministic study-history scenario, and the cards screenshot remains a separate localized concept-card list scenario.
 
-The derived marketing-material flow then takes those four localized screenshots and builds one horizontal PNG per locale in the same order:
+The derived marketing-material flow then takes those five localized screenshots and builds one horizontal PNG per locale in the same order:
 
 1. screenshot 1
 2. screenshot 2
 3. screenshot 3
 4. screenshot 4
+5. screenshot 5
 
-All four screenshots sit on one dark-gray background with equal spacing between screenshots and all four outer edges.
+All five screenshots sit on one dark-gray background with equal spacing between screenshots and all four outer edges.
 
 ## Files involved
 
@@ -38,12 +41,14 @@ Main scripts:
 
 - `scripts/capture-ios-marketing-screenshot.sh`
 - `scripts/capture-ios-review-screenshots.sh`
+- `scripts/capture-ios-progress-screenshot.sh`
 - `scripts/capture-ios-cards-screenshot.sh`
 - `scripts/build-ios-marketing-materials.sh`
 
 Manual XCUITest entrypoints:
 
 - `apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingReviewScreenshotsTests.swift`
+- `apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingProgressScreenshotTests.swift`
 - `apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingCardsScreenshotTests.swift`
 
 Shared screenshot support:
@@ -56,7 +61,8 @@ What each layer does:
 
 - `capture-ios-marketing-screenshot.sh` resolves the locale, selects the already booted simulator, derives the device family, runs one `-only-testing` XCUITest target, and verifies that each expected PNG was written.
 - `capture-ios-review-screenshots.sh` runs the combined review scenario and verifies screenshots 1, 2, and 4 in one pass.
-- `capture-ios-cards-screenshot.sh` runs the separate cards-list scenario and verifies screenshot 3.
+- `capture-ios-progress-screenshot.sh` runs the separate Progress scenario and verifies screenshot 3.
+- `capture-ios-cards-screenshot.sh` runs the separate cards-list scenario and verifies screenshot 5.
 - `build-ios-marketing-materials.sh` can regenerate raw localized screenshots, compose the horizontal derived PNGs, and optimize the final files.
 - `MarketingManualScreenshotTestCase.swift` gates these tests behind the wrapper-provided runtime configuration, falls back to the launch environment only if that file is absent, and writes the PNG file.
 - `MarketingScreenshotFixtures.swift` defines the canonical locale list, locale aliases, localized fixture text, and the expected output filenames.
@@ -136,26 +142,30 @@ There are no locale subdirectories. Locale is encoded in the file name:
 
 - `<locale>-<index>_<slug>.png`
 
-Current filenames:
+Expected generated raw screenshot filenames:
 
 - `<locale>-1_review-card-front-app-store-opportunity-cost.png`
 - `<locale>-2_review-card-result-app-store-opportunity-cost.png`
-- `<locale>-3_cards-list-app-store-vocabulary.png`
+- `<locale>-3_progress-app-store-study-history.png`
 - `<locale>-4_review-card-ai-draft-app-store-opportunity-cost.png`
+- `<locale>-5_cards-list-app-store-vocabulary.png`
 
-Examples:
+Expected generated raw screenshot path examples:
 
 - `apps/ios/docs/media/app-store-screenshots/iphone/en-US-1_review-card-front-app-store-opportunity-cost.png`
 - `apps/ios/docs/media/app-store-screenshots/ipad/ar-4_review-card-ai-draft-app-store-opportunity-cost.png`
+- `apps/ios/docs/media/app-store-screenshots/iphone/en-US-5_cards-list-app-store-vocabulary.png`
 
-Derived marketing-material filenames:
+Expected generated derived marketing-material filenames:
 
-- `<locale>-1-2-3-4-horizontal-dark-gray.png`
+- `<locale>-1-2-3-4-5-horizontal-dark-gray.png`
 
-Examples:
+Expected generated derived marketing-material path examples:
 
-- `apps/ios/docs/media/marketing-materials/iphone/en-US-1-2-3-4-horizontal-dark-gray.png`
-- `apps/ios/docs/media/marketing-materials/ipad/es-ES-1-2-3-4-horizontal-dark-gray.png`
+- `apps/ios/docs/media/marketing-materials/iphone/en-US-1-2-3-4-5-horizontal-dark-gray.png`
+- `apps/ios/docs/media/marketing-materials/ipad/es-ES-1-2-3-4-5-horizontal-dark-gray.png`
+
+Do not reference a five-shot derived PNG from a README or other always-rendered document until that exact generated file exists in the repository.
 
 ## Prerequisites
 
@@ -193,6 +203,12 @@ That one review run writes:
 - screenshot 2: review result
 - screenshot 4: review AI draft
 
+Progress remains a separate one-PNG run:
+
+```bash
+bash scripts/capture-ios-progress-screenshot.sh
+```
+
 Cards list remains a separate one-PNG run:
 
 ```bash
@@ -208,19 +224,20 @@ bash scripts/capture-ios-review-screenshots.sh --locale es-ES
 Or use the environment variable instead:
 
 ```bash
-FLASHCARDS_MARKETING_SCREENSHOT_LOCALE=zh-Hans bash scripts/capture-ios-cards-screenshot.sh
+FLASHCARDS_MARKETING_SCREENSHOT_LOCALE=zh-Hans bash scripts/capture-ios-progress-screenshot.sh
 ```
 
-## Generate all four screenshots for one locale
+## Generate all five screenshots for one locale
 
-Use one locale explicitly and run the two supported wrappers in order:
+Use one locale explicitly and run the three supported wrappers in order:
 
 ```bash
 bash scripts/capture-ios-review-screenshots.sh --locale es-ES
+bash scripts/capture-ios-progress-screenshot.sh --locale es-ES
 bash scripts/capture-ios-cards-screenshot.sh --locale es-ES
 ```
 
-Do not run these two wrappers at the same time. Run the second command only after the first one exits.
+Do not run these wrappers at the same time. Run the next command only after the previous one exits.
 
 Or set the locale once in the environment:
 
@@ -228,12 +245,13 @@ Or set the locale once in the environment:
 export FLASHCARDS_MARKETING_SCREENSHOT_LOCALE=es-ES
 
 bash scripts/capture-ios-review-screenshots.sh
+bash scripts/capture-ios-progress-screenshot.sh
 bash scripts/capture-ios-cards-screenshot.sh
 ```
 
 ## Build derived marketing materials
 
-The derived-material builder is the wrapper that turns the four localized screenshots into one horizontal PNG on a dark-gray background.
+The derived-material builder is the wrapper that turns the five localized screenshots into one horizontal PNG on a dark-gray background.
 
 Default behavior:
 
@@ -281,6 +299,7 @@ For a clean multi-locale run, keep one simulator family booted and loop through 
 ```bash
 for locale in en-US ar zh-Hans de hi ja ru es-MX es-ES; do
   bash scripts/capture-ios-review-screenshots.sh --locale "$locale"
+  bash scripts/capture-ios-progress-screenshot.sh --locale "$locale"
   bash scripts/capture-ios-cards-screenshot.sh --locale "$locale"
 done
 ```
@@ -307,7 +326,7 @@ bash scripts/build-ios-marketing-materials.sh --all-locales
 - The scripts expect every declared screenshot file to exist after the XCUITest finishes and fail if any expected PNG was not written.
 - Manual screenshot tests run only through the wrapper scripts because the wrapper writes the required runtime configuration file and also provides environment fallback values.
 - Locale-specific content is deterministic and comes from the fixture files listed above. Update those files if the screenshot copy or seeded cards need to change.
-- The derived marketing-material builder depends on the raw screenshot filenames staying aligned with screenshots 1, 2, 3, and 4.
+- The derived marketing-material builder depends on the raw screenshot filenames staying aligned with screenshots 1, 2, 3, 4, and 5.
 - The `visually-lossless` optimization mode is not mathematically lossless. It is a high-quality palette reduction step intended to reduce PNG size aggressively while keeping UI screenshots visually unchanged in normal review.
 - The `lossless` optimization mode keeps pixels unchanged but usually saves less space than `visually-lossless`.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run src/localDb/reviews.test.ts src/localDb/cards.test.ts src/screens/ReviewScreen.test.tsx",
+    "test": "vitest run src/localDb/reviews.test.ts src/localDb/cards.test.ts src/screens/ReviewScreen.test.tsx src/appData/progressSource.test.tsx",
     "test:e2e": "FLASHCARDS_E2E_TARGET=prod playwright test",
     "test:e2e:local": "node ./scripts/check-local-e2e-stack.mjs && FLASHCARDS_E2E_TARGET=local playwright test",
     "test:e2e:prod": "FLASHCARDS_E2E_TARGET=prod playwright test"

--- a/apps/web/src/appData/progress/useProgressSource.ts
+++ b/apps/web/src/appData/progress/useProgressSource.ts
@@ -210,6 +210,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     });
   }, [
     accessibleWorkspaceIds,
+    canLoadServerBase,
     manualRefreshVersion,
     progressLocalVersion,
     summaryInput,
@@ -253,6 +254,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     });
   }, [
     accessibleWorkspaceIds,
+    canLoadServerBase,
     manualRefreshVersion,
     progressLocalVersion,
     seriesInput,

--- a/apps/web/src/appData/progressSource.test.tsx
+++ b/apps/web/src/appData/progressSource.test.tsx
@@ -566,6 +566,76 @@ describe("useProgressSource", () => {
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("local_only");
   });
 
+  it("keeps local progress visible when server eligibility turns off during an in-flight refresh", async () => {
+    const deferredSummary = createDeferredPromise<ProgressSummaryPayload>();
+    const deferredSeries = createDeferredPromise<ProgressSeries>();
+    const currentSeriesInput = buildCurrentSeriesInput();
+    loadProgressSummaryMock.mockImplementation(() => deferredSummary.promise);
+    loadProgressSeriesMock.mockImplementation(() => deferredSeries.promise);
+    loadLocalProgressSummaryMock.mockResolvedValue({
+      currentStreakDays: 3,
+      hasReviewedToday: true,
+      lastReviewedOn: currentSeriesInput.to,
+      activeReviewDays: 4,
+    });
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      {
+        date: currentSeriesInput.to,
+        reviewCount: 2,
+      },
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(loadProgressSummaryMock).toHaveBeenCalledTimes(1);
+    expect(loadProgressSeriesMock).toHaveBeenCalledTimes(1);
+    expect(harness.getApi().progressSourceState.summary.isLoading).toBe(false);
+    expect(harness.getApi().progressSourceState.series.isLoading).toBe(false);
+
+    harness.rerender({
+      sessionVerificationState: "verified",
+      cloudSettings: linkingReadyCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+    await flushEffects();
+
+    expect(loadProgressSummaryMock).toHaveBeenCalledTimes(1);
+    expect(loadProgressSeriesMock).toHaveBeenCalledTimes(1);
+    expect(loadLocalProgressSummaryMock).toHaveBeenCalledTimes(2);
+    expect(loadLocalProgressDailyReviewsMock).toHaveBeenCalledTimes(2);
+    expect(harness.getApi().progressSourceState.summary.isLoading).toBe(false);
+    expect(harness.getApi().progressSourceState.series.isLoading).toBe(false);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("local_only");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(4);
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("local_only");
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+      date: currentSeriesInput.to,
+      reviewCount: 2,
+    });
+
+    deferredSummary.resolve(buildServerSummary(9, "2026-04-18T09:19:00.000Z"));
+    deferredSeries.resolve(buildServerSeries(9, "2026-04-18T09:19:00.000Z"));
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.serverBase).toBeNull();
+    expect(harness.getApi().progressSourceState.series.serverBase).toBeNull();
+    expect(harness.getApi().progressSourceState.summary.isLoading).toBe(false);
+    expect(harness.getApi().progressSourceState.series.isLoading).toBe(false);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(4);
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+      date: currentSeriesInput.to,
+      reviewCount: 2,
+    });
+  });
+
   it("ignores server responses after sections disable their scopes", async () => {
     const deferredSummary = createDeferredPromise<ProgressSummaryPayload>();
     const deferredSeries = createDeferredPromise<ProgressSeries>();

--- a/scripts/build-ios-marketing-materials.sh
+++ b/scripts/build-ios-marketing-materials.sh
@@ -16,7 +16,7 @@ Usage:
 
 What it does:
   1. Optionally regenerates the raw localized iOS App Store screenshots.
-  2. Builds one horizontal marketing PNG per locale from screenshots 1, 2, 3, and 4.
+  2. Builds one horizontal marketing PNG per locale from screenshots 1, 2, 3, 4, and 5.
   3. Optimizes the generated PNG files.
 
 Locale selection:
@@ -211,8 +211,9 @@ resolve_screenshot_paths() {
     local -a screenshot_paths=(
         "$raw_screenshot_root/$family/${locale}-1_review-card-front-app-store-opportunity-cost.png"
         "$raw_screenshot_root/$family/${locale}-2_review-card-result-app-store-opportunity-cost.png"
-        "$raw_screenshot_root/$family/${locale}-3_cards-list-app-store-vocabulary.png"
+        "$raw_screenshot_root/$family/${locale}-3_progress-app-store-study-history.png"
         "$raw_screenshot_root/$family/${locale}-4_review-card-ai-draft-app-store-opportunity-cost.png"
+        "$raw_screenshot_root/$family/${locale}-5_cards-list-app-store-vocabulary.png"
     )
 
     local screenshot_path=""
@@ -231,6 +232,9 @@ capture_raw_screenshots_for_locale() {
 
     echo "Capturing raw review screenshots for locale $locale"
     "$repo_root/scripts/capture-ios-review-screenshots.sh" --locale "$locale"
+
+    echo "Capturing raw progress screenshot for locale $locale"
+    "$repo_root/scripts/capture-ios-progress-screenshot.sh" --locale "$locale"
 
     echo "Capturing raw cards screenshot for locale $locale"
     "$repo_root/scripts/capture-ios-cards-screenshot.sh" --locale "$locale"
@@ -423,7 +427,7 @@ for locale in "${resolved_locales[@]}"; do
     fi
 
     mapfile -t screenshot_paths < <(resolve_screenshot_paths "$resolved_family" "$locale")
-    output_path="$output_directory/${locale}-1-2-3-4-horizontal-dark-gray.png"
+    output_path="$output_directory/${locale}-1-2-3-4-5-horizontal-dark-gray.png"
 
     echo "Building marketing material for locale $locale"
     compose_marketing_material "$output_path" "${screenshot_paths[@]}"

--- a/scripts/capture-android-progress-screenshot.sh
+++ b/scripts/capture-android-progress-screenshot.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 android_dir="$repo_root/apps/android"
 locale_prefix="${FLASHCARDS_MARKETING_LOCALE_PREFIX:-en}"
-file_name="${locale_prefix}-5_cards-list-google-play-vocabulary.png"
+file_name="${locale_prefix}-3_progress-google-play-study-history.png"
 output_path="$repo_root/apps/android/docs/media/play-store-screenshots/$file_name"
-script_class="com.flashcardsopensourceapp.app.MarketingCardsScreenshotScript"
+script_class="com.flashcardsopensourceapp.app.MarketingProgressScreenshotScript"
 remote_screenshot_path="/sdcard/Download/flashcards-marketing-screenshots/$file_name"
 
 if [[ "$(adb get-state 2>/dev/null)" != "device" ]]; then
@@ -25,7 +25,7 @@ fi
 "$repo_root/scripts/android-dismiss-system-dialogs.sh"
 
 cd "$android_dir"
-echo "Running manual Android marketing screenshot script for the Cards screen."
+echo "Running manual Android marketing screenshot script for the Progress screen."
 ./gradlew :app:connectedMarketingScreenshotAndroidTest \
   "-Pandroid.testInstrumentationRunnerArguments.includeManualOnly=true" \
   "-Pandroid.testInstrumentationRunnerArguments.marketingLocalePrefix=$locale_prefix" \

--- a/scripts/capture-ios-progress-screenshot.sh
+++ b/scripts/capture-ios-progress-screenshot.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 "$repo_root/scripts/capture-ios-marketing-screenshot.sh" \
-  "MarketingCardsScreenshotTests/testGenerateConceptCardsListScreenshot" \
-  "the Cards list state" \
-  "5" \
-  "cards-list-app-store-vocabulary" \
+  "MarketingProgressScreenshotTests/testGenerateStudyHistoryProgressScreenshot" \
+  "the Progress study history state" \
+  "3" \
+  "progress-app-store-study-history" \
   "$@"


### PR DESCRIPTION
## Summary
- add Progress screenshot generators for iOS and Android
- move Cards screenshots after AI in the generated order
- update screenshot docs/scripts and Web progress regression test coverage

## Verification
- git diff --cached --check before commit
- subagent reviews approved iOS, Android, Web, and cross-platform screenshot/docs changes
- screenshot generators were intentionally not run