### PR TITLE
Improve seeded screenshot flows and guest cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,16 +50,16 @@ COOKIE_DOMAIN=localhost
 # 32 random bytes as hex (64 chars). Generate with: openssl rand -hex 32
 # SESSION_ENCRYPTION_KEY=
 #
-# Intentionally insecure review/demo bypass for pre-created Cognito accounts.
+# Intentionally insecure review account bypass for pre-created Cognito accounts.
 # Anyone who knows one of these emails and the shared password can sign in
-# without OTP, so use this only for review/demo accounts.
-# Every allowlisted demo email must use @example.com. Non-example.com values
+# without OTP, so use this only for review accounts.
+# Every allowlisted DEMO_EMAIL_DOSTIP value must use @example.com. Non-example.com values
 # are invalid and will fail auth startup.
 # For deployed auth, keep this allowlist in root .env and sync it to GitHub
 # Actions as CDK_DEMO_EMAIL_DOSTIP via scripts/setup-github.sh.
 # DEMO_EMAIL_DOSTIP=apple-for-review@example.com,google-for-review@example.com
 # Keep DEMO_PASSWORD_DOSTIP only in local untracked config.
-# Deployed auth should read the demo password from AWS Secrets Manager after
+# Deployed auth should read the review account password from AWS Secrets Manager after
 # scripts/setup-auth-secrets.sh stores it there.
 # DEMO_PASSWORD_DOSTIP=shared-insecure-demo-password
 #
@@ -159,5 +159,5 @@ COOKIE_DOMAIN=localhost
 # SESSION_ENCRYPTION_KEY=<from Secrets Manager>
 # ALLOWED_REDIRECT_URIS=https://example.com,https://app.example.com,https://admin.example.com
 # COOKIE_DOMAIN=example.com
-# DEMO_EMAIL_DOSTIP=<optional comma-separated insecure review/demo allowlist in @example.com only>
-# DEMO_PASSWORD_SECRET_ARN=<optional Secrets Manager ARN for the shared insecure review/demo password>
+# DEMO_EMAIL_DOSTIP=<optional comma-separated insecure review account allowlist in @example.com only>
+# DEMO_PASSWORD_SECRET_ARN=<optional Secrets Manager ARN for the shared insecure review account password>

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingCardsScreenshotScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingCardsScreenshotScript.kt
@@ -1,8 +1,7 @@
 package com.flashcardsopensourceapp.app
 
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.flashcardsopensourceapp.data.local.model.EffortLevel
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -15,7 +14,7 @@ private const val cardsScreenshotSlug: String = "cards-list-google-play-vocabula
 @ManualOnlyAndroidTest
 @RunWith(AndroidJUnit4::class)
 class MarketingCardsScreenshotScript {
-    private val appStateResetRule = AppStateResetRule()
+    private val appStateResetRule = MarketingScreenshotAppStateResetRule()
     private val composeRule = createMarketingScreenshotComposeRule()
 
     @get:Rule
@@ -26,6 +25,11 @@ class MarketingCardsScreenshotScript {
     @Test
     fun generateConceptCardsListScreenshot() {
         val localeConfig = activeMarketingScreenshotLocaleConfig()
+        runBlocking {
+            createRepositorySeedExecutor().seedCardsAndReviewsInGuestCloudWorkspace(
+                seedScenario = marketingCardsRepositorySeedScenario(localeConfig = localeConfig)
+            )
+        }
         val robot = MarketingScreenshotRobot(
             composeRule = composeRule,
             localeConfig = localeConfig
@@ -36,21 +40,7 @@ class MarketingCardsScreenshotScript {
             screenshotSlug = cardsScreenshotSlug
         )
 
-        robot.waitForCardsEmptyState()
-        localeConfig.cards.forEach { card ->
-            robot.createCard(
-                frontText = card.frontText,
-                backText = card.backText,
-                tags = listOf(card.subjectTag),
-                effortLevel = EffortLevel.MEDIUM
-            )
-        }
-
-        composeRule.waitUntil(timeoutMillis = 10_000L) {
-            localeConfig.cards.all { card ->
-                composeRule.onAllNodesWithText(card.frontText).fetchSemanticsNodes().isNotEmpty()
-            }
-        }
+        robot.waitForRepositorySeededCards(frontTexts = localeConfig.cards.map { card -> card.frontText })
 
         val screenshotPath = robot.saveScreenshot(fileName = cardsScreenshotFileName)
         val screenshotListing = robot.runShellCommand(command = "ls $screenshotPath")

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingProgressScreenshotScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingProgressScreenshotScript.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -13,7 +14,7 @@ private const val progressScreenshotSlug: String = "progress-google-play-study-h
 @ManualOnlyAndroidTest
 @RunWith(AndroidJUnit4::class)
 class MarketingProgressScreenshotScript {
-    private val appStateResetRule = AppStateResetRule()
+    private val appStateResetRule = MarketingScreenshotAppStateResetRule()
     private val composeRule = createMarketingScreenshotComposeRule()
 
     @get:Rule
@@ -24,6 +25,14 @@ class MarketingProgressScreenshotScript {
     @Test
     fun generateStudyHistoryProgressScreenshot() {
         val localeConfig = activeMarketingScreenshotLocaleConfig()
+        runBlocking {
+            createRepositorySeedExecutor().seedCardsAndReviewsInGuestCloudWorkspace(
+                seedScenario = marketingProgressRepositorySeedScenario(
+                    localeConfig = localeConfig,
+                    nowMillis = System.currentTimeMillis()
+                )
+            )
+        }
         val robot = MarketingScreenshotRobot(
             composeRule = composeRule,
             localeConfig = localeConfig

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingRepositorySeedScenarios.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingRepositorySeedScenarios.kt
@@ -1,0 +1,113 @@
+package com.flashcardsopensourceapp.app
+
+import com.flashcardsopensourceapp.data.local.model.EffortLevel
+import com.flashcardsopensourceapp.data.local.model.ReviewRating
+import java.time.Instant
+import java.time.ZoneId
+
+private data class MarketingReviewTimestamp(
+    val daysAgo: Long,
+    val hour: Int,
+    val minute: Int
+)
+
+internal fun marketingReviewRepositorySeedScenario(
+    localeConfig: MarketingScreenshotLocaleConfig
+): RepositorySeedScenario {
+    return RepositorySeedScenario(
+        cards = listOf(
+            RepositorySeedCard(
+                frontText = localeConfig.reviewCard.frontText,
+                backText = localeConfig.reviewCard.backText,
+                tags = localeConfig.reviewCard.tags,
+                effortLevel = EffortLevel.MEDIUM,
+                reviews = emptyList()
+            )
+        )
+    )
+}
+
+internal fun marketingCardsRepositorySeedScenario(
+    localeConfig: MarketingScreenshotLocaleConfig
+): RepositorySeedScenario {
+    return RepositorySeedScenario(
+        cards = localeConfig.cards.map { card ->
+            RepositorySeedCard(
+                frontText = card.frontText,
+                backText = card.backText,
+                tags = listOf(card.subjectTag),
+                effortLevel = EffortLevel.MEDIUM,
+                reviews = emptyList()
+            )
+        }
+    )
+}
+
+internal fun marketingProgressRepositorySeedScenario(
+    localeConfig: MarketingScreenshotLocaleConfig,
+    nowMillis: Long
+): RepositorySeedScenario {
+    require(localeConfig.cards.size >= 5) {
+        "Marketing progress screenshot requires at least 5 seeded cards."
+    }
+    val zoneId: ZoneId = ZoneId.systemDefault()
+    val reviewTimestamps: List<MarketingReviewTimestamp> = listOf(
+        MarketingReviewTimestamp(daysAgo = 6L, hour = 10, minute = 0),
+        MarketingReviewTimestamp(daysAgo = 4L, hour = 10, minute = 0),
+        MarketingReviewTimestamp(daysAgo = 2L, hour = 10, minute = 0),
+        MarketingReviewTimestamp(daysAgo = 1L, hour = 10, minute = 0),
+        MarketingReviewTimestamp(daysAgo = 0L, hour = 9, minute = 30)
+    )
+
+    return RepositorySeedScenario(
+        cards = localeConfig.cards.take(reviewTimestamps.size).zip(reviewTimestamps).map { (card, reviewTimestamp) ->
+            RepositorySeedCard(
+                frontText = card.frontText,
+                backText = card.backText,
+                tags = listOf(card.subjectTag),
+                effortLevel = EffortLevel.MEDIUM,
+                reviews = listOf(
+                    RepositorySeedReview(
+                        rating = ReviewRating.GOOD,
+                        reviewedAtMillis = resolveMarketingReviewTimestampMillis(
+                            nowMillis = nowMillis,
+                            zoneId = zoneId,
+                            reviewTimestamp = reviewTimestamp
+                        )
+                    )
+                )
+            )
+        }
+    )
+}
+
+private fun resolveMarketingReviewTimestampMillis(
+    nowMillis: Long,
+    zoneId: ZoneId,
+    reviewTimestamp: MarketingReviewTimestamp
+): Long {
+    val now = Instant.ofEpochMilli(nowMillis).atZone(zoneId)
+    val startOfTodayMillis: Long = now.toLocalDate()
+        .atStartOfDay(zoneId)
+        .toInstant()
+        .toEpochMilli()
+    val scheduledReview: Long = now.toLocalDate()
+        .minusDays(reviewTimestamp.daysAgo)
+        .atTime(reviewTimestamp.hour, reviewTimestamp.minute)
+        .atZone(zoneId)
+        .toInstant()
+        .toEpochMilli()
+    if (scheduledReview < nowMillis) {
+        return scheduledReview
+    }
+
+    require(reviewTimestamp.daysAgo == 0L) {
+        "Resolved marketing review timestamp must be in the past. nowMillis=$nowMillis scheduledReview=$scheduledReview"
+    }
+    val fallbackReviewMillis: Long = now.minusSeconds(1).toInstant().toEpochMilli()
+    return if (fallbackReviewMillis >= startOfTodayMillis) {
+        fallbackReviewMillis
+    } else {
+        startOfTodayMillis
+    }
+}

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingReviewScreenshotScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingReviewScreenshotScript.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -16,7 +17,7 @@ private const val reviewAiDraftScreenshotSlug: String =
 @ManualOnlyAndroidTest
 @RunWith(AndroidJUnit4::class)
 class MarketingReviewScreenshotScript {
-    private val appStateResetRule = AppStateResetRule()
+    private val appStateResetRule = MarketingScreenshotAppStateResetRule()
     private val composeRule = createMarketingScreenshotComposeRule()
 
     @get:Rule
@@ -27,6 +28,11 @@ class MarketingReviewScreenshotScript {
     @Test
     fun generateOpportunityCostReviewScreenshotFlow() {
         val localeConfig = activeMarketingScreenshotLocaleConfig()
+        runBlocking {
+            createRepositorySeedExecutor().seedCardsAndReviewsInGuestCloudWorkspace(
+                seedScenario = marketingReviewRepositorySeedScenario(localeConfig = localeConfig)
+            )
+        }
         val robot = MarketingScreenshotRobot(
             composeRule = composeRule,
             localeConfig = localeConfig

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotAppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotAppStateResetRule.kt
@@ -1,0 +1,62 @@
+package com.flashcardsopensourceapp.app
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.rules.ExternalResource
+
+private const val marketingScreenshotGuestCleanupTimeoutMillis: Long = 20_000L
+
+class MarketingScreenshotAppStateResetRule : ExternalResource() {
+    private val delegate = AppStateResetRule()
+
+    override fun before() {
+        runRemoteCleanupThenDelegate(delegateAction = delegate::before)
+    }
+
+    override fun after() {
+        runRemoteCleanupThenDelegate(delegateAction = delegate::after)
+    }
+
+    private fun runRemoteCleanupThenDelegate(delegateAction: () -> Unit) {
+        var primaryFailure: Throwable? = null
+
+        try {
+            deleteStoredGuestCloudSessionIfPresent()
+        } catch (error: Throwable) {
+            primaryFailure = error
+        }
+
+        try {
+            delegateAction()
+        } catch (error: Throwable) {
+            if (primaryFailure != null) {
+                primaryFailure.addSuppressed(error)
+            } else {
+                primaryFailure = error
+            }
+        }
+
+        if (primaryFailure != null) {
+            throw primaryFailure
+        }
+    }
+
+    private fun deleteStoredGuestCloudSessionIfPresent() {
+        val context: Context = ApplicationProvider.getApplicationContext<Context>()
+        val application = context as FlashcardsApplication
+
+        runBlocking {
+            withTimeout(marketingScreenshotGuestCleanupTimeoutMillis) {
+                // Marketing screenshot seeding creates a real guest cloud workspace,
+                // so the remote session must be deleted before the local reset
+                // drops the only stored guest token.
+                val appGraph = requireNotNull(application.appGraphOrNull) {
+                    "App graph is unavailable for marketing screenshot guest cleanup."
+                }
+                appGraph.deleteStoredGuestCloudSessionIfPresent()
+            }
+        }
+    }
+}

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -24,7 +23,6 @@ import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.test.core.app.ActivityScenario
-import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.flashcardsopensourceapp.app.livesmoke.dismissBlockingSystemDialogIfPresent
@@ -32,28 +30,15 @@ import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
 import com.flashcardsopensourceapp.app.navigation.ProgressDestination
 import com.flashcardsopensourceapp.app.navigation.ReviewDestination
-import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.feature.ai.R as AiFeatureR
 import com.flashcardsopensourceapp.feature.ai.aiComposerMessageFieldTag
 import com.flashcardsopensourceapp.feature.ai.aiComposerPendingAttachmentTag
 import com.flashcardsopensourceapp.feature.ai.aiComposerSendButtonTag
 import com.flashcardsopensourceapp.feature.ai.aiConversationSurfaceTag
-import com.flashcardsopensourceapp.feature.cards.cardEditorBackSummaryCardTag
-import com.flashcardsopensourceapp.feature.cards.cardEditorBackTextFieldTag
-import com.flashcardsopensourceapp.feature.cards.cardEditorEffortLevelTag
-import com.flashcardsopensourceapp.feature.cards.cardEditorFrontSummaryCardTag
-import com.flashcardsopensourceapp.feature.cards.cardEditorFrontTextFieldTag
-import com.flashcardsopensourceapp.feature.cards.cardEditorSaveButtonTag
-import com.flashcardsopensourceapp.feature.cards.cardEditorTagsSummaryCardTag
-import com.flashcardsopensourceapp.feature.cards.cardTagsAddButtonTag
-import com.flashcardsopensourceapp.feature.cards.cardTagsInputFieldTag
-import com.flashcardsopensourceapp.feature.cards.cardsAddCardButtonTag
-import com.flashcardsopensourceapp.feature.cards.cardsEmptyStateTag
 import com.flashcardsopensourceapp.feature.cards.cardsSearchFieldTag
 import com.flashcardsopensourceapp.feature.progress.progressReviewsActivityChartTag
 import com.flashcardsopensourceapp.feature.progress.progressReviewsSectionTag
 import com.flashcardsopensourceapp.feature.progress.progressStreakSectionTag
-import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag
 import com.flashcardsopensourceapp.feature.review.reviewRateAgainButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateEasyButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateGoodButtonTag
@@ -129,49 +114,14 @@ internal class MarketingScreenshotRobot(
     private val device: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private var hasAppliedLocale: Boolean = false
 
-    fun waitForCardsEmptyState() {
+    fun waitForRepositorySeededCards(frontTexts: List<String>) {
         ensureLocaleApplied()
         openCardsTab()
         waitUntilWithSystemDialogMitigation {
             composeRule.onAllNodesWithTag(cardsSearchFieldTag).fetchSemanticsNodes().isNotEmpty() &&
-                composeRule.onAllNodesWithTag(cardsEmptyStateTag).fetchSemanticsNodes().isNotEmpty()
-        }
-    }
-
-    fun createCard(frontText: String, backText: String, tags: List<String>, effortLevel: EffortLevel) {
-        ensureLocaleApplied()
-        openCardsTab()
-        clickTag(tag = cardsAddCardButtonTag)
-        updateCardText(
-            summaryCardTag = cardEditorFrontSummaryCardTag,
-            textFieldTag = cardEditorFrontTextFieldTag,
-            value = frontText
-        )
-        updateCardText(
-            summaryCardTag = cardEditorBackSummaryCardTag,
-            textFieldTag = cardEditorBackTextFieldTag,
-            value = backText
-        )
-        scrollToNode(matcher = hasTestTag(cardEditorEffortLevelTag(effortLevel = effortLevel)))
-        clickTag(tag = cardEditorEffortLevelTag(effortLevel = effortLevel))
-
-        if (tags.isNotEmpty()) {
-            clickTag(tag = cardEditorTagsSummaryCardTag)
-            tags.forEach { tag ->
-                dismissExternalSystemDialogIfPresent()
-                composeRule.onNodeWithTag(cardTagsInputFieldTag).performTextInput(tag)
-                composeRule.waitForIdle()
-                dismissExternalSystemDialogIfPresent()
-                clickTag(tag = cardTagsAddButtonTag)
-            }
-            tapBackIcon()
-        }
-
-        scrollToNode(matcher = hasTestTag(cardEditorSaveButtonTag))
-        clickTag(tag = cardEditorSaveButtonTag)
-        waitUntilWithSystemDialogMitigation {
-            composeRule.onAllNodesWithTag(cardsSearchFieldTag).fetchSemanticsNodes().isNotEmpty() &&
-                composeRule.onAllNodesWithText(frontText).fetchSemanticsNodes().isNotEmpty()
+                frontTexts.all { frontText ->
+                    composeRule.onAllNodesWithText(frontText).fetchSemanticsNodes().isNotEmpty()
+                }
         }
     }
 
@@ -205,13 +155,6 @@ internal class MarketingScreenshotRobot(
     }
 
     fun prepareOpportunityCostReviewCardForReview() {
-        waitForCardsEmptyState()
-        createCard(
-            frontText = localeConfig.reviewCard.frontText,
-            backText = localeConfig.reviewCard.backText,
-            tags = localeConfig.reviewCard.tags,
-            effortLevel = EffortLevel.MEDIUM
-        )
         openReviewTab()
         waitForReviewPrompt(frontText = localeConfig.reviewCard.frontText)
     }
@@ -232,9 +175,6 @@ internal class MarketingScreenshotRobot(
     }
 
     fun prepareStudyHistoryProgressScreen() {
-        prepareOpportunityCostReviewCardForReview()
-        revealAnswerAndWaitForRatings()
-        rateGoodAndWaitForReviewCompletion()
         openProgressTab()
         waitForLoadedProgressWithReviewActivity()
     }
@@ -326,31 +266,6 @@ internal class MarketingScreenshotRobot(
         hasAppliedLocale = true
     }
 
-    private fun updateCardText(summaryCardTag: String, textFieldTag: String, value: String) {
-        clickTag(tag = summaryCardTag)
-        dismissExternalSystemDialogIfPresent()
-        composeRule.onNodeWithTag(textFieldTag).performTextReplacement(value)
-        composeRule.waitForIdle()
-        dismissExternalSystemDialogIfPresent()
-        tapBackIcon()
-    }
-
-    private fun tapBackIcon() {
-        dismissExternalSystemDialogIfPresent()
-        if (composeRule.onAllNodes(matcher = hasContentDescription("Back")).fetchSemanticsNodes().isNotEmpty()) {
-            composeRule.onNodeWithContentDescription("Back").performClick()
-            composeRule.waitForIdle()
-            dismissExternalSystemDialogIfPresent()
-            return
-        }
-
-        composeRule.activity.runOnUiThread {
-            composeRule.activity.onBackPressedDispatcher.onBackPressed()
-        }
-        composeRule.waitForIdle()
-        dismissExternalSystemDialogIfPresent()
-    }
-
     private fun waitForNode(matcher: SemanticsMatcher) {
         waitUntilWithSystemDialogMitigation {
             composeRule.onAllNodes(matcher = matcher).fetchSemanticsNodes().isNotEmpty()
@@ -368,13 +283,6 @@ internal class MarketingScreenshotRobot(
         waitUntilWithSystemDialogMitigation {
             composeRule.onAllNodesWithText(frontText).fetchSemanticsNodes().isNotEmpty() &&
                 composeRule.onAllNodesWithTag(reviewShowAnswerButtonTag).fetchSemanticsNodes().isNotEmpty()
-        }
-    }
-
-    private fun rateGoodAndWaitForReviewCompletion() {
-        clickTag(tag = reviewRateGoodButtonTag)
-        waitUntilWithSystemDialogMitigation {
-            composeRule.onAllNodesWithTag(reviewEmptyStateTag).fetchSemanticsNodes().isNotEmpty()
         }
     }
 

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/RepositorySeedExecutor.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/RepositorySeedExecutor.kt
@@ -1,0 +1,245 @@
+package com.flashcardsopensourceapp.app
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.data.local.database.CardWithRelations
+import com.flashcardsopensourceapp.data.local.model.CardDraft
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.EffortLevel
+import com.flashcardsopensourceapp.data.local.model.ReviewRating
+import com.flashcardsopensourceapp.data.local.model.SyncStatus
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+
+internal data class RepositorySeedReview(
+    val rating: ReviewRating,
+    val reviewedAtMillis: Long
+)
+
+internal data class RepositorySeedCard(
+    val frontText: String,
+    val backText: String,
+    val tags: List<String>,
+    val effortLevel: EffortLevel,
+    val reviews: List<RepositorySeedReview>
+)
+
+internal data class RepositorySeedScenario(
+    val cards: List<RepositorySeedCard>
+)
+
+internal data class RepositorySeededCard(
+    val cardId: String,
+    val frontText: String,
+    val backText: String,
+    val tags: List<String>
+)
+
+internal data class RepositorySeedResult(
+    val workspaceId: String,
+    val cards: List<RepositorySeededCard>,
+    val reviewCount: Int
+)
+
+internal class RepositorySeedExecutor(
+    private val application: FlashcardsApplication
+) {
+    suspend fun seedCardsAndReviewsInCurrentWorkspace(
+        seedScenario: RepositorySeedScenario
+    ): RepositorySeedResult {
+        val appGraph: AppGraph = application.appGraph
+        appGraph.awaitStartup()
+        appGraph.ensureLocalWorkspaceShell(currentTimeMillis = System.currentTimeMillis())
+        val workspaceId: String = requireCurrentWorkspaceId(appGraph = appGraph)
+        return seedCardsAndReviews(
+            appGraph = appGraph,
+            workspaceId = workspaceId,
+            seedScenario = seedScenario
+        )
+    }
+
+    suspend fun seedCardsAndReviewsInGuestCloudWorkspace(
+        seedScenario: RepositorySeedScenario
+    ): RepositorySeedResult {
+        val appGraph: AppGraph = application.appGraph
+        appGraph.awaitStartup()
+        appGraph.ensureLocalWorkspaceShell(currentTimeMillis = System.currentTimeMillis())
+        val localWorkspaceId: String = requireCurrentWorkspaceId(appGraph = appGraph)
+        val guestSession = appGraph.ensureGuestCloudSession(workspaceId = localWorkspaceId)
+        val seedResult: RepositorySeedResult = seedCardsAndReviews(
+            appGraph = appGraph,
+            workspaceId = guestSession.workspaceId,
+            seedScenario = seedScenario
+        )
+        appGraph.syncRepository.syncNow()
+        verifyGuestCloudReadiness(
+            appGraph = appGraph,
+            expectedWorkspaceId = guestSession.workspaceId
+        )
+        return seedResult
+    }
+
+    private suspend fun seedCardsAndReviews(
+        appGraph: AppGraph,
+        workspaceId: String,
+        seedScenario: RepositorySeedScenario
+    ): RepositorySeedResult {
+        val seededCards: MutableList<RepositorySeededCard> = mutableListOf()
+        var reviewCount: Int = 0
+
+        seedScenario.cards.forEach { card ->
+            val createdCard: RepositorySeededCard = createCard(
+                appGraph = appGraph,
+                workspaceId = workspaceId,
+                seedCard = card
+            )
+            seededCards += createdCard
+            card.reviews.sortedBy(RepositorySeedReview::reviewedAtMillis).forEach { review ->
+                appGraph.reviewRepository.recordReview(
+                    cardId = createdCard.cardId,
+                    rating = review.rating,
+                    reviewedAtMillis = review.reviewedAtMillis
+                )
+                reviewCount += 1
+            }
+            if (card.reviews.isNotEmpty()) {
+                stabilizeReviewedCardSnapshotForSync(
+                    appGraph = appGraph,
+                    seededCard = createdCard,
+                    seedCard = card
+                )
+            }
+        }
+
+        return RepositorySeedResult(
+            workspaceId = workspaceId,
+            cards = seededCards.toList(),
+            reviewCount = reviewCount
+        )
+    }
+
+    private suspend fun createCard(
+        appGraph: AppGraph,
+        workspaceId: String,
+        seedCard: RepositorySeedCard
+    ): RepositorySeededCard {
+        val existingCardIds: Set<String> = appGraph.database.cardDao().observeCardsWithRelations().first().map { card ->
+            card.card.cardId
+        }.toSet()
+        appGraph.cardsRepository.createCard(
+            cardDraft = CardDraft(
+                frontText = seedCard.frontText,
+                backText = seedCard.backText,
+                tags = seedCard.tags,
+                effortLevel = seedCard.effortLevel
+            )
+        )
+        val createdCard: CardWithRelations = resolveCreatedCard(
+            appGraph = appGraph,
+            existingCardIds = existingCardIds,
+            expectedWorkspaceId = workspaceId
+        )
+        return RepositorySeededCard(
+            cardId = createdCard.card.cardId,
+            frontText = createdCard.card.frontText,
+            backText = createdCard.card.backText,
+            tags = createdCard.tags.map { tag -> tag.name }
+        )
+    }
+
+    private suspend fun stabilizeReviewedCardSnapshotForSync(
+        appGraph: AppGraph,
+        seededCard: RepositorySeededCard,
+        seedCard: RepositorySeedCard
+    ) {
+        delay(timeMillis = 5L)
+        appGraph.cardsRepository.updateCard(
+            cardId = seededCard.cardId,
+            cardDraft = CardDraft(
+                frontText = seedCard.frontText,
+                backText = seedCard.backText,
+                tags = seedCard.tags,
+                effortLevel = seedCard.effortLevel
+            )
+        )
+    }
+
+    private suspend fun resolveCreatedCard(
+        appGraph: AppGraph,
+        existingCardIds: Set<String>,
+        expectedWorkspaceId: String
+    ): CardWithRelations {
+        val newCards: List<CardWithRelations> = appGraph.database.cardDao().observeCardsWithRelations().first().filter { card ->
+            existingCardIds.contains(card.card.cardId).not()
+        }
+        require(newCards.size == 1) {
+            "Expected exactly one created card in workspace '$expectedWorkspaceId', but found ${newCards.size} new cards."
+        }
+        val createdCard: CardWithRelations = newCards.single()
+        require(createdCard.card.workspaceId == expectedWorkspaceId) {
+            "Expected seeded card workspace '$expectedWorkspaceId', but created '${createdCard.card.workspaceId}'."
+        }
+        return createdCard
+    }
+
+    private suspend fun verifyGuestCloudReadiness(
+        appGraph: AppGraph,
+        expectedWorkspaceId: String
+    ) {
+        val cloudSettings = appGraph.cloudAccountRepository.observeCloudSettings().first()
+        require(cloudSettings.cloudState == CloudAccountState.GUEST) {
+            "Expected guest cloud state after repository seeding, but was '${cloudSettings.cloudState}'."
+        }
+        require(cloudSettings.activeWorkspaceId == expectedWorkspaceId) {
+            "Expected active guest workspace '$expectedWorkspaceId', but was '${cloudSettings.activeWorkspaceId}'."
+        }
+        require(cloudSettings.linkedWorkspaceId == expectedWorkspaceId) {
+            "Expected linked guest workspace '$expectedWorkspaceId', but was '${cloudSettings.linkedWorkspaceId}'."
+        }
+
+        val currentWorkspaceId: String = requireCurrentWorkspaceId(appGraph = appGraph)
+        require(currentWorkspaceId == expectedWorkspaceId) {
+            "Expected current workspace '$expectedWorkspaceId', but found '$currentWorkspaceId'."
+        }
+
+        val outboxEntriesCount: Int = appGraph.database.outboxDao().countOutboxEntries()
+        require(outboxEntriesCount == 0) {
+            "Expected an empty outbox after repository seeding sync, but found $outboxEntriesCount pending entries."
+        }
+
+        val syncStatus = appGraph.syncRepository.observeSyncStatus().first()
+        require(syncStatus.status == SyncStatus.Idle) {
+            "Expected sync to be idle after repository seeding, but was '${syncStatus.status}'."
+        }
+        require(syncStatus.lastErrorMessage.isEmpty()) {
+            "Expected no sync error after repository seeding, but was '${syncStatus.lastErrorMessage}'."
+        }
+
+        val syncState = requireNotNull(
+            appGraph.database.syncStateDao().loadSyncState(workspaceId = expectedWorkspaceId)
+        ) {
+            "Expected sync state for seeded guest workspace '$expectedWorkspaceId'."
+        }
+        require(syncState.lastSuccessfulSyncAtMillis != null) {
+            "Expected a successful sync timestamp for seeded guest workspace '$expectedWorkspaceId'."
+        }
+        require(syncState.lastSyncError == null) {
+            "Expected no sync-state error for seeded guest workspace '$expectedWorkspaceId', but was '${syncState.lastSyncError}'."
+        }
+    }
+
+    private suspend fun requireCurrentWorkspaceId(
+        appGraph: AppGraph
+    ): String {
+        return requireNotNull(appGraph.database.workspaceDao().loadAnyWorkspace()?.workspaceId) {
+            "Expected a current workspace before repository seeding."
+        }
+    }
+}
+
+internal fun createRepositorySeedExecutor(): RepositorySeedExecutor {
+    val context: Context = ApplicationProvider.getApplicationContext<Context>()
+    val application = context as FlashcardsApplication
+    return RepositorySeedExecutor(application = application)
+}

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeScenarioHelpers.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeScenarioHelpers.kt
@@ -15,14 +15,15 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
-import com.flashcardsopensourceapp.app.FlashcardsApplication
+import com.flashcardsopensourceapp.app.RepositorySeedCard
+import com.flashcardsopensourceapp.app.RepositorySeedScenario
+import com.flashcardsopensourceapp.app.createRepositorySeedExecutor
 import com.flashcardsopensourceapp.data.local.ai.AiChatHistoryStore
 import com.flashcardsopensourceapp.data.local.ai.makeAiChatHistoryScopedWorkspaceId
 import com.flashcardsopensourceapp.data.local.model.AiChatContentPart
 import com.flashcardsopensourceapp.data.local.model.AiChatPersistedState
 import com.flashcardsopensourceapp.data.local.model.AiChatRole
 import com.flashcardsopensourceapp.data.local.model.AiChatToolCallStatus
-import com.flashcardsopensourceapp.data.local.model.CardDraft
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.feature.ai.aiAssistantMessageBubbleTag
@@ -134,21 +135,23 @@ internal fun LiveSmokeContext.rateVisibleReviewCardGood() {
     }
 }
 
-internal fun LiveSmokeContext.seedLocalCard(
+internal fun LiveSmokeContext.seedCardViaRepository(
     frontText: String,
     backText: String,
     markerTag: String
 ) {
-    val application = composeRule.activity.application as FlashcardsApplication
-    val appGraph = application.appGraph
     runBlocking {
-        appGraph.ensureLocalWorkspaceShell(currentTimeMillis = System.currentTimeMillis())
-        appGraph.cardsRepository.createCard(
-            cardDraft = CardDraft(
-                frontText = frontText,
-                backText = backText,
-                tags = listOf(markerTag),
-                effortLevel = EffortLevel.MEDIUM
+        createRepositorySeedExecutor().seedCardsAndReviewsInCurrentWorkspace(
+            seedScenario = RepositorySeedScenario(
+                cards = listOf(
+                    RepositorySeedCard(
+                        frontText = frontText,
+                        backText = backText,
+                        tags = listOf(markerTag),
+                        effortLevel = EffortLevel.MEDIUM,
+                        reviews = emptyList()
+                    )
+                )
             )
         )
     }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt
@@ -77,21 +77,21 @@ class LiveSmokeTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     @Test
-    fun manualCardCanBeReviewedInDefaultWorkspace() {
+    fun repositorySeededCardCanBeReviewedInDefaultWorkspace() {
         val runId: String = System.currentTimeMillis().toString()
-        val manualFrontText: String = "Manual review e2e android $runId"
-        val manualBackText: String = "Manual review answer e2e android $runId"
+        val seededFrontText: String = "Repository review e2e android $runId"
+        val seededBackText: String = "Repository review answer e2e android $runId"
 
-        liveSmokeContext.step("seed one manual card directly in the default local workspace") {
-            liveSmokeContext.seedLocalCard(
-                frontText = manualFrontText,
-                backText = manualBackText,
-                markerTag = "manual-review-$runId"
+        liveSmokeContext.step("repository-seed one card in the default workspace") {
+            liveSmokeContext.seedCardViaRepository(
+                frontText = seededFrontText,
+                backText = seededBackText,
+                markerTag = "repository-review-$runId"
             )
         }
-        liveSmokeContext.step("verify the seeded manual card in review") {
+        liveSmokeContext.step("verify the repository-seeded card in review") {
             liveSmokeContext.assertCardReachableInReview(
-                expectedFrontText = manualFrontText,
+                expectedFrontText = seededFrontText,
                 timeoutMillis = internalUiTimeoutMillis
             )
             liveSmokeContext.rateVisibleReviewCardGood()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -72,6 +72,10 @@ sealed interface AppStartupState {
     data class Failed(val message: String) : AppStartupState
 }
 
+data class AppGuestCloudSession(
+    val workspaceId: String
+)
+
 class AppGraph(
     context: Context
 ) {
@@ -273,6 +277,17 @@ class AppGraph(
             currentTimeMillis = currentTimeMillis
         )
         cloudPreferencesStore.hydrateCloudSettingsFromDatabase()
+    }
+
+    suspend fun ensureGuestCloudSession(workspaceId: String): AppGuestCloudSession {
+        val guestSession = cloudGuestSessionCoordinator.ensureGuestCloudSession(workspaceId = workspaceId)
+        return AppGuestCloudSession(
+            workspaceId = guestSession.workspaceId
+        )
+    }
+
+    suspend fun deleteStoredGuestCloudSessionIfPresent() {
+        cloudGuestSessionCoordinator.deleteStoredGuestCloudSessionIfPresent()
     }
 
     suspend fun awaitStartup() {

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudIdentityTestSupport.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudIdentityTestSupport.kt
@@ -592,6 +592,9 @@ internal class FakeCloudRemoteGateway private constructor(
         )
     }
 
+    override suspend fun deleteGuestSession(apiBaseUrl: String, guestToken: String) {
+    }
+
     override suspend fun fetchCloudAccount(
         apiBaseUrl: String,
         bearerToken: String

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteService.kt
@@ -122,6 +122,7 @@ interface CloudRemoteGateway {
     suspend fun sendCode(email: String, authBaseUrl: String): CloudSendCodeResult
     suspend fun verifyCode(challenge: CloudOtpChallenge, code: String, authBaseUrl: String): StoredCloudCredentials
     suspend fun refreshIdToken(refreshToken: String, authBaseUrl: String): StoredCloudCredentials
+    suspend fun deleteGuestSession(apiBaseUrl: String, guestToken: String)
     suspend fun fetchCloudAccount(apiBaseUrl: String, bearerToken: String): CloudAccountSnapshot
     suspend fun listLinkedWorkspaces(apiBaseUrl: String, bearerToken: String): List<CloudWorkspaceSummary>
     suspend fun prepareGuestUpgrade(apiBaseUrl: String, bearerToken: String, guestToken: String): CloudGuestUpgradeMode
@@ -335,6 +336,19 @@ class CloudRemoteService : CloudRemoteGateway {
                 expiresInSeconds = expiresIn
             )
         )
+    }
+
+    override
+    suspend fun deleteGuestSession(apiBaseUrl: String, guestToken: String) {
+        val response = postJson(
+            baseUrl = apiBaseUrl,
+            path = "/guest-auth/session/delete",
+            authorizationHeader = "Guest $guestToken",
+            body = null
+        )
+        require(response.requireCloudBoolean("ok", "deleteGuestSession.ok")) {
+            "Cloud delete-guest-session did not return ok=true."
+        }
     }
 
     override

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudGuestSessionCoordinator.kt
@@ -30,6 +30,10 @@ internal data class GuestCloudSessionRestoreResult(
     val shouldSync: Boolean
 )
 
+data class EnsuredGuestCloudSession(
+    val workspaceId: String
+)
+
 class CloudGuestSessionCoordinator(
     private val database: AppDatabase,
     private val preferencesStore: CloudPreferencesStore,
@@ -43,6 +47,22 @@ class CloudGuestSessionCoordinator(
 ) {
     suspend fun reconcilePersistedCloudStateForStartup() {
         reconcilePersistedCloudState()
+    }
+
+    suspend fun ensureGuestCloudSession(workspaceId: String): EnsuredGuestCloudSession {
+        val restoredSession = restoreGuestCloudSessionIfNeeded(
+            workspaceId = workspaceId,
+            createSessionIfMissing = true
+        )
+        return EnsuredGuestCloudSession(
+            workspaceId = restoredSession.session.workspaceId
+        )
+    }
+
+    suspend fun deleteStoredGuestCloudSessionIfPresent() {
+        operationCoordinator.runExclusive {
+            deleteStoredGuestCloudSessionIfPresentLocked()
+        }
     }
 
     internal suspend fun reconcilePersistedCloudState(): CloudIdentityReconciliationResult {
@@ -197,6 +217,25 @@ class CloudGuestSessionCoordinator(
         )
     }
 
+    private suspend fun deleteStoredGuestCloudSessionIfPresentLocked() {
+        val configuration = preferencesStore.currentServerConfiguration()
+        val storedGuestSession = guestSessionStore.loadAnySession(configuration = configuration)
+            ?: return
+
+        try {
+            remoteService.deleteGuestSession(
+                apiBaseUrl = storedGuestSession.apiBaseUrl,
+                guestToken = storedGuestSession.guestToken
+            )
+        } catch (error: Exception) {
+            if (isGuestSessionInvalidError(error = error).not()) {
+                throw error
+            }
+        }
+
+        clearStoredGuestCloudSessionLocalState(session = storedGuestSession)
+    }
+
     private suspend fun finishGuestCloudLinkNonCancellableLocked(
         session: StoredGuestAiSession,
         workspaceId: String?
@@ -273,6 +312,28 @@ class CloudGuestSessionCoordinator(
     private fun isCloudAuthorizationError(error: Exception): Boolean {
         return error is CloudRemoteException &&
             (error.statusCode == 401 || error.statusCode == 403)
+    }
+
+    private fun isGuestSessionInvalidError(error: Exception): Boolean {
+        return error is CloudRemoteException &&
+            error.statusCode == 401 &&
+            error.errorCode == "GUEST_AUTH_INVALID"
+    }
+
+    private suspend fun clearStoredGuestCloudSessionLocalState(session: StoredGuestAiSession) {
+        guestSessionStore.clearSession(localWorkspaceId = null)
+        guestSessionStore.clearSession(localWorkspaceId = session.workspaceId)
+
+        val currentCloudSettings = preferencesStore.currentCloudSettings()
+        val shouldDisconnectDeletedGuestState = currentCloudSettings.cloudState == CloudAccountState.GUEST &&
+            (
+                currentCloudSettings.linkedUserId == session.userId ||
+                    currentCloudSettings.linkedWorkspaceId == session.workspaceId ||
+                    currentCloudSettings.activeWorkspaceId == session.workspaceId
+                )
+        if (shouldDisconnectDeletedGuestState) {
+            resetCoordinator.disconnectCloudIdentityPreservingLocalState()
+        }
     }
 
     private suspend fun loadCurrentWorkspaceForRestoreOrNull(workspaceId: String?): WorkspaceEntity? {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalCloudAccountRepository.kt
@@ -116,7 +116,7 @@ class LocalCloudAccountRepository(
     }
 
     /**
-     * Review/demo accounts can skip OTP and return verified credentials
+     * Review accounts can skip OTP and return verified credentials
      * directly from `sendCode()`. The UI still needs the normal post-auth link
      * context so the live smoke can keep one continuous cross-screen story.
      *

--- a/apps/android/docs/marketing-screenshot-runbook.md
+++ b/apps/android/docs/marketing-screenshot-runbook.md
@@ -11,6 +11,7 @@ These screenshot flows are manual-only Android instrumentation entrypoints.
 They are not part of Android CI, release gates, or default `androidTest` runs.
 Each flow prepares a specific in-app state, captures a PNG on the emulator, and pulls that file into `apps/android/docs/media/play-store-screenshots/`.
 The wrappers run the dedicated `marketingScreenshot` app variant, which can include screenshot-only resource overlays from `apps/android/app/src/marketingScreenshot/res` without changing normal `debug` or `release` builds.
+The screenshot reset rule now deletes any stored guest cloud screenshot session through `POST /guest-auth/session/delete` before the local reset clears the guest token, both before and after a manual screenshot run.
 
 ## Current wrapper scripts
 

--- a/apps/android/docs/marketing-screenshots.md
+++ b/apps/android/docs/marketing-screenshots.md
@@ -78,6 +78,7 @@ FLASHCARDS_MARKETING_LOCALE_PREFIX=de-DE bash scripts/capture-android-review-scr
 These scripts are not part of Android CI, release gates, or default `androidTest` runs.
 They exist only to generate marketing screenshots on demand.
 They run `:app:connectedMarketingScreenshotAndroidTest`, not the normal debug instrumentation task, so screenshot-only translations do not affect the Play-first `debug` and `release` builds.
+The screenshot reset flow deletes the guest cloud session remotely before it clears local screenshot state so the seeded guest workspace does not remain on the backend after the run.
 
 The review wrapper script runs the combined manual-only review-chain entrypoint, saves screenshots 1, 2, and 4 into `/sdcard/Download/flashcards-marketing-screenshots/`, and then pulls those files into the committed marketing media directory.
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/CloudSendCodeNavigationOutcome.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/CloudSendCodeNavigationOutcome.kt
@@ -3,7 +3,7 @@ package com.flashcardsopensourceapp.feature.settings
 /**
  * Distinguishes the two valid navigation paths after `sendCode()`.
  *
- * Review/demo accounts can be fully verified by backend during the initial
+ * Review accounts can be fully verified by backend during the initial
  * send-code call. Those accounts must skip the OTP screen, but they still need
  * the normal post-auth workspace linking and initial sync flow.
  */

--- a/apps/auth/src/routes/sendCode.ts
+++ b/apps/auth/src/routes/sendCode.ts
@@ -105,7 +105,7 @@ export function createSendCodeApp(dependencies: SendCodeDependencies): Hono<Auth
     const requestId = getRequestId(c);
     const demoPassword = await dependencies.getDemoEmailPassword(email);
     if (demoPassword !== null) {
-      // This intentionally disables OTP protection for configured review/demo
+      // This intentionally disables OTP protection for configured review account
       // emails. The allowlist is restricted to synthetic @example.com accounts.
       // Anyone who knows one of these emails and the shared insecure demo
       // password can sign in to that account without OTP.

--- a/apps/auth/src/server/demoEmailAccess.ts
+++ b/apps/auth/src/server/demoEmailAccess.ts
@@ -13,10 +13,10 @@ let cachedDemoPasswordLoaders = new Map<string, Promise<string>>();
 let plaintextSecretLoader: (secretArn: string) => Promise<string> = getPlaintextSecret;
 
 /**
- * Normalizes one configured review/demo email before validation and lookup.
+ * Normalizes one configured review account email before validation and lookup.
  *
- * Demo email access is intentionally insecure and exists only for review/demo
- * accounts. Every allowlisted demo email must use the synthetic
+ * `DEMO_EMAIL_DOSTIP` access is intentionally insecure and exists only for
+ * review accounts. Every allowlisted email must use the synthetic
  * `@example.com` guardian domain.
  */
 function normalizeDemoEmailAccessValue(value: string): string {
@@ -25,14 +25,14 @@ function normalizeDemoEmailAccessValue(value: string): string {
 
 /**
  * Returns true only for emails inside the fixed guardian domain used by the
- * insecure review/demo bypass.
+ * insecure review account bypass.
  */
 function isGuardianDemoEmail(email: string): boolean {
   return email.endsWith(`@${demoEmailGuardianDomain}`);
 }
 
 /**
- * Parses and validates the configured review/demo allowlist.
+ * Parses and validates the configured review account allowlist.
  *
  * The bypass is intentionally insecure, so every configured email must be an
  * explicit allowlist entry and must also belong to `@example.com`.
@@ -46,7 +46,7 @@ function parseDemoEmailAllowlist(rawValue: string): ReadonlySet<string> {
   const invalidEmail = normalizedValues.find((value) => isGuardianDemoEmail(value) === false);
   if (invalidEmail !== undefined) {
     throw new Error(
-      `DEMO_EMAIL_DOSTIP only supports insecure review/demo emails in @${demoEmailGuardianDomain}, got "${invalidEmail}"`,
+      `DEMO_EMAIL_DOSTIP only supports insecure review account emails in @${demoEmailGuardianDomain}, got "${invalidEmail}"`,
     );
   }
 
@@ -54,7 +54,7 @@ function parseDemoEmailAllowlist(rawValue: string): ReadonlySet<string> {
 }
 
 /**
- * Loads the insecure review/demo bypass configuration from environment
+ * Loads the insecure review account bypass configuration from environment
  * variables and validates that the shared password is present when the
  * allowlist is enabled.
  */
@@ -70,13 +70,13 @@ export function getDemoEmailAccessConfig(): DemoEmailAccessConfig {
 
   if (sharedPassword !== "" && passwordSecretArn !== "") {
     throw new Error(
-      "Configure only one of DEMO_PASSWORD_DOSTIP or DEMO_PASSWORD_SECRET_ARN for insecure review/demo access",
+      "Configure only one of DEMO_PASSWORD_DOSTIP or DEMO_PASSWORD_SECRET_ARN for insecure review account access",
     );
   }
 
   if (emailAllowlist.size > 0 && sharedPassword === "" && passwordSecretArn === "") {
     throw new Error(
-      "DEMO_PASSWORD_DOSTIP or DEMO_PASSWORD_SECRET_ARN is required when DEMO_EMAIL_DOSTIP is configured for insecure review/demo access",
+      "DEMO_PASSWORD_DOSTIP or DEMO_PASSWORD_SECRET_ARN is required when DEMO_EMAIL_DOSTIP is configured for insecure review account access",
     );
   }
 
@@ -100,7 +100,8 @@ function getCachedDemoPassword(secretArn: string): Promise<string> {
 }
 
 /**
- * Returns the shared insecure demo password only for emails that are both
+ * Returns the shared insecure review account password only for emails that are
+ * both
  * allowlisted and protected by the `@example.com` guardian restriction.
  */
 export async function getDemoEmailPassword(email: string): Promise<string | null> {
@@ -116,7 +117,7 @@ export async function getDemoEmailPassword(email: string): Promise<string | null
   }
 
   if (config.passwordSecretArn === null) {
-    throw new Error("DEMO_PASSWORD_DOSTIP and DEMO_PASSWORD_SECRET_ARN are unavailable for configured demo email access");
+    throw new Error("DEMO_PASSWORD_DOSTIP and DEMO_PASSWORD_SECRET_ARN are unavailable for configured review account access");
   }
 
   return getCachedDemoPassword(config.passwordSecretArn);
@@ -130,7 +131,7 @@ export function setPlaintextSecretLoaderForTests(
 }
 
 /**
- * Clears the cached review/demo bypass config for test isolation.
+ * Clears the cached review account bypass config for test isolation.
  */
 export function resetDemoEmailAccessConfigForTests(): void {
   resolvedDemoEmailAccessConfig = undefined;

--- a/apps/auth/src/templates/login.ts
+++ b/apps/auth/src/templates/login.ts
@@ -637,7 +637,7 @@ export const renderLoginPage = (redirectUri: string, websiteHomeUrl: string, loc
                 typeof data.idToken === "string" && data.idToken !== ""
                 && typeof data.refreshToken === "string" && data.refreshToken !== ""
               ) {
-                // Review/demo emails can complete sign-in immediately.
+                // Configured review account emails can complete sign-in immediately.
                 window.location.href = redirectUri;
                 return;
               }

--- a/apps/backend/src/accountDeletion.ts
+++ b/apps/backend/src/accountDeletion.ts
@@ -122,8 +122,8 @@ async function deleteAccountDataInExecutor(
  * Fully deletes one real account, including the stale-token tombstone that
  * blocks the removed Cognito identity from reprovisioning.
  *
- * This path is not used for the insecure review/demo accounts configured via
- * `DEMO_EMAIL_DOSTIP`. Those `@example.com` demo accounts keep their Cognito
+ * This path is not used for the insecure review accounts configured via
+ * `DEMO_EMAIL_DOSTIP`. Those `@example.com` review accounts keep their Cognito
  * identity so they can be reused after their app data is cleared.
  */
 async function deleteRealAccountDataInExecutor(
@@ -136,7 +136,7 @@ async function deleteRealAccountDataInExecutor(
 }
 
 /**
- * Clears app data for one configured insecure review/demo account while
+ * Clears app data for one configured insecure review account while
  * preserving the Cognito identity for reuse.
  *
  * This path exists only for the explicit `DEMO_EMAIL_DOSTIP` allowlist inside

--- a/apps/backend/src/demoEmailAccess.ts
+++ b/apps/backend/src/demoEmailAccess.ts
@@ -11,7 +11,7 @@ function normalizeDemoEmailValue(value: string): string {
 }
 
 /**
- * Returns true only for the insecure review/demo accounts that must stay
+ * Returns true only for the insecure review accounts that must stay
  * inside the fixed `@example.com` guardian domain.
  */
 function isGuardianDemoEmail(email: string): boolean {
@@ -21,7 +21,7 @@ function isGuardianDemoEmail(email: string): boolean {
 /**
  * Parses the backend demo allowlist from `DEMO_EMAIL_DOSTIP`.
  *
- * This config exists only for the insecure review/demo accounts in the
+ * This config exists only for the insecure review accounts in the
  * `@example.com` domain. Real user emails must never be treated as demo
  * accounts by this helper.
  */
@@ -34,7 +34,7 @@ function parseDemoEmailAllowlist(rawValue: string): ReadonlySet<string> {
   const invalidEmail = normalizedValues.find((value) => isGuardianDemoEmail(value) === false);
   if (invalidEmail !== undefined) {
     throw new Error(
-      `DEMO_EMAIL_DOSTIP only supports insecure review/demo emails in @${demoEmailGuardianDomain}, got "${invalidEmail}"`,
+      `DEMO_EMAIL_DOSTIP only supports insecure review account emails in @${demoEmailGuardianDomain}, got "${invalidEmail}"`,
     );
   }
 
@@ -53,11 +53,11 @@ function getDemoEmailAccessConfig(): DemoEmailAccessConfig {
 }
 
 /**
- * Returns true only for configured insecure review/demo accounts from
+ * Returns true only for configured insecure review accounts from
  * `DEMO_EMAIL_DOSTIP`.
  *
  * This check is intentionally limited to the explicit allowlist of
- * `@example.com` demo emails. All real accounts must follow the normal
+ * `@example.com` review account emails. All real accounts must follow the normal
  * deletion flow that removes both data and the Cognito identity.
  */
 export function isConfiguredDemoEmail(email: string | null): boolean {

--- a/apps/backend/src/guestAuth.test.ts
+++ b/apps/backend/src/guestAuth.test.ts
@@ -5,6 +5,7 @@ import type pg from "pg";
 import type { DatabaseExecutor } from "./db";
 import {
   completeGuestUpgradeInExecutor,
+  deleteGuestSessionInExecutor,
   prepareGuestUpgradeInExecutor,
 } from "./guestAuth";
 import { HttpError } from "./errors";
@@ -327,12 +328,21 @@ function createGuestUpgradeExecutor(state: MutableState): DatabaseExecutor {
         return createQueryResult<Row>(rows);
       }
 
-      if (text.includes("FROM auth.user_identities")) {
+      if (text.includes("FROM auth.user_identities") && text.includes("provider_subject = $1")) {
         const providerSubject = params[0];
         const mappedUserId = typeof providerSubject === "string"
           ? state.identityMappings.get(providerSubject) ?? null
           : null;
         const rows = mappedUserId === null ? [] : [{ user_id: mappedUserId } as unknown as Row];
+        return createQueryResult<Row>(rows);
+      }
+
+      if (text.includes("FROM auth.user_identities") && text.includes("user_id = $1")) {
+        const userId = params[0];
+        const hasMapping = typeof userId === "string"
+          ? [...state.identityMappings.values()].some((mappedUserId) => mappedUserId === userId)
+          : false;
+        const rows = hasMapping ? [{ user_id: String(userId) } as unknown as Row] : [];
         return createQueryResult<Row>(rows);
       }
 
@@ -933,6 +943,112 @@ test("completeGuestUpgradeInExecutor reassigns guest installation ownership duri
   ));
   assert.ok(targetReplica);
   assert.equal(targetReplica?.user_id, targetUserId);
+});
+
+test("deleteGuestSessionInExecutor revokes and removes guest server state", async () => {
+  const guestToken = "guest-token-delete";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-delete",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject: "cognito-subject-delete",
+    targetUserId: "linked-user",
+    targetWorkspaceId: "target-workspace",
+    guestReplicaId: "guest-replica-delete",
+    installationId: "installation-delete",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+  await deleteGuestSessionInExecutor(executor, guestToken);
+
+  assert.equal(state.guestSession.revoked_at, "2026-04-02T14:01:16.000Z");
+  assert.equal(state.userSettings.has(guestUserId), false);
+  assert.equal(state.workspaces.has(guestWorkspaceId), false);
+  assert.equal(
+    state.workspaceReplicas.some((replica) => replica.workspace_id === guestWorkspaceId),
+    false,
+  );
+});
+
+test("deleteGuestSessionInExecutor rejects an already-revoked guest session", async () => {
+  const guestToken = "guest-token-delete-replay";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-delete-replay",
+    guestUserId: "guest-user",
+    guestWorkspaceId: "guest-workspace",
+    targetSubject: "cognito-subject-delete-replay",
+    targetUserId: "linked-user",
+    targetWorkspaceId: "target-workspace",
+    guestReplicaId: "guest-replica-delete-replay",
+    installationId: "installation-delete-replay",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+  await deleteGuestSessionInExecutor(executor, guestToken);
+
+  await assert.rejects(
+    async () => deleteGuestSessionInExecutor(executor, guestToken),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 401);
+      assert.equal(error.code, "GUEST_AUTH_INVALID");
+      return true;
+    },
+  );
+});
+
+test("deleteGuestSessionInExecutor rejects cleanup after a bound guest upgrade", async () => {
+  const guestToken = "guest-token-delete-bound";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const cognitoSubject = "cognito-subject-delete-bound";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-delete-bound",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject: "different-target-subject",
+    targetUserId: "linked-user",
+    targetWorkspaceId: "target-workspace",
+    guestReplicaId: "guest-replica-delete-bound",
+    installationId: "installation-delete-bound",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.identityMappings.clear();
+
+  const executor = createGuestUpgradeExecutor(state);
+  const preparation = await prepareGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    cognitoSubject,
+    "bound@example.com",
+  );
+
+  assert.equal(preparation.mode, "bound");
+
+  await assert.rejects(
+    async () => deleteGuestSessionInExecutor(executor, guestToken),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "GUEST_SESSION_DELETE_LINKED_ACCOUNT");
+      return true;
+    },
+  );
+
+  assert.equal(state.guestSession.revoked_at, null);
+  assert.equal(state.userSettings.has(guestUserId), true);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
+  assert.equal(state.identityMappings.get(cognitoSubject), guestUserId);
 });
 
 test("completeGuestUpgradeInExecutor with create_new creates and selects a new target workspace", async () => {

--- a/apps/backend/src/guestAuth.ts
+++ b/apps/backend/src/guestAuth.ts
@@ -1,5 +1,8 @@
 import { unsafeTransaction } from "./dbUnsafe";
 import {
+  deleteGuestSessionInExecutor,
+} from "./guestAuth/delete";
+import {
   authenticateGuestSession,
   createGuestSessionInExecutor,
 } from "./guestAuth/session";
@@ -21,7 +24,12 @@ export type {
   GuestUpgradeSelection,
 } from "./guestAuth/types";
 
-export { authenticateGuestSession, completeGuestUpgradeInExecutor, prepareGuestUpgradeInExecutor };
+export {
+  authenticateGuestSession,
+  completeGuestUpgradeInExecutor,
+  deleteGuestSessionInExecutor,
+  prepareGuestUpgradeInExecutor,
+};
 
 export async function createGuestSession(): Promise<GuestSessionSnapshot> {
   return unsafeTransaction(async (executor) => createGuestSessionInExecutor(executor));
@@ -45,4 +53,8 @@ export async function completeGuestUpgrade(
   return unsafeTransaction(
     async (executor) => completeGuestUpgradeInExecutor(executor, guestToken, cognitoSubject, selection),
   );
+}
+
+export async function deleteGuestSession(guestToken: string): Promise<void> {
+  return unsafeTransaction(async (executor) => deleteGuestSessionInExecutor(executor, guestToken));
 }

--- a/apps/backend/src/guestAuth/delete.ts
+++ b/apps/backend/src/guestAuth/delete.ts
@@ -1,0 +1,48 @@
+import type { DatabaseExecutor } from "../db";
+import { HttpError } from "../errors";
+import {
+  deleteUserSettingsInExecutor,
+  hasCognitoIdentityMappingForUserInExecutor,
+  deleteWorkspaceInExecutor,
+  loadGuestSessionInExecutor,
+  loadGuestWorkspaceIdInExecutor,
+  revokeGuestSessionInExecutor,
+} from "./store";
+
+export async function cleanupGuestSessionSourceInExecutor(
+  executor: DatabaseExecutor,
+  guestUserId: string,
+  guestSessionId: string,
+  guestWorkspaceId: string,
+): Promise<void> {
+  await revokeGuestSessionInExecutor(executor, guestUserId, guestSessionId);
+  await deleteWorkspaceInExecutor(executor, guestUserId, guestWorkspaceId);
+  await deleteUserSettingsInExecutor(executor, guestUserId);
+}
+
+/**
+ * Deletes one live guest session and its server-owned source rows.
+ *
+ * This operation is intentionally not idempotent. Callers must provide a live
+ * non-revoked guest token, and later attempts fail with `GUEST_AUTH_INVALID`.
+ */
+export async function deleteGuestSessionInExecutor(
+  executor: DatabaseExecutor,
+  guestToken: string,
+): Promise<void> {
+  const guestSession = await loadGuestSessionInExecutor(executor, guestToken, true);
+  if (await hasCognitoIdentityMappingForUserInExecutor(executor, guestSession.userId)) {
+    throw new HttpError(
+      409,
+      "Guest session is already linked to a signed-in account. Use /me/delete from that account instead.",
+      "GUEST_SESSION_DELETE_LINKED_ACCOUNT",
+    );
+  }
+  const guestWorkspaceId = await loadGuestWorkspaceIdInExecutor(executor, guestSession.userId);
+  await cleanupGuestSessionSourceInExecutor(
+    executor,
+    guestSession.userId,
+    guestSession.sessionId,
+    guestWorkspaceId,
+  );
+}

--- a/apps/backend/src/guestAuth/store.ts
+++ b/apps/backend/src/guestAuth/store.ts
@@ -401,6 +401,23 @@ export async function loadIdentityMappingInExecutor(
   return result.rows[0]?.user_id ?? null;
 }
 
+export async function hasCognitoIdentityMappingForUserInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+): Promise<boolean> {
+  const result = await executor.query<IdentityMappingRow>(
+    [
+      "SELECT user_id",
+      "FROM auth.user_identities",
+      "WHERE provider_type = 'cognito' AND user_id = $1",
+      "LIMIT 1",
+    ].join(" "),
+    [userId],
+  );
+
+  return result.rows[0] !== undefined;
+}
+
 export async function bindIdentityMappingInExecutor(
   executor: DatabaseExecutor,
   providerSubject: string,

--- a/apps/backend/src/guestAuth/upgrade.ts
+++ b/apps/backend/src/guestAuth/upgrade.ts
@@ -4,12 +4,11 @@ import {
   AUTO_CREATED_WORKSPACE_NAME,
   createWorkspaceInExecutor,
 } from "../workspaces";
+import { cleanupGuestSessionSourceInExecutor } from "./delete";
 import { mergeGuestWorkspaceIntoTargetInExecutor } from "./merge";
 import {
   assertTargetWorkspaceAccessInExecutor,
   bindIdentityMappingInExecutor,
-  deleteUserSettingsInExecutor,
-  deleteWorkspaceInExecutor,
   loadGuestSessionInExecutor,
   loadGuestSessionRecordInExecutor,
   loadGuestUpgradeReplayInExecutor,
@@ -18,7 +17,6 @@ import {
   loadWorkspaceNameInExecutor,
   loadWorkspaceSummaryInExecutor,
   recordGuestUpgradeHistoryInExecutor,
-  revokeGuestSessionInExecutor,
   selectWorkspaceForUserInExecutor,
   updateUserEmailInExecutor,
 } from "./store";
@@ -119,19 +117,6 @@ async function persistGuestUpgradeTargetSelectionInExecutor(
   // Keep the target account pointed at the post-merge workspace before guest
   // cleanup starts so replay/idempotency stays anchored to the same selection.
   await selectWorkspaceForUserInExecutor(executor, targetUserId, targetWorkspaceId);
-}
-
-async function cleanupGuestUpgradeSourceInExecutor(
-  executor: DatabaseExecutor,
-  guestUserId: string,
-  guestSessionId: string,
-  guestWorkspaceId: string,
-): Promise<void> {
-  // Cleanup stays in one source-scoped phase so destructive guest-side work is
-  // not interleaved with target writes.
-  await revokeGuestSessionInExecutor(executor, guestUserId, guestSessionId);
-  await deleteWorkspaceInExecutor(executor, guestUserId, guestWorkspaceId);
-  await deleteUserSettingsInExecutor(executor, guestUserId);
 }
 
 /**
@@ -240,7 +225,7 @@ export async function completeGuestUpgradeInExecutor(
   );
 
   // Phase 9: revoke and delete guest source rows.
-  await cleanupGuestUpgradeSourceInExecutor(
+  await cleanupGuestSessionSourceInExecutor(
     executor,
     guestSession.userId,
     guestSession.sessionId,

--- a/apps/backend/src/progress.test.ts
+++ b/apps/backend/src/progress.test.ts
@@ -337,7 +337,7 @@ test("loadUserProgressSummaryInExecutor merges all-time review dates across work
   });
 });
 
-test("loadUserProgressSeriesInExecutor queries review events with requested timezone day bucketing", async () => {
+test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_client in the requested timezone", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
@@ -364,6 +364,7 @@ test("loadUserProgressSeriesInExecutor queries review events with requested time
   assert.match(reviewQuery.text, /timezone\(\$2, review_events\.reviewed_at_client\)::date/);
   assert.match(reviewQuery.text, /review_events\.reviewed_at_client >= \(\(\$3::date\)::timestamp AT TIME ZONE \$2\)/);
   assert.match(reviewQuery.text, /review_events\.reviewed_at_client < \(\(\(\(\$4::date\) \+ 1\)::timestamp\) AT TIME ZONE \$2\)/);
+  assert.doesNotMatch(reviewQuery.text, /reviewed_at_server/);
   assert.deepEqual(reviewQuery.params, [
     "workspace-1",
     "America/Los_Angeles",
@@ -372,7 +373,7 @@ test("loadUserProgressSeriesInExecutor queries review events with requested time
   ]);
 });
 
-test("loadUserProgressSummaryInExecutor queries all-time distinct review dates with the requested timezone", async () => {
+test("loadUserProgressSummaryInExecutor derives active review dates from reviewed_at_client in the requested timezone", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
@@ -397,6 +398,7 @@ test("loadUserProgressSummaryInExecutor queries all-time distinct review dates w
     assert.fail("Expected an all-time review date query to be recorded");
   }
   assert.match(summaryQuery.text, /ORDER BY review_local_dates\.review_local_date DESC/);
+  assert.doesNotMatch(summaryQuery.text, /reviewed_at_server/);
   assert.deepEqual(summaryQuery.params, [
     "workspace-1",
     "America/Los_Angeles",

--- a/apps/backend/src/routes/guestAuth.test.ts
+++ b/apps/backend/src/routes/guestAuth.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AppEnv } from "../app";
+import type { AuthResult } from "../auth";
+import { AuthError } from "../auth";
+import { HttpError } from "../errors";
+import { createGuestAuthRoutes } from "./guestAuth";
+
+type GuestAuthTestAppOptions = Readonly<{
+  authResult: AuthResult;
+  onDeleteGuestSession?: (guestToken: string) => Promise<void>;
+}>;
+
+function createGuestAuthTestApp(options: GuestAuthTestAppOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-1");
+    await next();
+  });
+  app.onError((error, context) => {
+    if (error instanceof AuthError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: error.message,
+        requestId: context.get("requestId"),
+        code: "AUTH_UNAUTHORIZED",
+      });
+    }
+
+    if (error instanceof HttpError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: error.message,
+        requestId: context.get("requestId"),
+        code: error.code,
+      });
+    }
+
+    context.status(500);
+    return context.json({
+      error: "Request failed. Try again.",
+      requestId: context.get("requestId"),
+      code: "INTERNAL_ERROR",
+    });
+  });
+  app.route("/", createGuestAuthRoutes({
+    authenticateRequestFn: async () => options.authResult,
+    deleteGuestSessionFn: async (guestToken) => {
+      await options.onDeleteGuestSession?.(guestToken);
+    },
+  }));
+  return app;
+}
+
+function createAuthResult(transport: AuthResult["transport"]): AuthResult {
+  return {
+    userId: "guest-user",
+    email: null,
+    cognitoUsername: null,
+    subjectUserId: "guest-user",
+    transport,
+    connectionId: null,
+    selectedWorkspaceId: "guest-workspace",
+  };
+}
+
+test("POST /guest-auth/session/delete deletes a guest session with Guest authentication", async () => {
+  let deletedGuestToken: string | null = null;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("guest"),
+    onDeleteGuestSession: async (guestToken) => {
+      deletedGuestToken = guestToken;
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/session/delete", {
+    method: "POST",
+    headers: {
+      authorization: "Guest guest-token-delete-route",
+    },
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(deletedGuestToken, "guest-token-delete-route");
+  assert.deepEqual(await response.json(), { ok: true });
+});
+
+test("POST /guest-auth/session/delete rejects non-guest authentication", async () => {
+  let deleted = false;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("bearer"),
+    onDeleteGuestSession: async () => {
+      deleted = true;
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/session/delete", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt-token",
+    },
+  });
+
+  assert.equal(response.status, 403);
+  assert.equal(deleted, false);
+  assert.deepEqual(await response.json(), {
+    error: "Delete guest session requires Guest authentication.",
+    requestId: "request-1",
+    code: "GUEST_SESSION_DELETE_GUEST_AUTH_REQUIRED",
+  });
+});
+
+test("POST /guest-auth/session/delete returns 409 for a guest session already linked to an account", async () => {
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("guest"),
+    onDeleteGuestSession: async () => {
+      throw new HttpError(
+        409,
+        "Guest session is already linked to a signed-in account. Use /me/delete from that account instead.",
+        "GUEST_SESSION_DELETE_LINKED_ACCOUNT",
+      );
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/session/delete", {
+    method: "POST",
+    headers: {
+      authorization: "Guest guest-token-delete-route",
+    },
+  });
+
+  assert.equal(response.status, 409);
+  assert.deepEqual(await response.json(), {
+    error: "Guest session is already linked to a signed-in account. Use /me/delete from that account instead.",
+    requestId: "request-1",
+    code: "GUEST_SESSION_DELETE_LINKED_ACCOUNT",
+  });
+});

--- a/apps/backend/src/routes/guestAuth.ts
+++ b/apps/backend/src/routes/guestAuth.ts
@@ -4,6 +4,7 @@ import { HttpError } from "../errors";
 import {
   completeGuestUpgrade,
   createGuestSession,
+  deleteGuestSession,
   prepareGuestUpgrade,
   type GuestUpgradeSelection,
 } from "../guestAuth";
@@ -35,6 +36,11 @@ type GuestUpgradeCompleteEnvelope = Readonly<{
   }>;
 }>;
 
+type GuestAuthRoutesOptions = Readonly<{
+  authenticateRequestFn?: typeof authenticateRequest;
+  deleteGuestSessionFn?: typeof deleteGuestSession;
+}>;
+
 function parseGuestUpgradeSelection(value: unknown): GuestUpgradeSelection {
   const body = expectRecord(value);
   const type = expectNonEmptyString(body.type, "selection.type");
@@ -52,8 +58,23 @@ function parseGuestUpgradeSelection(value: unknown): GuestUpgradeSelection {
   throw new HttpError(400, "selection.type is invalid", "GUEST_UPGRADE_SELECTION_INVALID");
 }
 
-export function createGuestAuthRoutes(): Hono<AppEnv> {
+function expectGuestAuthorizationToken(authorizationHeader: string | undefined): string {
+  if (authorizationHeader === undefined || !authorizationHeader.startsWith("Guest ")) {
+    throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
+  }
+
+  const guestToken = authorizationHeader.slice(6).trim();
+  if (guestToken === "") {
+    throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
+  }
+
+  return guestToken;
+}
+
+export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
+  const authenticateRequestFn = options.authenticateRequestFn ?? authenticateRequest;
+  const deleteGuestSessionFn = options.deleteGuestSessionFn ?? deleteGuestSession;
 
   app.post("/guest-auth/session", async (context) => {
     const session = await createGuestSession();
@@ -64,8 +85,24 @@ export function createGuestAuthRoutes(): Hono<AppEnv> {
     } satisfies GuestSessionEnvelope);
   });
 
+  app.post("/guest-auth/session/delete", async (context) => {
+    const requestAuthInputs = extractRequestAuthInputs(context.req.raw);
+    const auth = await authenticateRequestFn(toAuthRequest(requestAuthInputs));
+    if (auth.transport !== "guest") {
+      throw new HttpError(
+        403,
+        "Delete guest session requires Guest authentication.",
+        "GUEST_SESSION_DELETE_GUEST_AUTH_REQUIRED",
+      );
+    }
+
+    const guestToken = expectGuestAuthorizationToken(requestAuthInputs.authorizationHeader);
+    await deleteGuestSessionFn(guestToken);
+    return context.json({ ok: true } as const);
+  });
+
   app.post("/guest-auth/upgrade/prepare", async (context) => {
-    const auth = await authenticateRequest(toAuthRequest(extractRequestAuthInputs(context.req.raw)));
+    const auth = await authenticateRequestFn(toAuthRequest(extractRequestAuthInputs(context.req.raw)));
     if (auth.transport !== "bearer" && auth.transport !== "session") {
       throw new HttpError(403, "Sign in before upgrading this guest session.", "GUEST_UPGRADE_HUMAN_AUTH_REQUIRED");
     }
@@ -79,7 +116,7 @@ export function createGuestAuthRoutes(): Hono<AppEnv> {
   });
 
   app.post("/guest-auth/upgrade/complete", async (context) => {
-    const auth = await authenticateRequest(toAuthRequest(extractRequestAuthInputs(context.req.raw)));
+    const auth = await authenticateRequestFn(toAuthRequest(extractRequestAuthInputs(context.req.raw)));
     if (auth.transport !== "bearer" && auth.transport !== "session") {
       throw new HttpError(403, "Sign in before upgrading this guest session.", "GUEST_UPGRADE_HUMAN_AUTH_REQUIRED");
     }

--- a/apps/backend/src/sync.input.test.ts
+++ b/apps/backend/src/sync.input.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { HttpError } from "./errors";
+import { parseSyncPushInput } from "./sync/input";
+
+type ReviewEventTimestampFixture = Readonly<{
+  clientUpdatedAt: string;
+  reviewedAtClient: string;
+}>;
+
+function createSyncPushInput(
+  fixture: ReviewEventTimestampFixture,
+): Readonly<{
+  installationId: string;
+  platform: "ios";
+  operations: ReadonlyArray<Readonly<{
+    operationId: string;
+    entityType: "review_event";
+    action: "append";
+    entityId: string;
+    clientUpdatedAt: string;
+    payload: Readonly<{
+      reviewEventId: string;
+      cardId: string;
+      clientEventId: string;
+      rating: 2;
+      reviewedAtClient: string;
+    }>;
+  }>>;
+}> {
+  return {
+    installationId: "installation-1",
+    platform: "ios",
+    operations: [
+      {
+        operationId: "operation-1",
+        entityType: "review_event",
+        action: "append",
+        entityId: "review-event-1",
+        clientUpdatedAt: fixture.clientUpdatedAt,
+        payload: {
+          reviewEventId: "review-event-1",
+          cardId: "card-1",
+          clientEventId: "client-event-1",
+          rating: 2,
+          reviewedAtClient: fixture.reviewedAtClient,
+        },
+      },
+    ],
+  };
+}
+
+test("parseSyncPushInput accepts backdated review_event timestamps through the normal sync push contract", () => {
+  const input = createSyncPushInput({
+    clientUpdatedAt: "2018-02-03T04:05:06.000Z",
+    reviewedAtClient: "2018-02-03T04:05:06.000Z",
+  });
+
+  const parsedInput = parseSyncPushInput(input);
+
+  assert.equal(parsedInput.operations[0]?.entityType, "review_event");
+  if (parsedInput.operations[0]?.entityType !== "review_event") {
+    assert.fail("Expected the parsed sync operation to remain a review_event");
+  }
+  assert.equal(parsedInput.operations[0].clientUpdatedAt, "2018-02-03T04:05:06.000Z");
+  assert.equal(parsedInput.operations[0].payload.reviewedAtClient, "2018-02-03T04:05:06.000Z");
+});
+
+test("parseSyncPushInput rejects review_event operations when clientUpdatedAt diverges from reviewedAtClient", () => {
+  const input = createSyncPushInput({
+    clientUpdatedAt: "2018-02-03T04:05:06.000Z",
+    reviewedAtClient: "2018-02-02T04:05:06.000Z",
+  });
+
+  assert.throws(
+    () => parseSyncPushInput(input),
+    (error: unknown) => {
+      if (!(error instanceof HttpError)) {
+        assert.fail("Expected parseSyncPushInput to throw HttpError");
+      }
+
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "SYNC_INVALID_INPUT");
+      assert.deepEqual(error.details?.validationIssues, [
+        {
+          path: "operations.0.clientUpdatedAt",
+          code: "custom",
+          message: "review_event clientUpdatedAt must match payload.reviewedAtClient",
+        },
+      ]);
+
+      return true;
+    },
+  );
+});

--- a/apps/backend/src/sync/input.ts
+++ b/apps/backend/src/sync/input.ts
@@ -4,6 +4,7 @@ import type {
   HttpErrorDetails,
   ValidationIssueSummary,
 } from "../errors";
+import { normalizeIsoTimestamp } from "../lww";
 
 type Platform = "ios" | "android" | "web";
 
@@ -138,19 +139,46 @@ const reviewEventOperationSchema = baseOperationSchema.extend({
   payload: reviewEventPushPayloadSchema,
 });
 
-const syncPushInputSchema = z.object({
+const syncPushOperationSchema = z.discriminatedUnion("entityType", [
+  cardOperationSchema,
+  deckOperationSchema,
+  workspaceSchedulerSettingsOperationSchema,
+  reviewEventOperationSchema,
+]);
+
+const syncPushInputBaseSchema = z.object({
   installationId: z.string().min(1),
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
-  operations: z.array(
-    z.discriminatedUnion("entityType", [
-      cardOperationSchema,
-      deckOperationSchema,
-      workspaceSchedulerSettingsOperationSchema,
-      reviewEventOperationSchema,
-    ]),
-  ),
+  operations: z.array(syncPushOperationSchema),
 });
+
+type SyncPushInputBase = z.infer<typeof syncPushInputBaseSchema>;
+
+function validateSyncPushReviewEventTimestamps(
+  input: SyncPushInputBase,
+  refinementContext: z.core.$RefinementCtx,
+): void {
+  for (const [operationIndex, operation] of input.operations.entries()) {
+    if (operation.entityType !== "review_event") {
+      continue;
+    }
+
+    const normalizedClientUpdatedAt = normalizeIsoTimestamp(operation.clientUpdatedAt, "clientUpdatedAt");
+    const normalizedReviewedAtClient = normalizeIsoTimestamp(operation.payload.reviewedAtClient, "reviewedAtClient");
+    if (normalizedClientUpdatedAt === normalizedReviewedAtClient) {
+      continue;
+    }
+
+    refinementContext.addIssue({
+      code: "custom",
+      path: ["operations", operationIndex, "clientUpdatedAt"],
+      message: "review_event clientUpdatedAt must match payload.reviewedAtClient",
+    });
+  }
+}
+
+const syncPushInputSchema = syncPushInputBaseSchema.superRefine(validateSyncPushReviewEventTimestamps);
 
 const syncPullInputSchema = z.object({
   installationId: z.string().min(1),

--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import UIKit
 
-private let flashcardsUITestResetStateEnvironmentKey: String = "FLASHCARDS_UI_TEST_RESET_STATE"
+private let flashcardsUITestLaunchScenarioEnvironmentKey: String = "FLASHCARDS_UI_TEST_LAUNCH_SCENARIO"
 private let flashcardsUITestSelectedTabEnvironmentKey: String = "FLASHCARDS_UI_TEST_SELECTED_TAB"
 private let flashcardsUITestAppNotificationTapTypeEnvironmentKey: String = "FLASHCARDS_UI_TEST_APP_NOTIFICATION_TAP_TYPE"
 private let flashcardsUITestAIHandoffCardEnvironmentKey: String = "FLASHCARDS_UI_TEST_AI_HANDOFF_CARD"
@@ -35,7 +35,19 @@ private enum FlashcardsUITestAIHandoffCard: String {
     case firstCard = "first_card"
 }
 
+private enum FlashcardsUITestLaunchError: LocalizedError {
+    case missingAIHandoffCard(FlashcardsUITestAIHandoffCard)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAIHandoffCard(.firstCard):
+            return "UI test AI handoff requested the first prepared card, but no UI test card is available."
+        }
+    }
+}
+
 private struct CloudSyncPollingTaskID: Hashable {
+    let isStartupReady: Bool
     let isSceneActive: Bool
     let selectedTab: AppTab
     let fastPollingUntil: Date?
@@ -43,6 +55,7 @@ private struct CloudSyncPollingTaskID: Hashable {
 }
 
 private struct ProgressContextWatcherTaskID: Hashable {
+    let isStartupReady: Bool
     let isSceneActive: Bool
     let refreshToken: Int
 }
@@ -74,19 +87,25 @@ private func consumeFlashcardsUITestAppNotificationTapRequest(processInfo: Proce
 }
 
 @MainActor
-private func makeFlashcardsUITestAIChatPresentationRequest(
-    processInfo: ProcessInfo,
-    store: FlashcardsStore
-) -> AIChatPresentationRequest? {
-    guard let rawValue = processInfo.environment[flashcardsUITestAIHandoffCardEnvironmentKey],
-          let handoffCard = FlashcardsUITestAIHandoffCard(rawValue: rawValue) else {
+private func makeFlashcardsUITestAIHandoffCard(
+    processInfo: ProcessInfo
+) -> FlashcardsUITestAIHandoffCard? {
+    guard let rawValue = processInfo.environment[flashcardsUITestAIHandoffCardEnvironmentKey] else {
         return nil
     }
 
+    return FlashcardsUITestAIHandoffCard(rawValue: rawValue)
+}
+
+@MainActor
+private func makeFlashcardsUITestAIChatPresentationRequest(
+    handoffCard: FlashcardsUITestAIHandoffCard,
+    store: FlashcardsStore
+) throws -> AIChatPresentationRequest {
     switch handoffCard {
     case .firstCard:
         guard let card = store.cards.first else {
-            return nil
+            throw FlashcardsUITestLaunchError.missingAIHandoffCard(.firstCard)
         }
 
         return .attachCard(makeAIChatCardReference(card: card))
@@ -100,6 +119,10 @@ struct FlashcardsApp: App {
     @State private var store: FlashcardsStore
     @State private var navigation: AppNavigationModel
     @State private var progressContextWatcherRefreshToken: Int
+    @State private var uiTestLaunchScenario: FlashcardsUITestLaunchScenario?
+    @State private var uiTestAIHandoffCard: FlashcardsUITestAIHandoffCard?
+    @State private var hasRunInitialStartup: Bool
+    @State private var isStartupReadyForBackgroundWork: Bool
 
     @MainActor
     init() {
@@ -108,18 +131,12 @@ struct FlashcardsApp: App {
         let selectedTab = processInfo.environment[flashcardsUITestSelectedTabEnvironmentKey]
             .flatMap(FlashcardsUITestSelectedTab.init(rawValue:))
             .map(\.appTab) ?? .review
-        if let resetStateRawValue = processInfo.environment[flashcardsUITestResetStateEnvironmentKey],
-           let resetState = FlashcardsUITestResetState(rawValue: resetStateRawValue) {
-            do {
-                try store.applyUITestResetState(resetState: resetState)
-            } catch {
-                store.globalErrorMessage = Flashcards.errorMessage(error: error)
-            }
+        let launchScenario = processInfo.environment[flashcardsUITestLaunchScenarioEnvironmentKey]
+            .flatMap(FlashcardsUITestLaunchScenario.init(rawValue:))
+        let aiHandoffCard = makeFlashcardsUITestAIHandoffCard(processInfo: processInfo)
+        if let launchScenario {
+            store.uiTestLaunchPreparationStatus = .running(launchScenario: launchScenario)
         }
-        let aiChatPresentationRequest = makeFlashcardsUITestAIChatPresentationRequest(
-            processInfo: processInfo,
-            store: store
-        )
         if let request = consumeFlashcardsUITestAppNotificationTapRequest(processInfo: processInfo) {
             let receivedMetadata = makeAppNotificationTapLogMetadata(
                 request: request,
@@ -173,10 +190,14 @@ struct FlashcardsApp: App {
                 selectedTab: selectedTab,
                 settingsPath: [],
                 cardsPresentationRequest: nil,
-                aiChatPresentationRequest: aiChatPresentationRequest
+                aiChatPresentationRequest: nil
             )
         )
         _progressContextWatcherRefreshToken = State(initialValue: 0)
+        _uiTestLaunchScenario = State(initialValue: launchScenario)
+        _uiTestAIHandoffCard = State(initialValue: aiHandoffCard)
+        _hasRunInitialStartup = State(initialValue: false)
+        _isStartupReadyForBackgroundWork = State(initialValue: false)
     }
 
     var body: some Scene {
@@ -185,23 +206,13 @@ struct FlashcardsApp: App {
                 .environment(store)
                 .environment(navigation)
                 .task {
-                    store.updateCurrentVisibleTab(tab: navigation.selectedTab)
-                    await store.resumePendingAccountDeletionIfNeeded()
-                    let now = Date()
-                    self.refreshProgressContext(now: now, restartWatcher: false)
-                    store.triggerCloudSyncIfLinked(
-                        trigger: CloudSyncTrigger(
-                            source: .appLaunch,
-                            now: now,
-                            extendsFastPolling: usesFastCloudSyncPolling(tab: navigation.selectedTab),
-                            allowsVisibleChangeBanner: true,
-                            surfacesGlobalErrorMessage: false
-                        )
-                    )
-                    store.reconcileReviewNotifications(trigger: .appActive, now: now)
-                    store.reconcileStrictReminders(trigger: .appActive, now: now)
+                    await self.runInitialAppStartupIfNeeded()
                 }
                 .onChange(of: scenePhase) { _, nextPhase in
+                    guard self.isStartupReadyForBackgroundWork else {
+                        return
+                    }
+
                     if nextPhase == .active {
                         let now = Date()
                         self.refreshProgressContext(now: now, restartWatcher: true)
@@ -244,6 +255,7 @@ struct FlashcardsApp: App {
 
     private var cloudSyncPollingTaskID: CloudSyncPollingTaskID {
         CloudSyncPollingTaskID(
+            isStartupReady: self.isStartupReadyForBackgroundWork,
             isSceneActive: self.scenePhase == .active,
             selectedTab: self.navigation.selectedTab,
             fastPollingUntil: self.store.cloudSyncFastPollingUntil,
@@ -252,13 +264,84 @@ struct FlashcardsApp: App {
     }
 
     private var isAppNotificationTapConsumptionReady: Bool {
-        self.scenePhase == .active
+        self.isStartupReadyForBackgroundWork && self.scenePhase == .active
     }
 
     private var progressContextWatcherTaskID: ProgressContextWatcherTaskID {
         ProgressContextWatcherTaskID(
+            isStartupReady: self.isStartupReadyForBackgroundWork,
             isSceneActive: self.scenePhase == .active,
             refreshToken: self.progressContextWatcherRefreshToken
+        )
+    }
+
+    @MainActor
+    private func runInitialAppStartupIfNeeded() async {
+        guard self.hasRunInitialStartup == false else {
+            return
+        }
+
+        self.hasRunInitialStartup = true
+
+        do {
+            try await self.runUITestLaunchScenarioIfNeeded()
+            try self.applyUITestAIHandoffIfNeeded()
+
+            self.store.updateCurrentVisibleTab(tab: self.navigation.selectedTab)
+            await self.store.resumePendingAccountDeletionIfNeeded()
+
+            let now = Date()
+            self.refreshProgressContext(now: now, restartWatcher: false)
+            if self.uiTestLaunchScenario == nil {
+                self.store.triggerCloudSyncIfLinked(
+                    trigger: CloudSyncTrigger(
+                        source: .appLaunch,
+                        now: now,
+                        extendsFastPolling: usesFastCloudSyncPolling(tab: self.navigation.selectedTab),
+                        allowsVisibleChangeBanner: true,
+                        surfacesGlobalErrorMessage: false
+                    )
+                )
+            }
+            self.store.reconcileReviewNotifications(trigger: .appActive, now: now)
+            self.store.reconcileStrictReminders(trigger: .appActive, now: now)
+
+            if let launchScenario = self.uiTestLaunchScenario {
+                self.store.uiTestLaunchPreparationStatus = .ready(launchScenario: launchScenario)
+            }
+            self.isStartupReadyForBackgroundWork = true
+        } catch {
+            self.store.globalErrorMessage = Flashcards.errorMessage(error: error)
+            if let launchScenario = self.uiTestLaunchScenario {
+                self.store.uiTestLaunchPreparationStatus = .failed(
+                    launchScenario: launchScenario,
+                    message: Flashcards.errorMessage(error: error)
+                )
+            }
+        }
+    }
+
+    @MainActor
+    private func runUITestLaunchScenarioIfNeeded() async throws {
+        guard let launchScenario = self.uiTestLaunchScenario else {
+            return
+        }
+
+        try await self.store.executeUITestLaunchScenario(
+            launchScenario: launchScenario,
+            processInfo: ProcessInfo.processInfo
+        )
+    }
+
+    @MainActor
+    private func applyUITestAIHandoffIfNeeded() throws {
+        guard let handoffCard = self.uiTestAIHandoffCard else {
+            return
+        }
+
+        self.navigation.aiChatPresentationRequest = try makeFlashcardsUITestAIChatPresentationRequest(
+            handoffCard: handoffCard,
+            store: self.store
         )
     }
 
@@ -273,7 +356,7 @@ struct FlashcardsApp: App {
 
     @MainActor
     private func handleProgressContextSystemChange() {
-        guard self.scenePhase == .active else {
+        guard self.isStartupReadyForBackgroundWork, self.scenePhase == .active else {
             return
         }
 
@@ -282,12 +365,12 @@ struct FlashcardsApp: App {
 
     @MainActor
     private func consumePendingAppNotificationTapIfNeeded() async {
-        guard self.scenePhase == .active else {
+        guard self.isStartupReadyForBackgroundWork, self.scenePhase == .active else {
             return
         }
 
         await Task.yield()
-        guard self.scenePhase == .active else {
+        guard self.isStartupReadyForBackgroundWork, self.scenePhase == .active else {
             return
         }
 
@@ -335,14 +418,16 @@ struct FlashcardsApp: App {
 
     @MainActor
     private func runCloudSyncPollingLoop() async {
-        guard self.scenePhase == .active else {
+        guard self.isStartupReadyForBackgroundWork, self.scenePhase == .active else {
             return
         }
         guard self.store.isCloudSyncBlocked == false else {
             return
         }
 
-        while Task.isCancelled == false && self.scenePhase == .active {
+        while Task.isCancelled == false
+            && self.isStartupReadyForBackgroundWork
+            && self.scenePhase == .active {
             let intervalSeconds = self.store.currentCloudSyncPollingInterval(
                 selectedTab: self.navigation.selectedTab,
                 now: Date()
@@ -357,7 +442,9 @@ struct FlashcardsApp: App {
                 return
             }
 
-            guard Task.isCancelled == false, self.scenePhase == .active else {
+            guard Task.isCancelled == false,
+                  self.isStartupReadyForBackgroundWork,
+                  self.scenePhase == .active else {
                 return
             }
             guard self.store.isCloudSyncBlocked == false else {
@@ -378,11 +465,13 @@ struct FlashcardsApp: App {
 
     @MainActor
     private func runProgressContextWatcherLoop() async {
-        guard self.scenePhase == .active else {
+        guard self.isStartupReadyForBackgroundWork, self.scenePhase == .active else {
             return
         }
 
-        while Task.isCancelled == false && self.scenePhase == .active {
+        while Task.isCancelled == false
+            && self.isStartupReadyForBackgroundWork
+            && self.scenePhase == .active {
             let now = Date()
             let nextRollover = nextProgressContextRolloverDate(now: now)
             let intervalSeconds = nextRollover.timeIntervalSince(now)
@@ -402,7 +491,9 @@ struct FlashcardsApp: App {
                 return
             }
 
-            guard Task.isCancelled == false, self.scenePhase == .active else {
+            guard Task.isCancelled == false,
+                  self.isStartupReadyForBackgroundWork,
+                  self.scenePhase == .active else {
                 return
             }
 

--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -175,6 +175,17 @@ struct RootTabView: View {
                     AccountDeletionProgressView()
                         .environment(store)
                 }
+
+                if let uiTestLaunchPreparationValue = store.uiTestLaunchPreparationStatus.accessibilityValue {
+                    Text("ui-test-launch-preparation-status")
+                        .font(.system(size: 1))
+                        .foregroundStyle(.clear)
+                        .allowsHitTesting(false)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityIdentifier(UITestIdentifier.uiTestLaunchPreparationStatus)
+                        .accessibilityLabel("UI test launch preparation status")
+                        .accessibilityValue(uiTestLaunchPreparationValue)
+                }
             }
         }
         .onChange(of: navigation.selectedTab) { _, nextTab in

--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum UITestIdentifier {
+    static let uiTestLaunchPreparationStatus: String = "uiTest.launchPreparationStatus"
     static let cloudWorkspaceChooserScreen: String = "cloudSignIn.workspaceChooserScreen"
     static let cloudSignInScreen: String = "cloudSignIn.screen"
     static let cloudSignInInlineAuthError: String = "cloudSignIn.inlineAuthError"

--- a/apps/ios/Flashcards/Flashcards/Cloud/CloudDiagnosticsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/CloudDiagnosticsSupport.swift
@@ -4,6 +4,7 @@ import OSLog
 enum CloudFlowPhase: String {
     case authSendCode = "auth_send_code"
     case authVerifyCode = "auth_verify_code"
+    case guestSessionDelete = "guest_session_delete"
     case workspaceList = "workspace_list"
     case workspaceCreate = "workspace_create"
     case workspaceSelect = "workspace_select"

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudAccount.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudAccount.swift
@@ -115,6 +115,61 @@ extension FlashcardsStore {
         return restoredGuestSession.session
     }
 
+    func prepareGuestCloudSessionForUITestLaunch() async throws -> CloudLinkedSession {
+        try await self.loadOrCreateGuestCloudSession()
+    }
+
+    /**
+     Marketing screenshot launches use short-lived guest cloud workspaces.
+     Delete any stored guest session remotely before the existing local reset
+     boundary so each manual run starts from a clean cloud state.
+
+     If the backend already deleted the guest session, treat the stale local
+     token as an already-cleaned state, clear local guest credentials, and
+     continue with the reset. Any other delete failure still blocks the run.
+     */
+    func deleteStoredGuestCloudSessionForUITestCleanupIfNeeded() async throws -> Bool {
+        guard let storedGuestSession = try self.loadGuestSessionForCurrentConfiguration() else {
+            return false
+        }
+
+        do {
+            try await self.dependencies.guestCloudAuthService.deleteGuestSession(
+                apiBaseUrl: storedGuestSession.apiBaseUrl,
+                guestToken: storedGuestSession.guestToken
+            )
+        } catch {
+            guard self.isGuestSessionInvalidError(error) else {
+                throw error
+            }
+
+            logFlashcardsError(
+                domain: "cloud",
+                action: "guest_session_delete_stale_local_credentials",
+                metadata: [
+                    "apiBaseUrl": storedGuestSession.apiBaseUrl,
+                    "message": Flashcards.errorMessage(error: error),
+                ]
+            )
+        }
+
+        try self.dependencies.guestCredentialStore.clearGuestSession()
+        return true
+    }
+
+    private func isGuestSessionInvalidError(_ error: Error) -> Bool {
+        guard let guestCloudAuthError = error as? GuestCloudAuthError else {
+            return false
+        }
+
+        switch guestCloudAuthError {
+        case .invalidResponse(let details, let statusCode):
+            return statusCode == 401 && details.code == "GUEST_AUTH_INVALID"
+        case .invalidBaseUrl, .invalidResponseBody:
+            return false
+        }
+    }
+
     func restoreGuestCloudSessionIfNeeded(
         trigger: CloudSyncTrigger
     ) async throws -> (session: CloudLinkedSession, didRunSync: Bool) {

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudUITest.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudUITest.swift
@@ -2,16 +2,63 @@ import Foundation
 
 private let marketingScreenshotLocalizationEnvironmentKey: String = "FLASHCARDS_MARKETING_SCREENSHOT_LOCALIZATION"
 
-enum FlashcardsUITestResetState: String {
-    case localGuest = "local_guest"
-    case localGuestSeededManualReviewCard = "local_guest_seeded_manual_review_card"
-    case localGuestSeededAIReviewCard = "local_guest_seeded_ai_review_card"
+enum FlashcardsUITestLaunchScenario: String {
+    case guestEmptyWorkspace = "guest_empty_workspace"
+    case guestManualReviewCard = "guest_manual_review_card"
+    case guestAIReviewCard = "guest_ai_review_card"
     case marketingOpportunityCostReviewCard = "marketing_opportunity_cost_review_card"
     case marketingConceptCards = "marketing_concept_cards"
     case marketingProgress = "marketing_progress"
+    case marketingGuestSessionCleanup = "marketing_guest_session_cleanup"
+
+    var requiresGuestCloudBootstrap: Bool {
+        switch self {
+        case .guestEmptyWorkspace, .guestManualReviewCard, .guestAIReviewCard:
+            return false
+        case .marketingOpportunityCostReviewCard, .marketingConceptCards, .marketingProgress:
+            return true
+        case .marketingGuestSessionCleanup:
+            return false
+        }
+    }
+
+    var requiresStoredGuestRemoteCleanup: Bool {
+        switch self {
+        case .marketingOpportunityCostReviewCard,
+                .marketingConceptCards,
+                .marketingProgress,
+                .marketingGuestSessionCleanup:
+            return true
+        case .guestEmptyWorkspace, .guestManualReviewCard, .guestAIReviewCard:
+            return false
+        }
+    }
 }
 
-private struct FlashcardsUITestSeedCard {
+enum FlashcardsUITestLaunchPreparationStatus: Equatable {
+    case hidden
+    case running(launchScenario: FlashcardsUITestLaunchScenario)
+    case ready(launchScenario: FlashcardsUITestLaunchScenario)
+    case failed(launchScenario: FlashcardsUITestLaunchScenario, message: String)
+
+    var accessibilityValue: String? {
+        switch self {
+        case .hidden:
+            return nil
+        case .running(let launchScenario):
+            return "state=running;launchScenario=\(launchScenario.rawValue)"
+        case .ready(let launchScenario):
+            return "state=ready;launchScenario=\(launchScenario.rawValue)"
+        case .failed(let launchScenario, let message):
+            let sanitizedMessage = message
+                .replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return "state=failed;launchScenario=\(launchScenario.rawValue);message=\(sanitizedMessage)"
+        }
+    }
+}
+
+private struct FlashcardsUITestFixtureCard {
     let frontText: String
     let backText: String
     let tags: [String]
@@ -19,26 +66,26 @@ private struct FlashcardsUITestSeedCard {
 
 private struct FlashcardsUITestMarketingLocaleFixture {
     let localizationCode: String
-    let reviewCard: FlashcardsUITestSeedCard
-    let conceptCards: [FlashcardsUITestSeedCard]
+    let reviewCard: FlashcardsUITestFixtureCard
+    let conceptCards: [FlashcardsUITestFixtureCard]
 }
 
 private struct FlashcardsUITestMarketingProgressReviewSeed {
-    let card: FlashcardsUITestSeedCard
+    let card: FlashcardsUITestFixtureCard
     let reviewedAtDayOffset: Int
     let rating: ReviewRating
 }
 
-private enum FlashcardsUITestSeedData {
-    static let manualReviewCard: FlashcardsUITestSeedCard = FlashcardsUITestSeedCard(
-        frontText: "Smoke seeded manual review question",
-        backText: "Smoke seeded manual review answer",
+private enum FlashcardsUITestLaunchScenarioData {
+    static let manualReviewCard: FlashcardsUITestFixtureCard = FlashcardsUITestFixtureCard(
+        frontText: "Smoke guest manual review question",
+        backText: "Smoke guest manual review answer",
         tags: []
     )
-    static let aiReviewCard: FlashcardsUITestSeedCard = FlashcardsUITestSeedCard(
-        frontText: "Smoke seeded AI review question",
-        backText: "Smoke seeded AI review answer",
-        tags: ["smoke-seeded-ai-review"]
+    static let aiReviewCard: FlashcardsUITestFixtureCard = FlashcardsUITestFixtureCard(
+        frontText: "Smoke guest AI review question",
+        backText: "Smoke guest AI review answer",
+        tags: ["smoke-guest-ai-review"]
     )
 }
 
@@ -49,6 +96,17 @@ private enum FlashcardsUITestMarketingProgressSeedError: LocalizedError {
         switch self {
         case .reviewedAtDateCreationFailed(let dayOffset):
             return "Failed to create marketing progress review timestamp for day offset \(dayOffset)."
+        }
+    }
+}
+
+private enum FlashcardsUITestLaunchScenarioError: LocalizedError {
+    case createdCardCountMismatch(expected: Int, actual: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .createdCardCountMismatch(let expected, let actual):
+            return "Expected \(expected) UI test cards but created \(actual)."
         }
     }
 }
@@ -109,7 +167,7 @@ private enum FlashcardsUITestMarketingFixtures {
     static let fixtures: [FlashcardsUITestMarketingLocaleFixture] = [
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "en-US",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "In economics, what is opportunity cost?",
                 backText: """
                 Opportunity cost is the value of the next best alternative you give up when you choose one option over another.
@@ -119,37 +177,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["economics"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "In economics, what is opportunity cost?",
                     backText: "The value of the next best alternative you give up when you choose one option over another.",
                     tags: ["economics"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "In biology, what is osmosis?",
                     backText: "The movement of water through a membrane from lower solute concentration to higher solute concentration.",
                     tags: ["biology"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "In statistics, what is standard deviation?",
                     backText: "A measure of how spread out values are around the average.",
                     tags: ["statistics"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "In chemistry, what is a catalyst?",
                     backText: "A substance that speeds up a chemical reaction without being consumed by it.",
                     tags: ["chemistry"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "In psychology, what is cognitive bias?",
                     backText: "A systematic pattern of thinking that can distort judgment and decision-making.",
                     tags: ["psychology"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "In physics, what is velocity?",
                     backText: "The speed of an object together with the direction of its motion.",
                     tags: ["physics"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "In computer science, what is recursion?",
                     backText: "A method where a function solves a problem by calling itself on smaller versions of that problem.",
                     tags: ["computer science"]
@@ -158,7 +216,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "ar",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "في الاقتصاد، ما هي تكلفة الفرصة البديلة؟",
                 backText: """
                 تكلفة الفرصة البديلة هي قيمة أفضل بديل تتخلى عنه عندما تختار خيارًا بدلًا من آخر.
@@ -168,37 +226,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["اقتصاد"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "في الاقتصاد، ما هي تكلفة الفرصة البديلة؟",
                     backText: "هي قيمة أفضل بديل تتخلى عنه عندما تختار خيارًا بدلًا من آخر.",
                     tags: ["اقتصاد"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "في علم الأحياء، ما هو التناضح؟",
                     backText: "هو انتقال الماء عبر غشاء من تركيز أقل للمذاب إلى تركيز أعلى للمذاب.",
                     tags: ["أحياء"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "في الإحصاء، ما هو الانحراف المعياري؟",
                     backText: "هو مقياس يوضح مدى تشتت القيم حول المتوسط.",
                     tags: ["إحصاء"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "في الكيمياء، ما هو العامل الحفاز؟",
                     backText: "هو مادة تسرّع التفاعل الكيميائي من دون أن تُستهلك أثناء التفاعل.",
                     tags: ["كيمياء"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "في علم النفس، ما هو التحيز المعرفي؟",
                     backText: "هو نمط منهجي في التفكير يمكن أن يشوّه الحكم واتخاذ القرار.",
                     tags: ["علم النفس"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "في الفيزياء، ما هي السرعة المتجهة؟",
                     backText: "هي مقدار حركة الجسم مع تحديد اتجاه هذه الحركة.",
                     tags: ["فيزياء"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "في علوم الحاسوب، ما هو الاستدعاء الذاتي؟",
                     backText: "هو أسلوب تحل فيه الدالة المشكلة عبر استدعاء نفسها على نسخ أصغر من المشكلة.",
                     tags: ["علوم الحاسوب"]
@@ -207,7 +265,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "zh-Hans",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "在经济学中，什么是机会成本？",
                 backText: """
                 机会成本是当你在多个选项中做出选择时，所放弃的最佳替代方案的价值。
@@ -217,37 +275,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["经济学"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "在经济学中，什么是机会成本？",
                     backText: "是在做出选择时所放弃的最佳替代方案的价值。",
                     tags: ["经济学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "在生物学中，什么是渗透作用？",
                     backText: "是水分通过膜从低溶质浓度一侧向高溶质浓度一侧移动的过程。",
                     tags: ["生物学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "在统计学中，什么是标准差？",
                     backText: "是衡量数据围绕平均值分散程度的指标。",
                     tags: ["统计学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "在化学中，什么是催化剂？",
                     backText: "是在不被消耗的情况下加快化学反应速度的物质。",
                     tags: ["化学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "在心理学中，什么是认知偏差？",
                     backText: "是一种可能扭曲判断与决策的系统性思维模式。",
                     tags: ["心理学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "在物理学中，什么是速度？",
                     backText: "是物体运动快慢及其方向的综合量。",
                     tags: ["物理学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "在计算机科学中，什么是递归？",
                     backText: "是一种通过让函数调用自身来解决更小规模同类问题的方法。",
                     tags: ["计算机科学"]
@@ -256,7 +314,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "de",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "Was sind in der Volkswirtschaftslehre Opportunitätskosten?",
                 backText: """
                 Opportunitätskosten sind der Wert der besten Alternative, auf die man verzichtet, wenn man sich für eine andere Option entscheidet.
@@ -266,37 +324,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["Volkswirtschaft"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Was sind in der Volkswirtschaftslehre Opportunitätskosten?",
                     backText: "Der Wert der besten Alternative, auf die man bei einer Entscheidung verzichtet.",
                     tags: ["Volkswirtschaft"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Was ist in der Biologie Osmose?",
                     backText: "Die Bewegung von Wasser durch eine Membran von niedrigerer zu höherer Konzentration gelöster Stoffe.",
                     tags: ["Biologie"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Was bezeichnet in der Statistik die Standardabweichung?",
                     backText: "Ein Maß dafür, wie stark Werte um den Durchschnitt streuen.",
                     tags: ["Statistik"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Was ist in der Chemie ein Katalysator?",
                     backText: "Ein Stoff, der eine chemische Reaktion beschleunigt, ohne selbst verbraucht zu werden.",
                     tags: ["Chemie"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Was ist in der Psychologie eine kognitive Verzerrung?",
                     backText: "Ein systematisches Denkmuster, das Urteile und Entscheidungen verfälschen kann.",
                     tags: ["Psychologie"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Was ist in der Physik Geschwindigkeit?",
                     backText: "Die Schnelligkeit einer Bewegung zusammen mit ihrer Richtung.",
                     tags: ["Physik"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Was bedeutet in der Informatik Rekursion?",
                     backText: "Eine Methode, bei der eine Funktion ein Problem löst, indem sie sich mit kleineren Teilproblemen selbst aufruft.",
                     tags: ["Informatik"]
@@ -305,7 +363,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "hi",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "अर्थशास्त्र में अवसर लागत क्या होती है?",
                 backText: """
                 अवसर लागत उस सबसे अच्छे विकल्प का मूल्य है, जिसे आप किसी दूसरी पसंद को चुनते समय छोड़ देते हैं।
@@ -315,37 +373,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["अर्थशास्त्र"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "अर्थशास्त्र में अवसर लागत क्या होती है?",
                     backText: "किसी विकल्प को चुनते समय छोड़े गए सबसे अच्छे वैकल्पिक विकल्प का मूल्य।",
                     tags: ["अर्थशास्त्र"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "जीवविज्ञान में परासरण क्या है?",
                     backText: "वह प्रक्रिया जिसमें पानी झिल्ली के आर-पार कम विलेय सांद्रता से अधिक विलेय सांद्रता की ओर बढ़ता है।",
                     tags: ["जीवविज्ञान"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "सांख्यिकी में मानक विचलन क्या है?",
                     backText: "यह बताने वाला माप कि मान औसत के आसपास कितने फैले हुए हैं।",
                     tags: ["सांख्यिकी"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "रसायन विज्ञान में उत्प्रेरक क्या होता है?",
                     backText: "ऐसा पदार्थ जो स्वयं खर्च हुए बिना रासायनिक अभिक्रिया की गति बढ़ाता है।",
                     tags: ["रसायन"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "मनोविज्ञान में संज्ञानात्मक पक्षपात क्या है?",
                     backText: "सोचने का ऐसा व्यवस्थित पैटर्न जो निर्णय और आकलन को विकृत कर सकता है।",
                     tags: ["मनोविज्ञान"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "भौतिकी में वेग क्या है?",
                     backText: "किसी वस्तु की चाल और उसकी दिशा का संयुक्त माप।",
                     tags: ["भौतिकी"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "कंप्यूटर विज्ञान में रिकर्शन क्या है?",
                     backText: "ऐसी विधि जिसमें कोई फ़ंक्शन समस्या के छोटे रूपों को हल करने के लिए स्वयं को ही पुकारता है।",
                     tags: ["कंप्यूटर विज्ञान"]
@@ -354,7 +412,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "ja",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "経済学でいう機会費用とは何ですか？",
                 backText: """
                 機会費用とは、ある選択をしたときに諦める最良の代替案の価値のことです。
@@ -364,37 +422,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["経済学"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "経済学でいう機会費用とは何ですか？",
                     backText: "ある選択をしたときに諦める最良の代替案の価値です。",
                     tags: ["経済学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "生物学でいう浸透とは何ですか？",
                     backText: "溶質濃度の低い側から高い側へ、水が膜を通って移動する現象です。",
                     tags: ["生物学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "統計学でいう標準偏差とは何ですか？",
                     backText: "値が平均の周りにどの程度ばらついているかを表す指標です。",
                     tags: ["統計学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "化学でいう触媒とは何ですか？",
                     backText: "自らは消費されずに化学反応を速める物質です。",
                     tags: ["化学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "心理学でいう認知バイアスとは何ですか？",
                     backText: "判断や意思決定をゆがめるおそれのある、系統的な思考の偏りです。",
                     tags: ["心理学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "物理学でいう速度とは何ですか？",
                     backText: "物体の動く速さとその向きをあわせて表す量です。",
                     tags: ["物理学"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "情報科学でいう再帰とは何ですか？",
                     backText: "関数が自分自身を呼び出しながら、より小さな同種の問題を解く方法です。",
                     tags: ["情報科学"]
@@ -403,7 +461,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "ru",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "Что такое альтернативная стоимость в экономике?",
                 backText: """
                 Альтернативная стоимость — это ценность лучшего варианта, от которого вы отказываетесь, выбирая другой вариант.
@@ -413,37 +471,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["экономика"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Что такое альтернативная стоимость в экономике?",
                     backText: "Это ценность лучшего варианта, от которого вы отказываетесь, делая выбор.",
                     tags: ["экономика"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Что такое осмос в биологии?",
                     backText: "Это движение воды через мембрану из области с меньшей концентрацией растворённых веществ в область с большей концентрацией.",
                     tags: ["биология"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Что такое стандартное отклонение в статистике?",
                     backText: "Это мера того, насколько сильно значения разбросаны вокруг среднего.",
                     tags: ["статистика"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Что такое катализатор в химии?",
                     backText: "Это вещество, которое ускоряет химическую реакцию и при этом не расходуется.",
                     tags: ["химия"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Что такое когнитивное искажение в психологии?",
                     backText: "Это систематический шаблон мышления, который может искажать суждения и решения.",
                     tags: ["психология"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Что такое векторная скорость в физике?",
                     backText: "Это величина, которая описывает быстроту движения объекта и его направление.",
                     tags: ["физика"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "Что такое рекурсия в информатике?",
                     backText: "Это способ решения задачи, при котором функция вызывает саму себя для более маленьких версий той же задачи.",
                     tags: ["информатика"]
@@ -452,7 +510,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "es-MX",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "En economía, ¿qué es el costo de oportunidad?",
                 backText: """
                 El costo de oportunidad es el valor de la mejor alternativa a la que renuncias cuando eliges una opción en lugar de otra.
@@ -462,37 +520,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["economía"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En economía, ¿qué es el costo de oportunidad?",
                     backText: "El valor de la mejor alternativa a la que renuncias cuando eliges otra opción.",
                     tags: ["economía"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En biología, ¿qué es la ósmosis?",
                     backText: "El movimiento del agua a través de una membrana desde una concentración menor de solutos hacia una mayor.",
                     tags: ["biología"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En estadística, ¿qué es la desviación estándar?",
                     backText: "Una medida de qué tan dispersos están los valores alrededor del promedio.",
                     tags: ["estadística"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En química, ¿qué es un catalizador?",
                     backText: "Una sustancia que acelera una reacción química sin consumirse en el proceso.",
                     tags: ["química"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En psicología, ¿qué es un sesgo cognitivo?",
                     backText: "Un patrón sistemático de pensamiento que puede distorsionar el juicio y la toma de decisiones.",
                     tags: ["psicología"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En física, ¿qué es la velocidad?",
                     backText: "La rapidez de un objeto junto con la dirección de su movimiento.",
                     tags: ["física"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En ciencias de la computación, ¿qué es la recursión?",
                     backText: "Un método en el que una función resuelve un problema llamándose a sí misma sobre versiones más pequeñas del mismo problema.",
                     tags: ["computación"]
@@ -501,7 +559,7 @@ private enum FlashcardsUITestMarketingFixtures {
         ),
         FlashcardsUITestMarketingLocaleFixture(
             localizationCode: "es-ES",
-            reviewCard: FlashcardsUITestSeedCard(
+            reviewCard: FlashcardsUITestFixtureCard(
                 frontText: "En economía, ¿qué es el coste de oportunidad?",
                 backText: """
                 El coste de oportunidad es el valor de la mejor alternativa a la que renuncias cuando eliges una opción en lugar de otra.
@@ -511,37 +569,37 @@ private enum FlashcardsUITestMarketingFixtures {
                 tags: ["economía"]
             ),
             conceptCards: [
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En economía, ¿qué es el coste de oportunidad?",
                     backText: "El valor de la mejor alternativa a la que renuncias cuando eliges otra opción.",
                     tags: ["economía"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En biología, ¿qué es la ósmosis?",
                     backText: "El movimiento del agua a través de una membrana desde una concentración menor de solutos hacia una mayor.",
                     tags: ["biología"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En estadística, ¿qué es la desviación típica?",
                     backText: "Una medida de lo dispersos que están los valores alrededor de la media.",
                     tags: ["estadística"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En química, ¿qué es un catalizador?",
                     backText: "Una sustancia que acelera una reacción química sin consumirse en el proceso.",
                     tags: ["química"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En psicología, ¿qué es un sesgo cognitivo?",
                     backText: "Un patrón sistemático de pensamiento que puede distorsionar el juicio y la toma de decisiones.",
                     tags: ["psicología"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En física, ¿qué es la velocidad?",
                     backText: "La rapidez de un objeto junto con la dirección de su movimiento.",
                     tags: ["física"]
                 ),
-                FlashcardsUITestSeedCard(
+                FlashcardsUITestFixtureCard(
                     frontText: "En informática, ¿qué es la recursión?",
                     backText: "Un método en el que una función resuelve un problema llamándose a sí misma sobre versiones más pequeñas del mismo problema.",
                     tags: ["informática"]
@@ -574,53 +632,77 @@ private enum FlashcardsUITestMarketingFixtures {
 
 @MainActor
 extension FlashcardsStore {
-    func applyUITestResetState(resetState: FlashcardsUITestResetState) throws {
-        try self.resetLocalStateForCloudIdentityChange()
-
-        switch resetState {
-        case .localGuest:
+    func applyUITestLaunchScenarioContent(
+        launchScenario: FlashcardsUITestLaunchScenario,
+        processInfo: ProcessInfo
+    ) throws {
+        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        switch launchScenario {
+        case .guestEmptyWorkspace:
             return
-        case .localGuestSeededManualReviewCard:
-            try self.seedUITestCard(card: FlashcardsUITestSeedData.manualReviewCard)
-        case .localGuestSeededAIReviewCard:
-            try self.seedUITestCard(card: FlashcardsUITestSeedData.aiReviewCard)
+        case .guestManualReviewCard:
+            try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.manualReviewCard, context: context)
+        case .guestAIReviewCard:
+            try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.aiReviewCard, context: context)
         case .marketingOpportunityCostReviewCard:
-            let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: ProcessInfo.processInfo)
-            try self.seedUITestCard(card: localeFixture.reviewCard)
+            let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: processInfo)
+            try self.createUITestCard(card: localeFixture.reviewCard, context: context)
         case .marketingConceptCards:
-            let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: ProcessInfo.processInfo)
-            try self.seedUITestCards(cards: localeFixture.conceptCards)
+            let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: processInfo)
+            try self.createUITestCards(cards: localeFixture.conceptCards, context: context)
         case .marketingProgress:
-            let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: ProcessInfo.processInfo)
-            try self.seedUITestProgress(cards: localeFixture.conceptCards)
+            let localeFixture = try FlashcardsUITestMarketingFixtures.localeFixture(processInfo: processInfo)
+            try self.createUITestProgressData(cards: localeFixture.conceptCards, context: context)
+        case .marketingGuestSessionCleanup:
+            return
         }
     }
 
-    private func seedUITestCards(cards: [FlashcardsUITestSeedCard]) throws {
-        for card in cards {
-            try self.seedUITestCard(card: card)
+    private func createUITestCards(
+        cards: [FlashcardsUITestFixtureCard],
+        context: LocalMutationContext
+    ) throws {
+        let inputs = cards.map { card in
+            self.cardEditorInput(card: card)
         }
+        _ = try context.database.createCards(workspaceId: context.workspaceId, inputs: inputs)
     }
 
-    private func seedUITestCard(card: FlashcardsUITestSeedCard) throws {
-        try self.saveCard(
+    private func createUITestCard(
+        card: FlashcardsUITestFixtureCard,
+        context: LocalMutationContext
+    ) throws {
+        _ = try context.database.saveCard(
+            workspaceId: context.workspaceId,
             input: self.cardEditorInput(card: card),
-            editingCardId: nil
+            cardId: nil
         )
     }
 
-    private func seedUITestProgress(cards: [FlashcardsUITestSeedCard]) throws {
-        let context: LocalMutationContext = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+    private func createUITestProgressData(
+        cards: [FlashcardsUITestFixtureCard],
+        context: LocalMutationContext
+    ) throws {
         let reviewSeeds: [FlashcardsUITestMarketingProgressReviewSeed] = try self.marketingProgressReviewSeeds(cards: cards)
         let now: Date = Date()
         let calendar: Calendar = Calendar.current
+        let createdCards = try context.database.createCards(
+            workspaceId: context.workspaceId,
+            inputs: reviewSeeds.map { reviewSeed in
+                self.cardEditorInput(card: reviewSeed.card)
+            }
+        )
 
-        for reviewSeed in reviewSeeds {
-            let card: Card = try context.database.saveCard(
-                workspaceId: context.workspaceId,
-                input: self.cardEditorInput(card: reviewSeed.card),
-                cardId: nil
+        guard createdCards.count == reviewSeeds.count else {
+            throw FlashcardsUITestLaunchScenarioError.createdCardCountMismatch(
+                expected: reviewSeeds.count,
+                actual: createdCards.count
             )
+        }
+
+        for index in reviewSeeds.indices {
+            let reviewSeed = reviewSeeds[index]
+            let card = createdCards[index]
             let reviewedAtClient: String = try self.marketingProgressReviewedAtClient(
                 dayOffset: reviewSeed.reviewedAtDayOffset,
                 now: now,
@@ -635,12 +717,10 @@ extension FlashcardsStore {
                 )
             )
         }
-
-        try self.reload(now: now, refreshVisibleProgress: false)
     }
 
     private func marketingProgressReviewSeeds(
-        cards: [FlashcardsUITestSeedCard]
+        cards: [FlashcardsUITestFixtureCard]
     ) throws -> [FlashcardsUITestMarketingProgressReviewSeed] {
         guard cards.count >= 7 else {
             throw LocalStoreError.validation("Marketing progress screenshots require at least 7 fixture cards.")
@@ -662,14 +742,11 @@ extension FlashcardsStore {
         now: Date,
         calendar: Calendar
     ) throws -> String {
+        let startOfToday = calendar.startOfDay(for: now)
         guard let todayNoon: Date = calendar.date(
-            bySettingHour: 12,
-            minute: 0,
-            second: 0,
-            of: now,
-            matchingPolicy: .nextTime,
-            repeatedTimePolicy: .first,
-            direction: .forward
+            byAdding: .hour,
+            value: 12,
+            to: startOfToday
         ),
             let reviewedAt: Date = calendar.date(
                 byAdding: .day,
@@ -683,7 +760,7 @@ extension FlashcardsStore {
         return formatIsoTimestamp(date: reviewedAt)
     }
 
-    private func cardEditorInput(card: FlashcardsUITestSeedCard) -> CardEditorInput {
+    private func cardEditorInput(card: FlashcardsUITestFixtureCard) -> CardEditorInput {
         CardEditorInput(
             frontText: card.frontText,
             backText: card.backText,

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsUITestLaunchCoordinator.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsUITestLaunchCoordinator.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+private struct FlashcardsUITestPreservedLaunchState {
+    let pendingAppNotificationTapData: Data?
+
+    @MainActor
+    init(userDefaults: UserDefaults) {
+        self.pendingAppNotificationTapData = userDefaults.data(forKey: pendingAppNotificationTapUserDefaultsKey)
+    }
+
+    @MainActor
+    func restore(userDefaults: UserDefaults) {
+        if let pendingAppNotificationTapData = self.pendingAppNotificationTapData {
+            userDefaults.set(pendingAppNotificationTapData, forKey: pendingAppNotificationTapUserDefaultsKey)
+        } else {
+            userDefaults.removeObject(forKey: pendingAppNotificationTapUserDefaultsKey)
+        }
+    }
+}
+
+private struct FlashcardsUITestLaunchCoordinator {
+    let launchScenario: FlashcardsUITestLaunchScenario
+    let processInfo: ProcessInfo
+
+    @MainActor
+    func execute(store: FlashcardsStore) async throws {
+        let preservedLaunchState = FlashcardsUITestPreservedLaunchState(userDefaults: store.userDefaults)
+
+        if self.launchScenario.requiresStoredGuestRemoteCleanup {
+            try await store.deleteStoredGuestCloudSessionForUITestCleanupIfNeeded()
+        }
+
+        do {
+            try store.resetLocalStateForCloudIdentityChange()
+        } catch {
+            preservedLaunchState.restore(userDefaults: store.userDefaults)
+            throw error
+        }
+
+        preservedLaunchState.restore(userDefaults: store.userDefaults)
+        if self.launchScenario == .marketingGuestSessionCleanup {
+            return
+        }
+        guard self.launchScenario.requiresGuestCloudBootstrap else {
+            try store.applyUITestLaunchScenarioContent(
+                launchScenario: self.launchScenario,
+                processInfo: self.processInfo
+            )
+            try store.reload(now: Date(), refreshVisibleProgress: false)
+            return
+        }
+
+        let guestSession = try await store.prepareGuestCloudSessionForUITestLaunch()
+        try store.applyUITestLaunchScenarioContent(
+            launchScenario: self.launchScenario,
+            processInfo: self.processInfo
+        )
+        try await store.finishCloudLink(
+            linkedSession: guestSession,
+            trigger: store.manualCloudSyncTrigger(now: Date())
+        )
+    }
+}
+
+@MainActor
+extension FlashcardsStore {
+    func executeUITestLaunchScenario(
+        launchScenario: FlashcardsUITestLaunchScenario,
+        processInfo: ProcessInfo
+    ) async throws {
+        let coordinator = FlashcardsUITestLaunchCoordinator(
+            launchScenario: launchScenario,
+            processInfo: processInfo
+        )
+        try await coordinator.execute(store: self)
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Cloud/GuestCloudAuthService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/GuestCloudAuthService.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+private let guestSessionDeleteMaxAttempts: Int = 3
+private let guestSessionDeleteRetryDelayNanoseconds: UInt64 = 250_000_000
+
 enum GuestCloudAuthError: LocalizedError {
     case invalidBaseUrl(String)
     case invalidResponse(CloudApiErrorDetails, Int)
@@ -21,6 +24,10 @@ private struct GuestSessionEnvelope: Decodable {
     let guestToken: String
     let userId: String
     let workspaceId: String
+}
+
+private struct DeleteGuestSessionResponse: Decodable {
+    let ok: Bool
 }
 
 private struct GuestUpgradePrepareRequest: Encodable {
@@ -81,6 +88,58 @@ final class GuestCloudAuthService {
         )
     }
 
+    func deleteGuestSession(
+        apiBaseUrl: String,
+        guestToken: String
+    ) async throws {
+        logCloudFlowPhase(phase: .guestSessionDelete, outcome: "start")
+
+        var lastError: Error?
+        for attempt in 1...guestSessionDeleteMaxAttempts {
+            do {
+                try await self.performGuestSessionDelete(
+                    apiBaseUrl: apiBaseUrl,
+                    guestToken: guestToken
+                )
+                logCloudFlowPhase(phase: .guestSessionDelete, outcome: "success")
+                return
+            } catch let error as CancellationError {
+                throw error
+            } catch {
+                lastError = error
+
+                if attempt < guestSessionDeleteMaxAttempts {
+                    logFlashcardsError(
+                        domain: "cloud",
+                        action: "guest_session_delete_retry",
+                        metadata: [
+                            "attempt": String(attempt),
+                            "maxAttempts": String(guestSessionDeleteMaxAttempts),
+                            "apiBaseUrl": apiBaseUrl,
+                            "message": Flashcards.errorMessage(error: error),
+                        ]
+                    )
+                    try await Task.sleep(nanoseconds: guestSessionDeleteRetryDelayNanoseconds)
+                    continue
+                }
+
+                logCloudFlowPhase(
+                    phase: .guestSessionDelete,
+                    outcome: "failure",
+                    errorMessage: Flashcards.errorMessage(error: error)
+                )
+            }
+        }
+
+        guard let lastError else {
+            throw GuestCloudAuthError.invalidResponseBody(
+                "Guest session deletion did not produce a result"
+            )
+        }
+
+        throw lastError
+    }
+
     func prepareGuestUpgrade(
         apiBaseUrl: String,
         bearerToken: String,
@@ -138,13 +197,45 @@ final class GuestCloudAuthService {
         return url
     }
 
-    private func request<Response: Decodable, Body: Encodable>(
+    private func performGuestSessionDelete(
+        apiBaseUrl: String,
+        guestToken: String
+    ) async throws {
+        let (data, _) = try await self.performRequest(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: "Guest \(guestToken)",
+            path: "/guest-auth/session/delete",
+            method: "POST",
+            body: Optional<String>.none
+        )
+
+        if data.isEmpty {
+            return
+        }
+
+        do {
+            let response = try self.decoder.decode(DeleteGuestSessionResponse.self, from: data)
+            guard response.ok else {
+                throw GuestCloudAuthError.invalidResponseBody(
+                    "Guest session deletion did not return ok=true"
+                )
+            }
+        } catch let error as GuestCloudAuthError {
+            throw error
+        } catch {
+            throw GuestCloudAuthError.invalidResponseBody(
+                "Failed to decode guest session delete response"
+            )
+        }
+    }
+
+    private func performRequest<Body: Encodable>(
         apiBaseUrl: String,
         authorizationHeader: String?,
         path: String,
         method: String,
         body: Body?
-    ) async throws -> Response {
+    ) async throws -> (Data, HTTPURLResponse) {
         var request = URLRequest(url: try self.makeUrl(apiBaseUrl: apiBaseUrl, path: path))
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -166,6 +257,24 @@ final class GuestCloudAuthService {
             let details = decodeCloudApiErrorDetails(data: data, requestId: requestId)
             throw GuestCloudAuthError.invalidResponse(details, httpResponse.statusCode)
         }
+
+        return (data, httpResponse)
+    }
+
+    private func request<Response: Decodable, Body: Encodable>(
+        apiBaseUrl: String,
+        authorizationHeader: String?,
+        path: String,
+        method: String,
+        body: Body?
+    ) async throws -> Response {
+        let (data, _) = try await self.performRequest(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            path: path,
+            method: method,
+            body: body
+        )
 
         do {
             return try self.decoder.decode(Response.self, from: data)

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
@@ -91,6 +91,7 @@ final class FlashcardsStore {
     var isReviewNotificationPrePromptPresented: Bool
     var accountDeletionState: AccountDeletionState
     var accountDeletionSuccessMessage: String?
+    var uiTestLaunchPreparationStatus: FlashcardsUITestLaunchPreparationStatus
     var localReadVersion: Int
 
     @ObservationIgnored let database: LocalDatabase?
@@ -336,6 +337,7 @@ final class FlashcardsStore {
         self.isReviewNotificationPrePromptPresented = false
         self.accountDeletionState = .hidden
         self.accountDeletionSuccessMessage = nil
+        self.uiTestLaunchPreparationStatus = .hidden
         self.localReadVersion = 0
         self.database = database
         self.dependencies = dependencies

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStoreSupport.swift
@@ -98,6 +98,10 @@ protocol GuestCloudAuthServing {
         apiBaseUrl: String,
         configurationMode: CloudServiceConfigurationMode
     ) async throws -> StoredGuestCloudSession
+    func deleteGuestSession(
+        apiBaseUrl: String,
+        guestToken: String
+    ) async throws
     func prepareGuestUpgrade(
         apiBaseUrl: String,
         bearerToken: String,

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
@@ -360,7 +360,7 @@ struct CloudSignInSheet: View {
                     self.otpSheetState = nextOtpSheetState.withChallenge(nextChallenge)
                 case .verifiedCredentials(let credentials):
                     // This intentionally insecure path exists only for
-                    // configured review/demo emails on the auth service.
+                    // configured review account emails on the auth service.
                     self.otpSheetState = nil
                     self.handleVerifiedAuthContext(
                         CloudVerifiedAuthContext(

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeAiTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeAiTests.swift
@@ -3,7 +3,7 @@ import XCTest
 final class LiveSmokeAiTests: LiveSmokeTestCase {
     @MainActor
     func testLiveSmokeGuestAiCardCreationFlow() throws {
-        try self.launchApplication(resetState: .localGuest, selectedTab: .ai)
+        try self.launchApplication(launchScenario: .guestEmptyWorkspace, selectedTab: .ai)
 
         try self.step("create one guest AI card and confirm the insert completed") {
             try self.createAiCardWithConfirmation()
@@ -12,7 +12,7 @@ final class LiveSmokeAiTests: LiveSmokeTestCase {
 
     @MainActor
     func testLiveSmokeGuestAiChatResetFlow() throws {
-        try self.launchApplication(resetState: .localGuest, selectedTab: .ai)
+        try self.launchApplication(launchScenario: .guestEmptyWorkspace, selectedTab: .ai)
 
         try self.step("create one guest AI conversation before reset") {
             try self.createGuestAiConversationForReset()

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeCardsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeCardsTests.swift
@@ -4,18 +4,18 @@ final class LiveSmokeCardsTests: LiveSmokeTestCase {
     @MainActor
     func testLiveSmokeManualCardCreationFlow() throws {
         let context = self.makeRunContext()
-        try self.launchApplication(resetState: .localGuest, selectedTab: .cards)
+        try self.launchApplication(launchScenario: .guestEmptyWorkspace, selectedTab: .cards)
 
-        try self.step("create one local manual card without login") {
+        try self.step("create one guest manual card without login") {
             try self.createManualCard(frontText: context.manualFrontText, backText: context.manualBackText)
         }
     }
 
     @MainActor
     func testLiveSmokeCardsEditorAiHandoffFlow() throws {
-        try self.launchApplication(resetState: .localGuestSeededManualReviewCard, selectedTab: .cards)
+        try self.launchApplication(launchScenario: .guestManualReviewCard, selectedTab: .cards)
 
-        try self.step("open the seeded card editor and hand off to AI") {
+        try self.step("open the guest manual card editor and hand off to AI") {
             try self.openFirstCardForEditing()
             try self.handoffEditedCardToAIAndAssertDraftAttachment()
         }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeRTLTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeRTLTests.swift
@@ -6,7 +6,7 @@ final class LiveSmokeRTLTests: LiveSmokeTestCase {
     func testLiveSmokeArabicRTLTopLevelNavigation() throws {
         try self.step("launch Arabic RTL review surface") {
             try self.launchArabicRTLApplication(
-                resetState: .localGuestSeededManualReviewCard,
+                launchScenario: .guestManualReviewCard,
                 selectedTab: .review
             )
             try self.assertElementExists(
@@ -48,7 +48,7 @@ final class LiveSmokeRTLTests: LiveSmokeTestCase {
 
     @MainActor
     private func launchArabicRTLApplication(
-        resetState: LiveSmokeLaunchResetState?,
+        launchScenario: LiveSmokeLaunchScenario?,
         selectedTab: LiveSmokeSelectedTab
     ) throws {
         if self.isApplicationRunning {
@@ -56,7 +56,7 @@ final class LiveSmokeRTLTests: LiveSmokeTestCase {
         }
 
         try self.launchApplication(
-            resetState: resetState,
+            launchScenario: launchScenario,
             selectedTab: selectedTab,
             launchLocalization: .arabic
         )

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
@@ -3,22 +3,22 @@ import XCTest
 final class LiveSmokeReviewTests: LiveSmokeTestCase {
     @MainActor
     func testLiveSmokeManualCardReviewFlow() throws {
-        try self.launchApplication(resetState: .localGuestSeededManualReviewCard, selectedTab: .review)
+        try self.launchApplication(launchScenario: .guestManualReviewCard, selectedTab: .review)
 
-        try self.step("review the seeded manual card") {
+        try self.step("review the guest manual card") {
             try self.reviewCurrentCard(
-                expectedFrontText: LiveSmokeSeededData.manualReviewFrontText
+                expectedFrontText: LiveSmokeLaunchFixtureData.manualReviewFrontText
             )
         }
     }
 
     @MainActor
     func testLiveSmokeGuestAiCardReviewFlow() throws {
-        try self.launchApplication(resetState: .localGuestSeededAIReviewCard, selectedTab: .review)
+        try self.launchApplication(launchScenario: .guestAIReviewCard, selectedTab: .review)
 
-        try self.step("review the seeded AI card") {
+        try self.step("review the guest AI card") {
             try self.reviewCurrentCard(
-                expectedFrontText: LiveSmokeSeededData.aiReviewFrontText
+                expectedFrontText: LiveSmokeLaunchFixtureData.aiReviewFrontText
             )
         }
     }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSettingsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSettingsTests.swift
@@ -3,9 +3,9 @@ import XCTest
 
 final class LiveSmokeSettingsTests: LiveSmokeTestCase {
     @MainActor
-    func testLiveSmokeLocalNavigationFlow() throws {
-        try self.step("verify local navigation surfaces without login") {
-            try self.launchApplication(resetState: .localGuest, selectedTab: .cards)
+    func testLiveSmokeGuestNavigationFlow() throws {
+        try self.step("verify guest navigation surfaces without login") {
+            try self.launchApplication(launchScenario: .guestEmptyWorkspace, selectedTab: .cards)
             try self.assertElementExists(
                 identifier: LiveSmokeIdentifier.cardsAddButton,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -99,7 +99,7 @@ final class LiveSmokeSettingsTests: LiveSmokeTestCase {
     func testLiveSmokeNotificationTapColdStartOpensReviewOnce() throws {
         try self.step("verify notification tap cold start opens review once") {
             try self.launchApplicationWithAppNotificationTap(
-                resetState: .localGuestSeededManualReviewCard,
+                launchScenario: .guestManualReviewCard,
                 selectedTab: .cards,
                 appNotificationTapType: .reviewReminder
             )
@@ -119,7 +119,7 @@ final class LiveSmokeSettingsTests: LiveSmokeTestCase {
     func testLiveSmokeUnsupportedNotificationTapDoesNotNavigate() throws {
         try self.step("verify unsupported notification tap stays on selected tab") {
             try self.launchApplicationWithAppNotificationTap(
-                resetState: .localGuest,
+                launchScenario: .guestEmptyWorkspace,
                 selectedTab: .cards,
                 appNotificationTapType: .unsupported
             )

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeConfiguration.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeConfiguration.swift
@@ -4,18 +4,19 @@ import OSLog
 enum LiveSmokeConfiguration {
     static let shortUiTimeoutSeconds: TimeInterval = 10
     static let longUiTimeoutSeconds: TimeInterval = 30
+    static let launchPreparationTimeoutSeconds: TimeInterval = 60
     static let optionalProbeTimeoutSeconds: TimeInterval = 3
     static let reviewInitialProbeTimeoutSeconds: TimeInterval = 15
     static let reviewInteractionTimeoutSeconds: TimeInterval = 10
     static let reviewEmailEnvironmentKey: String = "FLASHCARDS_LIVE_REVIEW_EMAIL"
-    static let resetStateEnvironmentKey: String = "FLASHCARDS_UI_TEST_RESET_STATE"
+    static let launchScenarioEnvironmentKey: String = "FLASHCARDS_UI_TEST_LAUNCH_SCENARIO"
     static let selectedTabEnvironmentKey: String = "FLASHCARDS_UI_TEST_SELECTED_TAB"
     static let appNotificationTapTypeEnvironmentKey: String = "FLASHCARDS_UI_TEST_APP_NOTIFICATION_TAP_TYPE"
     static let maximumStoredBreadcrumbCount: Int = 30
 }
 
 struct LiveSmokeLaunchRequest {
-    let resetState: LiveSmokeLaunchResetState?
+    let launchScenario: LiveSmokeLaunchScenario?
     let selectedTab: LiveSmokeSelectedTab
     let launchLocalization: LiveSmokeLaunchLocalization
     let appNotificationTapType: LiveSmokeAppNotificationTapType?

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeDiagnostics.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeDiagnostics.swift
@@ -104,9 +104,9 @@ extension LiveSmokeTestCase {
             return "<app not initialized>"
         }
 
-        let resetState = self.app.launchEnvironment[LiveSmokeConfiguration.resetStateEnvironmentKey] ?? "-"
+        let launchScenario = self.app.launchEnvironment[LiveSmokeConfiguration.launchScenarioEnvironmentKey] ?? "-"
         let selectedTab = self.app.launchEnvironment[LiveSmokeConfiguration.selectedTabEnvironmentKey] ?? "-"
-        return "resetState=\(resetState) selectedTab=\(selectedTab)"
+        return "launchScenario=\(launchScenario) selectedTab=\(selectedTab)"
     }
 
     @MainActor

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeFailure.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeFailure.swift
@@ -28,6 +28,7 @@ enum LiveSmokeFailure: LocalizedError {
     case aiRunReportedError(message: String, screen: String, step: String)
     case unexpectedAiConversationState(message: String, screen: String, step: String)
     case appDidNotReachForeground(timeoutSeconds: TimeInterval, appState: String, step: String)
+    case uiTestLaunchPreparationFailed(launchScenario: String, message: String, screen: String, step: String)
 
     var errorDescription: String? {
         switch self {
@@ -74,6 +75,8 @@ enum LiveSmokeFailure: LocalizedError {
             return "AI conversation reached an unexpected state during step '\(step)'. Current screen: \(screen). \(message)"
         case .appDidNotReachForeground(let timeoutSeconds, let appState, let step):
             return "Application did not reach runningForeground within \(formatDuration(seconds: timeoutSeconds)) during step '\(step)'. App state: \(appState)"
+        case .uiTestLaunchPreparationFailed(let launchScenario, let message, let screen, let step):
+            return "UI test launch scenario '\(launchScenario)' failed during step '\(step)'. Current screen: \(screen). \(message)"
         }
     }
 }

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeIdentifiers.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum LiveSmokeIdentifier {
+    static let uiTestLaunchPreparationStatus: String = "uiTest.launchPreparationStatus"
     static let cloudWorkspaceChooserScreen: String = "cloudSignIn.workspaceChooserScreen"
     static let cloudSignInScreen: String = "cloudSignIn.screen"
     static let cloudSignInInlineAuthError: String = "cloudSignIn.inlineAuthError"
@@ -91,13 +92,14 @@ enum LiveSmokeIdentifier {
     static let aiAssistantVisibleText: String = "ai.assistantVisibleText"
 }
 
-enum LiveSmokeLaunchResetState: String {
-    case localGuest = "local_guest"
-    case localGuestSeededManualReviewCard = "local_guest_seeded_manual_review_card"
-    case localGuestSeededAIReviewCard = "local_guest_seeded_ai_review_card"
+enum LiveSmokeLaunchScenario: String {
+    case guestEmptyWorkspace = "guest_empty_workspace"
+    case guestManualReviewCard = "guest_manual_review_card"
+    case guestAIReviewCard = "guest_ai_review_card"
     case marketingOpportunityCostReviewCard = "marketing_opportunity_cost_review_card"
     case marketingConceptCards = "marketing_concept_cards"
     case marketingProgress = "marketing_progress"
+    case marketingGuestSessionCleanup = "marketing_guest_session_cleanup"
 }
 
 struct LiveSmokeTabBarItemLookup {
@@ -375,9 +377,9 @@ struct LiveSmokeAIToolCallCheck {
     let completedSqlSummaries: [String]
 }
 
-enum LiveSmokeSeededData {
-    static let manualReviewFrontText: String = "Smoke seeded manual review question"
-    static let aiReviewFrontText: String = "Smoke seeded AI review question"
+enum LiveSmokeLaunchFixtureData {
+    static let manualReviewFrontText: String = "Smoke guest manual review question"
+    static let aiReviewFrontText: String = "Smoke guest AI review question"
 }
 
 let aiComposerPlaceholderText: String = "Ask about cards, review history, or propose a change..."

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeLaunching.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeLaunching.swift
@@ -3,11 +3,11 @@ import XCTest
 extension LiveSmokeTestCase {
     @MainActor
     func launchApplication(
-        resetState: LiveSmokeLaunchResetState?,
+        launchScenario: LiveSmokeLaunchScenario?,
         selectedTab: LiveSmokeSelectedTab
     ) throws {
         try self.launchApplication(
-            resetState: resetState,
+            launchScenario: launchScenario,
             selectedTab: selectedTab,
             launchLocalization: .english
         )
@@ -15,13 +15,13 @@ extension LiveSmokeTestCase {
 
     @MainActor
     func launchApplication(
-        resetState: LiveSmokeLaunchResetState?,
+        launchScenario: LiveSmokeLaunchScenario?,
         selectedTab: LiveSmokeSelectedTab,
         launchLocalization: LiveSmokeLaunchLocalization
     ) throws {
         try self.launchApplication(
             request: LiveSmokeLaunchRequest(
-                resetState: resetState,
+                launchScenario: launchScenario,
                 selectedTab: selectedTab,
                 launchLocalization: launchLocalization,
                 appNotificationTapType: nil
@@ -31,12 +31,12 @@ extension LiveSmokeTestCase {
 
     @MainActor
     func launchApplicationWithAppNotificationTap(
-        resetState: LiveSmokeLaunchResetState?,
+        launchScenario: LiveSmokeLaunchScenario?,
         selectedTab: LiveSmokeSelectedTab,
         appNotificationTapType: LiveSmokeAppNotificationTapType
     ) throws {
         try self.launchApplicationWithAppNotificationTap(
-            resetState: resetState,
+            launchScenario: launchScenario,
             selectedTab: selectedTab,
             launchLocalization: .english,
             appNotificationTapType: appNotificationTapType
@@ -45,14 +45,14 @@ extension LiveSmokeTestCase {
 
     @MainActor
     func launchApplicationWithAppNotificationTap(
-        resetState: LiveSmokeLaunchResetState?,
+        launchScenario: LiveSmokeLaunchScenario?,
         selectedTab: LiveSmokeSelectedTab,
         launchLocalization: LiveSmokeLaunchLocalization,
         appNotificationTapType: LiveSmokeAppNotificationTapType
     ) throws {
         try self.launchApplication(
             request: LiveSmokeLaunchRequest(
-                resetState: resetState,
+                launchScenario: launchScenario,
                 selectedTab: selectedTab,
                 launchLocalization: launchLocalization,
                 appNotificationTapType: appNotificationTapType
@@ -113,6 +113,91 @@ extension LiveSmokeTestCase {
     }
 
     @MainActor
+    func waitForUITestLaunchPreparation(
+        launchScenario: LiveSmokeLaunchScenario,
+        timeout: TimeInterval
+    ) throws {
+        try self.runWithInlineRawScreenStateOnFailure(action: "wait_for_ui_test_launch_preparation.\(launchScenario.rawValue)") {
+            let element = self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.uiTestLaunchPreparationStatus)
+                .firstMatch
+            let readyValue = "state=ready;launchScenario=\(launchScenario.rawValue)"
+            let failedValuePrefix = "state=failed;launchScenario=\(launchScenario.rawValue)"
+
+            self.logSmokeBreadcrumb(
+                event: "wait_start",
+                action: "wait_for_ui_test_launch_preparation",
+                identifier: LiveSmokeIdentifier.uiTestLaunchPreparationStatus,
+                timeoutSeconds: formatDuration(seconds: timeout),
+                durationSeconds: "-",
+                result: "start",
+                note: readyValue
+            )
+
+            let startedAt = Date()
+            let deadline = startedAt.addingTimeInterval(timeout)
+            while Date() < deadline {
+                if element.exists {
+                    let currentValue = self.elementValue(element: element)
+                    if currentValue.contains(readyValue) {
+                        let durationSeconds = Date().timeIntervalSince(startedAt)
+                        self.logSmokeBreadcrumb(
+                            event: "wait_end",
+                            action: "wait_for_ui_test_launch_preparation",
+                            identifier: LiveSmokeIdentifier.uiTestLaunchPreparationStatus,
+                            timeoutSeconds: formatDuration(seconds: timeout),
+                            durationSeconds: formatDuration(seconds: durationSeconds),
+                            result: "success",
+                            note: currentValue
+                        )
+                        return
+                    }
+
+                    if currentValue.contains(failedValuePrefix) {
+                        throw LiveSmokeFailure.uiTestLaunchPreparationFailed(
+                            launchScenario: launchScenario.rawValue,
+                            message: currentValue,
+                            screen: self.currentScreenSummary(),
+                            step: self.currentStepTitle
+                        )
+                    }
+                }
+
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+            }
+
+            let durationSeconds = Date().timeIntervalSince(startedAt)
+            self.logSmokeBreadcrumb(
+                event: "wait_end",
+                action: "wait_for_ui_test_launch_preparation",
+                identifier: LiveSmokeIdentifier.uiTestLaunchPreparationStatus,
+                timeoutSeconds: formatDuration(seconds: timeout),
+                durationSeconds: formatDuration(seconds: durationSeconds),
+                result: "failure",
+                note: element.exists ? self.elementValue(element: element) : "missing_marker"
+            )
+
+            if element.exists == false {
+                throw LiveSmokeFailure.missingElement(
+                    identifier: LiveSmokeIdentifier.uiTestLaunchPreparationStatus,
+                    timeoutSeconds: timeout,
+                    screen: self.currentScreenSummary(),
+                    step: self.currentStepTitle
+                )
+            }
+
+            throw LiveSmokeFailure.unexpectedElementValue(
+                identifier: LiveSmokeIdentifier.uiTestLaunchPreparationStatus,
+                expectedValue: readyValue,
+                actualValue: self.elementValue(element: element),
+                timeoutSeconds: timeout,
+                screen: self.currentScreenSummary(),
+                step: self.currentStepTitle
+            )
+        }
+    }
+
+    @MainActor
     var isApplicationRunning: Bool {
         guard self.app != nil else {
             return false
@@ -162,6 +247,12 @@ extension LiveSmokeTestCase {
         self.logActionStart(action: action, identifier: "application")
         self.app.launch()
         try self.waitForApplicationToReachForeground(timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        if let launchScenario = request.launchScenario {
+            try self.waitForUITestLaunchPreparation(
+                launchScenario: launchScenario,
+                timeout: LiveSmokeConfiguration.launchPreparationTimeoutSeconds
+            )
+        }
         if request.appNotificationTapType == nil {
             try self.waitForSelectedTabScreen(
                 selectedTab: request.selectedTab,
@@ -174,15 +265,15 @@ extension LiveSmokeTestCase {
     @MainActor
     private func configureLaunchEnvironment(request: LiveSmokeLaunchRequest) {
         self.currentLaunchLocalization = request.launchLocalization
-        self.app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.resetStateEnvironmentKey)
+        self.app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.launchScenarioEnvironmentKey)
         self.app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.appNotificationTapTypeEnvironmentKey)
         self.app.launchEnvironment[LiveSmokeConfiguration.selectedTabEnvironmentKey] = request.selectedTab.rawValue
         self.app.launchArguments = self.strippingAppleLocalizationLaunchArguments(
             arguments: self.app.launchArguments
         )
         self.app.launchArguments += request.launchLocalization.launchArguments
-        if let resetState = request.resetState {
-            self.app.launchEnvironment[LiveSmokeConfiguration.resetStateEnvironmentKey] = resetState.rawValue
+        if let launchScenario = request.launchScenario {
+            self.app.launchEnvironment[LiveSmokeConfiguration.launchScenarioEnvironmentKey] = launchScenario.rawValue
         }
         if let appNotificationTapType = request.appNotificationTapType {
             self.app.launchEnvironment[LiveSmokeConfiguration.appNotificationTapTypeEnvironmentKey] = appNotificationTapType.rawValue

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeWorkspaceFlows.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeWorkspaceFlows.swift
@@ -20,7 +20,7 @@ extension LiveSmokeTestCase {
         scenario: () throws -> Void
     ) throws {
         try self.launchApplication(
-            resetState: .localGuest,
+            launchScenario: .guestEmptyWorkspace,
             selectedTab: .settings
         )
 

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingCardsScreenshotTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingCardsScreenshotTests.swift
@@ -8,7 +8,7 @@ final class MarketingCardsScreenshotTests: MarketingManualScreenshotTestCase {
 
         try self.step("launch marketing cards list state") {
             try self.launchMarketingApplication(
-                resetState: .marketingConceptCards,
+                launchScenario: .marketingConceptCards,
                 selectedTab: .cards,
                 aiHandoffCard: nil
             )

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
@@ -83,6 +83,34 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
         self.runtimeConfiguration = runtimeConfiguration
     }
 
+    override func tearDownWithError() throws {
+        var cleanupError: Error?
+
+        if self.runtimeConfiguration?.includeManualScreenshotTests == true {
+            do {
+                try MainActor.assumeIsolated {
+                    try self.runMarketingGuestSessionCleanup()
+                }
+            } catch {
+                cleanupError = error
+            }
+        }
+
+        self.runtimeConfiguration = nil
+
+        do {
+            try super.tearDownWithError()
+        } catch {
+            if cleanupError == nil {
+                cleanupError = error
+            }
+        }
+
+        if let cleanupError {
+            throw cleanupError
+        }
+    }
+
     @MainActor
     func marketingLocaleFixture() throws -> MarketingScreenshotLocaleFixture {
         let rawValue = try self.manualRuntimeConfiguration().localizationCode
@@ -95,7 +123,7 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
 
     @MainActor
     func launchMarketingApplication(
-        resetState: LiveSmokeLaunchResetState,
+        launchScenario: LiveSmokeLaunchScenario,
         selectedTab: LiveSmokeSelectedTab,
         aiHandoffCard: String?
     ) throws {
@@ -104,7 +132,7 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
         self.currentLaunchLocalization = localeFixture.tabBarFallbackLocalization
         self.configureMarketingLaunchEnvironment(
             app: self.app,
-            resetState: resetState,
+            launchScenario: launchScenario,
             selectedTab: selectedTab,
             localeFixture: localeFixture,
             aiHandoffCard: aiHandoffCard
@@ -113,6 +141,10 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
         self.logActionStart(action: "launch_app", identifier: "application")
         self.app.launch()
         try self.waitForApplicationToReachForeground(timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        try self.waitForUITestLaunchPreparation(
+            launchScenario: launchScenario,
+            timeout: LiveSmokeConfiguration.launchPreparationTimeoutSeconds
+        )
         try self.waitForSelectedTabScreen(
             selectedTab: selectedTab,
             timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -130,7 +162,7 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
         let localeFixture = try self.marketingLocaleFixture()
 
         try self.launchMarketingApplication(
-            resetState: .marketingOpportunityCostReviewCard,
+            launchScenario: .marketingOpportunityCostReviewCard,
             selectedTab: .review,
             aiHandoffCard: nil
         )
@@ -149,7 +181,7 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
         }
 
         try self.launchMarketingApplication(
-            resetState: .marketingOpportunityCostReviewCard,
+            launchScenario: .marketingOpportunityCostReviewCard,
             selectedTab: .ai,
             aiHandoffCard: "first_card"
         )
@@ -160,7 +192,7 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
         let localeFixture: MarketingScreenshotLocaleFixture = try self.marketingLocaleFixture()
 
         try self.launchMarketingApplication(
-            resetState: .marketingProgress,
+            launchScenario: .marketingProgress,
             selectedTab: .progress,
             aiHandoffCard: nil
         )
@@ -253,6 +285,39 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
     }
 
     @MainActor
+    private func runMarketingGuestSessionCleanup() throws {
+        let localeFixture = try self.marketingLocaleFixture()
+
+        if self.isApplicationRunning {
+            self.app.terminate()
+        }
+
+        self.app = XCUIApplication()
+        self.currentLaunchLocalization = localeFixture.tabBarFallbackLocalization
+        self.configureMarketingLaunchEnvironment(
+            app: self.app,
+            launchScenario: .marketingGuestSessionCleanup,
+            selectedTab: .settings,
+            localeFixture: localeFixture,
+            aiHandoffCard: nil
+        )
+
+        self.logActionStart(action: "launch_app_cleanup", identifier: "application")
+        self.app.launch()
+        try self.waitForApplicationToReachForeground(timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        try self.waitForUITestLaunchPreparation(
+            launchScenario: .marketingGuestSessionCleanup,
+            timeout: LiveSmokeConfiguration.launchPreparationTimeoutSeconds
+        )
+        self.logActionEnd(
+            action: "launch_app_cleanup",
+            identifier: "application",
+            result: "success",
+            note: "marketing guest cleanup finished"
+        )
+    }
+
+    @MainActor
     func assertElementExists(
         identifier: String,
         index: Int,
@@ -282,16 +347,16 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
     @MainActor
     private func configureMarketingLaunchEnvironment(
         app: XCUIApplication,
-        resetState: LiveSmokeLaunchResetState,
+        launchScenario: LiveSmokeLaunchScenario,
         selectedTab: LiveSmokeSelectedTab,
         localeFixture: MarketingScreenshotLocaleFixture,
         aiHandoffCard: String?
     ) {
-        app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.resetStateEnvironmentKey)
+        app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.launchScenarioEnvironmentKey)
         app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.appNotificationTapTypeEnvironmentKey)
         app.launchEnvironment.removeValue(forKey: MarketingScreenshotEnvironment.aiHandoffCardKey)
         app.launchEnvironment[LiveSmokeConfiguration.selectedTabEnvironmentKey] = selectedTab.rawValue
-        app.launchEnvironment[LiveSmokeConfiguration.resetStateEnvironmentKey] = resetState.rawValue
+        app.launchEnvironment[LiveSmokeConfiguration.launchScenarioEnvironmentKey] = launchScenario.rawValue
         app.launchEnvironment[MarketingScreenshotEnvironment.localizationKey] = localeFixture.localizationCode
         if let aiHandoffCard {
             app.launchEnvironment[MarketingScreenshotEnvironment.aiHandoffCardKey] = aiHandoffCard

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -113,7 +113,7 @@ The iOS app uses native Apple test tooling only:
 - release-gate UI coverage lives in the grouped `apps/ios/Flashcards/FlashcardsUITests/LiveSmoke*Tests.swift` files, with shared smoke infrastructure in `apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport`
 - accessibility identifiers used by the live smoke flows live in `apps/ios/Flashcards/Flashcards/UITestIdentifiers.swift`
 
-The iOS release-gate smoke coverage is split into independent grouped flows across Review, Cards, AI, and Settings. Only one grouped smoke signs into the linked demo account and verifies linked workspace lifecycle. The remaining grouped smokes stay guest/local and do not perform login.
+The iOS release-gate smoke coverage is split into independent grouped flows across Review, Cards, AI, and Settings. Only one grouped smoke signs into the linked review account and verifies linked workspace lifecycle. The remaining grouped smokes stay guest/local and do not perform login.
 
 Guest AI availability is part of the iOS release contract. The guest AI smoke must pass without login, and a guest-AI-disabled or guest-quota-exhausted response is a real release-gate failure.
 

--- a/apps/ios/docs/marketing-screenshots.md
+++ b/apps/ios/docs/marketing-screenshots.md
@@ -66,7 +66,17 @@ What each layer does:
 - `build-ios-marketing-materials.sh` can regenerate raw localized screenshots, compose the horizontal derived PNGs, and optimize the final files.
 - `MarketingManualScreenshotTestCase.swift` gates these tests behind the wrapper-provided runtime configuration, falls back to the launch environment only if that file is absent, and writes the PNG file.
 - `MarketingScreenshotFixtures.swift` defines the canonical locale list, locale aliases, localized fixture text, and the expected output filenames.
-- `FlashcardsStore+CloudUITest.swift` seeds the localized UI-test content used by the screenshot flows.
+- `FlashcardsStore+CloudUITest.swift` seeds the localized UI-test content used by the screenshot flows and defines the dedicated guest-session cleanup launch scenario used at the end of each manual test.
+
+## Guest cloud cleanup lifecycle
+
+The manual screenshot flows now treat guest cloud sessions as short-lived per-run fixtures:
+
+- before each marketing screenshot bootstrap, the app deletes any stored guest session remotely through `POST /guest-auth/session/delete` and then performs the existing local identity reset
+- after each manual screenshot test, XCTest relaunches the app in a dedicated cleanup scenario and waits for the UI-test readiness marker before finishing teardown
+- the cleanup relaunch clears the final guest session remotely and then runs the same local reset path, so both cloud and local screenshot state are removed predictably
+
+This is why the screenshot wrappers must still run sequentially. The cleanup relaunch is part of the supported lifecycle, not an optional background best effort.
 
 ## Supported locales
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -44,7 +44,7 @@ Local smoke prerequisites:
 
 - root `.env` must keep `AUTH_MODE=cognito`
 - local auth/backend must have real Cognito config (`COGNITO_USER_POOL_ID`, `COGNITO_CLIENT_ID`, `COGNITO_REGION`, `SESSION_ENCRYPTION_KEY`)
-- review/demo sign-in should be enabled locally with `DEMO_EMAIL_DOSTIP` and `DEMO_PASSWORD_DOSTIP`
+- review account sign-in should be enabled locally with `DEMO_EMAIL_DOSTIP` and `DEMO_PASSWORD_DOSTIP`
 - start the local data/auth stack first with `make db-up`, `make auth-dev`, and `make backend-dev`
 
 The local smoke preflight fails fast if local auth or backend is unavailable, or if the Playwright target is misconfigured to mix localhost with deployed origins.

--- a/apps/web/e2e/live-smoke.spec.ts
+++ b/apps/web/e2e/live-smoke.spec.ts
@@ -1,7 +1,7 @@
 import { test } from "./live-smoke/fixture";
 import { runAiCardCreationFlow, runAiConversationResetFlow } from "./live-smoke/flows/ai";
 import { runLinkedWorkspaceSetupFlow } from "./live-smoke/flows/auth-workspace";
-import { runManualCardReviewFlow } from "./live-smoke/flows/cards-review";
+import { runSeededCardReviewFlow } from "./live-smoke/flows/cards-review";
 import { runResetProgressFlow } from "./live-smoke/flows/reset-progress";
 import { runWorkspaceCleanupFlow } from "./live-smoke/flows/settings-cleanup";
 import {
@@ -15,7 +15,7 @@ import {
  * The groups share state on purpose so the web release gate stays close to the
  * existing flow while making failures easier to attribute.
  */
-test.describe.serial("live smoke flow uses the real demo account across review, cards, AI, and settings", () => {
+test.describe.serial("live smoke flow uses the configured review account across the seeded linked workspace, review, cards, AI, and settings", () => {
   test.afterAll(async ({ liveSmokeSession }) => {
     const cleanupInfo = test.info();
     const { page, diagnostics } = liveSmokeSession;
@@ -35,15 +35,15 @@ test.describe.serial("live smoke flow uses the real demo account across review, 
     }
   });
 
-  test("linked workspace shows account status and workspace state", async ({ liveSmokeSession }) => {
+  test("configured review account creates and seeds a linked workspace", async ({ liveSmokeSession }) => {
     await runLinkedWorkspaceSetupFlow(liveSmokeSession);
   });
 
-  test("manual card can be created and reviewed in the linked workspace", async ({ liveSmokeSession }) => {
-    await runManualCardReviewFlow(liveSmokeSession);
+  test("seeded linked-workspace card can be reviewed", async ({ liveSmokeSession }) => {
+    await runSeededCardReviewFlow(liveSmokeSession);
   });
 
-  test("resetting all progress makes the reviewed card due again", async ({ liveSmokeSession }) => {
+  test("resetting all progress makes the seeded card due again", async ({ liveSmokeSession }) => {
     await runResetProgressFlow(liveSmokeSession);
   });
 

--- a/apps/web/e2e/live-smoke/fixture.ts
+++ b/apps/web/e2e/live-smoke/fixture.ts
@@ -7,6 +7,7 @@ import {
 } from "../live-smoke.diagnostics";
 import { liveSmokeEnvironment, reviewEmail } from "./config";
 import { buildScenario, runIdFromClock } from "./scenario";
+import { enableTestSeedBridge } from "./seedBridge";
 import type { LiveSmokeSession } from "./types";
 
 type LiveSmokeWorkerFixtures = {
@@ -25,6 +26,7 @@ export const test = base.extend<LiveSmokeTestFixtures, LiveSmokeWorkerFixtures>(
       ignoreHTTPSErrors: true,
       locale: liveSmokeBrowserLocale,
     });
+    await enableTestSeedBridge(context);
     const page = await context.newPage();
     const diagnostics = createLiveSmokeDiagnostics(page);
     const liveSmokeSession: LiveSmokeSession = {

--- a/apps/web/e2e/live-smoke/flows/auth-workspace.ts
+++ b/apps/web/e2e/live-smoke/flows/auth-workspace.ts
@@ -9,8 +9,12 @@ import {
   trackedWaitForUrl,
 } from "../../live-smoke.actions";
 import { authBaseUrl, externalUiTimeoutMs, localUiTimeoutMs } from "../config";
+import { seedLinkedWorkspaceForTest } from "../seedBridge";
 import { runLiveSmokeStep } from "../steps";
 import type { LiveSmokeSession } from "../types";
+
+const seededCardCreatedAt = "2024-02-01T09:00:00.000Z";
+const seededCardReviewedAt = "2024-02-01T09:10:00.000Z";
 
 export async function runLinkedWorkspaceSetupFlow(session: LiveSmokeSession): Promise<void> {
   await runLiveSmokeStep(session, "sign in with the configured review account", async () => {
@@ -22,8 +26,12 @@ export async function runLinkedWorkspaceSetupFlow(session: LiveSmokeSession): Pr
     session.cleanupRequested = true;
   });
 
-  await runLiveSmokeStep(session, "verify linked account status and workspace state", async () => {
+  await runLiveSmokeStep(session, "verify linked account status in the new workspace", async () => {
     await assertLinkedAccountStatus(session);
+  });
+
+  await runLiveSmokeStep(session, "seed deterministic linked-workspace review data", async () => {
+    await seedDeterministicWorkspaceData(session);
   });
 }
 
@@ -158,6 +166,41 @@ async function assertLinkedAccountStatus(session: LiveSmokeSession): Promise<voi
     page.locator(".settings-detail-grid .settings-summary-card").nth(1),
     externalUiTimeoutMs,
   );
+}
+
+async function seedDeterministicWorkspaceData(session: LiveSmokeSession): Promise<void> {
+  const { page, diagnostics, scenario } = session;
+  const seedResult = await seedLinkedWorkspaceForTest(
+    page,
+    diagnostics,
+    {
+      cards: [
+        {
+          frontText: scenario.seededFrontText,
+          backText: scenario.seededBackText,
+          tags: [],
+          effortLevel: "medium",
+          createdAt: seededCardCreatedAt,
+          reviews: [
+            {
+              rating: 0,
+              reviewedAtClient: seededCardReviewedAt,
+            },
+          ],
+        },
+      ],
+    },
+    scenario.workspaceName,
+  );
+
+  if (seedResult.cards.length !== 1) {
+    throw new Error(`Expected exactly one seeded card, received ${seedResult.cards.length}`);
+  }
+
+  const seededCard = seedResult.cards[0];
+  if (seededCard.frontText !== scenario.seededFrontText) {
+    throw new Error(`Seeded card front text mismatch: expected ${scenario.seededFrontText}, received ${seededCard.frontText}`);
+  }
 }
 
 function buildLoginUrl(appBaseUrl: string): string {

--- a/apps/web/e2e/live-smoke/flows/cards-review.ts
+++ b/apps/web/e2e/live-smoke/flows/cards-review.ts
@@ -3,7 +3,6 @@ import { expect, type Locator, type Page } from "@playwright/test";
 import {
   trackedClick,
   trackedExpectAttribute,
-  trackedExpectVisible,
   trackedFill,
 } from "../../live-smoke.actions";
 import { externalUiTimeoutMs, localUiTimeoutMs, reviewPostSubmitTimeoutMs } from "../config";
@@ -26,70 +25,51 @@ type PostReviewObservation = Readonly<{
   reviewedCardQueueDueState: ReviewQueueDueState;
 }>;
 
-export async function runManualCardReviewFlow(session: LiveSmokeSession): Promise<void> {
-  await runLiveSmokeStep(session, "create one manual card", async () => {
-    await createManualCard(session);
-  });
-
-  await runLiveSmokeStep(session, "verify the manual card in cards and review it", async () => {
-    await assertCardVisibleInCards(session);
-    await reviewCardFromQueue(session);
+export async function runSeededCardReviewFlow(session: LiveSmokeSession): Promise<void> {
+  await runLiveSmokeStep(session, "verify the seeded card in cards and review it", async () => {
+    await assertSeededCardVisibleInCards(session);
+    await reviewSeededCardFromQueue(session);
   });
 }
 
-async function createManualCard(session: LiveSmokeSession): Promise<void> {
-  const { page, diagnostics, scenario } = session;
-  await trackedClick(diagnostics, "open cards navigation", page.locator('nav.nav a[href="/cards"]').first());
-  await trackedClick(diagnostics, "open new card screen", page.getByTestId("cards-new-card"));
-  await trackedFill(diagnostics, `fill card front text ${scenario.manualFrontText}`, page.getByTestId("card-form-front-text"), scenario.manualFrontText);
-  await trackedFill(diagnostics, `fill card back text ${scenario.manualBackText}`, page.getByTestId("card-form-back-text"), scenario.manualBackText);
-  await trackedClick(diagnostics, "submit manual card", page.getByTestId("card-form-save"));
-  await trackedExpectVisible(
-    diagnostics,
-    "confirm cards screen is visible after manual card save",
-    page.getByTestId("cards-screen"),
-    externalUiTimeoutMs,
-  );
-}
-
-async function assertCardVisibleInCards(session: LiveSmokeSession): Promise<void> {
+async function assertSeededCardVisibleInCards(session: LiveSmokeSession): Promise<void> {
   const { page, diagnostics, scenario } = session;
   await trackedClick(diagnostics, "open cards navigation for verification", page.locator('nav.nav a[href="/cards"]').first());
   const searchInput = page.getByTestId("cards-search-input");
   await trackedFill(diagnostics, "clear cards search input", searchInput, "");
-  await trackedFill(diagnostics, `fill cards search input with ${scenario.manualFrontText}`, searchInput, scenario.manualFrontText);
+  await trackedFill(diagnostics, `fill cards search input with ${scenario.seededFrontText}`, searchInput, scenario.seededFrontText);
   await waitForCardVisibleUnlessSyncing(
     page,
     diagnostics,
-    `confirm cards list shows ${scenario.manualFrontText}`,
-    page.locator(`[data-testid="cards-row"][data-card-front-text=${JSON.stringify(scenario.manualFrontText)}]`).first(),
+    `confirm cards list shows ${scenario.seededFrontText}`,
+    page.locator(`[data-testid="cards-row"][data-card-front-text=${JSON.stringify(scenario.seededFrontText)}]`).first(),
     localUiTimeoutMs,
   );
 }
 
-async function reviewCardFromQueue(session: LiveSmokeSession): Promise<void> {
+async function reviewSeededCardFromQueue(session: LiveSmokeSession): Promise<void> {
   const { page, diagnostics, scenario } = session;
   const currentReviewFrontCard = page.getByTestId("review-current-front-card");
   const reviewPane = page.getByTestId("review-pane");
   const reviewedQueueCard = page.locator(
-    `[data-testid="review-queue-card"][data-card-front-text=${JSON.stringify(scenario.manualFrontText)}]`,
+    `[data-testid="review-queue-card"][data-card-front-text=${JSON.stringify(scenario.seededFrontText)}]`,
   ).first();
   await trackedClick(diagnostics, "open review navigation", page.locator('nav.nav a[href="/review"]').first());
   await trackedExpectAttribute(
     diagnostics,
-    `confirm review queue shows ${scenario.manualFrontText}`,
+    `confirm review queue shows ${scenario.seededFrontText}`,
     currentReviewFrontCard,
     "data-card-front-text",
-    scenario.manualFrontText,
+    scenario.seededFrontText,
     localUiTimeoutMs,
   );
   const reviewedCardId = await currentReviewFrontCard.getAttribute("data-card-id");
   if (reviewedCardId === null || reviewedCardId === "") {
-    throw new Error(`Review current card id is unavailable for ${scenario.manualFrontText}`);
+    throw new Error(`Review current card id is unavailable for ${scenario.seededFrontText}`);
   }
   await trackedClick(diagnostics, "reveal review answer", page.getByTestId("review-reveal-answer"));
   await trackedClick(diagnostics, "submit Good review answer", page.getByTestId("review-rate-good"));
-  await session.diagnostics.runAction(`confirm review pane and queue update after reviewing ${scenario.manualFrontText}`, async () => {
+  await session.diagnostics.runAction(`confirm review pane and queue update after reviewing ${scenario.seededFrontText}`, async () => {
     await expect.poll(
       async (): Promise<boolean> => {
         const observation = await observePostReviewState(reviewPane, reviewedQueueCard);

--- a/apps/web/e2e/live-smoke/flows/reset-progress.ts
+++ b/apps/web/e2e/live-smoke/flows/reset-progress.ts
@@ -15,33 +15,33 @@ import type { LiveSmokeSession } from "../types";
 const resetPreviewTimeoutMs = externalUiTimeoutMs + localUiTimeoutMs;
 
 export async function runResetProgressFlow(session: LiveSmokeSession): Promise<void> {
-  await runLiveSmokeStep(session, "confirm the reviewed manual card still exists in cards", async () => {
-    await confirmReviewedManualCardStillExists(session);
+  await runLiveSmokeStep(session, "confirm the reviewed seeded card still exists in cards", async () => {
+    await confirmReviewedSeededCardStillExists(session);
   });
 
-  await runLiveSmokeStep(session, "reset the reviewed manual card through the danger zone flow", async () => {
+  await runLiveSmokeStep(session, "reset the reviewed seeded card through the danger zone flow", async () => {
     await completeResetProgressFlow(session);
   });
 
   await runLiveSmokeStep(session, "confirm the card becomes due again after reset", async () => {
-    await confirmReviewedManualCardBecomesDueAgain(session);
+    await confirmReviewedSeededCardBecomesDueAgain(session);
   });
 }
 
-async function confirmReviewedManualCardStillExists(session: LiveSmokeSession): Promise<void> {
+async function confirmReviewedSeededCardStillExists(session: LiveSmokeSession): Promise<void> {
   const { page, diagnostics, scenario } = session;
 
   await trackedClick(diagnostics, "open cards navigation before reset", page.locator('nav.nav a[href="/cards"]').first());
   await trackedFill(
     diagnostics,
-    `search cards for ${scenario.manualFrontText}`,
+    `search cards for ${scenario.seededFrontText}`,
     page.getByTestId("cards-search-input"),
-    scenario.manualFrontText,
+    scenario.seededFrontText,
   );
   await trackedExpectVisible(
     diagnostics,
-    `confirm cards list still shows ${scenario.manualFrontText}`,
-    page.locator(`[data-testid="cards-row"][data-card-front-text=${JSON.stringify(scenario.manualFrontText)}]`).first(),
+    `confirm cards list still shows ${scenario.seededFrontText}`,
+    page.locator(`[data-testid="cards-row"][data-card-front-text=${JSON.stringify(scenario.seededFrontText)}]`).first(),
     externalUiTimeoutMs,
   );
 }
@@ -128,16 +128,16 @@ async function completeResetProgressFlow(session: LiveSmokeSession): Promise<voi
   );
 }
 
-async function confirmReviewedManualCardBecomesDueAgain(session: LiveSmokeSession): Promise<void> {
+async function confirmReviewedSeededCardBecomesDueAgain(session: LiveSmokeSession): Promise<void> {
   const { page, diagnostics, scenario } = session;
 
   await trackedClick(diagnostics, "open review navigation after reset", page.locator('nav.nav a[href="/review"]').first());
   await trackedExpectAttribute(
     diagnostics,
-    `confirm the reviewed card becomes due again: ${scenario.manualFrontText}`,
+    `confirm the reviewed card becomes due again: ${scenario.seededFrontText}`,
     page.getByTestId("review-current-front-card"),
     "data-card-front-text",
-    scenario.manualFrontText,
+    scenario.seededFrontText,
     externalUiTimeoutMs,
   );
 }

--- a/apps/web/e2e/live-smoke/scenario.ts
+++ b/apps/web/e2e/live-smoke/scenario.ts
@@ -7,7 +7,7 @@ export function runIdFromClock(): string {
 export function buildScenario(runId: string): LiveSmokeScenario {
   return {
     workspaceName: `E2E web ${runId}`,
-    manualFrontText: `Manual e2e web ${runId}`,
-    manualBackText: `Manual answer e2e web ${runId}`,
+    seededFrontText: `Seeded e2e web ${runId}`,
+    seededBackText: `Seeded answer e2e web ${runId}`,
   };
 }

--- a/apps/web/e2e/live-smoke/seedBridge.ts
+++ b/apps/web/e2e/live-smoke/seedBridge.ts
@@ -1,0 +1,70 @@
+import { expect, type BrowserContext, type Page } from "@playwright/test";
+
+import type {
+  TestSeedRequest,
+  TestSeedResult,
+} from "../../src/appData/testSeedBridge";
+import type { LiveSmokeDiagnostics } from "../live-smoke.diagnostics";
+import { externalUiTimeoutMs } from "./config";
+
+export async function enableTestSeedBridge(context: BrowserContext): Promise<void> {
+  await context.addInitScript(() => {
+    window.__FLASHCARDS_E2E__ = {
+      ...window.__FLASHCARDS_E2E__,
+      enableTestSeedBridge: true,
+    };
+  });
+}
+
+export async function seedLinkedWorkspaceForTest(
+  page: Page,
+  diagnostics: LiveSmokeDiagnostics,
+  request: TestSeedRequest,
+  expectedWorkspaceName: string,
+): Promise<TestSeedResult> {
+  return diagnostics.runAction(`seed linked workspace through the appData test bridge for ${expectedWorkspaceName}`, async () => {
+    await expect.poll(
+      async () => page.evaluate(() => window.__FLASHCARDS_TEST_SEED_BRIDGE__?.workspaceName ?? null),
+      { timeout: externalUiTimeoutMs },
+    ).toBe(expectedWorkspaceName);
+
+    const invocationResult = await page.evaluate(async ({
+      seedRequest,
+      workspaceName,
+    }: {
+      seedRequest: TestSeedRequest;
+      workspaceName: string;
+    }) => {
+      const bridge = window.__FLASHCARDS_TEST_SEED_BRIDGE__;
+      if (bridge === undefined) {
+        throw new Error("AppData test seed bridge is unavailable");
+      }
+
+      if (bridge.workspaceName !== workspaceName) {
+        throw new Error(
+          `AppData test seed bridge is bound to an unexpected workspace: `
+          + `expected ${workspaceName}, received ${bridge.workspaceName}`,
+        );
+      }
+
+      return {
+        bridgeWorkspaceId: bridge.workspaceId,
+        bridgeWorkspaceName: bridge.workspaceName,
+        seedResult: await bridge.seedLinkedWorkspace(seedRequest),
+      };
+    }, {
+      seedRequest: request,
+      workspaceName: expectedWorkspaceName,
+    });
+
+    if (invocationResult.seedResult.workspaceId !== invocationResult.bridgeWorkspaceId) {
+      throw new Error(
+        `AppData test seed bridge returned an unexpected workspace id: `
+        + `expected ${invocationResult.bridgeWorkspaceId} (${invocationResult.bridgeWorkspaceName}), `
+        + `received ${invocationResult.seedResult.workspaceId}`,
+      );
+    }
+
+    return invocationResult.seedResult;
+  });
+}

--- a/apps/web/e2e/live-smoke/types.ts
+++ b/apps/web/e2e/live-smoke/types.ts
@@ -4,8 +4,8 @@ import type { LiveSmokeDiagnostics } from "../live-smoke.diagnostics";
 
 export type LiveSmokeScenario = Readonly<{
   workspaceName: string;
-  manualFrontText: string;
-  manualBackText: string;
+  seededFrontText: string;
+  seededBackText: string;
 }>;
 
 export type CompletedSqlToolCall = Readonly<{

--- a/apps/web/src/appData/provider.tsx
+++ b/apps/web/src/appData/provider.tsx
@@ -18,6 +18,7 @@ import type {
 import { ALL_CARDS_REVIEW_FILTER, isReviewFilterEqual } from "./domain";
 import type { AppDataContextValue, Props, SessionLoadState } from "./types";
 import { useProgressInvalidationRefresh } from "./progressInvalidation";
+import { isTestSeedBridgeEnabled, type AppDataTestSeedBridge } from "./testSeedBridge";
 import { useSyncEngine } from "./useSyncEngine";
 import { useWorkspaceSession } from "./useWorkspaceSession";
 import type { SessionVerificationState } from "./warmStart";
@@ -176,6 +177,37 @@ export function AppDataProvider(props: Props): ReactElement {
       isCancelled = true;
     };
   }, [activeWorkspace, localReadVersion]);
+
+  useEffect(() => {
+    if (
+      isTestSeedBridgeEnabled(window) === false
+      || sessionLoadState !== "ready"
+      || sessionVerificationState !== "verified"
+      || activeWorkspace === null
+    ) {
+      delete window.__FLASHCARDS_TEST_SEED_BRIDGE__;
+      return;
+    }
+
+    const bridge: AppDataTestSeedBridge = {
+      workspaceId: activeWorkspace.workspaceId,
+      workspaceName: activeWorkspace.name,
+      seedLinkedWorkspace: syncEngine.seedLinkedWorkspace,
+    };
+
+    window.__FLASHCARDS_TEST_SEED_BRIDGE__ = bridge;
+
+    return () => {
+      if (window.__FLASHCARDS_TEST_SEED_BRIDGE__ === bridge) {
+        delete window.__FLASHCARDS_TEST_SEED_BRIDGE__;
+      }
+    };
+  }, [
+    activeWorkspace,
+    sessionLoadState,
+    sessionVerificationState,
+    syncEngine.seedLinkedWorkspace,
+  ]);
 
   const selectReviewFilter = useCallback(function selectReviewFilter(reviewFilter: ReviewFilter): void {
     if (isReviewFilterEqual(selectedReviewFilterState, reviewFilter)) {

--- a/apps/web/src/appData/testSeedBridge.ts
+++ b/apps/web/src/appData/testSeedBridge.ts
@@ -1,0 +1,51 @@
+import type {
+  CreateCardInput,
+} from "../types";
+
+export type TestSeedReviewInput = Readonly<{
+  rating: 0 | 1 | 2 | 3;
+  reviewedAtClient: string;
+}>;
+
+export type TestSeedCardInput = CreateCardInput & Readonly<{
+  createdAt: string;
+  reviews: ReadonlyArray<TestSeedReviewInput>;
+}>;
+
+export type TestSeedRequest = Readonly<{
+  cards: ReadonlyArray<TestSeedCardInput>;
+}>;
+
+export type TestSeedCardResult = Readonly<{
+  cardId: string;
+  frontText: string;
+  createdAt: string;
+  dueAt: string | null;
+  reviewsApplied: number;
+}>;
+
+export type TestSeedResult = Readonly<{
+  workspaceId: string;
+  cards: ReadonlyArray<TestSeedCardResult>;
+}>;
+
+export type AppDataTestSeedBridge = Readonly<{
+  workspaceId: string;
+  workspaceName: string;
+  seedLinkedWorkspace: (request: TestSeedRequest) => Promise<TestSeedResult>;
+}>;
+
+export type AppDataE2eConfig = Readonly<{
+  enableTestSeedBridge: boolean;
+}>;
+
+declare global {
+  interface Window {
+    __FLASHCARDS_E2E__?: AppDataE2eConfig;
+    __FLASHCARDS_TEST_SEED_BRIDGE__?: AppDataTestSeedBridge;
+  }
+}
+
+export function isTestSeedBridgeEnabled(targetWindow: Window): boolean {
+  return targetWindow.__FLASHCARDS_E2E__?.enableTestSeedBridge === true;
+}

--- a/apps/web/src/appData/useSyncEngine.ts
+++ b/apps/web/src/appData/useSyncEngine.ts
@@ -46,7 +46,6 @@ import type {
   CreateCardInput,
   CreateDeckInput,
   Deck,
-  ReviewEvent,
   SessionInfo,
   SyncBootstrapEntry,
   UpdateCardInput,
@@ -81,6 +80,7 @@ import {
   toReviewableCardState,
 } from "./domain";
 import { invalidateLocalProgress, invalidateProgress } from "./progressInvalidation";
+import type { TestSeedCardInput, TestSeedRequest, TestSeedResult } from "./testSeedBridge";
 import type { SessionLoadState } from "./types";
 import type { SessionVerificationState } from "./warmStart";
 
@@ -113,6 +113,7 @@ type SyncEngine = Readonly<{
   deleteCardItem: (cardId: string) => Promise<Card>;
   deleteDeckItem: (deckId: string) => Promise<Deck>;
   submitReviewItem: (cardId: string, rating: 0 | 1 | 2 | 3) => Promise<Card>;
+  seedLinkedWorkspace: (request: TestSeedRequest) => Promise<TestSeedResult>;
 }>;
 
 async function requireCard(workspaceId: string, cardId: string): Promise<Card> {
@@ -163,6 +164,51 @@ function isProgressReviewEventOperation(
   record: PersistedOutboxRecord,
 ): boolean {
   return record.operation.entityType === "review_event" && record.operation.action === "append";
+}
+
+function requireSeedTimestamp(label: string, value: string): number {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`${label} must be a valid ISO timestamp: ${value}`);
+  }
+
+  return timestamp;
+}
+
+function validateSeedCardInput(card: TestSeedCardInput, cardIndex: number): void {
+  const createdAtTimestamp = requireSeedTimestamp(`Seed card ${cardIndex} createdAt`, card.createdAt);
+  let previousTimestamp = createdAtTimestamp;
+
+  for (const [reviewIndex, review] of card.reviews.entries()) {
+    const currentTimestamp = requireSeedTimestamp(
+      `Seed card ${cardIndex} review ${reviewIndex} reviewedAtClient`,
+      review.reviewedAtClient,
+    );
+
+    if (currentTimestamp <= previousTimestamp) {
+      throw new Error(
+        `Seed card ${cardIndex} review ${reviewIndex} reviewedAtClient must be later than the previous mutation timestamp`,
+      );
+    }
+
+    previousTimestamp = currentTimestamp;
+  }
+}
+
+function validateSeedRequest(request: TestSeedRequest): void {
+  for (const [cardIndex, card] of request.cards.entries()) {
+    validateSeedCardInput(card, cardIndex);
+  }
+}
+
+type WorkspaceSeedReadiness = Readonly<{
+  workspaceSettingsLoaded: boolean;
+  hotStateHydrated: boolean;
+  reviewHistoryHydrated: boolean;
+}>;
+
+function isWorkspaceSeedReady(readiness: WorkspaceSeedReadiness): boolean {
+  return readiness.workspaceSettingsLoaded && readiness.hotStateHydrated && readiness.reviewHistoryHydrated;
 }
 
 export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
@@ -236,6 +282,22 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
       await activeSync;
     }
+  }, []);
+
+  const loadWorkspaceSeedReadiness = useCallback(async function loadWorkspaceSeedReadiness(
+    workspaceId: string,
+  ): Promise<WorkspaceSeedReadiness> {
+    const [workspaceSettings, hotStateHydrated, reviewHistoryHydrated] = await Promise.all([
+      loadWorkspaceSettings(workspaceId),
+      hasHydratedHotState(workspaceId),
+      hasHydratedReviewHistory(workspaceId),
+    ]);
+
+    return {
+      workspaceSettingsLoaded: workspaceSettings !== null,
+      hotStateHydrated,
+      reviewHistoryHydrated,
+    };
   }, []);
 
   const runSyncForWorkspaceInternal = useCallback(async function runSyncForWorkspaceInternal(
@@ -456,6 +518,42 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     await runSyncForWorkspaceInternal(activeWorkspace, ignoreSyncError);
   }, [activeWorkspace, ignoreSyncError, runSyncForWorkspaceInternal]);
 
+  const ensureWorkspaceSeedReady = useCallback(async function ensureWorkspaceSeedReady(
+    workspace: WorkspaceSummary,
+  ): Promise<void> {
+    const workspaceId = workspace.workspaceId;
+
+    await waitForWorkspaceSyncToSettle(workspaceId);
+
+    let readiness = await loadWorkspaceSeedReadiness(workspaceId);
+    if (isWorkspaceSeedReady(readiness)) {
+      await refreshWorkspaceView(workspaceId);
+      return;
+    }
+
+    await runSyncForWorkspace(workspace);
+    await waitForWorkspaceSyncToSettle(workspaceId);
+    await refreshWorkspaceView(workspaceId);
+
+    readiness = await loadWorkspaceSeedReadiness(workspaceId);
+    if (isWorkspaceSeedReady(readiness)) {
+      return;
+    }
+
+    throw new Error(
+      `Workspace bootstrap is not ready for deterministic seed data: `
+      + `workspaceId=${workspaceId} `
+      + `workspaceSettingsLoaded=${String(readiness.workspaceSettingsLoaded)} `
+      + `hotStateHydrated=${String(readiness.hotStateHydrated)} `
+      + `reviewHistoryHydrated=${String(readiness.reviewHistoryHydrated)}`,
+    );
+  }, [
+    loadWorkspaceSeedReadiness,
+    refreshWorkspaceView,
+    runSyncForWorkspace,
+    waitForWorkspaceSyncToSettle,
+  ]);
+
   useEffect(() => {
     if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null || activeWorkspace === null) {
       return;
@@ -493,13 +591,15 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
 
-  const createCardItem = useCallback(async function createCardItem(input: CreateCardInput): Promise<Card> {
-    if (activeWorkspaceId === null || activeWorkspace === null) {
+  const createCardItemLocally = useCallback(async function createCardItemLocally(
+    input: CreateCardInput,
+    clientUpdatedAt: string,
+  ): Promise<Card> {
+    if (activeWorkspaceId === null) {
       throw new Error("Workspace is unavailable");
     }
 
     const normalizedInput = normalizeCreateCardInput(input);
-    const clientUpdatedAt = nowIso();
     const operationId = crypto.randomUUID().toLowerCase();
     const installationId = requireCloudInstallationId(await loadCloudSettings());
     const nextCard = buildInitialCard(normalizedInput, clientUpdatedAt, installationId, operationId);
@@ -514,10 +614,91 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     await putCard(activeWorkspaceId, nextCard);
     await putOutboxRecord(nextOutboxRecord);
+    return nextCard;
+  }, [activeWorkspaceId]);
+
+  const submitReviewItemLocally = useCallback(async function submitReviewItemLocally(
+    cardId: string,
+    rating: 0 | 1 | 2 | 3,
+    reviewedAtClient: string,
+  ): Promise<Card> {
+    if (activeWorkspaceId === null) {
+      throw new Error("Workspace is unavailable");
+    }
+
+    const [existingCard, schedulerSettings, cloudSettings] = await Promise.all([
+      requireCard(activeWorkspaceId, cardId),
+      loadWorkspaceSettings(activeWorkspaceId),
+      loadCloudSettings(),
+    ]);
+    if (schedulerSettings === null) {
+      throw new Error("Workspace scheduler settings are not loaded");
+    }
+
+    const reviewEventId = crypto.randomUUID().toLowerCase();
+    const clientEventId = crypto.randomUUID().toLowerCase();
+    const cardOperationId = crypto.randomUUID().toLowerCase();
+    const installationId = requireCloudInstallationId(cloudSettings);
+    const schedule = computeReviewSchedule(
+      toReviewableCardState(existingCard),
+      {
+        algorithm: schedulerSettings.algorithm,
+        desiredRetention: schedulerSettings.desiredRetention,
+        learningStepsMinutes: schedulerSettings.learningStepsMinutes,
+        relearningStepsMinutes: schedulerSettings.relearningStepsMinutes,
+        maximumIntervalDays: schedulerSettings.maximumIntervalDays,
+        enableFuzz: schedulerSettings.enableFuzz,
+      },
+      rating as ReviewRating,
+      new Date(reviewedAtClient),
+    );
+
+    const nextCard = buildReviewedCard(existingCard, schedule, reviewedAtClient, installationId, cardOperationId);
+    const nextReviewEvent = buildReviewEvent(
+      activeWorkspaceId,
+      cardId,
+      installationId,
+      rating,
+      reviewedAtClient,
+      reviewEventId,
+      clientEventId,
+    );
+
+    const reviewEventOutboxRecord: PersistedOutboxRecord = {
+      operationId: reviewEventId,
+      workspaceId: activeWorkspaceId,
+      createdAt: reviewedAtClient,
+      attemptCount: 0,
+      lastError: "",
+      operation: buildReviewEventAppendOperation(nextReviewEvent),
+    };
+
+    const cardOutboxRecord: PersistedOutboxRecord = {
+      operationId: cardOperationId,
+      workspaceId: activeWorkspaceId,
+      createdAt: reviewedAtClient,
+      attemptCount: 0,
+      lastError: "",
+      operation: buildCardUpsertOperation(nextCard),
+    };
+
+    await putReviewEvent(nextReviewEvent);
+    await putCard(activeWorkspaceId, nextCard);
+    await putOutboxRecord(reviewEventOutboxRecord);
+    await putOutboxRecord(cardOutboxRecord);
+    return nextCard;
+  }, [activeWorkspaceId]);
+
+  const createCardItem = useCallback(async function createCardItem(input: CreateCardInput): Promise<Card> {
+    if (activeWorkspaceId === null || activeWorkspace === null) {
+      throw new Error("Workspace is unavailable");
+    }
+
+    const nextCard = await createCardItemLocally(input, nowIso());
     bumpLocalReadVersion();
     void runSyncForWorkspace(activeWorkspace);
     return nextCard;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, createCardItemLocally, runSyncForWorkspace]);
 
   const createDeckItem = useCallback(async function createDeckItem(input: CreateDeckInput): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
@@ -662,71 +843,73 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    const [existingCard, schedulerSettings] = await Promise.all([
-      requireCard(activeWorkspaceId, cardId),
-      loadWorkspaceSettings(activeWorkspaceId),
-    ]);
-    if (schedulerSettings === null) {
-      throw new Error("Workspace scheduler settings are not loaded");
-    }
-
-    const reviewedAtClient = nowIso();
-    const reviewEventId = crypto.randomUUID().toLowerCase();
-    const clientEventId = crypto.randomUUID().toLowerCase();
-    const cardOperationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(await loadCloudSettings());
-    const schedule = computeReviewSchedule(
-      toReviewableCardState(existingCard),
-      {
-        algorithm: schedulerSettings.algorithm,
-        desiredRetention: schedulerSettings.desiredRetention,
-        learningStepsMinutes: schedulerSettings.learningStepsMinutes,
-        relearningStepsMinutes: schedulerSettings.relearningStepsMinutes,
-        maximumIntervalDays: schedulerSettings.maximumIntervalDays,
-        enableFuzz: schedulerSettings.enableFuzz,
-      },
-      rating as ReviewRating,
-      new Date(reviewedAtClient),
-    );
-
-    const nextCard = buildReviewedCard(existingCard, schedule, reviewedAtClient, installationId, cardOperationId);
-    const nextReviewEvent = buildReviewEvent(
-      activeWorkspaceId,
-      cardId,
-      installationId,
-      rating,
-      reviewedAtClient,
-      reviewEventId,
-      clientEventId,
-    );
-
-    const reviewEventOutboxRecord: PersistedOutboxRecord = {
-      operationId: reviewEventId,
-      workspaceId: activeWorkspaceId,
-      createdAt: reviewedAtClient,
-      attemptCount: 0,
-      lastError: "",
-      operation: buildReviewEventAppendOperation(nextReviewEvent),
-    };
-
-    const cardOutboxRecord: PersistedOutboxRecord = {
-      operationId: cardOperationId,
-      workspaceId: activeWorkspaceId,
-      createdAt: reviewedAtClient,
-      attemptCount: 0,
-      lastError: "",
-      operation: buildCardUpsertOperation(nextCard),
-    };
-
-    await putReviewEvent(nextReviewEvent);
-    await putCard(activeWorkspaceId, nextCard);
-    await putOutboxRecord(reviewEventOutboxRecord);
-    await putOutboxRecord(cardOutboxRecord);
+    const nextCard = await submitReviewItemLocally(cardId, rating, nowIso());
     bumpLocalReadVersion();
     invalidateLocalProgress();
     void runSyncForWorkspace(activeWorkspace);
     return nextCard;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace, submitReviewItemLocally]);
+
+  const seedLinkedWorkspace = useCallback(async function seedLinkedWorkspace(
+    request: TestSeedRequest,
+  ): Promise<TestSeedResult> {
+    if (
+      activeWorkspace === null
+      || activeWorkspaceId === null
+      || sessionLoadState !== "ready"
+      || sessionVerificationState !== "verified"
+      || session === null
+    ) {
+      throw new Error("Linked workspace is not ready for deterministic seed data");
+    }
+
+    validateSeedRequest(request);
+    await ensureWorkspaceSeedReady(activeWorkspace);
+
+    const seededCards: Array<TestSeedResult["cards"][number]> = [];
+    let didChangeProgressHistory = false;
+
+    for (const seedCard of request.cards) {
+      let nextCard = await createCardItemLocally(seedCard, seedCard.createdAt);
+
+      for (const review of seedCard.reviews) {
+        nextCard = await submitReviewItemLocally(nextCard.cardId, review.rating, review.reviewedAtClient);
+        didChangeProgressHistory = true;
+      }
+
+      seededCards.push({
+        cardId: nextCard.cardId,
+        frontText: nextCard.frontText,
+        createdAt: seedCard.createdAt,
+        dueAt: nextCard.dueAt,
+        reviewsApplied: seedCard.reviews.length,
+      });
+    }
+
+    bumpLocalReadVersion();
+    if (didChangeProgressHistory) {
+      invalidateLocalProgress();
+    }
+
+    await runSyncForWorkspace(activeWorkspace);
+    await waitForWorkspaceSyncToSettle(activeWorkspaceId);
+
+    return {
+      workspaceId: activeWorkspaceId,
+      cards: seededCards,
+    };
+  }, [
+    activeWorkspace,
+    activeWorkspaceId,
+    bumpLocalReadVersion,
+    createCardItemLocally,
+    runSyncForWorkspace,
+    session,
+    sessionLoadState,
+    sessionVerificationState,
+    ensureWorkspaceSeedReady,
+    submitReviewItemLocally,
+  ]);
 
   return {
     runSync,
@@ -743,5 +926,6 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     deleteCardItem,
     deleteDeckItem,
     submitReviewItem,
+    seedLinkedWorkspace,
   };
 }

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -187,7 +187,7 @@ const enCatalog = {
     },
     accountSettings: {
       title: "Account Settings",
-      description: "Review account status, support, connections, and danger-zone actions.",
+      description: "Account status, support, connections, and danger-zone actions.",
       value: "Account",
     },
     device: {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,10 +207,12 @@ Implemented sync behavior:
   - `lastModifiedByDeviceId`
   - `lastOperationId`
 - Review events are append-only and deduplicated by `(workspace_id, device_id, client_event_id)`.
+- Review events use the normal `POST /v1/workspaces/:workspaceId/sync/push` contract for both live and historical submissions. For `review_event` operations, `clientUpdatedAt` must equal `payload.reviewedAtClient`.
 - Mutable state and review history are synchronized through separate lanes:
   - hot mutable roots use `sync.hot_changes` plus direct materialization from canonical tables
   - review history uses `content.review_events.review_sequence`
 - Local sync state keeps separate cursors for hot state and review history instead of one global checkpoint.
+- Progress, streaks, and chart day buckets are derived from `content.review_events.reviewed_at_client` in the requested timezone, not from server ingest time.
 
 ## Scheduling architecture
 

--- a/docs/backend-web-deployment.md
+++ b/docs/backend-web-deployment.md
@@ -47,7 +47,7 @@ Use it only against the local stack:
 
 1. keep root `.env` in `AUTH_MODE=cognito`
 2. set `COGNITO_USER_POOL_ID`, `COGNITO_CLIENT_ID`, `COGNITO_REGION`, and `SESSION_ENCRYPTION_KEY`
-3. set `DEMO_EMAIL_DOSTIP` and `DEMO_PASSWORD_DOSTIP` for the local review/demo account
+3. set `DEMO_EMAIL_DOSTIP` and `DEMO_PASSWORD_DOSTIP` for the local review account
 4. start `make db-up`
 5. start `make auth-dev`
 6. start `make backend-dev`
@@ -94,7 +94,7 @@ bash scripts/first-deploy.sh \
 The first deploy flow:
 
 - stores required runtime secrets in AWS Secrets Manager
-- stores optional AI and demo auth secrets in AWS Secrets Manager when configured
+- stores optional AI and review account auth secrets in AWS Secrets Manager when configured
 - requests ACM certificates for API, auth, web, and apex redirect when needed
 - requests the ACM certificate for `admin.<domain>` when needed
 - assembles `infra/aws/cdk.context.local.json` as the local CDK input
@@ -128,11 +128,11 @@ bash scripts/setup-github.sh
 Run only the secret setup scripts you actually need. `setup-github.sh` rediscovers the current AWS ARNs and fills in any missing matching GitHub variables afterward, leaving existing values untouched.
 This bootstrap-only rule also applies to `CDK_ADMIN_EMAILS`: after the first setup, change that GitHub variable manually when you need to change the deployed bootstrap admin list.
 
-## Optional review/demo auth
+## Optional review account auth
 
-`DEMO_EMAIL_DOSTIP` enables insecure instant sign-in only for listed review/demo emails in the `example.com` domain. `DEMO_PASSWORD_DOSTIP` stores the shared review/demo password. Keep both values as explicit deploy config and store the shared password in AWS Secrets Manager for deployed environments.
+`DEMO_EMAIL_DOSTIP` enables insecure instant sign-in only for listed review account emails in the `example.com` domain. `DEMO_PASSWORD_DOSTIP` stores the shared review account password. Keep both values as explicit deploy config and store the shared password in AWS Secrets Manager for deployed environments.
 
-If review/demo access is enabled, create the matching `@example.com` Cognito users manually and keep their emails and shared password aligned with the deployed allowlist and demo password secret. The intended setup flow is:
+If review account access is enabled, create the matching `@example.com` Cognito users manually and keep their emails and shared password aligned with the deployed allowlist and review account password secret. The intended setup flow is:
 
 1. keep `DEMO_EMAIL_DOSTIP` and `DEMO_PASSWORD_DOSTIP` in the local root `.env`
 2. run `bash scripts/setup-auth-secrets.sh --region <aws-region>`

--- a/docs/ios-ci-cd.md
+++ b/docs/ios-ci-cd.md
@@ -10,7 +10,7 @@ The intended iOS release order is:
 1. Native XCUITest grouped live smoke in the grouped `apps/ios/Flashcards/FlashcardsUITests/LiveSmoke*Tests.swift` files
 2. Archive and distribution from Xcode Cloud
 
-The live smoke coverage is split into independent grouped flows across Review, Cards, AI, and Settings. Only one grouped smoke signs into the linked demo account, creates an isolated linked workspace, verifies relaunch persistence, and deletes that workspace before exit. The remaining grouped smokes stay guest/local and do not perform login.
+The live smoke coverage is split into independent grouped flows across Review, Cards, AI, and Settings. Only one grouped smoke signs into the linked review account, creates an isolated linked workspace, verifies relaunch persistence, and deletes that workspace before exit. The remaining grouped smokes stay guest/local and do not perform login.
 
 Guest AI availability is part of the iOS release contract. The guest AI smoke must pass without login, and a guest-AI-disabled or guest-quota-exhausted response is treated as a real release failure.
 
@@ -43,13 +43,13 @@ The required environment values are documented in [`docs/ios-local-setup.md`](io
 
 `ci_post_clone.sh` fails the build before `xcodebuild` if any required variable is missing or if any URL value is malformed for `.xcconfig` usage.
 
-If the workflow injects the review/demo email for the login smoke path explicitly, use `FLASHCARDS_LIVE_REVIEW_EMAIL`.
+If the workflow injects the review email for the login smoke path explicitly, use `FLASHCARDS_LIVE_REVIEW_EMAIL`.
 
 Recommended value for this repository:
 
 - `FLASHCARDS_LIVE_REVIEW_EMAIL=apple-review@example.com`
 
-This keeps the login smoke path pinned to the intended review/demo account instead of relying on the default value embedded in the UI test code.
+This keeps the login smoke path pinned to the intended review account instead of relying on the default value embedded in the UI test code.
 
 `FLASHCARDS_LIVE_REVIEW_EMAIL` remains optional.
 

--- a/docs/ios-local-setup.md
+++ b/docs/ios-local-setup.md
@@ -64,7 +64,7 @@ Xcode Cloud builds now fail in `ci_post_clone.sh` before `xcodebuild` starts if 
 
 The iOS release-gate and monitoring expectations are documented in [`docs/ios-ci-cd.md`](ios-ci-cd.md).
 
-If Xcode Cloud should pin the live smoke flow to the standard review/demo account explicitly, also set:
+If Xcode Cloud should pin the live smoke flow to the standard review account explicitly, also set:
 
 - `FLASHCARDS_LIVE_REVIEW_EMAIL=apple-review@example.com`
 

--- a/infra/aws/lib/api-gateway.ts
+++ b/infra/aws/lib/api-gateway.ts
@@ -431,7 +431,9 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   chat.addResource("transcriptions").addMethod("POST", integration);
 
   const guestAuth = restApi.root.addResource("guest-auth");
-  guestAuth.addResource("session").addMethod("POST", integration);
+  const guestSession = guestAuth.addResource("session");
+  guestSession.addMethod("POST", integration);
+  guestSession.addResource("delete").addMethod("POST", integration);
   const guestUpgrade = guestAuth.addResource("upgrade");
   guestUpgrade.addResource("prepare").addMethod("POST", integration);
   guestUpgrade.addResource("complete").addMethod("POST", integration);

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -44,7 +44,7 @@ echo "=== Configure optional AI secrets ==="
 bash "${ROOT_DIR}/scripts/setup-ai-secrets.sh" --region "$REGION"
 
 if [[ -n "${DEMO_PASSWORD_DOSTIP:-}" ]]; then
-  echo "=== Configure optional demo auth secret ==="
+  echo "=== Configure optional review account auth secret ==="
   bash "${ROOT_DIR}/scripts/setup-auth-secrets.sh" --region "$REGION"
 fi
 


### PR DESCRIPTION
## Summary\n- replace UI-driven screenshot seeding with deterministic repository-backed seed flows across clients\n- add guest remote cleanup for cloud-backed marketing screenshot runs on backend, iOS, and Android\n- tighten live-smoke and workspace seed infrastructure plus supporting docs/comments\n\n## Validation\n- backend targeted lint and guest auth tests\n- android targeted compile checks\n- ios staged diff checks and build settings resolution\n- independent review approve\n\n## Notes\n- screenshot generators, simulators, emulators, and end-to-end screenshot runs were not executed in this change set