### PR TITLE
Fix Android screenshot test CI compilation

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AppStateResetRule.kt
@@ -23,7 +23,7 @@ private val testOnlyPreferenceNames: List<String> = listOf(
     "flashcards-ai-chat-guest-session"
 )
 
-class AppStateResetRule : ExternalResource() {
+open class AppStateResetRule : ExternalResource() {
     private val device: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
     companion object {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotAppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotAppStateResetRule.kt
@@ -4,22 +4,19 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import org.junit.rules.ExternalResource
 
 private const val marketingScreenshotGuestCleanupTimeoutMillis: Long = 20_000L
 
-class MarketingScreenshotAppStateResetRule : ExternalResource() {
-    private val delegate = AppStateResetRule()
-
+class MarketingScreenshotAppStateResetRule : AppStateResetRule() {
     override fun before() {
-        runRemoteCleanupThenDelegate(delegateAction = delegate::before)
+        runRemoteCleanupThenReset(resetAction = { super.before() })
     }
 
     override fun after() {
-        runRemoteCleanupThenDelegate(delegateAction = delegate::after)
+        runRemoteCleanupThenReset(resetAction = { super.after() })
     }
 
-    private fun runRemoteCleanupThenDelegate(delegateAction: () -> Unit) {
+    private fun runRemoteCleanupThenReset(resetAction: () -> Unit) {
         var primaryFailure: Throwable? = null
 
         try {
@@ -29,7 +26,7 @@ class MarketingScreenshotAppStateResetRule : ExternalResource() {
         }
 
         try {
-            delegateAction()
+            resetAction()
         } catch (error: Throwable) {
             if (primaryFailure != null) {
                 primaryFailure.addSuppressed(error)

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeScenarioHelpers.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeScenarioHelpers.kt
@@ -885,7 +885,7 @@ private fun LiveSmokeContext.reviewEmptyStateTitleOrNull(): String? {
 
 private fun LiveSmokeContext.localCardSnapshotOrNull(expectedFrontText: String): String? {
     return runBlocking {
-        val database = (composeRule.activity.application as FlashcardsApplication).appGraph.database
+        val database = appGraph().database
         val matchingCard = database.cardDao()
             .observeCardsWithRelations()
             .first()


### PR DESCRIPTION
## Summary
- make the base app reset rule extensible for the marketing screenshot cleanup rule
- switch the marketing screenshot reset rule from delegate calls to inheritance-based lifecycle hooks
- reuse the existing live-smoke appGraph helper to avoid the broken androidTest application cast

## Validation
- git diff --check
- bash scripts/run-android-ci.sh