### PR TITLE
[codex] Hide review queue on narrow web pane

### DIFF
--- a/apps/web/src/styles/features/review.css
+++ b/apps/web/src/styles/features/review.css
@@ -1,4 +1,6 @@
 .review-screen-panel {
+  container-type: inline-size;
+  container-name: review-screen;
   grid-template-rows: auto minmax(0, 1fr);
   height: min(880px, calc(100dvh - 76px));
   min-height: min(760px, calc(100dvh - 76px));
@@ -833,6 +835,16 @@
 
 .review-editor-ai-btn {
   color: var(--accent-strong);
+}
+
+@container review-screen (max-width: 980px) {
+  .review-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .review-queue-panel {
+    display: none;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## What changed
- added a container query on the web review screen panel
- collapse the review layout to one column when the available review pane width is narrow
- hide the review queue panel in that narrow-pane state so the current card remains readable when the AI sidebar is open

## Why
- the previous breakpoint only depended on viewport width
- with the AI sidebar open, the browser viewport could still be wide while the actual review pane became too narrow
- that caused the queue to remain visible and squeeze the main review content

## Impact
- web review now responds to the real available pane width instead of only the full window width
- no backend or mobile behavior changes

## Validation
- npm run test
- npm run build
