### PR TITLE
[codex] Route AI chat by explicit workspace

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatLiveRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatLiveRemoteService.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import java.net.HttpURLConnection
+import java.net.URLEncoder
 import java.net.URL
 import java.nio.charset.StandardCharsets
 
@@ -25,10 +26,12 @@ class AiChatLiveRemoteService(
         sessionId: String,
         runId: String,
         liveStream: AiChatLiveStreamEnvelope,
+        workspaceId: String?,
         afterCursor: String?,
         resumeDiagnostics: AiChatResumeDiagnostics?,
     ): Flow<AiChatLiveEvent> = flow {
-        val authorization = if (liveStream.authorization.startsWith(prefix = "Live ")) {
+        val usesSignedLiveAuthorization = liveStream.authorization.startsWith(prefix = "Live ")
+        val authorization = if (usesSignedLiveAuthorization) {
             liveStream.authorization
         } else {
             authorizationHeader
@@ -38,6 +41,11 @@ class AiChatLiveRemoteService(
             authorization = authorization,
             sessionId = sessionId,
             runId = runId,
+            workspaceId = if (usesSignedLiveAuthorization) {
+                null
+            } else {
+                requireFallbackWorkspaceId(workspaceId = workspaceId)
+            },
             afterCursor = afterCursor,
             resumeDiagnostics = resumeDiagnostics,
             emitEvent = { event ->
@@ -87,18 +95,18 @@ class AiChatLiveRemoteService(
         authorization: String,
         sessionId: String,
         runId: String,
+        workspaceId: String?,
         afterCursor: String?,
         resumeDiagnostics: AiChatResumeDiagnostics?,
         emitEvent: suspend (AiChatLiveEvent) -> Boolean
     ) {
-        val urlString = buildString {
-            append(liveUrl.removeSuffix("/"))
-            append("?sessionId=$sessionId")
-            append("&runId=$runId")
-            if (afterCursor != null) {
-                append("&afterCursor=$afterCursor")
-            }
-        }
+        val urlString = buildLiveUrl(
+            liveUrl = liveUrl,
+            sessionId = sessionId,
+            runId = runId,
+            workspaceId = workspaceId,
+            afterCursor = afterCursor
+        )
         val connection = (URL(urlString).openConnection() as HttpURLConnection)
         connection.requestMethod = "GET"
         connection.connectTimeout = 15_000
@@ -168,5 +176,40 @@ class AiChatLiveRemoteService(
         } finally {
             connection.disconnect()
         }
+    }
+
+    private fun requireFallbackWorkspaceId(workspaceId: String?): String {
+        return requireNotNull(workspaceId?.trim()?.ifEmpty { null }) {
+            "AI live attach requires an active workspace when signed Live authorization is unavailable."
+        }
+    }
+
+    private fun buildLiveUrl(
+        liveUrl: String,
+        sessionId: String,
+        runId: String,
+        workspaceId: String?,
+        afterCursor: String?
+    ): String {
+        val queryParameters = mutableListOf(
+            "sessionId=${encodeQueryValue(value = sessionId)}",
+            "runId=${encodeQueryValue(value = runId)}"
+        )
+        workspaceId?.let { resolvedWorkspaceId ->
+            queryParameters.add("workspaceId=${encodeQueryValue(value = resolvedWorkspaceId)}")
+        }
+        afterCursor?.let { resolvedAfterCursor ->
+            queryParameters.add("afterCursor=${encodeQueryValue(value = resolvedAfterCursor)}")
+        }
+
+        return buildString {
+            append(liveUrl.removeSuffix("/"))
+            append("?")
+            append(queryParameters.joinToString(separator = "&"))
+        }
+    }
+
+    private fun encodeQueryValue(value: String): String {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8)
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteService.kt
@@ -37,6 +37,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
+import java.net.URLEncoder
 import java.net.URL
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -113,16 +114,15 @@ class AiChatRemoteService(
     suspend fun loadSnapshot(
         apiBaseUrl: String,
         authorizationHeader: String,
-        sessionId: String?
+        sessionId: String?,
+        workspaceId: String?
     ): AiChatSessionSnapshot = withContext(dispatchers.io) {
-        val path = if (sessionId.isNullOrBlank()) {
-            "/chat"
-        } else {
-            "/chat?sessionId=$sessionId"
-        }
         val connection = openConnection(
             apiBaseUrl = apiBaseUrl,
-            path = path,
+            path = buildSnapshotPath(
+                sessionId = sessionId,
+                workspaceId = workspaceId
+            ),
             method = "GET",
             authorizationHeader = authorizationHeader
         )
@@ -140,12 +140,16 @@ class AiChatRemoteService(
         authorizationHeader: String,
         sessionId: String,
         limit: Int,
+        workspaceId: String?,
         resumeDiagnostics: AiChatResumeDiagnostics?
     ): AiChatBootstrapResponse = withContext(dispatchers.io) {
-        val path = "/chat?limit=$limit&sessionId=$sessionId"
         val connection = openConnection(
             apiBaseUrl = apiBaseUrl,
-            path = path,
+            path = buildBootstrapPath(
+                sessionId = sessionId,
+                limit = limit,
+                workspaceId = workspaceId
+            ),
             method = "GET",
             authorizationHeader = authorizationHeader,
             extraHeaders = resumeDiagnosticsHeaders(resumeDiagnostics = resumeDiagnostics)
@@ -164,12 +168,17 @@ class AiChatRemoteService(
         authorizationHeader: String,
         sessionId: String,
         beforeCursor: String,
-        limit: Int
+        limit: Int,
+        workspaceId: String?
     ): AiChatOlderMessagesResponse = withContext(dispatchers.io) {
-        val path = "/chat?sessionId=$sessionId&limit=$limit&before=$beforeCursor"
         val connection = openConnection(
             apiBaseUrl = apiBaseUrl,
-            path = path,
+            path = buildOlderMessagesPath(
+                sessionId = sessionId,
+                beforeCursor = beforeCursor,
+                limit = limit,
+                workspaceId = workspaceId
+            ),
             method = "GET",
             authorizationHeader = authorizationHeader
         )
@@ -193,6 +202,7 @@ class AiChatRemoteService(
         sessionId: String,
         runId: String,
         liveStream: AiChatLiveStreamEnvelope,
+        workspaceId: String?,
         afterCursor: String?,
         resumeDiagnostics: AiChatResumeDiagnostics?
     ): Flow<AiChatLiveEvent> {
@@ -201,6 +211,7 @@ class AiChatRemoteService(
             sessionId = sessionId,
             runId = runId,
             liveStream = liveStream,
+            workspaceId = workspaceId,
             afterCursor = afterCursor,
             resumeDiagnostics = resumeDiagnostics
         )
@@ -238,7 +249,8 @@ class AiChatRemoteService(
     suspend fun stopRun(
         apiBaseUrl: String,
         authorizationHeader: String,
-        sessionId: String
+        sessionId: String,
+        workspaceId: String?
     ): AiChatStopRunResponse = withContext(dispatchers.io) {
         val connection = openConnection(
             apiBaseUrl = apiBaseUrl,
@@ -252,10 +264,11 @@ class AiChatRemoteService(
             connection.doOutput = true
             connection.outputStream.use { outputStream ->
                 outputStream.write(
-                    JSONObject()
-                        .put("sessionId", sessionId)
-                        .toString()
-                        .toByteArray(StandardCharsets.UTF_8)
+                    putOptionalWorkspaceId(
+                        payload = JSONObject()
+                            .put("sessionId", sessionId),
+                        workspaceId = workspaceId
+                    ).toString().toByteArray(StandardCharsets.UTF_8)
                 )
             }
             val responseBody = readResponseBody(connection = connection)
@@ -269,6 +282,7 @@ class AiChatRemoteService(
         apiBaseUrl: String,
         authorizationHeader: String,
         sessionId: String,
+        workspaceId: String?,
         fileName: String,
         mediaType: String,
         audioBytes: ByteArray
@@ -289,6 +303,7 @@ class AiChatRemoteService(
                     encodeMultipartAudioBody(
                         boundary = boundary,
                         sessionId = sessionId,
+                        workspaceId = workspaceId,
                         fileName = fileName,
                         mediaType = mediaType,
                         audioBytes = audioBytes
@@ -359,7 +374,10 @@ class AiChatRemoteService(
             .put("timezone", request.timezone)
 
         return putOptionalUiLocale(
-            payload = payload,
+            payload = putOptionalWorkspaceId(
+                payload = payload,
+                workspaceId = request.workspaceId
+            ),
             uiLocale = request.uiLocale
         )
     }
@@ -369,9 +387,22 @@ class AiChatRemoteService(
             .put("sessionId", request.sessionId)
 
         return putOptionalUiLocale(
-            payload = payload,
+            payload = putOptionalWorkspaceId(
+                payload = payload,
+                workspaceId = request.workspaceId
+            ),
             uiLocale = request.uiLocale
         )
+    }
+
+    private fun putOptionalWorkspaceId(
+        payload: JSONObject,
+        workspaceId: String?
+    ): JSONObject {
+        workspaceId?.takeIf { value -> value.isNotBlank() }?.let { resolvedWorkspaceId ->
+            payload.put("workspaceId", resolvedWorkspaceId)
+        }
+        return payload
     }
 
     private fun putOptionalUiLocale(
@@ -423,23 +454,31 @@ class AiChatRemoteService(
     private fun encodeMultipartAudioBody(
         boundary: String,
         sessionId: String,
+        workspaceId: String?,
         fileName: String,
         mediaType: String,
         audioBytes: ByteArray
     ): ByteArray {
         val outputStream = ByteArrayOutputStream()
-        outputStream.write("--$boundary\r\n".toByteArray(StandardCharsets.UTF_8))
-        outputStream.write(
-            "Content-Disposition: form-data; name=\"sessionId\"\r\n\r\n"
-                .toByteArray(StandardCharsets.UTF_8)
+        writeMultipartTextField(
+            outputStream = outputStream,
+            boundary = boundary,
+            fieldName = "sessionId",
+            fieldValue = sessionId
         )
-        outputStream.write(sessionId.toByteArray(StandardCharsets.UTF_8))
-        outputStream.write("\r\n".toByteArray(StandardCharsets.UTF_8))
-
-        outputStream.write("--$boundary\r\n".toByteArray(StandardCharsets.UTF_8))
-        outputStream.write(
-            "Content-Disposition: form-data; name=\"source\"\r\n\r\nandroid\r\n"
-                .toByteArray(StandardCharsets.UTF_8)
+        workspaceId?.takeIf { value -> value.isNotBlank() }?.let { resolvedWorkspaceId ->
+            writeMultipartTextField(
+                outputStream = outputStream,
+                boundary = boundary,
+                fieldName = "workspaceId",
+                fieldValue = resolvedWorkspaceId
+            )
+        }
+        writeMultipartTextField(
+            outputStream = outputStream,
+            boundary = boundary,
+            fieldName = "source",
+            fieldValue = "android"
         )
         outputStream.write("--$boundary\r\n".toByteArray(StandardCharsets.UTF_8))
         outputStream.write(
@@ -450,6 +489,79 @@ class AiChatRemoteService(
         outputStream.write(audioBytes)
         outputStream.write("\r\n--$boundary--\r\n".toByteArray(StandardCharsets.UTF_8))
         return outputStream.toByteArray()
+    }
+
+    private fun writeMultipartTextField(
+        outputStream: ByteArrayOutputStream,
+        boundary: String,
+        fieldName: String,
+        fieldValue: String
+    ) {
+        outputStream.write("--$boundary\r\n".toByteArray(StandardCharsets.UTF_8))
+        outputStream.write(
+            "Content-Disposition: form-data; name=\"$fieldName\"\r\n\r\n"
+                .toByteArray(StandardCharsets.UTF_8)
+        )
+        outputStream.write(fieldValue.toByteArray(StandardCharsets.UTF_8))
+        outputStream.write("\r\n".toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private fun buildSnapshotPath(
+        sessionId: String?,
+        workspaceId: String?
+    ): String {
+        val queryParameters = mutableListOf<String>()
+        sessionId?.takeIf { value -> value.isNotBlank() }?.let { resolvedSessionId ->
+            queryParameters.add("sessionId=${encodeQueryValue(value = resolvedSessionId)}")
+        }
+        workspaceId?.takeIf { value -> value.isNotBlank() }?.let { resolvedWorkspaceId ->
+            queryParameters.add("workspaceId=${encodeQueryValue(value = resolvedWorkspaceId)}")
+        }
+        return buildChatPath(queryParameters = queryParameters)
+    }
+
+    private fun buildBootstrapPath(
+        sessionId: String,
+        limit: Int,
+        workspaceId: String?
+    ): String {
+        val queryParameters = mutableListOf(
+            "limit=$limit",
+            "sessionId=${encodeQueryValue(value = sessionId)}"
+        )
+        workspaceId?.takeIf { value -> value.isNotBlank() }?.let { resolvedWorkspaceId ->
+            queryParameters.add("workspaceId=${encodeQueryValue(value = resolvedWorkspaceId)}")
+        }
+        return buildChatPath(queryParameters = queryParameters)
+    }
+
+    private fun buildOlderMessagesPath(
+        sessionId: String,
+        beforeCursor: String,
+        limit: Int,
+        workspaceId: String?
+    ): String {
+        val queryParameters = mutableListOf(
+            "sessionId=${encodeQueryValue(value = sessionId)}",
+            "limit=$limit",
+            "before=${encodeQueryValue(value = beforeCursor)}"
+        )
+        workspaceId?.takeIf { value -> value.isNotBlank() }?.let { resolvedWorkspaceId ->
+            queryParameters.add("workspaceId=${encodeQueryValue(value = resolvedWorkspaceId)}")
+        }
+        return buildChatPath(queryParameters = queryParameters)
+    }
+
+    private fun buildChatPath(queryParameters: List<String>): String {
+        return if (queryParameters.isEmpty()) {
+            "/chat"
+        } else {
+            "/chat?${queryParameters.joinToString(separator = "&")}"
+        }
+    }
+
+    private fun encodeQueryValue(value: String): String {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8)
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/AiChatModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/AiChatModels.kt
@@ -293,6 +293,7 @@ sealed interface AiChatWireContentPart {
 
 data class AiChatStartRunRequest(
     val sessionId: String,
+    val workspaceId: String?,
     val clientRequestId: String,
     val content: List<AiChatWireContentPart>,
     val timezone: String,
@@ -301,6 +302,7 @@ data class AiChatStartRunRequest(
 
 data class AiChatNewSessionRequest(
     val sessionId: String,
+    val workspaceId: String?,
     val uiLocale: String?,
 )
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/AiRepositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/AiRepositories.kt
@@ -111,12 +111,14 @@ class LocalAiChatRepository(
     }
 
     override suspend fun loadChatSnapshot(workspaceId: String?, sessionId: String?): AiChatSessionSnapshot? {
-        val session = authorizedSession(workspaceId = workspaceId)
+        val remoteWorkspaceId = requireRemoteWorkspaceId(workspaceId = workspaceId)
+        val session = authorizedSession(workspaceId = remoteWorkspaceId)
         return try {
             aiChatRemoteService.loadSnapshot(
                 apiBaseUrl = session.apiBaseUrl,
                 authorizationHeader = session.authorizationHeader,
-                sessionId = sessionId
+                sessionId = sessionId,
+                workspaceId = remoteWorkspaceId
             )
         } catch (error: AiChatRemoteException) {
             if (error.statusCode == 404) {
@@ -189,12 +191,14 @@ class LocalAiChatRepository(
         limit: Int,
         resumeDiagnostics: AiChatResumeDiagnostics?
     ): AiChatBootstrapResponse {
-        val session = authorizedSession(workspaceId = workspaceId)
+        val remoteWorkspaceId = requireRemoteWorkspaceId(workspaceId = workspaceId)
+        val session = authorizedSession(workspaceId = remoteWorkspaceId)
         return aiChatRemoteService.loadBootstrap(
             apiBaseUrl = session.apiBaseUrl,
             authorizationHeader = session.authorizationHeader,
             sessionId = sessionId,
             limit = limit,
+            workspaceId = remoteWorkspaceId,
             resumeDiagnostics = resumeDiagnostics
         )
     }
@@ -204,12 +208,14 @@ class LocalAiChatRepository(
         sessionId: String,
         uiLocale: String?
     ): AiChatSessionSnapshot {
-        val session = authorizedSession(workspaceId = workspaceId)
+        val remoteWorkspaceId = requireRemoteWorkspaceId(workspaceId = workspaceId)
+        val session = authorizedSession(workspaceId = remoteWorkspaceId)
         return aiChatRemoteService.createNewSession(
             apiBaseUrl = session.apiBaseUrl,
             authorizationHeader = session.authorizationHeader,
             request = AiChatNewSessionRequest(
                 sessionId = sessionId,
+                workspaceId = remoteWorkspaceId,
                 uiLocale = uiLocale
             )
         )
@@ -222,11 +228,13 @@ class LocalAiChatRepository(
         mediaType: String,
         audioBytes: ByteArray
     ): AiChatTranscriptionResult {
-        val session = authorizedSession(workspaceId = workspaceId)
+        val remoteWorkspaceId = requireRemoteWorkspaceId(workspaceId = workspaceId)
+        val session = authorizedSession(workspaceId = remoteWorkspaceId)
         return aiChatRemoteService.transcribeAudio(
             apiBaseUrl = session.apiBaseUrl,
             authorizationHeader = session.authorizationHeader,
             sessionId = sessionId,
+            workspaceId = remoteWorkspaceId,
             fileName = fileName,
             mediaType = mediaType,
             audioBytes = audioBytes
@@ -255,10 +263,12 @@ class LocalAiChatRepository(
         content: List<AiChatContentPart>,
         uiLocale: String?
     ): AiChatStartRunResponse {
-        val session = authorizedSession(workspaceId = workspaceId)
+        val remoteWorkspaceId = requireRemoteWorkspaceId(workspaceId = workspaceId)
+        val session = authorizedSession(workspaceId = remoteWorkspaceId)
         val resolvedSessionId = requireExplicitAiChatSessionIdForRun(state = state)
         val request = AiChatStartRunRequest(
             sessionId = resolvedSessionId,
+            workspaceId = remoteWorkspaceId,
             clientRequestId = java.util.UUID.randomUUID().toString().lowercase(),
             content = buildAiChatRequestContent(content = content),
             timezone = TimeZone.getDefault().id,
@@ -320,6 +330,7 @@ class LocalAiChatRepository(
                     sessionId = sessionId,
                     runId = runId,
                     liveStream = liveStream,
+                    workspaceId = workspaceId,
                     afterCursor = afterCursor,
                     resumeDiagnostics = resumeDiagnostics
                 )
@@ -328,11 +339,13 @@ class LocalAiChatRepository(
     }
 
     override suspend fun stopRun(workspaceId: String?, sessionId: String): AiChatStopRunResponse {
-        val session = authorizedSession(workspaceId = workspaceId)
+        val remoteWorkspaceId = requireRemoteWorkspaceId(workspaceId = workspaceId)
+        val session = authorizedSession(workspaceId = remoteWorkspaceId)
         return aiChatRemoteService.stopRun(
             apiBaseUrl = session.apiBaseUrl,
             authorizationHeader = session.authorizationHeader,
-            sessionId = sessionId
+            sessionId = sessionId,
+            workspaceId = remoteWorkspaceId
         )
     }
 
@@ -379,6 +392,12 @@ class LocalAiChatRepository(
             workspaceId = workspaceId,
             cloudSettings = preferencesStore.currentCloudSettings()
         )
+    }
+
+    private fun requireRemoteWorkspaceId(workspaceId: String?): String {
+        return requireNotNull(workspaceId?.trim()?.ifEmpty { null }) {
+            "AI remote request requires an active workspace. Reopen AI from a workspace and try again."
+        }
     }
 
     private suspend fun refreshedCredentials(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteWireTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteWireTest.kt
@@ -12,6 +12,8 @@ import com.flashcardsopensourceapp.data.local.model.AiChatWireContentPart
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.sun.net.httpserver.HttpServer
 import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.toList
@@ -26,6 +28,7 @@ import org.junit.Test
 class AiChatRemoteWireTest {
     private val appVersion: String = "1.2.1"
     private val testUiLocale: String = "es-ES"
+    private val testWorkspaceId: String = "workspace-1"
 
     private fun makeDispatchers(): AiCoroutineDispatchers {
         return AiCoroutineDispatchers(io = Dispatchers.IO)
@@ -42,9 +45,28 @@ class AiChatRemoteWireTest {
         )
     }
 
+    private fun parseQueryParameters(rawQuery: String?): Map<String, String> {
+        if (rawQuery.isNullOrBlank()) {
+            return emptyMap()
+        }
+
+        return rawQuery.split("&")
+            .filter(String::isNotBlank)
+            .associate { entry ->
+                val separatorIndex = entry.indexOf('=')
+                if (separatorIndex < 0) {
+                    URLDecoder.decode(entry, StandardCharsets.UTF_8) to ""
+                } else {
+                    URLDecoder.decode(entry.substring(startIndex = 0, endIndex = separatorIndex), StandardCharsets.UTF_8) to
+                        URLDecoder.decode(entry.substring(startIndex = separatorIndex + 1), StandardCharsets.UTF_8)
+                }
+            }
+    }
+
     @Test
     fun loadBootstrapIncludesResumeDiagnosticsHeaders() = runBlocking {
         val headersRef = AtomicReference<Map<String, String>>(emptyMap())
+        val queryParametersRef = AtomicReference<Map<String, String>>(emptyMap())
         val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
         server.createContext("/chat") { exchange ->
             headersRef.set(
@@ -52,6 +74,7 @@ class AiChatRemoteWireTest {
                     key to value.joinToString(separator = ",")
                 }
             )
+            queryParametersRef.set(parseQueryParameters(rawQuery = exchange.requestURI.rawQuery))
             val body = """
                 {
                   "sessionId": "session-1",
@@ -102,6 +125,7 @@ class AiChatRemoteWireTest {
                 authorizationHeader = "Bearer token-1",
                 sessionId = "session-1",
                 limit = 20,
+                workspaceId = testWorkspaceId,
                 resumeDiagnostics = AiChatResumeDiagnostics(
                     resumeAttemptId = 41L,
                     clientPlatform = "android",
@@ -113,6 +137,9 @@ class AiChatRemoteWireTest {
             assertEquals("session-1", response.conversationScopeId)
             assertEquals("run-1", response.activeRun?.runId)
             assertEquals("5", response.activeRun?.live?.cursor)
+            assertEquals("session-1", queryParametersRef.get()["sessionId"])
+            assertEquals("20", queryParametersRef.get()["limit"])
+            assertEquals(testWorkspaceId, queryParametersRef.get()["workspaceId"])
             assertEquals("41", headersRef.get()["X-chat-resume-attempt-id"])
             assertEquals("android", headersRef.get()["X-client-platform"])
             assertEquals(appVersion, headersRef.get()["X-client-version"])
@@ -166,6 +193,7 @@ class AiChatRemoteWireTest {
                 authorizationHeader = "Bearer token-1",
                 request = AiChatStartRunRequest(
                     sessionId = "session-1",
+                    workspaceId = testWorkspaceId,
                     clientRequestId = "request-1",
                     content = listOf(AiChatWireContentPart.Text(text = "Hello")),
                     timezone = "Europe/Madrid",
@@ -175,6 +203,7 @@ class AiChatRemoteWireTest {
 
             val requestBody = JSONObject(requestBodyRef.get())
             assertEquals("session-1", requestBody.getString("sessionId"))
+            assertEquals(testWorkspaceId, requestBody.getString("workspaceId"))
             assertEquals(testUiLocale, requestBody.getString("uiLocale"))
         } finally {
             server.stop(0)
@@ -225,12 +254,14 @@ class AiChatRemoteWireTest {
                 authorizationHeader = "Bearer token-1",
                 request = AiChatNewSessionRequest(
                     sessionId = "session-1",
+                    workspaceId = testWorkspaceId,
                     uiLocale = testUiLocale
                 )
             )
 
             val requestBody = JSONObject(requestBodyRef.get())
             assertEquals("session-1", requestBody.getString("sessionId"))
+            assertEquals(testWorkspaceId, requestBody.getString("workspaceId"))
             assertEquals(testUiLocale, requestBody.getString("uiLocale"))
         } finally {
             server.stop(0)
@@ -281,13 +312,196 @@ class AiChatRemoteWireTest {
                 authorizationHeader = "Bearer token-1",
                 request = AiChatNewSessionRequest(
                     sessionId = "session-1",
+                    workspaceId = testWorkspaceId,
                     uiLocale = null
                 )
             )
 
             val requestBody = JSONObject(requestBodyRef.get())
             assertEquals("session-1", requestBody.getString("sessionId"))
+            assertEquals(testWorkspaceId, requestBody.getString("workspaceId"))
             assertFalse(requestBody.has("uiLocale"))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun loadSnapshotIncludesWorkspaceIdQueryParameter() = runBlocking {
+        val queryParametersRef = AtomicReference<Map<String, String>>(emptyMap())
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/chat") { exchange ->
+            queryParametersRef.set(parseQueryParameters(rawQuery = exchange.requestURI.rawQuery))
+            val body = """
+                {
+                  "sessionId": "session-1",
+                  "conversationScopeId": "session-1",
+                  "conversation": {
+                    "updatedAt": 100,
+                    "mainContentInvalidationVersion": 200,
+                    "messages": [],
+                    "hasOlder": false,
+                    "oldestCursor": null
+                  },
+                  "composerSuggestions": [],
+                  "chatConfig": {
+                    "provider": { "id": "openai", "label": "OpenAI" },
+                    "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
+                    "reasoning": { "effort": "medium", "label": "Medium" },
+                    "features": {
+                      "modelPickerEnabled": false,
+                      "dictationEnabled": true,
+                      "attachmentsEnabled": true
+                    },
+                    "liveUrl": null
+                  },
+                  "activeRun": null
+                }
+            """.trimIndent().toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(body) }
+        }
+        server.start()
+
+        try {
+            val service = makeRemoteService()
+            service.loadSnapshot(
+                apiBaseUrl = "http://127.0.0.1:${server.address.port}",
+                authorizationHeader = "Bearer token-1",
+                sessionId = "session-1",
+                workspaceId = testWorkspaceId
+            )
+
+            assertEquals("session-1", queryParametersRef.get()["sessionId"])
+            assertEquals(testWorkspaceId, queryParametersRef.get()["workspaceId"])
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun loadOlderMessagesIncludesWorkspaceIdQueryParameter() = runBlocking {
+        val queryParametersRef = AtomicReference<Map<String, String>>(emptyMap())
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/chat") { exchange ->
+            queryParametersRef.set(parseQueryParameters(rawQuery = exchange.requestURI.rawQuery))
+            val body = """
+                {
+                  "sessionId": "session-1",
+                  "conversationScopeId": "session-1",
+                  "conversation": {
+                    "updatedAt": 100,
+                    "mainContentInvalidationVersion": 200,
+                    "messages": [],
+                    "hasOlder": false,
+                    "oldestCursor": null
+                  },
+                  "composerSuggestions": [],
+                  "chatConfig": {
+                    "provider": { "id": "openai", "label": "OpenAI" },
+                    "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
+                    "reasoning": { "effort": "medium", "label": "Medium" },
+                    "features": {
+                      "modelPickerEnabled": false,
+                      "dictationEnabled": true,
+                      "attachmentsEnabled": true
+                    },
+                    "liveUrl": null
+                  },
+                  "activeRun": null
+                }
+            """.trimIndent().toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(body) }
+        }
+        server.start()
+
+        try {
+            val service = makeRemoteService()
+            service.loadOlderMessages(
+                apiBaseUrl = "http://127.0.0.1:${server.address.port}",
+                authorizationHeader = "Bearer token-1",
+                sessionId = "session-1",
+                beforeCursor = "cursor-1",
+                limit = 20,
+                workspaceId = testWorkspaceId
+            )
+
+            assertEquals("session-1", queryParametersRef.get()["sessionId"])
+            assertEquals("cursor-1", queryParametersRef.get()["before"])
+            assertEquals("20", queryParametersRef.get()["limit"])
+            assertEquals(testWorkspaceId, queryParametersRef.get()["workspaceId"])
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun stopRunIncludesWorkspaceIdWhenPresent() = runBlocking {
+        val requestBodyRef = AtomicReference("")
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/chat/stop") { exchange ->
+            requestBodyRef.set(exchange.requestBody.bufferedReader().use { reader -> reader.readText() })
+            val body = """
+                {
+                  "sessionId": "session-1",
+                  "stopped": true,
+                  "stillRunning": false
+                }
+            """.trimIndent().toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(body) }
+        }
+        server.start()
+
+        try {
+            val service = makeRemoteService()
+            service.stopRun(
+                apiBaseUrl = "http://127.0.0.1:${server.address.port}",
+                authorizationHeader = "Bearer token-1",
+                sessionId = "session-1",
+                workspaceId = testWorkspaceId
+            )
+
+            val requestBody = JSONObject(requestBodyRef.get())
+            assertEquals("session-1", requestBody.getString("sessionId"))
+            assertEquals(testWorkspaceId, requestBody.getString("workspaceId"))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun transcribeAudioIncludesWorkspaceIdMultipartField() = runBlocking {
+        val requestBodyRef = AtomicReference("")
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/chat/transcriptions") { exchange ->
+            requestBodyRef.set(String(exchange.requestBody.readBytes(), StandardCharsets.UTF_8))
+            val body = """
+                {
+                  "text": "Hello",
+                  "sessionId": "session-1"
+                }
+            """.trimIndent().toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(body) }
+        }
+        server.start()
+
+        try {
+            val service = makeRemoteService()
+            service.transcribeAudio(
+                apiBaseUrl = "http://127.0.0.1:${server.address.port}",
+                authorizationHeader = "Bearer token-1",
+                sessionId = "session-1",
+                workspaceId = testWorkspaceId,
+                fileName = "recording.wav",
+                mediaType = "audio/wav",
+                audioBytes = "sample-audio".toByteArray(StandardCharsets.UTF_8)
+            )
+
+            assertTrue(requestBodyRef.get().contains("name=\"sessionId\"\r\n\r\nsession-1"))
+            assertTrue(requestBodyRef.get().contains("name=\"workspaceId\"\r\n\r\n$testWorkspaceId"))
         } finally {
             server.stop(0)
         }
@@ -561,7 +775,7 @@ class AiChatRemoteWireTest {
     @Test
     fun liveAttachIncludesResumeDiagnosticsHeadersAndRunIdQueryParam() = runBlocking {
         val headersRef = AtomicReference<Map<String, String>>(emptyMap())
-        val queryRef = AtomicReference("")
+        val queryParametersRef = AtomicReference<Map<String, String>>(emptyMap())
         val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
         server.createContext("/live") { exchange ->
             headersRef.set(
@@ -569,7 +783,7 @@ class AiChatRemoteWireTest {
                     key to value.joinToString(separator = ",")
                 }
             )
-            queryRef.set(exchange.requestURI.rawQuery ?: "")
+            queryParametersRef.set(parseQueryParameters(rawQuery = exchange.requestURI.rawQuery))
             val body = """
                 event: run_terminal
                 data: {"type":"run_terminal","sessionId":"session-1","conversationScopeId":"session-1","runId":"run-1","cursor":"12","sequenceNumber":3,"streamEpoch":"run-1","outcome":"completed"}
@@ -592,6 +806,7 @@ class AiChatRemoteWireTest {
                     authorization = "Live token-2",
                     expiresAt = 123L
                 ),
+                workspaceId = testWorkspaceId,
                 afterCursor = "5",
                 resumeDiagnostics = AiChatResumeDiagnostics(
                     resumeAttemptId = 42L,
@@ -604,9 +819,61 @@ class AiChatRemoteWireTest {
             assertEquals("android", headersRef.get()["X-client-platform"])
             assertEquals(appVersion, headersRef.get()["X-client-version"])
             assertEquals("Live token-2", headersRef.get()["Authorization"])
-            assertTrue(queryRef.get().contains("sessionId=session-1"))
-            assertTrue(queryRef.get().contains("runId=run-1"))
-            assertTrue(queryRef.get().contains("afterCursor=5"))
+            assertEquals("session-1", queryParametersRef.get()["sessionId"])
+            assertEquals("run-1", queryParametersRef.get()["runId"])
+            assertEquals("5", queryParametersRef.get()["afterCursor"])
+            assertFalse(queryParametersRef.get().containsKey("workspaceId"))
+            assertEquals(1, events.size)
+            require(events.single() is AiChatLiveEvent.RunTerminal)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun liveAttachFallbackAuthorizationIncludesWorkspaceIdQueryParam() = runBlocking {
+        val headersRef = AtomicReference<Map<String, String>>(emptyMap())
+        val queryParametersRef = AtomicReference<Map<String, String>>(emptyMap())
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/live") { exchange ->
+            headersRef.set(
+                exchange.requestHeaders.entries.associate { (key, value) ->
+                    key to value.joinToString(separator = ",")
+                }
+            )
+            queryParametersRef.set(parseQueryParameters(rawQuery = exchange.requestURI.rawQuery))
+            val body = """
+                event: run_terminal
+                data: {"type":"run_terminal","sessionId":"session-1","conversationScopeId":"session-1","runId":"run-1","cursor":"12","sequenceNumber":3,"streamEpoch":"run-1","outcome":"completed"}
+
+            """.trimIndent().toByteArray()
+            exchange.responseHeaders.add("Content-Type", "text/event-stream")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(body) }
+        }
+        server.start()
+
+        try {
+            val service = makeLiveRemoteService()
+            val events = service.attachLiveRun(
+                authorizationHeader = "Bearer token-1",
+                sessionId = "session-1",
+                runId = "run-1",
+                liveStream = AiChatLiveStreamEnvelope(
+                    url = "http://127.0.0.1:${server.address.port}/live",
+                    authorization = "Bearer ignored-live-stream-token",
+                    expiresAt = 123L
+                ),
+                workspaceId = testWorkspaceId,
+                afterCursor = "5",
+                resumeDiagnostics = null
+            ).toList()
+
+            assertEquals("Bearer token-1", headersRef.get()["Authorization"])
+            assertEquals("session-1", queryParametersRef.get()["sessionId"])
+            assertEquals("run-1", queryParametersRef.get()["runId"])
+            assertEquals("5", queryParametersRef.get()["afterCursor"])
+            assertEquals(testWorkspaceId, queryParametersRef.get()["workspaceId"])
             assertEquals(1, events.size)
             require(events.single() is AiChatLiveEvent.RunTerminal)
         } finally {
@@ -643,6 +910,7 @@ class AiChatRemoteWireTest {
                     authorization = "Live token-2",
                     expiresAt = 123L
                 ),
+                workspaceId = testWorkspaceId,
                 afterCursor = "5",
                 resumeDiagnostics = null
             ).toList()

--- a/apps/backend/src/chat/liveRequest.ts
+++ b/apps/backend/src/chat/liveRequest.ts
@@ -1,7 +1,10 @@
 import { authenticateRequest, type AuthResult } from "../auth";
 import { HttpError } from "../errors";
 import { ensureUserProfile, type UserProfile } from "../ensureUser";
-import { requireAccessibleSelectedWorkspaceId } from "../server/requestContext";
+import {
+  parseOptionalWorkspaceIdParam,
+  resolveAccessibleChatWorkspaceId,
+} from "../server/requestContext";
 import { assertChatLiveRunAccess } from "./liveAccess";
 import {
   CHAT_LIVE_AFTER_CURSOR_INVALID_CODE,
@@ -27,7 +30,7 @@ type HandleLiveRequestDependencies = Readonly<{
   authenticateRequestFn: typeof authenticateRequest;
   ensureUserProfileFn: typeof ensureUserProfile;
   verifyChatLiveAuthorizationHeaderFn: typeof verifyChatLiveAuthorizationHeader;
-  requireAccessibleSelectedWorkspaceIdFn: typeof requireAccessibleSelectedWorkspaceId;
+  resolveAccessibleChatWorkspaceIdFn: typeof resolveAccessibleChatWorkspaceId;
   assertChatLiveRunAccessFn: typeof assertChatLiveRunAccess;
 }>;
 
@@ -35,7 +38,7 @@ const defaultHandleLiveRequestDependencies: HandleLiveRequestDependencies = {
   authenticateRequestFn: authenticateRequest,
   ensureUserProfileFn: ensureUserProfile,
   verifyChatLiveAuthorizationHeaderFn: verifyChatLiveAuthorizationHeader,
-  requireAccessibleSelectedWorkspaceIdFn: requireAccessibleSelectedWorkspaceId,
+  resolveAccessibleChatWorkspaceIdFn: resolveAccessibleChatWorkspaceId,
   assertChatLiveRunAccessFn: assertChatLiveRunAccess,
 };
 
@@ -120,15 +123,19 @@ export async function handleLiveRequest(
   const userProfile: UserProfile | null = authResult.transport === "api_key"
     ? null
     : await liveRequestDependencies.ensureUserProfileFn(authResult.userId, null);
+  const explicitWorkspaceId = parseOptionalWorkspaceIdParam(url.searchParams.get("workspaceId") ?? undefined);
 
   let workspaceId: string;
   try {
-    workspaceId = await liveRequestDependencies.requireAccessibleSelectedWorkspaceIdFn({
-      userId: authResult.userId,
-      selectedWorkspaceId: authResult.transport === "api_key"
-        ? authResult.selectedWorkspaceId
-        : userProfile?.selectedWorkspaceId ?? null,
-    });
+    workspaceId = await liveRequestDependencies.resolveAccessibleChatWorkspaceIdFn(
+      {
+        userId: authResult.userId,
+        selectedWorkspaceId: authResult.transport === "api_key"
+          ? authResult.selectedWorkspaceId
+          : userProfile?.selectedWorkspaceId ?? null,
+      },
+      explicitWorkspaceId,
+    );
   } catch (error) {
     if (
       error instanceof HttpError

--- a/apps/backend/src/chat/tests/chat-live-errors.test.ts
+++ b/apps/backend/src/chat/tests/chat-live-errors.test.ts
@@ -7,6 +7,8 @@ import {
 } from "../liveErrors";
 import { handleLiveRequest } from "../liveRequest";
 
+const EXPLICIT_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
+
 test("handleLiveRequest rejects a live attach request without runId using a stable error code", async () => {
   await assert.rejects(
     async () => handleLiveRequest(
@@ -43,7 +45,7 @@ test("handleLiveRequest rejects a signed live token when the run is no longer ac
           sessionId: "session-1",
           runId: "run-1",
         }),
-        requireAccessibleSelectedWorkspaceIdFn: async () => "workspace-1",
+        resolveAccessibleChatWorkspaceIdFn: async () => "workspace-1",
         assertChatLiveRunAccessFn: async () => {
           throw new HttpError(404, "Chat live stream not found.", "CHAT_LIVE_NOT_FOUND");
         },
@@ -57,6 +59,65 @@ test("handleLiveRequest rejects a signed live token when the run is no longer ac
       return true;
     },
   );
+});
+
+test("handleLiveRequest prefers an explicit workspaceId for non-Live auth fallback", async () => {
+  let assertedWorkspaceId: string | null = null;
+
+  const result = await handleLiveRequest(
+    new URL(`https://chat-live.example.com/?sessionId=session-1&runId=run-1&workspaceId=${EXPLICIT_WORKSPACE_ID}`),
+    "Bearer test-token",
+    {
+      "X-Chat-Resume-Attempt-Id": "resume-1",
+      "X-Client-Platform": "web",
+      "X-Client-Version": "web-test",
+    },
+    {
+      authenticateRequestFn: async () => ({
+        userId: "user-1",
+        email: null,
+        cognitoUsername: null,
+        subjectUserId: "user-1",
+        transport: "bearer",
+        connectionId: null,
+        selectedWorkspaceId: null,
+      }),
+      ensureUserProfileFn: async () => ({
+        userId: "user-1",
+        selectedWorkspaceId: "workspace-legacy",
+        email: null,
+        locale: "en",
+        createdAt: "2026-03-30T00:00:00.000Z",
+      }),
+      verifyChatLiveAuthorizationHeaderFn: async () => {
+        throw new Error("verifyChatLiveAuthorizationHeaderFn should not run for Bearer auth");
+      },
+      resolveAccessibleChatWorkspaceIdFn: async (requestContext, explicitWorkspaceId) => {
+        assert.equal(requestContext.selectedWorkspaceId, "workspace-legacy");
+        assert.equal(explicitWorkspaceId, EXPLICIT_WORKSPACE_ID);
+        if (explicitWorkspaceId === undefined) {
+          throw new Error("explicitWorkspaceId should be defined");
+        }
+
+        return explicitWorkspaceId;
+      },
+      assertChatLiveRunAccessFn: async (_userId, workspaceId) => {
+        assertedWorkspaceId = workspaceId;
+      },
+    },
+  );
+
+  assert.equal(assertedWorkspaceId, EXPLICIT_WORKSPACE_ID);
+  assert.deepEqual(result, {
+    sessionId: "session-1",
+    runId: "run-1",
+    afterCursor: undefined,
+    userId: "user-1",
+    workspaceId: EXPLICIT_WORKSPACE_ID,
+    resumeAttemptId: "resume-1",
+    clientPlatform: "web",
+    clientVersion: "web-test",
+  });
 });
 
 test("createChatLiveErrorResponse returns a request id and stable code for HttpError failures", () => {

--- a/apps/backend/src/chat/tests/chat-routes.test.ts
+++ b/apps/backend/src/chat/tests/chat-routes.test.ts
@@ -13,6 +13,8 @@ import type { RequestContext } from "../../server/requestContext";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
 const SESSION_TWO = "22222222-2222-4222-8222-222222222222";
+const EXPLICIT_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
+const LEGACY_WORKSPACE_ID = "workspace-legacy";
 
 function createRequestContext(): RequestContext {
   return {
@@ -24,6 +26,13 @@ function createRequestContext(): RequestContext {
     userSettingsCreatedAt: "2026-03-30T00:00:00.000Z",
     transport: "bearer",
     connectionId: null,
+  };
+}
+
+function createRequestContextWithSelectedWorkspace(selectedWorkspaceId: string | null): RequestContext {
+  return {
+    ...createRequestContext(),
+    selectedWorkspaceId,
   };
 }
 
@@ -620,6 +629,48 @@ test("DELETE /chat is no longer routed", async () => {
   assert.equal(response.status, 404);
 });
 
+test("GET /chat prefers an explicit workspaceId query param over the legacy selected-workspace fallback", async () => {
+  const requestedWorkspaceIds: string[] = [];
+  const app = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContextWithSelectedWorkspace(LEGACY_WORKSPACE_ID),
+    }),
+    getRecoveredChatSessionSnapshotFn: async (_userId, workspaceId) => {
+      requestedWorkspaceIds.push(workspaceId);
+      return createSnapshot([]);
+    },
+  });
+
+  const response = await app.request(
+    `http://localhost/chat?sessionId=${SESSION_ONE}&workspaceId=${EXPLICIT_WORKSPACE_ID}`,
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(requestedWorkspaceIds, [EXPLICIT_WORKSPACE_ID]);
+});
+
+test("GET /chat preserves the legacy selected-workspace fallback when workspaceId is omitted", async () => {
+  let requestedWorkspaceId: string | null = null;
+  const app = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContextWithSelectedWorkspace(LEGACY_WORKSPACE_ID),
+    }),
+    getRecoveredChatSessionSnapshotFn: async (_userId, workspaceId) => {
+      requestedWorkspaceId = workspaceId;
+      return createSnapshot([]);
+    },
+  });
+
+  const response = await app.request(`http://localhost/chat?sessionId=${SESSION_ONE}`);
+
+  assert.equal(response.status, 200);
+  assert.equal(requestedWorkspaceId, LEGACY_WORKSPACE_ID);
+});
+
 test("GET /chat returns assistant item ids in snapshot history and strips attachment payloads", async () => {
   const app = createChatRoutes({
     allowedOrigins: [],
@@ -742,7 +793,7 @@ test("GET /chat stops before store access when the selected workspace is no long
       requestAuthInputs: {} as never,
       requestContext: createRequestContext(),
     }),
-    requireAccessibleSelectedWorkspaceIdFn: async () => {
+    resolveAccessibleChatWorkspaceIdFn: async () => {
       throw new HttpError(404, "Workspace not found", "WORKSPACE_NOT_FOUND");
     },
     getRecoveredChatSessionSnapshotFn: async () => {
@@ -1038,6 +1089,67 @@ test("POST /chat can return an active run before the current turn appears in mes
   });
 });
 
+test("POST /chat rejects an inaccessible explicit workspaceId before preparing a run", async () => {
+  let prepareChatRunRequested = false;
+  const routes = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContextWithSelectedWorkspace(LEGACY_WORKSPACE_ID),
+    }),
+    resolveAccessibleChatWorkspaceIdFn: async (_requestContext, explicitWorkspaceId) => {
+      assert.equal(explicitWorkspaceId, EXPLICIT_WORKSPACE_ID);
+      throw new HttpError(404, "Workspace not found", "WORKSPACE_NOT_FOUND");
+    },
+    prepareChatRunFn: async () => {
+      prepareChatRunRequested = true;
+      throw new Error("prepareChatRunFn should not run");
+    },
+  });
+  const app = new Hono();
+  app.onError((error, context) => {
+    const httpError = toHttpErrorLike(error);
+    if (httpError !== null) {
+      context.status(httpError.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: httpError.message,
+        requestId: null,
+        code: httpError.code,
+      });
+    }
+
+    context.status(500);
+    return context.json({
+      error: "Request failed. Try again.",
+      requestId: null,
+      code: "INTERNAL_ERROR",
+    });
+  });
+  app.route("/", routes);
+
+  const response = await app.request("http://localhost/chat", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sessionId: SESSION_ONE,
+      clientRequestId: "client-request-explicit-workspace",
+      content: [{ type: "text", text: "hello" }],
+      timezone: "Europe/Madrid",
+      workspaceId: EXPLICIT_WORKSPACE_ID,
+    }),
+  });
+
+  assert.equal(prepareChatRunRequested, false);
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    error: "Workspace not found",
+    requestId: null,
+    code: "WORKSPACE_NOT_FOUND",
+  });
+});
+
 test("POST /chat without uiLocale preserves the legacy request contract", async () => {
   let preparedUiLocale: string | null = "unexpected";
   const app = createChatRoutes({
@@ -1215,5 +1327,83 @@ test("POST /chat/stop returns not found for an unknown explicit session id", asy
     error: `Chat session not found: ${SESSION_TWO}`,
     requestId: null,
     code: null,
+  });
+});
+
+test("POST /chat/new uses an explicit workspaceId from JSON before the legacy selected-workspace fallback", async () => {
+  const requestedWorkspaceIds: string[] = [];
+  const app = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContextWithSelectedWorkspace(LEGACY_WORKSPACE_ID),
+    }),
+    getChatSessionIdFn: async (_userId, workspaceId) => {
+      requestedWorkspaceIds.push(workspaceId);
+      return SESSION_ONE;
+    },
+    getRecoveredChatSessionSnapshotFn: async () => ({
+      ...createSnapshot([]),
+      composerSuggestions: buildInitialChatComposerSuggestions(undefined),
+    }),
+  });
+
+  const response = await app.request("http://localhost/chat/new", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sessionId: SESSION_ONE,
+      workspaceId: EXPLICIT_WORKSPACE_ID,
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(requestedWorkspaceIds, [EXPLICIT_WORKSPACE_ID]);
+});
+
+test("POST /chat/stop uses an explicit workspaceId from JSON before the legacy selected-workspace fallback", async () => {
+  const requestedWorkspaceIds: string[] = [];
+  const app = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContextWithSelectedWorkspace(LEGACY_WORKSPACE_ID),
+    }),
+    getChatSessionIdFn: async (_userId, workspaceId) => {
+      requestedWorkspaceIds.push(workspaceId);
+      return SESSION_ONE;
+    },
+    requestChatRunCancellationFn: async (_userId, workspaceId, sessionId) => {
+      requestedWorkspaceIds.push(workspaceId);
+      return {
+        sessionId,
+        runId: "run-stop-1",
+        stopped: true,
+        stillRunning: false,
+      };
+    },
+  });
+
+  const response = await app.request("http://localhost/chat/stop", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sessionId: SESSION_ONE,
+      workspaceId: EXPLICIT_WORKSPACE_ID,
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(requestedWorkspaceIds, [EXPLICIT_WORKSPACE_ID, EXPLICIT_WORKSPACE_ID]);
+  assert.deepEqual(await response.json(), {
+    sessionId: SESSION_ONE,
+    conversationScopeId: SESSION_ONE,
+    runId: "run-stop-1",
+    stopped: true,
+    stillRunning: false,
   });
 });

--- a/apps/backend/src/chat/tests/chat-transcriptions-routes.test.ts
+++ b/apps/backend/src/chat/tests/chat-transcriptions-routes.test.ts
@@ -8,6 +8,8 @@ import { createChatTranscriptionsRoutes } from "../../routes/chatTranscriptions"
 import type { RequestContext } from "../../server/requestContext";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
+const EXPLICIT_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
+const LEGACY_WORKSPACE_ID = "workspace-legacy";
 
 function createRequestContext(): RequestContext {
   return {
@@ -19,6 +21,13 @@ function createRequestContext(): RequestContext {
     userSettingsCreatedAt: "2026-03-30T00:00:00.000Z",
     transport: "bearer",
     connectionId: null,
+  };
+}
+
+function createRequestContextWithSelectedWorkspace(selectedWorkspaceId: string | null): RequestContext {
+  return {
+    ...createRequestContext(),
+    selectedWorkspaceId,
   };
 }
 
@@ -40,6 +49,49 @@ function toHttpErrorLike(error: unknown): { statusCode: number; message: string;
 
   return { statusCode, message, code };
 }
+
+test("POST /chat/transcriptions prefers an explicit workspaceId multipart field over the legacy selected-workspace fallback", async () => {
+  const requestedWorkspaceIds: string[] = [];
+  const app = createChatTranscriptionsRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContextWithSelectedWorkspace(LEGACY_WORKSPACE_ID),
+    }),
+    getRecoveredChatSessionSnapshotFn: async (_userId, workspaceId, sessionId) => {
+      requestedWorkspaceIds.push(workspaceId);
+      return {
+        sessionId: sessionId ?? SESSION_ONE,
+        runState: "idle",
+        activeRunId: null,
+        updatedAt: 1,
+        activeRunHeartbeatAt: null,
+        composerSuggestions: [],
+        mainContentInvalidationVersion: 0,
+        messages: [],
+      };
+    },
+    transcribeAudioFn: async () => "hello",
+  });
+
+  const formData = new FormData();
+  formData.set("file", new File(["audio"], "note.m4a", { type: "audio/m4a" }));
+  formData.set("source", "web");
+  formData.set("sessionId", SESSION_ONE);
+  formData.set("workspaceId", EXPLICIT_WORKSPACE_ID);
+
+  const response = await app.request("http://localhost/chat/transcriptions", {
+    method: "POST",
+    body: formData,
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(requestedWorkspaceIds, [EXPLICIT_WORKSPACE_ID]);
+  assert.deepEqual(await response.json(), {
+    text: "hello",
+    sessionId: SESSION_ONE,
+  });
+});
 
 test("POST /chat/transcriptions resolves the explicit sessionId exactly once", async () => {
   const requestedSessionIds: Array<string | undefined> = [];
@@ -143,7 +195,7 @@ test("POST /chat/transcriptions stops before session recovery when the selected 
       requestAuthInputs: {} as never,
       requestContext: createRequestContext(),
     }),
-    requireAccessibleSelectedWorkspaceIdForAiDictationFn: async () => {
+    resolveAccessibleAiDictationWorkspaceIdFn: async () => {
       throw new HttpError(404, "Workspace not found", "WORKSPACE_NOT_FOUND");
     },
     getRecoveredChatSessionSnapshotFn: async () => {

--- a/apps/backend/src/chat/transcriptions.ts
+++ b/apps/backend/src/chat/transcriptions.ts
@@ -5,6 +5,7 @@
 import { Buffer } from "node:buffer";
 import { toFile } from "openai";
 import { HttpError } from "../errors";
+import { expectUuidString } from "../server/requestParsing";
 import { getObservedOpenAIClient } from "./openai/client";
 import {
   classifyChatTranscriptionFailure,
@@ -31,6 +32,7 @@ export type ChatTranscriptionUpload = Readonly<{
   file: File;
   source: ChatTranscriptionSource;
   sessionId?: string;
+  workspaceId?: string;
 }>;
 
 export type ChatTranscriptionRequestContext = Readonly<{
@@ -142,11 +144,16 @@ export async function parseChatTranscriptionUpload(request: Request): Promise<Ch
   const sessionId = typeof sessionValue === "string" && sessionValue.trim() !== ""
     ? sessionValue.trim()
     : undefined;
+  const workspaceValue = formData.get("workspaceId");
+  const workspaceId = workspaceValue === null
+    ? undefined
+    : expectUuidString(workspaceValue, "workspaceId");
 
   return {
     file: fileValue,
     source: sourceValue,
     sessionId,
+    workspaceId,
   };
 }
 

--- a/apps/backend/src/progress.ts
+++ b/apps/backend/src/progress.ts
@@ -414,6 +414,8 @@ async function buildUserProgressSummaryInExecutor(
   const validatedInput = validateProgressSummaryInput(request);
   const reviewDates = new Set<string>();
   await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
+  // Human progress stays intentionally user-wide across every workspace the
+  // user can still access; AI workspace routing does not change that contract.
   const workspaceIds = await listUserWorkspaceIdsInExecutor(executor, request.userId);
   let lastReviewedOn: string | null = null;
 

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -46,8 +46,10 @@ import {
 } from "../chat/liveAuth";
 import {
   loadRequestContextFromRequest,
-  requireAccessibleSelectedWorkspaceId,
+  parseOptionalWorkspaceIdParam,
+  resolveAccessibleChatWorkspaceId,
   type RequestContext,
+  type WorkspaceRequestContext,
 } from "../server/requestContext";
 import {
   expectNonEmptyString,
@@ -111,6 +113,10 @@ export type ChatRequestBody = Readonly<{
   clientRequestId: string;
   content: ReadonlyArray<ChatContentPart>;
   timezone: string;
+  // Optional explicit routing during the workspaceId client migration. Older
+  // released clients still rely on the server-side selected-workspace
+  // fallback until every supported build sends workspaceId.
+  workspaceId?: string;
   // Optional for backward compatibility with released clients that still send
   // the pre-uiLocale request shape. Remove once the minimum supported client
   // versions all send uiLocale.
@@ -123,6 +129,10 @@ type NewChatRequestBody = Readonly<{
   // with older released clients, and remove the session-less path in a future
   // legacy chat cleanup.
   sessionId?: string;
+  // Optional explicit routing during the workspaceId client migration. Older
+  // released clients still rely on the server-side selected-workspace
+  // fallback until every supported build sends workspaceId.
+  workspaceId?: string;
   // Optional for backward compatibility with released clients that still send
   // the pre-uiLocale request shape. Remove once the minimum supported client
   // versions all send uiLocale.
@@ -131,6 +141,10 @@ type NewChatRequestBody = Readonly<{
 
 type StopChatRequestBody = Readonly<{
   sessionId: string;
+  // Optional explicit routing during the workspaceId client migration. Older
+  // released clients still rely on the server-side selected-workspace
+  // fallback until every supported build sends workspaceId.
+  workspaceId?: string;
 }>;
 
 type ChatRoutesOptions = Readonly<{
@@ -148,7 +162,7 @@ type ChatRoutesOptions = Readonly<{
   createChatLiveStreamEnvelopeFn?: typeof createChatLiveStreamEnvelope;
   resolveLiveCursorFn?: typeof resolveLiveCursor;
   listChatMessagesLatestFn?: typeof listChatMessagesLatest;
-  requireAccessibleSelectedWorkspaceIdFn?: typeof requireAccessibleSelectedWorkspaceId;
+  resolveAccessibleChatWorkspaceIdFn?: typeof resolveAccessibleChatWorkspaceId;
 }>;
 
 const chatResumeContractViolationCode = "CHAT_LIVE_RESUME_CONTRACT_VIOLATION";
@@ -303,6 +317,14 @@ function parseChatContentParts(value: unknown, context: string): ReadonlyArray<C
   return value.map((part, index) => parseChatContentPart(part, `${context}[${index}]`));
 }
 
+function parseOptionalWorkspaceIdField(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return expectUuidString(value, "workspaceId");
+}
+
 /**
  * Rejects request fields that are not part of the backend-owned chat contract.
  */
@@ -330,6 +352,7 @@ export function parseChatRequestBody(value: unknown): ChatRequestBody {
     clientRequestId: expectNonEmptyString(body.clientRequestId, "clientRequestId"),
     content: parseChatContentParts(body.content, "content"),
     timezone: expectNonEmptyString(body.timezone, "timezone"),
+    workspaceId: parseOptionalWorkspaceIdField(body.workspaceId),
     uiLocale: parseOptionalUiLocale(body.uiLocale, "uiLocale"),
   };
 }
@@ -344,6 +367,7 @@ export function parseNewChatRequestBody(value: unknown): NewChatRequestBody {
     sessionId: body.sessionId === undefined
       ? undefined
       : expectUuidString(body.sessionId, "sessionId"),
+    workspaceId: parseOptionalWorkspaceIdField(body.workspaceId),
     uiLocale: parseOptionalUiLocale(body.uiLocale, "uiLocale"),
   };
 }
@@ -356,6 +380,7 @@ export function parseStopChatRequestBody(value: unknown): StopChatRequestBody {
 
   return {
     sessionId: expectUuidString(body.sessionId, "sessionId"),
+    workspaceId: parseOptionalWorkspaceIdField(body.workspaceId),
   };
 }
 
@@ -712,12 +737,18 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
   const createChatLiveStreamEnvelopeFn = options.createChatLiveStreamEnvelopeFn ?? createChatLiveStreamEnvelope;
   const resolveLiveCursorFn = options.resolveLiveCursorFn ?? resolveLiveCursor;
   const listChatMessagesLatestFn = options.listChatMessagesLatestFn ?? listChatMessagesLatest;
-  const requireAccessibleSelectedWorkspaceIdFn = options.requireAccessibleSelectedWorkspaceIdFn
+  const resolveAccessibleChatWorkspaceIdFn = options.resolveAccessibleChatWorkspaceIdFn
     ?? (options.loadRequestContextFromRequestFn === undefined
-      ? requireAccessibleSelectedWorkspaceId
-      : async (requestContext: RequestContext): Promise<string> => {
+      ? resolveAccessibleChatWorkspaceId
+      : async (requestContext: WorkspaceRequestContext, explicitWorkspaceId: string | undefined): Promise<string> => {
+        if (explicitWorkspaceId !== undefined) {
+          return explicitWorkspaceId;
+        }
+
         // Route tests often stub request context directly and do not exercise
         // the real workspace access path, so keep a minimal local fallback.
+        // Legacy fallback for released AI clients that still omit workspaceId.
+        // TODO: Remove this fallback once every supported AI client sends workspaceId.
         if (requestContext.selectedWorkspaceId === null) {
           throw new HttpError(
             409,
@@ -735,7 +766,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
       options.allowedOrigins,
       loadRequestContextFromRequestFn,
     );
-    const workspaceId = await requireAccessibleSelectedWorkspaceIdFn(requestContext);
+    const explicitWorkspaceId = parseOptionalWorkspaceIdParam(context.req.query("workspaceId") ?? undefined);
+    const workspaceId = await resolveAccessibleChatWorkspaceIdFn(requestContext, explicitWorkspaceId);
     const sessionId = parseOptionalSessionIdQuery(context.req.query("sessionId") ?? undefined);
     const limitParam = context.req.query("limit") ?? undefined;
     const resumeDiagnostics = readChatResumeDiagnosticsHeaders(context.req.raw);
@@ -808,8 +840,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
       options.allowedOrigins,
       loadRequestContextFromRequestFn,
     );
-    const workspaceId = await requireAccessibleSelectedWorkspaceIdFn(requestContext);
     const body = parseChatRequestBody(await parseJsonBody(context.req.raw));
+    const workspaceId = await resolveAccessibleChatWorkspaceIdFn(requestContext, body.workspaceId);
     const resumeDiagnostics = readChatResumeDiagnosticsHeaders(context.req.raw);
     context.header("X-Chat-Request-Id", body.clientRequestId);
 
@@ -868,8 +900,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
       options.allowedOrigins,
       loadRequestContextFromRequestFn,
     );
-    const workspaceId = await requireAccessibleSelectedWorkspaceIdFn(requestContext);
     const body = parseNewChatRequestBody(await parseJsonBody(context.req.raw));
+    const workspaceId = await resolveAccessibleChatWorkspaceIdFn(requestContext, body.workspaceId);
 
     // Preferred modern flow: clients send an explicit client-generated
     // sessionId. First-party clients at 1.2.1 already follow that flow.
@@ -996,8 +1028,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
       options.allowedOrigins,
       loadRequestContextFromRequestFn,
     );
-    const workspaceId = await requireAccessibleSelectedWorkspaceIdFn(requestContext);
     const body = parseStopChatRequestBody(await parseJsonBody(context.req.raw));
+    const workspaceId = await resolveAccessibleChatWorkspaceIdFn(requestContext, body.workspaceId);
 
     let sessionId: string | null;
     try {

--- a/apps/backend/src/routes/chatTranscriptions.ts
+++ b/apps/backend/src/routes/chatTranscriptions.ts
@@ -19,7 +19,8 @@ import {
 } from "../guestAiQuota";
 import {
   loadRequestContextFromRequest,
-  requireAccessibleSelectedWorkspaceIdForAiDictation,
+  resolveAccessibleAiDictationWorkspaceId,
+  type WorkspaceRequestContext,
 } from "../server/requestContext";
 import type { AppEnv } from "../app";
 
@@ -27,7 +28,7 @@ type ChatTranscriptionsRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
   loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
   getRecoveredChatSessionSnapshotFn?: typeof getRecoveredChatSessionSnapshot;
-  requireAccessibleSelectedWorkspaceIdForAiDictationFn?: typeof requireAccessibleSelectedWorkspaceIdForAiDictation;
+  resolveAccessibleAiDictationWorkspaceIdFn?: typeof resolveAccessibleAiDictationWorkspaceId;
   transcribeAudioFn?: (
     upload: ChatTranscriptionUpload,
     requestContext: ChatTranscriptionRequestContext,
@@ -78,12 +79,18 @@ export function createChatTranscriptionsRoutes(options: ChatTranscriptionsRoutes
   const app = new Hono<AppEnv>();
   const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
   const getRecoveredChatSessionSnapshotFn = options.getRecoveredChatSessionSnapshotFn ?? getRecoveredChatSessionSnapshot;
-  const requireAccessibleSelectedWorkspaceIdForAiDictationFn = options.requireAccessibleSelectedWorkspaceIdForAiDictationFn
+  const resolveAccessibleAiDictationWorkspaceIdFn = options.resolveAccessibleAiDictationWorkspaceIdFn
     ?? (options.loadRequestContextFromRequestFn === undefined
-      ? requireAccessibleSelectedWorkspaceIdForAiDictation
-      : async (requestContext): Promise<string> => {
+      ? resolveAccessibleAiDictationWorkspaceId
+      : async (requestContext: WorkspaceRequestContext, explicitWorkspaceId): Promise<string> => {
+        if (explicitWorkspaceId !== undefined) {
+          return explicitWorkspaceId;
+        }
+
         // Route tests often stub request context directly and do not exercise
         // the real workspace access path, so keep a minimal local fallback.
+        // Legacy fallback for released AI clients that still omit workspaceId.
+        // TODO: Remove this fallback once every supported AI client sends workspaceId.
         if (requestContext.selectedWorkspaceId === null) {
           throw new HttpError(403, "A workspace must be selected before using AI dictation.", "AI_WORKSPACE_REQUIRED");
         }
@@ -96,7 +103,7 @@ export function createChatTranscriptionsRoutes(options: ChatTranscriptionsRoutes
   app.post("/chat/transcriptions", async (context) => {
     const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     const upload = await parseChatTranscriptionUpload(context.req.raw);
-    const workspaceId = await requireAccessibleSelectedWorkspaceIdForAiDictationFn(requestContext);
+    const workspaceId = await resolveAccessibleAiDictationWorkspaceIdFn(requestContext, upload.workspaceId);
     const sessionId = await resolveChatTranscriptionSessionId(
       requestContext.userId,
       workspaceId,

--- a/apps/backend/src/server/requestContext.ts
+++ b/apps/backend/src/server/requestContext.ts
@@ -30,11 +30,29 @@ export type WorkspaceAccessRequestContext = Readonly<{
   userId: string;
 }>;
 
+type WorkspaceSelectionErrorConfig = Readonly<{
+  statusCode: 403 | 409;
+  message: string;
+  code: "AI_WORKSPACE_REQUIRED" | "WORKSPACE_SELECTION_REQUIRED";
+}>;
+
 type LoadRequestContextDependencies = Readonly<{
   authenticateRequestFn: typeof authenticateRequest;
   isDeletedSubjectFn: typeof isDeletedSubject;
   ensureUserProfileFn: typeof ensureUserProfile;
 }>;
+
+const chatWorkspaceSelectionRequiredError: WorkspaceSelectionErrorConfig = {
+  statusCode: 409,
+  message: "Select a workspace before using this endpoint",
+  code: "WORKSPACE_SELECTION_REQUIRED",
+};
+
+const aiDictationWorkspaceRequiredError: WorkspaceSelectionErrorConfig = {
+  statusCode: 403,
+  message: "A workspace must be selected before using AI dictation.",
+  code: "AI_WORKSPACE_REQUIRED",
+};
 
 export function getAllowedOrigins(): Array<string> {
   const raw = process.env.BACKEND_ALLOWED_ORIGINS ?? "http://localhost:3000,http://localhost:3001";
@@ -118,6 +136,14 @@ export function parseWorkspaceIdParam(value: string | undefined): string {
   return trimmedValue;
 }
 
+export function parseOptionalWorkspaceIdParam(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return parseWorkspaceIdParam(value);
+}
+
 export function requireSelectedWorkspaceId(requestContext: RequestContext): string {
   if (requestContext.selectedWorkspaceId === null) {
     throw new HttpError(
@@ -138,6 +164,51 @@ export async function requireAccessibleWorkspaceId(
   return workspaceId;
 }
 
+function throwWorkspaceSelectionError(errorConfig: WorkspaceSelectionErrorConfig): never {
+  throw new HttpError(errorConfig.statusCode, errorConfig.message, errorConfig.code);
+}
+
+export async function resolveAccessibleWorkspaceIdWithLegacySelectedWorkspaceFallback(
+  requestContext: WorkspaceRequestContext,
+  explicitWorkspaceId: string | undefined,
+  missingWorkspaceError: WorkspaceSelectionErrorConfig,
+): Promise<string> {
+  if (explicitWorkspaceId !== undefined) {
+    return requireAccessibleWorkspaceId(requestContext, explicitWorkspaceId);
+  }
+
+  // Legacy fallback for released AI clients that still rely on server-side
+  // selected-workspace routing instead of sending an explicit workspaceId.
+  // TODO: Remove this fallback once every supported AI client sends workspaceId.
+  if (requestContext.selectedWorkspaceId === null) {
+    throwWorkspaceSelectionError(missingWorkspaceError);
+  }
+
+  return requireAccessibleWorkspaceId(requestContext, requestContext.selectedWorkspaceId);
+}
+
+export async function resolveAccessibleChatWorkspaceId(
+  requestContext: WorkspaceRequestContext,
+  explicitWorkspaceId: string | undefined,
+): Promise<string> {
+  return resolveAccessibleWorkspaceIdWithLegacySelectedWorkspaceFallback(
+    requestContext,
+    explicitWorkspaceId,
+    chatWorkspaceSelectionRequiredError,
+  );
+}
+
+export async function resolveAccessibleAiDictationWorkspaceId(
+  requestContext: WorkspaceRequestContext,
+  explicitWorkspaceId: string | undefined,
+): Promise<string> {
+  return resolveAccessibleWorkspaceIdWithLegacySelectedWorkspaceFallback(
+    requestContext,
+    explicitWorkspaceId,
+    aiDictationWorkspaceRequiredError,
+  );
+}
+
 /**
  * Resolves the currently selected workspace and revalidates access before a
  * workspace-bound route continues with business logic.
@@ -145,15 +216,7 @@ export async function requireAccessibleWorkspaceId(
 export async function requireAccessibleSelectedWorkspaceId(
   requestContext: WorkspaceRequestContext,
 ): Promise<string> {
-  if (requestContext.selectedWorkspaceId === null) {
-    throw new HttpError(
-      409,
-      "Select a workspace before using this endpoint",
-      "WORKSPACE_SELECTION_REQUIRED",
-    );
-  }
-
-  return requireAccessibleWorkspaceId(requestContext, requestContext.selectedWorkspaceId);
+  return resolveAccessibleChatWorkspaceId(requestContext, undefined);
 }
 
 /**
@@ -163,11 +226,7 @@ export async function requireAccessibleSelectedWorkspaceId(
 export async function requireAccessibleSelectedWorkspaceIdForAiDictation(
   requestContext: WorkspaceRequestContext,
 ): Promise<string> {
-  if (requestContext.selectedWorkspaceId === null) {
-    throw new HttpError(403, "A workspace must be selected before using AI dictation.", "AI_WORKSPACE_REQUIRED");
-  }
-
-  return requireAccessibleWorkspaceId(requestContext, requestContext.selectedWorkspaceId);
+  return resolveAccessibleAiDictationWorkspaceId(requestContext, undefined);
 }
 
 export function requireAgentConnectionId(requestContext: RequestContext): string {

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatConversationModels.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatConversationModels.swift
@@ -57,6 +57,8 @@ struct AIChatStartRunRequestBody: Codable, Hashable, Sendable {
     let timezone: String
     // Keep this additive field optional while older client and backend builds roll out independently.
     let uiLocale: String?
+    // Keep this additive field optional while older client and backend builds roll out independently.
+    let workspaceId: String?
 }
 
 enum AIChatComposerPhase: String, Hashable, Sendable {
@@ -157,6 +159,8 @@ struct AIChatNewSessionRequestBody: Codable, Hashable, Sendable {
     let sessionId: String?
     // Keep this additive field optional while older client and backend builds roll out independently.
     let uiLocale: String?
+    // Keep this additive field optional while older client and backend builds roll out independently.
+    let workspaceId: String?
 }
 
 struct AIChatNewSessionResponse: Codable, Hashable, Sendable {
@@ -188,6 +192,44 @@ struct AIChatStopRunResponse: Decodable, Hashable, Sendable {
     let sessionId: String
     let stopped: Bool
     let stillRunning: Bool
+}
+
+struct AIChatStopRunRequestBody: Codable, Hashable, Sendable {
+    let sessionId: String
+    // Keep this additive field optional while older client and backend builds roll out independently.
+    let workspaceId: String?
+}
+
+extension AIChatStartRunRequestBody {
+    init(
+        sessionId: String?,
+        clientRequestId: String,
+        content: [AIChatContentPart],
+        timezone: String,
+        uiLocale: String?
+    ) {
+        self.init(
+            sessionId: sessionId,
+            clientRequestId: clientRequestId,
+            content: content,
+            timezone: timezone,
+            uiLocale: uiLocale,
+            workspaceId: nil
+        )
+    }
+}
+
+extension AIChatNewSessionRequestBody {
+    init(
+        sessionId: String?,
+        uiLocale: String?
+    ) {
+        self.init(
+            sessionId: sessionId,
+            uiLocale: uiLocale,
+            workspaceId: nil
+        )
+    }
 }
 
 func currentAIChatUILocaleIdentifier() -> String? {

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatService.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatService.swift
@@ -61,7 +61,13 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
         sessionId: String?
     ) async throws -> AIChatSessionSnapshot {
         let clientRequestId = UUID().uuidString.lowercased()
-        let path = makeChatPath(basePath: "/chat", sessionId: sessionId)
+        let path = makeChatPath(
+            basePath: "/chat",
+            queryItems: [
+                URLQueryItem(name: "sessionId", value: sessionId),
+                URLQueryItem(name: "workspaceId", value: session.workspaceId)
+            ]
+        )
         let request = try self.makeRequest(
             session: session,
             path: path,
@@ -106,12 +112,14 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
         resumeAttemptDiagnostics: AIChatResumeAttemptDiagnostics?
     ) async throws -> AIChatBootstrapResponse {
         let clientRequestId = UUID().uuidString.lowercased()
-        var path = "/chat?limit=\(limit)"
-        if let sessionId, sessionId.isEmpty == false {
-            let allowedCharacters = CharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "+&=?"))
-            let encoded = sessionId.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? sessionId
-            path += "&sessionId=\(encoded)"
-        }
+        let path = makeChatPath(
+            basePath: "/chat",
+            queryItems: [
+                URLQueryItem(name: "limit", value: String(limit)),
+                URLQueryItem(name: "sessionId", value: sessionId),
+                URLQueryItem(name: "workspaceId", value: session.workspaceId)
+            ]
+        )
         let request = try self.makeRequest(
             session: session,
             path: path,
@@ -155,10 +163,15 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
         limit: Int
     ) async throws -> AIChatOlderMessagesResponse {
         let clientRequestId = UUID().uuidString.lowercased()
-        let allowedCharacters = CharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "+&=?"))
-        let encodedSessionId = sessionId.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? sessionId
-        let encodedCursor = beforeCursor.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? beforeCursor
-        let path = "/chat?sessionId=\(encodedSessionId)&limit=\(limit)&before=\(encodedCursor)"
+        let path = makeChatPath(
+            basePath: "/chat",
+            queryItems: [
+                URLQueryItem(name: "sessionId", value: sessionId),
+                URLQueryItem(name: "limit", value: String(limit)),
+                URLQueryItem(name: "before", value: beforeCursor),
+                URLQueryItem(name: "workspaceId", value: session.workspaceId)
+            ]
+        )
         let request = try self.makeRequest(
             session: session,
             path: path,
@@ -210,11 +223,19 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
         request: AIChatStartRunRequestBody
     ) async throws -> AIChatStartRunResponse {
         let clientRequestId = request.clientRequestId
+        let requestBody = AIChatStartRunRequestBody(
+            sessionId: request.sessionId,
+            clientRequestId: request.clientRequestId,
+            content: request.content,
+            timezone: request.timezone,
+            uiLocale: request.uiLocale,
+            workspaceId: session.workspaceId
+        )
         let urlRequest = try self.makeJsonRequest(
             session: session,
             path: "/chat",
             method: "POST",
-            body: request,
+            body: requestBody,
             clientRequestId: clientRequestId
         )
         let data = try await self.execute(
@@ -251,11 +272,16 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
         request: AIChatNewSessionRequestBody
     ) async throws -> AIChatNewSessionResponse {
         let clientRequestId = UUID().uuidString.lowercased()
+        let requestBody = AIChatNewSessionRequestBody(
+            sessionId: request.sessionId,
+            uiLocale: request.uiLocale,
+            workspaceId: session.workspaceId
+        )
         let urlRequest = try self.makeJsonRequest(
             session: session,
             path: "/chat/new",
             method: "POST",
-            body: request,
+            body: requestBody,
             clientRequestId: clientRequestId
         )
         let data = try await self.execute(
@@ -295,7 +321,10 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
             session: session,
             path: "/chat/stop",
             method: "POST",
-            body: ["sessionId": sessionId],
+            body: AIChatStopRunRequestBody(
+                sessionId: sessionId,
+                workspaceId: session.workspaceId
+            ),
             clientRequestId: clientRequestId
         )
         let data = try await self.execute(
@@ -479,14 +508,26 @@ private func extractChatRequestId(httpResponse: HTTPURLResponse) -> String? {
     return nil
 }
 
-private func makeChatPath(basePath: String, sessionId: String?) -> String {
-    guard let sessionId, sessionId.isEmpty == false else {
+private func makeChatPath(basePath: String, queryItems: [URLQueryItem]) -> String {
+    let encodedQueryItems: [URLQueryItem] = queryItems.compactMap { item -> URLQueryItem? in
+        guard let value = item.value, value.isEmpty == false else {
+            return nil
+        }
+
+        return URLQueryItem(name: item.name, value: value)
+    }
+
+    guard encodedQueryItems.isEmpty == false else {
         return basePath
     }
 
-    let allowedCharacters = CharacterSet.urlQueryAllowed.subtracting(CharacterSet(charactersIn: "+&=?"))
-    let encodedSessionId = sessionId.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? sessionId
-    return "\(basePath)?sessionId=\(encodedSessionId)"
+    var components = URLComponents()
+    components.queryItems = encodedQueryItems
+    guard let percentEncodedQuery = components.percentEncodedQuery, percentEncodedQuery.isEmpty == false else {
+        return basePath
+    }
+
+    return "\(basePath)?\(percentEncodedQuery)"
 }
 
 private func formatAIChatUserError(summary: String, diagnostics: AIChatFailureDiagnostics) -> String {

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatVoiceDictation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatVoiceDictation.swift
@@ -293,6 +293,7 @@ extension AIChatTranscriptionService: AIChatAudioTranscribing {
         request.httpBody = try self.makeMultipartBody(
             boundary: boundary,
             sessionId: sessionId,
+            workspaceId: session.workspaceId,
             recordedAudio: recordedAudio
         )
         return request
@@ -330,6 +331,7 @@ extension AIChatTranscriptionService: AIChatAudioTranscribing {
     private func makeMultipartBody(
         boundary: String,
         sessionId: String?,
+        workspaceId: String?,
         recordedAudio: AIChatRecordedAudio
     ) throws -> Data {
         let audioData = try Data(contentsOf: recordedAudio.fileUrl)
@@ -338,6 +340,11 @@ extension AIChatTranscriptionService: AIChatAudioTranscribing {
             body.append(Data("--\(boundary)\r\n".utf8))
             body.append(Data("Content-Disposition: form-data; name=\"sessionId\"\r\n\r\n".utf8))
             body.append(Data("\(sessionId)\r\n".utf8))
+        }
+        if let workspaceId, workspaceId.isEmpty == false {
+            body.append(Data("--\(boundary)\r\n".utf8))
+            body.append(Data("Content-Disposition: form-data; name=\"workspaceId\"\r\n\r\n".utf8))
+            body.append(Data("\(workspaceId)\r\n".utf8))
         }
         body.append(Data("--\(boundary)\r\n".utf8))
         body.append(Data("Content-Disposition: form-data; name=\"source\"\r\n\r\n".utf8))

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatResumeDiagnosticsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatResumeDiagnosticsTests.swift
@@ -52,6 +52,10 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-Chat-Resume-Attempt-Id"), "11")
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-Client-Platform"), aiChatClientPlatform)
             XCTAssertEqual(request.value(forHTTPHeaderField: "X-Client-Version"), aiChatAppVersion())
+            let queryItems = try aiChatQueryItems(request: request)
+            XCTAssertEqual(queryItems.first(where: { $0.name == "limit" })?.value, "20")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "sessionId" })?.value, "session-1")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "workspaceId" })?.value, "workspace-1")
             expectation.fulfill()
             return (
                 HTTPURLResponse(
@@ -75,6 +79,80 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
         await self.fulfillment(of: [expectation], timeout: 1.0)
     }
 
+    func testLoadSnapshotIncludesWorkspaceIdQueryItem() async throws {
+        let expectation = XCTestExpectation(description: "Snapshot request captured")
+        let service = AIChatService(
+            session: self.makeURLSession(),
+            encoder: JSONEncoder(),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        AIChatTestURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/chat")
+            let queryItems = try aiChatQueryItems(request: request)
+            XCTAssertEqual(queryItems.first(where: { $0.name == "sessionId" })?.value, "session-1")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "workspaceId" })?.value, "workspace-1")
+            expectation.fulfill()
+            return (
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                Data(Self.bootstrapResponseJSON.utf8)
+            )
+        }
+
+        let response = try await service.loadSnapshot(
+            session: self.makeLinkedSession(),
+            sessionId: "session-1"
+        )
+
+        XCTAssertEqual(response.sessionId, "session-1")
+        await self.fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testLoadOlderMessagesIncludesWorkspaceIdQueryItem() async throws {
+        let expectation = XCTestExpectation(description: "Older messages request captured")
+        let service = AIChatService(
+            session: self.makeURLSession(),
+            encoder: JSONEncoder(),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        AIChatTestURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/chat")
+            let queryItems = try aiChatQueryItems(request: request)
+            XCTAssertEqual(queryItems.first(where: { $0.name == "sessionId" })?.value, "session-1")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "limit" })?.value, "10")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "before" })?.value, "cursor-1")
+            XCTAssertEqual(queryItems.first(where: { $0.name == "workspaceId" })?.value, "workspace-1")
+            expectation.fulfill()
+            return (
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                Data(Self.bootstrapResponseJSON.utf8)
+            )
+        }
+
+        let response = try await service.loadOlderMessages(
+            session: self.makeLinkedSession(),
+            sessionId: "session-1",
+            beforeCursor: "cursor-1",
+            limit: 10
+        )
+
+        XCTAssertTrue(response.messages.isEmpty)
+        XCTAssertFalse(response.hasOlder)
+        XCTAssertNil(response.oldestCursor)
+        await self.fulfillment(of: [expectation], timeout: 1.0)
+    }
+
     func testStartRunEncodesUILocaleInRequestBody() async throws {
         let expectation = XCTestExpectation(description: "Start run request captured")
         let service = AIChatService(
@@ -90,6 +168,7 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
             XCTAssertEqual(payload.sessionId, "session-1")
             XCTAssertEqual(payload.timezone, TimeZone.current.identifier)
             XCTAssertEqual(payload.uiLocale, currentAIChatUILocaleIdentifier())
+            XCTAssertEqual(payload.workspaceId, "workspace-1")
             expectation.fulfill()
             return (
                 HTTPURLResponse(
@@ -109,7 +188,8 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
                 clientRequestId: "request-1",
                 content: [.text("Help me review this.")],
                 timezone: TimeZone.current.identifier,
-                uiLocale: currentAIChatUILocaleIdentifier()
+                uiLocale: currentAIChatUILocaleIdentifier(),
+                workspaceId: nil
             )
         )
 
@@ -131,6 +211,7 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
             let payload = try JSONDecoder().decode(AIChatEncodedNewSessionRequest.self, from: body)
             XCTAssertEqual(payload.sessionId, "session-1")
             XCTAssertEqual(payload.uiLocale, currentAIChatUILocaleIdentifier())
+            XCTAssertEqual(payload.workspaceId, "workspace-1")
             expectation.fulfill()
             return (
                 HTTPURLResponse(
@@ -147,7 +228,8 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
             session: self.makeLinkedSession(),
             request: AIChatNewSessionRequestBody(
                 sessionId: "session-1",
-                uiLocale: currentAIChatUILocaleIdentifier()
+                uiLocale: currentAIChatUILocaleIdentifier(),
+                workspaceId: nil
             )
         )
 
@@ -155,7 +237,92 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
         await self.fulfillment(of: [expectation], timeout: 1.0)
     }
 
-    func testRequestBodiesOmitUILocaleWhenUnavailable() throws {
+    func testStopRunEncodesWorkspaceIdInRequestBody() async throws {
+        let expectation = XCTestExpectation(description: "Stop run request captured")
+        let service = AIChatService(
+            session: self.makeURLSession(),
+            encoder: JSONEncoder(),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        AIChatTestURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/chat/stop")
+            let body = try XCTUnwrap(aiChatRequestBodyData(request: request))
+            let payload = try JSONDecoder().decode(AIChatEncodedStopRunRequest.self, from: body)
+            XCTAssertEqual(payload.sessionId, "session-1")
+            XCTAssertEqual(payload.workspaceId, "workspace-1")
+            expectation.fulfill()
+            return (
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                Data(Self.stopRunResponseJSON.utf8)
+            )
+        }
+
+        let response = try await service.stopRun(
+            session: self.makeLinkedSession(),
+            sessionId: "session-1"
+        )
+
+        XCTAssertEqual(response.sessionId, "session-1")
+        XCTAssertTrue(response.stopped)
+        XCTAssertFalse(response.stillRunning)
+        await self.fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testDictationUploadEncodesWorkspaceIdInMultipartBody() async throws {
+        let expectation = XCTestExpectation(description: "Dictation request captured")
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+        let recordedAudioUrl = temporaryDirectory.appendingPathComponent(UUID().uuidString.lowercased()).appendingPathExtension("m4a")
+        try Data("audio-test".utf8).write(to: recordedAudioUrl)
+        defer {
+            try? FileManager.default.removeItem(at: recordedAudioUrl)
+        }
+
+        let transcriptionService = AIChatTranscriptionService(
+            session: self.makeURLSession(),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        AIChatTestURLProtocol.requestHandler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/chat/transcriptions")
+            let body = try XCTUnwrap(aiChatRequestBodyData(request: request))
+            let multipartBody = String(decoding: body, as: UTF8.self)
+            XCTAssertTrue(multipartBody.contains("name=\"sessionId\"\r\n\r\nsession-1\r\n"))
+            XCTAssertTrue(multipartBody.contains("name=\"workspaceId\"\r\n\r\nworkspace-1\r\n"))
+            XCTAssertTrue(multipartBody.contains("name=\"source\"\r\n\r\nios\r\n"))
+            expectation.fulfill()
+            return (
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )!,
+                Data(Self.transcriptionResponseJSON.utf8)
+            )
+        }
+
+        let response = try await transcriptionService.transcribe(
+            session: self.makeLinkedSession(),
+            sessionId: "session-1",
+            recordedAudio: AIChatRecordedAudio(
+                fileUrl: recordedAudioUrl,
+                fileName: "chat-dictation.m4a",
+                mediaType: "audio/mp4"
+            )
+        )
+
+        XCTAssertEqual(response.text, "Transcribed text")
+        XCTAssertEqual(response.sessionId, "session-1")
+        await self.fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func testRequestBodiesOmitOptionalWireFieldsWhenUnavailable() throws {
         let encoder = JSONEncoder()
         let startRunData = try encoder.encode(
             AIChatStartRunRequestBody(
@@ -163,7 +330,8 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
                 clientRequestId: "request-1",
                 content: [.text("Help me review this.")],
                 timezone: "Europe/Madrid",
-                uiLocale: nil
+                uiLocale: nil,
+                workspaceId: nil
             )
         )
         let startRunPayload = String(
@@ -173,16 +341,30 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
         let newSessionData = try encoder.encode(
             AIChatNewSessionRequestBody(
                 sessionId: "session-1",
-                uiLocale: nil
+                uiLocale: nil,
+                workspaceId: nil
             )
         )
         let newSessionPayload = String(
             decoding: newSessionData,
             as: UTF8.self
         )
+        let stopRunData = try encoder.encode(
+            AIChatStopRunRequestBody(
+                sessionId: "session-1",
+                workspaceId: nil
+            )
+        )
+        let stopRunPayload = String(
+            decoding: stopRunData,
+            as: UTF8.self
+        )
 
         XCTAssertFalse(startRunPayload.contains("\"uiLocale\""))
+        XCTAssertFalse(startRunPayload.contains("\"workspaceId\""))
         XCTAssertFalse(newSessionPayload.contains("\"uiLocale\""))
+        XCTAssertFalse(newSessionPayload.contains("\"workspaceId\""))
+        XCTAssertFalse(stopRunPayload.contains("\"workspaceId\""))
     }
 
     func testLiveStreamConnectIncludesResumeDiagnosticsHeaders() async throws {
@@ -351,6 +533,21 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
       }
     }
     """
+
+    private static let stopRunResponseJSON: String = """
+    {
+      "sessionId": "session-1",
+      "stopped": true,
+      "stillRunning": false
+    }
+    """
+
+    private static let transcriptionResponseJSON: String = """
+    {
+      "text": "Transcribed text",
+      "sessionId": "session-1"
+    }
+    """
 }
 
 private struct AIChatEncodedStartRunRequest: Decodable {
@@ -359,11 +556,23 @@ private struct AIChatEncodedStartRunRequest: Decodable {
     let content: [AIChatContentPart]
     let timezone: String
     let uiLocale: String?
+    let workspaceId: String?
 }
 
 private struct AIChatEncodedNewSessionRequest: Decodable {
     let sessionId: String?
     let uiLocale: String?
+    let workspaceId: String?
+}
+
+private struct AIChatEncodedStopRunRequest: Decodable {
+    let sessionId: String
+    let workspaceId: String?
+}
+
+private func aiChatQueryItems(request: URLRequest) throws -> [URLQueryItem] {
+    let url = try XCTUnwrap(request.url)
+    return URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
 }
 
 private func aiChatRequestBodyData(request: URLRequest) -> Data? {

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -5,6 +5,7 @@ import {
   AuthRedirectError,
   buildLoginUrl,
   createNewChatSession,
+  getChatSnapshot,
   getPreferredAuthUiLocale,
   getSession,
   loadProgressSummary,
@@ -13,6 +14,7 @@ import {
   setNavigationHandlerForTests,
   startChatRun,
   stopChatRun,
+  transcribeChatAudio,
 } from "./api";
 import { isAuthResetRequired } from "./accountDeletion";
 import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
@@ -161,6 +163,26 @@ function createChatConfigResponseValue(): Readonly<{
 function createStartChatRunResponse(): Response {
   return new Response(JSON.stringify({
     accepted: true,
+    sessionId: "session-1",
+    conversationScopeId: "session-1",
+    conversation: {
+      messages: [],
+      updatedAt: 1,
+      mainContentInvalidationVersion: 0,
+    },
+    composerSuggestions: [],
+    chatConfig: createChatConfigResponseValue(),
+    activeRun: null,
+  }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function createChatSnapshotResponse(): Response {
+  return new Response(JSON.stringify({
     sessionId: "session-1",
     conversationScopeId: "session-1",
     conversation: {
@@ -500,14 +522,14 @@ describe("progress API decoding", () => {
   });
 });
 
-describe("AI chat locale transport", () => {
+describe("AI chat transport", () => {
   it("bootstraps session transport before the first unsafe chat request", async () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(createSessionResponse())
       .mockResolvedValueOnce(createNewChatSessionResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    await createNewChatSession("session-1", "es-ES");
+    await createNewChatSession("session-1", "workspace-1", "es-ES");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/me");
@@ -525,8 +547,8 @@ describe("AI chat locale transport", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const [firstResponse, secondResponse] = await Promise.all([
-      createNewChatSession("session-1", "en"),
-      createNewChatSession("session-2", "en"),
+      createNewChatSession("session-1", "workspace-1", "en"),
+      createNewChatSession("session-2", "workspace-1", "en"),
     ]);
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -544,7 +566,7 @@ describe("AI chat locale transport", () => {
       .mockResolvedValueOnce(createNewChatSessionResponse());
     vi.stubGlobal("fetch", fetchMock);
 
-    await createNewChatSession("session-1", "en");
+    await createNewChatSession("session-1", "workspace-1", "en");
 
     expect(fetchMock).toHaveBeenCalledTimes(5);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/me");
@@ -561,14 +583,14 @@ describe("AI chat locale transport", () => {
       }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(createNewChatSession("session-1", "en")).rejects.toThrow(
+    await expect(createNewChatSession("session-1", "workspace-1", "en")).rejects.toThrow(
       "CSRF token is not loaded for this browser session",
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("includes uiLocale in POST /chat requests", async () => {
+  it("includes workspaceId and uiLocale in POST /chat requests", async () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(createSessionResponse())
       .mockResolvedValueOnce(createStartChatRunResponse());
@@ -577,6 +599,7 @@ describe("AI chat locale transport", () => {
     await getSession();
     await startChatRun({
       sessionId: "session-1",
+      workspaceId: "workspace-1",
       clientRequestId: "request-1",
       content: [{ type: "text", text: "hello" }],
       timezone: "Europe/Madrid",
@@ -586,6 +609,7 @@ describe("AI chat locale transport", () => {
     const chatRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
     expect(chatRequestInit?.body).toBe(JSON.stringify({
       sessionId: "session-1",
+      workspaceId: "workspace-1",
       clientRequestId: "request-1",
       content: [{ type: "text", text: "hello" }],
       timezone: "Europe/Madrid",
@@ -593,20 +617,36 @@ describe("AI chat locale transport", () => {
     }));
   });
 
-  it("includes uiLocale in POST /chat/new requests", async () => {
+  it("includes workspaceId and uiLocale in POST /chat/new requests", async () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(createSessionResponse())
       .mockResolvedValueOnce(createNewChatSessionResponse());
     vi.stubGlobal("fetch", fetchMock);
 
     await getSession();
-    await createNewChatSession("session-1", "es-ES");
+    await createNewChatSession("session-1", "workspace-1", "es-ES");
 
     const chatRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
     expect(chatRequestInit?.body).toBe(JSON.stringify({
       sessionId: "session-1",
+      workspaceId: "workspace-1",
       uiLocale: "es-ES",
     }));
+  });
+
+  it("includes workspaceId in GET /chat requests", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createSessionResponse())
+      .mockResolvedValueOnce(createChatSnapshotResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getSession();
+    await getChatSnapshot("session-1", "workspace-1");
+
+    const requestUrl = new URL(String(fetchMock.mock.calls[1]?.[0]));
+    expect(requestUrl.pathname).toBe("/v1/chat");
+    expect(requestUrl.searchParams.get("sessionId")).toBe("session-1");
+    expect(requestUrl.searchParams.get("workspaceId")).toBe("workspace-1");
   });
 
   it("accepts reduced POST /chat/stop responses without unused run identifiers", async () => {
@@ -616,7 +656,7 @@ describe("AI chat locale transport", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await getSession();
-    await expect(stopChatRun("session-1")).resolves.toEqual({
+    await expect(stopChatRun("session-1", "workspace-1")).resolves.toEqual({
       sessionId: "session-1",
       stopped: true,
       stillRunning: false,
@@ -625,6 +665,42 @@ describe("AI chat locale transport", () => {
     const chatRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
     expect(chatRequestInit?.body).toBe(JSON.stringify({
       sessionId: "session-1",
+      workspaceId: "workspace-1",
     }));
+  });
+
+  it("includes workspaceId in POST /chat/transcriptions requests", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createSessionResponse())
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        text: "hello",
+        sessionId: "session-1",
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getSession();
+    await transcribeChatAudio(
+      new Blob(["audio"], { type: "audio/webm" }),
+      "web",
+      "session-1",
+      "workspace-1",
+    );
+
+    const chatRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
+    const formData = chatRequestInit?.body;
+    expect(formData).toBeInstanceOf(FormData);
+    if (!(formData instanceof FormData)) {
+      throw new Error("Expected FormData");
+    }
+
+    expect(formData.get("sessionId")).toBe("session-1");
+    expect(formData.get("workspaceId")).toBe("workspace-1");
+    expect(formData.get("source")).toBe("web");
+    expect(formData.get("file")).toBeInstanceOf(File);
   });
 });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -51,6 +51,7 @@ import type {
   SessionInfo,
   StartChatRunRequestBody,
   StartChatRunResponse,
+  StopChatRunRequestBody,
   StopChatRunResponse,
   SyncBootstrapEntry,
   SyncBootstrapPullResult,
@@ -777,17 +778,26 @@ export async function queryCards(
   }, allowAuthRecovery), `POST /workspaces/${workspaceId}/cards/query`);
 }
 
-export async function getChatSnapshot(sessionId: string): Promise<ChatSessionSnapshot> {
-  return parseChatSessionSnapshotResponse(await requestJson(`/chat?sessionId=${encodeURIComponent(sessionId)}`, {
+function buildChatSnapshotPath(sessionId: string, workspaceId: string): string {
+  const searchParams = new URLSearchParams({
+    sessionId,
+    workspaceId,
+  });
+  return `/chat?${searchParams.toString()}`;
+}
+
+export async function getChatSnapshot(sessionId: string, workspaceId: string): Promise<ChatSessionSnapshot> {
+  return parseChatSessionSnapshotResponse(await requestJson(buildChatSnapshotPath(sessionId, workspaceId), {
     method: "GET",
   }, allowAuthRecovery), "GET /chat");
 }
 
 export async function getChatSnapshotWithResumeDiagnostics(
   sessionId: string,
+  workspaceId: string,
   diagnostics: ChatResumeRequestDiagnostics,
 ): Promise<ChatSessionSnapshot> {
-  return parseChatSessionSnapshotResponse(await requestJson(`/chat?sessionId=${encodeURIComponent(sessionId)}`, {
+  return parseChatSessionSnapshotResponse(await requestJson(buildChatSnapshotPath(sessionId, workspaceId), {
     method: "GET",
     headers: {
       "X-Chat-Resume-Attempt-Id": String(diagnostics.resumeAttemptId),
@@ -806,10 +816,12 @@ export async function startChatRun(body: StartChatRunRequestBody): Promise<Start
 
 export async function createNewChatSession(
   sessionId: string,
+  workspaceId: string,
   uiLocale: Locale,
 ): Promise<NewChatSessionResponse> {
   const requestBody: NewChatSessionRequestBody = {
     sessionId,
+    workspaceId,
     uiLocale,
   };
 
@@ -819,10 +831,15 @@ export async function createNewChatSession(
   }, allowAuthRecovery), "POST /chat/new");
 }
 
-export async function stopChatRun(sessionId: string): Promise<StopChatRunResponse> {
+export async function stopChatRun(sessionId: string, workspaceId: string): Promise<StopChatRunResponse> {
+  const requestBody: StopChatRunRequestBody = {
+    sessionId,
+    workspaceId,
+  };
+
   return parseStopChatRunResponse(await requestJson("/chat/stop", {
     method: "POST",
-    body: JSON.stringify({ sessionId }),
+    body: JSON.stringify(requestBody),
   }, allowAuthRecovery), "POST /chat/stop");
 }
 
@@ -857,6 +874,7 @@ export async function transcribeChatAudio(
   blob: Blob,
   source: ChatTranscriptionSource,
   sessionId: string,
+  workspaceId: string,
 ): Promise<ChatTranscriptionResponse> {
   const mediaType = normalizeAudioMediaType(blob.type === "" ? "audio/webm" : blob.type);
   const file = new File([blob], `chat-dictation.${extensionForAudioMediaType(mediaType)}`, { type: mediaType });
@@ -864,6 +882,7 @@ export async function transcribeChatAudio(
   formData.append("file", file);
   formData.append("source", source);
   formData.append("sessionId", sessionId);
+  formData.append("workspaceId", workspaceId);
 
   return parseChatTranscriptionResponse(await requestJson("/chat/transcriptions", {
     method: "POST",

--- a/apps/web/src/chat/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel.tsx
@@ -626,11 +626,16 @@ export function ChatPanel(props: Props): ReactElement {
         return;
       }
 
+      if (activeWorkspaceId === null) {
+        throw new Error(t("chatPanel.transientErrors.workspaceRequired"));
+      }
+
       const sessionId = await ensureRemoteSession();
       const transcription = await transcribeChatAudio(
         audioBlob,
         "web",
         sessionId,
+        activeWorkspaceId,
       );
       if (transcription.sessionId !== sessionId) {
         throw new Error(t("chatPanel.errors.transcriptionUnexpectedSessionId"));

--- a/apps/web/src/chat/sessionController/useActions.ts
+++ b/apps/web/src/chat/sessionController/useActions.ts
@@ -133,12 +133,16 @@ export function useChatSessionActions(
   const provisionRemoteSession = useCallback(async (
     sessionId: string,
   ): Promise<NewChatSessionResponse> => {
+    if (workspaceId === null) {
+      throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
+    }
+
     const activeProvisioning = getActiveProvisioningState();
     if (activeProvisioning !== null && activeProvisioning.sessionId === sessionId) {
       return activeProvisioning.promise;
     }
 
-    const nextPromise = createNewChatSession(sessionId, uiLocale);
+    const nextPromise = createNewChatSession(sessionId, workspaceId, uiLocale);
     remoteSessionProvisioningRef.current = {
       workspaceId,
       sessionId,
@@ -390,6 +394,7 @@ export function useChatSessionActions(
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const requestBody = {
       sessionId,
+      workspaceId,
       clientRequestId: sendParams.clientRequestId,
       content: contentParts,
       timezone,
@@ -493,7 +498,11 @@ export function useChatSessionActions(
 
     dispatch({ type: "stop_requested" });
     try {
-      const response = await stopChatRun(state.currentSessionId);
+      if (workspaceId === null) {
+        throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
+      }
+
+      const response = await stopChatRun(state.currentSessionId, workspaceId);
       if (response.stopped && response.stillRunning === false && hasActiveLiveConnection() === false) {
         reconcileTerminalSnapshot();
         dispatch({

--- a/apps/web/src/chat/sessionController/useSnapshotSync.ts
+++ b/apps/web/src/chat/sessionController/useSnapshotSync.ts
@@ -659,9 +659,13 @@ export function useChatSessionSnapshotSync(
     });
 
     try {
+      if (workspaceId === null) {
+        throw new Error(uiMessages.workspaceRequired);
+      }
+
       const snapshot = resumeAttemptId === null
-        ? await getChatSnapshot(sessionId)
-        : await getChatSnapshotWithResumeDiagnostics(sessionId, { resumeAttemptId });
+        ? await getChatSnapshot(sessionId, workspaceId)
+        : await getChatSnapshotWithResumeDiagnostics(sessionId, workspaceId, { resumeAttemptId });
       if (requestVersion !== snapshotRequestVersionRef.current) {
         return null;
       }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -264,6 +264,8 @@ export type ChatSessionSnapshot = Readonly<{
 
 export type StartChatRunRequestBody = Readonly<{
   sessionId: string;
+  // Optional on the wire so older backend/client contract phases keep working.
+  workspaceId?: string;
   clientRequestId: string;
   content: ReadonlyArray<ContentPart>;
   timezone: string;
@@ -278,6 +280,8 @@ export type StartChatRunResponse = ChatSessionSnapshot & Readonly<{
 
 export type NewChatSessionRequestBody = Readonly<{
   sessionId: string;
+  // Optional on the wire so older backend/client contract phases keep working.
+  workspaceId?: string;
   // Optional so newer clients can hint the active UI locale without breaking older contract phases.
   uiLocale?: Locale;
 }>;
@@ -293,6 +297,12 @@ export type StopChatRunResponse = Readonly<{
   sessionId: string;
   stopped: boolean;
   stillRunning: boolean;
+}>;
+
+export type StopChatRunRequestBody = Readonly<{
+  sessionId: string;
+  // Optional on the wire so older backend/client contract phases keep working.
+  workspaceId?: string;
 }>;
 
 /** Mirrors the iOS local workspace payload used by local AI tools. */


### PR DESCRIPTION
## What changed
- route backend-owned AI chat endpoints by explicit `workspaceId` when clients provide it
- keep a legacy selected-workspace fallback on the backend for already released clients that do not send `workspaceId`
- update Web, iOS, and Android AI transports to always send `workspaceId` for snapshot, bootstrap, history, start, new session, stop, transcription, and Android live attach fallback
- add and extend backend, Android, Web, and iOS request-level coverage for the new routing behavior

## Why
AI chat still depended on the server-selected workspace even when the device already knew its active workspace. That made AI requests vulnerable to cross-device workspace selection drift. This change makes new clients workspace-explicit while keeping old clients working through a documented legacy fallback.

## Impact
- new clients stop depending on another device's selected workspace for AI
- backend remains backward-compatible for shipped clients
- progress remains intentionally user-wide and unchanged

## Validation
- Android targeted wire test: `./gradlew :data:local:testDebugUnitTest --tests com.flashcardsopensourceapp.data.local.ai.AiChatRemoteWireTest`
- independent code review against `main`: approve, no findings
- `git diff --cached --check`
- additional worker-run validation was limited by local environment gaps: missing web deps, missing backend tooling packages, and an unrelated existing iOS UI-test target compile issue
