### PR TITLE
Move global metrics snapshot to all-time window

### DIFF
--- a/apps/backend/src/globalMetrics/reporting.test.ts
+++ b/apps/backend/src/globalMetrics/reporting.test.ts
@@ -22,7 +22,7 @@ function createQueryResult<Row extends QueryResultRow>(
   };
 }
 
-test("generateGlobalMetricsSnapshotWithDependencies uses all-time totals before asOfUtc and 90-day rows for the day series", async () => {
+test("generateGlobalMetricsSnapshotWithDependencies uses all-time totals before asOfUtc and all-time rows from the historical start date", async () => {
   const recordedQueries: Array<RecordedQuery> = [];
   const client = {
     query: async <Row extends QueryResultRow>(
@@ -31,10 +31,18 @@ test("generateGlobalMetricsSnapshotWithDependencies uses all-time totals before 
     ): Promise<pg.QueryResult<Row>> => {
       recordedQueries.push({ text, params });
 
+      if (text.includes("AS historical_start_date")) {
+        return createQueryResult([
+          {
+            historical_start_date: "2026-03-07",
+          },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
       if (text.includes("to_char((review_events.reviewed_at_server AT TIME ZONE 'UTC')::date")) {
         return createQueryResult([
           {
-            review_date: "2026-01-23",
+            review_date: "2026-03-07",
             unique_reviewing_users: 2,
             total_review_events: 3,
             web_review_events: 1,
@@ -56,10 +64,10 @@ test("generateGlobalMetricsSnapshotWithDependencies uses all-time totals before 
         return createQueryResult([
           {
             unique_reviewing_users: 8,
-            total_review_events: 12,
-            web_review_events: 4,
-            android_review_events: 5,
-            ios_review_events: 3,
+            total_review_events: 5,
+            web_review_events: 2,
+            android_review_events: 2,
+            ios_review_events: 1,
           },
         ]) as unknown as pg.QueryResult<Row>;
       }
@@ -75,10 +83,13 @@ test("generateGlobalMetricsSnapshotWithDependencies uses all-time totals before 
     now: () => new Date("2026-04-23T09:30:00.000Z"),
   });
 
-  assert.equal(recordedQueries.length, 2);
+  assert.equal(recordedQueries.length, 3);
 
-  const totalsQuery = recordedQueries[0];
-  const daySeriesQuery = recordedQueries[1];
+  const historicalStartDateQuery = recordedQueries[0];
+  const totalsQuery = recordedQueries[1];
+  const daySeriesQuery = recordedQueries[2];
+  assert.match(historicalStartDateQuery?.text ?? "", /AS historical_start_date/);
+  assert.deepEqual(historicalStartDateQuery?.params, ["2026-04-23T00:00:00.000Z"]);
   assert.match(totalsQuery?.text ?? "", /WHERE review_events\.reviewed_at_server < \$1::timestamptz/);
   assert.doesNotMatch(totalsQuery?.text ?? "", /review_events\.reviewed_at_server >= \$1::timestamptz/);
   assert.deepEqual(totalsQuery?.params, ["2026-04-23T00:00:00.000Z"]);
@@ -86,13 +97,81 @@ test("generateGlobalMetricsSnapshotWithDependencies uses all-time totals before 
   assert.match(daySeriesQuery?.text ?? "", /WHERE review_events\.reviewed_at_server >= \$1::timestamptz/);
   assert.match(daySeriesQuery?.text ?? "", /AND review_events\.reviewed_at_server < \$2::timestamptz/);
   assert.deepEqual(daySeriesQuery?.params, [
-    "2026-01-23T00:00:00.000Z",
+    "2026-03-07T00:00:00.000Z",
     "2026-04-23T00:00:00.000Z",
   ]);
 
   assert.equal(snapshot.totals.uniqueReviewingUsers, 8);
-  assert.equal(snapshot.totals.reviewEvents.total, 12);
+  assert.equal(snapshot.totals.reviewEvents.total, 5);
   assert.equal(snapshot.days[0]?.reviewEvents.total, 3);
-  assert.equal(snapshot.days[89]?.reviewEvents.total, 2);
+  assert.equal(snapshot.days[46]?.reviewEvents.total, 2);
   assert.equal(snapshot.days.reduce((sum, day) => sum + day.reviewEvents.total, 0), 5);
+});
+
+test("generateGlobalMetricsSnapshotWithDependencies emits a single zero day when no historical review date exists", async () => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const client = {
+    query: async <Row extends QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<unknown>,
+    ): Promise<pg.QueryResult<Row>> => {
+      recordedQueries.push({ text, params });
+
+      if (text.includes("AS historical_start_date")) {
+        return createQueryResult([
+          {
+            historical_start_date: null,
+          },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("to_char((review_events.reviewed_at_server AT TIME ZONE 'UTC')::date")) {
+        return createQueryResult([]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("COUNT(DISTINCT workspace_replicas.user_id)::int AS unique_reviewing_users")) {
+        return createQueryResult([
+          {
+            unique_reviewing_users: 0,
+            total_review_events: 0,
+            web_review_events: 0,
+            android_review_events: 0,
+            ios_review_events: 0,
+          },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      throw new Error(`Unexpected global metrics reporting query: ${text}`);
+    },
+  } as unknown as pg.PoolClient;
+
+  const snapshot = await generateGlobalMetricsSnapshotWithDependencies({
+    withReportingReadOnlyTransactionFn: async <Result>(
+      run: (transactionClient: pg.PoolClient) => Promise<Result>,
+    ): Promise<Result> => run(client),
+    now: () => new Date("2026-04-23T09:30:00.000Z"),
+  });
+
+  assert.equal(recordedQueries.length, 3);
+  assert.deepEqual(recordedQueries[2]?.params, [
+    "2026-04-22T00:00:00.000Z",
+    "2026-04-23T00:00:00.000Z",
+  ]);
+  assert.equal(snapshot.from, "2026-04-22");
+  assert.equal(snapshot.to, "2026-04-22");
+  assert.equal(snapshot.totals.reviewEvents.total, 0);
+  assert.deepEqual(snapshot.days, [
+    {
+      date: "2026-04-22",
+      uniqueReviewingUsers: 0,
+      reviewEvents: {
+        total: 0,
+        byPlatform: {
+          web: 0,
+          android: 0,
+          ios: 0,
+        },
+      },
+    },
+  ]);
 });

--- a/apps/backend/src/globalMetrics/reporting.ts
+++ b/apps/backend/src/globalMetrics/reporting.ts
@@ -5,8 +5,26 @@ import {
   createGlobalMetricsSnapshotWindow,
   type GlobalMetricsSnapshot,
   type GlobalMetricsSnapshotDayRow,
+  type GlobalMetricsSnapshotHistoricalStartDate,
   type GlobalMetricsSnapshotTotalsRow,
 } from "./snapshot";
+
+type GlobalMetricsSnapshotHistoricalStartDateRow = Readonly<{
+  historical_start_date: string | null;
+}>;
+
+function buildGlobalMetricsSnapshotHistoricalStartDateSql(): string {
+  return [
+    "SELECT",
+    "  to_char(MIN((review_events.reviewed_at_server AT TIME ZONE 'UTC')::date), 'YYYY-MM-DD') AS historical_start_date",
+    "FROM content.review_events AS review_events",
+    "INNER JOIN sync.workspace_replicas AS workspace_replicas",
+    "  ON workspace_replicas.replica_id = review_events.replica_id",
+    "WHERE review_events.reviewed_at_server < $1::timestamptz",
+    "  AND workspace_replicas.actor_kind = 'client_installation'",
+    "  AND workspace_replicas.platform IN ('web', 'android', 'ios')",
+  ].join(" ");
+}
 
 function buildGlobalMetricsSnapshotTotalsSql(): string {
   return [
@@ -63,6 +81,23 @@ async function loadGlobalMetricsSnapshotTotalsRowInExecutor(
   return row;
 }
 
+async function loadGlobalMetricsSnapshotHistoricalStartDateInExecutor(
+  executor: pg.PoolClient,
+  asOfUtc: string,
+): Promise<GlobalMetricsSnapshotHistoricalStartDate> {
+  const result = await executor.query<GlobalMetricsSnapshotHistoricalStartDateRow>(
+    buildGlobalMetricsSnapshotHistoricalStartDateSql(),
+    [asOfUtc],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error("Global metrics historical start date query returned no rows.");
+  }
+
+  return row.historical_start_date;
+}
+
 async function loadGlobalMetricsSnapshotDayRowsInExecutor(
   executor: pg.PoolClient,
   rangeStartUtc: string,
@@ -84,9 +119,21 @@ type GenerateGlobalMetricsSnapshotDependencies = Readonly<{
 export async function generateGlobalMetricsSnapshotWithDependencies(
   dependencies: GenerateGlobalMetricsSnapshotDependencies,
 ): Promise<GlobalMetricsSnapshot> {
-  const window = createGlobalMetricsSnapshotWindow(dependencies.now());
+  const now = dependencies.now();
+  const provisionalWindow = createGlobalMetricsSnapshotWindow({
+    now,
+    historicalStartDate: null,
+  });
 
   return dependencies.withReportingReadOnlyTransactionFn(async (client) => {
+    const historicalStartDate = await loadGlobalMetricsSnapshotHistoricalStartDateInExecutor(
+      client,
+      provisionalWindow.asOfUtc,
+    );
+    const window = createGlobalMetricsSnapshotWindow({
+      now,
+      historicalStartDate,
+    });
     const totalsRow = await loadGlobalMetricsSnapshotTotalsRowInExecutor(
       client,
       window.asOfUtc,

--- a/apps/backend/src/globalMetrics/snapshot.test.ts
+++ b/apps/backend/src/globalMetrics/snapshot.test.ts
@@ -3,36 +3,44 @@ import test from "node:test";
 import {
   buildGlobalMetricsSnapshot,
   createGlobalMetricsSnapshotWindow,
+  globalMetricsSnapshotSchemaVersion,
+  parseGlobalMetricsSnapshotJson,
 } from "./snapshot";
 
-test("createGlobalMetricsSnapshotWindow uses the trailing 90 complete UTC days", () => {
-  const window = createGlobalMetricsSnapshotWindow(new Date("2026-04-23T13:45:56.789Z"));
+test("createGlobalMetricsSnapshotWindow uses the historical all-time UTC day window", () => {
+  const window = createGlobalMetricsSnapshotWindow({
+    now: new Date("2026-04-23T13:45:56.789Z"),
+    historicalStartDate: "2026-03-07",
+  });
 
   assert.equal(window.generatedAtUtc, "2026-04-23T13:45:56.789Z");
   assert.equal(window.asOfUtc, "2026-04-23T00:00:00.000Z");
-  assert.equal(window.from, "2026-01-23");
+  assert.equal(window.from, "2026-03-07");
   assert.equal(window.to, "2026-04-22");
-  assert.equal(window.rangeStartUtc, "2026-01-23T00:00:00.000Z");
+  assert.equal(window.rangeStartUtc, "2026-03-07T00:00:00.000Z");
   assert.equal(window.rangeEndUtc, "2026-04-23T00:00:00.000Z");
-  assert.equal(window.days.length, 90);
-  assert.equal(window.days[0], "2026-01-23");
-  assert.equal(window.days[89], "2026-04-22");
+  assert.equal(window.days.length, 47);
+  assert.equal(window.days[0], "2026-03-07");
+  assert.equal(window.days[46], "2026-04-22");
 });
 
 test("buildGlobalMetricsSnapshot zero-fills missing UTC dates and keeps unique users total separate from day sums", () => {
-  const window = createGlobalMetricsSnapshotWindow(new Date("2026-04-23T09:30:00.000Z"));
+  const window = createGlobalMetricsSnapshotWindow({
+    now: new Date("2026-04-23T09:30:00.000Z"),
+    historicalStartDate: "2026-03-07",
+  });
   const snapshot = buildGlobalMetricsSnapshot({
     window,
     totalsRow: {
       unique_reviewing_users: 8,
-      total_review_events: 12,
-      web_review_events: 4,
-      android_review_events: 5,
-      ios_review_events: 3,
+      total_review_events: 5,
+      web_review_events: 2,
+      android_review_events: 2,
+      ios_review_events: 1,
     },
     dayRows: [
       {
-        review_date: "2026-01-23",
+        review_date: "2026-03-07",
         unique_reviewing_users: 2,
         total_review_events: 3,
         web_review_events: 1,
@@ -50,21 +58,21 @@ test("buildGlobalMetricsSnapshot zero-fills missing UTC dates and keeps unique u
     ],
   });
 
-  assert.equal(snapshot.schemaVersion, 1);
-  assert.equal(snapshot.from, "2026-01-23");
+  assert.equal(snapshot.schemaVersion, globalMetricsSnapshotSchemaVersion);
+  assert.equal(snapshot.from, "2026-03-07");
   assert.equal(snapshot.to, "2026-04-22");
   assert.equal(snapshot.totals.uniqueReviewingUsers, 8);
   assert.deepEqual(snapshot.totals.reviewEvents, {
-    total: 12,
+    total: 5,
     byPlatform: {
-      web: 4,
-      android: 5,
-      ios: 3,
+      web: 2,
+      android: 2,
+      ios: 1,
     },
   });
-  assert.equal(snapshot.days.length, 90);
+  assert.equal(snapshot.days.length, 47);
   assert.deepEqual(snapshot.days[0], {
-    date: "2026-01-23",
+    date: "2026-03-07",
     uniqueReviewingUsers: 2,
     reviewEvents: {
       total: 3,
@@ -76,7 +84,7 @@ test("buildGlobalMetricsSnapshot zero-fills missing UTC dates and keeps unique u
     },
   });
   assert.deepEqual(snapshot.days[1], {
-    date: "2026-01-24",
+    date: "2026-03-08",
     uniqueReviewingUsers: 0,
     reviewEvents: {
       total: 0,
@@ -87,7 +95,7 @@ test("buildGlobalMetricsSnapshot zero-fills missing UTC dates and keeps unique u
       },
     },
   });
-  assert.deepEqual(snapshot.days[89], {
+  assert.deepEqual(snapshot.days[46], {
     date: "2026-04-22",
     uniqueReviewingUsers: 2,
     reviewEvents: {
@@ -102,5 +110,139 @@ test("buildGlobalMetricsSnapshot zero-fills missing UTC dates and keeps unique u
 
   const daySeriesReviewEventTotal = snapshot.days.reduce((sum, day) => sum + day.reviewEvents.total, 0);
   assert.equal(daySeriesReviewEventTotal, 5);
-  assert.notEqual(snapshot.totals.reviewEvents.total, daySeriesReviewEventTotal);
+  assert.equal(snapshot.totals.reviewEvents.total, daySeriesReviewEventTotal);
+});
+
+test("createGlobalMetricsSnapshotWindow collapses to a single zero day when no historical review date exists", () => {
+  const window = createGlobalMetricsSnapshotWindow({
+    now: new Date("2026-04-23T13:45:56.789Z"),
+    historicalStartDate: null,
+  });
+
+  assert.equal(window.generatedAtUtc, "2026-04-23T13:45:56.789Z");
+  assert.equal(window.asOfUtc, "2026-04-23T00:00:00.000Z");
+  assert.equal(window.from, "2026-04-22");
+  assert.equal(window.to, "2026-04-22");
+  assert.equal(window.rangeStartUtc, "2026-04-22T00:00:00.000Z");
+  assert.equal(window.rangeEndUtc, "2026-04-23T00:00:00.000Z");
+  assert.deepEqual(window.days, ["2026-04-22"]);
+});
+
+test("buildGlobalMetricsSnapshot emits a zero-filled single day when no qualifying history exists", () => {
+  const snapshot = buildGlobalMetricsSnapshot({
+    window: createGlobalMetricsSnapshotWindow({
+      now: new Date("2026-04-23T09:30:00.000Z"),
+      historicalStartDate: null,
+    }),
+    totalsRow: {
+      unique_reviewing_users: 0,
+      total_review_events: 0,
+      web_review_events: 0,
+      android_review_events: 0,
+      ios_review_events: 0,
+    },
+    dayRows: [],
+  });
+
+  assert.equal(snapshot.schemaVersion, globalMetricsSnapshotSchemaVersion);
+  assert.equal(snapshot.from, "2026-04-22");
+  assert.equal(snapshot.to, "2026-04-22");
+  assert.equal(snapshot.totals.uniqueReviewingUsers, 0);
+  assert.deepEqual(snapshot.totals.reviewEvents, {
+    total: 0,
+    byPlatform: {
+      web: 0,
+      android: 0,
+      ios: 0,
+    },
+  });
+  assert.deepEqual(snapshot.days, [
+    {
+      date: "2026-04-22",
+      uniqueReviewingUsers: 0,
+      reviewEvents: {
+        total: 0,
+        byPlatform: {
+          web: 0,
+          android: 0,
+          ios: 0,
+        },
+      },
+    },
+  ]);
+});
+
+// TODO: Remove this rollout compatibility case after production no longer serves the legacy 90-day snapshot shape.
+test("parseGlobalMetricsSnapshotJson tolerates the legacy trailing-window snapshot during rollout", () => {
+  const days = Array.from({ length: 90 }, (_, index) => {
+    const date = new Date(Date.UTC(2026, 0, 23 + index)).toISOString().slice(0, 10);
+    if (index === 0) {
+      return {
+        date,
+        uniqueReviewingUsers: 2,
+        reviewEvents: {
+          total: 3,
+          byPlatform: {
+            web: 1,
+            android: 1,
+            ios: 1,
+          },
+        },
+      };
+    }
+
+    if (index === 89) {
+      return {
+        date,
+        uniqueReviewingUsers: 2,
+        reviewEvents: {
+          total: 2,
+          byPlatform: {
+            web: 1,
+            android: 1,
+            ios: 0,
+          },
+        },
+      };
+    }
+
+    return {
+      date,
+      uniqueReviewingUsers: 0,
+      reviewEvents: {
+        total: 0,
+        byPlatform: {
+          web: 0,
+          android: 0,
+          ios: 0,
+        },
+      },
+    };
+  });
+
+  const snapshot = parseGlobalMetricsSnapshotJson(JSON.stringify({
+    schemaVersion: globalMetricsSnapshotSchemaVersion,
+    generatedAtUtc: "2026-04-23T09:30:00.000Z",
+    asOfUtc: "2026-04-23T00:00:00.000Z",
+    from: "2026-01-23",
+    to: "2026-04-22",
+    totals: {
+      uniqueReviewingUsers: 8,
+      reviewEvents: {
+        total: 12,
+        byPlatform: {
+          web: 4,
+          android: 5,
+          ios: 3,
+        },
+      },
+    },
+    days,
+  }));
+
+  assert.equal(snapshot.schemaVersion, globalMetricsSnapshotSchemaVersion);
+  assert.equal(snapshot.from, "2026-01-23");
+  assert.equal(snapshot.to, "2026-04-22");
+  assert.equal(snapshot.days.length, 90);
+  assert.equal(snapshot.totals.reviewEvents.total, 12);
 });

--- a/apps/backend/src/globalMetrics/snapshot.ts
+++ b/apps/backend/src/globalMetrics/snapshot.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 
 const millisecondsPerDay = 86_400_000;
 const utcDatePattern = /^\d{4}-\d{2}-\d{2}$/;
-
-export const globalMetricsTrailingCompleteUtcDayCount = 90;
+const legacyGlobalMetricsSnapshotTrailingUtcDayCount = 90;
+export const globalMetricsSnapshotSchemaVersion = 1 as const;
 
 export type GlobalMetricsReviewEventsByPlatform = Readonly<{
   web: number;
@@ -23,7 +23,7 @@ export type GlobalMetricsSnapshotDay = Readonly<{
 }>;
 
 export type GlobalMetricsSnapshot = Readonly<{
-  schemaVersion: 1;
+  schemaVersion: typeof globalMetricsSnapshotSchemaVersion;
   generatedAtUtc: string;
   asOfUtc: string;
   from: string;
@@ -62,6 +62,8 @@ export type GlobalMetricsSnapshotDayRow = Readonly<{
   ios_review_events: number | string;
 }>;
 
+export type GlobalMetricsSnapshotHistoricalStartDate = string | null;
+
 const globalMetricsReviewEventsByPlatformSchema = z.object({
   web: z.number().int().nonnegative(),
   android: z.number().int().nonnegative(),
@@ -80,7 +82,7 @@ const globalMetricsSnapshotDaySchema = z.object({
 }).strict();
 
 export const globalMetricsSnapshotSchema = z.object({
-  schemaVersion: z.literal(1),
+  schemaVersion: z.literal(globalMetricsSnapshotSchemaVersion),
   generatedAtUtc: z.string().datetime(),
   asOfUtc: z.string().datetime(),
   from: z.string().regex(utcDatePattern),
@@ -226,12 +228,6 @@ function createSnapshotDayFromRow(row: GlobalMetricsSnapshotDayRow): GlobalMetri
 
 function assertSnapshotDayRange(snapshot: GlobalMetricsSnapshot): void {
   const expectedDates = createInclusiveUtcDateRange(snapshot.from, snapshot.to);
-  if (expectedDates.length !== globalMetricsTrailingCompleteUtcDayCount) {
-    throw new Error(
-      `Global metrics snapshot date window must cover exactly ${globalMetricsTrailingCompleteUtcDayCount} days.`,
-    );
-  }
-
   if (snapshot.days.length !== expectedDates.length) {
     throw new Error(
       `Global metrics snapshot days length must be ${expectedDates.length}, received ${snapshot.days.length}.`,
@@ -275,11 +271,6 @@ function assertSnapshotTimeWindow(snapshot: GlobalMetricsSnapshot): void {
   if (snapshot.to !== expectedTo) {
     throw new Error(`Global metrics snapshot to must equal ${expectedTo}.`);
   }
-
-  const expectedFrom = formatUtcDate(shiftUtcDate(asOfDate, -globalMetricsTrailingCompleteUtcDayCount));
-  if (snapshot.from !== expectedFrom) {
-    throw new Error(`Global metrics snapshot from must equal ${expectedFrom}.`);
-  }
 }
 
 function assertReviewEventsByPlatformSum(
@@ -296,33 +287,82 @@ function assertReviewEventsByPlatformSum(
   }
 }
 
-function assertSnapshotReviewEventShapes(snapshot: GlobalMetricsSnapshot): void {
-  assertReviewEventsByPlatformSum(snapshot.totals.reviewEvents, "totals.reviewEvents");
+function calculateSnapshotReviewEventSums(snapshot: GlobalMetricsSnapshot): GlobalMetricsReviewEvents {
+  let daySeriesTotal = 0;
+  let daySeriesWebTotal = 0;
+  let daySeriesAndroidTotal = 0;
+  let daySeriesIosTotal = 0;
 
   for (const day of snapshot.days) {
     assertReviewEventsByPlatformSum(day.reviewEvents, `days.${day.date}.reviewEvents`);
+    daySeriesTotal += day.reviewEvents.total;
+    daySeriesWebTotal += day.reviewEvents.byPlatform.web;
+    daySeriesAndroidTotal += day.reviewEvents.byPlatform.android;
+    daySeriesIosTotal += day.reviewEvents.byPlatform.ios;
+  }
+
+  return createReviewEvents(
+    daySeriesTotal,
+    daySeriesWebTotal,
+    daySeriesAndroidTotal,
+    daySeriesIosTotal,
+  );
+}
+
+function assertSnapshotReviewEventShapes(snapshot: GlobalMetricsSnapshot): void {
+  assertReviewEventsByPlatformSum(snapshot.totals.reviewEvents, "totals.reviewEvents");
+  calculateSnapshotReviewEventSums(snapshot);
+}
+
+function assertSnapshotReviewEventSeriesMatchesDays(snapshot: GlobalMetricsSnapshot): void {
+  const daySeriesReviewEvents = calculateSnapshotReviewEventSums(snapshot);
+  if (
+    snapshot.totals.reviewEvents.total !== daySeriesReviewEvents.total
+    || snapshot.totals.reviewEvents.byPlatform.web !== daySeriesReviewEvents.byPlatform.web
+    || snapshot.totals.reviewEvents.byPlatform.android !== daySeriesReviewEvents.byPlatform.android
+    || snapshot.totals.reviewEvents.byPlatform.ios !== daySeriesReviewEvents.byPlatform.ios
+  ) {
+    throw new Error(
+      "Global metrics snapshot totals.reviewEvents must equal the sum of day review events.",
+    );
   }
 }
 
-function assertGlobalMetricsSnapshotInvariants(snapshot: GlobalMetricsSnapshot): void {
+function assertGlobalMetricsSnapshotStructuralInvariants(snapshot: GlobalMetricsSnapshot): void {
   assertSnapshotTimeWindow(snapshot);
   assertSnapshotDayRange(snapshot);
   assertSnapshotReviewEventShapes(snapshot);
 }
 
-export function createGlobalMetricsSnapshotWindow(now: Date): GlobalMetricsSnapshotWindow {
-  if (Number.isNaN(now.getTime())) {
+function isLegacyTrailingWindowSnapshot(snapshot: GlobalMetricsSnapshot): boolean {
+  // Existing deployments can still hold the old bounded snapshot until the first
+  // post-deploy seed rewrites the same S3 key with the all-time payload.
+  const asOfDate = parseCanonicalUtcTimestamp(snapshot.asOfUtc, "asOfUtc");
+  const expectedLegacyFrom = formatUtcDate(shiftUtcDate(asOfDate, -legacyGlobalMetricsSnapshotTrailingUtcDayCount));
+  return snapshot.from === expectedLegacyFrom && snapshot.days.length === legacyGlobalMetricsSnapshotTrailingUtcDayCount;
+}
+
+export function createGlobalMetricsSnapshotWindow(params: Readonly<{
+  now: Date;
+  historicalStartDate: GlobalMetricsSnapshotHistoricalStartDate;
+}>): GlobalMetricsSnapshotWindow {
+  if (Number.isNaN(params.now.getTime())) {
     throw new Error("Global metrics snapshot window requires a valid generation time.");
   }
 
-  const asOfDate = createUtcMidnightBoundary(now);
+  const asOfDate = createUtcMidnightBoundary(params.now);
   const toDate = shiftUtcDate(asOfDate, -1);
-  const fromDate = shiftUtcDate(asOfDate, -globalMetricsTrailingCompleteUtcDayCount);
+  const fromDate = params.historicalStartDate === null
+    ? toDate
+    : parseUtcDate(params.historicalStartDate, "historicalStartDate");
+  if (fromDate.getTime() > toDate.getTime()) {
+    throw new Error("Global metrics snapshot historicalStartDate must be less than or equal to to.");
+  }
   const from = formatUtcDate(fromDate);
   const to = formatUtcDate(toDate);
 
   return {
-    generatedAtUtc: now.toISOString(),
+    generatedAtUtc: params.now.toISOString(),
     asOfUtc: asOfDate.toISOString(),
     from,
     to,
@@ -354,7 +394,7 @@ export function buildGlobalMetricsSnapshot(params: Readonly<{
   }
 
   const snapshot: GlobalMetricsSnapshot = {
-    schemaVersion: 1,
+    schemaVersion: globalMetricsSnapshotSchemaVersion,
     generatedAtUtc: params.window.generatedAtUtc,
     asOfUtc: params.window.asOfUtc,
     from: params.window.from,
@@ -386,7 +426,8 @@ export function buildGlobalMetricsSnapshot(params: Readonly<{
     days: params.window.days.map((date) => daysByDate.get(date) ?? createEmptySnapshotDay(date)),
   };
 
-  assertGlobalMetricsSnapshotInvariants(snapshot);
+  assertGlobalMetricsSnapshotStructuralInvariants(snapshot);
+  assertSnapshotReviewEventSeriesMatchesDays(snapshot);
   return snapshot;
 }
 
@@ -410,6 +451,15 @@ export function parseGlobalMetricsSnapshotJson(value: string): GlobalMetricsSnap
   }
 
   const snapshot: GlobalMetricsSnapshot = parsedSnapshot.data;
-  assertGlobalMetricsSnapshotInvariants(snapshot);
+  assertGlobalMetricsSnapshotStructuralInvariants(snapshot);
+
+  try {
+    assertSnapshotReviewEventSeriesMatchesDays(snapshot);
+  } catch (error) {
+    if (!isLegacyTrailingWindowSnapshot(snapshot)) {
+      throw error;
+    }
+  }
+
   return snapshot;
 }

--- a/apps/backend/src/routes/globalSnapshot.test.ts
+++ b/apps/backend/src/routes/globalSnapshot.test.ts
@@ -16,7 +16,10 @@ import { createGlobalSnapshotRoutes, globalSnapshotPath } from "./globalSnapshot
 
 function createSnapshotFixture(): GlobalMetricsSnapshot {
   return buildGlobalMetricsSnapshot({
-    window: createGlobalMetricsSnapshotWindow(new Date("2026-04-23T09:30:00.000Z")),
+    window: createGlobalMetricsSnapshotWindow({
+      now: new Date("2026-04-23T09:30:00.000Z"),
+      historicalStartDate: "2026-03-07",
+    }),
     totalsRow: {
       unique_reviewing_users: 3,
       total_review_events: 5,
@@ -26,7 +29,7 @@ function createSnapshotFixture(): GlobalMetricsSnapshot {
     },
     dayRows: [
       {
-        review_date: "2026-01-23",
+        review_date: "2026-03-07",
         unique_reviewing_users: 2,
         total_review_events: 3,
         web_review_events: 1,

--- a/docs/global-metrics.md
+++ b/docs/global-metrics.md
@@ -30,22 +30,22 @@ The JSON contract is:
   "schemaVersion": 1,
   "generatedAtUtc": "2026-04-23T01:00:12.345Z",
   "asOfUtc": "2026-04-23T00:00:00.000Z",
-  "from": "2026-01-23",
+  "from": "2026-04-21",
   "to": "2026-04-22",
   "totals": {
     "uniqueReviewingUsers": 8,
     "reviewEvents": {
-      "total": 12,
+      "total": 5,
       "byPlatform": {
-        "web": 4,
-        "android": 5,
-        "ios": 3
+        "web": 2,
+        "android": 2,
+        "ios": 1
       }
     }
   },
   "days": [
     {
-      "date": "2026-01-23",
+      "date": "2026-04-21",
       "uniqueReviewingUsers": 2,
       "reviewEvents": {
         "total": 3,
@@ -53,6 +53,18 @@ The JSON contract is:
           "web": 1,
           "android": 1,
           "ios": 1
+        }
+      }
+    },
+    {
+      "date": "2026-04-22",
+      "uniqueReviewingUsers": 2,
+      "reviewEvents": {
+        "total": 2,
+        "byPlatform": {
+          "web": 1,
+          "android": 1,
+          "ios": 0
         }
       }
     }
@@ -68,17 +80,19 @@ Contract rules:
 - `from` and `to` are inclusive UTC dates for the `days` array.
 - `totals.uniqueReviewingUsers` is a number.
 - `totals.reviewEvents.total` is a number and must equal the sum of `totals.reviewEvents.byPlatform`.
-- `days` is an ordered, zero-filled 90-item UTC date series from `from` through `to`.
+- `days` is an ordered, zero-filled all-time UTC date series from `from` through `to`.
 - Each `days[]` entry contains `date`, `uniqueReviewingUsers`, and `reviewEvents`.
 - `to` is always the UTC day immediately before `asOfUtc`.
-- `from` is always 90 complete UTC days before `asOfUtc`.
+- `from` is the earliest included UTC day with qualifying persisted review activity before `asOfUtc`.
+- If there is no qualifying review activity before `asOfUtc`, `from` equals `to` and `days` contains one zero-value UTC day.
+- `totals.reviewEvents` equals the sum of the all-time `days[].reviewEvents` series because both cover the same all-time date range.
 
 ## Counting Semantics
 
 The snapshot uses `content.review_events.reviewed_at_server` and UTC calendar days.
 
 - `totals` are cumulative for all matching review activity before `asOfUtc`.
-- `days` covers only the trailing 90 complete UTC days from `from` through `to`.
+- `days` covers all complete UTC days from `from` through `to`.
 - Missing days are represented as explicit zero-value entries instead of being omitted.
 - `reviewEvents.byPlatform` contains `web`, `android`, and `ios`.
 - Do not infer per-platform unique user counts from review-event volume.
@@ -90,7 +104,8 @@ That means these counts are not immutable historical authorship: if the current 
 
 - Treat the snapshot as a cached daily aggregate, not a live analytics stream.
 - Render UTC dates exactly as provided instead of converting bucket labels into local time.
-- Do not expect the `totals` counters to equal the sum of the 90-day `days` series.
+- Expect the payload to grow by one `days[]` row per UTC day after the first qualifying review date, and possibly grow backward if older review history is backfilled later.
+- Treat `totals` as the canonical headline counters; for review events they should match the sum of the all-time `days` series.
 - Websites can fetch this endpoint when visibility is enabled, and future mobile-app endpoint consumers can do the same once those clients add UI.
 
 Deployment details are documented in [docs/backend-web-deployment.md](./backend-web-deployment.md).

--- a/scripts/check-public-endpoints.sh
+++ b/scripts/check-public-endpoints.sh
@@ -358,7 +358,6 @@ required_top_level_keys = ["schemaVersion", "generatedAtUtc", "asOfUtc", "from",
 required_total_keys = ["uniqueReviewingUsers", "reviewEvents"]
 required_review_event_keys = ["total", "byPlatform"]
 expected_platform_keys = ["web", "android", "ios"]
-expected_day_count = 90
 
 
 def require(condition: bool, message: str) -> None:
@@ -404,7 +403,7 @@ require(isinstance(payload["to"], str), "to must be a string")
 to_date = datetime.date.fromisoformat(payload["to"])
 require(from_date <= to_date, "from must be less than or equal to to")
 require(to_date == (as_of.date() - datetime.timedelta(days=1)), "to must be the UTC day immediately before asOfUtc")
-require(from_date == (as_of.date() - datetime.timedelta(days=expected_day_count)), "from must be the UTC day window start")
+expected_day_count = (to_date - from_date).days + 1
 
 totals = payload["totals"]
 require(isinstance(totals, dict), "totals must be an object")
@@ -418,6 +417,10 @@ require(len(days) == expected_day_count, f"days must contain exactly {expected_d
 
 seen_dates: set[str] = set()
 previous_date: datetime.date | None = None
+day_review_total = 0
+day_review_web_total = 0
+day_review_android_total = 0
+day_review_ios_total = 0
 for index, entry in enumerate(days):
     label = f"days[{index}]"
     require(isinstance(entry, dict), f"{label} must be an object")
@@ -433,6 +436,15 @@ for index, entry in enumerate(days):
     previous_date = current_date
     require_non_negative_int(entry["uniqueReviewingUsers"], f"{label}.uniqueReviewingUsers")
     validate_review_events(entry["reviewEvents"], f"{label}.reviewEvents")
+    day_review_total += entry["reviewEvents"]["total"]
+    day_review_web_total += entry["reviewEvents"]["byPlatform"]["web"]
+    day_review_android_total += entry["reviewEvents"]["byPlatform"]["android"]
+    day_review_ios_total += entry["reviewEvents"]["byPlatform"]["ios"]
+
+require(day_review_total == totals["reviewEvents"]["total"], "totals.reviewEvents.total must equal the sum of day review events")
+require(day_review_web_total == totals["reviewEvents"]["byPlatform"]["web"], "totals.reviewEvents.byPlatform.web must equal the sum of day web review events")
+require(day_review_android_total == totals["reviewEvents"]["byPlatform"]["android"], "totals.reviewEvents.byPlatform.android must equal the sum of day android review events")
+require(day_review_ios_total == totals["reviewEvents"]["byPlatform"]["ios"], "totals.reviewEvents.byPlatform.ios must equal the sum of day ios review events")
 PY
 }
 


### PR DESCRIPTION
## Summary
- switch the global metrics snapshot to an all-time window derived from the earliest qualifying review date
- keep the existing /v1/global/snapshot surface and storage key while tolerating the legacy 90-day payload during rollout
- update docs, checks, and targeted tests for the new all-time contract
