### PR TITLE
Add admin review date range filters

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -60,4 +60,6 @@ The dashboard shows four review charts:
 - daily active users by platform
 - daily review events by platform
 
+The default chart range starts on the first calendar day with any `content.review_events.reviewed_at_server` row and ends on today, inclusive, in the dashboard timezone. The dashboard includes date range filters that can narrow the chart range and reset back to that default.
+
 Its SQL lives in the admin frontend as a chart-owned query and runs through the generic admin reporting endpoint.

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -7,7 +7,11 @@ import {
 } from "./adminApi";
 import { getAdminAppConfig, type AdminAppConfig } from "./config";
 import { ReviewEventsByDateDashboard } from "./reports/reviewEventsByDate/ReviewEventsByDateDashboard";
-import { loadReviewEventsByDateReport } from "./reports/reviewEventsByDate/query";
+import {
+  loadReviewEventsByDateDefaultRange,
+  loadReviewEventsByDateReport,
+  type ReviewEventsByDateRange,
+} from "./reports/reviewEventsByDate/query";
 
 type AppState =
   | Readonly<{ status: "loading" }>
@@ -16,9 +20,16 @@ type AppState =
   | Readonly<{ status: "error"; message: string }>
   | Readonly<{
       status: "ready";
+      config: AdminAppConfig;
       session: AdminSession;
+      timezone: string;
+      defaultRange: ReviewEventsByDateRange;
       report: ReviewEventsByDateReport;
+      isReportLoading: boolean;
+      dateRangeError: string;
     }>;
+
+const calendarDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/u;
 
 function resolveBrowserTimezone(): string {
   try {
@@ -28,22 +39,57 @@ function resolveBrowserTimezone(): string {
   }
 }
 
-function formatDateOnly(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, "0");
-  const day = `${date.getDate()}`.padStart(2, "0");
-  return `${year}-${month}-${day}`;
+function parseCalendarDate(date: string, fieldName: string): Date {
+  const match = calendarDatePattern.exec(date);
+  if (match === null) {
+    throw new Error(`${fieldName} must be a valid YYYY-MM-DD date.`);
+  }
+
+  const year = Number.parseInt(match[1], 10);
+  const monthIndex = Number.parseInt(match[2], 10) - 1;
+  const day = Number.parseInt(match[3], 10);
+  const parsedDate = new Date(Date.UTC(year, monthIndex, day));
+
+  if (
+    Number.isNaN(parsedDate.getTime())
+    || parsedDate.getUTCFullYear() !== year
+    || parsedDate.getUTCMonth() !== monthIndex
+    || parsedDate.getUTCDate() !== day
+  ) {
+    throw new Error(`${fieldName} must be a valid calendar date.`);
+  }
+
+  return parsedDate;
 }
 
-function getDefaultRange(): Readonly<{ from: string; to: string }> {
-  const endDate = new Date();
-  const startDate = new Date(endDate);
-  startDate.setDate(endDate.getDate() - 89);
+function compareCalendarDates(left: string, right: string): number {
+  return parseCalendarDate(left, "Date").getTime() - parseCalendarDate(right, "Date").getTime();
+}
 
-  return {
-    from: formatDateOnly(startDate),
-    to: formatDateOnly(endDate),
-  };
+function validateRequestedRange(
+  range: ReviewEventsByDateRange,
+  defaultRange: ReviewEventsByDateRange,
+): string | null {
+  try {
+    parseCalendarDate(range.from, "From date");
+    parseCalendarDate(range.to, "To date");
+  } catch (error) {
+    return error instanceof Error ? error.message : "Date range is invalid.";
+  }
+
+  if (compareCalendarDates(range.from, range.to) > 0) {
+    return "From date must be on or before To date.";
+  }
+
+  if (compareCalendarDates(range.from, defaultRange.from) < 0) {
+    return `From date must be on or after ${defaultRange.from}.`;
+  }
+
+  if (compareCalendarDates(range.to, defaultRange.to) > 0) {
+    return `To date must be on or before ${defaultRange.to}.`;
+  }
+
+  return null;
 }
 
 function redirectToLogin(config: AdminAppConfig): void {
@@ -92,19 +138,42 @@ function ErrorState(props: Readonly<{ message: string }>): JSX.Element {
   );
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Unexpected admin app error.";
+}
+
 export default function App(): JSX.Element {
   const [appState, setAppState] = useState<AppState>({ status: "loading" });
+
+  function handleTerminalAdminError(error: unknown, config: AdminAppConfig): boolean {
+    if (error instanceof AdminApiError) {
+      if (error.status === 401) {
+        setAppState({ status: "redirecting" });
+        redirectToLogin(config);
+        return true;
+      }
+
+      if (error.status === 403 && error.code === "ADMIN_ACCESS_REQUIRED") {
+        setAppState({ status: "denied" });
+        return true;
+      }
+    }
+
+    return false;
+  }
 
   useEffect(() => {
     let cancelled = false;
 
     async function load(): Promise<void> {
+      let config: AdminAppConfig | null = null;
+
       try {
-        const config = getAdminAppConfig();
+        config = getAdminAppConfig();
         const session = await fetchAdminSession(config);
         const timezone = resolveBrowserTimezone();
-        const range = getDefaultRange();
-        const report = await loadReviewEventsByDateReport(config, timezone, range.from, range.to);
+        const defaultRange = await loadReviewEventsByDateDefaultRange(config, timezone);
+        const report = await loadReviewEventsByDateReport(config, timezone, defaultRange.from, defaultRange.to);
 
         if (cancelled) {
           return;
@@ -112,32 +181,26 @@ export default function App(): JSX.Element {
 
         setAppState({
           status: "ready",
+          config,
           session,
+          timezone,
+          defaultRange,
           report,
+          isReportLoading: false,
+          dateRangeError: "",
         });
       } catch (error) {
         if (cancelled) {
           return;
         }
 
-        if (error instanceof AdminApiError) {
-          if (error.status === 401) {
-            setAppState({ status: "redirecting" });
-            const config = getAdminAppConfig();
-            redirectToLogin(config);
-            return;
-          }
-
-          if (error.status === 403 && error.code === "ADMIN_ACCESS_REQUIRED") {
-            setAppState({ status: "denied" });
-            return;
-          }
+        if (config !== null && handleTerminalAdminError(error, config)) {
+          return;
         }
 
-        const message = error instanceof Error ? error.message : "Unexpected admin app error.";
         setAppState({
           status: "error",
-          message,
+          message: getErrorMessage(error),
         });
       }
     }
@@ -148,6 +211,74 @@ export default function App(): JSX.Element {
       cancelled = true;
     };
   }, []);
+
+  async function reloadReport(range: ReviewEventsByDateRange): Promise<void> {
+    if (appState.status !== "ready" || appState.isReportLoading) {
+      return;
+    }
+
+    const validationError = validateRequestedRange(range, appState.defaultRange);
+    if (validationError !== null) {
+      setAppState({
+        ...appState,
+        dateRangeError: validationError,
+      });
+      return;
+    }
+
+    const readyState = appState;
+    setAppState({
+      ...readyState,
+      isReportLoading: true,
+      dateRangeError: "",
+    });
+
+    try {
+      const report = await loadReviewEventsByDateReport(
+        readyState.config,
+        readyState.timezone,
+        range.from,
+        range.to,
+      );
+
+      setAppState((currentState) => {
+        if (currentState.status !== "ready") {
+          return currentState;
+        }
+
+        return {
+          ...currentState,
+          report,
+          isReportLoading: false,
+          dateRangeError: "",
+        };
+      });
+    } catch (error) {
+      if (handleTerminalAdminError(error, readyState.config)) {
+        return;
+      }
+
+      setAppState((currentState) => {
+        if (currentState.status !== "ready") {
+          return currentState;
+        }
+
+        return {
+          ...currentState,
+          isReportLoading: false,
+          dateRangeError: getErrorMessage(error),
+        };
+      });
+    }
+  }
+
+  function resetReportRange(): void {
+    if (appState.status !== "ready") {
+      return;
+    }
+
+    void reloadReport(appState.defaultRange);
+  }
 
   if (appState.status === "loading" || appState.status === "redirecting") {
     return <LoadingState />;
@@ -165,6 +296,11 @@ export default function App(): JSX.Element {
     <ReviewEventsByDateDashboard
       report={appState.report}
       adminEmail={appState.session.email}
+      defaultRange={appState.defaultRange}
+      isReportLoading={appState.isReportLoading}
+      dateRangeError={appState.dateRangeError}
+      onDateRangeApply={(range) => void reloadReport(range)}
+      onDateRangeReset={resetReportRange}
     />
   );
 }

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent, type JSX } from "react";
 import * as d3 from "d3";
 import {
   reviewEventPlatforms,
@@ -7,6 +7,7 @@ import {
   type ReviewEventsByDatePlatformReviewEventTotal,
   type ReviewEventsByDateReport,
 } from "../../adminApi";
+import type { ReviewEventsByDateRange } from "./query";
 
 type ChartTooltipState = Readonly<{
   visible: boolean;
@@ -329,6 +330,11 @@ export function ReviewEventsByDateDashboard(
   props: Readonly<{
     report: ReviewEventsByDateReport;
     adminEmail: string;
+    defaultRange: ReviewEventsByDateRange;
+    isReportLoading: boolean;
+    dateRangeError: string;
+    onDateRangeApply: (range: ReviewEventsByDateRange) => void;
+    onDateRangeReset: () => void;
   }>,
 ): JSX.Element {
   const uniqueUsersChartRef = useRef<SVGSVGElement | null>(null);
@@ -341,6 +347,43 @@ export function ReviewEventsByDateDashboard(
     left: 0,
     top: 0,
   });
+  const [draftRange, setDraftRange] = useState<ReviewEventsByDateRange>({
+    from: props.report.from,
+    to: props.report.to,
+  });
+
+  useEffect(() => {
+    setDraftRange({
+      from: props.report.from,
+      to: props.report.to,
+    });
+  }, [props.report.from, props.report.to]);
+
+  function handleFromDateChange(event: ChangeEvent<HTMLInputElement>): void {
+    const from = event.currentTarget.value;
+    setDraftRange((currentRange) => ({
+      ...currentRange,
+      from,
+    }));
+  }
+
+  function handleToDateChange(event: ChangeEvent<HTMLInputElement>): void {
+    const to = event.currentTarget.value;
+    setDraftRange((currentRange) => ({
+      ...currentRange,
+      to,
+    }));
+  }
+
+  function handleDateRangeSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    props.onDateRangeApply(draftRange);
+  }
+
+  function handleDateRangeReset(): void {
+    setDraftRange(props.defaultRange);
+    props.onDateRangeReset();
+  }
 
   const dates = useMemo(
     () => props.report.dateTotals.map((item) => item.date),
@@ -678,7 +721,7 @@ export function ReviewEventsByDateDashboard(
   const summaryCards = [
     { label: "Total Review Events", value: props.report.totalReviewEvents.toLocaleString("en-US") },
     { label: "Users With Review Events", value: props.report.users.length.toLocaleString("en-US") },
-    { label: "Dates With Review Events", value: props.report.dateTotals.length.toLocaleString("en-US") },
+    { label: "Days In Range", value: props.report.dateTotals.length.toLocaleString("en-US") },
     { label: "Peak Daily Volume", value: peakDailyVolume.toLocaleString("en-US") },
     { label: "Peak Daily Unique Users", value: peakDailyUniqueUsers.toLocaleString("en-US") },
   ];
@@ -697,6 +740,53 @@ export function ReviewEventsByDateDashboard(
           <span className="hero-badge">Signed in as {props.adminEmail}</span>
           <span className="hero-badge">Range {formatDateRangeLabel(props.report.from)} to {formatDateRangeLabel(props.report.to)}</span>
         </div>
+      </section>
+
+      <section className="filter-panel" aria-labelledby="review-date-range-title">
+        <div className="filter-panel-header">
+          <div>
+            <p className="eyebrow">Filters</p>
+            <h2 id="review-date-range-title">Date Range</h2>
+          </div>
+          <span className={`filter-status${props.isReportLoading ? " active" : ""}`} aria-live="polite">
+            {props.isReportLoading ? "Updating" : `Default ${props.defaultRange.from} to ${props.defaultRange.to}`}
+          </span>
+        </div>
+        <form className="date-filter-form" noValidate onSubmit={handleDateRangeSubmit}>
+          <label className="date-filter-field">
+            <span>From</span>
+            <input
+              type="date"
+              value={draftRange.from}
+              min={props.defaultRange.from}
+              max={props.defaultRange.to}
+              disabled={props.isReportLoading}
+              onChange={handleFromDateChange}
+            />
+          </label>
+          <label className="date-filter-field">
+            <span>To</span>
+            <input
+              type="date"
+              value={draftRange.to}
+              min={props.defaultRange.from}
+              max={props.defaultRange.to}
+              disabled={props.isReportLoading}
+              onChange={handleToDateChange}
+            />
+          </label>
+          <div className="date-filter-actions">
+            <button className="filter-button filter-button-primary" type="submit" disabled={props.isReportLoading}>
+              Apply
+            </button>
+            <button className="filter-button" type="button" disabled={props.isReportLoading} onClick={handleDateRangeReset}>
+              Reset
+            </button>
+          </div>
+        </form>
+        {props.dateRangeError !== "" ? (
+          <p className="filter-error" role="alert">{props.dateRangeError}</p>
+        ) : null}
       </section>
 
       <section className="summary-grid">

--- a/apps/admin/src/reports/reviewEventsByDate/query.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/query.ts
@@ -24,6 +24,16 @@ type ReviewEventsByDateQueryRow = Readonly<{
   review_event_count: string | number;
 }>;
 
+export type ReviewEventsByDateRange = Readonly<{
+  from: string;
+  to: string;
+}>;
+
+type ReviewEventsByDateDefaultRangeQueryRow = Readonly<{
+  from_date: string;
+  to_date: string;
+}>;
+
 function parseCalendarDate(date: string): Date {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(date);
   if (match === null) {
@@ -108,6 +118,25 @@ function toReviewEventsByDateQueryRow(resultSetRow: Readonly<Record<string, Admi
     platform: assertPlatform(resultSetRow.platform ?? null, "platform"),
     review_event_count: toInteger(resultSetRow.review_event_count ?? null, "review_event_count"),
   };
+}
+
+function toReviewEventsByDateDefaultRangeQueryRow(
+  resultSetRow: Readonly<Record<string, AdminQueryValue>>,
+): ReviewEventsByDateDefaultRangeQueryRow {
+  return {
+    from_date: assertIsString(resultSetRow.from_date ?? null, "from_date"),
+    to_date: assertIsString(resultSetRow.to_date ?? null, "to_date"),
+  };
+}
+
+function assertValidDateRange(range: ReviewEventsByDateRange, fieldName: string): ReviewEventsByDateRange {
+  const fromDate = parseCalendarDate(range.from);
+  const toDate = parseCalendarDate(range.to);
+  if (fromDate.getTime() > toDate.getTime()) {
+    throw new Error(`Review events ${fieldName} date range is invalid: ${range.from} > ${range.to}`);
+  }
+
+  return range;
 }
 
 function buildReviewEventsByDateUsers(rows: ReadonlyArray<ReviewEventsByDateRow>): ReadonlyArray<ReviewEventsByDateUser> {
@@ -238,7 +267,23 @@ function buildReviewEventsByDateReport(
   };
 }
 
+export function buildReviewEventsByDateDefaultRangeSql(timezone: string): string {
+  const escapedTimezone = escapeSqlStringLiteral(timezone);
+
+  return [
+    "SELECT",
+    "  COALESCE(",
+    `    to_char(MIN(timezone(${escapedTimezone}, review_events.reviewed_at_server)::date), 'YYYY-MM-DD'),`,
+    `    to_char(timezone(${escapedTimezone}, now())::date, 'YYYY-MM-DD')`,
+    "  ) AS from_date,",
+    `  to_char(timezone(${escapedTimezone}, now())::date, 'YYYY-MM-DD') AS to_date`,
+    "FROM content.review_events AS review_events",
+  ].join("\n");
+}
+
 export function buildReviewEventsByDateSql(timezone: string, from: string, to: string): string {
+  assertValidDateRange({ from, to }, "report");
+
   return [
     "SELECT",
     "  to_char(timezone(",
@@ -273,6 +318,36 @@ export function buildReviewEventsByDateSql(timezone: string, from: string, to: s
     "  workspace_replicas.user_id ASC,",
     "  workspace_replicas.platform ASC",
   ].join("\n");
+}
+
+export async function loadReviewEventsByDateDefaultRange(
+  config: AdminAppConfig,
+  timezone: string,
+): Promise<ReviewEventsByDateRange> {
+  const response = await runAdminQuery(config, buildReviewEventsByDateDefaultRangeSql(timezone));
+  if (response.resultSets.length !== 1) {
+    throw new Error("Review events default range query must return exactly one result set.");
+  }
+
+  const resultSet = response.resultSets[0];
+  if (resultSet === undefined) {
+    throw new Error("Review events default range query result set is missing.");
+  }
+
+  if (resultSet.rows.length !== 1) {
+    throw new Error(`Review events default range query must return exactly one row. Got ${resultSet.rows.length}.`);
+  }
+
+  const row = resultSet.rows[0];
+  if (row === undefined) {
+    throw new Error("Review events default range query row is missing.");
+  }
+
+  const rangeRow = toReviewEventsByDateDefaultRangeQueryRow(row);
+  return assertValidDateRange({
+    from: rangeRow.from_date,
+    to: rangeRow.to_date,
+  }, "default");
 }
 
 export async function loadReviewEventsByDateReport(

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -127,6 +127,125 @@ h2 {
   margin: 24px 0;
 }
 
+.filter-panel {
+  display: grid;
+  gap: 16px;
+  margin: 24px 0;
+  padding: 18px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  box-shadow: var(--shadow-soft);
+}
+
+.filter-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.filter-status {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.filter-status.active {
+  color: var(--text);
+  border-color: rgba(214, 90, 56, 0.42);
+  background: rgba(196, 75, 45, 0.16);
+}
+
+.date-filter-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 240px)) auto;
+  align-items: end;
+  gap: 12px;
+}
+
+.date-filter-field {
+  display: grid;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.date-filter-field input {
+  width: 100%;
+  height: 42px;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: none;
+  padding: 0 12px;
+  outline: none;
+}
+
+.date-filter-field input:focus {
+  border-color: rgba(214, 90, 56, 0.78);
+  box-shadow: 0 0 0 3px rgba(196, 75, 45, 0.18);
+}
+
+.date-filter-field input:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.date-filter-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.filter-button {
+  height: 42px;
+  padding: 0 15px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.filter-button-primary {
+  border-color: rgba(214, 90, 56, 0.6);
+  background: var(--accent);
+}
+
+.filter-button:disabled {
+  cursor: wait;
+  opacity: 0.62;
+}
+
+.filter-button:not(:disabled):hover {
+  border-color: rgba(255, 255, 255, 0.24);
+  transform: translateY(-1px);
+}
+
+.filter-error {
+  margin: 0;
+  color: #ffb6a6;
+  font-size: 13px;
+  font-weight: 700;
+}
+
 .metric-card,
 .state-panel {
   background: var(--panel);
@@ -325,6 +444,22 @@ h2 {
   .chart-meta {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .filter-panel-header {
+    flex-direction: column;
+  }
+
+  .date-filter-form {
+    grid-template-columns: 1fr;
+  }
+
+  .date-filter-actions {
+    width: 100%;
+  }
+
+  .filter-button {
+    flex: 1 1 120px;
   }
 
   .chart-meta-right,

--- a/docs/admin-app.md
+++ b/docs/admin-app.md
@@ -68,6 +68,8 @@ The query payload includes:
 Current v1 attribution contract for `review-events-by-date`:
 
 - the report is intended for the current single-effective-learner workspace model
+- the default chart range starts on the first calendar day with any `content.review_events.reviewed_at_server` row and ends on today, inclusive, in the report timezone
+- dashboard date range filters can narrow that range, and Reset returns to the same first-review-day-through-today default
 - `users[]` and `rows[].userId` are derived from the current `sync.workspace_replicas.user_id` label for stacked per-user event volume
 - platform charts derive `web` / `android` / `ios` from `content.review_events.replica_id -> sync.workspace_replicas.platform`
 - that label is acceptable for today's product shape, but it is not a durable historical review-author field
@@ -141,6 +143,8 @@ The admin frontend fails fast on any other non-local hostname. Do not serve the 
 - a listed admin email loads the dashboard
 - a signed-in non-admin sees the access denied page
 - network traces show `POST /v1/admin/reports/query` for dashboard data
+- the default date filter starts on the first review-event day and ends on today
 - unique-users, stacked-by-user, platform-users, and platform-events charts all render
+- narrowing the date filter reloads all charts, and Reset restores the default range
 - no persistent email or user list is shown in the dashboard UI; stacked-by-user hover tooltips may reveal the current email and user ID for the hovered segment
 - backend logs do not show writes through the reporting path


### PR DESCRIPTION
## Summary
- default admin review charts to the first review-event day through today
- add date range filters with reset behavior for the admin dashboard
- document the default range and filter smoke expectations

## Validation
- npm run build --prefix apps/admin