### PR TITLE
[codex] Harden marketing screenshot guest cleanup

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AppStateResetRule.kt
@@ -24,71 +24,18 @@ private val testOnlyPreferenceNames: List<String> = listOf(
 )
 
 open class AppStateResetRule : ExternalResource() {
-    private val device: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
     companion object {
-        private const val appResetTimeoutMillis: Long = 20_000L
         private const val localeApplyTimeoutMillis: Long = 5_000L
-        private const val uiIdleTimeoutMillis: Long = 5_000L
     }
 
     override fun before() {
         applyConfiguredMarketingScreenshotLocaleOverride()
-        resetAppState()
+        resetAndroidTestAppState()
     }
 
     override fun after() {
-        resetAppState()
+        resetAndroidTestAppState()
         clearConfiguredMarketingScreenshotLocaleOverride()
-    }
-
-    private fun resetAppState() {
-        waitForUiIdle(phase = "before resetting app state")
-
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val application = context as FlashcardsApplication
-
-        runBlocking {
-            withTimeout(appResetTimeoutMillis) {
-                application.closeAppGraph()
-                clearTestOnlySharedPreferences(context = context)
-                application.recreateAppGraphAndAwaitStartup()
-                application.appGraph.cloudAccountRepository.logout()
-            }
-        }
-        NotificationManagerCompat.from(context).cancelAll()
-        waitForUiIdle(phase = "after resetting app state")
-    }
-
-    private fun waitForUiIdle(phase: String) {
-        device.dismissBlockingSystemDialogIfPresent()
-        val latch = CountDownLatch(1)
-        InstrumentationRegistry.getInstrumentation().waitForIdle {
-            latch.countDown()
-        }
-        val didBecomeIdle = latch.await(uiIdleTimeoutMillis, TimeUnit.MILLISECONDS)
-        device.dismissBlockingSystemDialogIfPresent()
-        if (didBecomeIdle.not()) {
-            val blockingSystemDialogSummary = device.currentBlockingSystemDialogSummaryOrNull() ?: "none"
-            throw IllegalStateException(
-                "Timed out after $uiIdleTimeoutMillis ms waiting for instrumentation to become idle $phase. " +
-                    "blockingSystemDialog=$blockingSystemDialogSummary"
-            )
-        }
-    }
-
-    private fun clearTestOnlySharedPreferences(context: Context) {
-        testOnlyPreferenceNames.forEach { preferenceName ->
-            val sharedPreferences = context.getSharedPreferences(preferenceName, Context.MODE_PRIVATE)
-            val didCommitClear = sharedPreferences.edit().clear().commit()
-            if (didCommitClear.not()) {
-                throw IllegalStateException("Failed to clear shared preferences '$preferenceName'.")
-            }
-            val didDeletePreferences = context.deleteSharedPreferences(preferenceName)
-            if (didDeletePreferences.not() && sharedPreferences.all.isNotEmpty()) {
-                throw IllegalStateException("Failed to delete shared preferences '$preferenceName'.")
-            }
-        }
     }
 
     private fun applyConfiguredMarketingScreenshotLocaleOverride() {
@@ -178,5 +125,58 @@ open class AppStateResetRule : ExternalResource() {
             "Timed out after $localeApplyTimeoutMillis ms while $phase. " +
                 "expectedLanguageTags='$expectedLanguageTags' actualLanguageTags='$actualLanguageTags'."
         )
+    }
+}
+
+internal fun resetAndroidTestAppState() {
+    waitForAndroidTestUiIdle(phase = "before resetting app state")
+
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val application = context as FlashcardsApplication
+
+    runBlocking {
+        withTimeout(appResetTimeoutMillis) {
+            application.closeAppGraph()
+            clearTestOnlySharedPreferences(context = context)
+            application.recreateAppGraphAndAwaitStartup()
+            application.appGraph.cloudAccountRepository.logout()
+        }
+    }
+    NotificationManagerCompat.from(context).cancelAll()
+    waitForAndroidTestUiIdle(phase = "after resetting app state")
+}
+
+private const val appResetTimeoutMillis: Long = 20_000L
+private const val uiIdleTimeoutMillis: Long = 5_000L
+
+private fun waitForAndroidTestUiIdle(phase: String) {
+    val device: UiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    device.dismissBlockingSystemDialogIfPresent()
+    val latch = CountDownLatch(1)
+    InstrumentationRegistry.getInstrumentation().waitForIdle {
+        latch.countDown()
+    }
+    val didBecomeIdle = latch.await(uiIdleTimeoutMillis, TimeUnit.MILLISECONDS)
+    device.dismissBlockingSystemDialogIfPresent()
+    if (didBecomeIdle.not()) {
+        val blockingSystemDialogSummary = device.currentBlockingSystemDialogSummaryOrNull() ?: "none"
+        throw IllegalStateException(
+            "Timed out after $uiIdleTimeoutMillis ms waiting for instrumentation to become idle $phase. " +
+                "blockingSystemDialog=$blockingSystemDialogSummary"
+        )
+    }
+}
+
+private fun clearTestOnlySharedPreferences(context: Context) {
+    testOnlyPreferenceNames.forEach { preferenceName ->
+        val sharedPreferences = context.getSharedPreferences(preferenceName, Context.MODE_PRIVATE)
+        val didCommitClear = sharedPreferences.edit().clear().commit()
+        if (didCommitClear.not()) {
+            throw IllegalStateException("Failed to clear shared preferences '$preferenceName'.")
+        }
+        val didDeletePreferences = context.deleteSharedPreferences(preferenceName)
+        if (didDeletePreferences.not() && sharedPreferences.all.isNotEmpty()) {
+            throw IllegalStateException("Failed to delete shared preferences '$preferenceName'.")
+        }
     }
 }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotGuestCleanupScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotGuestCleanupScript.kt
@@ -1,0 +1,36 @@
+package com.flashcardsopensourceapp.app
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val marketingScreenshotGuestCleanupTimeoutMillis: Long = 20_000L
+
+@ManualOnlyAndroidTest
+@RunWith(AndroidJUnit4::class)
+class MarketingScreenshotGuestCleanupScript {
+    @Test
+    fun deleteStoredGuestSessionThenResetLocalState() {
+        deleteStoredMarketingScreenshotGuestCloudSessionIfPresent()
+        resetAndroidTestAppState()
+    }
+}
+
+private fun deleteStoredMarketingScreenshotGuestCloudSessionIfPresent() {
+    val context: Context = ApplicationProvider.getApplicationContext<Context>()
+    val application = context as FlashcardsApplication
+
+    runBlocking {
+        withTimeout(marketingScreenshotGuestCleanupTimeoutMillis) {
+            val appGraph = requireNotNull(application.appGraphOrNull) {
+                "App graph is unavailable for marketing screenshot guest cleanup."
+            }
+            appGraph.awaitStartup()
+            appGraph.deleteStoredGuestCloudSessionIfPresent()
+        }
+    }
+}

--- a/apps/android/docs/marketing-screenshot-runbook.md
+++ b/apps/android/docs/marketing-screenshot-runbook.md
@@ -11,7 +11,8 @@ These screenshot flows are manual-only Android instrumentation entrypoints.
 They are not part of Android CI, release gates, or default `androidTest` runs.
 Each flow prepares a specific in-app state, captures a PNG on the emulator, and pulls that file into `apps/android/docs/media/play-store-screenshots/`.
 The wrappers run the dedicated `marketingScreenshot` app variant, which can include screenshot-only resource overlays from `apps/android/app/src/marketingScreenshot/res` without changing normal `debug` or `release` builds.
-The screenshot reset rule now deletes any stored guest cloud screenshot session through `POST /guest-auth/session/delete` before the local reset clears the guest token, both before and after a manual screenshot run.
+The wrapper now runs a dedicated guest cleanup entrypoint before the screenshot flow and again from an exit trap after the wrapper finishes, including failure exits.
+The screenshot reset rule also deletes any stored guest cloud screenshot session through `POST /guest-auth/session/delete` before the local reset clears the guest token, both before and after the manual screenshot test body.
 
 ## Current wrapper scripts
 

--- a/apps/android/docs/marketing-screenshots.md
+++ b/apps/android/docs/marketing-screenshots.md
@@ -35,6 +35,7 @@ The unified screenshot flow captures an exam-prep concept card about opportunity
 - cards list with the shared opportunity-cost prompt pinned to the top
 
 - Manual screenshot entrypoint: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingAllScreenshotsScript.kt`
+- Manual guest cleanup entrypoint: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotGuestCleanupScript.kt`
 - Shared screenshot helpers: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MarketingScreenshotTestSupport.kt`
 - Supported manual wrapper script: `scripts/capture-android-marketing-screenshots.sh`
 - Expected generated output PNG targets:
@@ -67,7 +68,8 @@ FLASHCARDS_MARKETING_LOCALE_PREFIX=de-DE bash scripts/capture-android-marketing-
 These scripts are not part of Android CI, release gates, or default `androidTest` runs.
 They exist only to generate marketing screenshots on demand.
 They run `:app:connectedMarketingScreenshotAndroidTest`, not the normal debug instrumentation task, so screenshot-only translations do not affect the Play-first `debug` and `release` builds.
-The screenshot reset flow deletes the guest cloud session remotely before it clears local screenshot state so the seeded guest workspace does not remain on the backend after the run.
+The wrapper also runs a dedicated guest cleanup entrypoint before the screenshot flow and again from an exit trap after the wrapper finishes, including failure exits.
+The screenshot reset flow remains as an in-test defense: it deletes the guest cloud session remotely before it clears local screenshot state so the seeded guest workspace does not remain on the backend after the run.
 
 The unified wrapper script runs one manual-only entrypoint, seeds one guest workspace, saves screenshots 1, 2, 3, 4, and 5 into `/sdcard/Download/flashcards-marketing-screenshots/`, and then pulls those files into the committed marketing media directory.
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsUITestLaunchCoordinator.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsUITestLaunchCoordinator.swift
@@ -27,7 +27,7 @@ private struct FlashcardsUITestLaunchCoordinator {
         let preservedLaunchState = FlashcardsUITestPreservedLaunchState(userDefaults: store.userDefaults)
 
         if self.launchScenario.requiresStoredGuestRemoteCleanup {
-            try await store.deleteStoredGuestCloudSessionForUITestCleanupIfNeeded()
+            _ = try await store.deleteStoredGuestCloudSessionForUITestCleanupIfNeeded()
         }
 
         do {

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
@@ -192,6 +192,15 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
     }
 
     @MainActor
+    func runMarketingGuestSessionCleanupNow() throws {
+        let runtimeConfiguration = try self.manualRuntimeConfiguration()
+        try Self.runMarketingGuestSessionCleanup(
+            runtimeConfiguration: runtimeConfiguration,
+            existingApplication: self.app
+        )
+    }
+
+    @MainActor
     func assertReviewProgressBadge() throws {
         let reviewProgressBadge = self.app.buttons[LiveSmokeIdentifier.reviewProgressBadge]
         if try self.waitForElementValueContaining(

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingReviewScreenshotsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingReviewScreenshotsTests.swift
@@ -3,6 +3,11 @@ import XCTest
 
 final class MarketingScreenshotsTests: MarketingManualScreenshotTestCase {
     @MainActor
+    func testCleanupMarketingGuestSession() throws {
+        try self.runMarketingGuestSessionCleanupNow()
+    }
+
+    @MainActor
     func testGenerateMarketingScreenshots() throws {
         let localeFixture = try self.launchMarketingScreenshots()
 

--- a/apps/ios/docs/marketing-screenshots.md
+++ b/apps/ios/docs/marketing-screenshots.md
@@ -67,8 +67,9 @@ What each layer does:
 
 The manual screenshot flows now treat guest cloud sessions as short-lived per-run fixtures:
 
-- before each marketing screenshot bootstrap, the app deletes any stored guest session remotely through `POST /guest-auth/session/delete` and then performs the existing local identity reset
-- after each manual screenshot test, XCTest relaunches the app in a dedicated cleanup scenario and waits for the UI-test readiness marker before finishing teardown
+- before each marketing screenshot bootstrap, the wrapper runs a dedicated cleanup XCUITest entrypoint that relaunches the app, deletes any stored guest session remotely through `POST /guest-auth/session/delete`, and performs the existing local identity reset
+- after each manual screenshot test, XCTest still relaunches the app in the same dedicated cleanup scenario and waits for the UI-test readiness marker before finishing teardown
+- the wrapper also registers an exit trap that runs the dedicated cleanup XCUITest entrypoint after `xcodebuild` exits, including failure exits, before it removes the runtime configuration file
 - the cleanup relaunch clears the final guest session remotely and then runs the same local reset path, so both cloud and local screenshot state are removed predictably
 
 This is why the screenshot wrappers must still run sequentially. The cleanup relaunch is part of the supported lifecycle, not an optional background best effort.

--- a/scripts/capture-android-marketing-screenshots.sh
+++ b/scripts/capture-android-marketing-screenshots.sh
@@ -6,6 +6,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 android_dir="$repo_root/apps/android"
 locale_prefix="${FLASHCARDS_MARKETING_LOCALE_PREFIX:-en}"
 script_class="com.flashcardsopensourceapp.app.MarketingAllScreenshotsScript"
+cleanup_script_class="com.flashcardsopensourceapp.app.MarketingScreenshotGuestCleanupScript"
 output_dir="$repo_root/apps/android/docs/media/play-store-screenshots"
 remote_screenshot_dir="/sdcard/Download/flashcards-marketing-screenshots"
 file_names=(
@@ -34,13 +35,40 @@ if [[ "$device_sdk" != "36" ]]; then
     exit 1
 fi
 
+run_marketing_guest_cleanup() {
+    "$repo_root/scripts/android-dismiss-system-dialogs.sh"
+    (
+        cd "$android_dir"
+        echo "Running Android marketing screenshot guest cleanup."
+        ./gradlew :app:connectedMarketingScreenshotAndroidTest \
+          "-Pandroid.testInstrumentationRunnerArguments.includeManualOnly=true" \
+          "-Pandroid.testInstrumentationRunnerArguments.clearPackageData=false" \
+          "-Pandroid.testInstrumentationRunnerArguments.marketingLocalePrefix=$locale_prefix" \
+          "-Pandroid.testInstrumentationRunnerArguments.class=$cleanup_script_class"
+    )
+}
+
+cleanup_on_exit() {
+    local exit_status="$?"
+    if ! run_marketing_guest_cleanup; then
+        echo "ERROR: Android marketing screenshot guest cleanup failed." >&2
+        if [[ "$exit_status" -eq 0 ]]; then
+            exit_status=1
+        fi
+    fi
+    exit "$exit_status"
+}
+
 "$repo_root/scripts/android-set-device-locale.sh" "$locale_prefix"
 "$repo_root/scripts/android-dismiss-system-dialogs.sh"
+trap cleanup_on_exit EXIT
+run_marketing_guest_cleanup
 
 cd "$android_dir"
 echo "Running the unified Android marketing screenshot flow."
 ./gradlew :app:connectedMarketingScreenshotAndroidTest \
   "-Pandroid.testInstrumentationRunnerArguments.includeManualOnly=true" \
+  "-Pandroid.testInstrumentationRunnerArguments.clearPackageData=false" \
   "-Pandroid.testInstrumentationRunnerArguments.marketingLocalePrefix=$locale_prefix" \
   "-Pandroid.testInstrumentationRunnerArguments.class=$script_class"
 

--- a/scripts/capture-ios-marketing-screenshot.sh
+++ b/scripts/capture-ios-marketing-screenshot.sh
@@ -145,6 +145,7 @@ fi
 test_identifier="${positional_arguments[0]}"
 description="${positional_arguments[1]}"
 expected_screenshot_indices=("${positional_arguments[@]:2}")
+cleanup_test_identifier="MarketingScreenshotsTests/testCleanupMarketingGuestSession"
 
 localization_code="$(resolve_requested_locale "$requested_locale")"
 
@@ -189,6 +190,43 @@ cleanup_runtime_configuration() {
     if [[ -n "$screenshot_run_marker_path" ]]; then
         rm -f "$screenshot_run_marker_path"
     fi
+}
+
+run_ios_marketing_xcodebuild_test() {
+    local selected_test_identifier="$1"
+
+    FLASHCARDS_INCLUDE_MANUAL_SCREENSHOT_TESTS=true \
+    FLASHCARDS_MARKETING_SCREENSHOT_OUTPUT_DIRECTORY="$output_directory" \
+    FLASHCARDS_MARKETING_SCREENSHOT_LOCALIZATION="$localization_code" \
+    xcodebuild \
+      -project "$project_path" \
+      -scheme "$scheme_name" \
+      -destination "platform=iOS Simulator,id=$simulator_id" \
+      "-only-testing:Flashcards Open Source App UI Tests/$selected_test_identifier" \
+      test
+}
+
+run_ios_marketing_guest_cleanup() {
+    echo "Running iOS marketing screenshot guest cleanup."
+    run_ios_marketing_xcodebuild_test "$cleanup_test_identifier"
+}
+
+cleanup_on_exit() {
+    local exit_status="$?"
+
+    set +e
+    run_ios_marketing_guest_cleanup
+    local cleanup_status="$?"
+    cleanup_runtime_configuration
+
+    if [[ "$cleanup_status" -ne 0 ]]; then
+        echo "ERROR: iOS marketing screenshot guest cleanup failed." >&2
+        if [[ "$exit_status" -eq 0 ]]; then
+            exit_status=1
+        fi
+    fi
+
+    exit "$exit_status"
 }
 
 resolve_booted_simulator_id() {
@@ -286,23 +324,16 @@ device_family="$(resolve_device_family "$simulator_name")"
 output_directory="$repo_root/apps/ios/docs/media/app-store-screenshots/$device_family"
 
 mkdir -p "$output_directory"
-trap cleanup_runtime_configuration EXIT
 write_runtime_configuration "$output_directory" "$localization_code"
 screenshot_run_marker_path="$(mktemp -t flashcards-open-source-app-ios-marketing-screenshot-run)"
+trap cleanup_on_exit EXIT
 
 echo "Running manual iOS marketing screenshot script for $description on $simulator_name."
 echo "Locale: $localization_code"
 xcrun simctl bootstatus "$simulator_id" -b
 
-FLASHCARDS_INCLUDE_MANUAL_SCREENSHOT_TESTS=true \
-FLASHCARDS_MARKETING_SCREENSHOT_OUTPUT_DIRECTORY="$output_directory" \
-FLASHCARDS_MARKETING_SCREENSHOT_LOCALIZATION="$localization_code" \
-xcodebuild \
-  -project "$project_path" \
-  -scheme "$scheme_name" \
-  -destination "platform=iOS Simulator,id=$simulator_id" \
-  "-only-testing:Flashcards Open Source App UI Tests/$test_identifier" \
-  test
+run_ios_marketing_guest_cleanup
+run_ios_marketing_xcodebuild_test "$test_identifier"
 
 for screenshot_index in "${expected_screenshot_indices[@]}"; do
     output_path="$(resolve_screenshot_path_for_index "$output_directory" "$localization_code" "$screenshot_index" "$screenshot_run_marker_path")"


### PR DESCRIPTION
## Summary
- Add dedicated Android marketing screenshot guest cleanup instrumentation entrypoint and run it before/after screenshot generation.
- Add dedicated iOS marketing screenshot cleanup XCUITest entrypoint and run it from the wrapper before the screenshot test and from the EXIT trap.
- Keep existing in-test cleanup/reset defenses and document the supported lifecycle.

## Root Cause
Marketing screenshot flows could leave guest cloud sessions behind when process/test teardown did not complete. Android relied too heavily on test teardown; iOS had cleanup during test lifecycle but the wrapper did not force a separate cleanup launch after xcodebuild failures.

## Validation
- `git --no-pager diff --check`
- `bash -n scripts/capture-android-marketing-screenshots.sh`
- `bash -n scripts/capture-ios-marketing-screenshot.sh`
- `bash -n scripts/capture-ios-marketing-screenshots.sh`
- Previously run in this worktree: `./gradlew :app:assembleMarketingScreenshot :app:assembleMarketingScreenshotAndroidTest`
- Previously run in this worktree: `xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'generic/platform=iOS Simulator' build-for-testing`