### PR TITLE
[codex] Raise notification prompt threshold to six reviews

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter
 import org.json.JSONArray
 import org.json.JSONObject
 
-const val reviewNotificationPermissionPromptThreshold: Int = 3
+const val reviewNotificationPermissionPromptThreshold: Int = 6
 const val defaultDailyReminderHour: Int = 10
 const val defaultDailyReminderMinute: Int = 0
 const val dailyReminderSchedulingHorizonDays: Int = 7

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt
@@ -588,6 +588,10 @@ class LocalReviewRepository(
         )
     }
 
+    override suspend fun countRecordedReviews(): Int {
+        return database.reviewLogDao().countReviewLogs()
+    }
+
     override suspend fun recordReview(cardId: String, rating: ReviewRating, reviewedAtMillis: Long) {
         database.withTransaction {
             val card = requireNotNull(database.cardDao().loadCard(cardId = cardId)) {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -97,6 +97,8 @@ interface ReviewRepository {
         limit: Int
     ): ReviewTimelinePage
 
+    suspend fun countRecordedReviews(): Int
+
     suspend fun recordReview(cardId: String, rating: ReviewRating, reviewedAtMillis: Long)
 }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -42,6 +42,10 @@ import kotlinx.coroutines.launch
 
 private const val reviewPreviewPageSize: Int = 20
 
+private fun hasEnoughReviewHistoryForNotificationPrompt(reviewCount: Int): Boolean {
+    return reviewCount >= reviewNotificationPermissionPromptThreshold
+}
+
 private data class ReviewDraftState(
     val requestedFilter: ReviewFilter,
     val presentedCardId: String?,
@@ -502,7 +506,7 @@ class ReviewViewModel(
     /**
      * Records successful review bookkeeping and optionally shows the notification pre-prompt.
      */
-    private fun handleSuccessfulReviewRecorded(
+    private suspend fun handleSuccessfulReviewRecorded(
         reviewedAtMillis: Long,
         shouldShowNotificationPermissionPrePrompt: Boolean
     ) {
@@ -510,6 +514,7 @@ class ReviewViewModel(
         reviewNotificationsStore.saveLastActiveAtMillis(timestampMillis = nowMillis)
         val nextReviewCount = reviewNotificationsStore.loadSuccessfulReviewCount() + 1
         reviewNotificationsStore.saveSuccessfulReviewCount(count = nextReviewCount)
+        val reviewCount = maxOf(nextReviewCount, reviewRepository.countRecordedReviews())
         onReviewNotificationsChanged(ReviewNotificationsReconcileTrigger.REVIEW_RECORDED)
         onSuccessfulReviewRecorded(reviewedAtMillis)
 
@@ -518,7 +523,7 @@ class ReviewViewModel(
         }
 
         val promptState = reviewNotificationsStore.loadPromptState()
-        if (nextReviewCount < reviewNotificationPermissionPromptThreshold) {
+        if (hasEnoughReviewHistoryForNotificationPrompt(reviewCount = reviewCount).not()) {
             return
         }
         if (promptState.hasShownPrePrompt || promptState.hasRequestedSystemPermission || promptState.hasDismissedPrePrompt) {

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+Read.swift
@@ -36,6 +36,10 @@ extension LocalDatabase {
         try self.cardStore.loadActiveCardCount(workspaceId: workspaceId)
     }
 
+    func loadReviewEventCount() throws -> Int {
+        try self.core.scalarInt(sql: "SELECT COUNT(*) FROM review_events", values: [])
+    }
+
     func loadActiveDecks(workspaceId: String) throws -> [Deck] {
         try self.deckStore.loadDecks(workspaceId: workspaceId)
     }

--- a/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+ReviewNotifications.swift
@@ -167,12 +167,13 @@ extension FlashcardsStore {
         self.userDefaults.set(now.timeIntervalSince1970, forKey: reviewNotificationLastActiveAtUserDefaultsKey)
         self.reconcileReviewNotifications(trigger: .reviewRecorded, now: now)
         self.recordSuccessfulStrictReminderReview(reviewedAt: reviewedAt, now: now)
+        let reviewCount = self.loadReviewNotificationPromptReviewCount(persistedReviewCount: nextCount)
         Task { @MainActor in
             let permissionStatus = await resolveReviewNotificationPermissionStatus()
             guard permissionStatus == .notRequested else {
                 return
             }
-            guard nextCount >= reviewNotificationPermissionPromptThreshold else {
+            guard hasEnoughReviewHistoryForNotificationPrompt(reviewCount: reviewCount) else {
                 return
             }
             guard self.notificationPermissionPromptState.hasShownPrePrompt == false else {
@@ -193,6 +194,25 @@ extension FlashcardsStore {
                     hasDismissedPrePrompt: false
                 )
             )
+        }
+    }
+
+    private func loadReviewNotificationPromptReviewCount(persistedReviewCount: Int) -> Int {
+        guard let database = self.database else {
+            return persistedReviewCount
+        }
+
+        do {
+            return max(persistedReviewCount, try database.loadReviewEventCount())
+        } catch {
+            logFlashcardsError(
+                domain: "ios_notifications",
+                action: "review_prompt_count_load_failed",
+                metadata: [
+                    "message": Flashcards.errorMessage(error: error)
+                ]
+            )
+            return persistedReviewCount
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewNotificationsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewNotificationsSupport.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import UserNotifications
 
-let reviewNotificationPermissionPromptThreshold: Int = 3
+let reviewNotificationPermissionPromptThreshold: Int = 6
 let defaultDailyReminderHour: Int = 10
 let defaultDailyReminderMinute: Int = 0
 let dailyReminderSchedulingHorizonDays: Int = 7
@@ -333,6 +333,10 @@ func makeDefaultNotificationPermissionPromptState() -> NotificationPermissionPro
         hasRequestedSystemPermission: false,
         hasDismissedPrePrompt: false
     )
+}
+
+func hasEnoughReviewHistoryForNotificationPrompt(reviewCount: Int) -> Bool {
+    reviewCount >= reviewNotificationPermissionPromptThreshold
 }
 
 func makeReviewNotificationsSettingsUserDefaultsKey(workspaceId: String) -> String {


### PR DESCRIPTION
## Summary
- raise the review notification pre-prompt threshold from 3 to 6 on iOS and Android
- count persisted local review history so existing users with enough reviews are eligible on the next successful review

## Validation
- ./gradlew :feature:review:compileDebugKotlin :data:local:compileDebugKotlin
- xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'generic/platform=iOS Simulator' build
- git --no-pager diff --check