### PR TITLE
Fix Cognito signup password generation

### DIFF
--- a/apps/auth/src/cognitoAuth.test.ts
+++ b/apps/auth/src/cognitoAuth.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { __internal } from "./server/cognitoAuth.js";
+
+const REQUIRED_CLASS_SELECTION_SIZES: readonly number[] = [26, 26, 10, 32];
+
+const countMatches = (value: string, pattern: RegExp): number => {
+  const matches = value.match(pattern);
+  return matches === null ? 0 : matches.length;
+};
+
+test("Cognito sign-up password explicitly sources every required user-pool class", () => {
+  const randomIndexMaxExclusiveValues: number[] = [];
+  const selectFirstIndex = (maxExclusive: number): number => {
+    assert.ok(maxExclusive > 0);
+    randomIndexMaxExclusiveValues.push(maxExclusive);
+    return 0;
+  };
+
+  const password = __internal.createCognitoSignUpPasswordWithRandomIndex(selectFirstIndex);
+
+  assert.deepEqual(
+    randomIndexMaxExclusiveValues.slice(0, REQUIRED_CLASS_SELECTION_SIZES.length),
+    REQUIRED_CLASS_SELECTION_SIZES,
+  );
+  assert.equal(password.length, 64);
+  assert.equal(countMatches(password, /[A-Z]/g), 1);
+  assert.equal(countMatches(password, /[a-z]/g), 61);
+  assert.equal(countMatches(password, /[0-9]/g), 1);
+  assert.equal(
+    countMatches(password, /[\^$*.[\]{}()?"!@#%&/\\,><':;|_~`=+\-]/g),
+    1,
+  );
+});

--- a/apps/auth/src/server/cognitoAuth.ts
+++ b/apps/auth/src/server/cognitoAuth.ts
@@ -4,7 +4,7 @@
  * Calls the Cognito IDP endpoint directly via fetch — no AWS SDK needed.
  * Uses USER_AUTH flow with EMAIL_OTP challenge (Essentials tier).
  */
-import { randomBytes } from "node:crypto";
+import { randomInt } from "node:crypto";
 import {
   createCognitoTypedError,
   getCognitoErrorType,
@@ -81,11 +81,71 @@ type CognitoFetchFunction = (
   body: Record<string, unknown>,
 ) => Promise<Record<string, unknown>>;
 
+type RandomIndex = (maxExclusive: number) => number;
+
+const COGNITO_SIGN_UP_PASSWORD_LENGTH = 64;
+const COGNITO_SIGN_UP_PASSWORD_LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
+const COGNITO_SIGN_UP_PASSWORD_UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const COGNITO_SIGN_UP_PASSWORD_DIGITS = "0123456789";
+const COGNITO_SIGN_UP_PASSWORD_SYMBOLS = "^$*.[]{}()?\"!@#%&/\\,><':;|_~`=+-";
+const COGNITO_SIGN_UP_PASSWORD_ALPHABET = [
+  COGNITO_SIGN_UP_PASSWORD_LOWERCASE,
+  COGNITO_SIGN_UP_PASSWORD_UPPERCASE,
+  COGNITO_SIGN_UP_PASSWORD_DIGITS,
+  COGNITO_SIGN_UP_PASSWORD_SYMBOLS,
+].join("");
+
+function pickRandomCharacter(characters: string, randomIndex: RandomIndex): string {
+  const index = randomIndex(characters.length);
+  const character = characters[index];
+  if (character === undefined) {
+    throw new Error("Password character selection produced an out-of-range index");
+  }
+  return character;
+}
+
+function shuffleCharacters(
+  characters: ReadonlyArray<string>,
+  randomIndex: RandomIndex,
+): ReadonlyArray<string> {
+  const shuffledCharacters = [...characters];
+  for (let index = shuffledCharacters.length - 1; index > 0; index -= 1) {
+    const swapIndex = randomIndex(index + 1);
+    const currentCharacter = shuffledCharacters[index];
+    const swapCharacter = shuffledCharacters[swapIndex];
+    if (currentCharacter === undefined || swapCharacter === undefined) {
+      throw new Error("Password character shuffle produced an out-of-range index");
+    }
+    shuffledCharacters[index] = swapCharacter;
+    shuffledCharacters[swapIndex] = currentCharacter;
+  }
+  return shuffledCharacters;
+}
+
+function createCognitoSignUpPasswordWithRandomIndex(randomIndex: RandomIndex): string {
+  const requiredCharacters = [
+    pickRandomCharacter(COGNITO_SIGN_UP_PASSWORD_LOWERCASE, randomIndex),
+    pickRandomCharacter(COGNITO_SIGN_UP_PASSWORD_UPPERCASE, randomIndex),
+    pickRandomCharacter(COGNITO_SIGN_UP_PASSWORD_DIGITS, randomIndex),
+    pickRandomCharacter(COGNITO_SIGN_UP_PASSWORD_SYMBOLS, randomIndex),
+  ];
+  const remainingLength = COGNITO_SIGN_UP_PASSWORD_LENGTH - requiredCharacters.length;
+  const randomCharacters = Array.from(
+    { length: remainingLength },
+    () => pickRandomCharacter(COGNITO_SIGN_UP_PASSWORD_ALPHABET, randomIndex),
+  );
+  return shuffleCharacters([...requiredCharacters, ...randomCharacters], randomIndex).join("");
+}
+
+function createCognitoSignUpPassword(): string {
+  return createCognitoSignUpPasswordWithRandomIndex(randomInt);
+}
+
 const signUpUser = async (email: string): Promise<void> => {
   await cognitoFetch("SignUp", {
     ClientId: getClientId(),
     Username: email,
-    Password: randomBytes(48).toString("base64"),
+    Password: createCognitoSignUpPassword(),
     UserAttributes: [{ Name: "email", Value: email }],
   });
 };
@@ -280,6 +340,8 @@ export const signInWithPassword = async (
 ): Promise<TokenResult> => signInWithPasswordViaCognito(cognitoFetch, email, password);
 
 export const __internal = {
+  createCognitoSignUpPassword,
+  createCognitoSignUpPasswordWithRandomIndex,
   signInWithPasswordViaCognito,
 };
 


### PR DESCRIPTION
## Summary

Fix Cognito sign-up password generation for new email OTP users.

## Root Cause

The previous internal SignUp password used `randomBytes(48).toString("base64")`. Cognito's deployed user-pool policy requires at least one uppercase character, lowercase character, number, and symbol; base64 can randomly omit symbols, causing `/api/send-code` to fail before OTP delivery.

## Changes

- Generate a 64-character password with `crypto.randomInt`.
- Explicitly source one lowercase, uppercase, digit, and Cognito-allowed symbol.
- Fill the rest from the full allowed alphabet and shuffle positions.
- Add a deterministic regression test for required character class sourcing.

## Validation

- `npm run build` in `apps/auth`
- `npm test` in `apps/auth` (20 tests passed)
- Subagent security/code review found no blocking issues after the deterministic test fix.
