### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,7 +8,7 @@
       "name": "flashcards-open-source-app-api",
       "version": "1.2.1",
       "devDependencies": {
-        "@redocly/cli": "^2.29.2"
+        "@redocly/cli": "^2.30.0"
       },
       "engines": {
         "node": "24.x"
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.29.2.tgz",
-      "integrity": "sha512-QQOwkud3dk1kCtd+rutffauB7b4iEJOXFg4rTTVdKACD0/ifRBlyTd7GPswZm4nGyW5vDtS/UbyjMMhF//FkRQ==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.30.0.tgz",
+      "integrity": "sha512-hpMyiJFfyTk+FE+ksoD7HClN6ALxETsWwbuE2bkpJLYXnhnBMuGe42cuBo12mEXooXghH6UltaKktrRRg/FUYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -427,8 +427,8 @@
         "@opentelemetry/sdk-trace-node": "2.6.1",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/cli-otel": "0.1.2",
-        "@redocly/openapi-core": "2.29.2",
-        "@redocly/respect-core": "2.29.2",
+        "@redocly/openapi-core": "2.30.0",
+        "@redocly/respect-core": "2.30.0",
         "abort-controller": "^3.0.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "ajv-formats": "^3.0.1",
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.29.2.tgz",
-      "integrity": "sha512-je4yu+QgSOSx+wN5IcpCaoZwNAAnaLnmSeN8GDC6lX2l51ukyQBFjZ+/LeCrVgOrUA3aRZRRHgZoRtcemIfm+A==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.0.tgz",
+      "integrity": "sha512-ZwsTS/BHzfzmadf4qPcpBcYDQm78XoinmLTGQWzDKOpgnjNOV62YId79611ulHpYXndRG8vcVm5LJdvXqGp8Yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -515,16 +515,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.29.2.tgz",
-      "integrity": "sha512-V7TkUveOcR3IT3TANnPCxd6W2l9IezKYASoeJpYvtTNIXGjRD2VhtxRTjlonBXr/8bj8vdzQ96H2f51sgsJt5A==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.30.0.tgz",
+      "integrity": "sha512-Qzo2r7ZzbfBhB/OYXdaRGkCGCLQpHaHuQ/0WGFLtqtIouIhF1c0heC2STlGacH+T0MFkl0SU5sTkxpzetPuI8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.0",
-        "@redocly/openapi-core": "2.29.2",
+        "@redocly/openapi-core": "2.30.0",
         "ajv": "npm:@redocly/ajv@8.18.0",
         "better-ajv-errors": "^1.2.0",
         "colorette": "^2.0.20",

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "lint": "redocly lint src/openapi.yaml"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.29.2"
+    "@redocly/cli": "^2.30.0"
   },
   "overrides": {
     "fast-xml-parser": "5.5.10"

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -8,10 +8,10 @@
       "name": "flashcards-auth",
       "version": "1.2.1",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1036.0",
+        "@aws-sdk/client-secrets-manager": "^3.1037.0",
         "@hono/node-server": "^1.19.14",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.14",
+        "hono": "^4.12.15",
         "pg": "^8.20.0"
       },
       "devDependencies": {
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1036.0.tgz",
-      "integrity": "sha512-4Q0Rqh1CrNfwmAOrQF9FiuU2QmV51cTSa+rJJNan7/KzYUUlUFmavuWpKH+S3preT8iaTlCT0JyCqO46kg24RA==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1037.0.tgz",
+      "integrity": "sha512-SBXVNgXdzFeiuUod1AZXJexTDndPcpSTGOrVDe5Ny81Xq7d3r18th7ZTzvnc7BsD9MQa8SckNgOYscvi/fYZhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1863,9 +1863,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -10,10 +10,10 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1036.0",
+    "@aws-sdk/client-secrets-manager": "^3.1037.0",
     "@hono/node-server": "^1.19.14",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.14",
+    "hono": "^4.12.15",
     "pg": "^8.20.0"
   },
   "devDependencies": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -8,17 +8,17 @@
       "name": "flashcards-open-source-app-backend",
       "version": "1.2.1",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.1036.0",
-        "@aws-sdk/client-lambda": "^3.1036.0",
-        "@aws-sdk/client-s3": "^3.1036.0",
-        "@aws-sdk/client-secrets-manager": "^3.1036.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.1037.0",
+        "@aws-sdk/client-lambda": "^3.1037.0",
+        "@aws-sdk/client-s3": "^3.1037.0",
+        "@aws-sdk/client-secrets-manager": "^3.1037.0",
         "@hono/node-server": "^1.19.14",
         "@langfuse/openai": "^5.2.0",
         "@langfuse/otel": "^5.2.0",
         "@langfuse/tracing": "^5.2.0",
         "@opentelemetry/sdk-node": "^0.214.0",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.14",
+        "hono": "^4.12.15",
         "openai": "^6.34.0",
         "pg": "^8.20.0",
         "zod": "^4.3.6"
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1036.0.tgz",
-      "integrity": "sha512-KMpR/ZrWl8pxOxcYtja4E58Qans/F4fpykWPHG2RnHPWwJus73yZPF5XYyyvW1IK4kWcoY/ZlJC9lTzHYQC+3Q==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1037.0.tgz",
+      "integrity": "sha512-w0HuaMNtzcj6bErBX8/TVGbOz0a8JNCzPHLMq2u/ll4uuxl9Xut0njuy7vyY0/pYCuNE+no4uq+yHwn8U3ptgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1036.0.tgz",
-      "integrity": "sha512-1JwkI5NXsYrwyEhtBWb441c87DJAn+JFa1/7i1xtizuWX1ibEq9jQBGiz+eQfUZNkVMRnpIGiGDOETJobj+i9w==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1037.0.tgz",
+      "integrity": "sha512-QGlFTYge89OcrCJXO2fMkqbYrASOd5Ut3V58EYcuajGONIKOxxP6UYwrZE5vDMebNJi2mPLesDKaM7aH7oqcrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1036.0.tgz",
-      "integrity": "sha512-QGjLHw1xklwWX+MWt/7X66lMxjNQLOb0tjcwAU3PaBrYZ51kphDlfvc2sInNEsIU03+I158Y4WSMhl8l71SAsw==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1037.0.tgz",
+      "integrity": "sha512-DBmA1jAW8ST6C4srBxeL1/RLIir/d8WOm4s4mi59mGp6mBktHM59Kwb7GuURaCO60cotuce5zr0sKpMLPcBQyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1036.0.tgz",
-      "integrity": "sha512-4Q0Rqh1CrNfwmAOrQF9FiuU2QmV51cTSa+rJJNan7/KzYUUlUFmavuWpKH+S3preT8iaTlCT0JyCqO46kg24RA==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1037.0.tgz",
+      "integrity": "sha512-SBXVNgXdzFeiuUod1AZXJexTDndPcpSTGOrVDe5Ny81Xq7d3r18th7ZTzvnc7BsD9MQa8SckNgOYscvi/fYZhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -3172,9 +3172,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,17 +10,17 @@
     "test": "npm run bundle --prefix ../../api && node --test --import tsx src/*.test.ts src/**/*.test.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.1036.0",
-    "@aws-sdk/client-lambda": "^3.1036.0",
-    "@aws-sdk/client-s3": "^3.1036.0",
-    "@aws-sdk/client-secrets-manager": "^3.1036.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1037.0",
+    "@aws-sdk/client-lambda": "^3.1037.0",
+    "@aws-sdk/client-s3": "^3.1037.0",
+    "@aws-sdk/client-secrets-manager": "^3.1037.0",
     "@hono/node-server": "^1.19.14",
     "@langfuse/openai": "^5.2.0",
     "@langfuse/otel": "^5.2.0",
     "@langfuse/tracing": "^5.2.0",
     "@opentelemetry/sdk-node": "^0.214.0",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.14",
+    "hono": "^4.12.15",
     "openai": "^6.34.0",
     "pg": "^8.20.0",
     "zod": "^4.3.6"

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.2.1",
       "dependencies": {
         "@aws-crypto/client-node": "^4.2.2",
-        "@aws-sdk/client-cloudwatch": "^3.1036.0",
-        "@aws-sdk/client-s3": "^3.1036.0",
-        "aws-cdk-lib": "^2.250.0",
+        "@aws-sdk/client-cloudwatch": "^3.1037.0",
+        "@aws-sdk/client-s3": "^3.1037.0",
+        "aws-cdk-lib": "^2.251.0",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
@@ -37,9 +37,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.12.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.12.0.tgz",
-      "integrity": "sha512-xXB5Cu6uHQl8C0uYvS0gQjMwYGWQ/UcifssdzNOgTNxPky2r68mPXEJ1snvsoLhy44X9r2px0riRglIswKX4ug==",
+      "version": "53.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.18.0.tgz",
+      "integrity": "sha512-/fa6rOpokkfa5tVIdhsaexQq5MVVTSsZSD1Tu45YcrdyGRusGrM9RlPMCPrwvMS1UfdVFBhcgO9dl9ODWAWOeQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1036.0.tgz",
-      "integrity": "sha512-5TNbjNLvbFBVnO4raVC3SsE39O1eshpamibAvhoy+tHAdmHV29OP7yeIunbf/ulQebYELHjv4p+/ZqnlZ27ebA==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1037.0.tgz",
+      "integrity": "sha512-YEmsQuHnpUpTnEwoKCCALAU625MXgkCG3fo0eOGqdAVbkNAYXCcp8TF6z1Zj6UTKvZiCK3OeFlJVjJIDayxCPg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -656,9 +656,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1036.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1036.0.tgz",
-      "integrity": "sha512-QGjLHw1xklwWX+MWt/7X66lMxjNQLOb0tjcwAU3PaBrYZ51kphDlfvc2sInNEsIU03+I158Y4WSMhl8l71SAsw==",
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1037.0.tgz",
+      "integrity": "sha512-DBmA1jAW8ST6C4srBxeL1/RLIir/d8WOm4s4mi59mGp6mBktHM59Kwb7GuURaCO60cotuce5zr0sKpMLPcBQyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -2618,9 +2618,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.250.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.250.0.tgz",
-      "integrity": "sha512-8U8/S9VcmKSc3MHZWiB7P0IecgXoohI8Ya3dgtZMgbzC4mB+MEQmsYBeNgm4vzGQdRos8HjQLnFX1IBlZh7jQA==",
+      "version": "2.251.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.251.0.tgz",
+      "integrity": "sha512-H1Jfz2Oyejn+yG24i+By9fZpYfg+E3h1XnFCF2wnt/MyGOTIePRph7MRGkX73ap10ERSpmd0Ly58OLVykFoSQA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -2639,8 +2639,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.2",
+        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -2661,7 +2661,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -2676,7 +2676,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "^4.2.2",
-    "@aws-sdk/client-cloudwatch": "^3.1036.0",
-    "@aws-sdk/client-s3": "^3.1036.0",
-    "aws-cdk-lib": "^2.250.0",
+    "@aws-sdk/client-cloudwatch": "^3.1037.0",
+    "@aws-sdk/client-s3": "^3.1037.0",
+    "aws-cdk-lib": "^2.251.0",
     "constructs": "^10.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed
- updated Redocly CLI in `api`
- updated patch-level AWS SDK dependencies in `apps/auth`, `apps/backend`, and `infra/aws`
- updated `hono` patch releases in auth and backend
- updated `aws-cdk-lib` patch release in infra

## Why
These workspaces had safe dependency drift against current stable patch/minor releases. This keeps the repo aligned without taking major-version risk.

## Impact
Dependency manifests and lockfiles are refreshed for the touched modules only. Runtime/toolchain pins stay unchanged.

## Validation
- `npm run lint` in `api`
- `npm run build && npm test` in `apps/auth`
- `npm run lint && npm run build` in `apps/backend`
- `npm run build` in `infra/aws`
