### PR TITLE
Complete sync recovery flow

### DIFF
--- a/api/src/components/schemas/AgentErrorDetails.yaml
+++ b/api/src/components/schemas/AgentErrorDetails.yaml
@@ -1,9 +1,9 @@
 type: object
 additionalProperties: false
-required:
-  - validationIssues
 properties:
   validationIssues:
     type: array
     items:
       $ref: ./ValidationIssueSummary.yaml
+  syncConflict:
+    $ref: ./PublicSyncConflictDetails.yaml

--- a/api/src/components/schemas/PublicSyncConflictDetails.yaml
+++ b/api/src/components/schemas/PublicSyncConflictDetails.yaml
@@ -1,0 +1,28 @@
+type: object
+additionalProperties: false
+required:
+  - phase
+  - entityType
+  - entityId
+  - recoverable
+properties:
+  phase:
+    type: string
+  entityType:
+    type: string
+    enum:
+      - card
+      - deck
+      - review_event
+  entityId:
+    type: string
+  entryIndex:
+    type: integer
+    minimum: 0
+  reviewEventIndex:
+    type: integer
+    minimum: 0
+  recoverable:
+    type: boolean
+    enum:
+      - true

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -112,6 +112,7 @@ class AppGraph(
     internal val syncLocalStore = SyncLocalStore(
         database = database,
         preferencesStore = cloudPreferencesStore,
+        reviewPreferencesStore = reviewPreferencesStore,
         localProgressCacheStore = localProgressCacheStore
     )
     private val strictRemindersScheduler = AndroidStrictRemindersScheduler(context = context)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseMigrationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseMigrationTest.kt
@@ -9,6 +9,7 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.migration10To11
+import com.flashcardsopensourceapp.data.local.database.migration12To13
 import com.flashcardsopensourceapp.data.local.database.migration5To6
 import com.flashcardsopensourceapp.data.local.database.migration9To10
 import org.junit.After
@@ -235,6 +236,38 @@ class AppDatabaseMigrationTest {
         try {
             migration10To11.migrate(database)
             assertReviewLogsReviewedAtIndexExists(database = database)
+        } finally {
+            database.close()
+            openHelper.close()
+        }
+    }
+
+    @Test
+    fun migration12To13AddsPendingReviewHistoryImportMarkerDefaultFalse() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        createVersion12Database(context = context)
+
+        val openHelper = openDatabaseAtVersion(
+            context = context,
+            name = targetedMigrationDatabaseName,
+            version = 12
+        )
+        val database = openHelper.writableDatabase
+
+        try {
+            migration12To13.migrate(database)
+
+            assertEquals(
+                0L,
+                readSingleLong(
+                    database = database,
+                    sql = """
+                        SELECT pendingReviewHistoryImport
+                        FROM sync_state
+                        WHERE workspaceId = 'workspace-local'
+                    """.trimIndent()
+                )
+            )
         } finally {
             database.close()
             openHelper.close()
@@ -546,6 +579,58 @@ class AppDatabaseMigrationTest {
             """.trimIndent()
         )
         sqliteDatabase.version = 10
+        sqliteDatabase.close()
+    }
+
+    private fun createVersion12Database(context: Context) {
+        val databaseFile = context.getDatabasePath(targetedMigrationDatabaseName)
+        if (databaseFile.exists()) {
+            databaseFile.delete()
+        }
+        databaseFile.parentFile?.mkdirs()
+
+        val sqliteDatabase = SQLiteDatabase.openOrCreateDatabase(databaseFile, null)
+        sqliteDatabase.execSQL(
+            """
+            CREATE TABLE sync_state (
+                workspaceId TEXT NOT NULL PRIMARY KEY,
+                lastSyncCursor TEXT,
+                lastReviewSequenceId INTEGER NOT NULL,
+                hasHydratedHotState INTEGER NOT NULL,
+                hasHydratedReviewHistory INTEGER NOT NULL,
+                lastSyncAttemptAtMillis INTEGER,
+                lastSuccessfulSyncAtMillis INTEGER,
+                lastSyncError TEXT,
+                blockedInstallationId TEXT
+            )
+            """.trimIndent()
+        )
+        sqliteDatabase.execSQL(
+            """
+            INSERT INTO sync_state (
+                workspaceId,
+                lastSyncCursor,
+                lastReviewSequenceId,
+                hasHydratedHotState,
+                hasHydratedReviewHistory,
+                lastSyncAttemptAtMillis,
+                lastSuccessfulSyncAtMillis,
+                lastSyncError,
+                blockedInstallationId
+            ) VALUES (
+                'workspace-local',
+                '123',
+                456,
+                1,
+                0,
+                1000,
+                NULL,
+                NULL,
+                NULL
+            )
+            """.trimIndent()
+        )
+        sqliteDatabase.version = 12
         sqliteDatabase.close()
     }
 

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseTest.kt
@@ -33,6 +33,7 @@ import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
+import com.flashcardsopensourceapp.data.local.review.SharedPreferencesReviewPreferencesStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -61,6 +62,7 @@ class AppDatabaseTest {
         context = ApplicationProvider.getApplicationContext()
         context.deleteSharedPreferences("flashcards-cloud-metadata")
         context.deleteSharedPreferences("flashcards-cloud-secrets")
+        context.deleteSharedPreferences("flashcards-review-preferences")
         database = Room.inMemoryDatabaseBuilder(
             context = context,
             klass = AppDatabase::class.java
@@ -70,6 +72,7 @@ class AppDatabaseTest {
         syncLocalStore = SyncLocalStore(
             database = database,
             preferencesStore = preferencesStore,
+            reviewPreferencesStore = SharedPreferencesReviewPreferencesStore(context = context),
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
                 timeProvider = SystemProgressTimeProvider
@@ -83,6 +86,7 @@ class AppDatabaseTest {
         database.close()
         context.deleteSharedPreferences("flashcards-cloud-metadata")
         context.deleteSharedPreferences("flashcards-cloud-secrets")
+        context.deleteSharedPreferences("flashcards-review-preferences")
     }
 
     @Test

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudGuestSessionCoordinatorTest.kt
@@ -1,13 +1,20 @@
 package com.flashcardsopensourceapp.data.local
 
+import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.cloud.PendingGuestUpgradeState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
 import com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,6 +59,212 @@ class CloudGuestSessionCoordinatorTest {
         assertNull(environment.cloudPreferencesStore.currentCloudSettings().linkedEmail)
         assertNull(environment.cloudPreferencesStore.loadCredentials())
         assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+    }
+
+    @Test
+    fun startupReconciliationResumesPendingGuestUpgradeAfterBackendCompleteBeforeLocalSwitch() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val linkedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val accountSnapshot = createCloudAccountSnapshot(
+            userId = "user-1",
+            email = "user@example.com",
+            workspaces = listOf(linkedWorkspace)
+        )
+        val credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        val guestSession = createStoredGuestAiSession(
+            workspaceId = localWorkspaceId,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            guestToken = "guest-token",
+            userId = "guest-user"
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = guestSession.userId,
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = localWorkspaceId
+        )
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = localWorkspaceId,
+            session = guestSession
+        )
+        environment.cloudPreferencesStore.savePendingGuestUpgrade(
+            pendingGuestUpgradeState = PendingGuestUpgradeState(
+                configuration = makeOfficialCloudServiceConfiguration(),
+                credentials = credentials,
+                accountSnapshot = accountSnapshot,
+                guestSession = guestSession,
+                guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = linkedWorkspace.workspaceId),
+                completion = CloudGuestUpgradeCompletion(
+                    workspace = linkedWorkspace,
+                    reconciliation = null
+                )
+            )
+        )
+        assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertNotNull(environment.database.workspaceDao().loadWorkspaceById(localWorkspaceId))
+        assertNull(environment.database.workspaceDao().loadWorkspaceById(linkedWorkspace.workspaceId))
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNotNull(environment.cloudPreferencesStore.loadPendingGuestUpgrade())
+
+        val restartedRuntime = environment.createRestartedCloudGuestSessionRuntime(
+            remoteGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+                guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+                accountSnapshot = accountSnapshot,
+                bootstrapRemoteIsEmpty = false,
+                guestUpgradeReconciliation = null
+            )
+        )
+
+        restartedRuntime.cloudGuestSessionCoordinator.reconcilePersistedCloudStateForStartup()
+
+        assertEquals(
+            CloudAccountState.LINKED,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().cloudState
+        )
+        assertEquals(
+            linkedWorkspace.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId
+        )
+        assertEquals(
+            linkedWorkspace.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId
+        )
+        assertEquals(linkedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertNotNull(restartedRuntime.cloudPreferencesStore.loadCredentials())
+        assertNull(restartedRuntime.cloudPreferencesStore.loadPendingGuestUpgrade())
+        assertNull(
+            restartedRuntime.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )
+        )
+    }
+
+    @Test
+    fun startupReconciliationResumesPendingGuestUpgradeAfterLocalShellReplacementBeforeCloudSettingsUpdate() = runBlocking {
+        val guestWorkspaceId = environment.requireLocalWorkspaceId()
+        val linkedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val accountSnapshot = createCloudAccountSnapshot(
+            userId = "user-1",
+            email = "user@example.com",
+            workspaces = listOf(linkedWorkspace)
+        )
+        val credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        val guestSession = createStoredGuestAiSession(
+            workspaceId = guestWorkspaceId,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            guestToken = "guest-token",
+            userId = "guest-user"
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = guestSession.userId,
+            linkedWorkspaceId = guestWorkspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = guestWorkspaceId
+        )
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = guestWorkspaceId,
+            session = guestSession
+        )
+        environment.cloudPreferencesStore.savePendingGuestUpgrade(
+            pendingGuestUpgradeState = PendingGuestUpgradeState(
+                configuration = makeOfficialCloudServiceConfiguration(),
+                credentials = credentials,
+                accountSnapshot = accountSnapshot,
+                guestSession = guestSession,
+                guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = linkedWorkspace.workspaceId),
+                completion = CloudGuestUpgradeCompletion(
+                    workspace = linkedWorkspace,
+                    reconciliation = null
+                )
+            )
+        )
+        val switchedWorkspace = environment.createSyncLocalStore().migrateLocalShellToLinkedWorkspace(
+            workspace = linkedWorkspace,
+            remoteWorkspaceIsEmpty = false
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+            accountSnapshot = accountSnapshot,
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
+        )
+
+        assertEquals(linkedWorkspace.workspaceId, switchedWorkspace.workspaceId)
+        assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(guestWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertNull(environment.database.workspaceDao().loadWorkspaceById(guestWorkspaceId))
+        assertNotNull(environment.database.workspaceDao().loadWorkspaceById(linkedWorkspace.workspaceId))
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNotNull(environment.cloudPreferencesStore.loadPendingGuestUpgrade())
+
+        val restartedRuntime = environment.createRestartedCloudGuestSessionRuntime(
+            remoteGateway = remoteGateway
+        )
+
+        restartedRuntime.cloudGuestSessionCoordinator.reconcilePersistedCloudStateForStartup()
+
+        assertEquals(0, remoteGateway.completeGuestUpgradeCalls)
+        assertEquals(listOf(linkedWorkspace.workspaceId), remoteGateway.bootstrapPullWorkspaceIds)
+        assertEquals(
+            CloudAccountState.LINKED,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().cloudState
+        )
+        assertEquals(
+            linkedWorkspace.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId
+        )
+        assertEquals(
+            linkedWorkspace.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId
+        )
+        assertEquals(linkedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertNotNull(restartedRuntime.cloudPreferencesStore.loadCredentials())
+        assertNull(restartedRuntime.cloudPreferencesStore.loadPendingGuestUpgrade())
+        assertNull(
+            restartedRuntime.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )
+        )
+    }
+
+    @Test
+    fun startupReconciliationFailsExplicitlyWhenPendingGuestUpgradeStateIsCorrupt() = runBlocking {
+        val didWriteCorruptState = environment.context.getSharedPreferences(
+            "flashcards-cloud-secrets",
+            Context.MODE_PRIVATE
+        ).edit()
+            .putString("pending-guest-upgrade", "{")
+            .commit()
+        assertTrue(didWriteCorruptState)
+        val coordinator = environment.createCloudGuestSessionCoordinator(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+
+        try {
+            coordinator.reconcilePersistedCloudStateForStartup()
+            throw AssertionError("Expected corrupt pending guest upgrade state to fail explicitly.")
+        } catch (error: IllegalStateException) {
+            assertTrue(
+                error.message?.contains("Pending guest upgrade recovery state is corrupt and cannot be resumed.") == true
+            )
+        }
     }
 
     @Test

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudIdentityTestSupport.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudIdentityTestSupport.kt
@@ -338,7 +338,8 @@ internal fun syncStateEntityWithEmptyProgress(workspaceId: String): SyncStateEnt
         hasHydratedReviewHistory = false,
         lastSyncAttemptAtMillis = null,
         lastSuccessfulSyncAtMillis = null,
-        lastSyncError = null
+        lastSyncError = null,
+        blockedInstallationId = null
     )
 }
 
@@ -347,7 +348,9 @@ private data class FakeCloudRemoteGatewayConfig(
     val fetchAccountError: Exception?,
     val guestUpgradeMode: CloudGuestUpgradeMode?,
     val bootstrapPullError: Exception?,
-    val bootstrapRemoteIsEmpty: Boolean,
+    val bootstrapRemoteIsEmptyResponses: List<Boolean>,
+    val bootstrapPushErrors: List<Exception>,
+    val importReviewHistoryErrors: List<Exception>,
     val createdWorkspace: CloudWorkspaceSummary,
     val onFetchCloudAccountEntered: CompletableDeferred<Unit>?,
     val blockFetchCloudAccount: CompletableDeferred<Unit>?,
@@ -361,11 +364,16 @@ internal class FakeCloudRemoteGateway private constructor(
     private val fetchAccountError: Exception? = config.fetchAccountError
     private val guestUpgradeMode: CloudGuestUpgradeMode? = config.guestUpgradeMode
     private val bootstrapPullError: Exception? = config.bootstrapPullError
-    private val bootstrapRemoteIsEmpty: Boolean = config.bootstrapRemoteIsEmpty
+    private val bootstrapRemoteIsEmptyResponses: List<Boolean> = config.bootstrapRemoteIsEmptyResponses
+    private val bootstrapPushErrors: List<Exception> = config.bootstrapPushErrors
+    private val importReviewHistoryErrors: List<Exception> = config.importReviewHistoryErrors
     private val createdWorkspace: CloudWorkspaceSummary = config.createdWorkspace
     private val onFetchCloudAccountEntered: CompletableDeferred<Unit>? = config.onFetchCloudAccountEntered
     private val blockFetchCloudAccount: CompletableDeferred<Unit>? = config.blockFetchCloudAccount
     private val accountSnapshot: CloudAccountSnapshot = config.accountSnapshot
+    private var bootstrapPullResponseIndex: Int = 0
+    private var bootstrapPushErrorIndex: Int = 0
+    private var importReviewHistoryErrorIndex: Int = 0
 
     companion object {
         fun standard(): FakeCloudRemoteGateway {
@@ -375,7 +383,9 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = null,
                     guestUpgradeMode = null,
                     bootstrapPullError = null,
-                    bootstrapRemoteIsEmpty = true,
+                    bootstrapRemoteIsEmptyResponses = listOf(true),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = null,
                     blockFetchCloudAccount = null,
@@ -391,7 +401,9 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = null,
                     guestUpgradeMode = null,
                     bootstrapPullError = null,
-                    bootstrapRemoteIsEmpty = true,
+                    bootstrapRemoteIsEmptyResponses = listOf(true),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = null,
                     blockFetchCloudAccount = null,
@@ -407,7 +419,9 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = fetchAccountError,
                     guestUpgradeMode = null,
                     bootstrapPullError = null,
-                    bootstrapRemoteIsEmpty = true,
+                    bootstrapRemoteIsEmptyResponses = listOf(true),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = null,
                     blockFetchCloudAccount = null,
@@ -423,7 +437,9 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = null,
                     guestUpgradeMode = null,
                     bootstrapPullError = null,
-                    bootstrapRemoteIsEmpty = true,
+                    bootstrapRemoteIsEmptyResponses = listOf(true),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = null,
                     blockFetchCloudAccount = null,
@@ -439,7 +455,9 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = null,
                     guestUpgradeMode = null,
                     bootstrapPullError = bootstrapPullError,
-                    bootstrapRemoteIsEmpty = true,
+                    bootstrapRemoteIsEmptyResponses = listOf(true),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = null,
                     blockFetchCloudAccount = null,
@@ -459,7 +477,9 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = null,
                     guestUpgradeMode = guestUpgradeMode,
                     bootstrapPullError = null,
-                    bootstrapRemoteIsEmpty = bootstrapRemoteIsEmpty,
+                    bootstrapRemoteIsEmptyResponses = listOf(bootstrapRemoteIsEmpty),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = null,
                     blockFetchCloudAccount = null,
@@ -478,8 +498,52 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = null,
                     guestUpgradeMode = null,
                     bootstrapPullError = null,
-                    bootstrapRemoteIsEmpty = bootstrapRemoteIsEmpty,
+                    bootstrapRemoteIsEmptyResponses = listOf(bootstrapRemoteIsEmpty),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createdWorkspace,
+                    onFetchCloudAccountEntered = null,
+                    blockFetchCloudAccount = null,
+                    accountSnapshot = createDefaultAccountSnapshot()
+                )
+            )
+        }
+
+        fun forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses: List<Boolean>,
+            bootstrapPushErrors: List<Exception>
+        ): FakeCloudRemoteGateway {
+            return FakeCloudRemoteGateway(
+                config = createConfig(
+                    deleteFailuresRemaining = 0,
+                    fetchAccountError = null,
+                    guestUpgradeMode = null,
+                    bootstrapPullError = null,
+                    bootstrapRemoteIsEmptyResponses = bootstrapRemoteIsEmptyResponses,
+                    bootstrapPushErrors = bootstrapPushErrors,
+                    importReviewHistoryErrors = emptyList(),
+                    createdWorkspace = createDefaultCreatedWorkspace(),
+                    onFetchCloudAccountEntered = null,
+                    blockFetchCloudAccount = null,
+                    accountSnapshot = createDefaultAccountSnapshot()
+                )
+            )
+        }
+
+        fun forReviewHistoryImportScenario(
+            bootstrapRemoteIsEmptyResponses: List<Boolean>,
+            importReviewHistoryErrors: List<Exception>
+        ): FakeCloudRemoteGateway {
+            return FakeCloudRemoteGateway(
+                config = createConfig(
+                    deleteFailuresRemaining = 0,
+                    fetchAccountError = null,
+                    guestUpgradeMode = null,
+                    bootstrapPullError = null,
+                    bootstrapRemoteIsEmptyResponses = bootstrapRemoteIsEmptyResponses,
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = importReviewHistoryErrors,
+                    createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = null,
                     blockFetchCloudAccount = null,
                     accountSnapshot = createDefaultAccountSnapshot()
@@ -497,7 +561,9 @@ internal class FakeCloudRemoteGateway private constructor(
                     fetchAccountError = null,
                     guestUpgradeMode = null,
                     bootstrapPullError = null,
-                    bootstrapRemoteIsEmpty = true,
+                    bootstrapRemoteIsEmptyResponses = listOf(true),
+                    bootstrapPushErrors = emptyList(),
+                    importReviewHistoryErrors = emptyList(),
                     createdWorkspace = createDefaultCreatedWorkspace(),
                     onFetchCloudAccountEntered = onFetchCloudAccountEntered,
                     blockFetchCloudAccount = blockFetchCloudAccount,
@@ -511,7 +577,9 @@ internal class FakeCloudRemoteGateway private constructor(
             fetchAccountError: Exception?,
             guestUpgradeMode: CloudGuestUpgradeMode?,
             bootstrapPullError: Exception?,
-            bootstrapRemoteIsEmpty: Boolean,
+            bootstrapRemoteIsEmptyResponses: List<Boolean>,
+            bootstrapPushErrors: List<Exception>,
+            importReviewHistoryErrors: List<Exception>,
             createdWorkspace: CloudWorkspaceSummary,
             onFetchCloudAccountEntered: CompletableDeferred<Unit>?,
             blockFetchCloudAccount: CompletableDeferred<Unit>?,
@@ -522,7 +590,9 @@ internal class FakeCloudRemoteGateway private constructor(
                 fetchAccountError = fetchAccountError,
                 guestUpgradeMode = guestUpgradeMode,
                 bootstrapPullError = bootstrapPullError,
-                bootstrapRemoteIsEmpty = bootstrapRemoteIsEmpty,
+                bootstrapRemoteIsEmptyResponses = bootstrapRemoteIsEmptyResponses,
+                bootstrapPushErrors = bootstrapPushErrors,
+                importReviewHistoryErrors = importReviewHistoryErrors,
                 createdWorkspace = createdWorkspace,
                 onFetchCloudAccountEntered = onFetchCloudAccountEntered,
                 blockFetchCloudAccount = blockFetchCloudAccount,
@@ -562,6 +632,8 @@ internal class FakeCloudRemoteGateway private constructor(
     var selectWorkspaceCalls: Int = 0
     val renameWorkspaceIds = mutableListOf<String>()
     val bootstrapPullWorkspaceIds = mutableListOf<String>()
+    val bootstrapPushBodies = mutableListOf<JSONObject>()
+    val importReviewHistoryBodies = mutableListOf<JSONObject>()
     val createdWorkspaceId: String = createdWorkspace.workspaceId
 
     override suspend fun validateConfiguration(configuration: CloudServiceConfiguration) {
@@ -782,7 +854,7 @@ internal class FakeCloudRemoteGateway private constructor(
             nextCursor = null,
             hasMore = false,
             bootstrapHotChangeId = 0L,
-            remoteIsEmpty = bootstrapRemoteIsEmpty
+            remoteIsEmpty = nextBootstrapRemoteIsEmpty()
         )
     }
 
@@ -792,6 +864,10 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         body: JSONObject
     ): RemoteBootstrapPushResponse {
+        bootstrapPushBodies += JSONObject(body.toString())
+        nextBootstrapPushErrorOrNull()?.let { error ->
+            throw error
+        }
         return RemoteBootstrapPushResponse(
             appliedEntriesCount = 0,
             bootstrapHotChangeId = 0L
@@ -817,6 +893,10 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         body: JSONObject
     ): RemoteReviewHistoryImportResponse {
+        importReviewHistoryBodies += JSONObject(body.toString())
+        nextImportReviewHistoryErrorOrNull()?.let { error ->
+            throw error
+        }
         return RemoteReviewHistoryImportResponse(
             importedCount = 0,
             duplicateCount = 0,
@@ -837,5 +917,31 @@ internal class FakeCloudRemoteGateway private constructor(
                 isSelected = true
             )
         }
+    }
+
+    private fun nextBootstrapRemoteIsEmpty(): Boolean {
+        val response = bootstrapRemoteIsEmptyResponses.getOrElse(bootstrapPullResponseIndex) {
+            bootstrapRemoteIsEmptyResponses.lastOrNull() ?: true
+        }
+        bootstrapPullResponseIndex += 1
+        return response
+    }
+
+    private fun nextBootstrapPushErrorOrNull(): Exception? {
+        if (bootstrapPushErrorIndex >= bootstrapPushErrors.size) {
+            return null
+        }
+        val error = bootstrapPushErrors[bootstrapPushErrorIndex]
+        bootstrapPushErrorIndex += 1
+        return error
+    }
+
+    private fun nextImportReviewHistoryErrorOrNull(): Exception? {
+        if (importReviewHistoryErrorIndex >= importReviewHistoryErrors.size) {
+            return null
+        }
+        val error = importReviewHistoryErrors[importReviewHistoryErrorIndex]
+        importReviewHistoryErrorIndex += 1
+        return error
     }
 }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudIdentityTestSupport.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/CloudIdentityTestSupport.kt
@@ -15,6 +15,7 @@ import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
 import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapPullResponse
 import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemotePushOperationResult
 import com.flashcardsopensourceapp.data.local.cloud.RemotePullResponse
 import com.flashcardsopensourceapp.data.local.cloud.RemotePushResponse
 import com.flashcardsopensourceapp.data.local.cloud.RemoteReviewHistoryImportResponse
@@ -28,7 +29,11 @@ import com.flashcardsopensourceapp.data.local.database.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.database.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntity
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntityType
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeReconciliation
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeSelection
 import com.flashcardsopensourceapp.data.local.model.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
@@ -55,6 +60,8 @@ import com.flashcardsopensourceapp.data.local.repository.LocalCloudAccountReposi
 import com.flashcardsopensourceapp.data.local.repository.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.LocalSyncRepository
 import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
+import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
+import com.flashcardsopensourceapp.data.local.review.SharedPreferencesReviewPreferencesStore
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import org.json.JSONObject
@@ -63,6 +70,7 @@ internal class CloudIdentityTestEnvironment private constructor(
     val context: Context,
     val database: AppDatabase,
     val cloudPreferencesStore: CloudPreferencesStore,
+    val reviewPreferencesStore: ReviewPreferencesStore,
     val aiChatPreferencesStore: AiChatPreferencesStore,
     val aiChatHistoryStore: AiChatHistoryStore,
     val guestAiSessionStore: GuestAiSessionStore,
@@ -81,6 +89,7 @@ internal class CloudIdentityTestEnvironment private constructor(
                 klass = AppDatabase::class.java
             ).allowMainThreadQueries().build()
             val cloudPreferencesStore = CloudPreferencesStore(context = context, database = database)
+            val reviewPreferencesStore = SharedPreferencesReviewPreferencesStore(context = context)
             val aiChatPreferencesStore = AiChatPreferencesStore(context = context)
             val aiChatHistoryStore = AiChatHistoryStore(context = context)
             val guestAiSessionStore = GuestAiSessionStore(context = context)
@@ -106,6 +115,7 @@ internal class CloudIdentityTestEnvironment private constructor(
                 context = context,
                 database = database,
                 cloudPreferencesStore = cloudPreferencesStore,
+                reviewPreferencesStore = reviewPreferencesStore,
                 aiChatPreferencesStore = aiChatPreferencesStore,
                 aiChatHistoryStore = aiChatHistoryStore,
                 guestAiSessionStore = guestAiSessionStore,
@@ -131,6 +141,92 @@ internal class CloudIdentityTestEnvironment private constructor(
             resetCoordinator = resetCoordinator,
             guestSessionStore = guestAiSessionStore,
             appVersion = appVersion
+        )
+    }
+
+    suspend fun createRestartedCloudAccountRuntime(
+        remoteGateway: CloudRemoteGateway
+    ): RestartedCloudAccountRuntime {
+        val restartedCloudPreferencesStore = CloudPreferencesStore(context = context, database = database)
+        restartedCloudPreferencesStore.hydrateCloudSettingsFromDatabase()
+        val restartedAiChatPreferencesStore = AiChatPreferencesStore(context = context)
+        val restartedAiChatHistoryStore = AiChatHistoryStore(context = context)
+        val restartedGuestAiSessionStore = GuestAiSessionStore(context = context)
+        val restartedOperationCoordinator = CloudOperationCoordinator()
+        val restartedResetCoordinator = CloudIdentityResetCoordinator(
+            database = database,
+            cloudPreferencesStore = restartedCloudPreferencesStore,
+            aiChatPreferencesStore = restartedAiChatPreferencesStore,
+            aiChatHistoryStore = restartedAiChatHistoryStore,
+            guestAiSessionStore = restartedGuestAiSessionStore
+        )
+        val restartedSyncLocalStore = SyncLocalStore(
+            database = database,
+            preferencesStore = restartedCloudPreferencesStore,
+            reviewPreferencesStore = reviewPreferencesStore,
+            localProgressCacheStore = LocalProgressCacheStore(
+                database = database,
+                timeProvider = SystemProgressTimeProvider
+            )
+        )
+        val repository = LocalCloudAccountRepository(
+            database = database,
+            preferencesStore = restartedCloudPreferencesStore,
+            remoteService = remoteGateway,
+            syncLocalStore = restartedSyncLocalStore,
+            operationCoordinator = restartedOperationCoordinator,
+            resetCoordinator = restartedResetCoordinator,
+            guestSessionStore = restartedGuestAiSessionStore,
+            appVersion = appVersion
+        )
+        return RestartedCloudAccountRuntime(
+            repository = repository,
+            cloudPreferencesStore = restartedCloudPreferencesStore,
+            guestAiSessionStore = restartedGuestAiSessionStore,
+            syncLocalStore = restartedSyncLocalStore
+        )
+    }
+
+    suspend fun createRestartedCloudGuestSessionRuntime(
+        remoteGateway: CloudRemoteGateway
+    ): RestartedCloudGuestSessionRuntime {
+        val restartedCloudPreferencesStore = CloudPreferencesStore(context = context, database = database)
+        restartedCloudPreferencesStore.hydrateCloudSettingsFromDatabase()
+        val restartedAiChatPreferencesStore = AiChatPreferencesStore(context = context)
+        val restartedAiChatHistoryStore = AiChatHistoryStore(context = context)
+        val restartedGuestAiSessionStore = GuestAiSessionStore(context = context)
+        val restartedOperationCoordinator = CloudOperationCoordinator()
+        val restartedResetCoordinator = CloudIdentityResetCoordinator(
+            database = database,
+            cloudPreferencesStore = restartedCloudPreferencesStore,
+            aiChatPreferencesStore = restartedAiChatPreferencesStore,
+            aiChatHistoryStore = restartedAiChatHistoryStore,
+            guestAiSessionStore = restartedGuestAiSessionStore
+        )
+        val restartedSyncLocalStore = SyncLocalStore(
+            database = database,
+            preferencesStore = restartedCloudPreferencesStore,
+            reviewPreferencesStore = reviewPreferencesStore,
+            localProgressCacheStore = LocalProgressCacheStore(
+                database = database,
+                timeProvider = SystemProgressTimeProvider
+            )
+        )
+        val coordinator = CloudGuestSessionCoordinator(
+            database = database,
+            preferencesStore = restartedCloudPreferencesStore,
+            remoteService = remoteGateway,
+            syncLocalStore = restartedSyncLocalStore,
+            operationCoordinator = restartedOperationCoordinator,
+            resetCoordinator = restartedResetCoordinator,
+            guestSessionStore = restartedGuestAiSessionStore,
+            aiChatRemoteService = aiChatRemoteService,
+            appVersion = appVersion
+        )
+        return RestartedCloudGuestSessionRuntime(
+            cloudPreferencesStore = restartedCloudPreferencesStore,
+            guestAiSessionStore = restartedGuestAiSessionStore,
+            cloudGuestSessionCoordinator = coordinator
         )
     }
 
@@ -251,10 +347,11 @@ internal class CloudIdentityTestEnvironment private constructor(
         return cardId
     }
 
-    private fun createSyncLocalStore(): SyncLocalStore {
+    fun createSyncLocalStore(): SyncLocalStore {
         return SyncLocalStore(
             database = database,
             preferencesStore = cloudPreferencesStore,
+            reviewPreferencesStore = reviewPreferencesStore,
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
                 timeProvider = SystemProgressTimeProvider
@@ -263,9 +360,23 @@ internal class CloudIdentityTestEnvironment private constructor(
     }
 }
 
+internal data class RestartedCloudAccountRuntime(
+    val repository: LocalCloudAccountRepository,
+    val cloudPreferencesStore: CloudPreferencesStore,
+    val guestAiSessionStore: GuestAiSessionStore,
+    val syncLocalStore: SyncLocalStore
+)
+
+internal data class RestartedCloudGuestSessionRuntime(
+    val cloudPreferencesStore: CloudPreferencesStore,
+    val guestAiSessionStore: GuestAiSessionStore,
+    val cloudGuestSessionCoordinator: CloudGuestSessionCoordinator
+)
+
 internal fun clearCloudAndAiPreferences(context: Context) {
     context.deleteSharedPreferences("flashcards-cloud-metadata")
     context.deleteSharedPreferences("flashcards-cloud-secrets")
+    context.deleteSharedPreferences("flashcards-review-preferences")
     context.deleteSharedPreferences("flashcards-ai-chat-preferences")
     context.deleteSharedPreferences("flashcards-ai-chat-history")
     context.deleteSharedPreferences("flashcards-ai-chat-guest-session")
@@ -329,6 +440,41 @@ internal fun createCloudAccountSnapshot(
     )
 }
 
+internal fun createCloudGuestUpgradeReconciliation(
+    cardIds: List<String>,
+    deckIds: List<String>,
+    reviewEventIds: List<String>
+): CloudGuestUpgradeReconciliation {
+    return CloudGuestUpgradeReconciliation(
+        droppedEntities = buildList {
+            cardIds.forEach { cardId ->
+                add(
+                    CloudGuestUpgradeDroppedEntity(
+                        entityType = CloudGuestUpgradeDroppedEntityType.CARD,
+                        entityId = cardId
+                    )
+                )
+            }
+            deckIds.forEach { deckId ->
+                add(
+                    CloudGuestUpgradeDroppedEntity(
+                        entityType = CloudGuestUpgradeDroppedEntityType.DECK,
+                        entityId = deckId
+                    )
+                )
+            }
+            reviewEventIds.forEach { reviewEventId ->
+                add(
+                    CloudGuestUpgradeDroppedEntity(
+                        entityType = CloudGuestUpgradeDroppedEntityType.REVIEW_EVENT,
+                        entityId = reviewEventId
+                    )
+                )
+            }
+        }
+    )
+}
+
 internal fun syncStateEntityWithEmptyProgress(workspaceId: String): SyncStateEntity {
     return SyncStateEntity(
         workspaceId = workspaceId,
@@ -336,6 +482,7 @@ internal fun syncStateEntityWithEmptyProgress(workspaceId: String): SyncStateEnt
         lastReviewSequenceId = 0L,
         hasHydratedHotState = false,
         hasHydratedReviewHistory = false,
+        pendingReviewHistoryImport = false,
         lastSyncAttemptAtMillis = null,
         lastSuccessfulSyncAtMillis = null,
         lastSyncError = null,
@@ -347,6 +494,7 @@ private data class FakeCloudRemoteGatewayConfig(
     val deleteFailuresRemaining: Int,
     val fetchAccountError: Exception?,
     val guestUpgradeMode: CloudGuestUpgradeMode?,
+    val guestUpgradeReconciliation: CloudGuestUpgradeReconciliation?,
     val bootstrapPullError: Exception?,
     val bootstrapRemoteIsEmptyResponses: List<Boolean>,
     val bootstrapPushErrors: List<Exception>,
@@ -363,6 +511,7 @@ internal class FakeCloudRemoteGateway private constructor(
     private var deleteFailuresRemaining: Int = config.deleteFailuresRemaining
     private val fetchAccountError: Exception? = config.fetchAccountError
     private val guestUpgradeMode: CloudGuestUpgradeMode? = config.guestUpgradeMode
+    private val guestUpgradeReconciliation: CloudGuestUpgradeReconciliation? = config.guestUpgradeReconciliation
     private val bootstrapPullError: Exception? = config.bootstrapPullError
     private val bootstrapRemoteIsEmptyResponses: List<Boolean> = config.bootstrapRemoteIsEmptyResponses
     private val bootstrapPushErrors: List<Exception> = config.bootstrapPushErrors
@@ -382,6 +531,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = listOf(true),
                     bootstrapPushErrors = emptyList(),
@@ -400,6 +550,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = deleteFailuresRemaining,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = listOf(true),
                     bootstrapPushErrors = emptyList(),
@@ -418,6 +569,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = fetchAccountError,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = listOf(true),
                     bootstrapPushErrors = emptyList(),
@@ -436,6 +588,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = listOf(true),
                     bootstrapPushErrors = emptyList(),
@@ -454,6 +607,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = bootstrapPullError,
                     bootstrapRemoteIsEmptyResponses = listOf(true),
                     bootstrapPushErrors = emptyList(),
@@ -469,13 +623,15 @@ internal class FakeCloudRemoteGateway private constructor(
         fun forGuestUpgrade(
             guestUpgradeMode: CloudGuestUpgradeMode,
             accountSnapshot: CloudAccountSnapshot,
-            bootstrapRemoteIsEmpty: Boolean
+            bootstrapRemoteIsEmpty: Boolean,
+            guestUpgradeReconciliation: CloudGuestUpgradeReconciliation?
         ): FakeCloudRemoteGateway {
             return FakeCloudRemoteGateway(
                 config = createConfig(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = guestUpgradeMode,
+                    guestUpgradeReconciliation = guestUpgradeReconciliation,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = listOf(bootstrapRemoteIsEmpty),
                     bootstrapPushErrors = emptyList(),
@@ -497,6 +653,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = listOf(bootstrapRemoteIsEmpty),
                     bootstrapPushErrors = emptyList(),
@@ -518,6 +675,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = bootstrapRemoteIsEmptyResponses,
                     bootstrapPushErrors = bootstrapPushErrors,
@@ -539,6 +697,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = bootstrapRemoteIsEmptyResponses,
                     bootstrapPushErrors = emptyList(),
@@ -560,6 +719,7 @@ internal class FakeCloudRemoteGateway private constructor(
                     deleteFailuresRemaining = 0,
                     fetchAccountError = null,
                     guestUpgradeMode = null,
+                    guestUpgradeReconciliation = null,
                     bootstrapPullError = null,
                     bootstrapRemoteIsEmptyResponses = listOf(true),
                     bootstrapPushErrors = emptyList(),
@@ -576,6 +736,7 @@ internal class FakeCloudRemoteGateway private constructor(
             deleteFailuresRemaining: Int,
             fetchAccountError: Exception?,
             guestUpgradeMode: CloudGuestUpgradeMode?,
+            guestUpgradeReconciliation: CloudGuestUpgradeReconciliation?,
             bootstrapPullError: Exception?,
             bootstrapRemoteIsEmptyResponses: List<Boolean>,
             bootstrapPushErrors: List<Exception>,
@@ -589,6 +750,7 @@ internal class FakeCloudRemoteGateway private constructor(
                 deleteFailuresRemaining = deleteFailuresRemaining,
                 fetchAccountError = fetchAccountError,
                 guestUpgradeMode = guestUpgradeMode,
+                guestUpgradeReconciliation = guestUpgradeReconciliation,
                 bootstrapPullError = bootstrapPullError,
                 bootstrapRemoteIsEmptyResponses = bootstrapRemoteIsEmptyResponses,
                 bootstrapPushErrors = bootstrapPushErrors,
@@ -628,9 +790,15 @@ internal class FakeCloudRemoteGateway private constructor(
     var deleteAccountCalls: Int = 0
     var prepareGuestUpgradeCalls: Int = 0
     var completeGuestUpgradeCalls: Int = 0
+    val completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained = mutableListOf<Boolean>()
+    val completeGuestUpgradeSupportsDroppedEntities = mutableListOf<Boolean>()
     var createWorkspaceCalls: Int = 0
     var selectWorkspaceCalls: Int = 0
     val renameWorkspaceIds = mutableListOf<String>()
+    val syncRequestEvents = mutableListOf<String>()
+    val pushBodies = mutableListOf<JSONObject>()
+    val pullBodies = mutableListOf<JSONObject>()
+    val pullReviewHistoryBodies = mutableListOf<JSONObject>()
     val bootstrapPullWorkspaceIds = mutableListOf<String>()
     val bootstrapPushBodies = mutableListOf<JSONObject>()
     val importReviewHistoryBodies = mutableListOf<JSONObject>()
@@ -701,10 +869,17 @@ internal class FakeCloudRemoteGateway private constructor(
         apiBaseUrl: String,
         bearerToken: String,
         guestToken: String,
-        selection: CloudGuestUpgradeSelection
-    ): CloudWorkspaceSummary {
+        selection: CloudGuestUpgradeSelection,
+        guestWorkspaceSyncedAndOutboxDrained: Boolean,
+        supportsDroppedEntities: Boolean
+    ): CloudGuestUpgradeCompletion {
         completeGuestUpgradeCalls += 1
-        return resolveWorkspaceSelection(selection = selection)
+        completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained += guestWorkspaceSyncedAndOutboxDrained
+        completeGuestUpgradeSupportsDroppedEntities += supportsDroppedEntities
+        return CloudGuestUpgradeCompletion(
+            workspace = resolveWorkspaceSelection(selection = selection),
+            reconciliation = guestUpgradeReconciliation
+        )
     }
 
     override suspend fun createWorkspace(
@@ -827,7 +1002,17 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         body: JSONObject
     ): RemotePushResponse {
-        return RemotePushResponse(operations = emptyList())
+        syncRequestEvents += "push"
+        pushBodies += JSONObject(body.toString())
+        val operations = body.getJSONArray("operations")
+        return RemotePushResponse(
+            operations = List(operations.length()) { index ->
+                RemotePushOperationResult(
+                    operationId = operations.getJSONObject(index).getString("operationId"),
+                    resultingHotChangeId = 100L + index
+                )
+            }
+        )
     }
 
     override suspend fun pull(
@@ -836,6 +1021,8 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         body: JSONObject
     ): RemotePullResponse {
+        syncRequestEvents += "pull"
+        pullBodies += JSONObject(body.toString())
         return RemotePullResponse(changes = emptyList(), nextHotChangeId = 0L, hasMore = false)
     }
 
@@ -848,6 +1035,7 @@ internal class FakeCloudRemoteGateway private constructor(
         bootstrapPullError?.let { error ->
             throw error
         }
+        syncRequestEvents += "bootstrap_pull"
         bootstrapPullWorkspaceIds += workspaceId
         return RemoteBootstrapPullResponse(
             entries = emptyList(),
@@ -864,6 +1052,7 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         body: JSONObject
     ): RemoteBootstrapPushResponse {
+        syncRequestEvents += "bootstrap_push"
         bootstrapPushBodies += JSONObject(body.toString())
         nextBootstrapPushErrorOrNull()?.let { error ->
             throw error
@@ -880,6 +1069,8 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         body: JSONObject
     ): RemoteReviewHistoryPullResponse {
+        syncRequestEvents += "pull_review_history"
+        pullReviewHistoryBodies += JSONObject(body.toString())
         return RemoteReviewHistoryPullResponse(
             reviewEvents = emptyList(),
             nextReviewSequenceId = 0L,
@@ -893,6 +1084,7 @@ internal class FakeCloudRemoteGateway private constructor(
         workspaceId: String,
         body: JSONObject
     ): RemoteReviewHistoryImportResponse {
+        syncRequestEvents += "import_review_history"
         importReviewHistoryBodies += JSONObject(body.toString())
         nextImportReviewHistoryErrorOrNull()?.let { error ->
             throw error

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalCloudAccountRepositoryCloudIdentityTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalCloudAccountRepositoryCloudIdentityTest.kt
@@ -1,17 +1,41 @@
 package com.flashcardsopensourceapp.data.local
 
+import androidx.room.withTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.flashcardsopensourceapp.data.local.cloud.forkedCardId
-import com.flashcardsopensourceapp.data.local.cloud.forkedReviewEventId
+import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.cloud.CloudSyncConflictDetails
+import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemotePullResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemoteReviewHistoryPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.SyncLocalStore
+import com.flashcardsopensourceapp.data.local.cloud.syncWorkspaceForkRequiredErrorCode
+import com.flashcardsopensourceapp.data.local.database.CardEntity
+import com.flashcardsopensourceapp.data.local.database.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.OutboxEntryEntity
+import com.flashcardsopensourceapp.data.local.database.ReviewLogEntity
+import com.flashcardsopensourceapp.data.local.database.SyncStateEntity
+import com.flashcardsopensourceapp.data.local.database.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeSelection
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.EffortLevel
+import com.flashcardsopensourceapp.data.local.model.FsrsCardState
+import com.flashcardsopensourceapp.data.local.model.ReviewRating
+import com.flashcardsopensourceapp.data.local.model.SyncEntityType
+import com.flashcardsopensourceapp.data.local.model.SyncStatus
+import com.flashcardsopensourceapp.data.local.repository.CloudSyncBlockedException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
@@ -55,7 +79,8 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                     )
                 )
             ),
-            bootstrapRemoteIsEmpty = true
+            bootstrapRemoteIsEmpty = true,
+            guestUpgradeReconciliation = null
         )
         val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
         environment.cloudPreferencesStore.updateCloudSettings(
@@ -181,7 +206,8 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                     )
                 )
             ),
-            bootstrapRemoteIsEmpty = true
+            bootstrapRemoteIsEmpty = true,
+            guestUpgradeReconciliation = null
         )
         val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
         environment.guestAiSessionStore.saveSession(
@@ -211,8 +237,8 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
     }
 
     @Test
-    fun completeGuestUpgradeClearsGuestSessionAndLinksSelectedWorkspace() = runBlocking {
-        val guestWorkspaceId = "guest-workspace"
+    fun completeGuestUpgradeDrainsGuestSyncAndLinksSelectedWorkspace() = runBlocking {
+        val guestWorkspaceId = environment.requireLocalWorkspaceId()
         val selectedWorkspace = createCloudWorkspaceSummary(
             workspaceId = "workspace-linked",
             name = "Linked Workspace",
@@ -226,7 +252,8 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                 email = "user@example.com",
                 workspaces = listOf(selectedWorkspace)
             ),
-            bootstrapRemoteIsEmpty = true
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
         )
         val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
         environment.guestAiSessionStore.saveSession(
@@ -262,23 +289,712 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
         )
         assertEquals(1, remoteGateway.prepareGuestUpgradeCalls)
         assertEquals(1, remoteGateway.completeGuestUpgradeCalls)
+        assertEquals(listOf(guestWorkspaceId, selectedWorkspace.workspaceId), remoteGateway.bootstrapPullWorkspaceIds)
+        assertEquals(listOf(true), remoteGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
     }
 
     @Test
-    fun completeGuestUpgradeMergeRequiredPreservesLocalGuestDataWithoutBootstrapProbe() = runBlocking {
+    fun completeGuestUpgradeBlocksOutboxWritesWhileGuestDrainIsRunning() = runBlocking {
+        val guestWorkspaceId = environment.requireLocalWorkspaceId()
+        val selectedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val guestDrainEntered = CompletableDeferred<Unit>()
+        val releaseGuestDrain = CompletableDeferred<Unit>()
+        val baseGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(selectedWorkspace)
+            ),
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
+        )
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPullResponse {
+                if (authorizationHeader == "Guest guest-token" && workspaceId == guestWorkspaceId) {
+                    guestDrainEntered.complete(Unit)
+                    releaseGuestDrain.await()
+                }
+                return baseGateway.bootstrapPull(
+                    apiBaseUrl = apiBaseUrl,
+                    authorizationHeader = authorizationHeader,
+                    workspaceId = workspaceId,
+                    body = body
+                )
+            }
+        }
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        val syncLocalStore = environment.createSyncLocalStore()
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = guestWorkspaceId,
+            session = createStoredGuestAiSession(
+                workspaceId = guestWorkspaceId,
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "guest-token",
+                userId = "guest-user"
+            )
+        )
+        val linkContext = repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        val upgradeResult = async {
+            repository.completeGuestUpgrade(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
+            )
+        }
+        guestDrainEntered.await()
+
+        try {
+            syncLocalStore.enqueueCardUpsert(
+                card = createBlockedGuestUpgradeCard(workspaceId = guestWorkspaceId),
+                tags = emptyList()
+            )
+            throw AssertionError("Expected guest upgrade drain to block local outbox writes.")
+        } catch (error: IllegalStateException) {
+            assertEquals(
+                "Guest upgrade is finishing. Wait for account linking to complete before changing cards.",
+                error.message
+            )
+        }
+
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+
+        releaseGuestDrain.complete(Unit)
+
+        assertEquals(selectedWorkspace.workspaceId, upgradeResult.await().workspaceId)
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(1, baseGateway.completeGuestUpgradeCalls)
+        assertEquals(listOf(true), baseGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
+    }
+
+    @Test
+    fun completeGuestUpgradeWaitsForInFlightOutboxMutationTransactionToCommitBeforeDrain() = runBlocking {
+        val guestWorkspaceId = environment.requireLocalWorkspaceId()
+        val selectedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val transactionStarted = CompletableDeferred<Unit>()
+        val releaseOutboxInsert = CompletableDeferred<Unit>()
+        val outboxInsertedInsideTransaction = CompletableDeferred<Unit>()
+        val releaseTransactionCommit = CompletableDeferred<Unit>()
+        val guestDrainEntered = CompletableDeferred<Unit>()
+        val baseGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(selectedWorkspace)
+            ),
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
+        )
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPullResponse {
+                if (authorizationHeader == "Guest guest-token" && workspaceId == guestWorkspaceId) {
+                    guestDrainEntered.complete(Unit)
+                }
+                return baseGateway.bootstrapPull(
+                    apiBaseUrl = apiBaseUrl,
+                    authorizationHeader = authorizationHeader,
+                    workspaceId = workspaceId,
+                    body = body
+                )
+            }
+        }
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        val syncLocalStore = environment.createSyncLocalStore()
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = guestWorkspaceId,
+            session = createStoredGuestAiSession(
+                workspaceId = guestWorkspaceId,
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "guest-token",
+                userId = "guest-user"
+            )
+        )
+        val linkContext = repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        val mutationResult = async {
+            environment.cloudPreferencesStore.runWithLocalOutboxMutationAllowed {
+                environment.database.withTransaction {
+                    transactionStarted.complete(Unit)
+                    releaseOutboxInsert.await()
+                    syncLocalStore.enqueueCardUpsert(
+                        card = createBlockedGuestUpgradeCard(workspaceId = guestWorkspaceId),
+                        tags = emptyList()
+                    )
+                    outboxInsertedInsideTransaction.complete(Unit)
+                    releaseTransactionCommit.await()
+                }
+            }
+        }
+        transactionStarted.await()
+
+        val upgradeResult = async {
+            repository.completeGuestUpgrade(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
+            )
+        }
+
+        assertNull(withTimeoutOrNull(timeMillis = 100L) { guestDrainEntered.await() })
+
+        releaseOutboxInsert.complete(Unit)
+        outboxInsertedInsideTransaction.await()
+        assertNull(withTimeoutOrNull(timeMillis = 100L) { guestDrainEntered.await() })
+
+        releaseTransactionCommit.complete(Unit)
+        mutationResult.await()
+
+        guestDrainEntered.await()
+        assertEquals(selectedWorkspace.workspaceId, upgradeResult.await().workspaceId)
+
+        val pushedOperations = baseGateway.pushBodies.single().getJSONArray("operations")
+        assertEquals(1, pushedOperations.length())
+        assertEquals("card-blocked-during-guest-upgrade", pushedOperations.getJSONObject(0).getString("entityId"))
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals(listOf(true), baseGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
+    }
+
+    @Test
+    fun completeGuestUpgradeDoesNotForkGuestIdentityWhenGuestDrainRequiresWorkspaceFork() = runBlocking {
+        val guestWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val seededCardId = environment.seedWorkspaceData(workspaceId = guestWorkspaceId)
+        val selectedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val baseGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(selectedWorkspace)
+            ),
+            bootstrapRemoteIsEmpty = true,
+            guestUpgradeReconciliation = null
+        )
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPush(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPushResponse {
+                baseGateway.syncRequestEvents += "bootstrap_push"
+                baseGateway.bootstrapPushBodies += JSONObject(body.toString())
+                if (authorizationHeader == "Guest guest-token" && workspaceId == guestWorkspaceId) {
+                    throw createWorkspaceForkRequiredError(
+                        path = "/sync/bootstrap",
+                        requestId = "request-guest-drain-fork",
+                        entityType = SyncEntityType.CARD,
+                        entityId = seededCardId
+                    )
+                }
+                return RemoteBootstrapPushResponse(
+                    appliedEntriesCount = 0,
+                    bootstrapHotChangeId = 0L
+                )
+            }
+        }
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = guestWorkspaceId,
+            session = createStoredGuestAiSession(
+                workspaceId = guestWorkspaceId,
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "guest-token",
+                userId = "guest-user"
+            )
+        )
+        val linkContext = repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        try {
+            repository.completeGuestUpgrade(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
+            )
+            throw AssertionError("Expected guest upgrade drain to block workspace fork recovery.")
+        } catch (error: IllegalStateException) {
+            assertTrue(error.message?.contains("Guest upgrade is paused because guest sync did not finish") == true)
+            assertTrue(error.cause is CloudSyncBlockedException)
+            assertTrue(
+                error.cause?.message?.contains(
+                    "automatic workspace identity fork recovery is disabled for this sync"
+                ) == true
+            )
+        }
+
+        val persistedSyncState = requireNotNull(
+            environment.database.syncStateDao().loadSyncState(workspaceId = guestWorkspaceId)
+        ) {
+            "Expected guest sync state to be blocked after fork recovery was disabled."
+        }
+        assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(guestWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertNotNull(environment.database.cardDao().loadCard(seededCardId))
+        assertEquals(0, baseGateway.completeGuestUpgradeCalls)
+        assertEquals(listOf(guestWorkspaceId), baseGateway.bootstrapPullWorkspaceIds)
+        assertEquals(1, baseGateway.bootstrapPushBodies.size)
+        assertEquals(installationId, persistedSyncState.blockedInstallationId)
+        assertEquals(
+            "Cloud sync bootstrap push is blocked for workspace '$guestWorkspaceId': " +
+                "automatic workspace identity fork recovery is disabled for this sync. " +
+                "Reference: request-guest-drain-fork",
+            persistedSyncState.lastSyncError
+        )
+    }
+
+    @Test
+    fun pendingGuestUpgradeCompletionResumesAfterRestartWhenLinkedHydrationFails() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val selectedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val storedGuestSession = createStoredGuestAiSession(
+            workspaceId = localWorkspaceId,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            guestToken = "guest-token",
+            userId = "guest-user"
+        )
+        val baseGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(selectedWorkspace)
+            ),
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
+        )
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPullResponse {
+                throw IllegalStateException("Hydration unavailable.")
+            }
+        }
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.database.syncStateDao().insertSyncState(
+            SyncStateEntity(
+                workspaceId = localWorkspaceId,
+                lastSyncCursor = "0",
+            lastReviewSequenceId = 0L,
+            hasHydratedHotState = true,
+            hasHydratedReviewHistory = true,
+            pendingReviewHistoryImport = false,
+            lastSyncAttemptAtMillis = null,
+            lastSuccessfulSyncAtMillis = null,
+            lastSyncError = null,
+                blockedInstallationId = null
+            )
+        )
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = localWorkspaceId,
+            session = storedGuestSession
+        )
+        val linkContext = repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        try {
+            repository.completeGuestUpgrade(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
+            )
+            throw AssertionError("Expected guest upgrade finalization to fail during linked hydration.")
+        } catch (error: IllegalStateException) {
+            assertTrue(
+                error.message?.contains(
+                    "Guest upgrade completed on the server, but Android could not hydrate linked workspace"
+                ) == true
+            )
+        }
+
+        assertEquals(1, baseGateway.completeGuestUpgradeCalls)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNotNull(environment.cloudPreferencesStore.loadPendingGuestUpgrade())
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(
+            storedGuestSession,
+            environment.guestAiSessionStore.loadAnySession(
+                configuration = com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration()
+            )
+        )
+
+        val restartedRuntime = environment.createRestartedCloudAccountRuntime(remoteGateway = baseGateway)
+
+        assertPendingGuestUpgradeBlocksLocalOutboxWrites(
+            syncLocalStore = restartedRuntime.syncLocalStore,
+            workspaceId = selectedWorkspace.workspaceId
+        )
+
+        restartedRuntime.repository.resumePendingAccountDeletionIfNeeded()
+
+        assertEquals(selectedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, baseGateway.prepareGuestUpgradeCalls)
+        assertEquals(1, baseGateway.completeGuestUpgradeCalls)
+        assertEquals(listOf(true), baseGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
+        assertEquals(listOf(true), baseGateway.completeGuestUpgradeSupportsDroppedEntities)
+        assertEquals(CloudAccountState.LINKED, restartedRuntime.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(
+            selectedWorkspace.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId
+        )
+        assertNotNull(restartedRuntime.cloudPreferencesStore.loadCredentials())
+        assertNull(
+            restartedRuntime.guestAiSessionStore.loadAnySession(
+                configuration = com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration()
+            )
+        )
+    }
+
+    @Test
+    fun pendingGuestUpgradeCompletionReplaysAfterBackendCompleteResponseIsLost() = runBlocking {
+        val guestWorkspaceId = environment.requireLocalWorkspaceId()
+        val selectedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val storedGuestSession = createStoredGuestAiSession(
+            workspaceId = guestWorkspaceId,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            guestToken = "guest-token",
+            userId = "guest-user"
+        )
+        val baseGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(selectedWorkspace)
+            ),
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
+        )
+        val responseLostGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun completeGuestUpgrade(
+                apiBaseUrl: String,
+                bearerToken: String,
+                guestToken: String,
+                selection: CloudGuestUpgradeSelection,
+                guestWorkspaceSyncedAndOutboxDrained: Boolean,
+                supportsDroppedEntities: Boolean
+            ): CloudGuestUpgradeCompletion {
+                val pendingGuestUpgradeState = requireNotNull(
+                    environment.cloudPreferencesStore.loadPendingGuestUpgrade()
+                ) {
+                    "Expected drained guest upgrade recovery intent before backend completion."
+                }
+                assertNull(pendingGuestUpgradeState.completion)
+                baseGateway.completeGuestUpgrade(
+                    apiBaseUrl = apiBaseUrl,
+                    bearerToken = bearerToken,
+                    guestToken = guestToken,
+                    selection = selection,
+                    guestWorkspaceSyncedAndOutboxDrained = guestWorkspaceSyncedAndOutboxDrained,
+                    supportsDroppedEntities = supportsDroppedEntities
+                )
+                throw IllegalStateException("Backend response was lost after guest upgrade completion.")
+            }
+        }
+        val repository = environment.createCloudAccountRepository(remoteGateway = responseLostGateway)
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = guestWorkspaceId,
+            session = storedGuestSession
+        )
+        val linkContext = repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        try {
+            repository.completeGuestUpgrade(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
+            )
+            throw AssertionError("Expected guest upgrade completion response loss.")
+        } catch (error: IllegalStateException) {
+            assertEquals("Backend response was lost after guest upgrade completion.", error.message)
+        }
+
+        val savedPendingGuestUpgradeState = requireNotNull(environment.cloudPreferencesStore.loadPendingGuestUpgrade())
+        assertNull(savedPendingGuestUpgradeState.completion)
+        assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals(1, baseGateway.completeGuestUpgradeCalls)
+
+        val replayGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPullResponse {
+                requireLinkedRecoveryAuthorization(authorizationHeader = authorizationHeader)
+                return baseGateway.bootstrapPull(
+                    apiBaseUrl = apiBaseUrl,
+                    authorizationHeader = authorizationHeader,
+                    workspaceId = workspaceId,
+                    body = body
+                )
+            }
+
+            override suspend fun pull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePullResponse {
+                requireLinkedRecoveryAuthorization(authorizationHeader = authorizationHeader)
+                return baseGateway.pull(
+                    apiBaseUrl = apiBaseUrl,
+                    authorizationHeader = authorizationHeader,
+                    workspaceId = workspaceId,
+                    body = body
+                )
+            }
+
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                requireLinkedRecoveryAuthorization(authorizationHeader = authorizationHeader)
+                return baseGateway.push(
+                    apiBaseUrl = apiBaseUrl,
+                    authorizationHeader = authorizationHeader,
+                    workspaceId = workspaceId,
+                    body = body
+                )
+            }
+
+            override suspend fun pullReviewHistory(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteReviewHistoryPullResponse {
+                requireLinkedRecoveryAuthorization(authorizationHeader = authorizationHeader)
+                return baseGateway.pullReviewHistory(
+                    apiBaseUrl = apiBaseUrl,
+                    authorizationHeader = authorizationHeader,
+                    workspaceId = workspaceId,
+                    body = body
+                )
+            }
+        }
+        val restartedRuntime = environment.createRestartedCloudAccountRuntime(remoteGateway = replayGateway)
+
+        restartedRuntime.repository.resumePendingAccountDeletionIfNeeded()
+
+        assertEquals(2, baseGateway.completeGuestUpgradeCalls)
+        assertEquals(1, baseGateway.prepareGuestUpgradeCalls)
+        assertEquals(listOf(true, true), baseGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
+        assertEquals(listOf(true, true), baseGateway.completeGuestUpgradeSupportsDroppedEntities)
+        assertEquals(CloudAccountState.LINKED, restartedRuntime.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(
+            selectedWorkspace.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId
+        )
+        assertEquals(
+            listOf(guestWorkspaceId, selectedWorkspace.workspaceId),
+            baseGateway.bootstrapPullWorkspaceIds
+        )
+        assertNull(restartedRuntime.cloudPreferencesStore.loadPendingGuestUpgrade())
+    }
+
+    @Test
+    fun completeGuestUpgradeBoundDoesNotCallBackendWhenGuestSyncIsBlocked() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val preservedSyncState = SyncStateEntity(
+            workspaceId = localWorkspaceId,
+            lastSyncCursor = "cursor-123",
+            lastReviewSequenceId = 456L,
+            hasHydratedHotState = true,
+            hasHydratedReviewHistory = true,
+            pendingReviewHistoryImport = false,
+            lastSyncAttemptAtMillis = 1_000L,
+            lastSuccessfulSyncAtMillis = 2_000L,
+            lastSyncError = "sync is blocked",
+            blockedInstallationId = installationId
+        )
+        environment.database.syncStateDao().insertSyncState(preservedSyncState)
+        val boundWorkspace = createCloudWorkspaceSummary(
+            workspaceId = localWorkspaceId,
+            name = "Bound Workspace",
+            createdAtMillis = 400L,
+            isSelected = true
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.BOUND,
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "guest-user",
+                email = "user@example.com",
+                workspaces = listOf(boundWorkspace)
+            ),
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = localWorkspaceId
+        )
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = localWorkspaceId,
+            session = createStoredGuestAiSession(
+                workspaceId = localWorkspaceId,
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "guest-token",
+                userId = "guest-user"
+            )
+        )
+        val linkContext = repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        try {
+            repository.completeGuestUpgrade(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = localWorkspaceId)
+            )
+            throw AssertionError("Expected bound guest upgrade to stop before backend completion.")
+        } catch (error: IllegalStateException) {
+            assertTrue(error.message?.contains("Guest upgrade is paused because guest sync did not finish") == true)
+        }
+
+        assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertNull(environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(preservedSyncState, environment.database.syncStateDao().loadSyncState(localWorkspaceId))
+        assertTrue(remoteGateway.bootstrapPullWorkspaceIds.isEmpty())
+        assertEquals(0, remoteGateway.completeGuestUpgradeCalls)
+        assertTrue(remoteGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained.isEmpty())
+        assertTrue(remoteGateway.completeGuestUpgradeSupportsDroppedEntities.isEmpty())
+    }
+
+    @Test
+    fun completeGuestUpgradeMergeRequiredDrainsGuestOutboxBeforeBackendComplete() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
         val seededCardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val survivingCardId = "card-surviving"
+        val droppedDeckId = "deck-dropped"
+        val explicitDroppedReviewLogId = "review-explicit-drop"
+        val pendingDroppedCardReviewEventId = "review-pending-card-drop"
+        val currentSettings = requireNotNull(
+            environment.database.workspaceSchedulerSettingsDao().loadWorkspaceSchedulerSettings(localWorkspaceId)
+        ) {
+            "Expected workspace scheduler settings for local workspace '$localWorkspaceId'."
+        }
         environment.database.syncStateDao().insertSyncState(
-            com.flashcardsopensourceapp.data.local.database.SyncStateEntity(
+            SyncStateEntity(
                 workspaceId = localWorkspaceId,
                 lastSyncCursor = "123",
                 lastReviewSequenceId = 456L,
                 hasHydratedHotState = true,
                 hasHydratedReviewHistory = true,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = 1_000L,
                 lastSuccessfulSyncAtMillis = 2_000L,
                 lastSyncError = "broken",
                 blockedInstallationId = null
+            )
+        )
+        environment.database.cardDao().insertCard(
+            CardEntity(
+                cardId = survivingCardId,
+                workspaceId = localWorkspaceId,
+                frontText = "Keep Question",
+                backText = "Keep Answer",
+                effortLevel = EffortLevel.MEDIUM,
+                dueAtMillis = null,
+                createdAtMillis = 110L,
+                updatedAtMillis = 110L,
+                reps = 0,
+                lapses = 0,
+                fsrsCardState = FsrsCardState.NEW,
+                fsrsStepIndex = null,
+                fsrsStability = null,
+                fsrsDifficulty = null,
+                fsrsLastReviewedAtMillis = null,
+                fsrsScheduledDays = null,
+                deletedAtMillis = null
+            )
+        )
+        environment.database.deckDao().insertDeck(
+            DeckEntity(
+                deckId = droppedDeckId,
+                workspaceId = localWorkspaceId,
+                name = "Dropped Deck",
+                filterDefinitionJson = JSONObject().put("version", 2).toString(),
+                createdAtMillis = 120L,
+                updatedAtMillis = 120L,
+                deletedAtMillis = null
+            )
+        )
+        environment.database.reviewLogDao().insertReviewLog(
+            ReviewLogEntity(
+                reviewLogId = explicitDroppedReviewLogId,
+                workspaceId = localWorkspaceId,
+                cardId = survivingCardId,
+                replicaId = "replica-explicit-drop",
+                clientEventId = "client-event-explicit-drop",
+                rating = ReviewRating.GOOD,
+                reviewedAtMillis = 210L,
+                reviewedAtServerIso = "2026-04-02T15:51:57.000Z"
             )
         )
         environment.database.outboxDao().insertOutboxEntry(
@@ -313,7 +1029,92 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                 lastError = null
             )
         )
-        val guestWorkspaceId = "guest-workspace"
+        environment.database.outboxDao().insertOutboxEntry(
+            OutboxEntryEntity(
+                outboxEntryId = "outbox-deck-1",
+                workspaceId = localWorkspaceId,
+                installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+                entityType = "deck",
+                entityId = droppedDeckId,
+                operationType = "upsert",
+                payloadJson = JSONObject()
+                    .put("deckId", droppedDeckId)
+                    .put("name", "Dropped Deck")
+                    .put("filterDefinition", JSONObject().put("version", 2))
+                    .put("createdAt", "2026-04-02T15:50:57.000Z")
+                    .put("deletedAt", JSONObject.NULL)
+                    .toString(),
+                clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+                createdAtMillis = 301L,
+                attemptCount = 0,
+                lastError = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            OutboxEntryEntity(
+                outboxEntryId = "outbox-review-event-card-drop",
+                workspaceId = localWorkspaceId,
+                installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+                entityType = "review_event",
+                entityId = pendingDroppedCardReviewEventId,
+                operationType = "append",
+                payloadJson = JSONObject()
+                    .put("reviewEventId", pendingDroppedCardReviewEventId)
+                    .put("cardId", seededCardId)
+                    .put("clientEventId", "client-event-card-drop")
+                    .put("rating", ReviewRating.GOOD.ordinal)
+                    .put("reviewedAtClient", "2026-04-02T15:50:57.000Z")
+                    .toString(),
+                clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+                createdAtMillis = 302L,
+                attemptCount = 0,
+                lastError = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            OutboxEntryEntity(
+                outboxEntryId = "outbox-review-event-explicit-drop",
+                workspaceId = localWorkspaceId,
+                installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+                entityType = "review_event",
+                entityId = explicitDroppedReviewLogId,
+                operationType = "append",
+                payloadJson = JSONObject()
+                    .put("reviewEventId", explicitDroppedReviewLogId)
+                    .put("cardId", survivingCardId)
+                    .put("clientEventId", "client-event-explicit-drop")
+                    .put("rating", ReviewRating.GOOD.ordinal)
+                    .put("reviewedAtClient", "2026-04-02T15:51:57.000Z")
+                    .toString(),
+                clientUpdatedAtIso = "2026-04-02T15:51:57.000Z",
+                createdAtMillis = 303L,
+                attemptCount = 0,
+                lastError = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            OutboxEntryEntity(
+                outboxEntryId = "outbox-settings-1",
+                workspaceId = localWorkspaceId,
+                installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+                entityType = "workspace_scheduler_settings",
+                entityId = localWorkspaceId,
+                operationType = "upsert",
+                payloadJson = JSONObject()
+                    .put("algorithm", currentSettings.algorithm)
+                    .put("desiredRetention", currentSettings.desiredRetention)
+                    .put("learningStepsMinutes", JSONArray(currentSettings.learningStepsMinutesJson))
+                    .put("relearningStepsMinutes", JSONArray(currentSettings.relearningStepsMinutesJson))
+                    .put("maximumIntervalDays", currentSettings.maximumIntervalDays)
+                    .put("enableFuzz", currentSettings.enableFuzz)
+                    .toString(),
+                clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+                createdAtMillis = 304L,
+                attemptCount = 0,
+                lastError = null
+            )
+        )
+        val guestWorkspaceId = localWorkspaceId
         val selectedWorkspace = createCloudWorkspaceSummary(
             workspaceId = "workspace-linked",
             name = "Linked Workspace",
@@ -327,7 +1128,12 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                 email = "user@example.com",
                 workspaces = listOf(selectedWorkspace)
             ),
-            bootstrapRemoteIsEmpty = false
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = createCloudGuestUpgradeReconciliation(
+                cardIds = listOf(seededCardId),
+                deckIds = listOf(droppedDeckId),
+                reviewEventIds = listOf(explicitDroppedReviewLogId)
+            )
         )
         val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
         environment.guestAiSessionStore.saveSession(
@@ -350,59 +1156,128 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
             selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
         )
 
-        val expectedForkedCardId = forkedCardId(
-            sourceWorkspaceId = localWorkspaceId,
-            destinationWorkspaceId = selectedWorkspace.workspaceId,
-            sourceCardId = seededCardId
-        )
-        val expectedForkedReviewEventId = forkedReviewEventId(
-            sourceWorkspaceId = localWorkspaceId,
-            destinationWorkspaceId = selectedWorkspace.workspaceId,
-            sourceReviewEventId = "review-$localWorkspaceId"
-        )
-        val forkedReviewLog = environment.database.reviewLogDao().loadReviewLogs().single()
-        val forkedOutboxEntry = environment.database.outboxDao()
-            .loadAllOutboxEntries(workspaceId = selectedWorkspace.workspaceId)
-            .single()
-        val forkedOutboxPayload = JSONObject(forkedOutboxEntry.payloadJson)
+        val pushedOperations = remoteGateway.pushBodies.single().getJSONArray("operations")
 
+        assertEquals(5, pushedOperations.length())
+        assertEquals("outbox-card-1", pushedOperations.getJSONObject(0).getString("operationId"))
+        assertEquals("outbox-deck-1", pushedOperations.getJSONObject(1).getString("operationId"))
+        assertEquals("outbox-review-event-card-drop", pushedOperations.getJSONObject(2).getString("operationId"))
+        assertEquals("outbox-review-event-explicit-drop", pushedOperations.getJSONObject(3).getString("operationId"))
+        assertEquals("outbox-settings-1", pushedOperations.getJSONObject(4).getString("operationId"))
         assertEquals(selectedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
-        assertNull(environment.database.cardDao().loadCard(seededCardId))
-        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
-        assertEquals(1, environment.database.reviewLogDao().countReviewLogs())
-        assertEquals(expectedForkedReviewEventId, forkedReviewLog.reviewLogId)
-        assertEquals(expectedForkedCardId, forkedReviewLog.cardId)
-        assertEquals(selectedWorkspace.workspaceId, forkedReviewLog.workspaceId)
-        assertEquals(1, environment.database.outboxDao().countOutboxEntries())
-        assertEquals(selectedWorkspace.workspaceId, forkedOutboxEntry.workspaceId)
-        assertEquals(expectedForkedCardId, forkedOutboxEntry.entityId)
-        assertEquals(expectedForkedCardId, forkedOutboxPayload.getString("cardId"))
         assertNull(environment.database.syncStateDao().loadSyncState(localWorkspaceId))
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals(listOf(selectedWorkspace.workspaceId), remoteGateway.bootstrapPullWorkspaceIds)
+        assertEquals(listOf(true), remoteGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
+        assertEquals(listOf(true), remoteGateway.completeGuestUpgradeSupportsDroppedEntities)
         assertEquals(
-            syncStateEntityWithEmptyProgress(workspaceId = selectedWorkspace.workspaceId),
-            environment.database.syncStateDao().loadSyncState(selectedWorkspace.workspaceId)
+            listOf("push", "pull", "pull_review_history", "bootstrap_pull", "pull", "pull_review_history"),
+            remoteGateway.syncRequestEvents
         )
-        assertTrue(remoteGateway.bootstrapPullWorkspaceIds.isEmpty())
     }
 
     @Test
-    fun completeGuestUpgradeIntoEmptyWorkspaceForksLocalDataAndRecreatesSyncState() = runBlocking {
+    fun completeGuestUpgradeMergeRequiredDoesNotCallBackendWhenGuestOutboxRemains() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
-        val seededCardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val schedulerSettings = requireNotNull(
+            environment.database.workspaceSchedulerSettingsDao().loadWorkspaceSchedulerSettings(localWorkspaceId)
+        ) {
+            "Expected workspace scheduler settings for local workspace '$localWorkspaceId'."
+        }
+        val selectedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val baseGateway = FakeCloudRemoteGateway.forGuestUpgrade(
+            guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(selectedWorkspace)
+            ),
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
+        )
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                baseGateway.syncRequestEvents += "push"
+                baseGateway.pushBodies += JSONObject(body.toString())
+                return RemotePushResponse(operations = emptyList())
+            }
+        }
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
         environment.database.syncStateDao().insertSyncState(
-            com.flashcardsopensourceapp.data.local.database.SyncStateEntity(
+            SyncStateEntity(
                 workspaceId = localWorkspaceId,
-                lastSyncCursor = "123",
-                lastReviewSequenceId = 456L,
+                lastSyncCursor = "0",
+                lastReviewSequenceId = 0L,
                 hasHydratedHotState = true,
                 hasHydratedReviewHistory = true,
-                lastSyncAttemptAtMillis = 1_000L,
-                lastSuccessfulSyncAtMillis = 2_000L,
-                lastSyncError = "broken",
+                pendingReviewHistoryImport = false,
+                lastSyncAttemptAtMillis = null,
+                lastSuccessfulSyncAtMillis = null,
+                lastSyncError = null,
                 blockedInstallationId = null
             )
         )
-        val guestWorkspaceId = "guest-workspace"
+        environment.database.outboxDao().insertOutboxEntry(
+            createGuestUpgradeSchedulerSettingsOutboxEntry(
+                outboxEntryId = "outbox-settings-1",
+                workspaceId = localWorkspaceId,
+                installationId = installationId,
+                schedulerSettings = schedulerSettings,
+                createdAtMillis = 300L
+            )
+        )
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = localWorkspaceId,
+            session = createStoredGuestAiSession(
+                workspaceId = localWorkspaceId,
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "guest-token",
+                userId = "guest-user"
+            )
+        )
+        val linkContext = repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        try {
+            repository.completeGuestUpgrade(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
+            )
+            throw AssertionError("Expected guest upgrade to stop while local outbox remains.")
+        } catch (error: IllegalStateException) {
+            assertTrue(error.message?.contains("still has 1 pending local sync operation") == true)
+        }
+
+        assertEquals(0, baseGateway.completeGuestUpgradeCalls)
+        assertTrue(baseGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained.isEmpty())
+        assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, environment.database.outboxDao().countOutboxEntries())
+    }
+
+    @Test
+    fun completeGuestUpgradeMergeRequiredDrainsEqualTimestampOutboxInStableOrder() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val schedulerSettings = requireNotNull(
+            environment.database.workspaceSchedulerSettingsDao().loadWorkspaceSchedulerSettings(localWorkspaceId)
+        ) {
+            "Expected workspace scheduler settings for local workspace '$localWorkspaceId'."
+        }
         val selectedWorkspace = createCloudWorkspaceSummary(
             workspaceId = "workspace-linked",
             name = "Linked Workspace",
@@ -416,13 +1291,43 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                 email = "user@example.com",
                 workspaces = listOf(selectedWorkspace)
             ),
-            bootstrapRemoteIsEmpty = true
+            bootstrapRemoteIsEmpty = false,
+            guestUpgradeReconciliation = null
         )
         val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.database.outboxDao().insertOutboxEntry(
+            createGuestUpgradeCardOutboxEntry(
+                outboxEntryId = "outbox-z-first",
+                workspaceId = localWorkspaceId,
+                installationId = installationId,
+                cardId = "card-first",
+                frontText = "First",
+                createdAtMillis = 300L
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            createGuestUpgradeSchedulerSettingsOutboxEntry(
+                outboxEntryId = "outbox-a-second",
+                workspaceId = localWorkspaceId,
+                installationId = installationId,
+                schedulerSettings = schedulerSettings,
+                createdAtMillis = 300L
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            createGuestUpgradeCardOutboxEntry(
+                outboxEntryId = "outbox-m-third",
+                workspaceId = localWorkspaceId,
+                installationId = installationId,
+                cardId = "card-third",
+                frontText = "Third",
+                createdAtMillis = 300L
+            )
+        )
         environment.guestAiSessionStore.saveSession(
-            localWorkspaceId = guestWorkspaceId,
+            localWorkspaceId = localWorkspaceId,
             session = createStoredGuestAiSession(
-                workspaceId = guestWorkspaceId,
+                workspaceId = localWorkspaceId,
                 configurationMode = CloudServiceConfigurationMode.OFFICIAL,
                 apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
                 guestToken = "guest-token",
@@ -439,31 +1344,15 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
             selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
         )
 
-        val expectedForkedCardId = forkedCardId(
-            sourceWorkspaceId = localWorkspaceId,
-            destinationWorkspaceId = selectedWorkspace.workspaceId,
-            sourceCardId = seededCardId
-        )
-        val expectedForkedReviewEventId = forkedReviewEventId(
-            sourceWorkspaceId = localWorkspaceId,
-            destinationWorkspaceId = selectedWorkspace.workspaceId,
-            sourceReviewEventId = "review-$localWorkspaceId"
-        )
-        val forkedReviewLog = environment.database.reviewLogDao().loadReviewLogs().single()
-
+        val pushedOperations = remoteGateway.pushBodies.single().getJSONArray("operations")
+        val pushedOperationIds = List(pushedOperations.length()) { index ->
+            pushedOperations.getJSONObject(index).getString("operationId")
+        }
+        assertEquals(listOf("outbox-z-first", "outbox-a-second", "outbox-m-third"), pushedOperationIds)
+        assertEquals(localWorkspaceId, pushedOperations.getJSONObject(1).getString("entityId"))
         assertEquals(selectedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
-        assertNull(environment.database.cardDao().loadCard(seededCardId))
-        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
-        assertEquals(selectedWorkspace.workspaceId, environment.database.cardDao().loadCard(expectedForkedCardId)?.workspaceId)
-        assertEquals(1, environment.database.reviewLogDao().countReviewLogs())
-        assertEquals(expectedForkedReviewEventId, forkedReviewLog.reviewLogId)
-        assertEquals(expectedForkedCardId, forkedReviewLog.cardId)
-        assertEquals(selectedWorkspace.workspaceId, forkedReviewLog.workspaceId)
-        assertNull(environment.database.syncStateDao().loadSyncState(localWorkspaceId))
-        assertEquals(
-            syncStateEntityWithEmptyProgress(workspaceId = selectedWorkspace.workspaceId),
-            environment.database.syncStateDao().loadSyncState(selectedWorkspace.workspaceId)
-        )
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals(listOf(true), remoteGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
     }
 
     @Test
@@ -553,6 +1442,52 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
     }
 
     @Test
+    fun completeLinkedWorkspaceTransitionPreservesBlockedSyncStateWhenInitialSyncBlocks() = runBlocking {
+        val initialLocalWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, true, true, true),
+            bootstrapPushErrors = listOf(
+                createWorkspaceForkRequiredErrorWithoutPublicConflictDetails(
+                    path = "/sync/bootstrap",
+                    requestId = "request-transition-bootstrap-1"
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        val expectedMessage =
+            "Cloud sync bootstrap push is blocked for workspace 'workspace-remote': backend did not provide public sync conflict details for automatic local id recovery. Reference: request-transition-bootstrap-1"
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = initialLocalWorkspaceId)
+
+        try {
+            repository.completeLinkedWorkspaceTransition(
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = "workspace-remote")
+            )
+            throw AssertionError("Expected linked workspace transition to fail when initial sync becomes blocked.")
+        } catch (error: IllegalStateException) {
+            assertTrue(error.message?.contains(expectedMessage) == true)
+        }
+
+        val persistedSyncState = requireNotNull(
+            environment.database.syncStateDao().loadSyncState(workspaceId = "workspace-remote")
+        ) {
+            "Expected persisted sync state for workspace 'workspace-remote'."
+        }
+        val recreatedRepository = environment.createSyncRepository(remoteGateway = FakeCloudRemoteGateway.standard())
+        val recreatedStatus = recreatedRepository.observeSyncStatus().first().status
+
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals("workspace-remote", environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals("workspace-remote", environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
+        assertEquals(installationId, persistedSyncState.blockedInstallationId)
+        assertEquals(expectedMessage, persistedSyncState.lastSyncError)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertTrue(recreatedStatus is SyncStatus.Blocked)
+        assertEquals(expectedMessage, (recreatedStatus as SyncStatus.Blocked).message)
+    }
+
+    @Test
     fun switchLinkedWorkspaceWaitsForForegroundSyncToFinish() = runBlocking {
         val initialLocalWorkspaceId = environment.requireLocalWorkspaceId()
         val fetchEntered = CompletableDeferred<Unit>()
@@ -586,5 +1521,180 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
             remoteGateway.createdWorkspaceId,
             environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId
         )
+    }
+}
+
+private fun createWorkspaceForkRequiredError(
+    path: String,
+    requestId: String,
+    entityType: SyncEntityType,
+    entityId: String
+): CloudRemoteException {
+    val remoteEntityType = when (entityType) {
+        SyncEntityType.CARD -> "card"
+        SyncEntityType.DECK -> "deck"
+        SyncEntityType.REVIEW_EVENT -> "review_event"
+        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> "workspace_scheduler_settings"
+    }
+    return CloudRemoteException(
+        message = "Cloud request failed with status 409 for $path",
+        statusCode = 409,
+        responseBody = JSONObject()
+            .put("code", syncWorkspaceForkRequiredErrorCode)
+            .put("requestId", requestId)
+            .put(
+                "details",
+                JSONObject().put(
+                    "syncConflict",
+                    JSONObject()
+                        .put("entityType", remoteEntityType)
+                        .put("entityId", entityId)
+                        .put("recoverable", true)
+                )
+            )
+            .toString(),
+        errorCode = syncWorkspaceForkRequiredErrorCode,
+        requestId = requestId,
+        syncConflict = CloudSyncConflictDetails(
+            entityType = entityType,
+            entityId = entityId,
+            entryIndex = null,
+            reviewEventIndex = null,
+            recoverable = true,
+            conflictingWorkspaceId = null,
+            remoteIsEmpty = null
+        )
+    )
+}
+
+private fun createWorkspaceForkRequiredErrorWithoutPublicConflictDetails(
+    path: String,
+    requestId: String
+): CloudRemoteException {
+    return CloudRemoteException(
+        message = "Cloud request failed with status 409 for $path",
+        statusCode = 409,
+        responseBody = JSONObject()
+            .put("code", syncWorkspaceForkRequiredErrorCode)
+            .put("requestId", requestId)
+            .toString(),
+        errorCode = syncWorkspaceForkRequiredErrorCode,
+        requestId = requestId,
+        syncConflict = null
+    )
+}
+
+private fun createGuestUpgradeCardOutboxEntry(
+    outboxEntryId: String,
+    workspaceId: String,
+    installationId: String,
+    cardId: String,
+    frontText: String,
+    createdAtMillis: Long
+): OutboxEntryEntity {
+    return OutboxEntryEntity(
+        outboxEntryId = outboxEntryId,
+        workspaceId = workspaceId,
+        installationId = installationId,
+        entityType = "card",
+        entityId = cardId,
+        operationType = "upsert",
+        payloadJson = JSONObject()
+            .put("cardId", cardId)
+            .put("frontText", frontText)
+            .put("backText", "Back")
+            .put("tags", JSONArray())
+            .put("effortLevel", "medium")
+            .put("dueAt", JSONObject.NULL)
+            .put("createdAt", "2026-04-02T15:50:57.000Z")
+            .put("reps", 0)
+            .put("lapses", 0)
+            .put("fsrsCardState", "new")
+            .put("fsrsStepIndex", JSONObject.NULL)
+            .put("fsrsStability", JSONObject.NULL)
+            .put("fsrsDifficulty", JSONObject.NULL)
+            .put("fsrsLastReviewedAt", JSONObject.NULL)
+            .put("fsrsScheduledDays", JSONObject.NULL)
+            .put("deletedAt", JSONObject.NULL)
+            .toString(),
+        clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+        createdAtMillis = createdAtMillis,
+        attemptCount = 0,
+        lastError = null
+    )
+}
+
+private fun createGuestUpgradeSchedulerSettingsOutboxEntry(
+    outboxEntryId: String,
+    workspaceId: String,
+    installationId: String,
+    schedulerSettings: WorkspaceSchedulerSettingsEntity,
+    createdAtMillis: Long
+): OutboxEntryEntity {
+    return OutboxEntryEntity(
+        outboxEntryId = outboxEntryId,
+        workspaceId = workspaceId,
+        installationId = installationId,
+        entityType = "workspace_scheduler_settings",
+        entityId = workspaceId,
+        operationType = "upsert",
+        payloadJson = JSONObject()
+            .put("algorithm", schedulerSettings.algorithm)
+            .put("desiredRetention", schedulerSettings.desiredRetention)
+            .put("learningStepsMinutes", JSONArray(schedulerSettings.learningStepsMinutesJson))
+            .put("relearningStepsMinutes", JSONArray(schedulerSettings.relearningStepsMinutesJson))
+            .put("maximumIntervalDays", schedulerSettings.maximumIntervalDays)
+            .put("enableFuzz", schedulerSettings.enableFuzz)
+            .toString(),
+        clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+        createdAtMillis = createdAtMillis,
+        attemptCount = 0,
+        lastError = null
+    )
+}
+
+private suspend fun assertPendingGuestUpgradeBlocksLocalOutboxWrites(
+    syncLocalStore: SyncLocalStore,
+    workspaceId: String
+) {
+    try {
+        syncLocalStore.enqueueCardUpsert(
+            card = createBlockedGuestUpgradeCard(workspaceId = workspaceId),
+            tags = emptyList()
+        )
+        throw AssertionError("Expected pending guest upgrade recovery to block local outbox writes.")
+    } catch (error: IllegalStateException) {
+        assertEquals(
+            "Guest upgrade recovery is pending. Wait for account linking recovery to finish before changing cards.",
+            error.message
+        )
+    }
+}
+
+private fun createBlockedGuestUpgradeCard(workspaceId: String): CardEntity {
+    return CardEntity(
+        cardId = "card-blocked-during-guest-upgrade",
+        workspaceId = workspaceId,
+        frontText = "Blocked Question",
+        backText = "Blocked Answer",
+        effortLevel = EffortLevel.MEDIUM,
+        dueAtMillis = null,
+        createdAtMillis = 500L,
+        updatedAtMillis = 500L,
+        reps = 0,
+        lapses = 0,
+        fsrsCardState = FsrsCardState.NEW,
+        fsrsStepIndex = null,
+        fsrsStability = null,
+        fsrsDifficulty = null,
+        fsrsLastReviewedAtMillis = null,
+        fsrsScheduledDays = null,
+        deletedAtMillis = null
+    )
+}
+
+private fun requireLinkedRecoveryAuthorization(authorizationHeader: String) {
+    require(authorizationHeader.startsWith(prefix = "Bearer ", ignoreCase = false)) {
+        "Pending guest upgrade recovery must not run guest workspace sync. Authorization='$authorizationHeader'."
     }
 }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalCloudAccountRepositoryCloudIdentityTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalCloudAccountRepositoryCloudIdentityTest.kt
@@ -1,6 +1,9 @@
 package com.flashcardsopensourceapp.data.local
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.cloud.forkedCardId
+import com.flashcardsopensourceapp.data.local.cloud.forkedReviewEventId
+import com.flashcardsopensourceapp.data.local.database.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
@@ -9,10 +12,13 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -259,9 +265,9 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
     }
 
     @Test
-    fun completeGuestUpgradeIntoNonEmptyWorkspaceReplacesLocalShellAndResetsSyncState() = runBlocking {
+    fun completeGuestUpgradeMergeRequiredPreservesLocalGuestDataWithoutBootstrapProbe() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
-        environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val seededCardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
         environment.database.syncStateDao().insertSyncState(
             com.flashcardsopensourceapp.data.local.database.SyncStateEntity(
                 workspaceId = localWorkspaceId,
@@ -271,7 +277,40 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                 hasHydratedReviewHistory = true,
                 lastSyncAttemptAtMillis = 1_000L,
                 lastSuccessfulSyncAtMillis = 2_000L,
-                lastSyncError = "broken"
+                lastSyncError = "broken",
+                blockedInstallationId = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            OutboxEntryEntity(
+                outboxEntryId = "outbox-card-1",
+                workspaceId = localWorkspaceId,
+                installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+                entityType = "card",
+                entityId = seededCardId,
+                operationType = "upsert",
+                payloadJson = JSONObject()
+                    .put("cardId", seededCardId)
+                    .put("frontText", "Question")
+                    .put("backText", "Answer")
+                    .put("tags", JSONArray())
+                    .put("effortLevel", "medium")
+                    .put("dueAt", JSONObject.NULL)
+                    .put("createdAt", "2026-04-02T15:50:57.000Z")
+                    .put("reps", 0)
+                    .put("lapses", 0)
+                    .put("fsrsCardState", "new")
+                    .put("fsrsStepIndex", JSONObject.NULL)
+                    .put("fsrsStability", JSONObject.NULL)
+                    .put("fsrsDifficulty", JSONObject.NULL)
+                    .put("fsrsLastReviewedAt", JSONObject.NULL)
+                    .put("fsrsScheduledDays", JSONObject.NULL)
+                    .put("deletedAt", JSONObject.NULL)
+                    .toString(),
+                clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+                createdAtMillis = 300L,
+                attemptCount = 0,
+                lastError = null
             )
         )
         val guestWorkspaceId = "guest-workspace"
@@ -311,18 +350,43 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
             selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
         )
 
+        val expectedForkedCardId = forkedCardId(
+            sourceWorkspaceId = localWorkspaceId,
+            destinationWorkspaceId = selectedWorkspace.workspaceId,
+            sourceCardId = seededCardId
+        )
+        val expectedForkedReviewEventId = forkedReviewEventId(
+            sourceWorkspaceId = localWorkspaceId,
+            destinationWorkspaceId = selectedWorkspace.workspaceId,
+            sourceReviewEventId = "review-$localWorkspaceId"
+        )
+        val forkedReviewLog = environment.database.reviewLogDao().loadReviewLogs().single()
+        val forkedOutboxEntry = environment.database.outboxDao()
+            .loadAllOutboxEntries(workspaceId = selectedWorkspace.workspaceId)
+            .single()
+        val forkedOutboxPayload = JSONObject(forkedOutboxEntry.payloadJson)
+
         assertEquals(selectedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
-        assertEquals(0, environment.database.cardDao().observeCardsWithRelations().first().size)
-        assertEquals(0, environment.database.reviewLogDao().countReviewLogs())
+        assertNull(environment.database.cardDao().loadCard(seededCardId))
+        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
+        assertEquals(1, environment.database.reviewLogDao().countReviewLogs())
+        assertEquals(expectedForkedReviewEventId, forkedReviewLog.reviewLogId)
+        assertEquals(expectedForkedCardId, forkedReviewLog.cardId)
+        assertEquals(selectedWorkspace.workspaceId, forkedReviewLog.workspaceId)
+        assertEquals(1, environment.database.outboxDao().countOutboxEntries())
+        assertEquals(selectedWorkspace.workspaceId, forkedOutboxEntry.workspaceId)
+        assertEquals(expectedForkedCardId, forkedOutboxEntry.entityId)
+        assertEquals(expectedForkedCardId, forkedOutboxPayload.getString("cardId"))
         assertNull(environment.database.syncStateDao().loadSyncState(localWorkspaceId))
         assertEquals(
             syncStateEntityWithEmptyProgress(workspaceId = selectedWorkspace.workspaceId),
             environment.database.syncStateDao().loadSyncState(selectedWorkspace.workspaceId)
         )
+        assertTrue(remoteGateway.bootstrapPullWorkspaceIds.isEmpty())
     }
 
     @Test
-    fun completeGuestUpgradeIntoEmptyWorkspacePreservesLocalDataAndRecreatesSyncState() = runBlocking {
+    fun completeGuestUpgradeIntoEmptyWorkspaceForksLocalDataAndRecreatesSyncState() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
         val seededCardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
         environment.database.syncStateDao().insertSyncState(
@@ -334,7 +398,8 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
                 hasHydratedReviewHistory = true,
                 lastSyncAttemptAtMillis = 1_000L,
                 lastSuccessfulSyncAtMillis = 2_000L,
-                lastSyncError = "broken"
+                lastSyncError = "broken",
+                blockedInstallationId = null
             )
         )
         val guestWorkspaceId = "guest-workspace"
@@ -374,10 +439,26 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
             selection = CloudWorkspaceLinkSelection.Existing(workspaceId = selectedWorkspace.workspaceId)
         )
 
+        val expectedForkedCardId = forkedCardId(
+            sourceWorkspaceId = localWorkspaceId,
+            destinationWorkspaceId = selectedWorkspace.workspaceId,
+            sourceCardId = seededCardId
+        )
+        val expectedForkedReviewEventId = forkedReviewEventId(
+            sourceWorkspaceId = localWorkspaceId,
+            destinationWorkspaceId = selectedWorkspace.workspaceId,
+            sourceReviewEventId = "review-$localWorkspaceId"
+        )
+        val forkedReviewLog = environment.database.reviewLogDao().loadReviewLogs().single()
+
         assertEquals(selectedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
-        assertNotNull(environment.database.cardDao().loadCard(seededCardId))
-        assertEquals(selectedWorkspace.workspaceId, environment.database.cardDao().loadCard(seededCardId)?.workspaceId)
+        assertNull(environment.database.cardDao().loadCard(seededCardId))
+        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
+        assertEquals(selectedWorkspace.workspaceId, environment.database.cardDao().loadCard(expectedForkedCardId)?.workspaceId)
         assertEquals(1, environment.database.reviewLogDao().countReviewLogs())
+        assertEquals(expectedForkedReviewEventId, forkedReviewLog.reviewLogId)
+        assertEquals(expectedForkedCardId, forkedReviewLog.cardId)
+        assertEquals(selectedWorkspace.workspaceId, forkedReviewLog.workspaceId)
         assertNull(environment.database.syncStateDao().loadSyncState(localWorkspaceId))
         assertEquals(
             syncStateEntityWithEmptyProgress(workspaceId = selectedWorkspace.workspaceId),

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalSyncRepositoryCloudIdentityTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalSyncRepositoryCloudIdentityTest.kt
@@ -1,9 +1,17 @@
 package com.flashcardsopensourceapp.data.local
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
+import com.flashcardsopensourceapp.data.local.cloud.CloudSyncConflictDetails
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.forkedCardId
+import com.flashcardsopensourceapp.data.local.cloud.forkedReviewEventId
+import com.flashcardsopensourceapp.data.local.cloud.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.database.CardEntity
+import com.flashcardsopensourceapp.data.local.database.OutboxEntryEntity
+import com.flashcardsopensourceapp.data.local.database.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
@@ -13,6 +21,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -50,7 +59,8 @@ class LocalSyncRepositoryCloudIdentityTest {
                     .put("requestId", "request-1")
                     .toString(),
                 errorCode = "ACCOUNT_DELETED",
-                requestId = "request-1"
+                requestId = "request-1",
+                syncConflict = null
             )
         )
         val repository = environment.createSyncRepository(remoteGateway = remoteGateway)
@@ -281,7 +291,8 @@ class LocalSyncRepositoryCloudIdentityTest {
                     .put("requestId", "request-platform-mismatch")
                     .toString(),
                 errorCode = "SYNC_INSTALLATION_PLATFORM_MISMATCH",
-                requestId = "request-platform-mismatch"
+                requestId = "request-platform-mismatch",
+                syncConflict = null
             )
         )
         val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
@@ -320,7 +331,8 @@ class LocalSyncRepositoryCloudIdentityTest {
                     .put("requestId", "request-replica-conflict")
                     .toString(),
                 errorCode = "SYNC_REPLICA_CONFLICT",
-                requestId = "request-replica-conflict"
+                requestId = "request-replica-conflict",
+                syncConflict = null
             )
         )
         val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
@@ -344,6 +356,333 @@ class LocalSyncRepositoryCloudIdentityTest {
             "Cloud request failed with status 409 for /sync/bootstrap-pull",
             (syncStatus as SyncStatus.Blocked).message
         )
+    }
+
+    @Test
+    fun syncBlocksWorkspaceForkRequiredPushConflictWithoutResettingIdentity() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val initialInstallationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val baseGateway = FakeCloudRemoteGateway.standard()
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                throw createWorkspaceForkRequiredError(
+                    path = "/sync/push",
+                    requestId = "request-push-fork",
+                    conflictingWorkspaceId = "workspace-conflict-source",
+                    remoteIsEmpty = false
+                )
+            }
+        }
+        val schedulerSettings = requireNotNull(
+            environment.database.workspaceSchedulerSettingsDao().loadWorkspaceSchedulerSettings(workspaceId)
+        ) {
+            "Expected workspace scheduler settings for workspace '$workspaceId'."
+        }
+        environment.database.syncStateDao().insertSyncState(
+            SyncStateEntity(
+                workspaceId = workspaceId,
+                lastSyncCursor = "0",
+                lastReviewSequenceId = 0L,
+                hasHydratedHotState = true,
+                hasHydratedReviewHistory = true,
+                lastSyncAttemptAtMillis = null,
+                lastSuccessfulSyncAtMillis = null,
+                lastSyncError = null,
+                blockedInstallationId = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            OutboxEntryEntity(
+                outboxEntryId = "outbox-1",
+                workspaceId = workspaceId,
+                installationId = initialInstallationId,
+                entityType = "workspace_scheduler_settings",
+                entityId = workspaceId,
+                operationType = "upsert",
+                payloadJson = JSONObject()
+                    .put("algorithm", schedulerSettings.algorithm)
+                    .put("desiredRetention", schedulerSettings.desiredRetention)
+                    .put("learningStepsMinutes", JSONArray(schedulerSettings.learningStepsMinutesJson))
+                    .put("relearningStepsMinutes", JSONArray(schedulerSettings.relearningStepsMinutesJson))
+                    .put("maximumIntervalDays", schedulerSettings.maximumIntervalDays)
+                    .put("enableFuzz", schedulerSettings.enableFuzz)
+                    .toString(),
+                clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+                createdAtMillis = 300L,
+                attemptCount = 0,
+                lastError = null
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            syncRepository.syncNow()
+        } catch (_: CloudRemoteException) {
+        }
+
+        val cloudSettings = environment.cloudPreferencesStore.currentCloudSettings()
+        val syncStatus = syncRepository.observeSyncStatus().first().status
+        assertEquals(CloudAccountState.LINKED, cloudSettings.cloudState)
+        assertEquals(initialInstallationId, cloudSettings.installationId)
+        assertEquals(workspaceId, cloudSettings.activeWorkspaceId)
+        assertEquals(workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertTrue(syncStatus is SyncStatus.Blocked)
+        assertEquals(
+            "Cloud request failed with status 409 for /sync/push",
+            (syncStatus as SyncStatus.Blocked).message
+        )
+    }
+
+    @Test
+    fun syncRecoversFromWorkspaceForkConflictDuringBootstrapPush() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val conflictingWorkspaceId = "workspace-conflict-source"
+        val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
+            bootstrapPushErrors = listOf(
+                createWorkspaceForkRequiredError(
+                    path = "/sync/bootstrap",
+                    requestId = "request-fork-bootstrap-1",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                )
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        syncRepository.syncNow()
+
+        val expectedForkedCardId = forkedCardId(
+            sourceWorkspaceId = conflictingWorkspaceId,
+            destinationWorkspaceId = workspaceId,
+            sourceCardId = seededCardId
+        )
+        val expectedForkedReviewEventId = forkedReviewEventId(
+            sourceWorkspaceId = conflictingWorkspaceId,
+            destinationWorkspaceId = workspaceId,
+            sourceReviewEventId = "review-$workspaceId"
+        )
+        val firstBootstrapEntries = remoteGateway.bootstrapPushBodies.first().getJSONArray("entries")
+        val secondBootstrapEntries = remoteGateway.bootstrapPushBodies.last().getJSONArray("entries")
+        val importedReviewEvent = remoteGateway.importReviewHistoryBodies.single()
+            .getJSONArray("reviewEvents")
+            .getJSONObject(0)
+
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertNull(environment.database.cardDao().loadCard(seededCardId))
+        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
+        assertEquals(
+            seededCardId,
+            findBootstrapEntryEntityId(entries = firstBootstrapEntries, entityType = "card")
+        )
+        assertEquals(
+            expectedForkedCardId,
+            findBootstrapEntryEntityId(entries = secondBootstrapEntries, entityType = "card")
+        )
+        assertEquals(expectedForkedCardId, importedReviewEvent.getString("cardId"))
+        assertEquals(expectedForkedReviewEventId, importedReviewEvent.getString("reviewEventId"))
+        assertEquals(2, remoteGateway.bootstrapPushBodies.size)
+    }
+
+    @Test
+    fun syncBlocksWorkspaceForkConflictAfterSingleAutomaticRetry() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val conflictingWorkspaceId = "workspace-conflict-source"
+        val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
+            bootstrapPushErrors = listOf(
+                createWorkspaceForkRequiredError(
+                    path = "/sync/bootstrap",
+                    requestId = "request-fork-bootstrap-1",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                ),
+                createWorkspaceForkRequiredError(
+                    path = "/sync/bootstrap",
+                    requestId = "request-fork-bootstrap-2",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                )
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            syncRepository.syncNow()
+        } catch (_: Exception) {
+        }
+
+        val expectedForkedCardId = forkedCardId(
+            sourceWorkspaceId = conflictingWorkspaceId,
+            destinationWorkspaceId = workspaceId,
+            sourceCardId = seededCardId
+        )
+        val syncStatus = syncRepository.observeSyncStatus().first().status
+
+        assertTrue(syncStatus is SyncStatus.Blocked)
+        assertEquals(
+            "Cloud sync bootstrap push is blocked for workspace '$workspaceId': automatic workspace identity fork already ran once in this sync attempt and the backend still requires another fork. Reference: request-fork-bootstrap-2",
+            (syncStatus as SyncStatus.Blocked).message
+        )
+        assertNull(environment.database.cardDao().loadCard(seededCardId))
+        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
+        assertEquals(2, remoteGateway.bootstrapPushBodies.size)
+    }
+
+    @Test
+    fun syncPersistsWorkspaceForkBlockAcrossRepositoryRecreation() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val conflictingWorkspaceId = "workspace-conflict-source"
+        val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val blockingGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
+            bootstrapPushErrors = listOf(
+                createWorkspaceForkRequiredError(
+                    path = "/sync/bootstrap",
+                    requestId = "request-fork-bootstrap-1",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                ),
+                createWorkspaceForkRequiredError(
+                    path = "/sync/bootstrap",
+                    requestId = "request-fork-bootstrap-2",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                )
+            )
+        )
+        val initialRepository = environment.createSyncRepository(remoteGateway = blockingGateway)
+        val expectedMessage =
+            "Cloud sync bootstrap push is blocked for workspace '$workspaceId': automatic workspace identity fork already ran once in this sync attempt and the backend still requires another fork. Reference: request-fork-bootstrap-2"
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            initialRepository.syncNow()
+        } catch (_: Exception) {
+        }
+
+        val persistedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected persisted sync state for workspace '$workspaceId'."
+        }
+        val recreatedGateway = FakeCloudRemoteGateway.standard()
+        val recreatedRepository = environment.createSyncRepository(remoteGateway = recreatedGateway)
+        val recreatedStatus = recreatedRepository.observeSyncStatus().first().status
+
+        assertEquals(expectedMessage, persistedSyncState.lastSyncError)
+        assertEquals(installationId, persistedSyncState.blockedInstallationId)
+        assertTrue(recreatedStatus is SyncStatus.Blocked)
+        assertEquals(expectedMessage, (recreatedStatus as SyncStatus.Blocked).message)
+        assertNull(environment.database.cardDao().loadCard(seededCardId))
+        assertEquals(2, blockingGateway.bootstrapPushBodies.size)
+
+        try {
+            recreatedRepository.syncNow()
+        } catch (error: IllegalStateException) {
+            assertEquals(expectedMessage, error.message)
+        }
+
+        assertTrue(recreatedGateway.bootstrapPullWorkspaceIds.isEmpty())
+        assertTrue(recreatedGateway.bootstrapPushBodies.isEmpty())
+        assertTrue(recreatedGateway.importReviewHistoryBodies.isEmpty())
+    }
+
+    @Test
+    fun disconnectClearsBlockedSyncStateAndSuppressesBlockedStatusAfterRecreation() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val conflictingWorkspaceId = "workspace-conflict-source"
+        val blockingGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
+            bootstrapPushErrors = listOf(
+                createWorkspaceForkRequiredError(
+                    path = "/sync/bootstrap",
+                    requestId = "request-fork-bootstrap-1",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                ),
+                createWorkspaceForkRequiredError(
+                    path = "/sync/bootstrap",
+                    requestId = "request-fork-bootstrap-2",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                )
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = blockingGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            syncRepository.syncNow()
+        } catch (_: Exception) {
+        }
+
+        assertTrue(syncRepository.observeSyncStatus().first().status is SyncStatus.Blocked)
+
+        environment.resetCoordinator.disconnectCloudIdentityPreservingLocalState()
+
+        val clearedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after disconnect."
+        }
+        val recreatedRepository = environment.createSyncRepository(remoteGateway = FakeCloudRemoteGateway.standard())
+
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertNull(clearedSyncState.blockedInstallationId)
+        assertNull(clearedSyncState.lastSyncError)
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertEquals(SyncStatus.Idle, recreatedRepository.observeSyncStatus().first().status)
+    }
+
+    @Test
+    fun syncBlocksReviewHistoryForkConflictWhenRemoteWorkspaceIsNoLongerEmpty() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val conflictingWorkspaceId = "workspace-conflict-source"
+        val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val remoteGateway = FakeCloudRemoteGateway.forReviewHistoryImportScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, false),
+            importReviewHistoryErrors = listOf(
+                createWorkspaceForkRequiredError(
+                    path = "/sync/review-history/import",
+                    requestId = "request-review-history-1",
+                    conflictingWorkspaceId = conflictingWorkspaceId,
+                    remoteIsEmpty = true
+                )
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            syncRepository.syncNow()
+        } catch (_: Exception) {
+        }
+
+        val syncStatus = syncRepository.observeSyncStatus().first().status
+
+        assertTrue(syncStatus is SyncStatus.Blocked)
+        assertEquals(
+            "Cloud sync review history import is blocked for workspace '$workspaceId': backend requested a workspace identity fork, but the remote workspace is not empty. Reference: request-review-history-1",
+            (syncStatus as SyncStatus.Blocked).message
+        )
+        assertNotNull(environment.database.cardDao().loadCard(seededCardId))
+        assertEquals(1, remoteGateway.bootstrapPushBodies.size)
+        assertEquals(1, remoteGateway.importReviewHistoryBodies.size)
     }
 
     @Test
@@ -386,4 +725,45 @@ class LocalSyncRepositoryCloudIdentityTest {
 
         assertEquals(listOf("workspace-after-lock"), remoteGateway.bootstrapPullWorkspaceIds)
     }
+}
+
+private fun createWorkspaceForkRequiredError(
+    path: String,
+    requestId: String,
+    conflictingWorkspaceId: String,
+    remoteIsEmpty: Boolean
+): CloudRemoteException {
+    return CloudRemoteException(
+        message = "Cloud request failed with status 409 for $path",
+        statusCode = 409,
+        responseBody = JSONObject()
+            .put("code", syncWorkspaceForkRequiredErrorCode)
+            .put("requestId", requestId)
+            .put(
+                "details",
+                JSONObject().put(
+                    "syncConflict",
+                    JSONObject()
+                        .put("conflictingWorkspaceId", conflictingWorkspaceId)
+                        .put("remoteIsEmpty", remoteIsEmpty)
+                )
+            )
+            .toString(),
+        errorCode = syncWorkspaceForkRequiredErrorCode,
+        requestId = requestId,
+        syncConflict = CloudSyncConflictDetails(
+            conflictingWorkspaceId = conflictingWorkspaceId,
+            remoteIsEmpty = remoteIsEmpty
+        )
+    )
+}
+
+private fun findBootstrapEntryEntityId(entries: org.json.JSONArray, entityType: String): String {
+    for (index in 0 until entries.length()) {
+        val entry = entries.getJSONObject(index)
+        if (entry.getString("entityType") == entityType) {
+            return entry.getString("entityId")
+        }
+    }
+    throw AssertionError("Missing bootstrap entry for entity type '$entityType'.")
 }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalSyncRepositoryCloudIdentityTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalSyncRepositoryCloudIdentityTest.kt
@@ -5,9 +5,14 @@ import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.cloud.CloudSyncConflictDetails
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
-import com.flashcardsopensourceapp.data.local.cloud.forkedCardId
-import com.flashcardsopensourceapp.data.local.cloud.forkedReviewEventId
+import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapEntry
+import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemotePushOperationResult
+import com.flashcardsopensourceapp.data.local.cloud.RemotePullResponse
 import com.flashcardsopensourceapp.data.local.cloud.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemoteReviewHistoryImportResponse
+import com.flashcardsopensourceapp.data.local.cloud.RemoteSyncChange
 import com.flashcardsopensourceapp.data.local.cloud.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.database.CardEntity
 import com.flashcardsopensourceapp.data.local.database.OutboxEntryEntity
@@ -16,7 +21,9 @@ import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.FsrsCardState
+import com.flashcardsopensourceapp.data.local.model.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.SyncStatus
+import com.flashcardsopensourceapp.data.local.repository.CloudSyncBlockedException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -25,6 +32,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -359,10 +367,13 @@ class LocalSyncRepositoryCloudIdentityTest {
     }
 
     @Test
-    fun syncBlocksWorkspaceForkRequiredPushConflictWithoutResettingIdentity() = runBlocking {
+    fun syncBlocksWorkspaceForkRequiredPushConflictWithoutPublicConflictDetails() = runBlocking {
         val workspaceId = environment.requireLocalWorkspaceId()
         val initialInstallationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
-        val baseGateway = FakeCloudRemoteGateway.standard()
+        val baseGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true),
+            bootstrapPushErrors = emptyList()
+        )
         val remoteGateway = object : CloudRemoteGateway by baseGateway {
             override suspend fun push(
                 apiBaseUrl: String,
@@ -370,11 +381,16 @@ class LocalSyncRepositoryCloudIdentityTest {
                 workspaceId: String,
                 body: JSONObject
             ): RemotePushResponse {
-                throw createWorkspaceForkRequiredError(
-                    path = "/sync/push",
+                throw CloudRemoteException(
+                    message = "Cloud request failed with status 409 for /sync/push",
+                    statusCode = 409,
+                    responseBody = JSONObject()
+                        .put("code", syncWorkspaceForkRequiredErrorCode)
+                        .put("requestId", "request-push-fork")
+                        .toString(),
+                    errorCode = syncWorkspaceForkRequiredErrorCode,
                     requestId = "request-push-fork",
-                    conflictingWorkspaceId = "workspace-conflict-source",
-                    remoteIsEmpty = false
+                    syncConflict = null
                 )
             }
         }
@@ -390,6 +406,7 @@ class LocalSyncRepositoryCloudIdentityTest {
                 lastReviewSequenceId = 0L,
                 hasHydratedHotState = true,
                 hasHydratedReviewHistory = true,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
                 lastSyncError = null,
@@ -424,11 +441,12 @@ class LocalSyncRepositoryCloudIdentityTest {
 
         try {
             syncRepository.syncNow()
-        } catch (_: CloudRemoteException) {
+        } catch (_: CloudSyncBlockedException) {
         }
 
         val cloudSettings = environment.cloudPreferencesStore.currentCloudSettings()
         val syncStatus = syncRepository.observeSyncStatus().first().status
+        val persistedOutboxEntry = environment.database.outboxDao().loadAllOutboxEntries(workspaceId = workspaceId).single()
         assertEquals(CloudAccountState.LINKED, cloudSettings.cloudState)
         assertEquals(initialInstallationId, cloudSettings.installationId)
         assertEquals(workspaceId, cloudSettings.activeWorkspaceId)
@@ -436,15 +454,647 @@ class LocalSyncRepositoryCloudIdentityTest {
         assertNotNull(environment.cloudPreferencesStore.loadCredentials())
         assertTrue(syncStatus is SyncStatus.Blocked)
         assertEquals(
-            "Cloud request failed with status 409 for /sync/push",
+            "Cloud sync push is blocked for workspace '$workspaceId': backend did not provide public sync conflict details for automatic local id recovery. Reference: request-push-fork",
             (syncStatus as SyncStatus.Blocked).message
         )
+        assertNull(persistedOutboxEntry.lastError)
+        assertTrue(baseGateway.bootstrapPullWorkspaceIds.isEmpty())
+    }
+
+    @Test
+    fun syncReIdsLocalCardAfterWorkspaceForkConflictDuringOrdinaryPush() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val initialInstallationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val seededCard = requireNotNull(environment.database.cardDao().loadCard(seededCardId)) {
+            "Expected seeded card '$seededCardId' for workspace '$workspaceId'."
+        }
+        val pushBodies = mutableListOf<JSONObject>()
+        val baseGateway = FakeCloudRemoteGateway.standard()
+        var pushAttempts = 0
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                pushBodies += JSONObject(body.toString())
+                pushAttempts += 1
+                if (pushAttempts == 1) {
+                    throw createWorkspaceForkRequiredError(
+                        path = "/sync/push",
+                        requestId = "request-push-fork-recover",
+                        entityType = SyncEntityType.CARD,
+                        entityId = seededCardId
+                    )
+                }
+
+                val operations = body.getJSONArray("operations")
+                return RemotePushResponse(
+                    operations = List(operations.length()) { index ->
+                        RemotePushOperationResult(
+                            operationId = operations.getJSONObject(index).getString("operationId"),
+                            resultingHotChangeId = 100L + index
+                        )
+                    }
+                )
+            }
+        }
+        environment.database.syncStateDao().insertSyncState(
+            SyncStateEntity(
+                workspaceId = workspaceId,
+                lastSyncCursor = "0",
+                lastReviewSequenceId = 0L,
+                hasHydratedHotState = true,
+                hasHydratedReviewHistory = true,
+                pendingReviewHistoryImport = false,
+                lastSyncAttemptAtMillis = null,
+                lastSuccessfulSyncAtMillis = null,
+                lastSyncError = null,
+                blockedInstallationId = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            OutboxEntryEntity(
+                outboxEntryId = "outbox-card-1",
+                workspaceId = workspaceId,
+                installationId = initialInstallationId,
+                entityType = "card",
+                entityId = seededCardId,
+                operationType = "upsert",
+                payloadJson = JSONObject()
+                    .put("cardId", seededCard.cardId)
+                    .put("frontText", seededCard.frontText)
+                    .put("backText", seededCard.backText)
+                    .put("tags", JSONArray())
+                    .put("effortLevel", "medium")
+                    .put("dueAt", JSONObject.NULL)
+                    .put("createdAt", "2026-04-02T15:50:57.000Z")
+                    .put("reps", seededCard.reps)
+                    .put("lapses", seededCard.lapses)
+                    .put("fsrsCardState", "new")
+                    .put("fsrsStepIndex", JSONObject.NULL)
+                    .put("fsrsStability", JSONObject.NULL)
+                    .put("fsrsDifficulty", JSONObject.NULL)
+                    .put("fsrsLastReviewedAt", JSONObject.NULL)
+                    .put("fsrsScheduledDays", JSONObject.NULL)
+                    .put("deletedAt", JSONObject.NULL)
+                    .toString(),
+                clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+                createdAtMillis = 300L,
+                attemptCount = 0,
+                lastError = null
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        syncRepository.syncNow()
+
+        val recoveredCardId = environment.database.cardDao().loadCards(workspaceId = workspaceId).single().cardId
+        val recoveredReviewLog = environment.database.reviewLogDao().loadReviewLogs(workspaceId = workspaceId).single()
+        val persistedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after push recovery."
+        }
+        val firstPushOperation = pushBodies.first().getJSONArray("operations").getJSONObject(0)
+        val secondPushOperation = pushBodies.last().getJSONArray("operations").getJSONObject(0)
+
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertNull(environment.database.cardDao().loadCard(seededCardId))
+        assertTrue(recoveredCardId != seededCardId)
+        assertEquals(recoveredCardId, recoveredReviewLog.cardId)
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals(2, pushBodies.size)
+        assertEquals(seededCardId, firstPushOperation.getString("entityId"))
+        assertEquals(seededCardId, firstPushOperation.getJSONObject("payload").getString("cardId"))
+        assertEquals(recoveredCardId, secondPushOperation.getString("entityId"))
+        assertEquals(recoveredCardId, secondPushOperation.getJSONObject("payload").getString("cardId"))
+        assertTrue(baseGateway.bootstrapPullWorkspaceIds.isEmpty())
+        assertTrue(baseGateway.bootstrapPushBodies.isEmpty())
+        assertTrue(baseGateway.importReviewHistoryBodies.isEmpty())
+        assertNull(persistedSyncState.lastSyncError)
+        assertNull(persistedSyncState.blockedInstallationId)
+    }
+
+    @Test
+    fun syncReplaysSkippedBootstrapHotRowsAfterDirtyOutboxPushIsIgnored() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val dirtyCard = CardEntity(
+            cardId = "card-dirty-bootstrap",
+            workspaceId = workspaceId,
+            frontText = "Local pending front",
+            backText = "Local pending back",
+            effortLevel = EffortLevel.MEDIUM,
+            dueAtMillis = null,
+            createdAtMillis = 100L,
+            updatedAtMillis = 200L,
+            reps = 0,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.NEW,
+            fsrsStepIndex = null,
+            fsrsStability = null,
+            fsrsDifficulty = null,
+            fsrsLastReviewedAtMillis = null,
+            fsrsScheduledDays = null,
+            deletedAtMillis = null
+        )
+        val remoteCardPayload = createRemoteCardHotPayload(
+            cardId = dirtyCard.cardId,
+            frontText = "Remote winning front",
+            backText = "Remote winning back",
+            tags = listOf("remote"),
+            clientUpdatedAt = "2026-04-02T15:55:57.000Z"
+        )
+        val hotPullCursors = mutableListOf<Long>()
+        val baseGateway = FakeCloudRemoteGateway.standard()
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPullResponse {
+                return RemoteBootstrapPullResponse(
+                    entries = listOf(
+                        RemoteBootstrapEntry(
+                            entityType = SyncEntityType.CARD,
+                            entityId = dirtyCard.cardId,
+                            action = "upsert",
+                            payload = JSONObject(remoteCardPayload.toString())
+                        )
+                    ),
+                    nextCursor = null,
+                    hasMore = false,
+                    bootstrapHotChangeId = 25L,
+                    remoteIsEmpty = false
+                )
+            }
+
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                val operations = body.getJSONArray("operations")
+                return RemotePushResponse(
+                    operations = List(operations.length()) { index ->
+                        RemotePushOperationResult(
+                            operationId = operations.getJSONObject(index).getString("operationId"),
+                            resultingHotChangeId = null
+                        )
+                    }
+                )
+            }
+
+            override suspend fun pull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePullResponse {
+                val afterHotChangeId = body.getLong("afterHotChangeId")
+                hotPullCursors += afterHotChangeId
+                if (afterHotChangeId != 0L) {
+                    return RemotePullResponse(
+                        changes = emptyList(),
+                        nextHotChangeId = afterHotChangeId,
+                        hasMore = false
+                    )
+                }
+                return RemotePullResponse(
+                    changes = listOf(
+                        RemoteSyncChange(
+                            changeId = 25L,
+                            entityType = SyncEntityType.CARD,
+                            entityId = dirtyCard.cardId,
+                            action = "upsert",
+                            payload = JSONObject(remoteCardPayload.toString())
+                        )
+                    ),
+                    nextHotChangeId = 25L,
+                    hasMore = false
+                )
+            }
+        }
+        environment.database.cardDao().insertCard(dirtyCard)
+        environment.database.outboxDao().insertOutboxEntry(
+            createCardOutboxEntry(
+                outboxEntryId = "outbox-dirty-bootstrap",
+                workspaceId = workspaceId,
+                installationId = installationId,
+                card = dirtyCard,
+                createdAtMillis = 300L
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        syncRepository.syncNow()
+
+        val syncedCard = requireNotNull(environment.database.cardDao().loadCard(dirtyCard.cardId)) {
+            "Expected dirty bootstrap card '${dirtyCard.cardId}' after sync."
+        }
+        val persistedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after dirty bootstrap replay."
+        }
+
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertEquals("Remote winning front", syncedCard.frontText)
+        assertEquals("Remote winning back", syncedCard.backText)
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals("25", persistedSyncState.lastSyncCursor)
+        assertTrue(persistedSyncState.hasHydratedHotState)
+        assertTrue(hotPullCursors.contains(0L))
+    }
+
+    @Test
+    fun syncReplaysBootstrapHotRowsDirtiedAfterBootstrapApplyBeforeFinalization() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val dirtyCardId = "card-final-dirty-bootstrap"
+        val remoteCardPayload = createRemoteCardHotPayload(
+            cardId = dirtyCardId,
+            frontText = "Remote winning final front",
+            backText = "Remote winning final back",
+            tags = listOf("remote"),
+            clientUpdatedAt = "2026-04-02T15:55:57.000Z"
+        )
+        val hotPullCursors: MutableList<Long> = mutableListOf()
+        var dirtiedAfterFirstBootstrapPage: Boolean = false
+        val baseGateway = FakeCloudRemoteGateway.standard()
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPullResponse {
+                if (body.isNull("cursor")) {
+                    return RemoteBootstrapPullResponse(
+                        entries = listOf(
+                            RemoteBootstrapEntry(
+                                entityType = SyncEntityType.CARD,
+                                entityId = dirtyCardId,
+                                action = "upsert",
+                                payload = JSONObject(remoteCardPayload.toString())
+                            )
+                        ),
+                        nextCursor = "page-2",
+                        hasMore = true,
+                        bootstrapHotChangeId = 10L,
+                        remoteIsEmpty = false
+                    )
+                }
+
+                if (dirtiedAfterFirstBootstrapPage.not()) {
+                    val appliedCard = requireNotNull(environment.database.cardDao().loadCard(dirtyCardId)) {
+                        "Expected first bootstrap page to apply card '$dirtyCardId'."
+                    }
+                    val localEditedCard = appliedCard.copy(
+                        frontText = "Local pending final front",
+                        backText = "Local pending final back",
+                        updatedAtMillis = 300L
+                    )
+                    environment.database.cardDao().updateCard(localEditedCard)
+                    environment.database.outboxDao().insertOutboxEntry(
+                        createCardOutboxEntry(
+                            outboxEntryId = "outbox-final-dirty-bootstrap",
+                            workspaceId = workspaceId,
+                            installationId = installationId,
+                            card = localEditedCard,
+                            createdAtMillis = 301L
+                        )
+                    )
+                    dirtiedAfterFirstBootstrapPage = true
+                }
+
+                return RemoteBootstrapPullResponse(
+                    entries = emptyList(),
+                    nextCursor = null,
+                    hasMore = false,
+                    bootstrapHotChangeId = 25L,
+                    remoteIsEmpty = false
+                )
+            }
+
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                val operations = body.getJSONArray("operations")
+                return RemotePushResponse(
+                    operations = List(operations.length()) { index ->
+                        RemotePushOperationResult(
+                            operationId = operations.getJSONObject(index).getString("operationId"),
+                            resultingHotChangeId = null
+                        )
+                    }
+                )
+            }
+
+            override suspend fun pull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePullResponse {
+                val afterHotChangeId = body.getLong("afterHotChangeId")
+                hotPullCursors += afterHotChangeId
+                if (afterHotChangeId != 0L) {
+                    return RemotePullResponse(
+                        changes = emptyList(),
+                        nextHotChangeId = afterHotChangeId,
+                        hasMore = false
+                    )
+                }
+                return RemotePullResponse(
+                    changes = listOf(
+                        RemoteSyncChange(
+                            changeId = 25L,
+                            entityType = SyncEntityType.CARD,
+                            entityId = dirtyCardId,
+                            action = "upsert",
+                            payload = JSONObject(remoteCardPayload.toString())
+                        )
+                    ),
+                    nextHotChangeId = 25L,
+                    hasMore = false
+                )
+            }
+        }
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        syncRepository.syncNow()
+
+        val syncedCard = requireNotNull(environment.database.cardDao().loadCard(dirtyCardId)) {
+            "Expected dirty bootstrap card '$dirtyCardId' after final dirty-key replay."
+        }
+        val persistedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after final dirty bootstrap replay."
+        }
+
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertTrue(dirtiedAfterFirstBootstrapPage)
+        assertEquals("Remote winning final front", syncedCard.frontText)
+        assertEquals("Remote winning final back", syncedCard.backText)
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals("25", persistedSyncState.lastSyncCursor)
+        assertTrue(persistedSyncState.hasHydratedHotState)
+        assertEquals(listOf(0L), hotPullCursors)
+    }
+
+    @Test
+    fun syncPullsFromDurableHotCursorAfterOrdinaryPushResultingHotChangeId() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val localCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val localCard = requireNotNull(environment.database.cardDao().loadCard(localCardId)) {
+            "Expected seeded card '$localCardId' for workspace '$workspaceId'."
+        }
+        val remoteCardId = "card-remote-between-push"
+        val remoteCardPayload = createRemoteCardHotPayload(
+            cardId = remoteCardId,
+            frontText = "Remote unseen front",
+            backText = "Remote unseen back",
+            tags = listOf("remote"),
+            clientUpdatedAt = "2026-04-02T15:56:57.000Z"
+        )
+        val hotPullCursors = mutableListOf<Long>()
+        val baseGateway = FakeCloudRemoteGateway.standard()
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                val operations = body.getJSONArray("operations")
+                return RemotePushResponse(
+                    operations = List(operations.length()) { index ->
+                        RemotePushOperationResult(
+                            operationId = operations.getJSONObject(index).getString("operationId"),
+                            resultingHotChangeId = 100L + index
+                        )
+                    }
+                )
+            }
+
+            override suspend fun pull(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePullResponse {
+                val afterHotChangeId = body.getLong("afterHotChangeId")
+                hotPullCursors += afterHotChangeId
+                if (afterHotChangeId != 5L) {
+                    return RemotePullResponse(
+                        changes = emptyList(),
+                        nextHotChangeId = afterHotChangeId,
+                        hasMore = false
+                    )
+                }
+                return RemotePullResponse(
+                    changes = listOf(
+                        RemoteSyncChange(
+                            changeId = 6L,
+                            entityType = SyncEntityType.CARD,
+                            entityId = remoteCardId,
+                            action = "upsert",
+                            payload = JSONObject(remoteCardPayload.toString())
+                        )
+                    ),
+                    nextHotChangeId = 100L,
+                    hasMore = false
+                )
+            }
+        }
+        environment.database.syncStateDao().insertSyncState(
+            SyncStateEntity(
+                workspaceId = workspaceId,
+                lastSyncCursor = "5",
+                lastReviewSequenceId = 0L,
+                hasHydratedHotState = true,
+                hasHydratedReviewHistory = true,
+                pendingReviewHistoryImport = false,
+                lastSyncAttemptAtMillis = null,
+                lastSuccessfulSyncAtMillis = 400L,
+                lastSyncError = null,
+                blockedInstallationId = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            createCardOutboxEntry(
+                outboxEntryId = "outbox-local-card",
+                workspaceId = workspaceId,
+                installationId = installationId,
+                card = localCard,
+                createdAtMillis = 500L
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        syncRepository.syncNow()
+
+        val remoteCard = requireNotNull(environment.database.cardDao().loadCard(remoteCardId)) {
+            "Expected pull to apply remote card '$remoteCardId'."
+        }
+        val persistedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after ordinary push sync."
+        }
+
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertEquals(listOf(5L), hotPullCursors)
+        assertEquals("Remote unseen front", remoteCard.frontText)
+        assertEquals("Remote unseen back", remoteCard.backText)
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals("100", persistedSyncState.lastSyncCursor)
+        assertTrue(baseGateway.bootstrapPullWorkspaceIds.isEmpty())
+    }
+
+    @Test
+    fun syncReIdsMultipleDistinctWorkspaceForkConflictsDuringOrdinaryPush() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val initialInstallationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val firstCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val firstCard = requireNotNull(environment.database.cardDao().loadCard(firstCardId)) {
+            "Expected seeded card '$firstCardId' for workspace '$workspaceId'."
+        }
+        val secondCardId = "card-second-$workspaceId"
+        val secondCard = CardEntity(
+            cardId = secondCardId,
+            workspaceId = workspaceId,
+            frontText = "Question 2",
+            backText = "Answer 2",
+            effortLevel = EffortLevel.MEDIUM,
+            dueAtMillis = null,
+            createdAtMillis = 110L,
+            updatedAtMillis = 110L,
+            reps = 0,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.NEW,
+            fsrsStepIndex = null,
+            fsrsStability = null,
+            fsrsDifficulty = null,
+            fsrsLastReviewedAtMillis = null,
+            fsrsScheduledDays = null,
+            deletedAtMillis = null
+        )
+        environment.database.cardDao().insertCard(secondCard)
+        val pushBodies = mutableListOf<JSONObject>()
+        val baseGateway = FakeCloudRemoteGateway.standard()
+        var pushAttempts = 0
+        val remoteGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun push(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemotePushResponse {
+                pushBodies += JSONObject(body.toString())
+                pushAttempts += 1
+                if (pushAttempts == 1) {
+                    throw createWorkspaceForkRequiredError(
+                        path = "/sync/push",
+                        requestId = "request-push-fork-first",
+                        entityType = SyncEntityType.CARD,
+                        entityId = firstCardId
+                    )
+                }
+                if (pushAttempts == 2) {
+                    throw createWorkspaceForkRequiredError(
+                        path = "/sync/push",
+                        requestId = "request-push-fork-second",
+                        entityType = SyncEntityType.CARD,
+                        entityId = secondCardId
+                    )
+                }
+
+                val operations = body.getJSONArray("operations")
+                return RemotePushResponse(
+                    operations = List(operations.length()) { index ->
+                        RemotePushOperationResult(
+                            operationId = operations.getJSONObject(index).getString("operationId"),
+                            resultingHotChangeId = 200L + index
+                        )
+                    }
+                )
+            }
+        }
+        environment.database.syncStateDao().insertSyncState(
+            SyncStateEntity(
+                workspaceId = workspaceId,
+                lastSyncCursor = "0",
+                lastReviewSequenceId = 0L,
+                hasHydratedHotState = true,
+                hasHydratedReviewHistory = true,
+                pendingReviewHistoryImport = false,
+                lastSyncAttemptAtMillis = null,
+                lastSuccessfulSyncAtMillis = null,
+                lastSyncError = null,
+                blockedInstallationId = null
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            createCardOutboxEntry(
+                outboxEntryId = "outbox-card-1",
+                workspaceId = workspaceId,
+                installationId = initialInstallationId,
+                card = firstCard,
+                createdAtMillis = 300L
+            )
+        )
+        environment.database.outboxDao().insertOutboxEntry(
+            createCardOutboxEntry(
+                outboxEntryId = "outbox-card-2",
+                workspaceId = workspaceId,
+                installationId = initialInstallationId,
+                card = secondCard,
+                createdAtMillis = 301L
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        syncRepository.syncNow()
+
+        val recoveredCardIds = environment.database.cardDao().loadCards(workspaceId = workspaceId).map(CardEntity::cardId)
+        val firstPushEntityIds = collectPushOperationEntityIds(pushBodies[0])
+        val secondPushEntityIds = collectPushOperationEntityIds(pushBodies[1])
+        val thirdPushEntityIds = collectPushOperationEntityIds(pushBodies[2])
+
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertEquals(2, recoveredCardIds.size)
+        assertFalse(recoveredCardIds.contains(firstCardId))
+        assertFalse(recoveredCardIds.contains(secondCardId))
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+        assertEquals(3, pushBodies.size)
+        assertTrue(firstPushEntityIds.contains(firstCardId))
+        assertTrue(firstPushEntityIds.contains(secondCardId))
+        assertFalse(secondPushEntityIds.contains(firstCardId))
+        assertTrue(secondPushEntityIds.contains(secondCardId))
+        assertFalse(thirdPushEntityIds.contains(firstCardId))
+        assertFalse(thirdPushEntityIds.contains(secondCardId))
+        assertTrue(baseGateway.bootstrapPullWorkspaceIds.isEmpty())
+        assertTrue(baseGateway.bootstrapPushBodies.isEmpty())
+        assertTrue(baseGateway.importReviewHistoryBodies.isEmpty())
     }
 
     @Test
     fun syncRecoversFromWorkspaceForkConflictDuringBootstrapPush() = runBlocking {
         val workspaceId = environment.requireLocalWorkspaceId()
-        val conflictingWorkspaceId = "workspace-conflict-source"
         val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
         val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
             bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
@@ -452,8 +1102,8 @@ class LocalSyncRepositoryCloudIdentityTest {
                 createWorkspaceForkRequiredError(
                     path = "/sync/bootstrap",
                     requestId = "request-fork-bootstrap-1",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.CARD,
+                    entityId = seededCardId
                 )
             )
         )
@@ -463,16 +1113,7 @@ class LocalSyncRepositoryCloudIdentityTest {
 
         syncRepository.syncNow()
 
-        val expectedForkedCardId = forkedCardId(
-            sourceWorkspaceId = conflictingWorkspaceId,
-            destinationWorkspaceId = workspaceId,
-            sourceCardId = seededCardId
-        )
-        val expectedForkedReviewEventId = forkedReviewEventId(
-            sourceWorkspaceId = conflictingWorkspaceId,
-            destinationWorkspaceId = workspaceId,
-            sourceReviewEventId = "review-$workspaceId"
-        )
+        val recoveredCardId = environment.database.cardDao().loadCards(workspaceId = workspaceId).single().cardId
         val firstBootstrapEntries = remoteGateway.bootstrapPushBodies.first().getJSONArray("entries")
         val secondBootstrapEntries = remoteGateway.bootstrapPushBodies.last().getJSONArray("entries")
         val importedReviewEvent = remoteGateway.importReviewHistoryBodies.single()
@@ -481,24 +1122,23 @@ class LocalSyncRepositoryCloudIdentityTest {
 
         assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
         assertNull(environment.database.cardDao().loadCard(seededCardId))
-        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
+        assertTrue(recoveredCardId != seededCardId)
         assertEquals(
             seededCardId,
             findBootstrapEntryEntityId(entries = firstBootstrapEntries, entityType = "card")
         )
         assertEquals(
-            expectedForkedCardId,
+            recoveredCardId,
             findBootstrapEntryEntityId(entries = secondBootstrapEntries, entityType = "card")
         )
-        assertEquals(expectedForkedCardId, importedReviewEvent.getString("cardId"))
-        assertEquals(expectedForkedReviewEventId, importedReviewEvent.getString("reviewEventId"))
+        assertEquals(recoveredCardId, importedReviewEvent.getString("cardId"))
+        assertEquals("review-$workspaceId", importedReviewEvent.getString("reviewEventId"))
         assertEquals(2, remoteGateway.bootstrapPushBodies.size)
     }
 
     @Test
-    fun syncBlocksWorkspaceForkConflictAfterSingleAutomaticRetry() = runBlocking {
+    fun syncBlocksRepeatedWorkspaceForkConflictAfterAutomaticRecovery() = runBlocking {
         val workspaceId = environment.requireLocalWorkspaceId()
-        val conflictingWorkspaceId = "workspace-conflict-source"
         val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
         val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
             bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
@@ -506,14 +1146,14 @@ class LocalSyncRepositoryCloudIdentityTest {
                 createWorkspaceForkRequiredError(
                     path = "/sync/bootstrap",
                     requestId = "request-fork-bootstrap-1",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.CARD,
+                    entityId = seededCardId
                 ),
                 createWorkspaceForkRequiredError(
                     path = "/sync/bootstrap",
                     requestId = "request-fork-bootstrap-2",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.CARD,
+                    entityId = seededCardId
                 )
             )
         )
@@ -526,20 +1166,16 @@ class LocalSyncRepositoryCloudIdentityTest {
         } catch (_: Exception) {
         }
 
-        val expectedForkedCardId = forkedCardId(
-            sourceWorkspaceId = conflictingWorkspaceId,
-            destinationWorkspaceId = workspaceId,
-            sourceCardId = seededCardId
-        )
         val syncStatus = syncRepository.observeSyncStatus().first().status
+        val recoveredCardId = environment.database.cardDao().loadCards(workspaceId = workspaceId).single().cardId
 
         assertTrue(syncStatus is SyncStatus.Blocked)
         assertEquals(
-            "Cloud sync bootstrap push is blocked for workspace '$workspaceId': automatic workspace identity fork already ran once in this sync attempt and the backend still requires another fork. Reference: request-fork-bootstrap-2",
+            "Cloud sync bootstrap push is blocked for workspace '$workspaceId': automatic local id recovery already repaired card '$seededCardId' in this sync attempt and the backend still reports the same conflict. Reference: request-fork-bootstrap-2",
             (syncStatus as SyncStatus.Blocked).message
         )
         assertNull(environment.database.cardDao().loadCard(seededCardId))
-        assertNotNull(environment.database.cardDao().loadCard(expectedForkedCardId))
+        assertTrue(recoveredCardId != seededCardId)
         assertEquals(2, remoteGateway.bootstrapPushBodies.size)
     }
 
@@ -547,7 +1183,6 @@ class LocalSyncRepositoryCloudIdentityTest {
     fun syncPersistsWorkspaceForkBlockAcrossRepositoryRecreation() = runBlocking {
         val workspaceId = environment.requireLocalWorkspaceId()
         val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
-        val conflictingWorkspaceId = "workspace-conflict-source"
         val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
         val blockingGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
             bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
@@ -555,20 +1190,20 @@ class LocalSyncRepositoryCloudIdentityTest {
                 createWorkspaceForkRequiredError(
                     path = "/sync/bootstrap",
                     requestId = "request-fork-bootstrap-1",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.CARD,
+                    entityId = seededCardId
                 ),
                 createWorkspaceForkRequiredError(
                     path = "/sync/bootstrap",
                     requestId = "request-fork-bootstrap-2",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.CARD,
+                    entityId = seededCardId
                 )
             )
         )
         val initialRepository = environment.createSyncRepository(remoteGateway = blockingGateway)
         val expectedMessage =
-            "Cloud sync bootstrap push is blocked for workspace '$workspaceId': automatic workspace identity fork already ran once in this sync attempt and the backend still requires another fork. Reference: request-fork-bootstrap-2"
+            "Cloud sync bootstrap push is blocked for workspace '$workspaceId': automatic local id recovery already repaired card '$seededCardId' in this sync attempt and the backend still reports the same conflict. Reference: request-fork-bootstrap-2"
 
         environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
 
@@ -605,21 +1240,21 @@ class LocalSyncRepositoryCloudIdentityTest {
     @Test
     fun disconnectClearsBlockedSyncStateAndSuppressesBlockedStatusAfterRecreation() = runBlocking {
         val workspaceId = environment.requireLocalWorkspaceId()
-        val conflictingWorkspaceId = "workspace-conflict-source"
+        val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
         val blockingGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
             bootstrapRemoteIsEmptyResponses = listOf(true, true, true),
             bootstrapPushErrors = listOf(
                 createWorkspaceForkRequiredError(
                     path = "/sync/bootstrap",
                     requestId = "request-fork-bootstrap-1",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.CARD,
+                    entityId = seededCardId
                 ),
                 createWorkspaceForkRequiredError(
                     path = "/sync/bootstrap",
                     requestId = "request-fork-bootstrap-2",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.CARD,
+                    entityId = seededCardId
                 )
             )
         )
@@ -649,18 +1284,291 @@ class LocalSyncRepositoryCloudIdentityTest {
     }
 
     @Test
-    fun syncBlocksReviewHistoryForkConflictWhenRemoteWorkspaceIsNoLongerEmpty() = runBlocking {
+    fun syncKeepsReviewHistoryImportMarkerWhenBootstrapPushCrashesAfterRemoteCommit() = runBlocking {
         val workspaceId = environment.requireLocalWorkspaceId()
-        val conflictingWorkspaceId = "workspace-conflict-source"
+        environment.seedWorkspaceData(workspaceId = workspaceId)
+        val baseGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true),
+            bootstrapPushErrors = emptyList()
+        )
+        val interruptedGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun bootstrapPush(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteBootstrapPushResponse {
+                val preCommitSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+                    "Expected pending review-history import marker before bootstrap push."
+                }
+                assertTrue(preCommitSyncState.pendingReviewHistoryImport)
+                assertFalse(preCommitSyncState.hasHydratedReviewHistory)
+
+                baseGateway.bootstrapPush(
+                    apiBaseUrl = apiBaseUrl,
+                    authorizationHeader = authorizationHeader,
+                    workspaceId = workspaceId,
+                    body = body
+                )
+
+                val postCommitSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+                    "Expected pending review-history import marker after bootstrap push commit."
+                }
+                assertTrue(postCommitSyncState.pendingReviewHistoryImport)
+                assertFalse(postCommitSyncState.hasHydratedReviewHistory)
+                throw IllegalStateException("Simulated process death after bootstrap hot state commit.")
+            }
+        }
+        val interruptedRepository = environment.createSyncRepository(remoteGateway = interruptedGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            interruptedRepository.syncNow()
+            throw AssertionError("Expected interrupted bootstrap push.")
+        } catch (error: IllegalStateException) {
+            assertEquals("Simulated process death after bootstrap hot state commit.", error.message)
+        }
+
+        val interruptedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after interrupted bootstrap push."
+        }
+        assertTrue(interruptedSyncState.pendingReviewHistoryImport)
+        assertFalse(interruptedSyncState.hasHydratedReviewHistory)
+        assertEquals(1, baseGateway.bootstrapPushBodies.size)
+        assertTrue(baseGateway.importReviewHistoryBodies.isEmpty())
+
+        val resumedGateway = FakeCloudRemoteGateway.forReviewHistoryImportScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(false),
+            importReviewHistoryErrors = emptyList()
+        )
+        val resumedRepository = environment.createSyncRepository(remoteGateway = resumedGateway)
+
+        resumedRepository.syncNow()
+
+        val importedReviewEvent = resumedGateway.importReviewHistoryBodies.single()
+            .getJSONArray("reviewEvents")
+            .getJSONObject(0)
+        val completedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after resumed review-history import."
+        }
+
+        assertEquals("review-$workspaceId", importedReviewEvent.getString("reviewEventId"))
+        assertEquals("card-$workspaceId", importedReviewEvent.getString("cardId"))
+        assertFalse(completedSyncState.pendingReviewHistoryImport)
+        assertTrue(completedSyncState.hasHydratedReviewHistory)
+        assertEquals(listOf(workspaceId), resumedGateway.bootstrapPullWorkspaceIds)
+        assertTrue(resumedGateway.bootstrapPushBodies.isEmpty())
+        assertEquals(
+            listOf(
+                "bootstrap_pull",
+                "import_review_history",
+                "pull",
+                "pull_review_history"
+            ),
+            resumedGateway.syncRequestEvents
+        )
+    }
+
+    @Test
+    fun syncRetriesBootstrapPushWhenPendingReviewHistoryMarkerSurvivesFailedPush() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        environment.seedWorkspaceData(workspaceId = workspaceId)
+        val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, true),
+            bootstrapPushErrors = listOf(IllegalStateException("Simulated bootstrap push failure before commit."))
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            syncRepository.syncNow()
+            throw AssertionError("Expected failed bootstrap push.")
+        } catch (error: IllegalStateException) {
+            assertEquals("Simulated bootstrap push failure before commit.", error.message)
+        }
+
+        val failedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after failed bootstrap push."
+        }
+        assertTrue(failedSyncState.pendingReviewHistoryImport)
+        assertFalse(failedSyncState.hasHydratedReviewHistory)
+        assertEquals(1, remoteGateway.bootstrapPushBodies.size)
+        assertTrue(remoteGateway.importReviewHistoryBodies.isEmpty())
+
+        syncRepository.syncNow()
+
+        val importedReviewEvent = remoteGateway.importReviewHistoryBodies.single()
+            .getJSONArray("reviewEvents")
+            .getJSONObject(0)
+        val completedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after retrying bootstrap push."
+        }
+
+        assertEquals("review-$workspaceId", importedReviewEvent.getString("reviewEventId"))
+        assertEquals("card-$workspaceId", importedReviewEvent.getString("cardId"))
+        assertEquals(2, remoteGateway.bootstrapPushBodies.size)
+        assertFalse(completedSyncState.pendingReviewHistoryImport)
+        assertTrue(completedSyncState.hasHydratedReviewHistory)
+        assertEquals(
+            listOf(
+                "bootstrap_pull",
+                "bootstrap_push",
+                "bootstrap_pull",
+                "bootstrap_push",
+                "import_review_history",
+                "pull",
+                "pull_review_history"
+            ),
+            remoteGateway.syncRequestEvents
+        )
+    }
+
+    @Test
+    fun syncResumesReviewHistoryImportAfterBootstrapPushCrashWhenRemoteIsNoLongerEmpty() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        environment.seedWorkspaceData(workspaceId = workspaceId)
+        val baseGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true),
+            bootstrapPushErrors = emptyList()
+        )
+        val interruptedGateway = object : CloudRemoteGateway by baseGateway {
+            override suspend fun importReviewHistory(
+                apiBaseUrl: String,
+                authorizationHeader: String,
+                workspaceId: String,
+                body: JSONObject
+            ): RemoteReviewHistoryImportResponse {
+                throw IllegalStateException("Simulated process death before review history import.")
+            }
+        }
+        val interruptedRepository = environment.createSyncRepository(remoteGateway = interruptedGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        try {
+            interruptedRepository.syncNow()
+            throw AssertionError("Expected interrupted review-history import.")
+        } catch (error: IllegalStateException) {
+            assertEquals("Simulated process death before review history import.", error.message)
+        }
+
+        val interruptedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after interrupted bootstrap push."
+        }
+        assertTrue(interruptedSyncState.pendingReviewHistoryImport)
+        assertFalse(interruptedSyncState.hasHydratedReviewHistory)
+        assertEquals(1, baseGateway.bootstrapPushBodies.size)
+        assertTrue(baseGateway.importReviewHistoryBodies.isEmpty())
+
+        val resumedGateway = FakeCloudRemoteGateway.forReviewHistoryImportScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(false),
+            importReviewHistoryErrors = emptyList()
+        )
+        val resumedRepository = environment.createSyncRepository(remoteGateway = resumedGateway)
+
+        resumedRepository.syncNow()
+
+        val importedReviewEvent = resumedGateway.importReviewHistoryBodies.single()
+            .getJSONArray("reviewEvents")
+            .getJSONObject(0)
+        val completedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after resumed review-history import."
+        }
+
+        assertEquals("review-$workspaceId", importedReviewEvent.getString("reviewEventId"))
+        assertEquals("card-$workspaceId", importedReviewEvent.getString("cardId"))
+        assertFalse(completedSyncState.pendingReviewHistoryImport)
+        assertTrue(completedSyncState.hasHydratedReviewHistory)
+        assertEquals(listOf(workspaceId), resumedGateway.bootstrapPullWorkspaceIds)
+        assertTrue(resumedGateway.bootstrapPushBodies.isEmpty())
+        assertEquals(
+            listOf(
+                "bootstrap_pull",
+                "import_review_history",
+                "pull",
+                "pull_review_history"
+            ),
+            resumedGateway.syncRequestEvents
+        )
+    }
+
+    @Test
+    fun syncRetriesReviewHistoryImportAfterReIdWithoutRestartingBootstrap() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
         val seededCardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val originalReviewEventId = "review-$workspaceId"
         val remoteGateway = FakeCloudRemoteGateway.forReviewHistoryImportScenario(
             bootstrapRemoteIsEmptyResponses = listOf(true, false),
             importReviewHistoryErrors = listOf(
                 createWorkspaceForkRequiredError(
                     path = "/sync/review-history/import",
                     requestId = "request-review-history-1",
-                    conflictingWorkspaceId = conflictingWorkspaceId,
-                    remoteIsEmpty = true
+                    entityType = SyncEntityType.REVIEW_EVENT,
+                    entityId = originalReviewEventId
+                )
+            )
+        )
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+
+        environment.prepareLinkedCloudIdentity(localWorkspaceId = workspaceId)
+
+        syncRepository.syncNow()
+
+        val recoveredReviewLog = environment.database.reviewLogDao().loadReviewLogs(workspaceId = workspaceId).single()
+        val firstImportedReviewEvent = remoteGateway.importReviewHistoryBodies.first()
+            .getJSONArray("reviewEvents")
+            .getJSONObject(0)
+        val secondImportedReviewEvent = remoteGateway.importReviewHistoryBodies.last()
+            .getJSONArray("reviewEvents")
+            .getJSONObject(0)
+        val persistedSyncState = requireNotNull(environment.database.syncStateDao().loadSyncState(workspaceId)) {
+            "Expected sync state for workspace '$workspaceId' after review-history import recovery."
+        }
+
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertNotNull(environment.database.cardDao().loadCard(seededCardId))
+        assertEquals(seededCardId, recoveredReviewLog.cardId)
+        assertTrue(recoveredReviewLog.reviewLogId != originalReviewEventId)
+        assertEquals(originalReviewEventId, firstImportedReviewEvent.getString("reviewEventId"))
+        assertEquals(recoveredReviewLog.reviewLogId, secondImportedReviewEvent.getString("reviewEventId"))
+        assertEquals(1, remoteGateway.bootstrapPullWorkspaceIds.size)
+        assertEquals(1, remoteGateway.bootstrapPushBodies.size)
+        assertEquals(2, remoteGateway.importReviewHistoryBodies.size)
+        assertTrue(persistedSyncState.hasHydratedReviewHistory)
+        assertEquals(
+            listOf(
+                "bootstrap_pull",
+                "bootstrap_push",
+                "import_review_history",
+                "import_review_history",
+                "pull",
+                "pull_review_history"
+            ),
+            remoteGateway.syncRequestEvents
+        )
+    }
+
+    @Test
+    fun syncBlocksRepeatedReviewHistoryImportForkConflictAfterAutomaticRecovery() = runBlocking {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        environment.seedWorkspaceData(workspaceId = workspaceId)
+        val originalReviewEventId = "review-$workspaceId"
+        val remoteGateway = FakeCloudRemoteGateway.forReviewHistoryImportScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, false),
+            importReviewHistoryErrors = listOf(
+                createWorkspaceForkRequiredError(
+                    path = "/sync/review-history/import",
+                    requestId = "request-review-history-1",
+                    entityType = SyncEntityType.REVIEW_EVENT,
+                    entityId = originalReviewEventId
+                ),
+                createWorkspaceForkRequiredError(
+                    path = "/sync/review-history/import",
+                    requestId = "request-review-history-2",
+                    entityType = SyncEntityType.REVIEW_EVENT,
+                    entityId = originalReviewEventId
                 )
             )
         )
@@ -677,12 +1585,21 @@ class LocalSyncRepositoryCloudIdentityTest {
 
         assertTrue(syncStatus is SyncStatus.Blocked)
         assertEquals(
-            "Cloud sync review history import is blocked for workspace '$workspaceId': backend requested a workspace identity fork, but the remote workspace is not empty. Reference: request-review-history-1",
+            "Cloud sync review history import is blocked for workspace '$workspaceId': automatic local id recovery already repaired review_event '$originalReviewEventId' in this sync attempt and the backend still reports the same conflict. Reference: request-review-history-2",
             (syncStatus as SyncStatus.Blocked).message
         )
-        assertNotNull(environment.database.cardDao().loadCard(seededCardId))
+        assertEquals(1, remoteGateway.bootstrapPullWorkspaceIds.size)
         assertEquals(1, remoteGateway.bootstrapPushBodies.size)
-        assertEquals(1, remoteGateway.importReviewHistoryBodies.size)
+        assertEquals(2, remoteGateway.importReviewHistoryBodies.size)
+        assertEquals(
+            listOf(
+                "bootstrap_pull",
+                "bootstrap_push",
+                "import_review_history",
+                "import_review_history"
+            ),
+            remoteGateway.syncRequestEvents
+        )
     }
 
     @Test
@@ -730,9 +1647,15 @@ class LocalSyncRepositoryCloudIdentityTest {
 private fun createWorkspaceForkRequiredError(
     path: String,
     requestId: String,
-    conflictingWorkspaceId: String,
-    remoteIsEmpty: Boolean
+    entityType: SyncEntityType,
+    entityId: String
 ): CloudRemoteException {
+    val remoteEntityType = when (entityType) {
+        SyncEntityType.CARD -> "card"
+        SyncEntityType.DECK -> "deck"
+        SyncEntityType.REVIEW_EVENT -> "review_event"
+        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> "workspace_scheduler_settings"
+    }
     return CloudRemoteException(
         message = "Cloud request failed with status 409 for $path",
         statusCode = 409,
@@ -744,18 +1667,97 @@ private fun createWorkspaceForkRequiredError(
                 JSONObject().put(
                     "syncConflict",
                     JSONObject()
-                        .put("conflictingWorkspaceId", conflictingWorkspaceId)
-                        .put("remoteIsEmpty", remoteIsEmpty)
+                        .put("entityType", remoteEntityType)
+                        .put("entityId", entityId)
+                        .put("recoverable", true)
                 )
             )
             .toString(),
         errorCode = syncWorkspaceForkRequiredErrorCode,
         requestId = requestId,
         syncConflict = CloudSyncConflictDetails(
-            conflictingWorkspaceId = conflictingWorkspaceId,
-            remoteIsEmpty = remoteIsEmpty
+            entityType = entityType,
+            entityId = entityId,
+            entryIndex = null,
+            reviewEventIndex = null,
+            recoverable = true,
+            conflictingWorkspaceId = null,
+            remoteIsEmpty = null
         )
     )
+}
+
+private fun createCardOutboxEntry(
+    outboxEntryId: String,
+    workspaceId: String,
+    installationId: String,
+    card: CardEntity,
+    createdAtMillis: Long
+): OutboxEntryEntity {
+    return OutboxEntryEntity(
+        outboxEntryId = outboxEntryId,
+        workspaceId = workspaceId,
+        installationId = installationId,
+        entityType = "card",
+        entityId = card.cardId,
+        operationType = "upsert",
+        payloadJson = JSONObject()
+            .put("cardId", card.cardId)
+            .put("frontText", card.frontText)
+            .put("backText", card.backText)
+            .put("tags", JSONArray())
+            .put("effortLevel", "medium")
+            .put("dueAt", JSONObject.NULL)
+            .put("createdAt", "2026-04-02T15:50:57.000Z")
+            .put("reps", card.reps)
+            .put("lapses", card.lapses)
+            .put("fsrsCardState", "new")
+            .put("fsrsStepIndex", JSONObject.NULL)
+            .put("fsrsStability", JSONObject.NULL)
+            .put("fsrsDifficulty", JSONObject.NULL)
+            .put("fsrsLastReviewedAt", JSONObject.NULL)
+            .put("fsrsScheduledDays", JSONObject.NULL)
+            .put("deletedAt", JSONObject.NULL)
+            .toString(),
+        clientUpdatedAtIso = "2026-04-02T15:50:57.000Z",
+        createdAtMillis = createdAtMillis,
+        attemptCount = 0,
+        lastError = null
+    )
+}
+
+private fun createRemoteCardHotPayload(
+    cardId: String,
+    frontText: String,
+    backText: String,
+    tags: List<String>,
+    clientUpdatedAt: String
+): JSONObject {
+    return JSONObject()
+        .put("cardId", cardId)
+        .put("frontText", frontText)
+        .put("backText", backText)
+        .put("tags", JSONArray(tags))
+        .put("effortLevel", "fast")
+        .put("dueAt", JSONObject.NULL)
+        .put("createdAt", "2026-04-02T15:50:57.000Z")
+        .put("clientUpdatedAt", clientUpdatedAt)
+        .put("reps", 0)
+        .put("lapses", 0)
+        .put("fsrsCardState", "new")
+        .put("fsrsStepIndex", JSONObject.NULL)
+        .put("fsrsStability", JSONObject.NULL)
+        .put("fsrsDifficulty", JSONObject.NULL)
+        .put("fsrsLastReviewedAt", JSONObject.NULL)
+        .put("fsrsScheduledDays", JSONObject.NULL)
+        .put("deletedAt", JSONObject.NULL)
+}
+
+private fun collectPushOperationEntityIds(pushBody: JSONObject): List<String> {
+    val operations = pushBody.getJSONArray("operations")
+    return List(operations.length()) { index ->
+        operations.getJSONObject(index).getString("entityId")
+    }
 }
 
 private fun findBootstrapEntryEntityId(entries: org.json.JSONArray, entityType: String): String {

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStoreContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStoreContractTest.kt
@@ -16,6 +16,7 @@ import com.flashcardsopensourceapp.data.local.database.WorkspaceSchedulerSetting
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.FsrsCardState
+import com.flashcardsopensourceapp.data.local.model.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.SyncOperationPayload
@@ -23,6 +24,8 @@ import com.flashcardsopensourceapp.data.local.model.encodeSchedulerStepListJson
 import com.flashcardsopensourceapp.data.local.model.makeDefaultWorkspaceSchedulerSettings
 import com.flashcardsopensourceapp.data.local.repository.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
+import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
+import com.flashcardsopensourceapp.data.local.review.SharedPreferencesReviewPreferencesStore
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
@@ -36,6 +39,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -46,6 +50,7 @@ class SyncLocalStoreContractTest {
     private lateinit var context: Context
     private lateinit var database: AppDatabase
     private lateinit var preferencesStore: CloudPreferencesStore
+    private lateinit var reviewPreferencesStore: ReviewPreferencesStore
     private lateinit var syncLocalStore: SyncLocalStore
 
     @Before
@@ -53,14 +58,17 @@ class SyncLocalStoreContractTest {
         context = ApplicationProvider.getApplicationContext()
         context.deleteSharedPreferences("flashcards-cloud-metadata")
         context.deleteSharedPreferences("flashcards-cloud-secrets")
+        context.deleteSharedPreferences("flashcards-review-preferences")
         database = Room.inMemoryDatabaseBuilder(
             context = context,
             klass = AppDatabase::class.java
         ).allowMainThreadQueries().build()
         preferencesStore = CloudPreferencesStore(context = context, database = database)
+        reviewPreferencesStore = SharedPreferencesReviewPreferencesStore(context = context)
         syncLocalStore = SyncLocalStore(
             database = database,
             preferencesStore = preferencesStore,
+            reviewPreferencesStore = reviewPreferencesStore,
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
                 timeProvider = SystemProgressTimeProvider
@@ -73,6 +81,7 @@ class SyncLocalStoreContractTest {
         database.close()
         context.deleteSharedPreferences("flashcards-cloud-metadata")
         context.deleteSharedPreferences("flashcards-cloud-secrets")
+        context.deleteSharedPreferences("flashcards-review-preferences")
     }
 
     @Test
@@ -129,6 +138,106 @@ class SyncLocalStoreContractTest {
         assertNull(card.fsrsLastReviewedAtMillis)
         assertNull(card.deletedAtMillis)
         assertNull(deck.deletedAtMillis)
+    }
+
+    @Test
+    fun applyBootstrapEntriesPreservesPendingLocalHotRows() = runBlocking {
+        insertWorkspaceShell()
+        val dirtyCard = CardEntity(
+            cardId = "card-dirty",
+            workspaceId = workspaceId,
+            frontText = "Local front",
+            backText = "Local back",
+            effortLevel = EffortLevel.MEDIUM,
+            dueAtMillis = null,
+            createdAtMillis = 1L,
+            updatedAtMillis = 2L,
+            reps = 0,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.NEW,
+            fsrsStepIndex = null,
+            fsrsStability = null,
+            fsrsDifficulty = null,
+            fsrsLastReviewedAtMillis = null,
+            fsrsScheduledDays = null,
+            deletedAtMillis = null
+        )
+        val dirtyDeck = DeckEntity(
+            deckId = "deck-dirty",
+            workspaceId = workspaceId,
+            name = "Local deck",
+            filterDefinitionJson = JSONObject()
+                .put("version", 2)
+                .put("tags", JSONArray().put("local"))
+                .toString(),
+            createdAtMillis = 3L,
+            updatedAtMillis = 4L,
+            deletedAtMillis = null
+        )
+        database.cardDao().insertCard(dirtyCard)
+        database.deckDao().insertDeck(dirtyDeck)
+        database.tagDao().insertTags(
+            listOf(
+                TagEntity(
+                    tagId = "tag-local",
+                    workspaceId = workspaceId,
+                    name = "local"
+                )
+            )
+        )
+        database.tagDao().insertCardTags(
+            listOf(CardTagEntity(cardId = dirtyCard.cardId, tagId = "tag-local"))
+        )
+        syncLocalStore.enqueueCardUpsert(card = dirtyCard, tags = listOf("local"))
+        syncLocalStore.enqueueDeckUpsert(deck = dirtyDeck)
+
+        syncLocalStore.applyBootstrapEntries(
+            workspaceId = workspaceId,
+            entries = listOf(
+                remoteCardBootstrapEntry(
+                    cardId = dirtyCard.cardId,
+                    frontText = "Remote front",
+                    backText = "Remote back",
+                    tags = listOf("remote"),
+                    clientUpdatedAt = "2026-03-27T19:10:00Z"
+                ),
+                remoteDeckBootstrapEntry(
+                    deckId = dirtyDeck.deckId,
+                    name = "Remote deck",
+                    clientUpdatedAt = "2026-03-27T19:11:00Z"
+                ),
+                remoteCardBootstrapEntry(
+                    cardId = "card-clean",
+                    frontText = "Clean front",
+                    backText = "Clean back",
+                    tags = listOf("clean"),
+                    clientUpdatedAt = "2026-03-27T19:12:00Z"
+                ),
+                remoteDeckBootstrapEntry(
+                    deckId = "deck-clean",
+                    name = "Clean deck",
+                    clientUpdatedAt = "2026-03-27T19:13:00Z"
+                )
+            )
+        )
+
+        val preservedCard = requireNotNull(database.cardDao().loadCard(dirtyCard.cardId))
+        val preservedDeck = requireNotNull(database.deckDao().loadDeck(dirtyDeck.deckId))
+        val cleanCard = requireNotNull(database.cardDao().loadCard("card-clean"))
+        val cleanDeck = requireNotNull(database.deckDao().loadDeck("deck-clean"))
+        val preservedCardTags = database.cardDao()
+            .observeCardsWithRelations()
+            .first()
+            .single { card -> card.card.cardId == dirtyCard.cardId }
+            .tags
+            .map(TagEntity::name)
+
+        assertEquals("Local front", preservedCard.frontText)
+        assertEquals("Local back", preservedCard.backText)
+        assertEquals(listOf("local"), preservedCardTags)
+        assertEquals("Local deck", preservedDeck.name)
+        assertEquals("Clean front", cleanCard.frontText)
+        assertEquals("Clean deck", cleanDeck.name)
     }
 
     @Test
@@ -219,6 +328,208 @@ class SyncLocalStoreContractTest {
     }
 
     @Test
+    fun reidentifyWorkspaceForkCardConflictRewritesLocalRowsAndOutboxReferences() = runBlocking {
+        insertWorkspaceShell()
+        val originalCard = CardEntity(
+            cardId = "card-1",
+            workspaceId = workspaceId,
+            frontText = "Front",
+            backText = "Back",
+            effortLevel = EffortLevel.MEDIUM,
+            dueAtMillis = null,
+            createdAtMillis = 1L,
+            updatedAtMillis = 2L,
+            reps = 1,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.REVIEW,
+            fsrsStepIndex = null,
+            fsrsStability = 3.5,
+            fsrsDifficulty = 4.0,
+            fsrsLastReviewedAtMillis = 3L,
+            fsrsScheduledDays = 5,
+            deletedAtMillis = null
+        )
+        val originalReviewLog = ReviewLogEntity(
+            reviewLogId = "review-log-1",
+            workspaceId = workspaceId,
+            cardId = originalCard.cardId,
+            replicaId = "replica-1",
+            clientEventId = "client-event-1",
+            rating = ReviewRating.GOOD,
+            reviewedAtMillis = 6L,
+            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+        )
+        database.cardDao().insertCard(originalCard)
+        database.tagDao().insertTags(
+            listOf(
+                TagEntity(
+                    tagId = "tag-1",
+                    workspaceId = workspaceId,
+                    name = "android"
+                )
+            )
+        )
+        database.tagDao().insertCardTags(
+            listOf(CardTagEntity(cardId = originalCard.cardId, tagId = "tag-1"))
+        )
+        database.reviewLogDao().insertReviewLog(originalReviewLog)
+        reviewPreferencesStore.saveSelectedReviewFilter(
+            workspaceId = workspaceId,
+            reviewFilter = ReviewFilter.Tag(tag = "android")
+        )
+        syncLocalStore.enqueueCardUpsert(card = originalCard, tags = listOf("android"))
+        syncLocalStore.enqueueReviewEventAppend(reviewLog = originalReviewLog)
+
+        val reidentifiedCardId = syncLocalStore.reidentifyWorkspaceForkConflictEntity(
+            workspaceId = workspaceId,
+            entityType = SyncEntityType.CARD,
+            entityId = originalCard.cardId
+        )
+
+        val reidentifiedCard = requireNotNull(database.cardDao().loadCard(reidentifiedCardId))
+        val reidentifiedReviewLog = database.reviewLogDao().loadReviewLogs(workspaceId = workspaceId).single()
+        val reidentifiedCardWithRelations = database.cardDao().observeCardsWithRelations().first().single()
+        val outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId = workspaceId)
+        val cardOutboxPayload = (
+            outboxEntries.first { entry -> entry.operation.entityType == SyncEntityType.CARD }
+                .operation.payload as SyncOperationPayload.Card
+            ).payload
+        val reviewEventOutboxPayload = (
+            outboxEntries.first { entry -> entry.operation.entityType == SyncEntityType.REVIEW_EVENT }
+                .operation.payload as SyncOperationPayload.ReviewEvent
+            ).payload
+
+        assertTrue(reidentifiedCardId != originalCard.cardId)
+        assertNull(database.cardDao().loadCard(originalCard.cardId))
+        assertEquals(originalCard.frontText, reidentifiedCard.frontText)
+        assertEquals(reidentifiedCardId, reidentifiedReviewLog.cardId)
+        assertEquals(originalReviewLog.reviewLogId, reidentifiedReviewLog.reviewLogId)
+        assertEquals(listOf("android"), reidentifiedCardWithRelations.tags.map(TagEntity::name))
+        assertEquals(reidentifiedCardId, cardOutboxPayload.cardId)
+        assertEquals(reidentifiedCardId, reviewEventOutboxPayload.cardId)
+        assertEquals(
+            reidentifiedCardId,
+            outboxEntries.first { entry -> entry.operation.entityType == SyncEntityType.CARD }.operation.entityId
+        )
+        assertEquals(
+            ReviewFilter.AllCards,
+            reviewPreferencesStore.loadSelectedReviewFilter(workspaceId = workspaceId)
+        )
+    }
+
+    @Test
+    fun reidentifyWorkspaceForkReviewEventConflictRewritesReviewLogAndOutbox() = runBlocking {
+        insertWorkspaceShell()
+        insertCard()
+        val originalReviewLog = ReviewLogEntity(
+            reviewLogId = "review-log-1",
+            workspaceId = workspaceId,
+            cardId = "card-1",
+            replicaId = "replica-1",
+            clientEventId = "client-event-1",
+            rating = ReviewRating.GOOD,
+            reviewedAtMillis = 6L,
+            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+        )
+        database.reviewLogDao().insertReviewLog(originalReviewLog)
+        syncLocalStore.enqueueReviewEventAppend(reviewLog = originalReviewLog)
+
+        val reidentifiedReviewEventId = syncLocalStore.reidentifyWorkspaceForkConflictEntity(
+            workspaceId = workspaceId,
+            entityType = SyncEntityType.REVIEW_EVENT,
+            entityId = originalReviewLog.reviewLogId
+        )
+
+        val reviewLog = database.reviewLogDao().loadReviewLogs(workspaceId = workspaceId).single()
+        val outboxEntry = syncLocalStore.loadOutboxEntries(workspaceId = workspaceId).single()
+        val outboxPayload = (outboxEntry.operation.payload as SyncOperationPayload.ReviewEvent).payload
+
+        assertTrue(reidentifiedReviewEventId != originalReviewLog.reviewLogId)
+        assertEquals(reidentifiedReviewEventId, reviewLog.reviewLogId)
+        assertEquals(originalReviewLog.cardId, reviewLog.cardId)
+        assertEquals(reidentifiedReviewEventId, outboxEntry.operation.entityId)
+        assertEquals(reidentifiedReviewEventId, outboxPayload.reviewEventId)
+        assertEquals(originalReviewLog.cardId, outboxPayload.cardId)
+    }
+
+    @Test
+    fun reidentifyWorkspaceForkDeckConflictRewritesDeckAndOutbox() = runBlocking {
+        insertWorkspaceShell()
+        val originalDeck = DeckEntity(
+            deckId = "deck-1",
+            workspaceId = workspaceId,
+            name = "Primary",
+            filterDefinitionJson = JSONObject().put("version", 2).toString(),
+            createdAtMillis = 4L,
+            updatedAtMillis = 5L,
+            deletedAtMillis = null
+        )
+        database.deckDao().insertDeck(originalDeck)
+        reviewPreferencesStore.saveSelectedReviewFilter(
+            workspaceId = workspaceId,
+            reviewFilter = ReviewFilter.Deck(deckId = originalDeck.deckId)
+        )
+        syncLocalStore.enqueueDeckUpsert(deck = originalDeck)
+
+        val reidentifiedDeckId = syncLocalStore.reidentifyWorkspaceForkConflictEntity(
+            workspaceId = workspaceId,
+            entityType = SyncEntityType.DECK,
+            entityId = originalDeck.deckId
+        )
+
+        val reidentifiedDeck = requireNotNull(database.deckDao().loadDeck(deckId = reidentifiedDeckId))
+        val outboxEntry = syncLocalStore.loadOutboxEntries(workspaceId = workspaceId).single()
+        val outboxPayload = (outboxEntry.operation.payload as SyncOperationPayload.Deck).payload
+
+        assertTrue(reidentifiedDeckId != originalDeck.deckId)
+        assertNull(database.deckDao().loadDeck(deckId = originalDeck.deckId))
+        assertEquals(originalDeck.name, reidentifiedDeck.name)
+        assertEquals(reidentifiedDeckId, outboxEntry.operation.entityId)
+        assertEquals(reidentifiedDeckId, outboxPayload.deckId)
+        assertEquals(
+            ReviewFilter.AllCards,
+            reviewPreferencesStore.loadSelectedReviewFilter(workspaceId = workspaceId)
+        )
+    }
+
+    @Test
+    fun loadCardTagsFiltersOutCrossWorkspaceTagLinks() = runBlocking {
+        insertWorkspaceShell()
+        database.workspaceDao().insertWorkspace(
+            WorkspaceEntity(
+                workspaceId = "workspace-2",
+                name = "Other",
+                createdAtMillis = 2L
+            )
+        )
+        insertCard()
+        database.tagDao().insertTags(
+            listOf(
+                TagEntity(
+                    tagId = "tag-local",
+                    workspaceId = workspaceId,
+                    name = "local"
+                ),
+                TagEntity(
+                    tagId = "tag-other",
+                    workspaceId = "workspace-2",
+                    name = "other"
+                )
+            )
+        )
+        database.tagDao().insertCardTags(
+            listOf(
+                CardTagEntity(cardId = "card-1", tagId = "tag-local"),
+                CardTagEntity(cardId = "card-1", tagId = "tag-other")
+            )
+        )
+
+        val cardTags = database.tagDao().loadCardTags(workspaceId = workspaceId)
+
+        assertEquals(listOf(CardTagEntity(cardId = "card-1", tagId = "tag-local")), cardTags)
+    }
+
+    @Test
     fun forkWorkspaceIdentityRewritesIdsReferencesAndResetsSyncState() = runBlocking {
         insertWorkspaceShell()
         val originalCard = CardEntity(
@@ -286,6 +597,7 @@ class SyncLocalStoreContractTest {
                 lastReviewSequenceId = 456L,
                 hasHydratedHotState = true,
                 hasHydratedReviewHistory = true,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = 7L,
                 lastSuccessfulSyncAtMillis = 8L,
                 lastSyncError = "broken",
@@ -372,6 +684,7 @@ class SyncLocalStoreContractTest {
                 lastReviewSequenceId = 0L,
                 hasHydratedHotState = false,
                 hasHydratedReviewHistory = false,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
                 lastSyncError = null,
@@ -426,6 +739,7 @@ class SyncLocalStoreContractTest {
                 lastReviewSequenceId = 456L,
                 hasHydratedHotState = true,
                 hasHydratedReviewHistory = true,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = 7L,
                 lastSuccessfulSyncAtMillis = 8L,
                 lastSyncError = "broken",
@@ -480,6 +794,7 @@ class SyncLocalStoreContractTest {
                 lastReviewSequenceId = 0L,
                 hasHydratedHotState = false,
                 hasHydratedReviewHistory = false,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
                 lastSyncError = null,
@@ -728,6 +1043,57 @@ private fun makeRemoteReviewHistoryEvent(
         rating = ReviewRating.GOOD.ordinal,
         reviewedAtClient = reviewedAtClient,
         reviewedAtServer = reviewedAtClient
+    )
+}
+
+private fun remoteCardBootstrapEntry(
+    cardId: String,
+    frontText: String,
+    backText: String,
+    tags: List<String>,
+    clientUpdatedAt: String
+): RemoteBootstrapEntry {
+    return RemoteBootstrapEntry(
+        entityType = SyncEntityType.CARD,
+        entityId = cardId,
+        action = "upsert",
+        payload = JSONObject()
+            .put("cardId", cardId)
+            .put("frontText", frontText)
+            .put("backText", backText)
+            .put("tags", JSONArray(tags))
+            .put("effortLevel", "fast")
+            .put("dueAt", JSONObject.NULL)
+            .put("createdAt", "2026-03-27T19:00:00Z")
+            .put("clientUpdatedAt", clientUpdatedAt)
+            .put("reps", 0)
+            .put("lapses", 0)
+            .put("fsrsCardState", "new")
+            .put("fsrsStepIndex", JSONObject.NULL)
+            .put("fsrsStability", JSONObject.NULL)
+            .put("fsrsDifficulty", JSONObject.NULL)
+            .put("fsrsLastReviewedAt", JSONObject.NULL)
+            .put("fsrsScheduledDays", JSONObject.NULL)
+            .put("deletedAt", JSONObject.NULL)
+    )
+}
+
+private fun remoteDeckBootstrapEntry(
+    deckId: String,
+    name: String,
+    clientUpdatedAt: String
+): RemoteBootstrapEntry {
+    return RemoteBootstrapEntry(
+        entityType = SyncEntityType.DECK,
+        entityId = deckId,
+        action = "upsert",
+        payload = JSONObject()
+            .put("deckId", deckId)
+            .put("name", name)
+            .put("filterDefinition", JSONObject().put("version", 2))
+            .put("createdAt", "2026-03-27T19:00:00Z")
+            .put("clientUpdatedAt", clientUpdatedAt)
+            .put("deletedAt", JSONObject.NULL)
     )
 }
 

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStoreContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStoreContractTest.kt
@@ -5,16 +5,22 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.AppDatabase
+import com.flashcardsopensourceapp.data.local.database.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.CardEntity
+import com.flashcardsopensourceapp.data.local.database.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.ReviewLogEntity
+import com.flashcardsopensourceapp.data.local.database.TagEntity
 import com.flashcardsopensourceapp.data.local.database.WorkspaceEntity
+import com.flashcardsopensourceapp.data.local.database.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.SyncOperationPayload
+import com.flashcardsopensourceapp.data.local.model.encodeSchedulerStepListJson
+import com.flashcardsopensourceapp.data.local.model.makeDefaultWorkspaceSchedulerSettings
 import com.flashcardsopensourceapp.data.local.repository.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
 import kotlinx.coroutines.CoroutineStart
@@ -28,6 +34,7 @@ import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Before
@@ -212,6 +219,333 @@ class SyncLocalStoreContractTest {
     }
 
     @Test
+    fun forkWorkspaceIdentityRewritesIdsReferencesAndResetsSyncState() = runBlocking {
+        insertWorkspaceShell()
+        val originalCard = CardEntity(
+            cardId = "card-1",
+            workspaceId = workspaceId,
+            frontText = "Front",
+            backText = "Back",
+            effortLevel = EffortLevel.MEDIUM,
+            dueAtMillis = null,
+            createdAtMillis = 1L,
+            updatedAtMillis = 2L,
+            reps = 1,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.REVIEW,
+            fsrsStepIndex = null,
+            fsrsStability = 3.5,
+            fsrsDifficulty = 4.0,
+            fsrsLastReviewedAtMillis = 3L,
+            fsrsScheduledDays = 5,
+            deletedAtMillis = 9L
+        )
+        val originalDeck = DeckEntity(
+            deckId = "deck-1",
+            workspaceId = workspaceId,
+            name = "Primary",
+            filterDefinitionJson = JSONObject().put("version", 2).toString(),
+            createdAtMillis = 4L,
+            updatedAtMillis = 5L,
+            deletedAtMillis = 10L
+        )
+        val originalReviewLog = ReviewLogEntity(
+            reviewLogId = "review-log-1",
+            workspaceId = workspaceId,
+            cardId = originalCard.cardId,
+            replicaId = "replica-1",
+            clientEventId = "client-event-1",
+            rating = ReviewRating.GOOD,
+            reviewedAtMillis = 6L,
+            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+        )
+        database.cardDao().insertCard(originalCard)
+        database.deckDao().insertDeck(originalDeck)
+        database.tagDao().insertTags(
+            listOf(
+                TagEntity(
+                    tagId = "tag-1",
+                    workspaceId = workspaceId,
+                    name = "android"
+                )
+            )
+        )
+        database.tagDao().insertCardTags(
+            listOf(
+                CardTagEntity(
+                    cardId = originalCard.cardId,
+                    tagId = "tag-1"
+                )
+            )
+        )
+        database.reviewLogDao().insertReviewLog(originalReviewLog)
+        database.syncStateDao().insertSyncState(
+            com.flashcardsopensourceapp.data.local.database.SyncStateEntity(
+                workspaceId = workspaceId,
+                lastSyncCursor = "123",
+                lastReviewSequenceId = 456L,
+                hasHydratedHotState = true,
+                hasHydratedReviewHistory = true,
+                lastSyncAttemptAtMillis = 7L,
+                lastSuccessfulSyncAtMillis = 8L,
+                lastSyncError = "broken",
+                blockedInstallationId = null
+            )
+        )
+        syncLocalStore.enqueueCardUpsert(card = originalCard, tags = listOf("android"))
+        syncLocalStore.enqueueDeckUpsert(deck = originalDeck)
+        syncLocalStore.enqueueReviewEventAppend(reviewLog = originalReviewLog)
+
+        syncLocalStore.forkWorkspaceIdentity(
+            currentLocalWorkspaceId = workspaceId,
+            sourceWorkspaceId = workspaceId,
+            destinationWorkspace = CloudWorkspaceSummary(
+                workspaceId = "workspace-2",
+                name = "Forked",
+                createdAtMillis = 2_000L,
+                isSelected = true
+            )
+        )
+
+        val expectedForkedCardId = forkedCardId(
+            sourceWorkspaceId = workspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceCardId = originalCard.cardId
+        )
+        val expectedForkedDeckId = forkedDeckId(
+            sourceWorkspaceId = workspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceDeckId = originalDeck.deckId
+        )
+        val expectedForkedReviewEventId = forkedReviewEventId(
+            sourceWorkspaceId = workspaceId,
+            destinationWorkspaceId = "workspace-2",
+            sourceReviewEventId = originalReviewLog.reviewLogId
+        )
+        val forkedCard = requireNotNull(database.cardDao().loadCard(expectedForkedCardId))
+        val forkedDeck = requireNotNull(database.deckDao().loadDeck(expectedForkedDeckId))
+        val forkedReviewLog = database.reviewLogDao().loadReviewLogs().single()
+        val forkedCardWithRelations = database.cardDao().observeCardsWithRelations().first().single()
+        val forkedOutboxEntries = syncLocalStore.loadOutboxEntries(workspaceId = "workspace-2")
+
+        assertNull(database.cardDao().loadCard(originalCard.cardId))
+        assertNull(database.deckDao().loadDeck(originalDeck.deckId))
+        assertEquals("workspace-2", database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals("workspace-2", forkedCard.workspaceId)
+        assertEquals(originalCard.frontText, forkedCard.frontText)
+        assertEquals(originalCard.deletedAtMillis, forkedCard.deletedAtMillis)
+        assertEquals("workspace-2", forkedDeck.workspaceId)
+        assertEquals(originalDeck.deletedAtMillis, forkedDeck.deletedAtMillis)
+        assertEquals(expectedForkedReviewEventId, forkedReviewLog.reviewLogId)
+        assertEquals(expectedForkedCardId, forkedReviewLog.cardId)
+        assertEquals("workspace-2", forkedReviewLog.workspaceId)
+        assertEquals(listOf("android"), forkedCardWithRelations.tags.map(TagEntity::name))
+        assertEquals(
+            setOf(expectedForkedCardId, expectedForkedDeckId, expectedForkedReviewEventId),
+            forkedOutboxEntries.map { entry -> entry.operation.entityId }.toSet()
+        )
+        assertEquals(
+            expectedForkedCardId,
+            (forkedOutboxEntries.first { entry -> entry.operation.entityType == com.flashcardsopensourceapp.data.local.model.SyncEntityType.CARD }
+                .operation.payload as SyncOperationPayload.Card).payload.cardId
+        )
+        assertEquals(
+            expectedForkedDeckId,
+            (forkedOutboxEntries.first { entry -> entry.operation.entityType == com.flashcardsopensourceapp.data.local.model.SyncEntityType.DECK }
+                .operation.payload as SyncOperationPayload.Deck).payload.deckId
+        )
+        assertEquals(
+            expectedForkedReviewEventId,
+            (forkedOutboxEntries.first { entry -> entry.operation.entityType == com.flashcardsopensourceapp.data.local.model.SyncEntityType.REVIEW_EVENT }
+                .operation.payload as SyncOperationPayload.ReviewEvent).payload.reviewEventId
+        )
+        assertEquals(
+            expectedForkedCardId,
+            (forkedOutboxEntries.first { entry -> entry.operation.entityType == com.flashcardsopensourceapp.data.local.model.SyncEntityType.REVIEW_EVENT }
+                .operation.payload as SyncOperationPayload.ReviewEvent).payload.cardId
+        )
+        assertNull(database.syncStateDao().loadSyncState(workspaceId))
+        assertEquals(
+            com.flashcardsopensourceapp.data.local.database.SyncStateEntity(
+                workspaceId = "workspace-2",
+                lastSyncCursor = null,
+                lastReviewSequenceId = 0L,
+                hasHydratedHotState = false,
+                hasHydratedReviewHistory = false,
+                lastSyncAttemptAtMillis = null,
+                lastSuccessfulSyncAtMillis = null,
+                lastSyncError = null,
+                blockedInstallationId = null
+            ),
+            database.syncStateDao().loadSyncState("workspace-2")
+        )
+        assertEquals(
+            "workspace-2",
+            database.workspaceSchedulerSettingsDao().loadWorkspaceSchedulerSettings("workspace-2")?.workspaceId
+        )
+    }
+
+    @Test
+    fun forkWorkspaceIdentityRewritesCurrentLocalShellUsingSourceNamespace() = runBlocking {
+        insertWorkspaceShell()
+        val originalCard = CardEntity(
+            cardId = "card-1",
+            workspaceId = workspaceId,
+            frontText = "Front",
+            backText = "Back",
+            effortLevel = EffortLevel.MEDIUM,
+            dueAtMillis = null,
+            createdAtMillis = 1L,
+            updatedAtMillis = 2L,
+            reps = 0,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.NEW,
+            fsrsStepIndex = null,
+            fsrsStability = null,
+            fsrsDifficulty = null,
+            fsrsLastReviewedAtMillis = null,
+            fsrsScheduledDays = null,
+            deletedAtMillis = null
+        )
+        val originalReviewLog = ReviewLogEntity(
+            reviewLogId = "review-log-1",
+            workspaceId = workspaceId,
+            cardId = originalCard.cardId,
+            replicaId = "replica-1",
+            clientEventId = "client-event-1",
+            rating = ReviewRating.GOOD,
+            reviewedAtMillis = 3L,
+            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+        )
+        database.cardDao().insertCard(originalCard)
+        database.reviewLogDao().insertReviewLog(originalReviewLog)
+        database.syncStateDao().insertSyncState(
+            com.flashcardsopensourceapp.data.local.database.SyncStateEntity(
+                workspaceId = workspaceId,
+                lastSyncCursor = "123",
+                lastReviewSequenceId = 456L,
+                hasHydratedHotState = true,
+                hasHydratedReviewHistory = true,
+                lastSyncAttemptAtMillis = 7L,
+                lastSuccessfulSyncAtMillis = 8L,
+                lastSyncError = "broken",
+                blockedInstallationId = null
+            )
+        )
+        syncLocalStore.enqueueCardUpsert(card = originalCard, tags = emptyList())
+        syncLocalStore.enqueueReviewEventAppend(reviewLog = originalReviewLog)
+
+        syncLocalStore.forkWorkspaceIdentity(
+            currentLocalWorkspaceId = workspaceId,
+            sourceWorkspaceId = "workspace-conflict-source",
+            destinationWorkspaceId = workspaceId
+        )
+
+        val expectedForkedCardId = forkedCardId(
+            sourceWorkspaceId = "workspace-conflict-source",
+            destinationWorkspaceId = workspaceId,
+            sourceCardId = originalCard.cardId
+        )
+        val expectedForkedReviewEventId = forkedReviewEventId(
+            sourceWorkspaceId = "workspace-conflict-source",
+            destinationWorkspaceId = workspaceId,
+            sourceReviewEventId = originalReviewLog.reviewLogId
+        )
+        val forkedReviewLog = database.reviewLogDao().loadReviewLogs().single()
+        val forkedOutboxEntries = syncLocalStore.loadOutboxEntries(workspaceId = workspaceId)
+
+        assertEquals(workspaceId, database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertNull(database.cardDao().loadCard(originalCard.cardId))
+        assertNotNull(database.cardDao().loadCard(expectedForkedCardId))
+        assertEquals(expectedForkedReviewEventId, forkedReviewLog.reviewLogId)
+        assertEquals(expectedForkedCardId, forkedReviewLog.cardId)
+        assertEquals(
+            setOf(expectedForkedCardId, expectedForkedReviewEventId),
+            forkedOutboxEntries.map { entry -> entry.operation.entityId }.toSet()
+        )
+        assertEquals(
+            expectedForkedCardId,
+            (forkedOutboxEntries.first { entry -> entry.operation.entityType == SyncEntityType.CARD }
+                .operation.payload as SyncOperationPayload.Card).payload.cardId
+        )
+        assertEquals(
+            expectedForkedReviewEventId,
+            (forkedOutboxEntries.first { entry -> entry.operation.entityType == SyncEntityType.REVIEW_EVENT }
+                .operation.payload as SyncOperationPayload.ReviewEvent).payload.reviewEventId
+        )
+        assertEquals(
+            com.flashcardsopensourceapp.data.local.database.SyncStateEntity(
+                workspaceId = workspaceId,
+                lastSyncCursor = null,
+                lastReviewSequenceId = 0L,
+                hasHydratedHotState = false,
+                hasHydratedReviewHistory = false,
+                lastSyncAttemptAtMillis = null,
+                lastSuccessfulSyncAtMillis = null,
+                lastSyncError = null,
+                blockedInstallationId = null
+            ),
+            database.syncStateDao().loadSyncState(workspaceId)
+        )
+    }
+
+    @Test
+    fun forkWorkspaceIdentityKeepsRowsWhenEffectiveIdsDoNotChange() = runBlocking {
+        insertWorkspaceShell()
+        val originalCard = CardEntity(
+            cardId = "card-1",
+            workspaceId = workspaceId,
+            frontText = "Front",
+            backText = "Back",
+            effortLevel = EffortLevel.MEDIUM,
+            dueAtMillis = null,
+            createdAtMillis = 1L,
+            updatedAtMillis = 2L,
+            reps = 0,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.NEW,
+            fsrsStepIndex = null,
+            fsrsStability = null,
+            fsrsDifficulty = null,
+            fsrsLastReviewedAtMillis = null,
+            fsrsScheduledDays = null,
+            deletedAtMillis = null
+        )
+        val originalReviewLog = ReviewLogEntity(
+            reviewLogId = "review-log-1",
+            workspaceId = workspaceId,
+            cardId = originalCard.cardId,
+            replicaId = "replica-1",
+            clientEventId = "client-event-1",
+            rating = ReviewRating.GOOD,
+            reviewedAtMillis = 3L,
+            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+        )
+        database.cardDao().insertCard(originalCard)
+        database.reviewLogDao().insertReviewLog(originalReviewLog)
+        syncLocalStore.enqueueCardUpsert(card = originalCard, tags = emptyList())
+        syncLocalStore.enqueueReviewEventAppend(reviewLog = originalReviewLog)
+
+        syncLocalStore.forkWorkspaceIdentity(
+            currentLocalWorkspaceId = workspaceId,
+            sourceWorkspaceId = workspaceId,
+            destinationWorkspaceId = workspaceId
+        )
+
+        val reviewLog = database.reviewLogDao().loadReviewLogs().single()
+        val outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId = workspaceId)
+
+        assertNotNull(database.cardDao().loadCard(originalCard.cardId))
+        assertEquals(1, database.reviewLogDao().countReviewLogs())
+        assertEquals(originalReviewLog.reviewLogId, reviewLog.reviewLogId)
+        assertEquals(originalCard.cardId, reviewLog.cardId)
+        assertEquals(
+            setOf(originalCard.cardId, originalReviewLog.reviewLogId),
+            outboxEntries.map { entry -> entry.operation.entityId }.toSet()
+        )
+    }
+
+    @Test
     fun migrateLocalShellEmitsReviewHistoryChangedEventWhenReviewLogsAreDeleted() = runBlocking {
         insertWorkspaceShell()
         insertCard()
@@ -334,6 +668,22 @@ class SyncLocalStoreContractTest {
                 workspaceId = workspaceId,
                 name = "Workspace",
                 createdAtMillis = 1L
+            )
+        )
+        val settings = makeDefaultWorkspaceSchedulerSettings(
+            workspaceId = workspaceId,
+            updatedAtMillis = 1L
+        )
+        database.workspaceSchedulerSettingsDao().insertWorkspaceSchedulerSettings(
+            WorkspaceSchedulerSettingsEntity(
+                workspaceId = settings.workspaceId,
+                algorithm = settings.algorithm,
+                desiredRetention = settings.desiredRetention,
+                learningStepsMinutesJson = encodeSchedulerStepListJson(settings.learningStepsMinutes),
+                relearningStepsMinutesJson = encodeSchedulerStepListJson(settings.relearningStepsMinutes),
+                maximumIntervalDays = settings.maximumIntervalDays,
+                enableFuzz = settings.enableFuzz,
+                updatedAtMillis = settings.updatedAtMillis
             )
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/bootstrap/LocalWorkspaceBootstrap.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/bootstrap/LocalWorkspaceBootstrap.kt
@@ -91,7 +91,8 @@ private suspend fun ensureLocalWorkspaceDependencies(
                 hasHydratedReviewHistory = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
-                lastSyncError = null
+                lastSyncError = null,
+                blockedInstallationId = null
             )
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/bootstrap/LocalWorkspaceBootstrap.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/bootstrap/LocalWorkspaceBootstrap.kt
@@ -89,6 +89,7 @@ private suspend fun ensureLocalWorkspaceDependencies(
                 lastReviewSequenceId = 0L,
                 hasHydratedHotState = false,
                 hasHydratedReviewHistory = false,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
                 lastSyncError = null,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudJsonContract.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudJsonContract.kt
@@ -95,6 +95,22 @@ internal fun JSONObject.requireCloudBoolean(key: String, fieldPath: String): Boo
     )
 }
 
+internal fun JSONObject.optCloudBooleanOrNull(key: String, fieldPath: String): Boolean? {
+    if (has(key).not()) {
+        return null
+    }
+    val value = requireCloudValue(key = key, fieldPath = fieldPath)
+    return when {
+        value === JSONObject.NULL -> null
+        value is Boolean -> value
+        else -> throw cloudContractMismatch(
+            fieldPath = fieldPath,
+            expected = "boolean or null",
+            actualValue = value
+        )
+    }
+}
+
 internal fun JSONObject.requireCloudObject(key: String, fieldPath: String): JSONObject {
     val value = requireCloudValue(key = key, fieldPath = fieldPath)
     return value as? JSONObject ?: throw cloudContractMismatch(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudJsonContract.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudJsonContract.kt
@@ -145,6 +145,22 @@ internal fun JSONObject.requireCloudArray(key: String, fieldPath: String): JSONA
     )
 }
 
+internal fun JSONObject.optCloudArrayOrNull(key: String, fieldPath: String): JSONArray? {
+    if (has(key).not()) {
+        return null
+    }
+    val value = requireCloudValue(key = key, fieldPath = fieldPath)
+    return when {
+        value === JSONObject.NULL -> null
+        value is JSONArray -> value
+        else -> throw cloudContractMismatch(
+            fieldPath = fieldPath,
+            expected = "array or null",
+            actualValue = value
+        )
+    }
+}
+
 internal fun JSONObject.requireCloudIsoTimestampMillis(key: String, fieldPath: String): Long {
     return parseCloudIsoTimestamp(
         value = requireCloudString(key = key, fieldPath = fieldPath),

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
@@ -6,16 +6,35 @@ import androidx.core.content.edit
 import com.flashcardsopensourceapp.data.local.database.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.AppLocalSettingsEntity
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
+import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntity
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntityType
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeReconciliation
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfiguration
+import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.makeCustomCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
 import java.util.UUID
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 
 private const val cloudMetadataPreferencesName: String = "flashcards-cloud-metadata"
 private const val cloudSecretPreferencesName: String = "flashcards-cloud-secrets"
@@ -32,6 +51,20 @@ private const val customOriginKey: String = "custom-origin"
 private const val refreshTokenKey: String = "refresh-token"
 private const val idTokenKey: String = "id-token"
 private const val idTokenExpiresAtMillisKey: String = "id-token-expires-at-millis"
+private const val pendingGuestUpgradeKey: String = "pending-guest-upgrade"
+private const val pendingGuestUpgradeLocalOutboxBlockReason: String =
+    "Guest upgrade recovery is pending. Wait for account linking recovery to finish before changing cards."
+
+private object LocalOutboxMutationContextKey : CoroutineContext.Key<LocalOutboxMutationContextElement>
+
+private class LocalOutboxMutationContextElement :
+    AbstractCoroutineContextElement(LocalOutboxMutationContextKey)
+
+private fun completedUnitSignal(): CompletableDeferred<Unit> {
+    val signal: CompletableDeferred<Unit> = CompletableDeferred()
+    signal.complete(Unit)
+    return signal
+}
 
 class CloudPreferencesStore(
     context: Context,
@@ -47,6 +80,10 @@ class CloudPreferencesStore(
     private val cloudSettingsState = MutableStateFlow(loadLegacyCloudSettingsEntity().toCloudSettings())
     private val accountDeletionState = MutableStateFlow(loadAccountDeletionState())
     private val serverConfigurationState = MutableStateFlow(loadServerConfiguration())
+    private val localOutboxWriteGate = Mutex()
+    private var localOutboxWriteBlockReason: String? = null
+    private var activeLocalOutboxMutationTransactions: Int = 0
+    private var localOutboxMutationTransactionsDrained: CompletableDeferred<Unit> = completedUnitSignal()
 
     fun observeCloudSettings(): StateFlow<CloudSettings> {
         return cloudSettingsState.asStateFlow()
@@ -100,6 +137,7 @@ class CloudPreferencesStore(
             remove(refreshTokenKey)
             remove(idTokenKey)
             remove(idTokenExpiresAtMillisKey)
+            remove(pendingGuestUpgradeKey)
         }
     }
 
@@ -108,6 +146,141 @@ class CloudPreferencesStore(
             putString(idTokenKey, idToken)
             putLong(idTokenExpiresAtMillisKey, idTokenExpiresAtMillis)
         }
+    }
+
+    internal fun loadPendingGuestUpgrade(): PendingGuestUpgradeState? {
+        val rawValue = securePreferences.getString(pendingGuestUpgradeKey, null) ?: return null
+        return try {
+            decodePendingGuestUpgrade(rawValue = rawValue)
+        } catch (error: JSONException) {
+            throw pendingGuestUpgradeRecoveryStateCorruptError(cause = error)
+        } catch (error: IllegalArgumentException) {
+            throw pendingGuestUpgradeRecoveryStateCorruptError(cause = error)
+        } catch (error: IllegalStateException) {
+            throw pendingGuestUpgradeRecoveryStateCorruptError(cause = error)
+        }
+    }
+
+    internal fun savePendingGuestUpgrade(pendingGuestUpgradeState: PendingGuestUpgradeState) {
+        securePreferences.edit(commit = true) {
+            putString(
+                pendingGuestUpgradeKey,
+                encodePendingGuestUpgrade(pendingGuestUpgradeState = pendingGuestUpgradeState).toString()
+            )
+        }
+    }
+
+    internal fun clearPendingGuestUpgrade() {
+        securePreferences.edit(commit = true) {
+            remove(pendingGuestUpgradeKey)
+        }
+    }
+
+    internal suspend fun <Result> runWithLocalOutboxWritesBlocked(
+        reason: String,
+        block: suspend () -> Result
+    ): Result {
+        val transactionsDrained = activateLocalOutboxWriteBlock(reason = reason)
+        try {
+            transactionsDrained.await()
+            return block()
+        } finally {
+            clearLocalOutboxWriteBlock()
+        }
+    }
+
+    internal suspend fun <Result> runWithLocalOutboxMutationAllowed(block: suspend () -> Result): Result {
+        beginLocalOutboxMutationTransaction()
+        try {
+            return withContext(LocalOutboxMutationContextElement()) {
+                block()
+            }
+        } finally {
+            finishLocalOutboxMutationTransaction()
+        }
+    }
+
+    internal suspend fun <Result> runWithLocalOutboxWritesAllowed(block: suspend () -> Result): Result {
+        if (isLocalOutboxMutationTransactionActive()) {
+            return block()
+        }
+
+        localOutboxWriteGate.lock()
+        try {
+            requireLocalOutboxWritesAllowedLocked()
+            return block()
+        } finally {
+            localOutboxWriteGate.unlock()
+        }
+    }
+
+    private suspend fun activateLocalOutboxWriteBlock(reason: String): CompletableDeferred<Unit> {
+        localOutboxWriteGate.lock()
+        try {
+            check(localOutboxWriteBlockReason == null) {
+                "Local outbox writes are already blocked. Existing reason='$localOutboxWriteBlockReason'"
+            }
+            check(hasPendingGuestUpgrade().not()) {
+                pendingGuestUpgradeLocalOutboxBlockReason
+            }
+            localOutboxWriteBlockReason = reason
+            return localOutboxMutationTransactionsDrained
+        } finally {
+            localOutboxWriteGate.unlock()
+        }
+    }
+
+    private suspend fun clearLocalOutboxWriteBlock() {
+        localOutboxWriteGate.lock()
+        try {
+            localOutboxWriteBlockReason = null
+        } finally {
+            localOutboxWriteGate.unlock()
+        }
+    }
+
+    private suspend fun beginLocalOutboxMutationTransaction() {
+        localOutboxWriteGate.lock()
+        try {
+            requireLocalOutboxWritesAllowedLocked()
+            if (activeLocalOutboxMutationTransactions == 0) {
+                localOutboxMutationTransactionsDrained = CompletableDeferred()
+            }
+            activeLocalOutboxMutationTransactions += 1
+        } finally {
+            localOutboxWriteGate.unlock()
+        }
+    }
+
+    private suspend fun finishLocalOutboxMutationTransaction() {
+        localOutboxWriteGate.lock()
+        try {
+            check(activeLocalOutboxMutationTransactions > 0) {
+                "Local outbox mutation transaction finished without a matching start."
+            }
+            activeLocalOutboxMutationTransactions -= 1
+            if (activeLocalOutboxMutationTransactions == 0) {
+                localOutboxMutationTransactionsDrained.complete(Unit)
+            }
+        } finally {
+            localOutboxWriteGate.unlock()
+        }
+    }
+
+    private suspend fun isLocalOutboxMutationTransactionActive(): Boolean {
+        return coroutineContext[LocalOutboxMutationContextKey] != null
+    }
+
+    private fun requireLocalOutboxWritesAllowedLocked() {
+        if (hasPendingGuestUpgrade()) {
+            throw IllegalStateException(pendingGuestUpgradeLocalOutboxBlockReason)
+        }
+        val blockedReason = localOutboxWriteBlockReason ?: return
+        throw IllegalStateException(blockedReason)
+    }
+
+    private fun hasPendingGuestUpgrade(): Boolean {
+        return securePreferences.contains(pendingGuestUpgradeKey)
     }
 
     suspend fun hydrateCloudSettingsFromDatabase(): CloudSettings {
@@ -309,6 +482,16 @@ class CloudPreferencesStore(
     }
 }
 
+internal data class PendingGuestUpgradeState(
+    val configuration: CloudServiceConfiguration,
+    val credentials: StoredCloudCredentials,
+    val accountSnapshot: CloudAccountSnapshot,
+    val guestSession: StoredGuestAiSession,
+    val guestUpgradeMode: CloudGuestUpgradeMode,
+    val selection: CloudWorkspaceLinkSelection,
+    val completion: CloudGuestUpgradeCompletion?
+)
+
 private fun AppLocalSettingsEntity.toCloudSettings(): CloudSettings {
     return CloudSettings(
         installationId = installationId,
@@ -319,6 +502,240 @@ private fun AppLocalSettingsEntity.toCloudSettings(): CloudSettings {
         activeWorkspaceId = activeWorkspaceId,
         updatedAtMillis = updatedAtMillis
     )
+}
+
+private fun encodePendingGuestUpgrade(pendingGuestUpgradeState: PendingGuestUpgradeState): JSONObject {
+    val jsonObject = JSONObject()
+        .put("configuration", encodeConfiguration(configuration = pendingGuestUpgradeState.configuration))
+        .put("credentials", encodeCredentials(credentials = pendingGuestUpgradeState.credentials))
+        .put("accountSnapshot", encodeAccountSnapshot(accountSnapshot = pendingGuestUpgradeState.accountSnapshot))
+        .put("guestSession", encodeGuestSession(session = pendingGuestUpgradeState.guestSession))
+        .put("guestUpgradeMode", pendingGuestUpgradeState.guestUpgradeMode.name)
+        .put("selection", encodeWorkspaceLinkSelection(selection = pendingGuestUpgradeState.selection))
+    val completion: CloudGuestUpgradeCompletion? = pendingGuestUpgradeState.completion
+    if (completion == null) {
+        jsonObject.put("completion", JSONObject.NULL)
+    } else {
+        jsonObject.put(
+            "completion",
+            encodeGuestUpgradeCompletion(completion = completion)
+        )
+    }
+    return jsonObject
+}
+
+private fun decodePendingGuestUpgrade(rawValue: String): PendingGuestUpgradeState {
+    val jsonObject = JSONObject(rawValue)
+    return PendingGuestUpgradeState(
+        configuration = decodeConfiguration(jsonObject = jsonObject.getJSONObject("configuration")),
+        credentials = decodeCredentials(jsonObject = jsonObject.getJSONObject("credentials")),
+        accountSnapshot = decodeAccountSnapshot(jsonObject = jsonObject.getJSONObject("accountSnapshot")),
+        guestSession = decodeGuestSession(jsonObject = jsonObject.getJSONObject("guestSession")),
+        guestUpgradeMode = CloudGuestUpgradeMode.valueOf(jsonObject.getString("guestUpgradeMode")),
+        selection = decodeWorkspaceLinkSelection(jsonObject = jsonObject.getJSONObject("selection")),
+        completion = decodeNullableGuestUpgradeCompletion(jsonObject = jsonObject)
+    )
+}
+
+private fun pendingGuestUpgradeRecoveryStateCorruptError(cause: Throwable): IllegalStateException {
+    return IllegalStateException(
+        "Pending guest upgrade recovery state is corrupt and cannot be resumed. " +
+            "Sign out and sign in again to reset cloud identity recovery. Cause='${cause.message}'.",
+        cause
+    )
+}
+
+private fun encodeConfiguration(configuration: CloudServiceConfiguration): JSONObject {
+    return JSONObject()
+        .put("mode", configuration.mode.name)
+        .putNullableString(key = "customOrigin", value = configuration.customOrigin)
+        .put("apiBaseUrl", configuration.apiBaseUrl)
+        .put("authBaseUrl", configuration.authBaseUrl)
+}
+
+private fun decodeConfiguration(jsonObject: JSONObject): CloudServiceConfiguration {
+    return CloudServiceConfiguration(
+        mode = CloudServiceConfigurationMode.valueOf(jsonObject.getString("mode")),
+        customOrigin = jsonObject.getNullableString(key = "customOrigin"),
+        apiBaseUrl = jsonObject.getString("apiBaseUrl"),
+        authBaseUrl = jsonObject.getString("authBaseUrl")
+    )
+}
+
+private fun encodeCredentials(credentials: StoredCloudCredentials): JSONObject {
+    return JSONObject()
+        .put("refreshToken", credentials.refreshToken)
+        .put("idToken", credentials.idToken)
+        .put("idTokenExpiresAtMillis", credentials.idTokenExpiresAtMillis)
+}
+
+private fun decodeCredentials(jsonObject: JSONObject): StoredCloudCredentials {
+    return StoredCloudCredentials(
+        refreshToken = jsonObject.getString("refreshToken"),
+        idToken = jsonObject.getString("idToken"),
+        idTokenExpiresAtMillis = jsonObject.getLong("idTokenExpiresAtMillis")
+    )
+}
+
+private fun encodeAccountSnapshot(accountSnapshot: CloudAccountSnapshot): JSONObject {
+    return JSONObject()
+        .put("userId", accountSnapshot.userId)
+        .putNullableString(key = "email", value = accountSnapshot.email)
+        .put("workspaces", encodeWorkspaces(workspaces = accountSnapshot.workspaces))
+}
+
+private fun decodeAccountSnapshot(jsonObject: JSONObject): CloudAccountSnapshot {
+    return CloudAccountSnapshot(
+        userId = jsonObject.getString("userId"),
+        email = jsonObject.getNullableString(key = "email"),
+        workspaces = decodeWorkspaces(jsonArray = jsonObject.getJSONArray("workspaces"))
+    )
+}
+
+private fun encodeWorkspaces(workspaces: List<CloudWorkspaceSummary>): JSONArray {
+    val jsonArray = JSONArray()
+    workspaces.forEach { workspace ->
+        jsonArray.put(encodeWorkspace(workspace = workspace))
+    }
+    return jsonArray
+}
+
+private fun decodeWorkspaces(jsonArray: JSONArray): List<CloudWorkspaceSummary> {
+    return buildList {
+        for (index in 0 until jsonArray.length()) {
+            add(decodeWorkspace(jsonObject = jsonArray.getJSONObject(index)))
+        }
+    }
+}
+
+private fun encodeWorkspace(workspace: CloudWorkspaceSummary): JSONObject {
+    return JSONObject()
+        .put("workspaceId", workspace.workspaceId)
+        .put("name", workspace.name)
+        .put("createdAtMillis", workspace.createdAtMillis)
+        .put("isSelected", workspace.isSelected)
+}
+
+private fun decodeWorkspace(jsonObject: JSONObject): CloudWorkspaceSummary {
+    return CloudWorkspaceSummary(
+        workspaceId = jsonObject.getString("workspaceId"),
+        name = jsonObject.getString("name"),
+        createdAtMillis = jsonObject.getLong("createdAtMillis"),
+        isSelected = jsonObject.getBoolean("isSelected")
+    )
+}
+
+private fun encodeGuestSession(session: StoredGuestAiSession): JSONObject {
+    return JSONObject()
+        .put("guestToken", session.guestToken)
+        .put("userId", session.userId)
+        .put("workspaceId", session.workspaceId)
+        .put("configurationMode", session.configurationMode.name)
+        .put("apiBaseUrl", session.apiBaseUrl)
+}
+
+private fun decodeGuestSession(jsonObject: JSONObject): StoredGuestAiSession {
+    return StoredGuestAiSession(
+        guestToken = jsonObject.getString("guestToken"),
+        userId = jsonObject.getString("userId"),
+        workspaceId = jsonObject.getString("workspaceId"),
+        configurationMode = CloudServiceConfigurationMode.valueOf(jsonObject.getString("configurationMode")),
+        apiBaseUrl = jsonObject.getString("apiBaseUrl")
+    )
+}
+
+private fun encodeWorkspaceLinkSelection(selection: CloudWorkspaceLinkSelection): JSONObject {
+    return when (selection) {
+        is CloudWorkspaceLinkSelection.Existing -> JSONObject()
+            .put("type", "existing")
+            .put("workspaceId", selection.workspaceId)
+
+        CloudWorkspaceLinkSelection.CreateNew -> JSONObject()
+            .put("type", "create_new")
+    }
+}
+
+private fun decodeWorkspaceLinkSelection(jsonObject: JSONObject): CloudWorkspaceLinkSelection {
+    return when (val selectionType = jsonObject.getString("type")) {
+        "existing" -> CloudWorkspaceLinkSelection.Existing(
+            workspaceId = jsonObject.getString("workspaceId")
+        )
+        "create_new" -> CloudWorkspaceLinkSelection.CreateNew
+        else -> throw IllegalStateException("Unknown pending guest upgrade selection type '$selectionType'.")
+    }
+}
+
+private fun encodeGuestUpgradeCompletion(completion: CloudGuestUpgradeCompletion): JSONObject {
+    val jsonObject = JSONObject()
+        .put("workspace", encodeWorkspace(workspace = completion.workspace))
+    if (completion.reconciliation == null) {
+        jsonObject.put("reconciliation", JSONObject.NULL)
+    } else {
+        jsonObject.put(
+            "reconciliation",
+            encodeGuestUpgradeReconciliation(reconciliation = completion.reconciliation)
+        )
+    }
+    return jsonObject
+}
+
+private fun decodeGuestUpgradeCompletion(jsonObject: JSONObject): CloudGuestUpgradeCompletion {
+    val reconciliation = if (jsonObject.isNull("reconciliation")) {
+        null
+    } else {
+        decodeGuestUpgradeReconciliation(jsonObject = jsonObject.getJSONObject("reconciliation"))
+    }
+    return CloudGuestUpgradeCompletion(
+        workspace = decodeWorkspace(jsonObject = jsonObject.getJSONObject("workspace")),
+        reconciliation = reconciliation
+    )
+}
+
+private fun decodeNullableGuestUpgradeCompletion(jsonObject: JSONObject): CloudGuestUpgradeCompletion? {
+    return if (jsonObject.isNull("completion")) {
+        null
+    } else {
+        decodeGuestUpgradeCompletion(jsonObject = jsonObject.getJSONObject("completion"))
+    }
+}
+
+private fun encodeGuestUpgradeReconciliation(reconciliation: CloudGuestUpgradeReconciliation): JSONObject {
+    val droppedEntities = JSONArray()
+    reconciliation.droppedEntities.forEach { droppedEntity ->
+        droppedEntities.put(
+            JSONObject()
+                .put("entityType", droppedEntity.entityType.name)
+                .put("entityId", droppedEntity.entityId)
+        )
+    }
+    return JSONObject().put("droppedEntities", droppedEntities)
+}
+
+private fun decodeGuestUpgradeReconciliation(jsonObject: JSONObject): CloudGuestUpgradeReconciliation {
+    val droppedEntities = jsonObject.getJSONArray("droppedEntities")
+    return CloudGuestUpgradeReconciliation(
+        droppedEntities = buildList {
+            for (index in 0 until droppedEntities.length()) {
+                val droppedEntity = droppedEntities.getJSONObject(index)
+                add(
+                    CloudGuestUpgradeDroppedEntity(
+                        entityType = CloudGuestUpgradeDroppedEntityType.valueOf(
+                            droppedEntity.getString("entityType")
+                        ),
+                        entityId = droppedEntity.getString("entityId")
+                    )
+                )
+            }
+        }
+    )
+}
+
+private fun JSONObject.getNullableString(key: String): String? {
+    return if (isNull(key)) {
+        null
+    } else {
+        getString(key)
+    }
 }
 
 private const val accountDeletionStatusHidden: String = "hidden"

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteService.kt
@@ -3,8 +3,12 @@ package com.flashcardsopensourceapp.data.local.cloud
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnection
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntity
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntityType
 import com.flashcardsopensourceapp.data.local.model.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeReconciliation
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeSelection
 import com.flashcardsopensourceapp.data.local.model.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
@@ -104,6 +108,11 @@ data class RemotePushResponse(
 )
 
 data class CloudSyncConflictDetails(
+    val entityType: SyncEntityType?,
+    val entityId: String?,
+    val entryIndex: Int?,
+    val reviewEventIndex: Int?,
+    val recoverable: Boolean?,
     val conflictingWorkspaceId: String?,
     val remoteIsEmpty: Boolean?
 )
@@ -137,8 +146,10 @@ interface CloudRemoteGateway {
         apiBaseUrl: String,
         bearerToken: String,
         guestToken: String,
-        selection: CloudGuestUpgradeSelection
-    ): CloudWorkspaceSummary
+        selection: CloudGuestUpgradeSelection,
+        guestWorkspaceSyncedAndOutboxDrained: Boolean,
+        supportsDroppedEntities: Boolean
+    ): CloudGuestUpgradeCompletion
 
     suspend fun createWorkspace(apiBaseUrl: String, bearerToken: String, name: String): CloudWorkspaceSummary
     suspend fun selectWorkspace(apiBaseUrl: String, bearerToken: String, workspaceId: String): CloudWorkspaceSummary
@@ -413,20 +424,30 @@ class CloudRemoteService : CloudRemoteGateway {
         apiBaseUrl: String,
         bearerToken: String,
         guestToken: String,
-        selection: CloudGuestUpgradeSelection
-    ): CloudWorkspaceSummary {
+        selection: CloudGuestUpgradeSelection,
+        guestWorkspaceSyncedAndOutboxDrained: Boolean,
+        supportsDroppedEntities: Boolean
+    ): CloudGuestUpgradeCompletion {
         val response = postJson(
             baseUrl = apiBaseUrl,
             path = "/guest-auth/upgrade/complete",
             authorizationHeader = "Bearer $bearerToken",
-            body = JSONObject()
-                .put("guestToken", guestToken)
-                .put("selection", encodeGuestUpgradeSelection(selection = selection))
+            body = buildGuestUpgradeCompleteRequest(
+                guestToken = guestToken,
+                selection = selection,
+                guestWorkspaceSyncedAndOutboxDrained = guestWorkspaceSyncedAndOutboxDrained,
+                supportsDroppedEntities = supportsDroppedEntities
+            )
         )
-        return parseWorkspace(
-            workspace = response.requireCloudObject("workspace", "guestUpgradeComplete.workspace"),
-            isSelected = true,
-            fieldPath = "guestUpgradeComplete.workspace"
+        return CloudGuestUpgradeCompletion(
+            workspace = parseWorkspace(
+                workspace = response.requireCloudObject("workspace", "guestUpgradeComplete.workspace"),
+                isSelected = true,
+                fieldPath = "guestUpgradeComplete.workspace"
+            ),
+            reconciliation = parseGuestUpgradeReconciliation(
+                response = response
+            )
         )
     }
 
@@ -660,6 +681,19 @@ class CloudRemoteService : CloudRemoteGateway {
         }
     }
 
+    internal fun buildGuestUpgradeCompleteRequest(
+        guestToken: String,
+        selection: CloudGuestUpgradeSelection,
+        guestWorkspaceSyncedAndOutboxDrained: Boolean,
+        supportsDroppedEntities: Boolean
+    ): JSONObject {
+        return JSONObject()
+            .put("guestToken", guestToken)
+            .put("selection", encodeGuestUpgradeSelection(selection = selection))
+            .put("guestWorkspaceSyncedAndOutboxDrained", guestWorkspaceSyncedAndOutboxDrained)
+            .put("supportsDroppedEntities", supportsDroppedEntities)
+    }
+
     private fun parseGuestUpgradeMode(rawMode: String, fieldPath: String): CloudGuestUpgradeMode {
         return when (rawMode) {
             "bound" -> CloudGuestUpgradeMode.BOUND
@@ -670,6 +704,62 @@ class CloudRemoteService : CloudRemoteGateway {
                 )
             }
         }
+    }
+
+    private fun parseGuestUpgradeReconciliation(response: JSONObject): CloudGuestUpgradeReconciliation? {
+        val droppedEntities = response.optCloudObjectOrNull(
+            key = "droppedEntities",
+            fieldPath = "guestUpgradeComplete.droppedEntities"
+        ) ?: return null
+        val droppedCardIds = droppedEntities.optCloudArrayOrNull(
+            key = "cardIds",
+            fieldPath = "guestUpgradeComplete.droppedEntities.cardIds"
+        ) ?: JSONArray()
+        val droppedDeckIds = droppedEntities.optCloudArrayOrNull(
+            key = "deckIds",
+            fieldPath = "guestUpgradeComplete.droppedEntities.deckIds"
+        ) ?: JSONArray()
+        val droppedReviewEventIds = droppedEntities.optCloudArrayOrNull(
+            key = "reviewEventIds",
+            fieldPath = "guestUpgradeComplete.droppedEntities.reviewEventIds"
+        ) ?: JSONArray()
+        return CloudGuestUpgradeReconciliation(
+            droppedEntities = buildList {
+                for (index in 0 until droppedCardIds.length()) {
+                    add(
+                        CloudGuestUpgradeDroppedEntity(
+                            entityType = CloudGuestUpgradeDroppedEntityType.CARD,
+                            entityId = droppedCardIds.requireCloudString(
+                                index = index,
+                                fieldPath = "guestUpgradeComplete.droppedEntities.cardIds[$index]"
+                            )
+                        )
+                    )
+                }
+                for (index in 0 until droppedDeckIds.length()) {
+                    add(
+                        CloudGuestUpgradeDroppedEntity(
+                            entityType = CloudGuestUpgradeDroppedEntityType.DECK,
+                            entityId = droppedDeckIds.requireCloudString(
+                                index = index,
+                                fieldPath = "guestUpgradeComplete.droppedEntities.deckIds[$index]"
+                            )
+                        )
+                    )
+                }
+                for (index in 0 until droppedReviewEventIds.length()) {
+                    add(
+                        CloudGuestUpgradeDroppedEntity(
+                            entityType = CloudGuestUpgradeDroppedEntityType.REVIEW_EVENT,
+                            entityId = droppedReviewEventIds.requireCloudString(
+                                index = index,
+                                fieldPath = "guestUpgradeComplete.droppedEntities.reviewEventIds[$index]"
+                            )
+                        )
+                    )
+                }
+            }
+        )
     }
 
     override
@@ -739,13 +829,17 @@ class CloudRemoteService : CloudRemoteGateway {
             authorizationHeader = authorizationHeader,
             body = body
         )
+        return parseRemotePushResponse(response = response)
+    }
+
+    internal fun parseRemotePushResponse(response: JSONObject): RemotePushResponse {
         val operations = response.requireCloudArray("operations", "push.operations")
         return RemotePushResponse(
             operations = buildList {
                 for (index in 0 until operations.length()) {
                     val entry = operations.requireCloudObject(index, "push.operations[$index]")
                     val status = entry.requireCloudString("status", "push.operations[$index].status")
-                    if (status != "applied" && status != "ignored" && status != "duplicate") {
+                    if (isAcknowledgedPushStatus(status = status).not()) {
                         throw CloudRemoteException(
                             message = "Cloud push failed for operation ${entry.requireCloudString("operationId", "push.operations[$index].operationId")}: ${entry.optCloudStringOrNull("error", "push.operations[$index].error").orEmpty()}",
                             statusCode = 200,
@@ -1005,6 +1099,10 @@ class CloudRemoteService : CloudRemoteGateway {
         }
     }
 
+    private fun isAcknowledgedPushStatus(status: String): Boolean {
+        return status == "applied" || status == "duplicate" || status == "ignored"
+    }
+
     private fun buildPaginatedPath(basePath: String, cursor: String?): String {
         val query = if (cursor == null) {
             "limit=100"
@@ -1223,7 +1321,33 @@ private fun parseSyncConflictDetails(details: JSONObject?): CloudSyncConflictDet
 
     return try {
         val syncConflict = details.optCloudObjectOrNull("syncConflict", "error.details.syncConflict") ?: return null
+        val rawEntityType = syncConflict.optCloudStringOrNull(
+            key = "entityType",
+            fieldPath = "error.details.syncConflict.entityType"
+        )
         CloudSyncConflictDetails(
+            entityType = rawEntityType?.let { value ->
+                parseSyncConflictEntityType(
+                    rawValue = value,
+                    fieldPath = "error.details.syncConflict.entityType"
+                )
+            },
+            entityId = syncConflict.optCloudStringOrNull(
+                key = "entityId",
+                fieldPath = "error.details.syncConflict.entityId"
+            ),
+            entryIndex = syncConflict.optCloudIntOrNull(
+                key = "entryIndex",
+                fieldPath = "error.details.syncConflict.entryIndex"
+            ),
+            reviewEventIndex = syncConflict.optCloudIntOrNull(
+                key = "reviewEventIndex",
+                fieldPath = "error.details.syncConflict.reviewEventIndex"
+            ),
+            recoverable = syncConflict.optCloudBooleanOrNull(
+                key = "recoverable",
+                fieldPath = "error.details.syncConflict.recoverable"
+            ),
             conflictingWorkspaceId = syncConflict.optCloudStringOrNull(
                 key = "conflictingWorkspaceId",
                 fieldPath = "error.details.syncConflict.conflictingWorkspaceId"
@@ -1235,5 +1359,16 @@ private fun parseSyncConflictDetails(details: JSONObject?): CloudSyncConflictDet
         )
     } catch (_: CloudContractMismatchException) {
         null
+    }
+}
+
+private fun parseSyncConflictEntityType(rawValue: String, fieldPath: String): SyncEntityType {
+    return when (rawValue) {
+        "card" -> SyncEntityType.CARD
+        "deck" -> SyncEntityType.DECK
+        "review_event" -> SyncEntityType.REVIEW_EVENT
+        else -> throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected one of [card, deck, review_event], got invalid string \"$rawValue\""
+        )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteService.kt
@@ -103,18 +103,25 @@ data class RemotePushResponse(
     val operations: List<RemotePushOperationResult>
 )
 
+data class CloudSyncConflictDetails(
+    val conflictingWorkspaceId: String?,
+    val remoteIsEmpty: Boolean?
+)
+
 class CloudRemoteException(
     message: String,
     val statusCode: Int?,
     val responseBody: String?,
     val errorCode: String?,
-    val requestId: String?
+    val requestId: String?,
+    val syncConflict: CloudSyncConflictDetails?
 ) : Exception(message)
 
-private data class ParsedCloudErrorPayload(
+internal data class ParsedCloudErrorPayload(
     val message: String?,
     val code: String?,
-    val requestId: String?
+    val requestId: String?,
+    val syncConflict: CloudSyncConflictDetails?
 )
 
 interface CloudRemoteGateway {
@@ -744,7 +751,8 @@ class CloudRemoteService : CloudRemoteGateway {
                             statusCode = 200,
                             responseBody = response.toString(),
                             errorCode = null,
-                            requestId = null
+                            requestId = null,
+                            syncConflict = null
                         )
                     }
                     add(
@@ -1123,7 +1131,8 @@ class CloudRemoteService : CloudRemoteGateway {
                     statusCode = statusCode,
                     responseBody = responseBody,
                     errorCode = parsedError?.code,
-                    requestId = parsedError?.requestId
+                    requestId = parsedError?.requestId,
+                    syncConflict = parsedError?.syncConflict
                 )
             }
 
@@ -1175,26 +1184,55 @@ private fun formatCloudRemoteErrorMessage(
     }
 }
 
-private fun parseCloudErrorPayload(responseBody: String): ParsedCloudErrorPayload? {
+internal fun parseCloudErrorPayload(responseBody: String): ParsedCloudErrorPayload? {
     if (responseBody.isBlank()) {
         return null
     }
 
     return try {
         val payload = JSONObject(responseBody)
-        val topLevelMessage = payload.optCloudStringOrNull("error", "error.message")
-        val topLevelCode = payload.optCloudStringOrNull("code", "error.code")
         val nestedErrorValue = payload.opt("error")
-        val nestedMessage = (nestedErrorValue as? JSONObject)?.optCloudStringOrNull("message", "error.error.message")
-        val nestedCode = (nestedErrorValue as? JSONObject)?.optCloudStringOrNull("code", "error.error.code")
+        val nestedErrorObject = nestedErrorValue as? JSONObject
+        val topLevelMessage = (nestedErrorValue as? String)
+            ?: payload.optCloudStringOrNull("message", "error.message")
+        val topLevelCode = payload.optCloudStringOrNull("code", "error.code")
+        val nestedMessage = nestedErrorObject?.optCloudStringOrNull("message", "error.error.message")
+        val nestedCode = nestedErrorObject?.optCloudStringOrNull("code", "error.error.code")
         val requestId = payload.optCloudStringOrNull("requestId", "error.requestId")
+        val topLevelDetails = payload.optCloudObjectOrNull("details", "error.details")
+        val nestedDetails = nestedErrorObject?.optCloudObjectOrNull("details", "error.error.details")
         ParsedCloudErrorPayload(
             message = topLevelMessage ?: nestedMessage,
             code = topLevelCode ?: nestedCode,
-            requestId = requestId
+            requestId = requestId,
+            syncConflict = parseSyncConflictDetails(
+                details = topLevelDetails ?: nestedDetails
+            )
         )
     } catch (_: JSONException) {
         null
+    } catch (_: CloudContractMismatchException) {
+        null
+    }
+}
+
+private fun parseSyncConflictDetails(details: JSONObject?): CloudSyncConflictDetails? {
+    if (details == null) {
+        return null
+    }
+
+    return try {
+        val syncConflict = details.optCloudObjectOrNull("syncConflict", "error.details.syncConflict") ?: return null
+        CloudSyncConflictDetails(
+            conflictingWorkspaceId = syncConflict.optCloudStringOrNull(
+                key = "conflictingWorkspaceId",
+                fieldPath = "error.details.syncConflict.conflictingWorkspaceId"
+            ),
+            remoteIsEmpty = syncConflict.optCloudBooleanOrNull(
+                key = "remoteIsEmpty",
+                fieldPath = "error.details.syncConflict.remoteIsEmpty"
+            )
+        )
     } catch (_: CloudContractMismatchException) {
         null
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStore.kt
@@ -37,6 +37,7 @@ import com.flashcardsopensourceapp.data.local.model.normalizeTags
 import com.flashcardsopensourceapp.data.local.model.parseIsoTimestamp
 import com.flashcardsopensourceapp.data.local.repository.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.loadCurrentWorkspaceOrNull
+import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -81,9 +82,20 @@ private data class WorkspaceForkIdMappings(
     val reviewEventIdsBySourceId: Map<String, String>
 )
 
+internal data class PendingLocalHotEntityKey(
+    val entityType: SyncEntityType,
+    val entityId: String
+)
+
+internal data class BootstrapApplyResult(
+    val skippedHotRows: Boolean,
+    val appliedHotEntityKeys: Set<PendingLocalHotEntityKey>
+)
+
 class SyncLocalStore(
     private val database: AppDatabase,
     private val preferencesStore: CloudPreferencesStore,
+    private val reviewPreferencesStore: ReviewPreferencesStore,
     private val localProgressCacheStore: LocalProgressCacheStore
 ) {
     private val reviewHistoryChangedEvents = MutableStateFlow<PendingReviewHistoryChangedEvent?>(value = null)
@@ -247,6 +259,10 @@ class SyncLocalStore(
         database.outboxDao().markOutboxEntriesFailed(operationIds, errorMessage)
     }
 
+    suspend fun countOutboxEntries(workspaceId: String): Int {
+        return database.outboxDao().countOutboxEntriesForWorkspace(workspaceId = workspaceId)
+    }
+
     suspend fun ensureSyncState(workspaceId: String): SyncStateEntity {
         val existingSyncState = database.syncStateDao().loadSyncState(workspaceId = workspaceId)
         if (existingSyncState != null) {
@@ -259,6 +275,7 @@ class SyncLocalStore(
             lastReviewSequenceId = 0L,
             hasHydratedHotState = false,
             hasHydratedReviewHistory = false,
+            pendingReviewHistoryImport = false,
             lastSyncAttemptAtMillis = null,
             lastSuccessfulSyncAtMillis = null,
             lastSyncError = null,
@@ -313,6 +330,23 @@ class SyncLocalStore(
         )
     }
 
+    suspend fun markReviewHistoryImportPending(workspaceId: String) {
+        val syncState = ensureSyncState(workspaceId = workspaceId)
+        database.syncStateDao().insertSyncState(
+            syncState.copy(
+                hasHydratedReviewHistory = false,
+                pendingReviewHistoryImport = true
+            )
+        )
+    }
+
+    suspend fun markReviewHistoryImportComplete(workspaceId: String) {
+        val syncState = ensureSyncState(workspaceId = workspaceId)
+        database.syncStateDao().insertSyncState(
+            syncState.copy(pendingReviewHistoryImport = false)
+        )
+    }
+
     suspend fun markSyncSuccess(
         workspaceId: String,
         lastSyncCursor: String,
@@ -320,6 +354,7 @@ class SyncLocalStore(
         hasHydratedHotState: Boolean,
         hasHydratedReviewHistory: Boolean
     ) {
+        val syncState = ensureSyncState(workspaceId = workspaceId)
         val nowMillis = System.currentTimeMillis()
         database.syncStateDao().insertSyncState(
             SyncStateEntity(
@@ -328,12 +363,43 @@ class SyncLocalStore(
                 lastReviewSequenceId = lastReviewSequenceId,
                 hasHydratedHotState = hasHydratedHotState,
                 hasHydratedReviewHistory = hasHydratedReviewHistory,
+                pendingReviewHistoryImport = syncState.pendingReviewHistoryImport,
                 lastSyncAttemptAtMillis = nowMillis,
                 lastSuccessfulSyncAtMillis = nowMillis,
                 lastSyncError = null,
                 blockedInstallationId = null
             )
         )
+    }
+
+    suspend fun reidentifyWorkspaceForkConflictEntity(
+        workspaceId: String,
+        entityType: SyncEntityType,
+        entityId: String
+    ): String {
+        return database.withTransaction {
+            when (entityType) {
+                SyncEntityType.CARD -> reidentifyCardWorkspaceForkConflictInTransaction(
+                    workspaceId = workspaceId,
+                    cardId = entityId
+                )
+
+                SyncEntityType.DECK -> reidentifyDeckWorkspaceForkConflictInTransaction(
+                    workspaceId = workspaceId,
+                    deckId = entityId
+                )
+
+                SyncEntityType.REVIEW_EVENT -> reidentifyReviewEventWorkspaceForkConflictInTransaction(
+                    workspaceId = workspaceId,
+                    reviewEventId = entityId
+                )
+
+                SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> throw IllegalArgumentException(
+                    "Cannot recover workspace fork conflict for unsupported entity type " +
+                        "'${entityType.toRemoteValue()}' in workspace '$workspaceId'."
+                )
+            }
+        }
     }
 
     suspend fun forkWorkspaceIdentity(
@@ -451,6 +517,35 @@ class SyncLocalStore(
         return resultingWorkspace
     }
 
+    /**
+     * Bound guest upgrade must reuse the existing local guest workspace as-is.
+     * Refresh the workspace shell metadata, but do not rewrite identity or
+     * clear any sync progress or blocked state.
+     */
+    suspend fun bindGuestUpgradeToLinkedWorkspace(workspace: CloudWorkspaceSummary): WorkspaceEntity {
+        val currentWorkspaceId = requireNotNull(currentWorkspaceIdOrNull()) {
+            "Bound guest upgrade requires a current local workspace."
+        }
+        check(currentWorkspaceId == workspace.workspaceId) {
+            "Bound guest upgrade must preserve the existing workspace identity. " +
+                "Current='$currentWorkspaceId' Remote='${workspace.workspaceId}'."
+        }
+        database.withTransaction {
+            refreshCurrentWorkspaceShellInTransaction(workspace)
+        }
+
+        val localWorkspaces = database.workspaceDao().loadWorkspaces()
+        check(localWorkspaces.size == 1) {
+            "Bound guest upgrade must leave exactly one local workspace. " +
+                "Local workspaces=${localWorkspaces.map(WorkspaceEntity::workspaceId)}"
+        }
+        return requireNotNull(
+            database.workspaceDao().loadWorkspaceById(workspace.workspaceId)
+        ) {
+            "Bound guest upgrade did not keep the expected local workspace '${workspace.workspaceId}'."
+        }
+    }
+
     suspend fun buildBootstrapEntries(workspaceId: String): JSONArray {
         val entries = JSONArray()
         database.cardDao().observeCardsWithRelations().first()
@@ -551,16 +646,47 @@ class SyncLocalStore(
         }
     }
 
-    suspend fun applyBootstrapEntries(workspaceId: String, entries: List<RemoteBootstrapEntry>) {
-        database.withTransaction {
+    internal suspend fun applyBootstrapEntries(workspaceId: String, entries: List<RemoteBootstrapEntry>): BootstrapApplyResult {
+        return database.withTransaction {
+            val pendingLocalHotEntityKeys: Set<PendingLocalHotEntityKey> =
+                loadPendingLocalHotEntityKeysInTransaction(workspaceId = workspaceId)
+            val appliedHotEntityKeys: MutableSet<PendingLocalHotEntityKey> = mutableSetOf()
+            var skippedHotRows = false
             entries.forEachIndexed { index, entry ->
+                val entryHotEntityKey: PendingLocalHotEntityKey? = entry.toPendingLocalHotEntityKey()
+                if (entryHotEntityKey != null && entryHotEntityKey in pendingLocalHotEntityKeys) {
+                    // Pending outbox rows are the local source of truth until the push phase drains them.
+                    skippedHotRows = true
+                    return@forEachIndexed
+                }
                 applyHotPayload(
                     workspaceId = workspaceId,
                     entityType = entry.entityType,
                     payload = entry.payload,
                     fieldPath = "bootstrap.entries[$index].payload"
                 )
+                if (entryHotEntityKey != null) {
+                    appliedHotEntityKeys += entryHotEntityKey
+                }
             }
+            BootstrapApplyResult(
+                skippedHotRows = skippedHotRows,
+                appliedHotEntityKeys = appliedHotEntityKeys
+            )
+        }
+    }
+
+    internal suspend fun hasPendingLocalHotRowsForAppliedBootstrapKeys(
+        workspaceId: String,
+        appliedHotEntityKeys: Set<PendingLocalHotEntityKey>
+    ): Boolean {
+        if (appliedHotEntityKeys.isEmpty()) {
+            return false
+        }
+
+        return database.withTransaction {
+            loadPendingLocalHotEntityKeysInTransaction(workspaceId = workspaceId)
+                .any { pendingHotEntityKey -> pendingHotEntityKey in appliedHotEntityKeys }
         }
     }
 
@@ -667,21 +793,30 @@ class SyncLocalStore(
         clientUpdatedAtIso: String,
         payloadJson: String
     ) {
-        database.outboxDao().insertOutboxEntry(
-            OutboxEntryEntity(
-                outboxEntryId = UUID.randomUUID().toString(),
-                workspaceId = workspaceId,
-                installationId = preferencesStore.currentCloudSettings().installationId,
-                entityType = entityType.toRemoteValue(),
-                entityId = entityId,
-                operationType = action.toRemoteValue(),
-                payloadJson = payloadJson,
-                clientUpdatedAtIso = clientUpdatedAtIso,
-                createdAtMillis = System.currentTimeMillis(),
-                attemptCount = 0,
-                lastError = null
+        preferencesStore.runWithLocalOutboxWritesAllowed {
+            database.outboxDao().insertOutboxEntry(
+                OutboxEntryEntity(
+                    outboxEntryId = UUID.randomUUID().toString(),
+                    workspaceId = workspaceId,
+                    installationId = preferencesStore.currentCloudSettings().installationId,
+                    entityType = entityType.toRemoteValue(),
+                    entityId = entityId,
+                    operationType = action.toRemoteValue(),
+                    payloadJson = payloadJson,
+                    clientUpdatedAtIso = clientUpdatedAtIso,
+                    createdAtMillis = System.currentTimeMillis(),
+                    attemptCount = 0,
+                    lastError = null
+                )
             )
-        )
+        }
+    }
+
+    private suspend fun loadPendingLocalHotEntityKeysInTransaction(workspaceId: String): Set<PendingLocalHotEntityKey> {
+        return database.outboxDao()
+            .loadAllOutboxEntries(workspaceId = workspaceId)
+            .mapNotNull(::pendingLocalHotEntityKey)
+            .toSet()
     }
 
     private suspend fun currentWorkspaceIdOrNull(): String? {
@@ -735,6 +870,7 @@ class SyncLocalStore(
                 lastReviewSequenceId = 0L,
                 hasHydratedHotState = false,
                 hasHydratedReviewHistory = false,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
                 lastSyncError = null,
@@ -908,6 +1044,10 @@ class SyncLocalStore(
         }
 
         if (destinationMatchesCurrentWorkspace) {
+            val didRewriteLocalEntityIds: Boolean = hasWorkspaceForkEntityIdRewrites(
+                snapshot = snapshot,
+                forkMappings = forkMappings
+            )
             snapshot.decks
                 .filter { deck ->
                     forkMappings.deckIdsBySourceId.requireMappedId(
@@ -924,6 +1064,9 @@ class SyncLocalStore(
                     ) != card.cardId
                 }
                 .forEach { card -> database.cardDao().deleteCard(card.cardId) }
+            if (didRewriteLocalEntityIds) {
+                resetVolatileWorkspaceSelectionsAfterLocalEntityReId(workspaceId = destinationWorkspace.workspaceId)
+            }
         } else {
             database.workspaceDao().deleteWorkspace(currentLocalWorkspaceId)
             database.syncStateDao().deleteSyncState(workspaceId = currentLocalWorkspaceId)
@@ -934,21 +1077,158 @@ class SyncLocalStore(
 
     private suspend fun loadWorkspaceForkSnapshot(workspaceId: String): WorkspaceForkSnapshot {
         val cards = database.cardDao().loadCards(workspaceId = workspaceId)
-        val cardTags = if (cards.isEmpty()) {
-            emptyList()
-        } else {
-            database.tagDao().loadCardTags(cardIds = cards.map(CardEntity::cardId))
-        }
         return WorkspaceForkSnapshot(
             cards = cards,
             decks = database.deckDao().loadDecks(workspaceId = workspaceId),
             tags = database.tagDao().loadTags(workspaceId = workspaceId),
-            cardTags = cardTags,
+            cardTags = database.tagDao().loadCardTags(workspaceId = workspaceId),
             reviewLogs = database.reviewLogDao().loadReviewLogs(workspaceId = workspaceId),
             outboxEntries = database.outboxDao().loadAllOutboxEntries(workspaceId = workspaceId),
             schedulerSettings = database.workspaceSchedulerSettingsDao()
                 .loadWorkspaceSchedulerSettings(workspaceId = workspaceId)
         )
+    }
+
+    private suspend fun reidentifyCardWorkspaceForkConflictInTransaction(
+        workspaceId: String,
+        cardId: String
+    ): String {
+        val card = requireNotNull(database.cardDao().loadCard(cardId = cardId)) {
+            "Cannot recover workspace fork conflict for card '$cardId' in workspace '$workspaceId' " +
+                "because the local card does not exist."
+        }
+        require(card.workspaceId == workspaceId) {
+            "Cannot recover workspace fork conflict for card '$cardId' in workspace '$workspaceId' " +
+                "because the local card belongs to workspace '${card.workspaceId}'."
+        }
+
+        val newCardId = generateFreshCardIdInTransaction()
+        database.cardDao().insertCard(card.copy(cardId = newCardId))
+        database.tagDao().reassignCardTagsToCard(oldCardId = cardId, newCardId = newCardId)
+        database.reviewLogDao().reassignReviewLogsToCard(
+            workspaceId = workspaceId,
+            oldCardId = cardId,
+            newCardId = newCardId
+        )
+        rewriteOutboxEntriesForWorkspaceForkEntityReId(
+            workspaceId = workspaceId,
+            entityType = SyncEntityType.CARD,
+            oldEntityId = cardId,
+            newEntityId = newCardId
+        )
+        database.cardDao().deleteCard(cardId = cardId)
+        resetVolatileWorkspaceSelectionsAfterLocalEntityReId(workspaceId = workspaceId)
+        return newCardId
+    }
+
+    private suspend fun reidentifyDeckWorkspaceForkConflictInTransaction(
+        workspaceId: String,
+        deckId: String
+    ): String {
+        val deck = requireNotNull(database.deckDao().loadDeck(deckId = deckId)) {
+            "Cannot recover workspace fork conflict for deck '$deckId' in workspace '$workspaceId' " +
+                "because the local deck does not exist."
+        }
+        require(deck.workspaceId == workspaceId) {
+            "Cannot recover workspace fork conflict for deck '$deckId' in workspace '$workspaceId' " +
+                "because the local deck belongs to workspace '${deck.workspaceId}'."
+        }
+
+        val newDeckId = generateFreshDeckIdInTransaction()
+        database.deckDao().insertDeck(deck.copy(deckId = newDeckId))
+        rewriteOutboxEntriesForWorkspaceForkEntityReId(
+            workspaceId = workspaceId,
+            entityType = SyncEntityType.DECK,
+            oldEntityId = deckId,
+            newEntityId = newDeckId
+        )
+        database.deckDao().deleteDeck(deckId = deckId)
+        resetVolatileWorkspaceSelectionsAfterLocalEntityReId(workspaceId = workspaceId)
+        return newDeckId
+    }
+
+    private suspend fun reidentifyReviewEventWorkspaceForkConflictInTransaction(
+        workspaceId: String,
+        reviewEventId: String
+    ): String {
+        val reviewLog = requireNotNull(database.reviewLogDao().loadReviewLog(reviewLogId = reviewEventId)) {
+            "Cannot recover workspace fork conflict for review_event '$reviewEventId' in workspace '$workspaceId' " +
+                "because the local review log does not exist."
+        }
+        require(reviewLog.workspaceId == workspaceId) {
+            "Cannot recover workspace fork conflict for review_event '$reviewEventId' in workspace '$workspaceId' " +
+                "because the local review log belongs to workspace '${reviewLog.workspaceId}'."
+        }
+
+        val newReviewEventId = generateFreshReviewEventIdInTransaction()
+        database.reviewLogDao().insertReviewLogs(
+            listOf(reviewLog.copy(reviewLogId = newReviewEventId))
+        )
+        rewriteOutboxEntriesForWorkspaceForkEntityReId(
+            workspaceId = workspaceId,
+            entityType = SyncEntityType.REVIEW_EVENT,
+            oldEntityId = reviewEventId,
+            newEntityId = newReviewEventId
+        )
+        database.reviewLogDao().deleteReviewLogs(reviewLogIds = listOf(reviewEventId))
+        resetVolatileWorkspaceSelectionsAfterLocalEntityReId(workspaceId = workspaceId)
+        return newReviewEventId
+    }
+
+    private suspend fun rewriteOutboxEntriesForWorkspaceForkEntityReId(
+        workspaceId: String,
+        entityType: SyncEntityType,
+        oldEntityId: String,
+        newEntityId: String
+    ) {
+        val rewrittenEntries = database.outboxDao()
+            .loadAllOutboxEntries(workspaceId = workspaceId)
+            .mapNotNull { entry ->
+                val rewrittenEntry = rewriteOutboxEntryForWorkspaceForkEntityReId(
+                    entry = entry,
+                    entityType = entityType,
+                    oldEntityId = oldEntityId,
+                    newEntityId = newEntityId
+                )
+                if (rewrittenEntry == entry) {
+                    null
+                } else {
+                    rewrittenEntry
+                }
+            }
+        if (rewrittenEntries.isNotEmpty()) {
+            database.outboxDao().insertOutboxEntries(rewrittenEntries)
+        }
+    }
+
+    private suspend fun generateFreshCardIdInTransaction(): String {
+        repeat(10) {
+            val candidate = UUID.randomUUID().toString()
+            if (database.cardDao().loadCard(cardId = candidate) == null) {
+                return candidate
+            }
+        }
+        throw IllegalStateException("Unable to generate a fresh local card id after 10 attempts.")
+    }
+
+    private suspend fun generateFreshDeckIdInTransaction(): String {
+        repeat(10) {
+            val candidate = UUID.randomUUID().toString()
+            if (database.deckDao().loadDeck(deckId = candidate) == null) {
+                return candidate
+            }
+        }
+        throw IllegalStateException("Unable to generate a fresh local deck id after 10 attempts.")
+    }
+
+    private suspend fun generateFreshReviewEventIdInTransaction(): String {
+        repeat(10) {
+            val candidate = UUID.randomUUID().toString()
+            if (database.reviewLogDao().loadReviewLog(reviewLogId = candidate) == null) {
+                return candidate
+            }
+        }
+        throw IllegalStateException("Unable to generate a fresh local review_event id after 10 attempts.")
     }
 
     private suspend fun replaceSyncStateWithEmptyProgress(workspaceId: String) {
@@ -959,12 +1239,21 @@ class SyncLocalStore(
                 lastReviewSequenceId = 0L,
                 hasHydratedHotState = false,
                 hasHydratedReviewHistory = false,
+                pendingReviewHistoryImport = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
                 lastSyncError = null,
                 blockedInstallationId = null
             )
         )
+    }
+
+    /**
+     * Local re-id recovery is rare; reset volatile persisted selections instead
+     * of preserving state that may still point at old entity ids.
+     */
+    private fun resetVolatileWorkspaceSelectionsAfterLocalEntityReId(workspaceId: String) {
+        reviewPreferencesStore.clearSelectedReviewFilter(workspaceId = workspaceId)
     }
 
     private suspend fun applyHotPayload(
@@ -1174,6 +1463,49 @@ class SyncLocalStore(
     }
 }
 
+private fun pendingLocalHotEntityKey(entry: OutboxEntryEntity): PendingLocalHotEntityKey? {
+    return parseSyncEntityType(entry.entityType).toPendingLocalHotEntityKey(entityId = entry.entityId)
+}
+
+private fun RemoteBootstrapEntry.toPendingLocalHotEntityKey(): PendingLocalHotEntityKey? {
+    return entityType.toPendingLocalHotEntityKey(entityId = entityId)
+}
+
+private fun SyncEntityType.toPendingLocalHotEntityKey(entityId: String): PendingLocalHotEntityKey? {
+    return when (this) {
+        SyncEntityType.CARD,
+        SyncEntityType.DECK,
+        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> PendingLocalHotEntityKey(
+            entityType = this,
+            entityId = entityId
+        )
+
+        SyncEntityType.REVIEW_EVENT -> null
+    }
+}
+
+private fun hasWorkspaceForkEntityIdRewrites(
+    snapshot: WorkspaceForkSnapshot,
+    forkMappings: WorkspaceForkIdMappings
+): Boolean {
+    return snapshot.cards.any { card ->
+        forkMappings.cardIdsBySourceId.requireMappedId(
+            entityType = "card",
+            sourceId = card.cardId
+        ) != card.cardId
+    } || snapshot.decks.any { deck ->
+        forkMappings.deckIdsBySourceId.requireMappedId(
+            entityType = "deck",
+            sourceId = deck.deckId
+        ) != deck.deckId
+    } || snapshot.reviewLogs.any { reviewLog ->
+        forkMappings.reviewEventIdsBySourceId.requireMappedId(
+            entityType = "review_event",
+            sourceId = reviewLog.reviewLogId
+        ) != reviewLog.reviewLogId
+    }
+}
+
 private fun buildWorkspaceForkIdMappings(
     sourceWorkspaceId: String,
     destinationWorkspaceId: String,
@@ -1279,6 +1611,96 @@ private fun rewriteOutboxEntryForFork(
         entityId = rewrittenEntityId,
         payloadJson = payloadJson.toString()
     )
+}
+
+private fun rewriteOutboxEntryForWorkspaceForkEntityReId(
+    entry: OutboxEntryEntity,
+    entityType: SyncEntityType,
+    oldEntityId: String,
+    newEntityId: String
+): OutboxEntryEntity {
+    val entryEntityType = parseSyncEntityType(entry.entityType)
+    val payloadJson = JSONObject(entry.payloadJson)
+    var rewrittenEntityId = entry.entityId
+    var changed = false
+
+    when (entityType) {
+        SyncEntityType.CARD -> {
+            if (entryEntityType == SyncEntityType.CARD) {
+                val payloadCardId = payloadJson.requireCloudString(
+                    key = "cardId",
+                    fieldPath = "reid.outbox.card.cardId"
+                )
+                if (entry.entityId == oldEntityId || payloadCardId == oldEntityId) {
+                    rewrittenEntityId = newEntityId
+                    payloadJson.put("cardId", newEntityId)
+                    changed = entry.entityId != newEntityId || payloadCardId != newEntityId
+                }
+            } else if (entryEntityType == SyncEntityType.REVIEW_EVENT) {
+                changed = replaceJsonStringReferenceIfMatches(
+                    payloadJson = payloadJson,
+                    key = "cardId",
+                    oldValue = oldEntityId,
+                    newValue = newEntityId,
+                    fieldPath = "reid.outbox.reviewEvent.cardId"
+                ) || changed
+            }
+        }
+
+        SyncEntityType.DECK -> {
+            if (entryEntityType == SyncEntityType.DECK) {
+                val payloadDeckId = payloadJson.requireCloudString(
+                    key = "deckId",
+                    fieldPath = "reid.outbox.deck.deckId"
+                )
+                if (entry.entityId == oldEntityId || payloadDeckId == oldEntityId) {
+                    rewrittenEntityId = newEntityId
+                    payloadJson.put("deckId", newEntityId)
+                    changed = entry.entityId != newEntityId || payloadDeckId != newEntityId
+                }
+            }
+        }
+
+        SyncEntityType.REVIEW_EVENT -> {
+            if (entryEntityType == SyncEntityType.REVIEW_EVENT) {
+                val payloadReviewEventId = payloadJson.requireCloudString(
+                    key = "reviewEventId",
+                    fieldPath = "reid.outbox.reviewEvent.reviewEventId"
+                )
+                if (entry.entityId == oldEntityId || payloadReviewEventId == oldEntityId) {
+                    rewrittenEntityId = newEntityId
+                    payloadJson.put("reviewEventId", newEntityId)
+                    changed = entry.entityId != newEntityId || payloadReviewEventId != newEntityId
+                }
+            }
+        }
+
+        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> Unit
+    }
+
+    return if (changed) {
+        entry.copy(
+            entityId = rewrittenEntityId,
+            payloadJson = payloadJson.toString()
+        )
+    } else {
+        entry
+    }
+}
+
+private fun replaceJsonStringReferenceIfMatches(
+    payloadJson: JSONObject,
+    key: String,
+    oldValue: String,
+    newValue: String,
+    fieldPath: String
+): Boolean {
+    val currentValue = payloadJson.requireCloudString(key = key, fieldPath = fieldPath)
+    if (currentValue != oldValue) {
+        return false
+    }
+    payloadJson.put(key, newValue)
+    return true
 }
 
 private fun Map<String, String>.requireMappedId(entityType: String, sourceId: String): String {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStore.kt
@@ -65,6 +65,22 @@ private data class PendingReviewHistoryChangedEvent(
     val event: ReviewHistoryChangedEvent
 )
 
+private data class WorkspaceForkSnapshot(
+    val cards: List<CardEntity>,
+    val decks: List<DeckEntity>,
+    val tags: List<TagEntity>,
+    val cardTags: List<CardTagEntity>,
+    val reviewLogs: List<ReviewLogEntity>,
+    val outboxEntries: List<OutboxEntryEntity>,
+    val schedulerSettings: WorkspaceSchedulerSettingsEntity?
+)
+
+private data class WorkspaceForkIdMappings(
+    val cardIdsBySourceId: Map<String, String>,
+    val deckIdsBySourceId: Map<String, String>,
+    val reviewEventIdsBySourceId: Map<String, String>
+)
+
 class SyncLocalStore(
     private val database: AppDatabase,
     private val preferencesStore: CloudPreferencesStore,
@@ -245,10 +261,20 @@ class SyncLocalStore(
             hasHydratedReviewHistory = false,
             lastSyncAttemptAtMillis = null,
             lastSuccessfulSyncAtMillis = null,
-            lastSyncError = null
+            lastSyncError = null,
+            blockedInstallationId = null
         )
         database.syncStateDao().insertSyncState(syncState)
         return syncState
+    }
+
+    suspend fun loadBlockedSyncMessage(workspaceId: String, installationId: String): String? {
+        val syncState = database.syncStateDao().loadSyncState(workspaceId = workspaceId) ?: return null
+        if (syncState.blockedInstallationId != installationId) {
+            return null
+        }
+
+        return syncState.lastSyncError ?: "Cloud sync is blocked for this installation."
     }
 
     suspend fun recordSyncAttempt(workspaceId: String) {
@@ -266,7 +292,23 @@ class SyncLocalStore(
         database.syncStateDao().insertSyncState(
             syncState.copy(
                 lastSyncAttemptAtMillis = System.currentTimeMillis(),
-                lastSyncError = errorMessage
+                lastSyncError = errorMessage,
+                blockedInstallationId = null
+            )
+        )
+    }
+
+    suspend fun markSyncBlocked(
+        workspaceId: String,
+        installationId: String,
+        errorMessage: String
+    ) {
+        val syncState = ensureSyncState(workspaceId = workspaceId)
+        database.syncStateDao().insertSyncState(
+            syncState.copy(
+                lastSyncAttemptAtMillis = System.currentTimeMillis(),
+                lastSyncError = errorMessage,
+                blockedInstallationId = installationId
             )
         )
     }
@@ -288,9 +330,51 @@ class SyncLocalStore(
                 hasHydratedReviewHistory = hasHydratedReviewHistory,
                 lastSyncAttemptAtMillis = nowMillis,
                 lastSuccessfulSyncAtMillis = nowMillis,
-                lastSyncError = null
+                lastSyncError = null,
+                blockedInstallationId = null
             )
         )
+    }
+
+    suspend fun forkWorkspaceIdentity(
+        currentLocalWorkspaceId: String,
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String
+    ): WorkspaceEntity {
+        val destinationWorkspace = requireNotNull(
+            database.workspaceDao().loadWorkspaceById(destinationWorkspaceId)
+        ) {
+            "Cannot fork workspace identity because local workspace '$destinationWorkspaceId' does not exist."
+        }
+        return forkWorkspaceIdentity(
+            currentLocalWorkspaceId = currentLocalWorkspaceId,
+            sourceWorkspaceId = sourceWorkspaceId,
+            destinationWorkspace = CloudWorkspaceSummary(
+                workspaceId = destinationWorkspace.workspaceId,
+                name = destinationWorkspace.name,
+                createdAtMillis = destinationWorkspace.createdAtMillis,
+                isSelected = true
+            )
+        )
+    }
+
+    suspend fun forkWorkspaceIdentity(
+        currentLocalWorkspaceId: String,
+        sourceWorkspaceId: String,
+        destinationWorkspace: CloudWorkspaceSummary
+    ): WorkspaceEntity {
+        database.withTransaction {
+            forkWorkspaceIdentityInTransaction(
+                currentLocalWorkspaceId = currentLocalWorkspaceId,
+                sourceWorkspaceId = sourceWorkspaceId,
+                destinationWorkspace = destinationWorkspace
+            )
+        }
+        return requireNotNull(
+            database.workspaceDao().loadWorkspaceById(destinationWorkspace.workspaceId)
+        ) {
+            "Workspace identity fork did not leave local workspace '${destinationWorkspace.workspaceId}'."
+        }
     }
 
     /**
@@ -304,9 +388,14 @@ class SyncLocalStore(
         remoteWorkspaceIsEmpty: Boolean
     ): WorkspaceEntity {
         val currentWorkspaceId = currentWorkspaceIdOrNull()
-        val didDeleteReviewHistory = remoteWorkspaceIsEmpty.not() && database.reviewLogDao().countReviewLogs() > 0
-        val migrationKind = if (remoteWorkspaceIsEmpty) {
-            "preserve_local_data"
+        val reusesCurrentWorkspace = currentWorkspaceId == workspace.workspaceId
+        val didDeleteReviewHistory = reusesCurrentWorkspace.not() &&
+            remoteWorkspaceIsEmpty.not() &&
+            database.reviewLogDao().countReviewLogs() > 0
+        val migrationKind = if (reusesCurrentWorkspace) {
+            "reuse_local_shell"
+        } else if (remoteWorkspaceIsEmpty) {
+            "fork_local_data"
         } else {
             "replace_local_shell"
         }
@@ -318,8 +407,17 @@ class SyncLocalStore(
             migrationKind = migrationKind
         )
         database.withTransaction {
-            if (remoteWorkspaceIsEmpty) {
-                preserveLocalDataForEmptyRemoteWorkspaceInTransaction(workspace)
+            if (reusesCurrentWorkspace) {
+                refreshCurrentWorkspaceShellInTransaction(workspace)
+            } else if (remoteWorkspaceIsEmpty) {
+                val sourceWorkspaceId = requireNotNull(currentWorkspaceId) {
+                    "Workspace is required before linking to cloud."
+                }
+                forkWorkspaceIdentityInTransaction(
+                    currentLocalWorkspaceId = sourceWorkspaceId,
+                    sourceWorkspaceId = sourceWorkspaceId,
+                    destinationWorkspace = workspace
+                )
             } else {
                 replaceLocalShellForNonEmptyRemoteWorkspaceInTransaction(workspace)
             }
@@ -639,55 +737,232 @@ class SyncLocalStore(
                 hasHydratedReviewHistory = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
-                lastSyncError = null
+                lastSyncError = null,
+                blockedInstallationId = null
             )
         )
     }
 
-    private suspend fun preserveLocalDataForEmptyRemoteWorkspaceInTransaction(workspace: CloudWorkspaceSummary) {
-        val currentWorkspace = requireNotNull(database.workspaceDao().loadAnyWorkspace()) {
-            "Workspace is required before linking to cloud."
+    private suspend fun refreshCurrentWorkspaceShellInTransaction(workspace: CloudWorkspaceSummary) {
+        val currentWorkspace = requireNotNull(database.workspaceDao().loadWorkspaceById(workspace.workspaceId)) {
+            "Workspace '${workspace.workspaceId}' is missing locally."
         }
-        if (currentWorkspace.workspaceId == workspace.workspaceId) {
-            database.workspaceDao().updateWorkspace(
-                currentWorkspace.copy(name = workspace.name)
-            )
-            return
-        }
-
-        database.syncStateDao().deleteSyncState(workspaceId = workspace.workspaceId)
-        database.workspaceDao().loadWorkspaceById(workspace.workspaceId)?.let {
-            database.workspaceDao().deleteWorkspace(workspace.workspaceId)
-        }
-        database.workspaceDao().insertWorkspace(
-            WorkspaceEntity(
-                workspaceId = workspace.workspaceId,
+        database.workspaceDao().updateWorkspace(
+            currentWorkspace.copy(
                 name = workspace.name,
                 createdAtMillis = workspace.createdAtMillis
             )
         )
-        database.cardDao().reassignWorkspace(currentWorkspace.workspaceId, workspace.workspaceId)
-        database.deckDao().reassignWorkspace(currentWorkspace.workspaceId, workspace.workspaceId)
-        database.tagDao().reassignWorkspace(currentWorkspace.workspaceId, workspace.workspaceId)
-        database.reviewLogDao().reassignWorkspace(currentWorkspace.workspaceId, workspace.workspaceId)
-        localProgressCacheStore.reassignWorkspaceInTransaction(
-            oldWorkspaceId = currentWorkspace.workspaceId,
-            newWorkspaceId = workspace.workspaceId
+    }
+
+    private suspend fun forkWorkspaceIdentityInTransaction(
+        currentLocalWorkspaceId: String,
+        sourceWorkspaceId: String,
+        destinationWorkspace: CloudWorkspaceSummary
+    ) {
+        val currentLocalWorkspace = requireNotNull(
+            database.workspaceDao().loadWorkspaceById(currentLocalWorkspaceId)
+        ) {
+            "Cannot fork workspace identity because current local workspace '$currentLocalWorkspaceId' does not exist."
+        }
+        val snapshot = loadWorkspaceForkSnapshot(workspaceId = currentLocalWorkspaceId)
+        val forkMappings = buildWorkspaceForkIdMappings(
+            sourceWorkspaceId = sourceWorkspaceId,
+            destinationWorkspaceId = destinationWorkspace.workspaceId,
+            cards = snapshot.cards,
+            decks = snapshot.decks,
+            reviewLogs = snapshot.reviewLogs
         )
-        database.workspaceSchedulerSettingsDao().reassignWorkspace(currentWorkspace.workspaceId, workspace.workspaceId)
-        database.outboxDao().reassignWorkspace(currentWorkspace.workspaceId, workspace.workspaceId)
-        database.workspaceDao().deleteWorkspace(currentWorkspace.workspaceId)
-        database.syncStateDao().deleteSyncState(workspaceId = currentWorkspace.workspaceId)
+        val destinationMatchesCurrentWorkspace = currentLocalWorkspaceId == destinationWorkspace.workspaceId
+
+        if (destinationMatchesCurrentWorkspace) {
+            database.workspaceDao().updateWorkspace(
+                currentLocalWorkspace.copy(
+                    name = destinationWorkspace.name,
+                    createdAtMillis = destinationWorkspace.createdAtMillis
+                )
+            )
+        } else {
+            database.syncStateDao().deleteSyncState(workspaceId = destinationWorkspace.workspaceId)
+            database.workspaceDao().loadWorkspaceById(destinationWorkspace.workspaceId)?.let {
+                database.workspaceDao().deleteWorkspace(destinationWorkspace.workspaceId)
+            }
+            database.workspaceDao().insertWorkspace(
+                WorkspaceEntity(
+                    workspaceId = destinationWorkspace.workspaceId,
+                    name = destinationWorkspace.name,
+                    createdAtMillis = destinationWorkspace.createdAtMillis
+                )
+            )
+            snapshot.schedulerSettings?.let {
+                database.workspaceSchedulerSettingsDao().reassignWorkspace(
+                    oldWorkspaceId = currentLocalWorkspaceId,
+                    newWorkspaceId = destinationWorkspace.workspaceId
+                )
+            }
+            if (snapshot.tags.isNotEmpty()) {
+                database.tagDao().reassignWorkspace(
+                    oldWorkspaceId = currentLocalWorkspaceId,
+                    newWorkspaceId = destinationWorkspace.workspaceId
+                )
+            }
+            localProgressCacheStore.reassignWorkspaceInTransaction(
+                oldWorkspaceId = currentLocalWorkspaceId,
+                newWorkspaceId = destinationWorkspace.workspaceId
+            )
+        }
+
+        if (snapshot.cards.isNotEmpty()) {
+            val cardsToInsert = snapshot.cards.mapNotNull { card ->
+                val rewrittenCardId = forkMappings.cardIdsBySourceId.requireMappedId(
+                    entityType = "card",
+                    sourceId = card.cardId
+                )
+                if (destinationMatchesCurrentWorkspace && rewrittenCardId == card.cardId) {
+                    return@mapNotNull null
+                }
+                card.copy(
+                    cardId = rewrittenCardId,
+                    workspaceId = destinationWorkspace.workspaceId
+                )
+            }
+            if (cardsToInsert.isNotEmpty()) {
+                database.cardDao().insertCards(cardsToInsert)
+            }
+        }
+        if (snapshot.decks.isNotEmpty()) {
+            val decksToInsert = snapshot.decks.mapNotNull { deck ->
+                val rewrittenDeckId = forkMappings.deckIdsBySourceId.requireMappedId(
+                    entityType = "deck",
+                    sourceId = deck.deckId
+                )
+                if (destinationMatchesCurrentWorkspace && rewrittenDeckId == deck.deckId) {
+                    return@mapNotNull null
+                }
+                deck.copy(
+                    deckId = rewrittenDeckId,
+                    workspaceId = destinationWorkspace.workspaceId
+                )
+            }
+            if (decksToInsert.isNotEmpty()) {
+                database.deckDao().insertDecks(decksToInsert)
+            }
+        }
+        if (snapshot.cardTags.isNotEmpty()) {
+            val cardTagsToInsert = snapshot.cardTags.mapNotNull { cardTag ->
+                val rewrittenCardId = forkMappings.cardIdsBySourceId.requireMappedId(
+                    entityType = "card",
+                    sourceId = cardTag.cardId
+                )
+                if (destinationMatchesCurrentWorkspace && rewrittenCardId == cardTag.cardId) {
+                    return@mapNotNull null
+                }
+                CardTagEntity(cardId = rewrittenCardId, tagId = cardTag.tagId)
+            }
+            if (cardTagsToInsert.isNotEmpty()) {
+                database.tagDao().insertCardTags(cardTagsToInsert)
+            }
+        }
+        if (snapshot.reviewLogs.isNotEmpty()) {
+            val reviewLogsToInsert = snapshot.reviewLogs.mapNotNull { reviewLog ->
+                val rewrittenReviewEventId = forkMappings.reviewEventIdsBySourceId.requireMappedId(
+                    entityType = "review_event",
+                    sourceId = reviewLog.reviewLogId
+                )
+                if (destinationMatchesCurrentWorkspace && rewrittenReviewEventId == reviewLog.reviewLogId) {
+                    return@mapNotNull null
+                }
+                reviewLog.copy(
+                    reviewLogId = rewrittenReviewEventId,
+                    workspaceId = destinationWorkspace.workspaceId,
+                    cardId = forkMappings.cardIdsBySourceId.requireMappedId(
+                        entityType = "card",
+                        sourceId = reviewLog.cardId
+                    )
+                )
+            }
+            if (reviewLogsToInsert.isNotEmpty()) {
+                database.reviewLogDao().insertReviewLogs(reviewLogsToInsert)
+            }
+        }
+        if (snapshot.outboxEntries.isNotEmpty()) {
+            val outboxEntriesToInsert = snapshot.outboxEntries.mapNotNull { entry ->
+                val rewrittenEntry = rewriteOutboxEntryForFork(
+                    entry = entry,
+                    destinationWorkspaceId = destinationWorkspace.workspaceId,
+                    forkMappings = forkMappings
+                )
+                if (
+                    destinationMatchesCurrentWorkspace &&
+                    rewrittenEntry.workspaceId == entry.workspaceId &&
+                    rewrittenEntry.entityId == entry.entityId &&
+                    rewrittenEntry.payloadJson == entry.payloadJson
+                ) {
+                    return@mapNotNull null
+                }
+                rewrittenEntry
+            }
+            if (outboxEntriesToInsert.isNotEmpty()) {
+                database.outboxDao().insertOutboxEntries(outboxEntriesToInsert)
+            }
+        }
+
+        if (destinationMatchesCurrentWorkspace) {
+            snapshot.decks
+                .filter { deck ->
+                    forkMappings.deckIdsBySourceId.requireMappedId(
+                        entityType = "deck",
+                        sourceId = deck.deckId
+                    ) != deck.deckId
+                }
+                .forEach { deck -> database.deckDao().deleteDeck(deck.deckId) }
+            snapshot.cards
+                .filter { card ->
+                    forkMappings.cardIdsBySourceId.requireMappedId(
+                        entityType = "card",
+                        sourceId = card.cardId
+                    ) != card.cardId
+                }
+                .forEach { card -> database.cardDao().deleteCard(card.cardId) }
+        } else {
+            database.workspaceDao().deleteWorkspace(currentLocalWorkspaceId)
+            database.syncStateDao().deleteSyncState(workspaceId = currentLocalWorkspaceId)
+        }
+
+        replaceSyncStateWithEmptyProgress(workspaceId = destinationWorkspace.workspaceId)
+    }
+
+    private suspend fun loadWorkspaceForkSnapshot(workspaceId: String): WorkspaceForkSnapshot {
+        val cards = database.cardDao().loadCards(workspaceId = workspaceId)
+        val cardTags = if (cards.isEmpty()) {
+            emptyList()
+        } else {
+            database.tagDao().loadCardTags(cardIds = cards.map(CardEntity::cardId))
+        }
+        return WorkspaceForkSnapshot(
+            cards = cards,
+            decks = database.deckDao().loadDecks(workspaceId = workspaceId),
+            tags = database.tagDao().loadTags(workspaceId = workspaceId),
+            cardTags = cardTags,
+            reviewLogs = database.reviewLogDao().loadReviewLogs(workspaceId = workspaceId),
+            outboxEntries = database.outboxDao().loadAllOutboxEntries(workspaceId = workspaceId),
+            schedulerSettings = database.workspaceSchedulerSettingsDao()
+                .loadWorkspaceSchedulerSettings(workspaceId = workspaceId)
+        )
+    }
+
+    private suspend fun replaceSyncStateWithEmptyProgress(workspaceId: String) {
         database.syncStateDao().insertSyncState(
             SyncStateEntity(
-                workspaceId = workspace.workspaceId,
+                workspaceId = workspaceId,
                 lastSyncCursor = null,
                 lastReviewSequenceId = 0L,
                 hasHydratedHotState = false,
                 hasHydratedReviewHistory = false,
                 lastSyncAttemptAtMillis = null,
                 lastSuccessfulSyncAtMillis = null,
-                lastSyncError = null
+                lastSyncError = null,
+                blockedInstallationId = null
             )
         )
     }
@@ -896,6 +1171,119 @@ class SyncLocalStore(
                 )
             }
         )
+    }
+}
+
+private fun buildWorkspaceForkIdMappings(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    cards: List<CardEntity>,
+    decks: List<DeckEntity>,
+    reviewLogs: List<ReviewLogEntity>
+): WorkspaceForkIdMappings {
+    return WorkspaceForkIdMappings(
+        cardIdsBySourceId = cards.associate { card ->
+            card.cardId to forkedCardId(
+                sourceWorkspaceId = sourceWorkspaceId,
+                destinationWorkspaceId = destinationWorkspaceId,
+                sourceCardId = card.cardId
+            )
+        },
+        deckIdsBySourceId = decks.associate { deck ->
+            deck.deckId to forkedDeckId(
+                sourceWorkspaceId = sourceWorkspaceId,
+                destinationWorkspaceId = destinationWorkspaceId,
+                sourceDeckId = deck.deckId
+            )
+        },
+        reviewEventIdsBySourceId = reviewLogs.associate { reviewLog ->
+            reviewLog.reviewLogId to forkedReviewEventId(
+                sourceWorkspaceId = sourceWorkspaceId,
+                destinationWorkspaceId = destinationWorkspaceId,
+                sourceReviewEventId = reviewLog.reviewLogId
+            )
+        }
+    )
+}
+
+private fun rewriteOutboxEntryForFork(
+    entry: OutboxEntryEntity,
+    destinationWorkspaceId: String,
+    forkMappings: WorkspaceForkIdMappings
+): OutboxEntryEntity {
+    val payloadJson = JSONObject(entry.payloadJson)
+    val entityType = parseSyncEntityType(entry.entityType)
+    val rewrittenEntityId = when (entityType) {
+        SyncEntityType.CARD -> forkMappings.cardIdsBySourceId.requireMappedId(
+            entityType = "card",
+            sourceId = entry.entityId
+        )
+
+        SyncEntityType.DECK -> forkMappings.deckIdsBySourceId.requireMappedId(
+            entityType = "deck",
+            sourceId = entry.entityId
+        )
+
+        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> destinationWorkspaceId
+
+        SyncEntityType.REVIEW_EVENT -> forkMappings.reviewEventIdsBySourceId.requireMappedId(
+            entityType = "review_event",
+            sourceId = entry.entityId
+        )
+    }
+    when (entityType) {
+        SyncEntityType.CARD -> {
+            payloadJson.put(
+                "cardId",
+                forkMappings.cardIdsBySourceId.requireMappedId(
+                    entityType = "card",
+                    sourceId = payloadJson.requireCloudString("cardId", "fork.outbox.card.cardId")
+                )
+            )
+        }
+
+        SyncEntityType.DECK -> {
+            payloadJson.put(
+                "deckId",
+                forkMappings.deckIdsBySourceId.requireMappedId(
+                    entityType = "deck",
+                    sourceId = payloadJson.requireCloudString("deckId", "fork.outbox.deck.deckId")
+                )
+            )
+        }
+
+        SyncEntityType.WORKSPACE_SCHEDULER_SETTINGS -> Unit
+
+        SyncEntityType.REVIEW_EVENT -> {
+            payloadJson.put(
+                "reviewEventId",
+                forkMappings.reviewEventIdsBySourceId.requireMappedId(
+                    entityType = "review_event",
+                    sourceId = payloadJson.requireCloudString(
+                        "reviewEventId",
+                        "fork.outbox.reviewEvent.reviewEventId"
+                    )
+                )
+            )
+            payloadJson.put(
+                "cardId",
+                forkMappings.cardIdsBySourceId.requireMappedId(
+                    entityType = "card",
+                    sourceId = payloadJson.requireCloudString("cardId", "fork.outbox.reviewEvent.cardId")
+                )
+            )
+        }
+    }
+    return entry.copy(
+        workspaceId = destinationWorkspaceId,
+        entityId = rewrittenEntityId,
+        payloadJson = payloadJson.toString()
+    )
+}
+
+private fun Map<String, String>.requireMappedId(entityType: String, sourceId: String): String {
+    return requireNotNull(this[sourceId]) {
+        "Workspace identity fork is missing mapped $entityType id for source id '$sourceId'."
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/WorkspaceIdentityFork.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/WorkspaceIdentityFork.kt
@@ -1,0 +1,84 @@
+package com.flashcardsopensourceapp.data.local.cloud
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.UUID
+
+private val cardIdentityForkNamespace: UUID = UUID.fromString("5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1")
+private val deckIdentityForkNamespace: UUID = UUID.fromString("98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4")
+private val reviewEventIdentityForkNamespace: UUID = UUID.fromString("3a214a3e-9c89-426d-a21f-11a5f5c1d6e8")
+
+internal const val syncWorkspaceForkRequiredErrorCode: String = "SYNC_WORKSPACE_FORK_REQUIRED"
+
+internal fun forkedCardId(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceCardId: String
+): String {
+    return forkedWorkspaceEntityId(
+        namespace = cardIdentityForkNamespace,
+        sourceWorkspaceId = sourceWorkspaceId,
+        destinationWorkspaceId = destinationWorkspaceId,
+        sourceEntityId = sourceCardId
+    )
+}
+
+internal fun forkedDeckId(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceDeckId: String
+): String {
+    return forkedWorkspaceEntityId(
+        namespace = deckIdentityForkNamespace,
+        sourceWorkspaceId = sourceWorkspaceId,
+        destinationWorkspaceId = destinationWorkspaceId,
+        sourceEntityId = sourceDeckId
+    )
+}
+
+internal fun forkedReviewEventId(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceReviewEventId: String
+): String {
+    return forkedWorkspaceEntityId(
+        namespace = reviewEventIdentityForkNamespace,
+        sourceWorkspaceId = sourceWorkspaceId,
+        destinationWorkspaceId = destinationWorkspaceId,
+        sourceEntityId = sourceReviewEventId
+    )
+}
+
+private fun forkedWorkspaceEntityId(
+    namespace: UUID,
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceEntityId: String
+): String {
+    if (sourceWorkspaceId == destinationWorkspaceId) {
+        return sourceEntityId
+    }
+
+    return uuidV5(
+        namespace = namespace,
+        name = "$sourceWorkspaceId:$destinationWorkspaceId:$sourceEntityId"
+    ).toString()
+}
+
+private fun uuidV5(namespace: UUID, name: String): UUID {
+    val hash = MessageDigest.getInstance("SHA-1").digest(
+        namespace.toByteArray() + name.toByteArray(StandardCharsets.UTF_8)
+    )
+    hash[6] = ((hash[6].toInt() and 0x0f) or 0x50).toByte()
+    hash[8] = ((hash[8].toInt() and 0x3f) or 0x80).toByte()
+    val buffer = ByteBuffer.wrap(hash, 0, 16)
+    return UUID(buffer.long, buffer.long)
+}
+
+private fun UUID.toByteArray(): ByteArray {
+    return ByteBuffer.allocate(16)
+        .putLong(mostSignificantBits)
+        .putLong(leastSignificantBits)
+        .array()
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/AppDatabase.kt
@@ -29,7 +29,7 @@ private const val androidInstallationId: String = "android-installation"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)
@@ -70,7 +70,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration8To9,
         migration9To10,
         migration10To11,
-        migration11To12
+        migration11To12,
+        migration12To13
     )
 }
 
@@ -666,5 +667,11 @@ val migration10To11: Migration = object : Migration(10, 11) {
 val migration11To12: Migration = object : Migration(11, 12) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE sync_state ADD COLUMN blockedInstallationId TEXT")
+    }
+}
+
+val migration12To13: Migration = object : Migration(12, 13) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE sync_state ADD COLUMN pendingReviewHistoryImport INTEGER NOT NULL DEFAULT 0")
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/AppDatabase.kt
@@ -29,7 +29,7 @@ private const val androidInstallationId: String = "android-installation"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 11,
+    version = 12,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)
@@ -69,7 +69,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration7To8,
         migration8To9,
         migration9To10,
-        migration10To11
+        migration10To11,
+        migration11To12
     )
 }
 
@@ -659,5 +660,11 @@ val migration10To11: Migration = object : Migration(10, 11) {
         db.execSQL(
             "CREATE INDEX IF NOT EXISTS index_review_logs_reviewedAtMillis ON review_logs(reviewedAtMillis)"
         )
+    }
+}
+
+val migration11To12: Migration = object : Migration(11, 12) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE sync_state ADD COLUMN blockedInstallationId TEXT")
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
@@ -295,8 +295,21 @@ interface TagDao {
     @Query("SELECT * FROM tags WHERE workspaceId = :workspaceId ORDER BY name ASC, tagId ASC")
     suspend fun loadTags(workspaceId: String): List<TagEntity>
 
-    @Query("SELECT * FROM card_tags WHERE cardId IN (:cardIds)")
-    suspend fun loadCardTags(cardIds: List<String>): List<CardTagEntity>
+    @Query(
+        """
+        SELECT card_tags.*
+        FROM card_tags
+        INNER JOIN cards ON cards.cardId = card_tags.cardId
+        INNER JOIN tags ON tags.tagId = card_tags.tagId
+        WHERE cards.workspaceId = :workspaceId
+            AND tags.workspaceId = :workspaceId
+        ORDER BY cards.createdAtMillis ASC, cards.cardId ASC, card_tags.tagId ASC
+        """
+    )
+    suspend fun loadCardTags(workspaceId: String): List<CardTagEntity>
+
+    @Query("UPDATE card_tags SET cardId = :newCardId WHERE cardId = :oldCardId")
+    suspend fun reassignCardTagsToCard(oldCardId: String, newCardId: String)
 
     @Query("SELECT EXISTS(SELECT 1 FROM tags WHERE workspaceId = :workspaceId AND LOWER(name) = LOWER(:tagName) LIMIT 1)")
     suspend fun hasTag(workspaceId: String, tagName: String): Boolean
@@ -347,11 +360,20 @@ interface ReviewLogDao {
     @Query("SELECT * FROM review_logs WHERE reviewLogId IN (:reviewLogIds)")
     suspend fun loadReviewLogs(reviewLogIds: List<String>): List<ReviewLogEntity>
 
+    @Query("SELECT * FROM review_logs WHERE reviewLogId = :reviewLogId LIMIT 1")
+    suspend fun loadReviewLog(reviewLogId: String): ReviewLogEntity?
+
     @Query("SELECT * FROM review_logs WHERE workspaceId = :workspaceId ORDER BY reviewedAtMillis DESC")
     suspend fun loadReviewLogs(workspaceId: String): List<ReviewLogEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertReviewLogs(reviewLogs: List<ReviewLogEntity>)
+
+    @Query("UPDATE review_logs SET cardId = :newCardId WHERE workspaceId = :workspaceId AND cardId = :oldCardId")
+    suspend fun reassignReviewLogsToCard(workspaceId: String, oldCardId: String, newCardId: String)
+
+    @Query("DELETE FROM review_logs WHERE reviewLogId IN (:reviewLogIds)")
+    suspend fun deleteReviewLogs(reviewLogIds: List<String>)
 
     @Query("DELETE FROM review_logs")
     suspend fun deleteAllReviewLogs()
@@ -374,10 +396,13 @@ interface OutboxDao {
     @Query("SELECT COUNT(*) FROM outbox_entries")
     suspend fun countOutboxEntries(): Int
 
-    @Query("SELECT * FROM outbox_entries WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC LIMIT :limit")
+    @Query("SELECT COUNT(*) FROM outbox_entries WHERE workspaceId = :workspaceId")
+    suspend fun countOutboxEntriesForWorkspace(workspaceId: String): Int
+
+    @Query("SELECT * FROM outbox_entries WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, rowid ASC LIMIT :limit")
     suspend fun loadOutboxEntries(workspaceId: String, limit: Int): List<OutboxEntryEntity>
 
-    @Query("SELECT * FROM outbox_entries WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, outboxEntryId ASC")
+    @Query("SELECT * FROM outbox_entries WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, rowid ASC")
     suspend fun loadAllOutboxEntries(workspaceId: String): List<OutboxEntryEntity>
 
     @Query(
@@ -386,7 +411,7 @@ interface OutboxDao {
         WHERE workspaceId = :workspaceId
             AND entityType = 'review_event'
             AND operationType = 'append'
-        ORDER BY createdAtMillis ASC
+        ORDER BY createdAtMillis ASC, rowid ASC
         """
     )
     suspend fun loadPendingReviewEventOutboxEntries(workspaceId: String): List<OutboxEntryEntity>
@@ -396,7 +421,7 @@ interface OutboxDao {
         SELECT * FROM outbox_entries
         WHERE entityType = 'review_event'
             AND operationType = 'append'
-        ORDER BY createdAtMillis ASC
+        ORDER BY createdAtMillis ASC, rowid ASC
         """
     )
     fun observePendingReviewEventOutboxEntries(): Flow<List<OutboxEntryEntity>>
@@ -416,8 +441,6 @@ interface OutboxDao {
     )
     suspend fun markOutboxEntriesFailed(operationIds: List<String>, errorMessage: String)
 
-    @Query("UPDATE outbox_entries SET workspaceId = :newWorkspaceId WHERE workspaceId = :oldWorkspaceId")
-    suspend fun reassignWorkspace(oldWorkspaceId: String, newWorkspaceId: String)
 }
 
 @Dao

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
@@ -103,6 +103,9 @@ interface DeckDao {
     @Query("SELECT * FROM decks WHERE deckId = :deckId LIMIT 1")
     suspend fun loadDeck(deckId: String): DeckEntity?
 
+    @Query("SELECT * FROM decks WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, deckId ASC")
+    suspend fun loadDecks(workspaceId: String): List<DeckEntity>
+
     @Query("SELECT COUNT(*) FROM decks")
     fun observeDeckCount(): Flow<Int>
 
@@ -144,6 +147,9 @@ interface CardDao {
 
     @Query("SELECT * FROM cards WHERE cardId = :cardId LIMIT 1")
     suspend fun loadCard(cardId: String): CardEntity?
+
+    @Query("SELECT * FROM cards WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, cardId ASC")
+    suspend fun loadCards(workspaceId: String): List<CardEntity>
 
     @Query(
         """
@@ -286,6 +292,12 @@ interface TagDao {
     @Query("SELECT * FROM tags WHERE workspaceId = :workspaceId")
     suspend fun loadTagsForWorkspace(workspaceId: String): List<TagEntity>
 
+    @Query("SELECT * FROM tags WHERE workspaceId = :workspaceId ORDER BY name ASC, tagId ASC")
+    suspend fun loadTags(workspaceId: String): List<TagEntity>
+
+    @Query("SELECT * FROM card_tags WHERE cardId IN (:cardIds)")
+    suspend fun loadCardTags(cardIds: List<String>): List<CardTagEntity>
+
     @Query("SELECT EXISTS(SELECT 1 FROM tags WHERE workspaceId = :workspaceId AND LOWER(name) = LOWER(:tagName) LIMIT 1)")
     suspend fun hasTag(workspaceId: String, tagName: String): Boolean
 
@@ -365,6 +377,9 @@ interface OutboxDao {
     @Query("SELECT * FROM outbox_entries WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC LIMIT :limit")
     suspend fun loadOutboxEntries(workspaceId: String, limit: Int): List<OutboxEntryEntity>
 
+    @Query("SELECT * FROM outbox_entries WHERE workspaceId = :workspaceId ORDER BY createdAtMillis ASC, outboxEntryId ASC")
+    suspend fun loadAllOutboxEntries(workspaceId: String): List<OutboxEntryEntity>
+
     @Query(
         """
         SELECT * FROM outbox_entries
@@ -427,6 +442,15 @@ interface SyncStateDao {
 
     @Query("UPDATE sync_state SET workspaceId = :newWorkspaceId WHERE workspaceId = :oldWorkspaceId")
     suspend fun reassignWorkspace(oldWorkspaceId: String, newWorkspaceId: String)
+
+    @Query(
+        """
+        UPDATE sync_state
+        SET lastSyncError = NULL, blockedInstallationId = NULL
+        WHERE blockedInstallationId IS NOT NULL
+        """
+    )
+    suspend fun clearBlockedSyncState()
 }
 
 @Dao

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseEntities.kt
@@ -211,6 +211,7 @@ data class SyncStateEntity(
     val lastReviewSequenceId: Long,
     val hasHydratedHotState: Boolean,
     val hasHydratedReviewHistory: Boolean,
+    val pendingReviewHistoryImport: Boolean,
     val lastSyncAttemptAtMillis: Long?,
     val lastSuccessfulSyncAtMillis: Long?,
     val lastSyncError: String?,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseEntities.kt
@@ -213,7 +213,8 @@ data class SyncStateEntity(
     val hasHydratedReviewHistory: Boolean,
     val lastSyncAttemptAtMillis: Long?,
     val lastSuccessfulSyncAtMillis: Long?,
-    val lastSyncError: String?
+    val lastSyncError: String?,
+    val blockedInstallationId: String?
 )
 
 @Entity(tableName = "progress_summary_cache")

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
@@ -74,6 +74,26 @@ enum class CloudGuestUpgradeMode {
     MERGE_REQUIRED
 }
 
+enum class CloudGuestUpgradeDroppedEntityType {
+    CARD,
+    DECK,
+    REVIEW_EVENT
+}
+
+data class CloudGuestUpgradeDroppedEntity(
+    val entityType: CloudGuestUpgradeDroppedEntityType,
+    val entityId: String
+)
+
+data class CloudGuestUpgradeReconciliation(
+    val droppedEntities: List<CloudGuestUpgradeDroppedEntity>
+)
+
+data class CloudGuestUpgradeCompletion(
+    val workspace: CloudWorkspaceSummary,
+    val reconciliation: CloudGuestUpgradeReconciliation?
+)
+
 sealed interface CloudGuestUpgradeSelection {
     data class Existing(
         val workspaceId: String

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudGuestSessionCoordinator.kt
@@ -84,6 +84,23 @@ class CloudGuestSessionCoordinator(
     }
 
     internal suspend fun reconcilePersistedCloudStateLocked(): CloudIdentityReconciliationResult {
+        val recoveredGuestUpgrade: CloudWorkspaceSummary? = resumePendingGuestUpgradeRecoveryIfNeeded(
+            database = database,
+            preferencesStore = preferencesStore,
+            remoteService = remoteService,
+            syncLocalStore = syncLocalStore,
+            guestSessionStore = guestSessionStore,
+            appVersion = appVersion
+        )
+        if (recoveredGuestUpgrade != null) {
+            return CloudIdentityReconciliationResult(
+                cloudSettings = preferencesStore.currentCloudSettings(),
+                restoredGuestSession = null,
+                guestRestoreRequiresSync = false,
+                didRunSync = false
+            )
+        }
+
         val currentCloudSettings = preferencesStore.currentCloudSettings()
         if (hasInvalidActiveWorkspaceId(cloudSettings = currentCloudSettings)) {
             normalizeActiveWorkspaceIdToLocalShell()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudIdentityResetCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudIdentityResetCoordinator.kt
@@ -67,6 +67,7 @@ class CloudIdentityResetCoordinator(
         withContext(Dispatchers.IO) {
             resetMutex.withLock {
                 cloudPreferencesStore.clearCredentials()
+                database.syncStateDao().clearBlockedSyncState()
                 val activeWorkspaceId = ensureLocalWorkspaceShell(
                     database = database,
                     currentTimeMillis = System.currentTimeMillis()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudRemoteErrors.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudRemoteErrors.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.data.local.repository
 
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.syncWorkspaceForkRequiredErrorCode
 
 internal fun isRemoteAccountDeletedError(error: Exception): Boolean {
     return error is CloudRemoteException
@@ -11,6 +12,7 @@ internal fun isRemoteAccountDeletedError(error: Exception): Boolean {
 internal fun isCloudIdentityConflictError(error: Exception): Boolean {
     return error is CloudRemoteException && (
         error.errorCode == "SYNC_INSTALLATION_PLATFORM_MISMATCH" ||
-            error.errorCode == "SYNC_REPLICA_CONFLICT"
+            error.errorCode == "SYNC_REPLICA_CONFLICT" ||
+            error.errorCode == syncWorkspaceForkRequiredErrorCode
         )
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudSyncRunner.kt
@@ -1,15 +1,18 @@
 package com.flashcardsopensourceapp.data.local.repository
 
+import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
 import com.flashcardsopensourceapp.data.local.cloud.putNullableDouble
 import com.flashcardsopensourceapp.data.local.cloud.putNullableInt
 import com.flashcardsopensourceapp.data.local.cloud.putNullableString
 import com.flashcardsopensourceapp.data.local.cloud.RemoteBootstrapPullResponse
 import com.flashcardsopensourceapp.data.local.cloud.SyncLocalStore
+import com.flashcardsopensourceapp.data.local.cloud.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.PersistedOutboxEntry
 import com.flashcardsopensourceapp.data.local.model.SyncOperationPayload
 import com.flashcardsopensourceapp.data.local.model.buildDeckFilterDefinitionJsonObject
+import kotlinx.coroutines.CancellationException
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -25,173 +28,284 @@ internal suspend fun runCloudSyncCore(
     remoteService: CloudRemoteGateway,
     syncLocalStore: SyncLocalStore
 ) {
+    val blockedMessage = syncLocalStore.loadBlockedSyncMessage(
+        workspaceId = workspaceId,
+        installationId = cloudSettings.installationId
+    )
+    if (blockedMessage != null) {
+        throw CloudSyncBlockedException(message = blockedMessage, cause = null)
+    }
     syncLocalStore.recordSyncAttempt(workspaceId)
-    val syncState = syncLocalStore.ensureSyncState(workspaceId)
-    var lastHotCursor = syncState.lastSyncCursor?.toLongOrNull() ?: 0L
-    var lastReviewSequenceId = syncState.lastReviewSequenceId
-    var hasHydratedHotState = syncState.hasHydratedHotState
-    var hasHydratedReviewHistory = syncState.hasHydratedReviewHistory
-    var bootstrapResponse: RemoteBootstrapPullResponse? = null
-
-    if (hasHydratedHotState.not()) {
-        bootstrapResponse = remoteService.bootstrapPull(
-            apiBaseUrl = syncSession.apiBaseUrl,
-            authorizationHeader = syncSession.authorizationHeader,
+    try {
+        val bootstrapState = runBootstrapHydrationWithForkRecovery(
+            cloudSettings = cloudSettings,
             workspaceId = workspaceId,
-            body = JSONObject()
-                .put("mode", "pull")
-                .put("installationId", cloudSettings.installationId)
-                .put("platform", androidClientPlatform)
-                .put("appVersion", appVersion)
-                .put("cursor", JSONObject.NULL)
-                .put("limit", bootstrapPageLimit)
+            syncSession = syncSession,
+            appVersion = appVersion,
+            remoteService = remoteService,
+            syncLocalStore = syncLocalStore
         )
+        var lastHotCursor = bootstrapState.lastHotCursor
+        var lastReviewSequenceId = bootstrapState.lastReviewSequenceId
+        val hasHydratedHotState = bootstrapState.hasHydratedHotState
+        val hasHydratedReviewHistory = bootstrapState.hasHydratedReviewHistory
 
-        if (bootstrapResponse.remoteIsEmpty) {
-            val bootstrapEntries = syncLocalStore.buildBootstrapEntries(workspaceId)
-            if (bootstrapEntries.length() > 0) {
-                val bootstrapPushResponse = remoteService.bootstrapPush(
+        val outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId)
+        if (outboxEntries.isNotEmpty()) {
+            try {
+                val pushResponse = remoteService.push(
                     apiBaseUrl = syncSession.apiBaseUrl,
                     authorizationHeader = syncSession.authorizationHeader,
                     workspaceId = workspaceId,
-                    body = JSONObject()
-                        .put("mode", "push")
-                        .put("installationId", cloudSettings.installationId)
-                        .put("platform", androidClientPlatform)
-                        .put("appVersion", appVersion)
-                        .put("entries", bootstrapEntries)
+                    body = buildPushRequest(
+                        installationId = cloudSettings.installationId,
+                        outboxEntries = outboxEntries,
+                        appVersion = appVersion
+                    )
                 )
-                lastHotCursor = bootstrapPushResponse.bootstrapHotChangeId ?: lastHotCursor
-            }
-        } else {
-            syncLocalStore.applyBootstrapEntries(workspaceId, bootstrapResponse.entries)
-            lastHotCursor = bootstrapResponse.bootstrapHotChangeId
-            var nextCursor = bootstrapResponse.nextCursor
-
-            while (bootstrapResponse.hasMore && nextCursor != null) {
-                val nextPage = remoteService.bootstrapPull(
-                    apiBaseUrl = syncSession.apiBaseUrl,
-                    authorizationHeader = syncSession.authorizationHeader,
-                    workspaceId = workspaceId,
-                    body = JSONObject()
-                        .put("mode", "pull")
-                        .put("installationId", cloudSettings.installationId)
-                        .put("platform", androidClientPlatform)
-                        .put("appVersion", appVersion)
-                        .put("cursor", nextCursor)
-                        .put("limit", bootstrapPageLimit)
-                )
-                syncLocalStore.applyBootstrapEntries(workspaceId, nextPage.entries)
-                nextCursor = nextPage.nextCursor
-                lastHotCursor = nextPage.bootstrapHotChangeId
-                if (nextPage.hasMore.not()) {
-                    break
+                syncLocalStore.deleteOutboxEntries(pushResponse.operations.map { result -> result.operationId })
+                val pushCursor = pushResponse.operations.mapNotNull { result -> result.resultingHotChangeId }.maxOrNull()
+                if (pushCursor != null && pushCursor > lastHotCursor) {
+                    lastHotCursor = pushCursor
                 }
-            }
-        }
-
-        hasHydratedHotState = true
-    }
-
-    if (hasHydratedReviewHistory.not()) {
-        if (bootstrapResponse?.remoteIsEmpty == true) {
-            val reviewEvents = syncLocalStore.buildReviewHistoryImportEvents(workspaceId)
-            if (reviewEvents.length() > 0) {
-                val importResponse = remoteService.importReviewHistory(
-                    apiBaseUrl = syncSession.apiBaseUrl,
-                    authorizationHeader = syncSession.authorizationHeader,
-                    workspaceId = workspaceId,
-                    body = JSONObject()
-                        .put("installationId", cloudSettings.installationId)
-                        .put("platform", androidClientPlatform)
-                        .put("appVersion", appVersion)
-                        .put("reviewEvents", reviewEvents)
+            } catch (error: Exception) {
+                syncLocalStore.markOutboxEntriesFailed(
+                    outboxEntries.map(PersistedOutboxEntry::operationId),
+                    error.message ?: "Cloud push failed."
                 )
-                lastReviewSequenceId = importResponse.nextReviewSequenceId ?: lastReviewSequenceId
+                throw error
             }
-        } else {
-            lastReviewSequenceId = pullAndApplyReviewHistoryBatch(
-                cloudSettings = cloudSettings,
-                workspaceId = workspaceId,
-                syncSession = syncSession,
-                appVersion = appVersion,
-                remoteService = remoteService,
-                syncLocalStore = syncLocalStore,
-                startingReviewSequenceId = lastReviewSequenceId
-            )
         }
 
-        hasHydratedReviewHistory = true
-    }
-
-    val outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId)
-    if (outboxEntries.isNotEmpty()) {
-        try {
-            val pushResponse = remoteService.push(
+        var hasMoreHotChanges = true
+        while (hasMoreHotChanges) {
+            val pullResponse = remoteService.pull(
                 apiBaseUrl = syncSession.apiBaseUrl,
                 authorizationHeader = syncSession.authorizationHeader,
                 workspaceId = workspaceId,
-                body = buildPushRequest(
-                    installationId = cloudSettings.installationId,
-                    outboxEntries = outboxEntries,
-                    appVersion = appVersion
-                )
-            )
-            syncLocalStore.deleteOutboxEntries(pushResponse.operations.map { result -> result.operationId })
-            val pushCursor = pushResponse.operations.mapNotNull { result -> result.resultingHotChangeId }.maxOrNull()
-            if (pushCursor != null && pushCursor > lastHotCursor) {
-                lastHotCursor = pushCursor
-            }
-        } catch (error: Exception) {
-            syncLocalStore.markOutboxEntriesFailed(
-                outboxEntries.map(PersistedOutboxEntry::operationId),
-                error.message ?: "Cloud push failed."
-            )
-            throw error
-        }
-    }
-
-    var hasMoreHotChanges = true
-    while (hasMoreHotChanges) {
-        val pullResponse = remoteService.pull(
-            apiBaseUrl = syncSession.apiBaseUrl,
-            authorizationHeader = syncSession.authorizationHeader,
-            workspaceId = workspaceId,
                 body = JSONObject()
                     .put("installationId", cloudSettings.installationId)
                     .put("platform", androidClientPlatform)
                     .put("appVersion", appVersion)
                     .put("afterHotChangeId", lastHotCursor)
-                .put("limit", syncPullPageLimit)
+                    .put("limit", syncPullPageLimit)
+            )
+            syncLocalStore.applyPullChanges(workspaceId, pullResponse.changes)
+            lastHotCursor = pullResponse.nextHotChangeId
+            hasMoreHotChanges = pullResponse.hasMore
+        }
+
+        lastReviewSequenceId = pullAndApplyReviewHistoryBatch(
+            cloudSettings = cloudSettings,
+            workspaceId = workspaceId,
+            syncSession = syncSession,
+            appVersion = appVersion,
+            remoteService = remoteService,
+            syncLocalStore = syncLocalStore,
+            startingReviewSequenceId = lastReviewSequenceId
         )
-        syncLocalStore.applyPullChanges(workspaceId, pullResponse.changes)
-        lastHotCursor = pullResponse.nextHotChangeId
-        hasMoreHotChanges = pullResponse.hasMore
+
+        syncLocalStore.markSyncSuccess(
+            workspaceId = workspaceId,
+            lastSyncCursor = lastHotCursor.toString(),
+            lastReviewSequenceId = lastReviewSequenceId,
+            hasHydratedHotState = hasHydratedHotState,
+            hasHydratedReviewHistory = hasHydratedReviewHistory
+        )
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Exception) {
+        if (error is CloudSyncBlockedException || isCloudIdentityConflictError(error = error)) {
+            syncLocalStore.markSyncBlocked(
+                workspaceId = workspaceId,
+                installationId = cloudSettings.installationId,
+                errorMessage = error.message ?: "Cloud sync is blocked for this installation."
+            )
+        }
+        throw error
     }
-
-    lastReviewSequenceId = pullAndApplyReviewHistoryBatch(
-        cloudSettings = cloudSettings,
-        workspaceId = workspaceId,
-        syncSession = syncSession,
-        appVersion = appVersion,
-        remoteService = remoteService,
-        syncLocalStore = syncLocalStore,
-        startingReviewSequenceId = lastReviewSequenceId
-    )
-
-    syncLocalStore.markSyncSuccess(
-        workspaceId = workspaceId,
-        lastSyncCursor = lastHotCursor.toString(),
-        lastReviewSequenceId = lastReviewSequenceId,
-        hasHydratedHotState = hasHydratedHotState,
-        hasHydratedReviewHistory = hasHydratedReviewHistory
-    )
 }
 
 internal data class CloudSyncSession(
     val apiBaseUrl: String,
     val authorizationHeader: String
 )
+
+private data class BootstrapHydrationState(
+    val lastHotCursor: Long,
+    val lastReviewSequenceId: Long,
+    val hasHydratedHotState: Boolean,
+    val hasHydratedReviewHistory: Boolean
+)
+
+private enum class WorkspaceForkRecoveryStage(
+    val label: String
+) {
+    BOOTSTRAP_PUSH(label = "bootstrap push"),
+    REVIEW_HISTORY_IMPORT(label = "review history import")
+}
+
+internal class CloudSyncBlockedException(
+    message: String,
+    cause: Throwable?
+) : Exception(message, cause)
+
+private suspend fun runBootstrapHydrationWithForkRecovery(
+    cloudSettings: CloudSettings,
+    workspaceId: String,
+    syncSession: CloudSyncSession,
+    appVersion: String,
+    remoteService: CloudRemoteGateway,
+    syncLocalStore: SyncLocalStore
+): BootstrapHydrationState {
+    var recoveryAttempted = false
+
+    while (true) {
+        val syncState = syncLocalStore.ensureSyncState(workspaceId)
+        var lastHotCursor = syncState.lastSyncCursor?.toLongOrNull() ?: 0L
+        var lastReviewSequenceId = syncState.lastReviewSequenceId
+        var hasHydratedHotState = syncState.hasHydratedHotState
+        var hasHydratedReviewHistory = syncState.hasHydratedReviewHistory
+        var bootstrapResponse: RemoteBootstrapPullResponse? = null
+
+        if (hasHydratedHotState.not()) {
+            bootstrapResponse = remoteService.bootstrapPull(
+                apiBaseUrl = syncSession.apiBaseUrl,
+                authorizationHeader = syncSession.authorizationHeader,
+                workspaceId = workspaceId,
+                body = buildInitialBootstrapPullRequest(
+                    installationId = cloudSettings.installationId,
+                    appVersion = appVersion,
+                    limit = bootstrapPageLimit
+                )
+            )
+
+            if (bootstrapResponse.remoteIsEmpty) {
+                val bootstrapEntries = syncLocalStore.buildBootstrapEntries(workspaceId)
+                if (bootstrapEntries.length() > 0) {
+                    try {
+                        val bootstrapPushResponse = remoteService.bootstrapPush(
+                            apiBaseUrl = syncSession.apiBaseUrl,
+                            authorizationHeader = syncSession.authorizationHeader,
+                            workspaceId = workspaceId,
+                            body = JSONObject()
+                                .put("mode", "push")
+                                .put("installationId", cloudSettings.installationId)
+                                .put("platform", androidClientPlatform)
+                                .put("appVersion", appVersion)
+                                .put("entries", bootstrapEntries)
+                        )
+                        lastHotCursor = bootstrapPushResponse.bootstrapHotChangeId ?: lastHotCursor
+                    } catch (error: Exception) {
+                        if (
+                            recoverWorkspaceForkConflictIfNeeded(
+                                cloudSettings = cloudSettings,
+                                workspaceId = workspaceId,
+                                syncSession = syncSession,
+                                appVersion = appVersion,
+                                remoteService = remoteService,
+                                syncLocalStore = syncLocalStore,
+                                error = error,
+                                stage = WorkspaceForkRecoveryStage.BOOTSTRAP_PUSH,
+                                recoveryAttempted = recoveryAttempted
+                            )
+                        ) {
+                            recoveryAttempted = true
+                            syncLocalStore.recordSyncAttempt(workspaceId = workspaceId)
+                            continue
+                        }
+                        throw error
+                    }
+                }
+            } else {
+                syncLocalStore.applyBootstrapEntries(workspaceId, bootstrapResponse.entries)
+                lastHotCursor = bootstrapResponse.bootstrapHotChangeId
+                var nextCursor = bootstrapResponse.nextCursor
+
+                while (bootstrapResponse.hasMore && nextCursor != null) {
+                    val nextPage = remoteService.bootstrapPull(
+                        apiBaseUrl = syncSession.apiBaseUrl,
+                        authorizationHeader = syncSession.authorizationHeader,
+                        workspaceId = workspaceId,
+                        body = buildPagedBootstrapPullRequest(
+                            installationId = cloudSettings.installationId,
+                            appVersion = appVersion,
+                            cursor = nextCursor,
+                            limit = bootstrapPageLimit
+                        )
+                    )
+                    syncLocalStore.applyBootstrapEntries(workspaceId, nextPage.entries)
+                    nextCursor = nextPage.nextCursor
+                    lastHotCursor = nextPage.bootstrapHotChangeId
+                    if (nextPage.hasMore.not()) {
+                        break
+                    }
+                }
+            }
+
+            hasHydratedHotState = true
+        }
+
+        if (hasHydratedReviewHistory.not()) {
+            if (bootstrapResponse?.remoteIsEmpty == true) {
+                val reviewEvents = syncLocalStore.buildReviewHistoryImportEvents(workspaceId)
+                if (reviewEvents.length() > 0) {
+                    try {
+                        val importResponse = remoteService.importReviewHistory(
+                            apiBaseUrl = syncSession.apiBaseUrl,
+                            authorizationHeader = syncSession.authorizationHeader,
+                            workspaceId = workspaceId,
+                            body = JSONObject()
+                                .put("installationId", cloudSettings.installationId)
+                                .put("platform", androidClientPlatform)
+                                .put("appVersion", appVersion)
+                                .put("reviewEvents", reviewEvents)
+                        )
+                        lastReviewSequenceId = importResponse.nextReviewSequenceId ?: lastReviewSequenceId
+                    } catch (error: Exception) {
+                        if (
+                            recoverWorkspaceForkConflictIfNeeded(
+                                cloudSettings = cloudSettings,
+                                workspaceId = workspaceId,
+                                syncSession = syncSession,
+                                appVersion = appVersion,
+                                remoteService = remoteService,
+                                syncLocalStore = syncLocalStore,
+                                error = error,
+                                stage = WorkspaceForkRecoveryStage.REVIEW_HISTORY_IMPORT,
+                                recoveryAttempted = recoveryAttempted
+                            )
+                        ) {
+                            recoveryAttempted = true
+                            syncLocalStore.recordSyncAttempt(workspaceId = workspaceId)
+                            continue
+                        }
+                        throw error
+                    }
+                }
+            } else {
+                lastReviewSequenceId = pullAndApplyReviewHistoryBatch(
+                    cloudSettings = cloudSettings,
+                    workspaceId = workspaceId,
+                    syncSession = syncSession,
+                    appVersion = appVersion,
+                    remoteService = remoteService,
+                    syncLocalStore = syncLocalStore,
+                    startingReviewSequenceId = lastReviewSequenceId
+                )
+            }
+
+            hasHydratedReviewHistory = true
+        }
+
+        return BootstrapHydrationState(
+            lastHotCursor = lastHotCursor,
+            lastReviewSequenceId = lastReviewSequenceId,
+            hasHydratedHotState = hasHydratedHotState,
+            hasHydratedReviewHistory = hasHydratedReviewHistory
+        )
+    }
+}
 
 private suspend fun pullAndApplyReviewHistoryBatch(
     cloudSettings: CloudSettings,
@@ -227,6 +341,109 @@ private suspend fun pullAndApplyReviewHistoryBatch(
     } catch (error: Exception) {
         syncLocalStore.discardReviewHistoryChangeBatch()
         throw error
+    }
+}
+
+private suspend fun recoverWorkspaceForkConflictIfNeeded(
+    cloudSettings: CloudSettings,
+    workspaceId: String,
+    syncSession: CloudSyncSession,
+    appVersion: String,
+    remoteService: CloudRemoteGateway,
+    syncLocalStore: SyncLocalStore,
+    error: Exception,
+    stage: WorkspaceForkRecoveryStage,
+    recoveryAttempted: Boolean
+): Boolean {
+    if (error !is CloudRemoteException || error.errorCode != syncWorkspaceForkRequiredErrorCode) {
+        return false
+    }
+    if (recoveryAttempted) {
+        throw CloudSyncBlockedException(
+            message = buildWorkspaceForkBlockedMessage(
+                workspaceId = workspaceId,
+                stage = stage,
+                reason = "automatic workspace identity fork already ran once in this sync attempt and the backend still requires another fork.",
+                requestId = error.requestId
+            ),
+            cause = error
+        )
+    }
+
+    val remoteEmptyProbe = remoteService.bootstrapPull(
+        apiBaseUrl = syncSession.apiBaseUrl,
+        authorizationHeader = syncSession.authorizationHeader,
+        workspaceId = workspaceId,
+        body = buildInitialBootstrapPullRequest(
+            installationId = cloudSettings.installationId,
+            appVersion = appVersion,
+            limit = 1
+        )
+    )
+    if (remoteEmptyProbe.remoteIsEmpty.not()) {
+        throw CloudSyncBlockedException(
+            message = buildWorkspaceForkBlockedMessage(
+                workspaceId = workspaceId,
+                stage = stage,
+                reason = "backend requested a workspace identity fork, but the remote workspace is not empty.",
+                requestId = error.requestId
+            ),
+            cause = error
+        )
+    }
+
+    val sourceWorkspaceId = requireNotNull(error.syncConflict?.conflictingWorkspaceId) {
+        "Cloud sync ${stage.label} cannot recover workspace '$workspaceId' because the backend did not provide syncConflict.conflictingWorkspaceId."
+    }
+    syncLocalStore.forkWorkspaceIdentity(
+        currentLocalWorkspaceId = workspaceId,
+        sourceWorkspaceId = sourceWorkspaceId,
+        destinationWorkspaceId = workspaceId
+    )
+    return true
+}
+
+private fun buildInitialBootstrapPullRequest(
+    installationId: String,
+    appVersion: String,
+    limit: Int
+): JSONObject {
+    return JSONObject()
+        .put("mode", "pull")
+        .put("installationId", installationId)
+        .put("platform", androidClientPlatform)
+        .put("appVersion", appVersion)
+        .put("cursor", JSONObject.NULL)
+        .put("limit", limit)
+}
+
+private fun buildPagedBootstrapPullRequest(
+    installationId: String,
+    appVersion: String,
+    cursor: String,
+    limit: Int
+): JSONObject {
+    return JSONObject()
+        .put("mode", "pull")
+        .put("installationId", installationId)
+        .put("platform", androidClientPlatform)
+        .put("appVersion", appVersion)
+        .put("cursor", cursor)
+        .put("limit", limit)
+}
+
+private fun buildWorkspaceForkBlockedMessage(
+    workspaceId: String,
+    stage: WorkspaceForkRecoveryStage,
+    reason: String,
+    requestId: String?
+): String {
+    val baseMessage = "Cloud sync ${stage.label} is blocked for workspace '$workspaceId': $reason"
+    val normalizedRequestId = requestId?.trim().orEmpty()
+    return if (normalizedRequestId.isEmpty()) {
+        baseMessage
+    } else {
+        "$baseMessage Reference: $normalizedRequestId"
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudSyncRunner.kt
@@ -2,6 +2,7 @@ package com.flashcardsopensourceapp.data.local.repository
 
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.cloud.PendingLocalHotEntityKey
 import com.flashcardsopensourceapp.data.local.cloud.putNullableDouble
 import com.flashcardsopensourceapp.data.local.cloud.putNullableInt
 import com.flashcardsopensourceapp.data.local.cloud.putNullableString
@@ -10,6 +11,7 @@ import com.flashcardsopensourceapp.data.local.cloud.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.cloud.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.PersistedOutboxEntry
+import com.flashcardsopensourceapp.data.local.model.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.SyncOperationPayload
 import com.flashcardsopensourceapp.data.local.model.buildDeckFilterDefinitionJsonObject
 import kotlinx.coroutines.CancellationException
@@ -18,6 +20,7 @@ import org.json.JSONObject
 
 private const val syncPullPageLimit: Int = 200
 private const val bootstrapPageLimit: Int = 200
+private const val maxWorkspaceForkRecoveriesPerSync: Int = 10
 internal const val androidClientPlatform: String = "android"
 
 internal suspend fun runCloudSyncCore(
@@ -26,7 +29,8 @@ internal suspend fun runCloudSyncCore(
     syncSession: CloudSyncSession,
     appVersion: String,
     remoteService: CloudRemoteGateway,
-    syncLocalStore: SyncLocalStore
+    syncLocalStore: SyncLocalStore,
+    workspaceForkRecoveryMode: CloudWorkspaceForkRecoveryMode
 ) {
     val blockedMessage = syncLocalStore.loadBlockedSyncMessage(
         workspaceId = workspaceId,
@@ -37,81 +41,111 @@ internal suspend fun runCloudSyncCore(
     }
     syncLocalStore.recordSyncAttempt(workspaceId)
     try {
-        val bootstrapState = runBootstrapHydrationWithForkRecovery(
-            cloudSettings = cloudSettings,
-            workspaceId = workspaceId,
-            syncSession = syncSession,
-            appVersion = appVersion,
-            remoteService = remoteService,
-            syncLocalStore = syncLocalStore
-        )
-        var lastHotCursor = bootstrapState.lastHotCursor
-        var lastReviewSequenceId = bootstrapState.lastReviewSequenceId
-        val hasHydratedHotState = bootstrapState.hasHydratedHotState
-        val hasHydratedReviewHistory = bootstrapState.hasHydratedReviewHistory
+        var workspaceForkRecoveryState = WorkspaceForkRecoveryState(recoveredConflicts = emptySet())
+        syncLoop@ while (true) {
+            val bootstrapState = runBootstrapHydrationWithForkRecovery(
+                cloudSettings = cloudSettings,
+                workspaceId = workspaceId,
+                syncSession = syncSession,
+                appVersion = appVersion,
+                remoteService = remoteService,
+                syncLocalStore = syncLocalStore,
+                initialRecoveryState = workspaceForkRecoveryState,
+                workspaceForkRecoveryMode = workspaceForkRecoveryMode
+            )
+            var lastHotCursor = bootstrapState.lastHotCursor
+            var lastReviewSequenceId = bootstrapState.lastReviewSequenceId
+            var hasHydratedHotState = bootstrapState.hasHydratedHotState
+            val hasHydratedReviewHistory = bootstrapState.hasHydratedReviewHistory
+            workspaceForkRecoveryState = bootstrapState.workspaceForkRecoveryState
 
-        val outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId)
-        if (outboxEntries.isNotEmpty()) {
-            try {
-                val pushResponse = remoteService.push(
+            var outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId)
+            while (outboxEntries.isNotEmpty()) {
+                try {
+                    val pushResponse = remoteService.push(
+                        apiBaseUrl = syncSession.apiBaseUrl,
+                        authorizationHeader = syncSession.authorizationHeader,
+                        workspaceId = workspaceId,
+                        body = buildPushRequest(
+                            installationId = cloudSettings.installationId,
+                            outboxEntries = outboxEntries,
+                            appVersion = appVersion
+                        )
+                    )
+                    val acknowledgedOperationIds = pushResponse.operations.map { result -> result.operationId }
+                    if (bootstrapState.hasSkippedBootstrapHotRows && acknowledgedOperationIds.isEmpty()) {
+                        throw IllegalStateException(
+                            "Cloud push acknowledged no outbox operations while replaying skipped bootstrap rows " +
+                                "for workspace '$workspaceId'."
+                        )
+                    }
+                    syncLocalStore.deleteOutboxEntries(acknowledgedOperationIds)
+                } catch (error: Exception) {
+                    val recoveredState = recoverWorkspaceForkConflictIfNeeded(
+                        workspaceId = workspaceId,
+                        syncLocalStore = syncLocalStore,
+                        error = error,
+                        stage = WorkspaceForkRecoveryStage.ORDINARY_PUSH,
+                        recoveryState = workspaceForkRecoveryState,
+                        workspaceForkRecoveryMode = workspaceForkRecoveryMode
+                    )
+                    if (recoveredState != null) {
+                        workspaceForkRecoveryState = recoveredState
+                        syncLocalStore.recordSyncAttempt(workspaceId = workspaceId)
+                        continue@syncLoop
+                    }
+                    syncLocalStore.markOutboxEntriesFailed(
+                        outboxEntries.map(PersistedOutboxEntry::operationId),
+                        error.message ?: "Cloud push failed."
+                    )
+                    throw error
+                }
+                if (bootstrapState.hasSkippedBootstrapHotRows.not()) {
+                    break
+                }
+                outboxEntries = syncLocalStore.loadOutboxEntries(workspaceId)
+            }
+
+            var hasMoreHotChanges = true
+            while (hasMoreHotChanges) {
+                val pullResponse = remoteService.pull(
                     apiBaseUrl = syncSession.apiBaseUrl,
                     authorizationHeader = syncSession.authorizationHeader,
                     workspaceId = workspaceId,
-                    body = buildPushRequest(
-                        installationId = cloudSettings.installationId,
-                        outboxEntries = outboxEntries,
-                        appVersion = appVersion
-                    )
+                    body = JSONObject()
+                        .put("installationId", cloudSettings.installationId)
+                        .put("platform", androidClientPlatform)
+                        .put("appVersion", appVersion)
+                        .put("afterHotChangeId", lastHotCursor)
+                        .put("limit", syncPullPageLimit)
                 )
-                syncLocalStore.deleteOutboxEntries(pushResponse.operations.map { result -> result.operationId })
-                val pushCursor = pushResponse.operations.mapNotNull { result -> result.resultingHotChangeId }.maxOrNull()
-                if (pushCursor != null && pushCursor > lastHotCursor) {
-                    lastHotCursor = pushCursor
-                }
-            } catch (error: Exception) {
-                syncLocalStore.markOutboxEntriesFailed(
-                    outboxEntries.map(PersistedOutboxEntry::operationId),
-                    error.message ?: "Cloud push failed."
-                )
-                throw error
+                syncLocalStore.applyPullChanges(workspaceId, pullResponse.changes)
+                lastHotCursor = pullResponse.nextHotChangeId
+                hasMoreHotChanges = pullResponse.hasMore
             }
-        }
+            if (bootstrapState.hasSkippedBootstrapHotRows) {
+                hasHydratedHotState = true
+            }
 
-        var hasMoreHotChanges = true
-        while (hasMoreHotChanges) {
-            val pullResponse = remoteService.pull(
-                apiBaseUrl = syncSession.apiBaseUrl,
-                authorizationHeader = syncSession.authorizationHeader,
+            lastReviewSequenceId = pullAndApplyReviewHistoryBatch(
+                cloudSettings = cloudSettings,
                 workspaceId = workspaceId,
-                body = JSONObject()
-                    .put("installationId", cloudSettings.installationId)
-                    .put("platform", androidClientPlatform)
-                    .put("appVersion", appVersion)
-                    .put("afterHotChangeId", lastHotCursor)
-                    .put("limit", syncPullPageLimit)
+                syncSession = syncSession,
+                appVersion = appVersion,
+                remoteService = remoteService,
+                syncLocalStore = syncLocalStore,
+                startingReviewSequenceId = lastReviewSequenceId
             )
-            syncLocalStore.applyPullChanges(workspaceId, pullResponse.changes)
-            lastHotCursor = pullResponse.nextHotChangeId
-            hasMoreHotChanges = pullResponse.hasMore
+
+            syncLocalStore.markSyncSuccess(
+                workspaceId = workspaceId,
+                lastSyncCursor = lastHotCursor.toString(),
+                lastReviewSequenceId = lastReviewSequenceId,
+                hasHydratedHotState = hasHydratedHotState,
+                hasHydratedReviewHistory = hasHydratedReviewHistory
+            )
+            break
         }
-
-        lastReviewSequenceId = pullAndApplyReviewHistoryBatch(
-            cloudSettings = cloudSettings,
-            workspaceId = workspaceId,
-            syncSession = syncSession,
-            appVersion = appVersion,
-            remoteService = remoteService,
-            syncLocalStore = syncLocalStore,
-            startingReviewSequenceId = lastReviewSequenceId
-        )
-
-        syncLocalStore.markSyncSuccess(
-            workspaceId = workspaceId,
-            lastSyncCursor = lastHotCursor.toString(),
-            lastReviewSequenceId = lastReviewSequenceId,
-            hasHydratedHotState = hasHydratedHotState,
-            hasHydratedReviewHistory = hasHydratedReviewHistory
-        )
     } catch (error: CancellationException) {
         throw error
     } catch (error: Exception) {
@@ -131,18 +165,40 @@ internal data class CloudSyncSession(
     val authorizationHeader: String
 )
 
+internal enum class CloudWorkspaceForkRecoveryMode {
+    ENABLED,
+    DISABLED
+}
+
 private data class BootstrapHydrationState(
     val lastHotCursor: Long,
     val lastReviewSequenceId: Long,
     val hasHydratedHotState: Boolean,
-    val hasHydratedReviewHistory: Boolean
+    val hasHydratedReviewHistory: Boolean,
+    val hasSkippedBootstrapHotRows: Boolean,
+    val workspaceForkRecoveryState: WorkspaceForkRecoveryState
+)
+
+private data class ReviewHistoryImportState(
+    val lastReviewSequenceId: Long,
+    val workspaceForkRecoveryState: WorkspaceForkRecoveryState
+)
+
+private data class WorkspaceForkRecoveryState(
+    val recoveredConflicts: Set<WorkspaceForkRecoveryKey>
+)
+
+private data class WorkspaceForkRecoveryKey(
+    val entityType: SyncEntityType,
+    val entityId: String
 )
 
 private enum class WorkspaceForkRecoveryStage(
     val label: String
 ) {
     BOOTSTRAP_PUSH(label = "bootstrap push"),
-    REVIEW_HISTORY_IMPORT(label = "review history import")
+    REVIEW_HISTORY_IMPORT(label = "review history import"),
+    ORDINARY_PUSH(label = "push")
 }
 
 internal class CloudSyncBlockedException(
@@ -156,9 +212,11 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
     syncSession: CloudSyncSession,
     appVersion: String,
     remoteService: CloudRemoteGateway,
-    syncLocalStore: SyncLocalStore
+    syncLocalStore: SyncLocalStore,
+    initialRecoveryState: WorkspaceForkRecoveryState,
+    workspaceForkRecoveryMode: CloudWorkspaceForkRecoveryMode
 ): BootstrapHydrationState {
-    var recoveryAttempted = false
+    var recoveryState = initialRecoveryState
 
     while (true) {
         val syncState = syncLocalStore.ensureSyncState(workspaceId)
@@ -166,6 +224,8 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
         var lastReviewSequenceId = syncState.lastReviewSequenceId
         var hasHydratedHotState = syncState.hasHydratedHotState
         var hasHydratedReviewHistory = syncState.hasHydratedReviewHistory
+        var hasPendingReviewHistoryImport = syncState.pendingReviewHistoryImport
+        var skippedBootstrapHotRows = false
         var bootstrapResponse: RemoteBootstrapPullResponse? = null
 
         if (hasHydratedHotState.not()) {
@@ -184,6 +244,8 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
                 val bootstrapEntries = syncLocalStore.buildBootstrapEntries(workspaceId)
                 if (bootstrapEntries.length() > 0) {
                     try {
+                        syncLocalStore.markReviewHistoryImportPending(workspaceId = workspaceId)
+                        hasPendingReviewHistoryImport = true
                         val bootstrapPushResponse = remoteService.bootstrapPush(
                             apiBaseUrl = syncSession.apiBaseUrl,
                             authorizationHeader = syncSession.authorizationHeader,
@@ -197,20 +259,16 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
                         )
                         lastHotCursor = bootstrapPushResponse.bootstrapHotChangeId ?: lastHotCursor
                     } catch (error: Exception) {
-                        if (
-                            recoverWorkspaceForkConflictIfNeeded(
-                                cloudSettings = cloudSettings,
-                                workspaceId = workspaceId,
-                                syncSession = syncSession,
-                                appVersion = appVersion,
-                                remoteService = remoteService,
-                                syncLocalStore = syncLocalStore,
-                                error = error,
-                                stage = WorkspaceForkRecoveryStage.BOOTSTRAP_PUSH,
-                                recoveryAttempted = recoveryAttempted
-                            )
-                        ) {
-                            recoveryAttempted = true
+                        val recoveredState = recoverWorkspaceForkConflictIfNeeded(
+                            workspaceId = workspaceId,
+                            syncLocalStore = syncLocalStore,
+                            error = error,
+                            stage = WorkspaceForkRecoveryStage.BOOTSTRAP_PUSH,
+                            recoveryState = recoveryState,
+                            workspaceForkRecoveryMode = workspaceForkRecoveryMode
+                        )
+                        if (recoveredState != null) {
+                            recoveryState = recoveredState
                             syncLocalStore.recordSyncAttempt(workspaceId = workspaceId)
                             continue
                         }
@@ -218,8 +276,12 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
                     }
                 }
             } else {
-                syncLocalStore.applyBootstrapEntries(workspaceId, bootstrapResponse.entries)
-                lastHotCursor = bootstrapResponse.bootstrapHotChangeId
+                val preBootstrapHotCursor = lastHotCursor
+                var latestBootstrapHotCursor = bootstrapResponse.bootstrapHotChangeId
+                val appliedBootstrapHotEntityKeys: MutableSet<PendingLocalHotEntityKey> = mutableSetOf()
+                val applyResult = syncLocalStore.applyBootstrapEntries(workspaceId, bootstrapResponse.entries)
+                skippedBootstrapHotRows = skippedBootstrapHotRows || applyResult.skippedHotRows
+                appliedBootstrapHotEntityKeys += applyResult.appliedHotEntityKeys
                 var nextCursor = bootstrapResponse.nextCursor
 
                 while (bootstrapResponse.hasMore && nextCursor != null) {
@@ -234,55 +296,47 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
                             limit = bootstrapPageLimit
                         )
                     )
-                    syncLocalStore.applyBootstrapEntries(workspaceId, nextPage.entries)
+                    val nextApplyResult = syncLocalStore.applyBootstrapEntries(workspaceId, nextPage.entries)
+                    skippedBootstrapHotRows = skippedBootstrapHotRows || nextApplyResult.skippedHotRows
+                    appliedBootstrapHotEntityKeys += nextApplyResult.appliedHotEntityKeys
                     nextCursor = nextPage.nextCursor
-                    lastHotCursor = nextPage.bootstrapHotChangeId
+                    latestBootstrapHotCursor = nextPage.bootstrapHotChangeId
                     if (nextPage.hasMore.not()) {
                         break
                     }
                 }
+                if (skippedBootstrapHotRows.not()) {
+                    skippedBootstrapHotRows = syncLocalStore.hasPendingLocalHotRowsForAppliedBootstrapKeys(
+                        workspaceId = workspaceId,
+                        appliedHotEntityKeys = appliedBootstrapHotEntityKeys
+                    )
+                }
+                lastHotCursor = if (skippedBootstrapHotRows) {
+                    preBootstrapHotCursor
+                } else {
+                    latestBootstrapHotCursor
+                }
             }
 
-            hasHydratedHotState = true
+            hasHydratedHotState = skippedBootstrapHotRows.not()
         }
 
         if (hasHydratedReviewHistory.not()) {
-            if (bootstrapResponse?.remoteIsEmpty == true) {
-                val reviewEvents = syncLocalStore.buildReviewHistoryImportEvents(workspaceId)
-                if (reviewEvents.length() > 0) {
-                    try {
-                        val importResponse = remoteService.importReviewHistory(
-                            apiBaseUrl = syncSession.apiBaseUrl,
-                            authorizationHeader = syncSession.authorizationHeader,
-                            workspaceId = workspaceId,
-                            body = JSONObject()
-                                .put("installationId", cloudSettings.installationId)
-                                .put("platform", androidClientPlatform)
-                                .put("appVersion", appVersion)
-                                .put("reviewEvents", reviewEvents)
-                        )
-                        lastReviewSequenceId = importResponse.nextReviewSequenceId ?: lastReviewSequenceId
-                    } catch (error: Exception) {
-                        if (
-                            recoverWorkspaceForkConflictIfNeeded(
-                                cloudSettings = cloudSettings,
-                                workspaceId = workspaceId,
-                                syncSession = syncSession,
-                                appVersion = appVersion,
-                                remoteService = remoteService,
-                                syncLocalStore = syncLocalStore,
-                                error = error,
-                                stage = WorkspaceForkRecoveryStage.REVIEW_HISTORY_IMPORT,
-                                recoveryAttempted = recoveryAttempted
-                            )
-                        ) {
-                            recoveryAttempted = true
-                            syncLocalStore.recordSyncAttempt(workspaceId = workspaceId)
-                            continue
-                        }
-                        throw error
-                    }
-                }
+            if (hasPendingReviewHistoryImport || bootstrapResponse?.remoteIsEmpty == true) {
+                val importState = importReviewHistoryWithForkRecovery(
+                    cloudSettings = cloudSettings,
+                    workspaceId = workspaceId,
+                    syncSession = syncSession,
+                    appVersion = appVersion,
+                    remoteService = remoteService,
+                    syncLocalStore = syncLocalStore,
+                    startingReviewSequenceId = lastReviewSequenceId,
+                    initialRecoveryState = recoveryState,
+                    workspaceForkRecoveryMode = workspaceForkRecoveryMode
+                )
+                lastReviewSequenceId = importState.lastReviewSequenceId
+                recoveryState = importState.workspaceForkRecoveryState
+                syncLocalStore.markReviewHistoryImportComplete(workspaceId = workspaceId)
             } else {
                 lastReviewSequenceId = pullAndApplyReviewHistoryBatch(
                     cloudSettings = cloudSettings,
@@ -302,8 +356,68 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
             lastHotCursor = lastHotCursor,
             lastReviewSequenceId = lastReviewSequenceId,
             hasHydratedHotState = hasHydratedHotState,
-            hasHydratedReviewHistory = hasHydratedReviewHistory
+            hasHydratedReviewHistory = hasHydratedReviewHistory,
+            hasSkippedBootstrapHotRows = skippedBootstrapHotRows,
+            workspaceForkRecoveryState = recoveryState
         )
+    }
+}
+
+private suspend fun importReviewHistoryWithForkRecovery(
+    cloudSettings: CloudSettings,
+    workspaceId: String,
+    syncSession: CloudSyncSession,
+    appVersion: String,
+    remoteService: CloudRemoteGateway,
+    syncLocalStore: SyncLocalStore,
+    startingReviewSequenceId: Long,
+    initialRecoveryState: WorkspaceForkRecoveryState,
+    workspaceForkRecoveryMode: CloudWorkspaceForkRecoveryMode
+): ReviewHistoryImportState {
+    var lastReviewSequenceId = startingReviewSequenceId
+    var recoveryState = initialRecoveryState
+
+    while (true) {
+        val reviewEvents = syncLocalStore.buildReviewHistoryImportEvents(workspaceId)
+        if (reviewEvents.length() == 0) {
+            return ReviewHistoryImportState(
+                lastReviewSequenceId = lastReviewSequenceId,
+                workspaceForkRecoveryState = recoveryState
+            )
+        }
+
+        try {
+            val importResponse = remoteService.importReviewHistory(
+                apiBaseUrl = syncSession.apiBaseUrl,
+                authorizationHeader = syncSession.authorizationHeader,
+                workspaceId = workspaceId,
+                body = JSONObject()
+                    .put("installationId", cloudSettings.installationId)
+                    .put("platform", androidClientPlatform)
+                    .put("appVersion", appVersion)
+                    .put("reviewEvents", reviewEvents)
+            )
+            lastReviewSequenceId = importResponse.nextReviewSequenceId ?: lastReviewSequenceId
+            return ReviewHistoryImportState(
+                lastReviewSequenceId = lastReviewSequenceId,
+                workspaceForkRecoveryState = recoveryState
+            )
+        } catch (error: Exception) {
+            val recoveredState = recoverWorkspaceForkConflictIfNeeded(
+                workspaceId = workspaceId,
+                syncLocalStore = syncLocalStore,
+                error = error,
+                stage = WorkspaceForkRecoveryStage.REVIEW_HISTORY_IMPORT,
+                recoveryState = recoveryState,
+                workspaceForkRecoveryMode = workspaceForkRecoveryMode
+            )
+            if (recoveredState != null) {
+                recoveryState = recoveredState
+                syncLocalStore.recordSyncAttempt(workspaceId = workspaceId)
+                continue
+            }
+            throw error
+        }
     }
 }
 
@@ -345,62 +459,109 @@ private suspend fun pullAndApplyReviewHistoryBatch(
 }
 
 private suspend fun recoverWorkspaceForkConflictIfNeeded(
-    cloudSettings: CloudSettings,
     workspaceId: String,
-    syncSession: CloudSyncSession,
-    appVersion: String,
-    remoteService: CloudRemoteGateway,
     syncLocalStore: SyncLocalStore,
     error: Exception,
     stage: WorkspaceForkRecoveryStage,
-    recoveryAttempted: Boolean
-): Boolean {
+    recoveryState: WorkspaceForkRecoveryState,
+    workspaceForkRecoveryMode: CloudWorkspaceForkRecoveryMode
+): WorkspaceForkRecoveryState? {
     if (error !is CloudRemoteException || error.errorCode != syncWorkspaceForkRequiredErrorCode) {
-        return false
+        return null
     }
-    if (recoveryAttempted) {
+    if (workspaceForkRecoveryMode == CloudWorkspaceForkRecoveryMode.DISABLED) {
         throw CloudSyncBlockedException(
             message = buildWorkspaceForkBlockedMessage(
                 workspaceId = workspaceId,
                 stage = stage,
-                reason = "automatic workspace identity fork already ran once in this sync attempt and the backend still requires another fork.",
+                reason = "automatic workspace identity fork recovery is disabled for this sync.",
+                requestId = error.requestId
+            ),
+            cause = error
+        )
+    }
+    val syncConflict = error.syncConflict
+    if (syncConflict == null) {
+        throw CloudSyncBlockedException(
+            message = buildWorkspaceForkBlockedMessage(
+                workspaceId = workspaceId,
+                stage = stage,
+                reason = "backend did not provide public sync conflict details for automatic local id recovery.",
+                requestId = error.requestId
+            ),
+            cause = error
+        )
+    }
+    if (syncConflict.recoverable != true) {
+        throw CloudSyncBlockedException(
+            message = buildWorkspaceForkBlockedMessage(
+                workspaceId = workspaceId,
+                stage = stage,
+                reason = "backend did not mark sync conflict ${formatSyncConflictForMessage(syncConflict.entityType, syncConflict.entityId)} as recoverable.",
+                requestId = error.requestId
+            ),
+            cause = error
+        )
+    }
+    val entityType = syncConflict.entityType
+    val entityId = syncConflict.entityId?.trim().orEmpty()
+    if (entityType == null || entityId.isEmpty()) {
+        throw CloudSyncBlockedException(
+            message = buildWorkspaceForkBlockedMessage(
+                workspaceId = workspaceId,
+                stage = stage,
+                reason = "backend public sync conflict details are missing entityType or entityId.",
+                requestId = error.requestId
+            ),
+            cause = error
+        )
+    }
+    val recoveryKey = WorkspaceForkRecoveryKey(entityType = entityType, entityId = entityId)
+    if (recoveryState.recoveredConflicts.contains(recoveryKey)) {
+        throw CloudSyncBlockedException(
+            message = buildWorkspaceForkBlockedMessage(
+                workspaceId = workspaceId,
+                stage = stage,
+                reason = "automatic local id recovery already repaired " +
+                    "${formatSyncConflictForMessage(entityType, entityId)} in this sync attempt and the backend still reports the same conflict.",
+                requestId = error.requestId
+            ),
+            cause = error
+        )
+    }
+    if (recoveryState.recoveredConflicts.size >= maxWorkspaceForkRecoveriesPerSync) {
+        throw CloudSyncBlockedException(
+            message = buildWorkspaceForkBlockedMessage(
+                workspaceId = workspaceId,
+                stage = stage,
+                reason = "automatic local id recovery reached the limit of $maxWorkspaceForkRecoveriesPerSync distinct conflicts in this sync attempt.",
                 requestId = error.requestId
             ),
             cause = error
         )
     }
 
-    val remoteEmptyProbe = remoteService.bootstrapPull(
-        apiBaseUrl = syncSession.apiBaseUrl,
-        authorizationHeader = syncSession.authorizationHeader,
-        workspaceId = workspaceId,
-        body = buildInitialBootstrapPullRequest(
-            installationId = cloudSettings.installationId,
-            appVersion = appVersion,
-            limit = 1
+    try {
+        syncLocalStore.reidentifyWorkspaceForkConflictEntity(
+            workspaceId = workspaceId,
+            entityType = entityType,
+            entityId = entityId
         )
-    )
-    if (remoteEmptyProbe.remoteIsEmpty.not()) {
+    } catch (recoveryError: Exception) {
         throw CloudSyncBlockedException(
             message = buildWorkspaceForkBlockedMessage(
                 workspaceId = workspaceId,
                 stage = stage,
-                reason = "backend requested a workspace identity fork, but the remote workspace is not empty.",
+                reason = "automatic local id recovery failed for ${formatSyncConflictForMessage(entityType, entityId)}: " +
+                    (recoveryError.message ?: recoveryError::class.java.simpleName),
                 requestId = error.requestId
             ),
-            cause = error
+            cause = recoveryError
         )
     }
-
-    val sourceWorkspaceId = requireNotNull(error.syncConflict?.conflictingWorkspaceId) {
-        "Cloud sync ${stage.label} cannot recover workspace '$workspaceId' because the backend did not provide syncConflict.conflictingWorkspaceId."
-    }
-    syncLocalStore.forkWorkspaceIdentity(
-        currentLocalWorkspaceId = workspaceId,
-        sourceWorkspaceId = sourceWorkspaceId,
-        destinationWorkspaceId = workspaceId
+    return WorkspaceForkRecoveryState(
+        recoveredConflicts = recoveryState.recoveredConflicts + recoveryKey
     )
-    return true
 }
 
 private fun buildInitialBootstrapPullRequest(
@@ -444,6 +605,16 @@ private fun buildWorkspaceForkBlockedMessage(
         baseMessage
     } else {
         "$baseMessage Reference: $normalizedRequestId"
+    }
+}
+
+private fun formatSyncConflictForMessage(entityType: SyncEntityType?, entityId: String?): String {
+    val remoteEntityType = entityType?.toRemoteValue() ?: "unknown"
+    val normalizedEntityId = entityId?.trim().orEmpty()
+    return if (normalizedEntityId.isEmpty()) {
+        "$remoteEntityType entity"
+    } else {
+        "$remoteEntityType '$normalizedEntityId'"
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalCloudAccountRepository.kt
@@ -9,6 +9,7 @@ import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.CloudOtpChallenge
@@ -166,7 +167,8 @@ class LocalCloudAccountRepository(
             applyLinkedWorkspace(
                 accountSnapshot = authenticatedSession.accountSnapshot,
                 bearerToken = authenticatedSession.credentials.idToken,
-                selectedWorkspace = selectedWorkspace
+                selectedWorkspace = selectedWorkspace,
+                migrationStrategy = LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP
             )
             preferencesStore.saveCredentials(authenticatedSession.credentials)
             selectedWorkspace
@@ -183,6 +185,9 @@ class LocalCloudAccountRepository(
             val guestSession = requireNotNull(activeGuestSession(configuration = configuration)) {
                 "Guest AI session is unavailable."
             }
+            val guestUpgradeMode = requireNotNull(linkContext.guestUpgradeMode) {
+                "Guest upgrade requires prepared guest upgrade context."
+            }
             val validatedSelection = validateWorkspaceSelection(
                 linkContext = linkContext,
                 selection = selection
@@ -197,7 +202,8 @@ class LocalCloudAccountRepository(
             applyLinkedWorkspace(
                 accountSnapshot = authenticatedSession.accountSnapshot,
                 bearerToken = authenticatedSession.credentials.idToken,
-                selectedWorkspace = selectedWorkspace
+                selectedWorkspace = selectedWorkspace,
+                migrationStrategy = guestUpgradeMode.toLinkedWorkspaceMigrationStrategy()
             )
             preferencesStore.saveCredentials(authenticatedSession.credentials)
             selectedWorkspace
@@ -666,25 +672,17 @@ class LocalCloudAccountRepository(
     private suspend fun applyLinkedWorkspace(
         accountSnapshot: CloudAccountSnapshot,
         bearerToken: String,
-        selectedWorkspace: CloudWorkspaceSummary
+        selectedWorkspace: CloudWorkspaceSummary,
+        migrationStrategy: LinkedWorkspaceMigrationStrategy
     ) {
-        val configuration = preferencesStore.currentServerConfiguration()
-        val bootstrapProbe = remoteService.bootstrapPull(
-            apiBaseUrl = configuration.apiBaseUrl,
-            authorizationHeader = "Bearer $bearerToken",
-            workspaceId = selectedWorkspace.workspaceId,
-            body = JSONObject()
-                .put("mode", "pull")
-                .put("installationId", preferencesStore.currentCloudSettings().installationId)
-                .put("platform", androidClientPlatform)
-                .put("appVersion", appVersion)
-                .put("cursor", JSONObject.NULL)
-                .put("limit", 1)
+        val remoteWorkspaceIsEmpty = resolveRemoteWorkspaceEmptiness(
+            bearerToken = bearerToken,
+            selectedWorkspace = selectedWorkspace,
+            migrationStrategy = migrationStrategy
         )
-
         val localLinkedWorkspace = syncLocalStore.migrateLocalShellToLinkedWorkspace(
             workspace = selectedWorkspace,
-            remoteWorkspaceIsEmpty = bootstrapProbe.remoteIsEmpty
+            remoteWorkspaceIsEmpty = remoteWorkspaceIsEmpty
         )
         check(localLinkedWorkspace.workspaceId == selectedWorkspace.workspaceId) {
             "Linked workspace migration produced an unexpected local workspace. " +
@@ -709,6 +707,32 @@ class LocalCloudAccountRepository(
         }
     }
 
+    private suspend fun resolveRemoteWorkspaceEmptiness(
+        bearerToken: String,
+        selectedWorkspace: CloudWorkspaceSummary,
+        migrationStrategy: LinkedWorkspaceMigrationStrategy
+    ): Boolean {
+        return when (migrationStrategy) {
+            LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP -> {
+                val configuration = preferencesStore.currentServerConfiguration()
+                remoteService.bootstrapPull(
+                    apiBaseUrl = configuration.apiBaseUrl,
+                    authorizationHeader = "Bearer $bearerToken",
+                    workspaceId = selectedWorkspace.workspaceId,
+                    body = JSONObject()
+                        .put("mode", "pull")
+                        .put("installationId", preferencesStore.currentCloudSettings().installationId)
+                        .put("platform", androidClientPlatform)
+                        .put("appVersion", appVersion)
+                        .put("cursor", JSONObject.NULL)
+                        .put("limit", 1)
+                ).remoteIsEmpty
+            }
+
+            LinkedWorkspaceMigrationStrategy.FORK_LOCAL_DATA -> true
+        }
+    }
+
     private suspend fun applyLinkedWorkspaceAndSync(
         authenticatedSession: AuthenticatedCloudSession,
         selectedWorkspace: CloudWorkspaceSummary
@@ -716,7 +740,8 @@ class LocalCloudAccountRepository(
         applyLinkedWorkspace(
             accountSnapshot = authenticatedSession.accountSnapshot,
             bearerToken = authenticatedSession.credentials.idToken,
-            selectedWorkspace = selectedWorkspace
+            selectedWorkspace = selectedWorkspace,
+            migrationStrategy = LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP
         )
         requireTransitionInvariant(
             stage = "after prefs update",
@@ -918,3 +943,15 @@ private data class ProgressCloudSession(
     val apiBaseUrl: String,
     val authorizationHeader: String
 )
+
+private enum class LinkedWorkspaceMigrationStrategy {
+    PROBE_REMOTE_BOOTSTRAP,
+    FORK_LOCAL_DATA
+}
+
+private fun CloudGuestUpgradeMode.toLinkedWorkspaceMigrationStrategy(): LinkedWorkspaceMigrationStrategy {
+    return when (this) {
+        CloudGuestUpgradeMode.BOUND -> LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP
+        CloudGuestUpgradeMode.MERGE_REQUIRED -> LinkedWorkspaceMigrationStrategy.FORK_LOCAL_DATA
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalCloudAccountRepository.kt
@@ -3,8 +3,10 @@ package com.flashcardsopensourceapp.data.local.repository
 import com.flashcardsopensourceapp.data.local.ai.GuestAiSessionStore
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.cloud.PendingGuestUpgradeState
 import com.flashcardsopensourceapp.data.local.cloud.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.AppDatabase
+import com.flashcardsopensourceapp.data.local.database.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
@@ -27,6 +29,7 @@ import com.flashcardsopensourceapp.data.local.model.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.makeCustomCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.shouldRefreshCloudIdToken
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import org.json.JSONObject
 
@@ -65,6 +68,7 @@ class LocalCloudAccountRepository(
 
     override suspend fun resumePendingAccountDeletionIfNeeded() {
         operationCoordinator.runExclusive {
+            resumePendingGuestUpgradeIfNeeded()
             if (preferencesStore.currentAccountDeletionState() == AccountDeletionState.Hidden) {
                 return@runExclusive
             }
@@ -89,6 +93,7 @@ class LocalCloudAccountRepository(
 
     override suspend fun prepareVerifiedSignIn(credentials: StoredCloudCredentials): CloudWorkspaceLinkContext {
         return operationCoordinator.runExclusive {
+            resumePendingGuestUpgradeIfNeeded()
             val configuration = preferencesStore.currentServerConfiguration()
             buildCloudWorkspaceLinkContext(
                 credentials = credentials,
@@ -99,6 +104,7 @@ class LocalCloudAccountRepository(
 
     override suspend fun verifyCode(challenge: CloudOtpChallenge, code: String): CloudWorkspaceLinkContext {
         return operationCoordinator.runExclusive {
+            resumePendingGuestUpgradeIfNeeded()
             val configuration = preferencesStore.currentServerConfiguration()
             val credentials = remoteService.verifyCode(
                 challenge = challenge,
@@ -157,6 +163,10 @@ class LocalCloudAccountRepository(
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary {
         return operationCoordinator.runExclusive {
+            val resumedGuestUpgrade = resumePendingGuestUpgradeIfNeeded()
+            if (resumedGuestUpgrade != null) {
+                return@runExclusive resumedGuestUpgrade
+            }
             val authenticatedSession = authenticatedSession(linkContext = linkContext)
             val selectedWorkspace = resolveWorkspaceSelection(
                 linkContext = linkContext,
@@ -167,8 +177,7 @@ class LocalCloudAccountRepository(
             applyLinkedWorkspace(
                 accountSnapshot = authenticatedSession.accountSnapshot,
                 bearerToken = authenticatedSession.credentials.idToken,
-                selectedWorkspace = selectedWorkspace,
-                migrationStrategy = LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP
+                selectedWorkspace = selectedWorkspace
             )
             preferencesStore.saveCredentials(authenticatedSession.credentials)
             selectedWorkspace
@@ -180,6 +189,10 @@ class LocalCloudAccountRepository(
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary {
         return operationCoordinator.runExclusive {
+            val resumedGuestUpgrade = resumePendingGuestUpgradeIfNeeded()
+            if (resumedGuestUpgrade != null) {
+                return@runExclusive resumedGuestUpgrade
+            }
             val authenticatedSession = authenticatedSession(linkContext = linkContext)
             val configuration = preferencesStore.currentServerConfiguration()
             val guestSession = requireNotNull(activeGuestSession(configuration = configuration)) {
@@ -192,21 +205,27 @@ class LocalCloudAccountRepository(
                 linkContext = linkContext,
                 selection = selection
             )
-            val selectedWorkspace = remoteService.completeGuestUpgrade(
-                apiBaseUrl = configuration.apiBaseUrl,
-                bearerToken = authenticatedSession.credentials.idToken,
-                guestToken = guestSession.guestToken,
-                selection = validatedSelection.toGuestUpgradeSelection()
-            )
-            clearGuestSessionsIfNeeded()
-            applyLinkedWorkspace(
-                accountSnapshot = authenticatedSession.accountSnapshot,
-                bearerToken = authenticatedSession.credentials.idToken,
-                selectedWorkspace = selectedWorkspace,
-                migrationStrategy = guestUpgradeMode.toLinkedWorkspaceMigrationStrategy()
-            )
-            preferencesStore.saveCredentials(authenticatedSession.credentials)
-            selectedWorkspace
+            preferencesStore.runWithLocalOutboxWritesBlocked(
+                reason = "Guest upgrade is finishing. Wait for account linking to complete before changing cards."
+            ) {
+                drainGuestWorkspaceBeforeUpgradeComplete(
+                    configuration = configuration,
+                    guestSession = guestSession
+                )
+                val pendingGuestUpgradeState = PendingGuestUpgradeState(
+                    configuration = configuration,
+                    credentials = authenticatedSession.credentials,
+                    accountSnapshot = authenticatedSession.accountSnapshot,
+                    guestSession = guestSession,
+                    guestUpgradeMode = guestUpgradeMode,
+                    selection = validatedSelection,
+                    completion = null
+                )
+                preferencesStore.savePendingGuestUpgrade(pendingGuestUpgradeState = pendingGuestUpgradeState)
+                requireNotNull(resumePendingGuestUpgradeIfNeeded()) {
+                    "Pending guest upgrade recovery did not find the saved upgrade state."
+                }
+            }
         }
     }
 
@@ -214,6 +233,10 @@ class LocalCloudAccountRepository(
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary {
         return operationCoordinator.runExclusive {
+            val resumedGuestUpgrade = resumePendingGuestUpgradeIfNeeded()
+            if (resumedGuestUpgrade != null) {
+                return@runExclusive resumedGuestUpgrade
+            }
             val authenticatedSession = authenticatedSession()
             val selectedWorkspace = when (selection) {
                 is CloudWorkspaceLinkSelection.Existing -> {
@@ -365,7 +388,8 @@ class LocalCloudAccountRepository(
                 ),
                 appVersion = appVersion,
                 remoteService = remoteService,
-                syncLocalStore = syncLocalStore
+                syncLocalStore = syncLocalStore,
+                workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.ENABLED
             )
             remoteService.loadWorkspaceResetProgressPreview(
                 apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
@@ -395,7 +419,8 @@ class LocalCloudAccountRepository(
                 ),
                 appVersion = appVersion,
                 remoteService = remoteService,
-                syncLocalStore = syncLocalStore
+                syncLocalStore = syncLocalStore,
+                workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.ENABLED
             )
             val result = remoteService.resetWorkspaceProgress(
                 apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
@@ -412,7 +437,8 @@ class LocalCloudAccountRepository(
                 ),
                 appVersion = appVersion,
                 remoteService = remoteService,
-                syncLocalStore = syncLocalStore
+                syncLocalStore = syncLocalStore,
+                workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.ENABLED
             )
             result
         }
@@ -550,6 +576,8 @@ class LocalCloudAccountRepository(
                 }
             }
             resetCoordinator.resetLocalStateForCloudIdentityChange()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             if (isRemoteAccountDeletedError(error = error)) {
                 resetCoordinator.resetLocalStateForCloudIdentityChange()
@@ -644,6 +672,80 @@ class LocalCloudAccountRepository(
         )
     }
 
+    private suspend fun resumePendingGuestUpgradeIfNeeded(): CloudWorkspaceSummary? {
+        return resumePendingGuestUpgradeRecoveryIfNeeded(
+            database = database,
+            preferencesStore = preferencesStore,
+            remoteService = remoteService,
+            syncLocalStore = syncLocalStore,
+            guestSessionStore = guestSessionStore,
+            appVersion = appVersion
+        )
+    }
+
+    /**
+     * Guest upgrade completion is allowed only after the current guest
+     * workspace has completed normal sync and Android has verified that no
+     * local guest outbox rows remain to migrate.
+     */
+    private suspend fun drainGuestWorkspaceBeforeUpgradeComplete(
+        configuration: CloudServiceConfiguration,
+        guestSession: StoredGuestAiSession
+    ) {
+        val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+        val guestWorkspaceId: String = requireNotNull(cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId) {
+            "Guest upgrade requires an active guest workspace."
+        }
+        require(cloudSettings.cloudState == CloudAccountState.GUEST) {
+            "Guest upgrade requires guest cloud state before completion."
+        }
+        require(guestWorkspaceId == guestSession.workspaceId) {
+            "Guest upgrade requires current guest workspace '$guestWorkspaceId' to match stored guest session " +
+                "'${guestSession.workspaceId}'. Restart the app and try signing in again."
+        }
+
+        try {
+            runCloudSyncCore(
+                cloudSettings = cloudSettings,
+                workspaceId = guestWorkspaceId,
+                syncSession = CloudSyncSession(
+                    apiBaseUrl = configuration.apiBaseUrl,
+                    authorizationHeader = "Guest ${guestSession.guestToken}"
+                ),
+                appVersion = appVersion,
+                remoteService = remoteService,
+                syncLocalStore = syncLocalStore,
+                workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.DISABLED
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            val preservesBlockedSyncState = error is CloudSyncBlockedException || isCloudIdentityConflictError(error = error)
+            if (preservesBlockedSyncState.not()) {
+                syncLocalStore.markSyncFailure(
+                    workspaceId = guestWorkspaceId,
+                    errorMessage = error.message ?: "Cloud sync failed."
+                )
+            }
+            throw IllegalStateException(
+                "Guest upgrade is paused because guest sync did not finish for workspace '$guestWorkspaceId'. " +
+                    "Check your connection and try signing in again. Cause=${error.message ?: "Cloud sync failed."}",
+                error
+            )
+        }
+
+        val remainingOutboxCount: Int = syncLocalStore.countOutboxEntries(workspaceId = guestWorkspaceId)
+        if (remainingOutboxCount > 0) {
+            val message: String = "Guest upgrade is paused because guest workspace '$guestWorkspaceId' still has " +
+                "$remainingOutboxCount pending local sync operation(s). Sync again before signing in."
+            syncLocalStore.markSyncFailure(
+                workspaceId = guestWorkspaceId,
+                errorMessage = message
+            )
+            throw IllegalStateException(message)
+        }
+    }
+
     private suspend fun resolveWorkspaceSelection(
         linkContext: CloudWorkspaceLinkContext,
         authenticatedSession: AuthenticatedCloudSession,
@@ -672,18 +774,30 @@ class LocalCloudAccountRepository(
     private suspend fun applyLinkedWorkspace(
         accountSnapshot: CloudAccountSnapshot,
         bearerToken: String,
-        selectedWorkspace: CloudWorkspaceSummary,
-        migrationStrategy: LinkedWorkspaceMigrationStrategy
+        selectedWorkspace: CloudWorkspaceSummary
     ) {
         val remoteWorkspaceIsEmpty = resolveRemoteWorkspaceEmptiness(
             bearerToken = bearerToken,
-            selectedWorkspace = selectedWorkspace,
-            migrationStrategy = migrationStrategy
+            selectedWorkspace = selectedWorkspace
         )
         val localLinkedWorkspace = syncLocalStore.migrateLocalShellToLinkedWorkspace(
             workspace = selectedWorkspace,
             remoteWorkspaceIsEmpty = remoteWorkspaceIsEmpty
         )
+        finalizeLinkedWorkspaceMigration(
+            accountSnapshot = accountSnapshot,
+            selectedWorkspace = selectedWorkspace,
+            localLinkedWorkspace = localLinkedWorkspace,
+            missingWorkspaceMessage = "Linked workspace is missing locally after cloud link."
+        )
+    }
+
+    private suspend fun finalizeLinkedWorkspaceMigration(
+        accountSnapshot: CloudAccountSnapshot,
+        selectedWorkspace: CloudWorkspaceSummary,
+        localLinkedWorkspace: WorkspaceEntity,
+        missingWorkspaceMessage: String
+    ) {
         check(localLinkedWorkspace.workspaceId == selectedWorkspace.workspaceId) {
             "Linked workspace migration produced an unexpected local workspace. " +
                 "Expected='${selectedWorkspace.workspaceId}' Actual='${localLinkedWorkspace.workspaceId}'."
@@ -699,7 +813,7 @@ class LocalCloudAccountRepository(
         val localCurrentWorkspace = requireCurrentWorkspace(
             database = database,
             preferencesStore = preferencesStore,
-            missingWorkspaceMessage = "Linked workspace is missing locally after cloud link."
+            missingWorkspaceMessage = missingWorkspaceMessage
         )
         check(localCurrentWorkspace.workspaceId == selectedWorkspace.workspaceId) {
             "Linked workspace '${selectedWorkspace.workspaceId}' did not become the current local workspace. " +
@@ -709,28 +823,21 @@ class LocalCloudAccountRepository(
 
     private suspend fun resolveRemoteWorkspaceEmptiness(
         bearerToken: String,
-        selectedWorkspace: CloudWorkspaceSummary,
-        migrationStrategy: LinkedWorkspaceMigrationStrategy
+        selectedWorkspace: CloudWorkspaceSummary
     ): Boolean {
-        return when (migrationStrategy) {
-            LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP -> {
-                val configuration = preferencesStore.currentServerConfiguration()
-                remoteService.bootstrapPull(
-                    apiBaseUrl = configuration.apiBaseUrl,
-                    authorizationHeader = "Bearer $bearerToken",
-                    workspaceId = selectedWorkspace.workspaceId,
-                    body = JSONObject()
-                        .put("mode", "pull")
-                        .put("installationId", preferencesStore.currentCloudSettings().installationId)
-                        .put("platform", androidClientPlatform)
-                        .put("appVersion", appVersion)
-                        .put("cursor", JSONObject.NULL)
-                        .put("limit", 1)
-                ).remoteIsEmpty
-            }
-
-            LinkedWorkspaceMigrationStrategy.FORK_LOCAL_DATA -> true
-        }
+        val configuration = preferencesStore.currentServerConfiguration()
+        return remoteService.bootstrapPull(
+            apiBaseUrl = configuration.apiBaseUrl,
+            authorizationHeader = "Bearer $bearerToken",
+            workspaceId = selectedWorkspace.workspaceId,
+            body = JSONObject()
+                .put("mode", "pull")
+                .put("installationId", preferencesStore.currentCloudSettings().installationId)
+                .put("platform", androidClientPlatform)
+                .put("appVersion", appVersion)
+                .put("cursor", JSONObject.NULL)
+                .put("limit", 1)
+        ).remoteIsEmpty
     }
 
     private suspend fun applyLinkedWorkspaceAndSync(
@@ -740,8 +847,7 @@ class LocalCloudAccountRepository(
         applyLinkedWorkspace(
             accountSnapshot = authenticatedSession.accountSnapshot,
             bearerToken = authenticatedSession.credentials.idToken,
-            selectedWorkspace = selectedWorkspace,
-            migrationStrategy = LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP
+            selectedWorkspace = selectedWorkspace
         )
         requireTransitionInvariant(
             stage = "after prefs update",
@@ -784,13 +890,19 @@ class LocalCloudAccountRepository(
                 ),
                 appVersion = appVersion,
                 remoteService = remoteService,
-                syncLocalStore = syncLocalStore
+                syncLocalStore = syncLocalStore,
+                workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.ENABLED
             )
         } catch (error: Exception) {
-            syncLocalStore.markSyncFailure(
-                workspaceId = workspaceId,
-                errorMessage = error.message ?: "Cloud sync failed."
+            val preservesBlockedSyncState = error is CloudSyncBlockedException || isCloudIdentityConflictError(
+                error = error
             )
+            if (preservesBlockedSyncState.not()) {
+                syncLocalStore.markSyncFailure(
+                    workspaceId = workspaceId,
+                    errorMessage = error.message ?: "Cloud sync failed."
+                )
+            }
             throw IllegalStateException(
                 buildTransitionInvariantMessage(
                     stage = "initial sync failed",
@@ -943,15 +1055,3 @@ private data class ProgressCloudSession(
     val apiBaseUrl: String,
     val authorizationHeader: String
 )
-
-private enum class LinkedWorkspaceMigrationStrategy {
-    PROBE_REMOTE_BOOTSTRAP,
-    FORK_LOCAL_DATA
-}
-
-private fun CloudGuestUpgradeMode.toLinkedWorkspaceMigrationStrategy(): LinkedWorkspaceMigrationStrategy {
-    return when (this) {
-        CloudGuestUpgradeMode.BOUND -> LinkedWorkspaceMigrationStrategy.PROBE_REMOTE_BOOTSTRAP
-        CloudGuestUpgradeMode.MERGE_REQUIRED -> LinkedWorkspaceMigrationStrategy.FORK_LOCAL_DATA
-    }
-}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressCacheStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressCacheStore.kt
@@ -168,6 +168,18 @@ class LocalProgressCacheStore(
         )
     }
 
+    suspend fun rebuildWorkspaceReviewHistoryInTransaction(
+        workspaceId: String,
+        updatedAtMillis: Long
+    ) {
+        rebuildWorkspaceInTransaction(
+            workspaceId = workspaceId,
+            timeZone = timeProvider.currentZoneId().id,
+            updatedAtMillis = updatedAtMillis,
+            incrementHistoryVersion = true
+        )
+    }
+
     suspend fun rebuildTimeZoneCache(
         timeZone: String,
         updatedAtMillis: Long

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt
@@ -109,7 +109,10 @@ class LocalCardsRepository(
             deletedAtMillis = null
         )
 
-        database.withTransaction {
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
             database.cardDao().insertCard(card = card)
             replaceCardTags(
                 database = database,
@@ -133,7 +136,10 @@ class LocalCardsRepository(
             deletedAtMillis = null
         )
 
-        database.withTransaction {
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
             database.cardDao().updateCard(card = updatedCard)
             replaceCardTags(
                 database = database,
@@ -150,7 +156,10 @@ class LocalCardsRepository(
             "Cannot delete missing card: $cardId"
         }
 
-        database.withTransaction {
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
             val deletedCard = card.copy(
                 updatedAtMillis = System.currentTimeMillis(),
                 deletedAtMillis = System.currentTimeMillis()
@@ -233,8 +242,13 @@ class LocalDecksRepository(
             deletedAtMillis = null
         )
 
-        database.deckDao().insertDeck(deck = deck)
-        syncLocalStore.enqueueDeckUpsert(deck)
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
+            database.deckDao().insertDeck(deck = deck)
+            syncLocalStore.enqueueDeckUpsert(deck)
+        }
     }
 
     override suspend fun updateDeck(deckId: String, deckDraft: DeckDraft) {
@@ -251,8 +265,13 @@ class LocalDecksRepository(
             deletedAtMillis = null
         )
 
-        database.deckDao().updateDeck(deck = updatedDeck)
-        syncLocalStore.enqueueDeckUpsert(updatedDeck)
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
+            database.deckDao().updateDeck(deck = updatedDeck)
+            syncLocalStore.enqueueDeckUpsert(updatedDeck)
+        }
     }
 
     override suspend fun deleteDeck(deckId: String) {
@@ -264,8 +283,13 @@ class LocalDecksRepository(
             updatedAtMillis = System.currentTimeMillis(),
             deletedAtMillis = System.currentTimeMillis()
         )
-        database.deckDao().updateDeck(deck = deletedDeck)
-        syncLocalStore.enqueueDeckUpsert(deletedDeck)
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
+            database.deckDao().updateDeck(deck = deletedDeck)
+            syncLocalStore.enqueueDeckUpsert(deletedDeck)
+        }
     }
 }
 
@@ -478,12 +502,14 @@ class LocalWorkspaceRepository(
             updatedAtMillis = System.currentTimeMillis()
         )
 
-        database.workspaceSchedulerSettingsDao().insertWorkspaceSchedulerSettings(
-            settings = toWorkspaceSchedulerSettingsEntity(settings = updatedSettings)
-        )
-        syncLocalStore.enqueueWorkspaceSchedulerSettingsUpsert(
-            settings = toWorkspaceSchedulerSettingsEntity(settings = updatedSettings)
-        )
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
+            val settingsEntity = toWorkspaceSchedulerSettingsEntity(settings = updatedSettings)
+            database.workspaceSchedulerSettingsDao().insertWorkspaceSchedulerSettings(settings = settingsEntity)
+            syncLocalStore.enqueueWorkspaceSchedulerSettingsUpsert(settings = settingsEntity)
+        }
     }
 }
 
@@ -593,7 +619,10 @@ class LocalReviewRepository(
     }
 
     override suspend fun recordReview(cardId: String, rating: ReviewRating, reviewedAtMillis: Long) {
-        database.withTransaction {
+        runLocalOutboxMutationTransaction(
+            database = database,
+            preferencesStore = preferencesStore
+        ) {
             val card = requireNotNull(database.cardDao().loadCard(cardId = cardId)) {
                 "Cannot review missing card: $cardId"
             }
@@ -690,6 +719,18 @@ private fun toCardSummary(card: CardWithRelations): CardSummary {
         fsrsScheduledDays = card.card.fsrsScheduledDays,
         deletedAtMillis = card.card.deletedAtMillis
     )
+}
+
+private suspend fun <Result> runLocalOutboxMutationTransaction(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    block: suspend () -> Result
+): Result {
+    return preferencesStore.runWithLocalOutboxMutationAllowed {
+        database.withTransaction {
+            block()
+        }
+    }
 }
 
 private fun toWorkspaceSchedulerSettingsEntity(settings: WorkspaceSchedulerSettings): WorkspaceSchedulerSettingsEntity {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalSyncRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalSyncRepository.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
 import com.flashcardsopensourceapp.data.local.cloud.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.AppDatabase
+import com.flashcardsopensourceapp.data.local.database.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 
 class LocalSyncRepository(
     private val database: AppDatabase,
@@ -44,7 +46,19 @@ class LocalSyncRepository(
     )
 
     override fun observeSyncStatus(): Flow<SyncStatusSnapshot> {
-        return syncStatusState.asStateFlow()
+        return combine(
+            syncStatusState.asStateFlow(),
+            preferencesStore.observeCloudSettings(),
+            observePersistedSyncStatus()
+        ) { inMemorySnapshot, cloudSettings, persistedSnapshot ->
+            mergeSyncStatusSnapshots(
+                inMemorySnapshot = sanitizeInMemorySyncStatus(
+                    snapshot = inMemorySnapshot,
+                    cloudState = cloudSettings.cloudState
+                ),
+                persistedSnapshot = persistedSnapshot
+            )
+        }
     }
 
     override suspend fun scheduleSync() {
@@ -67,8 +81,26 @@ class LocalSyncRepository(
         operationCoordinator.runExclusive {
             val currentCloudSettings = preferencesStore.currentCloudSettings()
             val previousCloudState = currentCloudSettings.cloudState
-            val currentStatus = syncStatusState.value.status
+            val currentSnapshot = sanitizeInMemorySyncStatus(
+                snapshot = syncStatusState.value,
+                cloudState = currentCloudSettings.cloudState
+            )
+            if (currentSnapshot != syncStatusState.value) {
+                syncStatusState.value = currentSnapshot
+            }
+            val currentStatus = currentSnapshot.status
             emitAutoSyncRequested(autoSyncRequest = autoSyncRequest)
+            val persistedSyncStatus = loadPersistedSyncStatus(cloudSettings = currentCloudSettings)
+            val persistedBlockedStatus = persistedSyncStatus?.status as? SyncStatus.Blocked
+            if (persistedBlockedStatus != null) {
+                syncStatusState.value = persistedSyncStatus
+                val error = IllegalStateException(persistedBlockedStatus.message)
+                emitAutoSyncFailure(
+                    autoSyncRequest = autoSyncRequest,
+                    error = error
+                )
+                throw error
+            }
             if (currentStatus is SyncStatus.Blocked) {
                 if (currentStatus.installationId == currentCloudSettings.installationId) {
                     val error = IllegalStateException(currentStatus.message)
@@ -150,7 +182,7 @@ class LocalSyncRepository(
                     emitAutoSyncSuccess(autoSyncRequest = autoSyncRequest)
                     return@runExclusive
                 }
-                if (isCloudIdentityConflictError(error = error)) {
+                if (isCloudIdentityConflictError(error = error) || error is CloudSyncBlockedException) {
                     val message = error.message ?: "Cloud sync is blocked for this installation."
                     syncStatusState.value = SyncStatusSnapshot(
                         status = SyncStatus.Blocked(
@@ -312,6 +344,29 @@ class LocalSyncRepository(
             accountSnapshot = accountSnapshot
         )
     }
+
+    private fun observePersistedSyncStatus(): Flow<SyncStatusSnapshot?> {
+        return combine(
+            preferencesStore.observeCloudSettings(),
+            database.syncStateDao().observeSyncStates()
+        ) { cloudSettings, syncStates ->
+            val workspaceId = cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId ?: return@combine null
+            syncStates.firstOrNull { syncState -> syncState.workspaceId == workspaceId }
+                ?.toPersistedSyncStatusSnapshot(
+                    installationId = cloudSettings.installationId,
+                    restoreBlockedStatus = cloudSettings.cloudState.shouldRestoreBlockedSyncStatus()
+                )
+        }
+    }
+
+    private suspend fun loadPersistedSyncStatus(cloudSettings: CloudSettings): SyncStatusSnapshot? {
+        val workspaceId = cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId ?: return null
+        val syncState = database.syncStateDao().loadSyncState(workspaceId = workspaceId) ?: return null
+        return syncState.toPersistedSyncStatusSnapshot(
+            installationId = cloudSettings.installationId,
+            restoreBlockedStatus = cloudSettings.cloudState.shouldRestoreBlockedSyncStatus()
+        )
+    }
 }
 
 private data class SyncAuthenticatedCloudSession(
@@ -324,3 +379,73 @@ private data class CloudSyncTarget(
     val workspaceId: String,
     val session: CloudSyncSession
 )
+
+private fun sanitizeInMemorySyncStatus(
+    snapshot: SyncStatusSnapshot,
+    cloudState: CloudAccountState
+): SyncStatusSnapshot {
+    if (cloudState.shouldRestoreBlockedSyncStatus() || snapshot.status !is SyncStatus.Blocked) {
+        return snapshot
+    }
+
+    return snapshot.copy(
+        status = SyncStatus.Idle,
+        lastErrorMessage = ""
+    )
+}
+
+private fun mergeSyncStatusSnapshots(
+    inMemorySnapshot: SyncStatusSnapshot,
+    persistedSnapshot: SyncStatusSnapshot?
+): SyncStatusSnapshot {
+    if (persistedSnapshot == null) {
+        return inMemorySnapshot
+    }
+
+    return when (inMemorySnapshot.status) {
+        SyncStatus.Idle -> persistedSnapshot
+        SyncStatus.Syncing -> inMemorySnapshot.copy(
+            lastSuccessfulSyncAtMillis = inMemorySnapshot.lastSuccessfulSyncAtMillis
+                ?: persistedSnapshot.lastSuccessfulSyncAtMillis
+        )
+
+        is SyncStatus.Blocked -> inMemorySnapshot.copy(
+            lastSuccessfulSyncAtMillis = inMemorySnapshot.lastSuccessfulSyncAtMillis
+                ?: persistedSnapshot.lastSuccessfulSyncAtMillis
+        )
+
+        is SyncStatus.Failed -> inMemorySnapshot.copy(
+            lastSuccessfulSyncAtMillis = inMemorySnapshot.lastSuccessfulSyncAtMillis
+                ?: persistedSnapshot.lastSuccessfulSyncAtMillis
+        )
+    }
+}
+
+private fun SyncStateEntity.toPersistedSyncStatusSnapshot(
+    installationId: String,
+    restoreBlockedStatus: Boolean
+): SyncStatusSnapshot {
+    val persistedBlockedStatus = toPersistedBlockedStatus(installationId = installationId)
+    val blockedStatus = if (restoreBlockedStatus) persistedBlockedStatus else null
+    val lastErrorMessage = if (restoreBlockedStatus.not() && persistedBlockedStatus != null) "" else lastSyncError.orEmpty()
+    return SyncStatusSnapshot(
+        status = blockedStatus ?: SyncStatus.Idle,
+        lastSuccessfulSyncAtMillis = lastSuccessfulSyncAtMillis,
+        lastErrorMessage = lastErrorMessage
+    )
+}
+
+private fun SyncStateEntity.toPersistedBlockedStatus(installationId: String): SyncStatus.Blocked? {
+    if (blockedInstallationId != installationId) {
+        return null
+    }
+
+    return SyncStatus.Blocked(
+        message = lastSyncError ?: "Cloud sync is blocked for this installation.",
+        installationId = installationId
+    )
+}
+
+private fun CloudAccountState.shouldRestoreBlockedSyncStatus(): Boolean {
+    return this == CloudAccountState.LINKED || this == CloudAccountState.GUEST
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalSyncRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalSyncRepository.kt
@@ -156,7 +156,8 @@ class LocalSyncRepository(
                     syncSession = syncTarget.session,
                     appVersion = appVersion,
                     remoteService = remoteService,
-                    syncLocalStore = syncLocalStore
+                    syncLocalStore = syncLocalStore,
+                    workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.ENABLED
                 )
                 syncStatusState.value = SyncStatusSnapshot(
                     status = SyncStatus.Idle,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/PendingGuestUpgradeRecovery.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/PendingGuestUpgradeRecovery.kt
@@ -1,0 +1,393 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import com.flashcardsopensourceapp.data.local.ai.GuestAiSessionStore
+import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
+import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.cloud.PendingGuestUpgradeState
+import com.flashcardsopensourceapp.data.local.cloud.SyncLocalStore
+import com.flashcardsopensourceapp.data.local.database.AppDatabase
+import com.flashcardsopensourceapp.data.local.database.WorkspaceEntity
+import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
+import com.flashcardsopensourceapp.data.local.model.CloudServiceConfiguration
+import com.flashcardsopensourceapp.data.local.model.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
+import com.flashcardsopensourceapp.data.local.model.StoredCloudCredentials
+import com.flashcardsopensourceapp.data.local.model.shouldRefreshCloudIdToken
+import kotlinx.coroutines.CancellationException
+
+internal suspend fun resumePendingGuestUpgradeRecoveryIfNeeded(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    remoteService: CloudRemoteGateway,
+    syncLocalStore: SyncLocalStore,
+    guestSessionStore: GuestAiSessionStore,
+    appVersion: String
+): CloudWorkspaceSummary? {
+    val pendingGuestUpgradeState: PendingGuestUpgradeState =
+        preferencesStore.loadPendingGuestUpgrade() ?: return null
+    val refreshedGuestUpgradeState: PendingGuestUpgradeState = refreshPendingGuestUpgradeCredentialsIfNeeded(
+        pendingGuestUpgradeState = pendingGuestUpgradeState,
+        preferencesStore = preferencesStore,
+        remoteService = remoteService
+    )
+    return finalizePendingGuestUpgradeRecovery(
+        database = database,
+        preferencesStore = preferencesStore,
+        syncLocalStore = syncLocalStore,
+        guestSessionStore = guestSessionStore,
+        remoteService = remoteService,
+        pendingGuestUpgradeState = refreshedGuestUpgradeState,
+        appVersion = appVersion
+    )
+}
+
+private suspend fun refreshPendingGuestUpgradeCredentialsIfNeeded(
+    pendingGuestUpgradeState: PendingGuestUpgradeState,
+    preferencesStore: CloudPreferencesStore,
+    remoteService: CloudRemoteGateway
+): PendingGuestUpgradeState {
+    if (
+        shouldRefreshCloudIdToken(
+            idTokenExpiresAtMillis = pendingGuestUpgradeState.credentials.idTokenExpiresAtMillis,
+            nowMillis = System.currentTimeMillis()
+        ).not()
+    ) {
+        return pendingGuestUpgradeState
+    }
+
+    val refreshedCredentials: StoredCloudCredentials = remoteService.refreshIdToken(
+        refreshToken = pendingGuestUpgradeState.credentials.refreshToken,
+        authBaseUrl = pendingGuestUpgradeState.configuration.authBaseUrl
+    )
+    val refreshedAccountSnapshot: CloudAccountSnapshot = fetchCloudAccount(
+        credentials = refreshedCredentials,
+        configuration = pendingGuestUpgradeState.configuration,
+        remoteService = remoteService
+    )
+    require(refreshedAccountSnapshot.userId == pendingGuestUpgradeState.accountSnapshot.userId) {
+        "Cloud account changed during pending guest upgrade recovery. Start sign-in again."
+    }
+    val refreshedGuestUpgradeState: PendingGuestUpgradeState = pendingGuestUpgradeState.copy(
+        credentials = refreshedCredentials,
+        accountSnapshot = refreshedAccountSnapshot
+    )
+    preferencesStore.savePendingGuestUpgrade(pendingGuestUpgradeState = refreshedGuestUpgradeState)
+    return refreshedGuestUpgradeState
+}
+
+private suspend fun fetchCloudAccount(
+    credentials: StoredCloudCredentials,
+    configuration: CloudServiceConfiguration,
+    remoteService: CloudRemoteGateway
+): CloudAccountSnapshot {
+    return remoteService.fetchCloudAccount(
+        apiBaseUrl = configuration.apiBaseUrl,
+        bearerToken = credentials.idToken
+    )
+}
+
+/**
+ * Pending guest upgrade state is written after guest sync has drained but
+ * before backend completion. Recovery can replay backend completion and never
+ * carries guest outbox rows into the linked workspace.
+ */
+private suspend fun finalizePendingGuestUpgradeRecovery(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    syncLocalStore: SyncLocalStore,
+    guestSessionStore: GuestAiSessionStore,
+    remoteService: CloudRemoteGateway,
+    pendingGuestUpgradeState: PendingGuestUpgradeState,
+    appVersion: String
+): CloudWorkspaceSummary {
+    val completion: CloudGuestUpgradeCompletion = completePendingGuestUpgradeIfNeeded(
+        preferencesStore = preferencesStore,
+        remoteService = remoteService,
+        pendingGuestUpgradeState = pendingGuestUpgradeState
+    )
+    applyPendingGuestUpgradeLinkedWorkspace(
+        database = database,
+        preferencesStore = preferencesStore,
+        syncLocalStore = syncLocalStore,
+        pendingGuestUpgradeState = pendingGuestUpgradeState,
+        completion = completion
+    )
+    preferencesStore.saveCredentials(pendingGuestUpgradeState.credentials)
+    requireNoPendingGuestUpgradeOutbox(
+        syncLocalStore = syncLocalStore,
+        workspaceId = completion.workspace.workspaceId
+    )
+    hydratePendingGuestUpgradeLinkedWorkspace(
+        preferencesStore = preferencesStore,
+        remoteService = remoteService,
+        syncLocalStore = syncLocalStore,
+        pendingGuestUpgradeState = pendingGuestUpgradeState,
+        completion = completion,
+        appVersion = appVersion
+    )
+    guestSessionStore.clearAllSessions()
+    preferencesStore.clearPendingGuestUpgrade()
+    return completion.workspace
+}
+
+private suspend fun completePendingGuestUpgradeIfNeeded(
+    preferencesStore: CloudPreferencesStore,
+    remoteService: CloudRemoteGateway,
+    pendingGuestUpgradeState: PendingGuestUpgradeState
+): CloudGuestUpgradeCompletion {
+    val savedCompletion: CloudGuestUpgradeCompletion? = pendingGuestUpgradeState.completion
+    if (savedCompletion != null) {
+        return savedCompletion
+    }
+
+    val completion: CloudGuestUpgradeCompletion = remoteService.completeGuestUpgrade(
+        apiBaseUrl = pendingGuestUpgradeState.configuration.apiBaseUrl,
+        bearerToken = pendingGuestUpgradeState.credentials.idToken,
+        guestToken = pendingGuestUpgradeState.guestSession.guestToken,
+        selection = pendingGuestUpgradeState.selection.toGuestUpgradeSelection(),
+        guestWorkspaceSyncedAndOutboxDrained = true,
+        supportsDroppedEntities = pendingGuestUpgradeState.guestUpgradeMode == CloudGuestUpgradeMode.MERGE_REQUIRED
+    )
+    preferencesStore.savePendingGuestUpgrade(
+        pendingGuestUpgradeState = pendingGuestUpgradeState.copy(completion = completion)
+    )
+    return completion
+}
+
+private suspend fun requireNoPendingGuestUpgradeOutbox(
+    syncLocalStore: SyncLocalStore,
+    workspaceId: String
+) {
+    val pendingOutboxCount: Int = syncLocalStore.countOutboxEntries(workspaceId = workspaceId)
+    require(pendingOutboxCount == 0) {
+        "Pending guest upgrade recovery cannot continue because linked workspace '$workspaceId' has " +
+            "$pendingOutboxCount local outbox operation(s). Restart the app before making more local changes."
+    }
+}
+
+private suspend fun hydratePendingGuestUpgradeLinkedWorkspace(
+    preferencesStore: CloudPreferencesStore,
+    remoteService: CloudRemoteGateway,
+    syncLocalStore: SyncLocalStore,
+    pendingGuestUpgradeState: PendingGuestUpgradeState,
+    completion: CloudGuestUpgradeCompletion,
+    appVersion: String
+) {
+    try {
+        runCloudSyncCore(
+            cloudSettings = preferencesStore.currentCloudSettings(),
+            workspaceId = completion.workspace.workspaceId,
+            syncSession = CloudSyncSession(
+                apiBaseUrl = pendingGuestUpgradeState.configuration.apiBaseUrl,
+                authorizationHeader = "Bearer ${pendingGuestUpgradeState.credentials.idToken}"
+            ),
+            appVersion = appVersion,
+            remoteService = remoteService,
+            syncLocalStore = syncLocalStore,
+            workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.ENABLED
+        )
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Exception) {
+        val preservesBlockedSyncState = error is CloudSyncBlockedException || isCloudIdentityConflictError(error = error)
+        if (preservesBlockedSyncState.not()) {
+            syncLocalStore.markSyncFailure(
+                workspaceId = completion.workspace.workspaceId,
+                errorMessage = error.message ?: "Cloud sync failed."
+            )
+        }
+        throw IllegalStateException(
+            "Guest upgrade completed on the server, but Android could not hydrate linked workspace " +
+                "'${completion.workspace.workspaceId}'. Check your connection and reopen the app to retry. " +
+                "Cause=${error.message ?: "Cloud sync failed."}",
+            error
+        )
+    }
+}
+
+private suspend fun applyPendingGuestUpgradeLinkedWorkspace(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    syncLocalStore: SyncLocalStore,
+    pendingGuestUpgradeState: PendingGuestUpgradeState,
+    completion: CloudGuestUpgradeCompletion
+) {
+    when (pendingGuestUpgradeState.guestUpgradeMode) {
+        CloudGuestUpgradeMode.BOUND -> applyBoundGuestUpgradeLinkedWorkspace(
+            database = database,
+            preferencesStore = preferencesStore,
+            syncLocalStore = syncLocalStore,
+            accountSnapshot = pendingGuestUpgradeState.accountSnapshot,
+            selectedWorkspace = completion.workspace
+        )
+
+        CloudGuestUpgradeMode.MERGE_REQUIRED -> applyDrainedMergeGuestUpgradeLinkedWorkspace(
+            database = database,
+            preferencesStore = preferencesStore,
+            syncLocalStore = syncLocalStore,
+            accountSnapshot = pendingGuestUpgradeState.accountSnapshot,
+            selectedWorkspace = completion.workspace
+        )
+    }
+}
+
+private suspend fun applyBoundGuestUpgradeLinkedWorkspace(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    syncLocalStore: SyncLocalStore,
+    accountSnapshot: CloudAccountSnapshot,
+    selectedWorkspace: CloudWorkspaceSummary
+) {
+    val localLinkedWorkspace: WorkspaceEntity = syncLocalStore.bindGuestUpgradeToLinkedWorkspace(
+        workspace = selectedWorkspace
+    )
+    finalizeGuestUpgradeLinkedWorkspaceMigration(
+        database = database,
+        preferencesStore = preferencesStore,
+        accountSnapshot = accountSnapshot,
+        selectedWorkspace = selectedWorkspace,
+        localLinkedWorkspace = localLinkedWorkspace,
+        missingWorkspaceMessage = "Linked workspace is missing locally after bound guest upgrade."
+    )
+}
+
+/**
+ * Merge-required upgrade drains guest sync before backend completion, so local
+ * finalization discards the guest shell/outbox and hydrates the linked
+ * workspace from remote cloud state already merged by the backend.
+ */
+private suspend fun applyDrainedMergeGuestUpgradeLinkedWorkspace(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    syncLocalStore: SyncLocalStore,
+    accountSnapshot: CloudAccountSnapshot,
+    selectedWorkspace: CloudWorkspaceSummary
+) {
+    val localLinkedWorkspace: WorkspaceEntity = loadAlreadyAppliedLinkedWorkspaceShellOrNull(
+        database = database,
+        selectedWorkspace = selectedWorkspace
+    ) ?: syncLocalStore.migrateLocalShellToLinkedWorkspace(
+        workspace = selectedWorkspace,
+        remoteWorkspaceIsEmpty = false
+    )
+    finalizeGuestUpgradeLinkedWorkspaceMigration(
+        database = database,
+        preferencesStore = preferencesStore,
+        accountSnapshot = accountSnapshot,
+        selectedWorkspace = selectedWorkspace,
+        localLinkedWorkspace = localLinkedWorkspace,
+        missingWorkspaceMessage = "Linked workspace is missing locally after guest upgrade."
+    )
+}
+
+private suspend fun loadAlreadyAppliedLinkedWorkspaceShellOrNull(
+    database: AppDatabase,
+    selectedWorkspace: CloudWorkspaceSummary
+): WorkspaceEntity? {
+    val localWorkspaces: List<WorkspaceEntity> = database.workspaceDao().loadWorkspaces()
+    if (localWorkspaces.size != 1) {
+        return null
+    }
+
+    val localWorkspace: WorkspaceEntity = localWorkspaces.single()
+    if (localWorkspace.workspaceId != selectedWorkspace.workspaceId) {
+        return null
+    }
+
+    val refreshedWorkspace: WorkspaceEntity = localWorkspace.copy(
+        name = selectedWorkspace.name,
+        createdAtMillis = selectedWorkspace.createdAtMillis
+    )
+    database.workspaceDao().updateWorkspace(workspace = refreshedWorkspace)
+    return refreshedWorkspace
+}
+
+private suspend fun finalizeGuestUpgradeLinkedWorkspaceMigration(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    accountSnapshot: CloudAccountSnapshot,
+    selectedWorkspace: CloudWorkspaceSummary,
+    localLinkedWorkspace: WorkspaceEntity,
+    missingWorkspaceMessage: String
+) {
+    check(localLinkedWorkspace.workspaceId == selectedWorkspace.workspaceId) {
+        "Linked workspace migration produced an unexpected local workspace. " +
+            "Expected='${selectedWorkspace.workspaceId}' Actual='${localLinkedWorkspace.workspaceId}'."
+    }
+
+    preferencesStore.updateCloudSettings(
+        cloudState = CloudAccountState.LINKED,
+        linkedUserId = accountSnapshot.userId,
+        linkedWorkspaceId = selectedWorkspace.workspaceId,
+        linkedEmail = accountSnapshot.email,
+        activeWorkspaceId = selectedWorkspace.workspaceId
+    )
+    val localCurrentWorkspace: WorkspaceEntity = requireCurrentWorkspace(
+        database = database,
+        preferencesStore = preferencesStore,
+        missingWorkspaceMessage = missingWorkspaceMessage
+    )
+    check(localCurrentWorkspace.workspaceId == selectedWorkspace.workspaceId) {
+        "Linked workspace '${selectedWorkspace.workspaceId}' did not become the current local workspace. " +
+            "Local workspace='${localCurrentWorkspace.workspaceId}'."
+    }
+    requireGuestUpgradeTransitionInvariant(
+        database = database,
+        preferencesStore = preferencesStore,
+        expectedWorkspaceId = selectedWorkspace.workspaceId
+    )
+}
+
+private suspend fun requireGuestUpgradeTransitionInvariant(
+    database: AppDatabase,
+    preferencesStore: CloudPreferencesStore,
+    expectedWorkspaceId: String
+) {
+    val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+    val localWorkspaceIds: List<String> = database.workspaceDao()
+        .loadWorkspaces()
+        .map(WorkspaceEntity::workspaceId)
+    require(localWorkspaceIds.size == 1) {
+        buildGuestUpgradeTransitionInvariantMessage(
+            expectedWorkspaceId = expectedWorkspaceId,
+            localWorkspaceIds = localWorkspaceIds,
+            cloudSettings = cloudSettings
+        )
+    }
+    require(localWorkspaceIds.single() == expectedWorkspaceId) {
+        buildGuestUpgradeTransitionInvariantMessage(
+            expectedWorkspaceId = expectedWorkspaceId,
+            localWorkspaceIds = localWorkspaceIds,
+            cloudSettings = cloudSettings
+        )
+    }
+    require(cloudSettings.linkedWorkspaceId == expectedWorkspaceId) {
+        buildGuestUpgradeTransitionInvariantMessage(
+            expectedWorkspaceId = expectedWorkspaceId,
+            localWorkspaceIds = localWorkspaceIds,
+            cloudSettings = cloudSettings
+        )
+    }
+    require(cloudSettings.activeWorkspaceId == expectedWorkspaceId) {
+        buildGuestUpgradeTransitionInvariantMessage(
+            expectedWorkspaceId = expectedWorkspaceId,
+            localWorkspaceIds = localWorkspaceIds,
+            cloudSettings = cloudSettings
+        )
+    }
+}
+
+private fun buildGuestUpgradeTransitionInvariantMessage(
+    expectedWorkspaceId: String,
+    localWorkspaceIds: List<String>,
+    cloudSettings: CloudSettings
+): String {
+    return "Pending guest upgrade recovery invariant failed. " +
+        "expectedWorkspaceId='$expectedWorkspaceId' " +
+        "activeWorkspaceId='${cloudSettings.activeWorkspaceId}' " +
+        "linkedWorkspaceId='${cloudSettings.linkedWorkspaceId}' " +
+        "localWorkspaceIds=$localWorkspaceIds"
+}

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteServiceTest.kt
@@ -1,10 +1,50 @@
 package com.flashcardsopensourceapp.data.local.cloud
 
+import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeSelection
+import com.flashcardsopensourceapp.data.local.model.SyncEntityType
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class CloudRemoteServiceTest {
+    @Test
+    fun buildGuestUpgradeCompleteRequestDeclaresDrainedGuestOutbox() {
+        val request = CloudRemoteService().buildGuestUpgradeCompleteRequest(
+            guestToken = "guest-token",
+            selection = CloudGuestUpgradeSelection.Existing(workspaceId = "workspace-linked"),
+            guestWorkspaceSyncedAndOutboxDrained = true,
+            supportsDroppedEntities = true
+        )
+
+        assertEquals("guest-token", request.getString("guestToken"))
+        assertEquals(true, request.getBoolean("guestWorkspaceSyncedAndOutboxDrained"))
+        assertEquals(true, request.getBoolean("supportsDroppedEntities"))
+        assertEquals("existing", request.getJSONObject("selection").getString("type"))
+        assertEquals("workspace-linked", request.getJSONObject("selection").getString("workspaceId"))
+    }
+
+    @Test
+    fun parseRemotePushResponseTreatsIgnoredAsAcknowledged() {
+        val response = JSONObject(
+            """
+            {
+              "operations": [
+                {
+                  "operationId": "operation-ignored",
+                  "status": "ignored"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val parsedResponse = CloudRemoteService().parseRemotePushResponse(response = response)
+
+        assertEquals(1, parsedResponse.operations.size)
+        assertEquals("operation-ignored", parsedResponse.operations.single().operationId)
+        assertEquals(null, parsedResponse.operations.single().resultingHotChangeId)
+    }
+
     @Test
     fun parseCloudProgressSummaryResponseReadsNestedSummaryObject() {
         val response = JSONObject(
@@ -66,6 +106,11 @@ class CloudRemoteServiceTest {
                         JSONObject().put(
                             "syncConflict",
                             JSONObject()
+                                .put("phase", "bootstrap")
+                                .put("entityType", "card")
+                                .put("entityId", "card-1")
+                                .put("entryIndex", 2)
+                                .put("recoverable", true)
                                 .put("conflictingWorkspaceId", "workspace-source")
                                 .put("remoteIsEmpty", true)
                         )
@@ -78,6 +123,10 @@ class CloudRemoteServiceTest {
 
         assertEquals(syncWorkspaceForkRequiredErrorCode, parsedError.code)
         assertEquals("request-1", parsedError.requestId)
+        assertEquals(SyncEntityType.CARD, parsedError.syncConflict?.entityType)
+        assertEquals("card-1", parsedError.syncConflict?.entityId)
+        assertEquals(2, parsedError.syncConflict?.entryIndex)
+        assertEquals(true, parsedError.syncConflict?.recoverable)
         assertEquals("workspace-source", parsedError.syncConflict?.conflictingWorkspaceId)
         assertEquals(true, parsedError.syncConflict?.remoteIsEmpty)
     }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/CloudRemoteServiceTest.kt
@@ -53,4 +53,32 @@ class CloudRemoteServiceTest {
             fieldPath = "progressSummary"
         )
     }
+
+    @Test
+    fun parseCloudErrorPayloadReadsSyncConflictDetails() {
+        val parsedError = requireNotNull(
+            parseCloudErrorPayload(
+                responseBody = JSONObject()
+                    .put("code", syncWorkspaceForkRequiredErrorCode)
+                    .put("requestId", "request-1")
+                    .put(
+                        "details",
+                        JSONObject().put(
+                            "syncConflict",
+                            JSONObject()
+                                .put("conflictingWorkspaceId", "workspace-source")
+                                .put("remoteIsEmpty", true)
+                        )
+                    )
+                    .toString()
+            )
+        ) {
+            "Expected parsed cloud error payload."
+        }
+
+        assertEquals(syncWorkspaceForkRequiredErrorCode, parsedError.code)
+        assertEquals("request-1", parsedError.requestId)
+        assertEquals("workspace-source", parsedError.syncConflict?.conflictingWorkspaceId)
+        assertEquals(true, parsedError.syncConflict?.remoteIsEmpty)
+    }
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepositoryTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepositoryTest.kt
@@ -284,6 +284,7 @@ class LocalProgressRepositoryTest {
                     lastReviewSequenceId = 7L,
                     hasHydratedHotState = true,
                     hasHydratedReviewHistory = true,
+                    pendingReviewHistoryImport = false,
                     lastSyncAttemptAtMillis = null,
                     lastSuccessfulSyncAtMillis = null,
                     lastSyncError = null,

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepositoryTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepositoryTest.kt
@@ -286,7 +286,8 @@ class LocalProgressRepositoryTest {
                     hasHydratedReviewHistory = true,
                     lastSyncAttemptAtMillis = null,
                     lastSuccessfulSyncAtMillis = null,
-                    lastSyncError = null
+                    lastSyncError = null,
+                    blockedInstallationId = null
                 )
             ),
             workspaceIds = listOf("workspace-1")

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -154,7 +154,8 @@ class CloudSignInViewModelTest {
                 statusCode = 400,
                 responseBody = "{\"error\":\"bad request\"}",
                 errorCode = "VALIDATION_ERROR",
-                requestId = "req-123"
+                requestId = "req-123",
+                syncConflict = null
             )
         )
         val viewModel = CloudSignInViewModel(

--- a/apps/backend/src/agentEnvelope.ts
+++ b/apps/backend/src/agentEnvelope.ts
@@ -1,3 +1,4 @@
+import type { HttpErrorDetails } from "./errors";
 import { getPublicAgentDocs } from "./publicUrls";
 
 export type AgentDocs = Readonly<{
@@ -19,13 +20,7 @@ export type AgentErrorEnvelope = Readonly<{
   error: Readonly<{
     code: string;
     message: string;
-    details?: Readonly<{
-      validationIssues: ReadonlyArray<Readonly<{
-        path: string;
-        code: string;
-        message: string;
-      }>>;
-    }>;
+    details?: HttpErrorDetails;
   }>;
   requestId?: string;
 }>;
@@ -49,13 +44,7 @@ export function createAgentErrorEnvelope(
   message: string,
   instructions: string,
   requestId?: string,
-  details?: Readonly<{
-    validationIssues: ReadonlyArray<Readonly<{
-      path: string;
-      code: string;
-      message: string;
-    }>>;
-  }>,
+  details?: HttpErrorDetails,
 ): AgentErrorEnvelope {
   return {
     ok: false,

--- a/apps/backend/src/agentEnvelope.ts
+++ b/apps/backend/src/agentEnvelope.ts
@@ -1,4 +1,4 @@
-import type { HttpErrorDetails } from "./errors";
+import type { PublicHttpErrorDetails } from "./errors";
 import { getPublicAgentDocs } from "./publicUrls";
 
 export type AgentDocs = Readonly<{
@@ -20,7 +20,7 @@ export type AgentErrorEnvelope = Readonly<{
   error: Readonly<{
     code: string;
     message: string;
-    details?: HttpErrorDetails;
+    details?: PublicHttpErrorDetails;
   }>;
   requestId?: string;
 }>;
@@ -44,7 +44,7 @@ export function createAgentErrorEnvelope(
   message: string,
   instructions: string,
   requestId?: string,
-  details?: HttpErrorDetails,
+  details?: PublicHttpErrorDetails,
 ): AgentErrorEnvelope {
   return {
     ok: false,

--- a/apps/backend/src/agentSetup.ts
+++ b/apps/backend/src/agentSetup.ts
@@ -6,7 +6,7 @@ import {
   type AgentErrorEnvelope,
 } from "./agentEnvelope";
 import type { AuthTransport } from "./auth";
-import type { HttpErrorDetails } from "./errors";
+import type { PublicHttpErrorDetails } from "./errors";
 import { getPublicApiBaseUrl } from "./publicUrls";
 import type { RequestContext } from "./server/requestContext";
 import type { WorkspaceSummary } from "./workspaces";
@@ -156,7 +156,7 @@ export function createAgentSetupErrorEnvelope(
   message: string,
   instructions: string,
   requestId?: string,
-  details?: HttpErrorDetails,
+  details?: PublicHttpErrorDetails,
 ): AgentErrorEnvelope {
   return createAgentErrorEnvelope(requestUrl, code, message, instructions, requestId, details);
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { AuthError } from "./auth";
 import { getAuthConfig } from "./authConfig";
-import { HttpError } from "./errors";
+import { createPublicHttpErrorDetails, HttpError, type PublicHttpErrorDetails } from "./errors";
 import { createChatRoutes } from "./routes/chat";
 import { createChatTranscriptionsRoutes } from "./routes/chatTranscriptions";
 import { createAgentRoutes } from "./routes/agent";
@@ -40,13 +40,14 @@ export function createPublicHttpErrorBody(error: HttpError, requestId: string): 
   error: string;
   requestId: string;
   code: string | null;
-  details?: import("./errors").HttpErrorDetails;
+  details?: PublicHttpErrorDetails;
 }> {
+  const publicDetails = createPublicHttpErrorDetails(error.details);
   return {
     error: error.message,
     requestId,
     code: error.code,
-    ...(error.details === null ? {} : { details: error.details }),
+    ...(publicDetails === null ? {} : { details: publicDetails }),
   };
 }
 
@@ -188,7 +189,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
             error.message,
             createAgentInstructions(error.code, error.statusCode),
             requestId,
-            error.details ?? undefined,
+            createPublicHttpErrorDetails(error.details) ?? undefined,
           ),
         );
       }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -36,6 +36,20 @@ export function getRouteMountPaths(basePath: string): ReadonlyArray<string> {
   return [basePath];
 }
 
+export function createPublicHttpErrorBody(error: HttpError, requestId: string): Readonly<{
+  error: string;
+  requestId: string;
+  code: string | null;
+  details?: import("./errors").HttpErrorDetails;
+}> {
+  return {
+    error: error.message,
+    requestId,
+    code: error.code,
+    ...(error.details === null ? {} : { details: error.details }),
+  };
+}
+
 function usesApiKeyAuthorizationHeader(request: Request): boolean {
   const authorizationHeader = request.headers.get("authorization");
   return authorizationHeader !== null && authorizationHeader.startsWith("ApiKey ");
@@ -188,11 +202,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
           ),
         );
       }
-      return context.json({
-        error: error.message,
-        requestId,
-        code: error.code,
-      });
+      return context.json(createPublicHttpErrorBody(error, requestId));
     }
 
     context.status(500);

--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -9,6 +9,10 @@ import {
   normalizeIsoTimestamp,
 } from "../lww";
 import { findLatestSyncChangeId } from "../syncChanges";
+import {
+  createSyncConflictHttpError,
+  findSyncConflictWorkspaceIdInExecutor,
+} from "../sync/fork";
 import { assertConsistentFsrsState } from "./fsrs";
 import {
   CARD_COLUMNS,
@@ -166,6 +170,86 @@ async function loadCardRowForMutation(
   return result.rows[0];
 }
 
+async function insertCardRowForSnapshotInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  input: CardSnapshotInput,
+  metadata: CardMutationMetadata,
+): Promise<CardRow | null> {
+  const result = await executor.query<CardRow>(
+    [
+      "INSERT INTO content.cards",
+      "(",
+      "card_id, workspace_id, front_text, back_text, tags, effort_level, due_at, created_at, reps, lapses,",
+      "fsrs_card_state, fsrs_step_index, fsrs_stability, fsrs_difficulty, fsrs_last_reviewed_at, fsrs_scheduled_days,",
+      "client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at",
+      ")",
+      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)",
+      "ON CONFLICT DO NOTHING",
+      "RETURNING",
+      CARD_COLUMNS,
+    ].join(" "),
+    [
+      input.cardId,
+      workspaceId,
+      input.frontText,
+      input.backText,
+      input.tags,
+      input.effortLevel,
+      input.dueAt,
+      input.createdAt,
+      input.reps,
+      input.lapses,
+      input.fsrsCardState,
+      input.fsrsStepIndex,
+      input.fsrsStability,
+      input.fsrsDifficulty,
+      input.fsrsLastReviewedAt,
+      input.fsrsScheduledDays,
+      metadata.clientUpdatedAt,
+      metadata.lastModifiedByReplicaId,
+      metadata.lastOperationId,
+      input.deletedAt,
+    ],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+async function resolveCardSnapshotInsertConflictInExecutor(
+  executor: DatabaseExecutor,
+  workspaceId: string,
+  cardId: string,
+): Promise<CardRow> {
+  const conflictingWorkspaceId = await findSyncConflictWorkspaceIdInExecutor(executor, {
+    entityType: "card",
+    entityId: cardId,
+  });
+
+  if (conflictingWorkspaceId === null) {
+    throw new Error(`Card insert was skipped but no conflicting workspace was found for ${cardId}`);
+  }
+
+  if (conflictingWorkspaceId !== workspaceId) {
+    throw createSyncConflictHttpError({
+      phase: "sync_write",
+      entityType: "card",
+      entityId: cardId,
+      conflictingWorkspaceId,
+      constraint: "cards_pkey",
+      sqlState: "23505",
+      table: "cards",
+    });
+  }
+
+  const existingRow = await loadCardRowForMutation(executor, workspaceId, cardId);
+  if (existingRow === undefined) {
+    throw new Error(`Card insert was skipped but the current workspace row was not found for ${cardId}`);
+  }
+
+  return existingRow;
+}
+
 export async function upsertCardSnapshotInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
@@ -175,58 +259,32 @@ export async function upsertCardSnapshotInExecutor(
   const normalizedInput = normalizeCardSnapshotInput(input);
   const normalizedMetadata = normalizeCardMutationMetadata(metadata);
 
-  const existingRow = await loadCardRowForMutation(executor, workspaceId, normalizedInput.cardId);
+  let existingRow = await loadCardRowForMutation(executor, workspaceId, normalizedInput.cardId);
 
   if (existingRow === undefined) {
-    const insertResult = await executor.query<CardRow>(
-      [
-        "INSERT INTO content.cards",
-        "(",
-        "card_id, workspace_id, front_text, back_text, tags, effort_level, due_at, created_at, reps, lapses,",
-        "fsrs_card_state, fsrs_step_index, fsrs_stability, fsrs_difficulty, fsrs_last_reviewed_at, fsrs_scheduled_days,",
-        "client_updated_at, last_modified_by_replica_id, last_operation_id, deleted_at",
-        ")",
-        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)",
-        "RETURNING",
-        CARD_COLUMNS,
-      ].join(" "),
-      [
-        normalizedInput.cardId,
-        workspaceId,
-        normalizedInput.frontText,
-        normalizedInput.backText,
-        normalizedInput.tags,
-        normalizedInput.effortLevel,
-        normalizedInput.dueAt,
-        normalizedInput.createdAt,
-        normalizedInput.reps,
-        normalizedInput.lapses,
-        normalizedInput.fsrsCardState,
-        normalizedInput.fsrsStepIndex,
-        normalizedInput.fsrsStability,
-        normalizedInput.fsrsDifficulty,
-        normalizedInput.fsrsLastReviewedAt,
-        normalizedInput.fsrsScheduledDays,
-        normalizedMetadata.clientUpdatedAt,
-        normalizedMetadata.lastModifiedByReplicaId,
-        normalizedMetadata.lastOperationId,
-        normalizedInput.deletedAt,
-      ],
+    const insertedRow = await insertCardRowForSnapshotInExecutor(
+      executor,
+      workspaceId,
+      normalizedInput,
+      normalizedMetadata,
     );
 
-    const insertedRow = insertResult.rows[0];
-    if (insertedRow === undefined) {
-      throw new Error("Card insert did not return a row");
+    if (insertedRow === null) {
+      existingRow = await resolveCardSnapshotInsertConflictInExecutor(
+        executor,
+        workspaceId,
+        normalizedInput.cardId,
+      );
+    } else {
+      const insertedCard = mapCard(insertedRow);
+      const changeId = await recordCardSyncChange(executor, workspaceId, insertedCard);
+
+      return {
+        card: insertedCard,
+        applied: true,
+        changeId,
+      };
     }
-
-    const insertedCard = mapCard(insertedRow);
-    const changeId = await recordCardSyncChange(executor, workspaceId, insertedCard);
-
-    return {
-      card: insertedCard,
-      applied: true,
-      changeId,
-    };
   }
 
   const existingCard = mapCard(existingRow);

--- a/apps/backend/src/cards/reviews.ts
+++ b/apps/backend/src/cards/reviews.ts
@@ -5,6 +5,10 @@ import {
   computeReviewSchedule,
   type ReviewableCardScheduleState,
 } from "../schedule";
+import {
+  createSyncConflictHttpError,
+  findSyncConflictWorkspaceIdInExecutor,
+} from "../sync/fork";
 import { getWorkspaceSchedulerConfig } from "../workspaceSchedulerSettings";
 import { validateOrResetReviewableCardRow } from "./fsrs";
 import {
@@ -81,7 +85,7 @@ export async function appendReviewEventSnapshotInExecutor(
       "INSERT INTO content.review_events",
       "(review_event_id, workspace_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server)",
       "VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, now()))",
-      "ON CONFLICT (workspace_id, replica_id, client_event_id) DO NOTHING",
+      "ON CONFLICT DO NOTHING",
       "RETURNING review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server",
     ].join(" "),
     [
@@ -107,6 +111,22 @@ export async function appendReviewEventSnapshotInExecutor(
     };
   }
 
+  const conflictingWorkspaceId = await findSyncConflictWorkspaceIdInExecutor(executor, {
+    entityType: "review_event",
+    entityId: reviewEvent.reviewEventId,
+  });
+  if (conflictingWorkspaceId !== null && conflictingWorkspaceId !== workspaceId) {
+    throw createSyncConflictHttpError({
+      phase: "review_event_write",
+      entityType: "review_event",
+      entityId: reviewEvent.reviewEventId,
+      conflictingWorkspaceId,
+      constraint: "review_events_pkey",
+      sqlState: "23505",
+      table: "review_events",
+    });
+  }
+
   const existingResult = await executor.query<ReviewHistoryRow>(
     [
       "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server",
@@ -121,7 +141,7 @@ export async function appendReviewEventSnapshotInExecutor(
 
   const existingRow = existingResult.rows[0];
   if (existingRow === undefined) {
-    throw new Error("Review event insert deduped but no stored review event was found");
+    throw new Error(`Review event insert deduped but no stored review event was found for ${operationId}`);
   }
 
   const existingReviewEvent = mapReviewHistoryItem(existingRow);

--- a/apps/backend/src/decks.ts
+++ b/apps/backend/src/decks.ts
@@ -21,6 +21,10 @@ import {
   type CursorPageInput,
 } from "./pagination";
 import { findLatestSyncChangeId, insertSyncChange } from "./syncChanges";
+import {
+  createSyncConflictHttpError,
+  findSyncConflictWorkspaceIdInExecutor,
+} from "./sync/fork";
 import type { EffortLevel } from "./cards";
 
 type TimestampValue = Date | string;
@@ -599,7 +603,7 @@ export async function upsertDeckSnapshotInExecutor(
     [workspaceId, normalizedInput.deckId],
   );
 
-  const existingRow = existingResult.rows[0];
+  let existingRow = existingResult.rows[0];
   if (existingRow === undefined) {
     const insertResult = await executor.query<DeckRow>(
       [
@@ -609,6 +613,7 @@ export async function upsertDeckSnapshotInExecutor(
         "last_modified_by_replica_id, last_operation_id, updated_at, deleted_at",
         ")",
         "VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, now(), $9)",
+        "ON CONFLICT DO NOTHING",
         "RETURNING deck_id, workspace_id, name, filter_definition, created_at, client_updated_at,",
         "last_modified_by_replica_id, last_operation_id, updated_at, deleted_at",
       ].join(" "),
@@ -626,18 +631,51 @@ export async function upsertDeckSnapshotInExecutor(
     );
 
     const insertedRow = insertResult.rows[0];
-    if (insertedRow === undefined) {
-      throw new Error("Deck insert did not return a row");
+    if (insertedRow !== undefined) {
+      const insertedDeck = mapDeck(insertedRow);
+      const changeId = await recordDeckSyncChange(executor, workspaceId, insertedDeck);
+
+      return {
+        deck: insertedDeck,
+        applied: true,
+        changeId,
+      };
     }
 
-    const insertedDeck = mapDeck(insertedRow);
-    const changeId = await recordDeckSyncChange(executor, workspaceId, insertedDeck);
+    const conflictingWorkspaceId = await findSyncConflictWorkspaceIdInExecutor(executor, {
+      entityType: "deck",
+      entityId: normalizedInput.deckId,
+    });
+    if (conflictingWorkspaceId === null) {
+      throw new Error(`Deck insert was skipped but no conflicting workspace was found for ${normalizedInput.deckId}`);
+    }
 
-    return {
-      deck: insertedDeck,
-      applied: true,
-      changeId,
-    };
+    if (conflictingWorkspaceId !== workspaceId) {
+      throw createSyncConflictHttpError({
+        phase: "sync_write",
+        entityType: "deck",
+        entityId: normalizedInput.deckId,
+        conflictingWorkspaceId,
+        constraint: "decks_pkey",
+        sqlState: "23505",
+        table: "decks",
+      });
+    }
+
+    const racedExistingResult = await executor.query<DeckRow>(
+      [
+        "SELECT deck_id, workspace_id, name, filter_definition, created_at, client_updated_at,",
+        "last_modified_by_replica_id, last_operation_id, updated_at, deleted_at",
+        "FROM content.decks",
+        "WHERE workspace_id = $1 AND deck_id = $2",
+        "FOR UPDATE",
+      ].join(" "),
+      [workspaceId, normalizedInput.deckId],
+    );
+    existingRow = racedExistingResult.rows[0];
+    if (existingRow === undefined) {
+      throw new Error(`Deck insert was skipped but the current workspace row was not found for ${normalizedInput.deckId}`);
+    }
   }
 
   const existingDeck = mapDeck(existingRow);

--- a/apps/backend/src/errors.ts
+++ b/apps/backend/src/errors.ts
@@ -24,6 +24,48 @@ export type HttpErrorDetails = Readonly<{
   syncConflict?: SyncConflictDetails;
 }>;
 
+export type PublicSyncConflictDetails = Readonly<{
+  phase: string;
+  entityType: SyncConflictEntityType;
+  entityId: string;
+  entryIndex?: number;
+  reviewEventIndex?: number;
+  recoverable: true;
+}>;
+
+export type PublicHttpErrorDetails = Readonly<{
+  validationIssues?: ReadonlyArray<ValidationIssueSummary>;
+  syncConflict?: PublicSyncConflictDetails;
+}>;
+
+function createPublicSyncConflictDetails(details: SyncConflictDetails): PublicSyncConflictDetails {
+  return {
+    phase: details.phase,
+    entityType: details.entityType,
+    entityId: details.entityId,
+    ...(details.entryIndex === undefined ? {} : { entryIndex: details.entryIndex }),
+    ...(details.reviewEventIndex === undefined ? {} : { reviewEventIndex: details.reviewEventIndex }),
+    recoverable: details.recoverable,
+  };
+}
+
+export function createPublicHttpErrorDetails(details: HttpErrorDetails | null): PublicHttpErrorDetails | null {
+  if (details === null) {
+    return null;
+  }
+
+  const validationIssues = details.validationIssues;
+  const syncConflict = details.syncConflict;
+  if (validationIssues === undefined && syncConflict === undefined) {
+    return null;
+  }
+
+  return {
+    ...(validationIssues === undefined ? {} : { validationIssues }),
+    ...(syncConflict === undefined ? {} : { syncConflict: createPublicSyncConflictDetails(syncConflict) }),
+  };
+}
+
 export class HttpError extends Error {
   readonly statusCode: number;
   readonly code: string | null;

--- a/apps/backend/src/errors.ts
+++ b/apps/backend/src/errors.ts
@@ -4,8 +4,24 @@ export type ValidationIssueSummary = Readonly<{
   message: string;
 }>;
 
+export type SyncConflictEntityType = "card" | "deck" | "review_event";
+
+export type SyncConflictDetails = Readonly<{
+  phase: string;
+  entityType: SyncConflictEntityType;
+  entityId: string;
+  conflictingWorkspaceId: string;
+  constraint: string | null;
+  sqlState: string | null;
+  table: string | null;
+  entryIndex?: number;
+  reviewEventIndex?: number;
+  recoverable: true;
+}>;
+
 export type HttpErrorDetails = Readonly<{
-  validationIssues: ReadonlyArray<ValidationIssueSummary>;
+  validationIssues?: ReadonlyArray<ValidationIssueSummary>;
+  syncConflict?: SyncConflictDetails;
 }>;
 
 export class HttpError extends Error {

--- a/apps/backend/src/guestAuth.test.ts
+++ b/apps/backend/src/guestAuth.test.ts
@@ -7,14 +7,10 @@ import {
   completeGuestUpgradeInExecutor,
   deleteGuestSessionInExecutor,
   prepareGuestUpgradeInExecutor,
+  type GuestUpgradeCompleteCapabilities,
 } from "./guestAuth";
 import { cleanupGuestSessionSourceInExecutor } from "./guestAuth/delete";
 import { HttpError } from "./errors";
-import {
-  forkCardIdForWorkspace,
-  forkDeckIdForWorkspace,
-  forkReviewEventIdForWorkspace,
-} from "./sync/fork";
 
 type GuestSessionState = Readonly<{
   session_id: string;
@@ -113,15 +109,23 @@ type ReviewEventState = Readonly<{
   reviewed_at_server: string;
 }>;
 
+type WorkspaceMembershipRole = "owner" | "member";
+
 type GuestUpgradeHistoryState = Readonly<{
   upgrade_id: string;
   source_guest_user_id: string;
   source_guest_workspace_id: string;
   source_guest_session_id: string;
+  source_guest_session_secret_hash: string | null;
   target_subject_user_id: string;
   target_user_id: string;
   target_workspace_id: string;
   selection_type: string;
+  dropped_entities: Readonly<{
+    cardIds: ReadonlyArray<string>;
+    deckIds: ReadonlyArray<string>;
+    reviewEventIds: ReadonlyArray<string>;
+  }> | null;
 }>;
 
 type GuestReplicaAliasState = Readonly<{
@@ -130,15 +134,57 @@ type GuestReplicaAliasState = Readonly<{
   target_replica_id: string;
 }>;
 
+type HotChangeState = Readonly<{
+  change_id: number;
+  workspace_id: string;
+  entity_type: string;
+  entity_id: string;
+}>;
+
+type ReviewEventClientEventDedupMergeFixture = Readonly<{
+  state: MutableState;
+  guestToken: string;
+  targetSubject: string;
+  targetWorkspaceId: string;
+  cardId: string;
+  guestReviewEventId: string;
+  targetReviewEventId: string;
+}>;
+
+const DROPPED_ENTITIES_UNSUPPORTED: GuestUpgradeCompleteCapabilities = {
+  guestWorkspaceSyncedAndOutboxDrained: true,
+  requiresGuestWorkspaceSyncedAndOutboxDrained: true,
+  supportsDroppedEntities: false,
+};
+
+const DROPPED_ENTITIES_SUPPORTED: GuestUpgradeCompleteCapabilities = {
+  guestWorkspaceSyncedAndOutboxDrained: true,
+  requiresGuestWorkspaceSyncedAndOutboxDrained: true,
+  supportsDroppedEntities: true,
+};
+
+const GUEST_SYNC_NOT_DRAINED: GuestUpgradeCompleteCapabilities = {
+  guestWorkspaceSyncedAndOutboxDrained: false,
+  requiresGuestWorkspaceSyncedAndOutboxDrained: true,
+  supportsDroppedEntities: true,
+};
+
+const LEGACY_REPLAY_CAPABILITIES: GuestUpgradeCompleteCapabilities = {
+  guestWorkspaceSyncedAndOutboxDrained: false,
+  requiresGuestWorkspaceSyncedAndOutboxDrained: false,
+  supportsDroppedEntities: false,
+};
+
 type MutableState = {
   currentUserId: string | null;
   currentWorkspaceId: string | null;
   nextHotChangeId: number;
-  guestSession: GuestSessionState;
+  guestSession: GuestSessionState | null;
   identityMappings: Map<string, string>;
   userSettings: Map<string, UserSettingsState>;
   workspaces: Map<string, WorkspaceState>;
   workspaceMemberships: Set<string>;
+  workspaceMembershipRoles: Map<string, WorkspaceMembershipRole>;
   workspaceReplicas: Array<WorkspaceReplicaState>;
   installations: Map<string, InstallationState>;
   cards: Array<CardState>;
@@ -146,6 +192,7 @@ type MutableState = {
   reviewEvents: Array<ReviewEventState>;
   guestUpgradeHistory: Array<GuestUpgradeHistoryState>;
   guestReplicaAliases: Array<GuestReplicaAliasState>;
+  hotChanges: Array<HotChangeState>;
 };
 
 function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
@@ -162,8 +209,35 @@ function membershipKey(userId: string, workspaceId: string): string {
   return `${userId}:${workspaceId}`;
 }
 
+function addWorkspaceMembership(
+  state: MutableState,
+  userId: string,
+  workspaceId: string,
+  role: WorkspaceMembershipRole,
+): void {
+  const key = membershipKey(userId, workspaceId);
+  state.workspaceMemberships.add(key);
+  state.workspaceMembershipRoles.set(key, role);
+}
+
 function hashGuestToken(guestToken: string): string {
   return createHash("sha256").update(guestToken, "utf8").digest("hex");
+}
+
+function toUuidFromSeedForTest(seed: string): string {
+  const digest = createHash("sha256").update(seed).digest("hex");
+  const baseHex = digest.slice(0, 32).split("");
+
+  baseHex[12] = "5";
+  baseHex[16] = ((parseInt(baseHex[16], 16) & 0x3) | 0x8).toString(16);
+
+  return [
+    baseHex.slice(0, 8).join(""),
+    baseHex.slice(8, 12).join(""),
+    baseHex.slice(12, 16).join(""),
+    baseHex.slice(16, 20).join(""),
+    baseHex.slice(20, 32).join(""),
+  ].join("-");
 }
 
 function createUserSettingsState(userId: string, workspaceId: string | null, email: string | null): UserSettingsState {
@@ -249,6 +323,10 @@ function createMergeState(params: Readonly<{
       membershipKey(params.guestUserId, params.guestWorkspaceId),
       membershipKey(params.targetUserId, params.targetWorkspaceId),
     ]),
+    workspaceMembershipRoles: new Map<string, WorkspaceMembershipRole>([
+      [membershipKey(params.guestUserId, params.guestWorkspaceId), "owner"],
+      [membershipKey(params.targetUserId, params.targetWorkspaceId), "owner"],
+    ]),
     workspaceReplicas: [{
       replica_id: params.guestReplicaId,
       workspace_id: params.guestWorkspaceId,
@@ -275,7 +353,1046 @@ function createMergeState(params: Readonly<{
     reviewEvents: [],
     guestUpgradeHistory: [],
     guestReplicaAliases: [],
+    hotChanges: [],
   };
+}
+
+function createReviewEventClientEventDedupMergeFixture(): ReviewEventClientEventDedupMergeFixture {
+  const guestToken = "guest-token-review-event-dedup";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const guestReplicaId = "guest-replica";
+  const installationId = "installation-review-event-dedup";
+  const targetSubject = "cognito-subject-review-event-dedup";
+  const cardId = "12121212-1212-4121-8121-121212121212";
+  const guestReviewEventId = "34343434-3434-4343-8343-343434343434";
+  const targetReviewEventId = "56565656-5656-4565-8565-565656565656";
+  const clientEventId = "same-client-event-dedup";
+  const targetReplicaId = toUuidFromSeedForTest(`${targetWorkspaceId}:${installationId}`);
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-review-event-dedup",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+
+  state.workspaceReplicas.push({
+    replica_id: targetReplicaId,
+    workspace_id: targetWorkspaceId,
+    user_id: targetUserId,
+    actor_kind: "client_installation",
+    installation_id: installationId,
+    actor_key: null,
+    platform: "ios",
+    app_version: "1.2.3",
+    created_at: "2026-04-02T13:50:00.000Z",
+    last_seen_at: "2026-04-02T13:50:00.000Z",
+  });
+  state.cards.push({
+    card_id: cardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Guest front",
+    back_text: "Guest back",
+    tags: ["guest"],
+    effort_level: "fast",
+    due_at: null,
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+  state.cards.push({
+    card_id: cardId,
+    workspace_id: targetWorkspaceId,
+    front_text: "Target front",
+    back_text: "Target back",
+    tags: ["target"],
+    effort_level: "medium",
+    due_at: null,
+    created_at: "2026-04-02T13:50:02.000Z",
+    reps: 1,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T13:50:03.000Z",
+    last_modified_by_replica_id: targetReplicaId,
+    last_operation_id: "target-card-op",
+    updated_at: "2026-04-02T13:50:03.000Z",
+    deleted_at: null,
+  });
+  state.reviewEvents.push({
+    review_event_id: guestReviewEventId,
+    workspace_id: guestWorkspaceId,
+    card_id: cardId,
+    replica_id: guestReplicaId,
+    client_event_id: clientEventId,
+    rating: 2,
+    reviewed_at_client: "2026-04-02T14:00:04.000Z",
+    reviewed_at_server: "2026-04-02T14:00:04.000Z",
+  });
+  state.reviewEvents.push({
+    review_event_id: targetReviewEventId,
+    workspace_id: targetWorkspaceId,
+    card_id: cardId,
+    replica_id: targetReplicaId,
+    client_event_id: clientEventId,
+    rating: 4,
+    reviewed_at_client: "2026-04-02T13:50:04.000Z",
+    reviewed_at_server: "2026-04-02T13:50:04.000Z",
+  });
+
+  return {
+    state,
+    guestToken,
+    targetSubject,
+    targetWorkspaceId,
+    cardId,
+    guestReviewEventId,
+    targetReviewEventId,
+  };
+}
+
+function createCardQueryRow(card: CardState): Readonly<Record<string, unknown>> {
+  return {
+    card_id: card.card_id,
+    front_text: card.front_text,
+    back_text: card.back_text,
+    tags: card.tags,
+    effort_level: card.effort_level,
+    due_at: card.due_at,
+    created_at: card.created_at,
+    reps: card.reps,
+    lapses: card.lapses,
+    fsrs_card_state: card.fsrs_card_state,
+    fsrs_step_index: card.fsrs_step_index,
+    fsrs_stability: card.fsrs_stability,
+    fsrs_difficulty: card.fsrs_difficulty,
+    fsrs_last_reviewed_at: card.fsrs_last_reviewed_at,
+    fsrs_scheduled_days: card.fsrs_scheduled_days,
+    client_updated_at: card.client_updated_at,
+    last_modified_by_replica_id: card.last_modified_by_replica_id,
+    last_operation_id: card.last_operation_id,
+    updated_at: card.updated_at,
+    deleted_at: card.deleted_at,
+  };
+}
+
+function createDeckQueryRow(deck: DeckState): Readonly<Record<string, unknown>> {
+  return {
+    deck_id: deck.deck_id,
+    workspace_id: deck.workspace_id,
+    name: deck.name,
+    filter_definition: deck.filter_definition,
+    created_at: deck.created_at,
+    client_updated_at: deck.client_updated_at,
+    last_modified_by_replica_id: deck.last_modified_by_replica_id,
+    last_operation_id: deck.last_operation_id,
+    updated_at: deck.updated_at,
+    deleted_at: deck.deleted_at,
+  };
+}
+
+function createReviewEventQueryRow(reviewEvent: ReviewEventState): Readonly<Record<string, unknown>> {
+  return {
+    review_event_id: reviewEvent.review_event_id,
+    workspace_id: reviewEvent.workspace_id,
+    card_id: reviewEvent.card_id,
+    replica_id: reviewEvent.replica_id,
+    client_event_id: reviewEvent.client_event_id,
+    rating: reviewEvent.rating,
+    reviewed_at_client: reviewEvent.reviewed_at_client,
+    reviewed_at_server: reviewEvent.reviewed_at_server,
+  };
+}
+
+function parseGuestUpgradeDroppedEntitiesState(
+  serializedDroppedEntities: string | null,
+): GuestUpgradeHistoryState["dropped_entities"] {
+  if (serializedDroppedEntities === null) {
+    return null;
+  }
+
+  const parsed = JSON.parse(serializedDroppedEntities) as GuestUpgradeHistoryState["dropped_entities"];
+  return parsed;
+}
+
+function countWorkspaceMembers(state: MutableState, workspaceId: string): number {
+  return [...state.workspaceMemberships]
+    .filter((membership) => membership.endsWith(`:${workspaceId}`))
+    .length;
+}
+
+function findSyncConflictWorkspaceId(
+  state: MutableState,
+  entityType: string,
+  entityId: string,
+): string | null {
+  if (entityType === "card") {
+    return state.cards.find((card) => card.card_id === entityId)?.workspace_id ?? null;
+  }
+
+  if (entityType === "deck") {
+    return state.decks.find((deck) => deck.deck_id === entityId)?.workspace_id ?? null;
+  }
+
+  if (entityType === "review_event") {
+    return state.reviewEvents.find((reviewEvent) => reviewEvent.review_event_id === entityId)?.workspace_id ?? null;
+  }
+
+  throw new Error(`Unexpected sync conflict entity type: ${entityType}`);
+}
+
+function deleteWorkspaceFromState(state: MutableState, workspaceId: string): void {
+  state.workspaces.delete(workspaceId);
+  state.workspaceReplicas = state.workspaceReplicas.filter((replica) => replica.workspace_id !== workspaceId);
+  state.workspaceMemberships = new Set(
+    [...state.workspaceMemberships].filter((value) => !value.endsWith(`:${workspaceId}`)),
+  );
+  state.workspaceMembershipRoles = new Map(
+    [...state.workspaceMembershipRoles].filter(([key]) => !key.endsWith(`:${workspaceId}`)),
+  );
+  state.cards = state.cards.filter((card) => card.workspace_id !== workspaceId);
+  state.decks = state.decks.filter((deck) => deck.workspace_id !== workspaceId);
+  state.reviewEvents = state.reviewEvents.filter((reviewEvent) => reviewEvent.workspace_id !== workspaceId);
+}
+
+type GuestUpgradeExecutorParam = string | number | boolean | Date | null | ReadonlyArray<string>;
+
+type GuestUpgradeExecutorScope = Readonly<{
+  requireCurrentUserScope: (userId: string) => void;
+  requireCurrentWorkspaceScope: (userId: string, workspaceId: string) => void;
+}>;
+
+function handleExecutorScopeQuery<Row extends pg.QueryResultRow>(
+  state: MutableState,
+  text: string,
+  params: ReadonlyArray<GuestUpgradeExecutorParam>,
+): pg.QueryResult<Row> | null {
+  if (!text.includes("set_config('app.user_id'")) {
+    return null;
+  }
+
+  state.currentUserId = typeof params[0] === "string" ? params[0] : null;
+  state.currentWorkspaceId = typeof params[1] === "string" && params[1] !== "" ? params[1] : null;
+  return createQueryResult<Row>([]);
+}
+
+function handleAuthExecutorQuery<Row extends pg.QueryResultRow>(
+  state: MutableState,
+  text: string,
+  params: ReadonlyArray<GuestUpgradeExecutorParam>,
+): pg.QueryResult<Row> | null {
+  if (text.includes("FROM auth.guest_sessions")) {
+    const requestedHash = params[0];
+    const guestSession = state.guestSession;
+    const rows = guestSession !== null && requestedHash === guestSession.session_secret_hash ? [{
+      session_id: guestSession.session_id,
+      user_id: guestSession.user_id,
+      revoked_at: guestSession.revoked_at,
+    } as unknown as Row] : [];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (
+    text.includes("FROM auth.guest_upgrade_history")
+    && text.includes("WHERE source_guest_session_id = $1")
+  ) {
+    const guestSessionId = params[0];
+    const guestUpgradeHistory = typeof guestSessionId === "string"
+      ? state.guestUpgradeHistory.find((row) => row.source_guest_session_id === guestSessionId)
+      : undefined;
+    const rows = guestUpgradeHistory === undefined ? [] : [{
+      source_guest_session_id: guestUpgradeHistory.source_guest_session_id,
+      target_subject_user_id: guestUpgradeHistory.target_subject_user_id,
+      target_user_id: guestUpgradeHistory.target_user_id,
+      target_workspace_id: guestUpgradeHistory.target_workspace_id,
+      dropped_entities: guestUpgradeHistory.dropped_entities,
+    } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (
+    text.includes("FROM auth.guest_upgrade_history")
+    && text.includes("WHERE source_guest_session_secret_hash = $1")
+  ) {
+    const guestSessionSecretHash = params[0];
+    const guestUpgradeHistory = typeof guestSessionSecretHash === "string"
+      ? state.guestUpgradeHistory.find((row) => row.source_guest_session_secret_hash === guestSessionSecretHash)
+      : undefined;
+    const rows = guestUpgradeHistory === undefined ? [] : [{
+      source_guest_session_id: guestUpgradeHistory.source_guest_session_id,
+      target_subject_user_id: guestUpgradeHistory.target_subject_user_id,
+      target_user_id: guestUpgradeHistory.target_user_id,
+      target_workspace_id: guestUpgradeHistory.target_workspace_id,
+      dropped_entities: guestUpgradeHistory.dropped_entities,
+    } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.includes("FROM auth.user_identities") && text.includes("provider_subject = $1")) {
+    const providerSubject = params[0];
+    const mappedUserId = typeof providerSubject === "string"
+      ? state.identityMappings.get(providerSubject) ?? null
+      : null;
+    const rows = mappedUserId === null ? [] : [{ user_id: mappedUserId } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.includes("FROM auth.user_identities") && text.includes("user_id = $1")) {
+    const userId = params[0];
+    const hasMapping = typeof userId === "string"
+      ? [...state.identityMappings.values()].some((mappedUserId) => mappedUserId === userId)
+      : false;
+    const rows = hasMapping ? [{ user_id: String(userId) } as unknown as Row] : [];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.includes("INSERT INTO auth.user_identities")) {
+    const providerSubject = String(params[0]);
+    const userId = String(params[1]);
+    if (!state.identityMappings.has(providerSubject)) {
+      state.identityMappings.set(providerSubject, userId);
+    }
+    return createQueryResult<Row>([]);
+  }
+
+  if (text.includes("INSERT INTO auth.guest_upgrade_history")) {
+    state.guestUpgradeHistory.push({
+      upgrade_id: String(params[0]),
+      source_guest_user_id: String(params[1]),
+      source_guest_workspace_id: String(params[2]),
+      source_guest_session_id: String(params[3]),
+      source_guest_session_secret_hash: String(params[4]),
+      target_subject_user_id: String(params[5]),
+      target_user_id: String(params[6]),
+      target_workspace_id: String(params[7]),
+      selection_type: String(params[8]),
+      dropped_entities: params[9] === null
+        ? null
+        : parseGuestUpgradeDroppedEntitiesState(String(params[9])),
+    });
+    return createQueryResult<Row>([]);
+  }
+
+  if (text.includes("INSERT INTO auth.guest_replica_aliases")) {
+    state.guestReplicaAliases.push({
+      source_guest_replica_id: String(params[0]),
+      upgrade_id: String(params[1]),
+      target_replica_id: String(params[2]),
+    });
+    return createQueryResult<Row>([]);
+  }
+
+  if (text === "UPDATE auth.guest_sessions SET revoked_at = now() WHERE session_id = $1") {
+    if (state.guestSession === null) {
+      return createQueryResult<Row>([]);
+    }
+
+    state.guestSession = {
+      ...state.guestSession,
+      revoked_at: "2026-04-02T14:01:16.000Z",
+    };
+    return createQueryResult<Row>([]);
+  }
+
+  return null;
+}
+
+function handleUserSettingsExecutorQuery<Row extends pg.QueryResultRow>(
+  state: MutableState,
+  text: string,
+  params: ReadonlyArray<GuestUpgradeExecutorParam>,
+  scope: GuestUpgradeExecutorScope,
+): pg.QueryResult<Row> | null {
+  if (text === "INSERT INTO org.user_settings (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING") {
+    const userId = String(params[0]);
+    scope.requireCurrentUserScope(userId);
+    if (!state.userSettings.has(userId)) {
+      state.userSettings.set(userId, createUserSettingsState(userId, null, null));
+    }
+    return createQueryResult<Row>([]);
+  }
+
+  if (text === "SELECT workspace_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE") {
+    const userId = params[0];
+    const row = typeof userId === "string" ? state.userSettings.get(userId) ?? null : null;
+    const rows = row === null ? [] : [{ workspace_id: row.workspace_id } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text === "UPDATE org.user_settings SET email = $1 WHERE user_id = $2") {
+    const email = params[0] === null ? null : String(params[0]);
+    const userId = String(params[1]);
+    scope.requireCurrentUserScope(userId);
+    const current = state.userSettings.get(userId);
+    if (current === undefined) {
+      throw new Error(`Missing user_settings row for ${userId}`);
+    }
+    state.userSettings.set(userId, {
+      ...current,
+      email,
+    });
+    return createQueryResult<Row>([]);
+  }
+
+  if (text === "UPDATE org.user_settings SET workspace_id = $1 WHERE user_id = $2") {
+    const workspaceId = String(params[0]);
+    const userId = String(params[1]);
+    scope.requireCurrentUserScope(userId);
+    const current = state.userSettings.get(userId) ?? createUserSettingsState(userId, null, null);
+    state.userSettings.set(userId, {
+      ...current,
+      workspace_id: workspaceId,
+    });
+    return createQueryResult<Row>([]);
+  }
+
+  if (text === "DELETE FROM org.user_settings WHERE user_id = $1") {
+    const userId = String(params[0]);
+    state.userSettings.delete(userId);
+    if (state.guestSession?.user_id === userId) {
+      state.guestSession = null;
+    }
+    for (const [providerSubject, mappedUserId] of state.identityMappings) {
+      if (mappedUserId === userId) {
+        state.identityMappings.delete(providerSubject);
+      }
+    }
+    return createQueryResult<Row>([]);
+  }
+
+  return null;
+}
+
+function handleWorkspaceExecutorQuery<Row extends pg.QueryResultRow>(
+  state: MutableState,
+  text: string,
+  params: ReadonlyArray<GuestUpgradeExecutorParam>,
+  scope: GuestUpgradeExecutorScope,
+): pg.QueryResult<Row> | null {
+  if (text.startsWith("SELECT") && text.includes("FROM org.workspaces AS workspaces")) {
+    const userId = params[0];
+    const workspaceId = params[1];
+    if (typeof userId !== "string" || typeof workspaceId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    if (!state.workspaceMemberships.has(membershipKey(userId, workspaceId))) {
+      return createQueryResult<Row>([]);
+    }
+
+    const workspace = state.workspaces.get(workspaceId);
+    const rows = workspace === undefined ? [] : [{
+      workspace_id: workspace.workspace_id,
+      name: workspace.name,
+      created_at: workspace.created_at,
+    } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (
+    text.includes("FROM org.workspace_memberships memberships")
+    && text.includes("memberships.role")
+    && text.includes("AS member_count")
+  ) {
+    const userId = params[0];
+    const workspaceId = params[1];
+    if (typeof userId !== "string" || typeof workspaceId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    if (state.currentUserId !== userId) {
+      return createQueryResult<Row>([]);
+    }
+
+    const membershipRole = state.workspaceMembershipRoles.get(membershipKey(userId, workspaceId));
+    if (membershipRole === undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const workspace = state.workspaces.get(workspaceId);
+    const memberCount = [...state.workspaceMemberships]
+      .filter((membership) => membership.endsWith(`:${workspaceId}`))
+      .length;
+    const rows = workspace === undefined ? [] : [{
+      workspace_id: workspace.workspace_id,
+      name: workspace.name,
+      created_at: workspace.created_at,
+      role: membershipRole,
+      member_count: memberCount,
+    } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.startsWith("SELECT") && text.includes("FROM org.workspaces") && text.includes("fsrs_algorithm")) {
+    const workspaceId = params[0];
+    const workspace = typeof workspaceId === "string" ? state.workspaces.get(workspaceId) : undefined;
+    const rows = workspace === undefined ? [] : [{
+      fsrs_algorithm: workspace.fsrs_algorithm,
+      fsrs_desired_retention: workspace.fsrs_desired_retention,
+      fsrs_learning_steps_minutes: workspace.fsrs_learning_steps_minutes,
+      fsrs_relearning_steps_minutes: workspace.fsrs_relearning_steps_minutes,
+      fsrs_maximum_interval_days: workspace.fsrs_maximum_interval_days,
+      fsrs_enable_fuzz: workspace.fsrs_enable_fuzz,
+      fsrs_client_updated_at: workspace.fsrs_client_updated_at,
+      fsrs_last_modified_by_replica_id: workspace.fsrs_last_modified_by_replica_id,
+      fsrs_last_operation_id: workspace.fsrs_last_operation_id,
+      fsrs_updated_at: workspace.fsrs_updated_at,
+    } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.startsWith("DELETE FROM org.workspaces AS workspaces")) {
+    const workspaceId = String(params[0]);
+    const userId = String(params[1]);
+    scope.requireCurrentUserScope(userId);
+    const membershipRole = state.workspaceMembershipRoles.get(membershipKey(userId, workspaceId));
+    const isOwner = membershipRole === "owner";
+    if (!isOwner || countWorkspaceMembers(state, workspaceId) !== 1 || !state.workspaces.has(workspaceId)) {
+      return createQueryResult<Row>([]);
+    }
+
+    deleteWorkspaceFromState(state, workspaceId);
+    return createQueryResult<Row>([{ workspace_id: workspaceId } as unknown as Row]);
+  }
+
+  if (text === "DELETE FROM org.workspaces WHERE workspace_id = $1") {
+    const workspaceId = String(params[0]);
+    deleteWorkspaceFromState(state, workspaceId);
+    return createQueryResult<Row>([]);
+  }
+
+  if (
+    text
+      === "INSERT INTO org.workspaces ( workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_replica_id, fsrs_last_operation_id ) VALUES ($1, $2, $3, $4, $5)"
+  ) {
+    const workspaceId = String(params[0]);
+    const name = String(params[1]);
+    const bootstrapTimestamp = String(params[2]);
+    const bootstrapReplicaId = String(params[3]);
+    const bootstrapOperationId = String(params[4]);
+    state.workspaces.set(workspaceId, {
+      workspace_id: workspaceId,
+      name,
+      created_at: bootstrapTimestamp,
+      fsrs_algorithm: "fsrs-6",
+      fsrs_desired_retention: 0.9,
+      fsrs_learning_steps_minutes: [1, 10],
+      fsrs_relearning_steps_minutes: [10],
+      fsrs_maximum_interval_days: 36500,
+      fsrs_enable_fuzz: true,
+      fsrs_client_updated_at: bootstrapTimestamp,
+      fsrs_last_modified_by_replica_id: bootstrapReplicaId,
+      fsrs_last_operation_id: bootstrapOperationId,
+      fsrs_updated_at: bootstrapTimestamp,
+    });
+    return createQueryResult<Row>([]);
+  }
+
+  if (text === "INSERT INTO org.workspace_memberships (workspace_id, user_id, role) VALUES ($1, $2, 'owner')") {
+    const workspaceId = String(params[0]);
+    const userId = String(params[1]);
+    addWorkspaceMembership(state, userId, workspaceId, "owner");
+    return createQueryResult<Row>([]);
+  }
+
+  if (text.startsWith("UPDATE org.workspaces SET")) {
+    const workspaceId = String(params[10]);
+    const current = state.workspaces.get(workspaceId);
+    if (current === undefined) {
+      throw new Error(`Missing workspace ${workspaceId}`);
+    }
+
+    state.workspaces.set(workspaceId, {
+      ...current,
+      fsrs_algorithm: String(params[0]),
+      fsrs_desired_retention: Number(params[1]),
+      fsrs_learning_steps_minutes: JSON.parse(String(params[2])) as ReadonlyArray<number>,
+      fsrs_relearning_steps_minutes: JSON.parse(String(params[3])) as ReadonlyArray<number>,
+      fsrs_maximum_interval_days: Number(params[4]),
+      fsrs_enable_fuzz: Boolean(params[5]),
+      fsrs_client_updated_at: String(params[6]),
+      fsrs_last_modified_by_replica_id: String(params[7]),
+      fsrs_last_operation_id: String(params[8]),
+      fsrs_updated_at: String(params[9]),
+    });
+    return createQueryResult<Row>([]);
+  }
+
+  return null;
+}
+
+function handleSyncExecutorQuery<Row extends pg.QueryResultRow>(
+  state: MutableState,
+  text: string,
+  params: ReadonlyArray<GuestUpgradeExecutorParam>,
+  scope: GuestUpgradeExecutorScope,
+): pg.QueryResult<Row> | null {
+  if (text.startsWith("SELECT") && text.includes("FROM sync.workspace_replicas")) {
+    const workspaceId = params[0];
+    const rows = typeof workspaceId !== "string"
+      ? []
+      : state.workspaceReplicas
+        .filter((replica) => replica.workspace_id === workspaceId)
+        .sort((left, right) => left.created_at.localeCompare(right.created_at) || left.replica_id.localeCompare(right.replica_id))
+        .map((replica) => ({ ...replica } as unknown as Row));
+    return createQueryResult<Row>(rows);
+  }
+
+  if (
+    text === "SELECT workspace_id FROM sync.find_conflicting_workspace_id($1, $2) LIMIT 1"
+  ) {
+    const entityType = String(params[0]);
+    const entityId = String(params[1]);
+    const conflictingWorkspaceId = findSyncConflictWorkspaceId(state, entityType, entityId);
+    const rows = conflictingWorkspaceId === null
+      ? []
+      : [{ workspace_id: conflictingWorkspaceId } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.includes("FROM sync.claim_installation")) {
+    const installationId = params[0];
+    const expectedPlatform = params[1];
+    const targetUserId = params[2];
+    const nextAppVersion = params[3];
+
+    if (
+      typeof installationId !== "string"
+      || typeof expectedPlatform !== "string"
+      || typeof targetUserId !== "string"
+    ) {
+      throw new Error("Invalid sync.claim_installation arguments");
+    }
+
+    const installation = state.installations.get(installationId);
+    if (installation === undefined) {
+      throw new Error("Expected installation row to exist for guest merge test");
+    }
+
+    if (installation.platform !== expectedPlatform) {
+      return createQueryResult<Row>([{
+        claim_status: "platform_mismatch",
+        installation_id: installation.installation_id,
+        platform: installation.platform,
+        previous_user_id: installation.user_id,
+        current_user_id: installation.user_id,
+      } as unknown as Row]);
+    }
+
+    const claimStatus = installation.user_id === targetUserId ? "refreshed" : "reassigned";
+    state.installations.set(installationId, {
+      installation_id: installation.installation_id,
+      user_id: targetUserId,
+      platform: installation.platform,
+      app_version: typeof nextAppVersion === "string" ? nextAppVersion : null,
+    });
+
+    return createQueryResult<Row>([{
+      claim_status: claimStatus,
+      installation_id: installation.installation_id,
+      platform: installation.platform,
+      previous_user_id: installation.user_id,
+      current_user_id: targetUserId,
+    } as unknown as Row]);
+  }
+
+  if (text.includes("INSERT INTO sync.workspace_replicas")) {
+    const replicaWorkspaceId = String(params[1]);
+    const replicaUserId = String(params[2]);
+    scope.requireCurrentWorkspaceScope(replicaUserId, replicaWorkspaceId);
+    const existingReplica = state.workspaceReplicas.find((replica) => replica.replica_id === params[0]);
+    if (existingReplica !== undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const nextReplica: WorkspaceReplicaState = {
+      replica_id: String(params[0]),
+      workspace_id: String(params[1]),
+      user_id: String(params[2]),
+      actor_kind: String(params[3]) as WorkspaceReplicaState["actor_kind"],
+      installation_id: params[4] === null ? null : String(params[4]),
+      actor_key: params[5] === null ? null : String(params[5]),
+      platform: String(params[6]) as WorkspaceReplicaState["platform"],
+      app_version: params[7] === null ? null : String(params[7]),
+      created_at: "2026-04-02T14:01:15.000Z",
+      last_seen_at: "2026-04-02T14:01:15.000Z",
+    };
+    state.workspaceReplicas.push(nextReplica);
+    return createQueryResult<Row>([{
+      replica_id: nextReplica.replica_id,
+      platform: nextReplica.platform,
+    } as unknown as Row]);
+  }
+
+  if (text.includes("UPDATE sync.workspace_replicas")) {
+    const replicaId = String(params[0]);
+    const workspaceId = String(params[1]);
+    const userId = String(params[2]);
+    scope.requireCurrentWorkspaceScope(userId, workspaceId);
+    const actorKind = String(params[3]);
+    const installationId = params[4] === null ? null : String(params[4]);
+    const actorKey = params[5] === null ? null : String(params[5]);
+    const platform = String(params[6]);
+    const appVersion = params[7] === null ? null : String(params[7]);
+    const index = state.workspaceReplicas.findIndex((replica) => (
+      replica.replica_id === replicaId
+      && replica.workspace_id === workspaceId
+      && replica.actor_kind === actorKind
+      && replica.installation_id === installationId
+      && replica.actor_key === actorKey
+      && replica.platform === platform
+    ));
+    if (index === -1) {
+      return createQueryResult<Row>([]);
+    }
+
+    const current = state.workspaceReplicas[index];
+    if (current === undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    state.workspaceReplicas[index] = {
+      ...current,
+      user_id: userId,
+      app_version: appVersion,
+      last_seen_at: "2026-04-02T14:01:16.000Z",
+    };
+    return createQueryResult<Row>([{
+      replica_id: replicaId,
+      platform,
+    } as unknown as Row]);
+  }
+
+  if (
+    text
+      === "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING"
+  ) {
+    return createQueryResult<Row>([]);
+  }
+
+  if (
+    text
+      === "INSERT INTO sync.hot_changes ( workspace_id, entity_type, entity_id, action, replica_id, operation_id, client_updated_at ) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING change_id"
+  ) {
+    const changeId = state.nextHotChangeId;
+    state.nextHotChangeId += 1;
+    state.hotChanges.push({
+      change_id: changeId,
+      workspace_id: String(params[0]),
+      entity_type: String(params[1]),
+      entity_id: String(params[2]),
+    });
+    return createQueryResult<Row>([{ change_id: changeId } as unknown as Row]);
+  }
+
+  if (
+    text.includes("FROM sync.hot_changes")
+    && text.includes("ORDER BY change_id DESC")
+  ) {
+    const workspaceId = String(params[0]);
+    const entityType = String(params[1]);
+    const entityId = String(params[2]);
+    const latestChange = state.hotChanges
+      .filter((change) => (
+        change.workspace_id === workspaceId
+        && change.entity_type === entityType
+        && change.entity_id === entityId
+      ))
+      .sort((left, right) => right.change_id - left.change_id)[0];
+    const rows = latestChange === undefined ? [] : [{ change_id: latestChange.change_id } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  return null;
+}
+
+function handleContentExecutorQuery<Row extends pg.QueryResultRow>(
+  state: MutableState,
+  text: string,
+  params: ReadonlyArray<GuestUpgradeExecutorParam>,
+): pg.QueryResult<Row> | null {
+  if (text.startsWith("SELECT") && text.includes("FROM content.cards")) {
+    const workspaceId = params[0];
+    if (typeof workspaceId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    const cardId = text.includes("WHERE workspace_id = $1 AND card_id = $2")
+      ? (typeof params[1] === "string" ? params[1] : null)
+      : null;
+    const rows = state.cards
+      .filter((card) => (
+        card.workspace_id === workspaceId
+        && (cardId === null || card.card_id === cardId)
+      ))
+      .sort((left, right) => left.created_at.localeCompare(right.created_at) || left.card_id.localeCompare(right.card_id))
+      .map((card) => createCardQueryRow(card) as unknown as Row);
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.startsWith("SELECT") && text.includes("FROM content.decks")) {
+    const workspaceId = params[0];
+    if (typeof workspaceId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    const deckId = text.includes("WHERE workspace_id = $1 AND deck_id = $2")
+      ? (typeof params[1] === "string" ? params[1] : null)
+      : null;
+    const rows = state.decks
+      .filter((deck) => (
+        deck.workspace_id === workspaceId
+        && (deckId === null || deck.deck_id === deckId)
+      ))
+      .sort((left, right) => left.created_at.localeCompare(right.created_at) || left.deck_id.localeCompare(right.deck_id))
+      .map((deck) => createDeckQueryRow(deck) as unknown as Row);
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text.startsWith("SELECT") && text.includes("FROM content.review_events")) {
+    const workspaceId = params[0];
+    if (typeof workspaceId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    const reviewEventId = text.includes("review_event_id = $2")
+      ? (typeof params[1] === "string" ? params[1] : null)
+      : null;
+    const replicaId = text.includes("replica_id = $3")
+      ? (typeof params[2] === "string" ? params[2] : null)
+      : null;
+    const clientEventId = text.includes("client_event_id = $4")
+      ? (typeof params[3] === "string" ? params[3] : null)
+      : null;
+    const rows = state.reviewEvents
+      .filter((reviewEvent) => {
+        if (reviewEvent.workspace_id !== workspaceId) {
+          return false;
+        }
+
+        if (reviewEventId === null && replicaId === null && clientEventId === null) {
+          return true;
+        }
+
+        return reviewEvent.review_event_id === reviewEventId
+          || (
+            replicaId !== null
+            && clientEventId !== null
+            && reviewEvent.replica_id === replicaId
+            && reviewEvent.client_event_id === clientEventId
+          );
+      })
+      .sort((left, right) => left.reviewed_at_server.localeCompare(right.reviewed_at_server) || left.review_event_id.localeCompare(right.review_event_id))
+      .map((reviewEvent) => createReviewEventQueryRow(reviewEvent) as unknown as Row);
+    return createQueryResult<Row>(rows);
+  }
+
+  if (
+    text === "DELETE FROM content.review_events WHERE workspace_id = $1"
+    || text === "DELETE FROM content.decks WHERE workspace_id = $1"
+    || text === "DELETE FROM content.cards WHERE workspace_id = $1"
+  ) {
+    const workspaceId = String(params[0]);
+    if (text.includes("content.review_events")) {
+      state.reviewEvents = state.reviewEvents.filter((reviewEvent) => reviewEvent.workspace_id !== workspaceId);
+    } else if (text.includes("content.decks")) {
+      state.decks = state.decks.filter((deck) => deck.workspace_id !== workspaceId);
+    } else {
+      state.cards = state.cards.filter((card) => card.workspace_id !== workspaceId);
+    }
+    return createQueryResult<Row>([]);
+  }
+
+  if (
+    text.startsWith("INSERT INTO content.cards")
+    && text.includes("ON CONFLICT DO NOTHING")
+  ) {
+    const cardId = String(params[0]);
+    const workspaceId = String(params[1]);
+    const existingCard = state.cards.find((card) => card.card_id === cardId);
+    if (existingCard !== undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const insertedCard: CardState = {
+      card_id: cardId,
+      workspace_id: workspaceId,
+      front_text: String(params[2]),
+      back_text: String(params[3]),
+      tags: Array.isArray(params[4]) ? params[4].map(String) : [],
+      effort_level: String(params[5]),
+      due_at: params[6] === null ? null : String(params[6]),
+      created_at: String(params[7]),
+      reps: Number(params[8]),
+      lapses: Number(params[9]),
+      fsrs_card_state: String(params[10]),
+      fsrs_step_index: params[11] === null ? null : Number(params[11]),
+      fsrs_stability: params[12] === null ? null : Number(params[12]),
+      fsrs_difficulty: params[13] === null ? null : Number(params[13]),
+      fsrs_last_reviewed_at: params[14] === null ? null : String(params[14]),
+      fsrs_scheduled_days: params[15] === null ? null : Number(params[15]),
+      client_updated_at: String(params[16]),
+      last_modified_by_replica_id: String(params[17]),
+      last_operation_id: String(params[18]),
+      updated_at: String(params[16]),
+      deleted_at: params[19] === null ? null : String(params[19]),
+    };
+    state.cards.push(insertedCard);
+    return createQueryResult<Row>([createCardQueryRow(insertedCard) as unknown as Row]);
+  }
+
+  if (text.startsWith("UPDATE content.cards")) {
+    const workspaceId = String(params[17]);
+    const cardId = String(params[18]);
+    const index = state.cards.findIndex((card) => card.workspace_id === workspaceId && card.card_id === cardId);
+    if (index === -1) {
+      return createQueryResult<Row>([]);
+    }
+
+    const current = state.cards[index];
+    if (current === undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const updatedCard: CardState = {
+      ...current,
+      front_text: String(params[0]),
+      back_text: String(params[1]),
+      tags: Array.isArray(params[2]) ? params[2].map(String) : [],
+      effort_level: String(params[3]),
+      due_at: params[4] === null ? null : String(params[4]),
+      reps: Number(params[5]),
+      lapses: Number(params[6]),
+      fsrs_card_state: String(params[7]),
+      fsrs_step_index: params[8] === null ? null : Number(params[8]),
+      fsrs_stability: params[9] === null ? null : Number(params[9]),
+      fsrs_difficulty: params[10] === null ? null : Number(params[10]),
+      fsrs_last_reviewed_at: params[11] === null ? null : String(params[11]),
+      fsrs_scheduled_days: params[12] === null ? null : Number(params[12]),
+      deleted_at: params[13] === null ? null : String(params[13]),
+      client_updated_at: String(params[14]),
+      last_modified_by_replica_id: String(params[15]),
+      last_operation_id: String(params[16]),
+      updated_at: String(params[14]),
+    };
+    state.cards[index] = updatedCard;
+    return createQueryResult<Row>([createCardQueryRow(updatedCard) as unknown as Row]);
+  }
+
+  if (
+    text.startsWith("INSERT INTO content.decks")
+    && text.includes("ON CONFLICT DO NOTHING")
+  ) {
+    const deckId = String(params[0]);
+    const workspaceId = String(params[1]);
+    const existingDeck = state.decks.find((deck) => deck.deck_id === deckId);
+    if (existingDeck !== undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const insertedDeck: DeckState = {
+      deck_id: deckId,
+      workspace_id: workspaceId,
+      name: String(params[2]),
+      filter_definition: JSON.parse(String(params[3])) as Readonly<Record<string, unknown>>,
+      created_at: String(params[4]),
+      client_updated_at: String(params[5]),
+      last_modified_by_replica_id: String(params[6]),
+      last_operation_id: String(params[7]),
+      updated_at: String(params[5]),
+      deleted_at: params[8] === null ? null : String(params[8]),
+    };
+    state.decks.push(insertedDeck);
+    return createQueryResult<Row>([createDeckQueryRow(insertedDeck) as unknown as Row]);
+  }
+
+  if (text.startsWith("UPDATE content.decks")) {
+    const workspaceId = String(params[7]);
+    const deckId = String(params[8]);
+    const index = state.decks.findIndex((deck) => deck.workspace_id === workspaceId && deck.deck_id === deckId);
+    if (index === -1) {
+      return createQueryResult<Row>([]);
+    }
+
+    const current = state.decks[index];
+    if (current === undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const updatedDeck: DeckState = {
+      ...current,
+      name: String(params[0]),
+      filter_definition: JSON.parse(String(params[1])) as Readonly<Record<string, unknown>>,
+      created_at: String(params[2]),
+      deleted_at: params[3] === null ? null : String(params[3]),
+      client_updated_at: String(params[4]),
+      last_modified_by_replica_id: String(params[5]),
+      last_operation_id: String(params[6]),
+      updated_at: String(params[4]),
+    };
+    state.decks[index] = updatedDeck;
+    return createQueryResult<Row>([createDeckQueryRow(updatedDeck) as unknown as Row]);
+  }
+
+  if (
+    text.startsWith("INSERT INTO content.review_events")
+    && text.includes("ON CONFLICT DO NOTHING")
+  ) {
+    const reviewEventId = String(params[0]);
+    const workspaceId = String(params[1]);
+    const replicaId = String(params[3]);
+    const clientEventId = String(params[4]);
+    const existingReviewEvent = state.reviewEvents.find((reviewEvent) => (
+      reviewEvent.review_event_id === reviewEventId
+      || (
+        reviewEvent.workspace_id === workspaceId
+        && reviewEvent.replica_id === replicaId
+        && reviewEvent.client_event_id === clientEventId
+      )
+    ));
+    if (existingReviewEvent !== undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const insertedReviewEvent: ReviewEventState = {
+      review_event_id: reviewEventId,
+      workspace_id: workspaceId,
+      card_id: String(params[2]),
+      replica_id: replicaId,
+      client_event_id: clientEventId,
+      rating: Number(params[5]),
+      reviewed_at_client: String(params[6]),
+      reviewed_at_server: String(params[7]),
+    };
+    state.reviewEvents.push(insertedReviewEvent);
+    return createQueryResult<Row>([createReviewEventQueryRow(insertedReviewEvent) as unknown as Row]);
+  }
+
+  return null;
 }
 
 function createGuestUpgradeExecutor(state: MutableState): DatabaseExecutor {
@@ -296,576 +1413,74 @@ function createGuestUpgradeExecutor(state: MutableState): DatabaseExecutor {
     );
   }
 
+  const scope: GuestUpgradeExecutorScope = {
+    requireCurrentUserScope,
+    requireCurrentWorkspaceScope,
+  };
+
   return {
     async query<Row extends pg.QueryResultRow>(
       text: string,
-      params: ReadonlyArray<string | number | boolean | Date | null | ReadonlyArray<string>>,
+      params: ReadonlyArray<GuestUpgradeExecutorParam>,
     ): Promise<pg.QueryResult<Row>> {
-      if (text.includes("set_config('app.user_id'")) {
-        state.currentUserId = typeof params[0] === "string" ? params[0] : null;
-        state.currentWorkspaceId = typeof params[1] === "string" && params[1] !== "" ? params[1] : null;
-        return createQueryResult<Row>([]);
+      const scopeResult = handleExecutorScopeQuery<Row>(state, text, params);
+      if (scopeResult !== null) {
+        return scopeResult;
       }
 
-      if (text.includes("FROM auth.guest_sessions")) {
-        const requestedHash = params[0];
-        const guestSession = state.guestSession;
-        const rows = requestedHash === guestSession.session_secret_hash ? [{
-          session_id: guestSession.session_id,
-          user_id: guestSession.user_id,
-          revoked_at: guestSession.revoked_at,
-        } as unknown as Row] : [];
-        return createQueryResult<Row>(rows);
+      const authResult = handleAuthExecutorQuery<Row>(state, text, params);
+      if (authResult !== null) {
+        return authResult;
       }
 
-      if (
-        text.includes("FROM auth.guest_upgrade_history")
-        && text.includes("WHERE source_guest_session_id = $1")
-      ) {
-        const guestSessionId = params[0];
-        const guestUpgradeHistory = typeof guestSessionId === "string"
-          ? state.guestUpgradeHistory.find((row) => row.source_guest_session_id === guestSessionId)
-          : undefined;
-        const rows = guestUpgradeHistory === undefined ? [] : [{
-          target_subject_user_id: guestUpgradeHistory.target_subject_user_id,
-          target_user_id: guestUpgradeHistory.target_user_id,
-          target_workspace_id: guestUpgradeHistory.target_workspace_id,
-        } as unknown as Row];
-        return createQueryResult<Row>(rows);
+      const userSettingsResult = handleUserSettingsExecutorQuery<Row>(state, text, params, scope);
+      if (userSettingsResult !== null) {
+        return userSettingsResult;
       }
 
-      if (text.includes("FROM auth.user_identities") && text.includes("provider_subject = $1")) {
-        const providerSubject = params[0];
-        const mappedUserId = typeof providerSubject === "string"
-          ? state.identityMappings.get(providerSubject) ?? null
-          : null;
-        const rows = mappedUserId === null ? [] : [{ user_id: mappedUserId } as unknown as Row];
-        return createQueryResult<Row>(rows);
+      const workspaceResult = handleWorkspaceExecutorQuery<Row>(state, text, params, scope);
+      if (workspaceResult !== null) {
+        return workspaceResult;
       }
 
-      if (text.includes("FROM auth.user_identities") && text.includes("user_id = $1")) {
-        const userId = params[0];
-        const hasMapping = typeof userId === "string"
-          ? [...state.identityMappings.values()].some((mappedUserId) => mappedUserId === userId)
-          : false;
-        const rows = hasMapping ? [{ user_id: String(userId) } as unknown as Row] : [];
-        return createQueryResult<Row>(rows);
+      const syncResult = handleSyncExecutorQuery<Row>(state, text, params, scope);
+      if (syncResult !== null) {
+        return syncResult;
       }
 
-      if (text.includes("INSERT INTO auth.user_identities")) {
-        const providerSubject = String(params[0]);
-        const userId = String(params[1]);
-        if (!state.identityMappings.has(providerSubject)) {
-          state.identityMappings.set(providerSubject, userId);
-        }
-        return createQueryResult<Row>([]);
-      }
-
-      if (text === "INSERT INTO org.user_settings (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING") {
-        const userId = String(params[0]);
-        requireCurrentUserScope(userId);
-        if (!state.userSettings.has(userId)) {
-          state.userSettings.set(userId, createUserSettingsState(userId, null, null));
-        }
-        return createQueryResult<Row>([]);
-      }
-
-      if (text === "SELECT workspace_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE") {
-        const userId = params[0];
-        const row = typeof userId === "string" ? state.userSettings.get(userId) ?? null : null;
-        const rows = row === null ? [] : [{ workspace_id: row.workspace_id } as unknown as Row];
-        return createQueryResult<Row>(rows);
-      }
-
-      if (text === "UPDATE org.user_settings SET email = $1 WHERE user_id = $2") {
-        const email = params[0] === null ? null : String(params[0]);
-        const userId = String(params[1]);
-        requireCurrentUserScope(userId);
-        const current = state.userSettings.get(userId);
-        if (current === undefined) {
-          throw new Error(`Missing user_settings row for ${userId}`);
-        }
-        state.userSettings.set(userId, {
-          ...current,
-          email,
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text === "UPDATE org.user_settings SET workspace_id = $1 WHERE user_id = $2") {
-        const workspaceId = String(params[0]);
-        const userId = String(params[1]);
-        requireCurrentUserScope(userId);
-        const current = state.userSettings.get(userId) ?? createUserSettingsState(userId, null, null);
-        state.userSettings.set(userId, {
-          ...current,
-          workspace_id: workspaceId,
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.includes("FROM org.workspaces AS workspaces")) {
-        const userId = params[0];
-        const workspaceId = params[1];
-        if (typeof userId !== "string" || typeof workspaceId !== "string") {
-          return createQueryResult<Row>([]);
-        }
-
-        if (!state.workspaceMemberships.has(membershipKey(userId, workspaceId))) {
-          return createQueryResult<Row>([]);
-        }
-
-        const workspace = state.workspaces.get(workspaceId);
-        const rows = workspace === undefined ? [] : [{
-          workspace_id: workspace.workspace_id,
-          name: workspace.name,
-          created_at: workspace.created_at,
-        } as unknown as Row];
-        return createQueryResult<Row>(rows);
-      }
-
-      if (
-        text.includes("FROM org.workspace_memberships memberships")
-        && text.includes("memberships.role")
-        && text.includes("AS member_count")
-      ) {
-        const userId = params[0];
-        const workspaceId = params[1];
-        if (typeof userId !== "string" || typeof workspaceId !== "string") {
-          return createQueryResult<Row>([]);
-        }
-
-        if (state.currentUserId !== userId) {
-          return createQueryResult<Row>([]);
-        }
-
-        if (!state.workspaceMemberships.has(membershipKey(userId, workspaceId))) {
-          return createQueryResult<Row>([]);
-        }
-
-        const workspace = state.workspaces.get(workspaceId);
-        const memberCount = [...state.workspaceMemberships]
-          .filter((membership) => membership.endsWith(`:${workspaceId}`))
-          .length;
-        const rows = workspace === undefined ? [] : [{
-          workspace_id: workspace.workspace_id,
-          name: workspace.name,
-          created_at: workspace.created_at,
-          role: "owner",
-          member_count: memberCount,
-        } as unknown as Row];
-        return createQueryResult<Row>(rows);
-      }
-
-      if (text.includes("FROM sync.workspace_replicas")) {
-        const workspaceId = params[0];
-        const rows = typeof workspaceId !== "string"
-          ? []
-          : state.workspaceReplicas
-            .filter((replica) => replica.workspace_id === workspaceId)
-            .sort((left, right) => left.created_at.localeCompare(right.created_at) || left.replica_id.localeCompare(right.replica_id))
-            .map((replica) => ({ ...replica } as unknown as Row));
-        return createQueryResult<Row>(rows);
-      }
-
-      if (text.includes("FROM content.cards")) {
-        const workspaceId = params[0];
-        const rows = typeof workspaceId !== "string"
-          ? []
-          : state.cards
-            .filter((card) => card.workspace_id === workspaceId)
-            .sort((left, right) => left.created_at.localeCompare(right.created_at) || left.card_id.localeCompare(right.card_id))
-            .map((card) => ({
-              card_id: card.card_id,
-              front_text: card.front_text,
-              back_text: card.back_text,
-              tags: card.tags,
-              effort_level: card.effort_level,
-              due_at: card.due_at,
-              created_at: card.created_at,
-              reps: card.reps,
-              lapses: card.lapses,
-              fsrs_card_state: card.fsrs_card_state,
-              fsrs_step_index: card.fsrs_step_index,
-              fsrs_stability: card.fsrs_stability,
-              fsrs_difficulty: card.fsrs_difficulty,
-              fsrs_last_reviewed_at: card.fsrs_last_reviewed_at,
-              fsrs_scheduled_days: card.fsrs_scheduled_days,
-              client_updated_at: card.client_updated_at,
-              last_modified_by_replica_id: card.last_modified_by_replica_id,
-              last_operation_id: card.last_operation_id,
-              updated_at: card.updated_at,
-              deleted_at: card.deleted_at,
-            } as unknown as Row));
-        return createQueryResult<Row>(rows);
-      }
-
-      if (text.includes("FROM content.decks")) {
-        const workspaceId = params[0];
-        const rows = typeof workspaceId !== "string"
-          ? []
-          : state.decks
-            .filter((deck) => deck.workspace_id === workspaceId)
-            .sort((left, right) => left.created_at.localeCompare(right.created_at) || left.deck_id.localeCompare(right.deck_id))
-            .map((deck) => ({
-              deck_id: deck.deck_id,
-              name: deck.name,
-              filter_definition: deck.filter_definition,
-              created_at: deck.created_at,
-              client_updated_at: deck.client_updated_at,
-              last_modified_by_replica_id: deck.last_modified_by_replica_id,
-              last_operation_id: deck.last_operation_id,
-              updated_at: deck.updated_at,
-              deleted_at: deck.deleted_at,
-            } as unknown as Row));
-        return createQueryResult<Row>(rows);
-      }
-
-      if (text.includes("FROM content.review_events")) {
-        const workspaceId = params[0];
-        const rows = typeof workspaceId !== "string"
-          ? []
-          : state.reviewEvents
-            .filter((reviewEvent) => reviewEvent.workspace_id === workspaceId)
-            .sort((left, right) => left.reviewed_at_server.localeCompare(right.reviewed_at_server) || left.review_event_id.localeCompare(right.review_event_id))
-            .map((reviewEvent) => ({
-              review_event_id: reviewEvent.review_event_id,
-              card_id: reviewEvent.card_id,
-              replica_id: reviewEvent.replica_id,
-              client_event_id: reviewEvent.client_event_id,
-              rating: reviewEvent.rating,
-              reviewed_at_client: reviewEvent.reviewed_at_client,
-              reviewed_at_server: reviewEvent.reviewed_at_server,
-            } as unknown as Row));
-        return createQueryResult<Row>(rows);
-      }
-
-      if (text.includes("FROM org.workspaces") && text.includes("fsrs_algorithm")) {
-        const workspaceId = params[0];
-        const workspace = typeof workspaceId === "string" ? state.workspaces.get(workspaceId) : undefined;
-        const rows = workspace === undefined ? [] : [{
-          fsrs_algorithm: workspace.fsrs_algorithm,
-          fsrs_desired_retention: workspace.fsrs_desired_retention,
-          fsrs_learning_steps_minutes: workspace.fsrs_learning_steps_minutes,
-          fsrs_relearning_steps_minutes: workspace.fsrs_relearning_steps_minutes,
-          fsrs_maximum_interval_days: workspace.fsrs_maximum_interval_days,
-          fsrs_enable_fuzz: workspace.fsrs_enable_fuzz,
-          fsrs_client_updated_at: workspace.fsrs_client_updated_at,
-          fsrs_last_modified_by_replica_id: workspace.fsrs_last_modified_by_replica_id,
-          fsrs_last_operation_id: workspace.fsrs_last_operation_id,
-          fsrs_updated_at: workspace.fsrs_updated_at,
-        } as unknown as Row];
-        return createQueryResult<Row>(rows);
-      }
-
-      if (
-        text === "DELETE FROM content.decks WHERE workspace_id = $1"
-        || text === "DELETE FROM content.cards WHERE workspace_id = $1"
-      ) {
-        const workspaceId = String(params[0]);
-        if (text.includes("content.decks")) {
-          state.decks = state.decks.filter((deck) => deck.workspace_id !== workspaceId);
-        } else {
-          state.cards = state.cards.filter((card) => card.workspace_id !== workspaceId);
-        }
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.includes("FROM sync.claim_installation")) {
-        const installationId = params[0];
-        const expectedPlatform = params[1];
-        const targetUserId = params[2];
-        const nextAppVersion = params[3];
-
-        if (
-          typeof installationId !== "string"
-          || typeof expectedPlatform !== "string"
-          || typeof targetUserId !== "string"
-        ) {
-          throw new Error("Invalid sync.claim_installation arguments");
-        }
-
-        const installation = state.installations.get(installationId);
-        if (installation === undefined) {
-          throw new Error("Expected installation row to exist for guest merge test");
-        }
-
-        if (installation.platform !== expectedPlatform) {
-          return createQueryResult<Row>([{
-            claim_status: "platform_mismatch",
-            installation_id: installation.installation_id,
-            platform: installation.platform,
-            previous_user_id: installation.user_id,
-            current_user_id: installation.user_id,
-          } as unknown as Row]);
-        }
-
-        const claimStatus = installation.user_id === targetUserId ? "refreshed" : "reassigned";
-        state.installations.set(installationId, {
-          installation_id: installation.installation_id,
-          user_id: targetUserId,
-          platform: installation.platform,
-          app_version: typeof nextAppVersion === "string" ? nextAppVersion : null,
-        });
-
-        return createQueryResult<Row>([{
-          claim_status: claimStatus,
-          installation_id: installation.installation_id,
-          platform: installation.platform,
-          previous_user_id: installation.user_id,
-          current_user_id: targetUserId,
-        } as unknown as Row]);
-      }
-
-      if (text.includes("INSERT INTO sync.workspace_replicas")) {
-        const replicaWorkspaceId = String(params[1]);
-        const replicaUserId = String(params[2]);
-        requireCurrentWorkspaceScope(replicaUserId, replicaWorkspaceId);
-        const existingReplica = state.workspaceReplicas.find((replica) => replica.replica_id === params[0]);
-        if (existingReplica !== undefined) {
-          return createQueryResult<Row>([]);
-        }
-
-        const nextReplica: WorkspaceReplicaState = {
-          replica_id: String(params[0]),
-          workspace_id: String(params[1]),
-          user_id: String(params[2]),
-          actor_kind: String(params[3]) as WorkspaceReplicaState["actor_kind"],
-          installation_id: params[4] === null ? null : String(params[4]),
-          actor_key: params[5] === null ? null : String(params[5]),
-          platform: String(params[6]) as WorkspaceReplicaState["platform"],
-          app_version: params[7] === null ? null : String(params[7]),
-          created_at: "2026-04-02T14:01:15.000Z",
-          last_seen_at: "2026-04-02T14:01:15.000Z",
-        };
-        state.workspaceReplicas.push(nextReplica);
-        return createQueryResult<Row>([{
-          replica_id: nextReplica.replica_id,
-          platform: nextReplica.platform,
-        } as unknown as Row]);
-      }
-
-      if (text.includes("UPDATE sync.workspace_replicas")) {
-        const replicaId = String(params[0]);
-        const workspaceId = String(params[1]);
-        const userId = String(params[2]);
-        requireCurrentWorkspaceScope(userId, workspaceId);
-        const actorKind = String(params[3]);
-        const installationId = params[4] === null ? null : String(params[4]);
-        const actorKey = params[5] === null ? null : String(params[5]);
-        const platform = String(params[6]);
-        const appVersion = params[7] === null ? null : String(params[7]);
-        const index = state.workspaceReplicas.findIndex((replica) => (
-          replica.replica_id === replicaId
-          && replica.workspace_id === workspaceId
-          && replica.actor_kind === actorKind
-          && replica.installation_id === installationId
-          && replica.actor_key === actorKey
-          && replica.platform === platform
-        ));
-        if (index === -1) {
-          return createQueryResult<Row>([]);
-        }
-
-        const current = state.workspaceReplicas[index];
-        if (current === undefined) {
-          return createQueryResult<Row>([]);
-        }
-
-        state.workspaceReplicas[index] = {
-          ...current,
-          user_id: userId,
-          app_version: appVersion,
-          last_seen_at: "2026-04-02T14:01:16.000Z",
-        };
-        return createQueryResult<Row>([{
-          replica_id: replicaId,
-          platform,
-        } as unknown as Row]);
-      }
-
-      if (text.includes("INSERT INTO auth.guest_upgrade_history")) {
-        state.guestUpgradeHistory.push({
-          upgrade_id: String(params[0]),
-          source_guest_user_id: String(params[1]),
-          source_guest_workspace_id: String(params[2]),
-          source_guest_session_id: String(params[3]),
-          target_subject_user_id: String(params[4]),
-          target_user_id: String(params[5]),
-          target_workspace_id: String(params[6]),
-          selection_type: String(params[7]),
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.includes("INSERT INTO auth.guest_replica_aliases")) {
-        state.guestReplicaAliases.push({
-          source_guest_replica_id: String(params[0]),
-          upgrade_id: String(params[1]),
-          target_replica_id: String(params[2]),
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text === "UPDATE auth.guest_sessions SET revoked_at = now() WHERE session_id = $1") {
-        state.guestSession = {
-          ...state.guestSession,
-          revoked_at: "2026-04-02T14:01:16.000Z",
-        };
-        return createQueryResult<Row>([]);
-      }
-
-      if (text === "DELETE FROM org.workspaces WHERE workspace_id = $1") {
-        const workspaceId = String(params[0]);
-        state.workspaces.delete(workspaceId);
-        state.workspaceReplicas = state.workspaceReplicas.filter((replica) => replica.workspace_id !== workspaceId);
-        state.workspaceMemberships = new Set(
-          [...state.workspaceMemberships].filter((value) => !value.endsWith(`:${workspaceId}`)),
-        );
-        state.cards = state.cards.filter((card) => card.workspace_id !== workspaceId);
-        state.decks = state.decks.filter((deck) => deck.workspace_id !== workspaceId);
-        state.reviewEvents = state.reviewEvents.filter((reviewEvent) => reviewEvent.workspace_id !== workspaceId);
-        return createQueryResult<Row>([]);
-      }
-
-      if (text === "DELETE FROM org.user_settings WHERE user_id = $1") {
-        state.userSettings.delete(String(params[0]));
-        return createQueryResult<Row>([]);
-      }
-
-      if (
-        text
-          === "INSERT INTO org.workspaces ( workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_replica_id, fsrs_last_operation_id ) VALUES ($1, $2, $3, $4, $5)"
-      ) {
-        const workspaceId = String(params[0]);
-        const name = String(params[1]);
-        const bootstrapTimestamp = String(params[2]);
-        const bootstrapReplicaId = String(params[3]);
-        const bootstrapOperationId = String(params[4]);
-        state.workspaces.set(workspaceId, {
-          workspace_id: workspaceId,
-          name,
-          created_at: bootstrapTimestamp,
-          fsrs_algorithm: "fsrs-6",
-          fsrs_desired_retention: 0.9,
-          fsrs_learning_steps_minutes: [1, 10],
-          fsrs_relearning_steps_minutes: [10],
-          fsrs_maximum_interval_days: 36500,
-          fsrs_enable_fuzz: true,
-          fsrs_client_updated_at: bootstrapTimestamp,
-          fsrs_last_modified_by_replica_id: bootstrapReplicaId,
-          fsrs_last_operation_id: bootstrapOperationId,
-          fsrs_updated_at: bootstrapTimestamp,
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text === "INSERT INTO org.workspace_memberships (workspace_id, user_id, role) VALUES ($1, $2, 'owner')") {
-        const workspaceId = String(params[0]);
-        const userId = String(params[1]);
-        state.workspaceMemberships.add(membershipKey(userId, workspaceId));
-        return createQueryResult<Row>([]);
-      }
-
-      if (
-        text
-          === "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING"
-      ) {
-        return createQueryResult<Row>([]);
-      }
-
-      if (
-        text
-          === "INSERT INTO sync.hot_changes ( workspace_id, entity_type, entity_id, action, replica_id, operation_id, client_updated_at ) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING change_id"
-      ) {
-        const changeId = state.nextHotChangeId;
-        state.nextHotChangeId += 1;
-        return createQueryResult<Row>([{ change_id: changeId } as unknown as Row]);
-      }
-
-      if (text.startsWith("INSERT INTO content.cards")) {
-        state.cards.push({
-          card_id: String(params[0]),
-          workspace_id: String(params[1]),
-          front_text: String(params[2]),
-          back_text: String(params[3]),
-          tags: Array.isArray(params[4]) ? params[4].map(String) : [],
-          effort_level: String(params[5]),
-          due_at: params[6] === null ? null : String(params[6]),
-          reps: Number(params[7]),
-          lapses: Number(params[8]),
-          updated_at: String(params[9]),
-          deleted_at: params[10] === null ? null : String(params[10]),
-          fsrs_card_state: String(params[11]),
-          fsrs_step_index: params[12] === null ? null : Number(params[12]),
-          fsrs_stability: params[13] === null ? null : Number(params[13]),
-          fsrs_difficulty: params[14] === null ? null : Number(params[14]),
-          fsrs_last_reviewed_at: params[15] === null ? null : String(params[15]),
-          fsrs_scheduled_days: params[16] === null ? null : Number(params[16]),
-          client_updated_at: String(params[17]),
-          last_modified_by_replica_id: String(params[18]),
-          last_operation_id: String(params[19]),
-          created_at: String(params[20]),
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.startsWith("INSERT INTO content.decks")) {
-        state.decks.push({
-          deck_id: String(params[0]),
-          workspace_id: String(params[1]),
-          name: String(params[2]),
-          filter_definition: JSON.parse(String(params[3])) as Readonly<Record<string, unknown>>,
-          created_at: String(params[4]),
-          updated_at: String(params[5]),
-          deleted_at: params[6] === null ? null : String(params[6]),
-          client_updated_at: String(params[7]),
-          last_modified_by_replica_id: String(params[8]),
-          last_operation_id: String(params[9]),
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.startsWith("INSERT INTO content.review_events")) {
-        state.reviewEvents.push({
-          review_event_id: String(params[0]),
-          workspace_id: String(params[1]),
-          card_id: String(params[2]),
-          replica_id: String(params[3]),
-          client_event_id: String(params[4]),
-          rating: Number(params[5]),
-          reviewed_at_client: String(params[6]),
-          reviewed_at_server: String(params[7]),
-        });
-        return createQueryResult<Row>([]);
-      }
-
-      if (text.startsWith("UPDATE org.workspaces SET")) {
-        const workspaceId = String(params[10]);
-        const current = state.workspaces.get(workspaceId);
-        if (current === undefined) {
-          throw new Error(`Missing workspace ${workspaceId}`);
-        }
-
-        state.workspaces.set(workspaceId, {
-          ...current,
-          fsrs_algorithm: String(params[0]),
-          fsrs_desired_retention: Number(params[1]),
-          fsrs_learning_steps_minutes: JSON.parse(String(params[2])) as ReadonlyArray<number>,
-          fsrs_relearning_steps_minutes: JSON.parse(String(params[3])) as ReadonlyArray<number>,
-          fsrs_maximum_interval_days: Number(params[4]),
-          fsrs_enable_fuzz: Boolean(params[5]),
-          fsrs_client_updated_at: String(params[6]),
-          fsrs_last_modified_by_replica_id: String(params[7]),
-          fsrs_last_operation_id: String(params[8]),
-          fsrs_updated_at: String(params[9]),
-        });
-        return createQueryResult<Row>([]);
+      const contentResult = handleContentExecutorQuery<Row>(state, text, params);
+      if (contentResult !== null) {
+        return contentResult;
       }
 
       throw new Error(`Unexpected query: ${text}`);
     },
   };
+}
+
+function isGuestUpgradeMergeOnlyExecutorQuery(text: string): boolean {
+  return text.includes("FROM sync.claim_installation")
+    || (text.startsWith("SELECT") && text.includes("FROM sync.workspace_replicas"))
+    || text.includes("INSERT INTO sync.workspace_replicas")
+    || text.includes("UPDATE sync.workspace_replicas")
+    || text.includes("INSERT INTO auth.guest_upgrade_history")
+    || text.includes("INSERT INTO auth.guest_replica_aliases")
+    || text === "UPDATE auth.guest_sessions SET revoked_at = now() WHERE session_id = $1"
+    || text === "SELECT workspace_id FROM sync.find_conflicting_workspace_id($1, $2) LIMIT 1"
+    || text.includes("FROM sync.hot_changes")
+    || text.includes("INSERT INTO sync.hot_changes")
+    || text.startsWith("DELETE FROM content.")
+    || text.startsWith("INSERT INTO content.")
+    || text.startsWith("UPDATE content.")
+    || text.startsWith("DELETE FROM org.workspaces")
+    || text === "DELETE FROM org.user_settings WHERE user_id = $1"
+    || text
+      === "INSERT INTO org.workspaces ( workspace_id, name, fsrs_client_updated_at, fsrs_last_modified_by_replica_id, fsrs_last_operation_id ) VALUES ($1, $2, $3, $4, $5)"
+    || text === "INSERT INTO org.workspace_memberships (workspace_id, user_id, role) VALUES ($1, $2, 'owner')"
+    || text
+      === "INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at) VALUES ($1, 0, now()) ON CONFLICT (workspace_id) DO NOTHING"
+    || text === "UPDATE org.user_settings SET workspace_id = $1 WHERE user_id = $2"
+    || text.startsWith("UPDATE org.workspaces SET");
 }
 
 test("prepareGuestUpgradeInExecutor binds a new cognito subject to the guest user and updates email", async () => {
@@ -962,6 +1577,7 @@ test("completeGuestUpgradeInExecutor reassigns guest installation ownership duri
       type: "existing",
       workspaceId: targetWorkspaceId,
     },
+    DROPPED_ENTITIES_UNSUPPORTED,
   );
 
   assert.equal(result.workspace.workspaceId, targetWorkspaceId);
@@ -969,7 +1585,7 @@ test("completeGuestUpgradeInExecutor reassigns guest installation ownership duri
   assert.equal(state.userSettings.get(targetUserId)?.workspace_id, targetWorkspaceId);
   assert.equal(state.userSettings.has(guestUserId), false);
   assert.equal(state.workspaces.has(guestWorkspaceId), false);
-  assert.equal(state.guestSession.revoked_at, "2026-04-02T14:01:16.000Z");
+  assert.equal(state.guestSession, null);
   assert.equal(state.guestUpgradeHistory.length, 1);
   assert.equal(state.guestReplicaAliases.length, 1);
   assert.equal(state.guestReplicaAliases[0]?.source_guest_replica_id, guestReplicaId);
@@ -1004,7 +1620,7 @@ test("completeGuestUpgradeInExecutor rejects selecting the guest workspace as th
     guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
     targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
   });
-  state.workspaceMemberships.add(membershipKey(targetUserId, guestWorkspaceId));
+  addWorkspaceMembership(state, targetUserId, guestWorkspaceId, "member");
 
   const executor = createGuestUpgradeExecutor(state);
 
@@ -1017,6 +1633,7 @@ test("completeGuestUpgradeInExecutor rejects selecting the guest workspace as th
         type: "existing",
         workspaceId: guestWorkspaceId,
       },
+      DROPPED_ENTITIES_UNSUPPORTED,
     ),
     (error: unknown) => {
       assert.ok(error instanceof HttpError);
@@ -1026,28 +1643,142 @@ test("completeGuestUpgradeInExecutor rejects selecting the guest workspace as th
     },
   );
 
-  assert.equal(state.guestSession.revoked_at, null);
+  assert.equal(state.guestSession?.revoked_at, null);
   assert.equal(state.guestUpgradeHistory.length, 0);
   assert.equal(state.installations.get(installationId)?.user_id, guestUserId);
   assert.equal(state.workspaces.has(guestWorkspaceId), true);
 });
 
-test("completeGuestUpgradeInExecutor deterministically forks copied ids into a different workspace", async () => {
-  const guestToken = "guest-token-forked-copy";
+test("completeGuestUpgradeInExecutor rejects merge_required completion before guest sync is drained", async () => {
+  const guestToken = "guest-token-not-drained";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const installationId = "installation-not-drained";
+  const targetSubject = "cognito-subject-not-drained";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-not-drained",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId: "guest-replica-not-drained",
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      guestToken,
+      targetSubject,
+      {
+        type: "existing",
+        workspaceId: targetWorkspaceId,
+      },
+      GUEST_SYNC_NOT_DRAINED,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "GUEST_UPGRADE_GUEST_SYNC_NOT_DRAINED");
+      assert.match(error.message, /guest outbox is empty/);
+      return true;
+    },
+  );
+
+  assert.equal(state.guestUpgradeHistory.length, 0);
+  assert.equal(state.guestSession?.revoked_at, null);
+  assert.equal(state.installations.get(installationId)?.user_id, guestUserId);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
+});
+
+test("completeGuestUpgradeInExecutor completes same-user bound path without guest drain or merge handling", async () => {
+  const guestToken = "guest-token-bound-complete";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const linkedUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const installationId = "installation-bound-complete";
+  const targetSubject = "cognito-subject-bound-complete";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-bound-complete",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId: linkedUserId,
+    targetWorkspaceId,
+    guestReplicaId: "guest-replica-bound-complete",
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.identityMappings.set(targetSubject, guestUserId);
+
+  const mergeOnlyQueries: Array<string> = [];
+  const baseExecutor = createGuestUpgradeExecutor(state);
+  const executor: DatabaseExecutor = {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<GuestUpgradeExecutorParam>,
+    ): Promise<pg.QueryResult<Row>> => {
+      if (isGuestUpgradeMergeOnlyExecutorQuery(text)) {
+        mergeOnlyQueries.push(text);
+      }
+
+      return baseExecutor.query<Row>(text, params);
+    },
+  };
+
+  const result = await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    GUEST_SYNC_NOT_DRAINED,
+  );
+
+  assert.equal(result.workspace.workspaceId, guestWorkspaceId);
+  assert.equal(result.outcome, "fresh_completion");
+  assert.equal(result.targetUserId, guestUserId);
+  assert.equal(result.targetWorkspaceId, guestWorkspaceId);
+  assert.equal(Object.hasOwn(result, "droppedEntities"), false);
+  assert.deepEqual(mergeOnlyQueries, []);
+  assert.equal(state.guestUpgradeHistory.length, 0);
+  assert.equal(state.guestReplicaAliases.length, 0);
+  assert.equal(state.guestSession?.revoked_at, null);
+  assert.equal(state.installations.get(installationId)?.user_id, guestUserId);
+  assert.equal(state.userSettings.get(guestUserId)?.workspace_id, guestWorkspaceId);
+  assert.equal(state.userSettings.get(linkedUserId)?.workspace_id, targetWorkspaceId);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
+});
+
+test("completeGuestUpgradeInExecutor preserves guest entity ids when merging into a different workspace", async () => {
+  const guestToken = "guest-token-preserved-ids";
   const guestUserId = "guest-user";
   const guestWorkspaceId = "guest-workspace";
   const targetUserId = "linked-user";
   const targetWorkspaceId = "target-workspace";
   const guestReplicaId = "guest-replica";
-  const installationId = "installation-forked-copy";
-  const targetSubject = "cognito-subject-forked-copy";
+  const installationId = "installation-preserved-ids";
+  const targetSubject = "cognito-subject-preserved-ids";
   const sourceCardId = "11111111-1111-4111-8111-111111111111";
   const sourceDeckId = "22222222-2222-4222-8222-222222222222";
   const sourceReviewEventId = "33333333-3333-4333-8333-333333333333";
 
   const state = createMergeState({
     guestToken,
-    guestSessionId: "guest-session-forked-copy",
+    guestSessionId: "guest-session-preserved-ids",
     guestUserId,
     guestWorkspaceId,
     targetSubject,
@@ -1109,7 +1840,7 @@ test("completeGuestUpgradeInExecutor deterministically forks copied ids into a d
   });
 
   const executor = createGuestUpgradeExecutor(state);
-  await completeGuestUpgradeInExecutor(
+  const result = await completeGuestUpgradeInExecutor(
     executor,
     guestToken,
     targetSubject,
@@ -1117,14 +1848,7 @@ test("completeGuestUpgradeInExecutor deterministically forks copied ids into a d
       type: "existing",
       workspaceId: targetWorkspaceId,
     },
-  );
-
-  const expectedCardId = forkCardIdForWorkspace(guestWorkspaceId, targetWorkspaceId, sourceCardId);
-  const expectedDeckId = forkDeckIdForWorkspace(guestWorkspaceId, targetWorkspaceId, sourceDeckId);
-  const expectedReviewEventId = forkReviewEventIdForWorkspace(
-    guestWorkspaceId,
-    targetWorkspaceId,
-    sourceReviewEventId,
+    DROPPED_ENTITIES_UNSUPPORTED,
   );
 
   const targetCard = state.cards.find((card) => card.workspace_id === targetWorkspaceId);
@@ -1132,17 +1856,815 @@ test("completeGuestUpgradeInExecutor deterministically forks copied ids into a d
   const targetReviewEvent = state.reviewEvents.find((reviewEvent) => reviewEvent.workspace_id === targetWorkspaceId);
 
   assert.ok(targetCard);
-  assert.equal(targetCard?.card_id, expectedCardId);
-  assert.notEqual(targetCard?.card_id, sourceCardId);
+  assert.equal(targetCard?.card_id, sourceCardId);
 
   assert.ok(targetDeck);
-  assert.equal(targetDeck?.deck_id, expectedDeckId);
-  assert.notEqual(targetDeck?.deck_id, sourceDeckId);
+  assert.equal(targetDeck?.deck_id, sourceDeckId);
 
   assert.ok(targetReviewEvent);
-  assert.equal(targetReviewEvent?.review_event_id, expectedReviewEventId);
-  assert.equal(targetReviewEvent?.card_id, expectedCardId);
-  assert.notEqual(targetReviewEvent?.review_event_id, sourceReviewEventId);
+  assert.equal(targetReviewEvent?.review_event_id, sourceReviewEventId);
+  assert.equal(targetReviewEvent?.card_id, sourceCardId);
+});
+
+test("completeGuestUpgradeInExecutor repairs legacy invalid guest card fsrs state during merge", async () => {
+  const guestToken = "guest-token-invalid-guest-card";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const guestReplicaId = "guest-replica";
+  const installationId = "installation-invalid-guest-card";
+  const targetSubject = "cognito-subject-invalid-guest-card";
+  const sourceCardId = "77777777-7777-4777-8777-777777777777";
+
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-invalid-guest-card",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.cards.push({
+    card_id: sourceCardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Legacy invalid front",
+    back_text: "Legacy invalid back",
+    tags: ["legacy"],
+    effort_level: "fast",
+    due_at: "2026-04-03T14:00:00.000Z",
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 3,
+    lapses: 1,
+    fsrs_card_state: "new",
+    fsrs_step_index: 0,
+    fsrs_stability: 0.212,
+    fsrs_difficulty: 6.4133,
+    fsrs_last_reviewed_at: "2026-04-02T14:00:01.000Z",
+    fsrs_scheduled_days: 1,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-invalid-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+  const result = await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_UNSUPPORTED,
+  );
+
+  const targetCard = state.cards.find((card) => (
+    card.workspace_id === targetWorkspaceId
+    && card.card_id === sourceCardId
+  ));
+
+  assert.ok(targetCard);
+  assert.equal(targetCard?.due_at, null);
+  assert.equal(targetCard?.reps, 0);
+  assert.equal(targetCard?.lapses, 0);
+  assert.equal(targetCard?.fsrs_card_state, "new");
+  assert.equal(targetCard?.fsrs_step_index, null);
+  assert.equal(targetCard?.fsrs_stability, null);
+  assert.equal(targetCard?.fsrs_difficulty, null);
+  assert.equal(targetCard?.fsrs_last_reviewed_at, null);
+  assert.equal(targetCard?.fsrs_scheduled_days, null);
+});
+
+test("completeGuestUpgradeInExecutor resolves same-id merge conflicts with LWW cards and idempotent review events", async () => {
+  const guestToken = "guest-token-same-id-conflicts";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const guestReplicaId = "guest-replica";
+  const installationId = "installation-same-id-conflicts";
+  const targetSubject = "cognito-subject-same-id-conflicts";
+  const sharedCardId = "44444444-4444-4444-8444-444444444444";
+  const sharedDeckId = "55555555-5555-4555-8555-555555555555";
+  const sharedReviewEventId = "66666666-6666-4666-8666-666666666666";
+
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-same-id-conflicts",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.cards.push({
+    card_id: sharedCardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Guest newer front",
+    back_text: "Guest newer back",
+    tags: ["guest"],
+    effort_level: "fast",
+    due_at: null,
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+  state.cards.push({
+    card_id: sharedCardId,
+    workspace_id: targetWorkspaceId,
+    front_text: "Target older front",
+    back_text: "Target older back",
+    tags: ["target"],
+    effort_level: "medium",
+    due_at: null,
+    created_at: "2026-04-02T13:59:59.000Z",
+    reps: 1,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:00.000Z",
+    last_modified_by_replica_id: "target-replica-existing",
+    last_operation_id: "target-card-op",
+    updated_at: "2026-04-02T14:00:00.000Z",
+    deleted_at: null,
+  });
+  state.decks.push({
+    deck_id: sharedDeckId,
+    workspace_id: guestWorkspaceId,
+    name: "Guest older deck",
+    filter_definition: {
+      version: 2,
+      effortLevels: ["fast"],
+      tags: ["guest"],
+    },
+    created_at: "2026-04-02T14:00:04.000Z",
+    client_updated_at: "2026-04-02T14:00:05.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-deck-op",
+    updated_at: "2026-04-02T14:00:05.000Z",
+    deleted_at: null,
+  });
+  state.decks.push({
+    deck_id: sharedDeckId,
+    workspace_id: targetWorkspaceId,
+    name: "Target newer deck",
+    filter_definition: {
+      version: 2,
+      effortLevels: ["medium"],
+      tags: ["target"],
+    },
+    created_at: "2026-04-02T13:59:59.000Z",
+    client_updated_at: "2026-04-02T14:10:00.000Z",
+    last_modified_by_replica_id: "target-replica-existing",
+    last_operation_id: "target-deck-op",
+    updated_at: "2026-04-02T14:10:00.000Z",
+    deleted_at: null,
+  });
+  state.reviewEvents.push({
+    review_event_id: sharedReviewEventId,
+    workspace_id: guestWorkspaceId,
+    card_id: sharedCardId,
+    replica_id: guestReplicaId,
+    client_event_id: "guest-client-event-1",
+    rating: 2,
+    reviewed_at_client: "2026-04-02T14:00:06.000Z",
+    reviewed_at_server: "2026-04-02T14:00:06.000Z",
+  });
+  state.reviewEvents.push({
+    review_event_id: sharedReviewEventId,
+    workspace_id: targetWorkspaceId,
+    card_id: sharedCardId,
+    replica_id: "target-replica-existing",
+    client_event_id: "target-client-event-1",
+    rating: 4,
+    reviewed_at_client: "2026-04-02T14:10:06.000Z",
+    reviewed_at_server: "2026-04-02T14:10:06.000Z",
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+  const result = await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_UNSUPPORTED,
+  );
+
+  const mergedCards = state.cards.filter((card) => card.card_id === sharedCardId);
+  const mergedDecks = state.decks.filter((deck) => deck.deck_id === sharedDeckId);
+  const mergedReviewEvents = state.reviewEvents.filter((reviewEvent) => reviewEvent.review_event_id === sharedReviewEventId);
+
+  assert.equal(mergedCards.length, 1);
+  assert.equal(mergedCards[0]?.workspace_id, targetWorkspaceId);
+  assert.equal(mergedCards[0]?.front_text, "Guest newer front");
+  assert.equal(mergedCards[0]?.back_text, "Guest newer back");
+
+  assert.equal(mergedDecks.length, 1);
+  assert.equal(mergedDecks[0]?.workspace_id, targetWorkspaceId);
+  assert.equal(mergedDecks[0]?.name, "Target newer deck");
+
+  assert.equal(mergedReviewEvents.length, 1);
+  assert.equal(mergedReviewEvents[0]?.workspace_id, targetWorkspaceId);
+  assert.equal(mergedReviewEvents[0]?.rating, 4);
+});
+
+test("completeGuestUpgradeInExecutor drops review events deduped to a different target id for capable clients", async () => {
+  const fixture = createReviewEventClientEventDedupMergeFixture();
+  const executor = createGuestUpgradeExecutor(fixture.state);
+  const result = await completeGuestUpgradeInExecutor(
+    executor,
+    fixture.guestToken,
+    fixture.targetSubject,
+    {
+      type: "existing",
+      workspaceId: fixture.targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_SUPPORTED,
+  );
+
+  assert.equal(result.outcome, "fresh_completion");
+  assert.deepEqual(result.droppedEntities, {
+    cardIds: [],
+    deckIds: [],
+    reviewEventIds: [fixture.guestReviewEventId],
+  });
+  assert.deepEqual(fixture.state.guestUpgradeHistory[0]?.dropped_entities, {
+    cardIds: [],
+    deckIds: [],
+    reviewEventIds: [fixture.guestReviewEventId],
+  });
+
+  const targetReviewEvents = fixture.state.reviewEvents.filter((reviewEvent) => (
+    reviewEvent.workspace_id === fixture.targetWorkspaceId
+  ));
+  assert.equal(targetReviewEvents.length, 1);
+  assert.equal(targetReviewEvents[0]?.review_event_id, fixture.targetReviewEventId);
+  assert.equal(
+    targetReviewEvents.some((reviewEvent) => reviewEvent.review_event_id === fixture.guestReviewEventId),
+    false,
+  );
+
+  const targetCard = fixture.state.cards.find((card) => (
+    card.workspace_id === fixture.targetWorkspaceId
+    && card.card_id === fixture.cardId
+  ));
+  assert.ok(targetCard);
+  assert.equal(targetCard?.front_text, "Guest front");
+});
+
+test("completeGuestUpgradeInExecutor rejects review events deduped to a different target id without droppedEntities support", async () => {
+  const fixture = createReviewEventClientEventDedupMergeFixture();
+  const executor = createGuestUpgradeExecutor(fixture.state);
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      fixture.guestToken,
+      fixture.targetSubject,
+      {
+        type: "existing",
+        workspaceId: fixture.targetWorkspaceId,
+      },
+      DROPPED_ENTITIES_UNSUPPORTED,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "GUEST_UPGRADE_DROPPED_ENTITIES_UNSUPPORTED");
+      assert.match(error.message, new RegExp(fixture.guestReviewEventId));
+      assert.match(error.message, new RegExp(fixture.targetReviewEventId));
+      return true;
+    },
+  );
+
+  assert.equal(fixture.state.guestUpgradeHistory.length, 0);
+  assert.equal(fixture.state.guestSession?.revoked_at, null);
+  assert.equal(
+    fixture.state.reviewEvents.some((reviewEvent) => (
+      reviewEvent.workspace_id === fixture.targetWorkspaceId
+      && reviewEvent.review_event_id === fixture.guestReviewEventId
+    )),
+    false,
+  );
+});
+
+test("completeGuestUpgradeInExecutor drops guest entities on third-workspace global-id conflicts and continues", async () => {
+  const guestToken = "guest-token-third-workspace-conflicts";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const guestReplicaId = "guest-replica";
+  const installationId = "installation-third-workspace-conflicts";
+  const targetSubject = "cognito-subject-third-workspace-conflicts";
+  const thirdUserId = "third-user";
+  const thirdWorkspaceId = "third-workspace";
+  const conflictingCardId = "77777777-7777-4777-8777-777777777777";
+  const mergedCardId = "88888888-8888-4888-8888-888888888888";
+  const conflictingDeckId = "99999999-9999-4999-8999-999999999999";
+  const conflictingReviewEventId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const skippedReviewEventId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const mergedReviewEventId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-third-workspace-conflicts",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.userSettings.set(
+    thirdUserId,
+    createUserSettingsState(thirdUserId, thirdWorkspaceId, "third@example.com"),
+  );
+  state.workspaces.set(
+    thirdWorkspaceId,
+    createWorkspaceState(
+      thirdWorkspaceId,
+      "Third workspace",
+      "2026-04-02T13:30:00.000Z",
+      "2026-04-02T13:30:00.000Z",
+      "third-replica-existing",
+      "third-op",
+    ),
+  );
+  addWorkspaceMembership(state, thirdUserId, thirdWorkspaceId, "owner");
+  state.cards.push({
+    card_id: conflictingCardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Guest conflicting front",
+    back_text: "Guest conflicting back",
+    tags: ["guest-conflict"],
+    effort_level: "fast",
+    due_at: null,
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-conflicting-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+  state.cards.push({
+    card_id: mergedCardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Guest kept front",
+    back_text: "Guest kept back",
+    tags: ["guest-kept"],
+    effort_level: "medium",
+    due_at: null,
+    created_at: "2026-04-02T14:00:04.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:05.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-kept-card-op",
+    updated_at: "2026-04-02T14:00:05.000Z",
+    deleted_at: null,
+  });
+  state.cards.push({
+    card_id: conflictingCardId,
+    workspace_id: thirdWorkspaceId,
+    front_text: "Third workspace front",
+    back_text: "Third workspace back",
+    tags: ["third"],
+    effort_level: "long",
+    due_at: null,
+    created_at: "2026-04-02T13:30:02.000Z",
+    reps: 5,
+    lapses: 1,
+    fsrs_card_state: "review",
+    fsrs_step_index: null,
+    fsrs_stability: 3.5,
+    fsrs_difficulty: 5.1,
+    fsrs_last_reviewed_at: "2026-04-01T13:30:00.000Z",
+    fsrs_scheduled_days: 4,
+    client_updated_at: "2026-04-02T13:30:03.000Z",
+    last_modified_by_replica_id: "third-replica-existing",
+    last_operation_id: "third-card-op",
+    updated_at: "2026-04-02T13:30:03.000Z",
+    deleted_at: null,
+  });
+  state.decks.push({
+    deck_id: conflictingDeckId,
+    workspace_id: guestWorkspaceId,
+    name: "Guest conflicting deck",
+    filter_definition: {
+      version: 2,
+      effortLevels: ["fast"],
+      tags: ["guest-conflict"],
+    },
+    created_at: "2026-04-02T14:00:06.000Z",
+    client_updated_at: "2026-04-02T14:00:07.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-conflicting-deck-op",
+    updated_at: "2026-04-02T14:00:07.000Z",
+    deleted_at: null,
+  });
+  state.decks.push({
+    deck_id: conflictingDeckId,
+    workspace_id: thirdWorkspaceId,
+    name: "Third workspace deck",
+    filter_definition: {
+      version: 2,
+      effortLevels: ["long"],
+      tags: ["third"],
+    },
+    created_at: "2026-04-02T13:30:04.000Z",
+    client_updated_at: "2026-04-02T13:30:05.000Z",
+    last_modified_by_replica_id: "third-replica-existing",
+    last_operation_id: "third-deck-op",
+    updated_at: "2026-04-02T13:30:05.000Z",
+    deleted_at: null,
+  });
+  state.reviewEvents.push({
+    review_event_id: skippedReviewEventId,
+    workspace_id: guestWorkspaceId,
+    card_id: conflictingCardId,
+    replica_id: guestReplicaId,
+    client_event_id: "guest-skipped-client-event",
+    rating: 1,
+    reviewed_at_client: "2026-04-02T14:00:08.000Z",
+    reviewed_at_server: "2026-04-02T14:00:08.000Z",
+  });
+  state.reviewEvents.push({
+    review_event_id: conflictingReviewEventId,
+    workspace_id: guestWorkspaceId,
+    card_id: mergedCardId,
+    replica_id: guestReplicaId,
+    client_event_id: "guest-conflicting-review-event",
+    rating: 2,
+    reviewed_at_client: "2026-04-02T14:00:09.000Z",
+    reviewed_at_server: "2026-04-02T14:00:09.000Z",
+  });
+  state.reviewEvents.push({
+    review_event_id: mergedReviewEventId,
+    workspace_id: guestWorkspaceId,
+    card_id: mergedCardId,
+    replica_id: guestReplicaId,
+    client_event_id: "guest-kept-review-event",
+    rating: 3,
+    reviewed_at_client: "2026-04-02T14:00:10.000Z",
+    reviewed_at_server: "2026-04-02T14:00:10.000Z",
+  });
+  state.reviewEvents.push({
+    review_event_id: conflictingReviewEventId,
+    workspace_id: thirdWorkspaceId,
+    card_id: conflictingCardId,
+    replica_id: "third-replica-existing",
+    client_event_id: "third-review-event",
+    rating: 4,
+    reviewed_at_client: "2026-04-02T13:30:06.000Z",
+    reviewed_at_server: "2026-04-02T13:30:06.000Z",
+  });
+
+  const expectedDroppedEntities = {
+    cardIds: [conflictingCardId],
+    deckIds: [conflictingDeckId],
+    reviewEventIds: [skippedReviewEventId, conflictingReviewEventId],
+  };
+
+  const executor = createGuestUpgradeExecutor(state);
+  const firstResult = await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_SUPPORTED,
+  );
+  const secondResult = await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_SUPPORTED,
+  );
+
+  assert.equal(firstResult.outcome, "fresh_completion");
+  assert.deepEqual(firstResult.droppedEntities, expectedDroppedEntities);
+  assert.equal(secondResult.outcome, "idempotent_replay");
+  assert.deepEqual(secondResult.droppedEntities, expectedDroppedEntities);
+  assert.deepEqual(state.guestUpgradeHistory[0]?.dropped_entities, expectedDroppedEntities);
+
+  assert.equal(state.cards.some((card) => card.workspace_id === guestWorkspaceId), false);
+  assert.equal(state.decks.some((deck) => deck.workspace_id === guestWorkspaceId), false);
+  assert.equal(state.reviewEvents.some((reviewEvent) => reviewEvent.workspace_id === guestWorkspaceId), false);
+
+  const keptTargetCard = state.cards.find((card) => (
+    card.workspace_id === targetWorkspaceId
+    && card.card_id === mergedCardId
+  ));
+  assert.ok(keptTargetCard);
+  assert.equal(keptTargetCard?.front_text, "Guest kept front");
+  assert.equal(keptTargetCard?.back_text, "Guest kept back");
+
+  const conflictingCards = state.cards.filter((card) => card.card_id === conflictingCardId);
+  assert.equal(conflictingCards.length, 1);
+  assert.equal(conflictingCards[0]?.workspace_id, thirdWorkspaceId);
+
+  const conflictingDecks = state.decks.filter((deck) => deck.deck_id === conflictingDeckId);
+  assert.equal(conflictingDecks.length, 1);
+  assert.equal(conflictingDecks[0]?.workspace_id, thirdWorkspaceId);
+
+  assert.equal(
+    state.reviewEvents.some((reviewEvent) => (
+      reviewEvent.workspace_id === targetWorkspaceId
+      && reviewEvent.review_event_id === skippedReviewEventId
+    )),
+    false,
+  );
+
+  const keptTargetReviewEvent = state.reviewEvents.find((reviewEvent) => (
+    reviewEvent.workspace_id === targetWorkspaceId
+    && reviewEvent.review_event_id === mergedReviewEventId
+  ));
+  assert.ok(keptTargetReviewEvent);
+  assert.equal(keptTargetReviewEvent?.card_id, mergedCardId);
+  assert.equal(keptTargetReviewEvent?.rating, 3);
+
+  const conflictingReviewEvents = state.reviewEvents.filter((reviewEvent) => (
+    reviewEvent.review_event_id === conflictingReviewEventId
+  ));
+  assert.equal(conflictingReviewEvents.length, 1);
+  assert.equal(conflictingReviewEvents[0]?.workspace_id, thirdWorkspaceId);
+});
+
+test("completeGuestUpgradeInExecutor rejects third-workspace global-id conflicts without droppedEntities support", async () => {
+  const guestToken = "guest-token-third-workspace-unsupported";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const guestReplicaId = "guest-replica";
+  const installationId = "installation-third-workspace-unsupported";
+  const targetSubject = "cognito-subject-third-workspace-unsupported";
+  const thirdUserId = "third-user";
+  const thirdWorkspaceId = "third-workspace";
+  const conflictingCardId = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-third-workspace-unsupported",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.userSettings.set(
+    thirdUserId,
+    createUserSettingsState(thirdUserId, thirdWorkspaceId, "third@example.com"),
+  );
+  state.workspaces.set(
+    thirdWorkspaceId,
+    createWorkspaceState(
+      thirdWorkspaceId,
+      "Third workspace",
+      "2026-04-02T13:30:00.000Z",
+      "2026-04-02T13:30:00.000Z",
+      "third-replica-existing",
+      "third-op",
+    ),
+  );
+  addWorkspaceMembership(state, thirdUserId, thirdWorkspaceId, "owner");
+  state.cards.push({
+    card_id: conflictingCardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Guest conflicting front",
+    back_text: "Guest conflicting back",
+    tags: ["guest-conflict"],
+    effort_level: "fast",
+    due_at: null,
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-conflicting-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+  state.cards.push({
+    card_id: conflictingCardId,
+    workspace_id: thirdWorkspaceId,
+    front_text: "Third workspace front",
+    back_text: "Third workspace back",
+    tags: ["third"],
+    effort_level: "long",
+    due_at: null,
+    created_at: "2026-04-02T13:30:02.000Z",
+    reps: 5,
+    lapses: 1,
+    fsrs_card_state: "review",
+    fsrs_step_index: null,
+    fsrs_stability: 3.5,
+    fsrs_difficulty: 5.1,
+    fsrs_last_reviewed_at: "2026-04-01T13:30:00.000Z",
+    fsrs_scheduled_days: 4,
+    client_updated_at: "2026-04-02T13:30:03.000Z",
+    last_modified_by_replica_id: "third-replica-existing",
+    last_operation_id: "third-card-op",
+    updated_at: "2026-04-02T13:30:03.000Z",
+    deleted_at: null,
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      guestToken,
+      targetSubject,
+      {
+        type: "existing",
+        workspaceId: targetWorkspaceId,
+      },
+      DROPPED_ENTITIES_UNSUPPORTED,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "GUEST_UPGRADE_DROPPED_ENTITIES_UNSUPPORTED");
+      assert.equal(error.message.includes(thirdWorkspaceId), false);
+      assert.deepEqual(error.details?.syncConflict, {
+        phase: "guest_upgrade_merge",
+        entityType: "card",
+        entityId: conflictingCardId,
+        conflictingWorkspaceId: thirdWorkspaceId,
+        constraint: null,
+        sqlState: null,
+        table: null,
+        recoverable: true,
+      });
+      return true;
+    },
+  );
+
+  assert.equal(state.guestUpgradeHistory.length, 0);
+  assert.equal(state.guestSession?.revoked_at, null);
+  assert.equal(
+    state.cards.some((card) => (
+      card.workspace_id === targetWorkspaceId
+      && card.card_id === conflictingCardId
+    )),
+    false,
+  );
+});
+
+test("completeGuestUpgradeInExecutor aborts when a conflict still points at the source guest workspace after cleanup", async () => {
+  const guestToken = "guest-token-source-conflict";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const guestReplicaId = "guest-replica-source-conflict";
+  const installationId = "installation-source-conflict";
+  const targetSubject = "cognito-subject-source-conflict";
+  const conflictingCardId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-source-conflict",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.cards.push({
+    card_id: conflictingCardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Guest source front",
+    back_text: "Guest source back",
+    tags: ["guest-source"],
+    effort_level: "fast",
+    due_at: null,
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-source-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+
+  const baseExecutor = createGuestUpgradeExecutor(state);
+  const executor: DatabaseExecutor = {
+    query: async (text, params) => {
+      if (text === "DELETE FROM content.cards WHERE workspace_id = $1") {
+        return createQueryResult([]);
+      }
+
+      return baseExecutor.query(text, params);
+    },
+  };
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      guestToken,
+      targetSubject,
+      {
+        type: "existing",
+        workspaceId: targetWorkspaceId,
+      },
+      DROPPED_ENTITIES_UNSUPPORTED,
+    ),
+    (error: unknown) => (
+      error instanceof Error
+      && error.message
+        === "Guest merge cleanup invariant failed for card dddddddd-dddd-4ddd-8ddd-dddddddddddd: "
+          + "source workspace guest-workspace still owns the conflicting id after cleanup"
+    ),
+  );
+
+  assert.equal(
+    state.cards.some((card) => (
+      card.workspace_id === targetWorkspaceId
+      && card.card_id === conflictingCardId
+    )),
+    false,
+  );
+  assert.equal(state.cards.filter((card) => card.card_id === conflictingCardId).length, 1);
+  assert.equal(state.cards[0]?.workspace_id, guestWorkspaceId);
+  assert.equal(state.guestSession?.revoked_at, null);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
 });
 
 test("deleteGuestSessionInExecutor revokes and removes guest server state", async () => {
@@ -1166,7 +2688,7 @@ test("deleteGuestSessionInExecutor revokes and removes guest server state", asyn
   const executor = createGuestUpgradeExecutor(state);
   await deleteGuestSessionInExecutor(executor, guestToken);
 
-  assert.equal(state.guestSession.revoked_at, "2026-04-02T14:01:16.000Z");
+  assert.equal(state.guestSession, null);
   assert.equal(state.userSettings.has(guestUserId), false);
   assert.equal(state.workspaces.has(guestWorkspaceId), false);
   assert.equal(
@@ -1204,9 +2726,45 @@ test("cleanupGuestSessionSourceInExecutor re-scopes to the guest user before che
     guestWorkspaceId,
   );
 
-  assert.equal(state.guestSession.revoked_at, "2026-04-02T14:01:16.000Z");
+  assert.equal(state.guestSession, null);
   assert.equal(state.userSettings.has(guestUserId), false);
   assert.equal(state.workspaces.has(guestWorkspaceId), false);
+});
+
+test("deleteGuestSessionInExecutor rejects guest cleanup when the guest user is not the workspace owner", async () => {
+  const guestToken = "guest-token-delete-non-owner";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-delete-non-owner",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject: "cognito-subject-delete-non-owner",
+    targetUserId: "linked-user",
+    targetWorkspaceId: "target-workspace",
+    guestReplicaId: "guest-replica-delete-non-owner",
+    installationId: "installation-delete-non-owner",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.workspaceMembershipRoles.set(membershipKey(guestUserId, guestWorkspaceId), "member");
+
+  const executor = createGuestUpgradeExecutor(state);
+
+  await assert.rejects(
+    deleteGuestSessionInExecutor(executor, guestToken),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 403);
+      assert.equal(error.code, "WORKSPACE_OWNER_REQUIRED");
+      return true;
+    },
+  );
+
+  assert.equal(state.guestSession?.revoked_at, null);
+  assert.equal(state.userSettings.has(guestUserId), true);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
 });
 
 test("deleteGuestSessionInExecutor rejects guest cleanup for a shared workspace", async () => {
@@ -1226,7 +2784,7 @@ test("deleteGuestSessionInExecutor rejects guest cleanup for a shared workspace"
     guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
     targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
   });
-  state.workspaceMemberships.add(membershipKey("shared-user", guestWorkspaceId));
+  addWorkspaceMembership(state, "shared-user", guestWorkspaceId, "member");
 
   const executor = createGuestUpgradeExecutor(state);
 
@@ -1240,7 +2798,7 @@ test("deleteGuestSessionInExecutor rejects guest cleanup for a shared workspace"
     },
   );
 
-  assert.equal(state.guestSession.revoked_at, null);
+  assert.equal(state.guestSession?.revoked_at, null);
   assert.equal(state.userSettings.has(guestUserId), true);
   assert.equal(state.workspaces.has(guestWorkspaceId), true);
   assert.equal(
@@ -1319,7 +2877,7 @@ test("deleteGuestSessionInExecutor rejects cleanup after a bound guest upgrade",
     },
   );
 
-  assert.equal(state.guestSession.revoked_at, null);
+  assert.equal(state.guestSession?.revoked_at, null);
   assert.equal(state.userSettings.has(guestUserId), true);
   assert.equal(state.workspaces.has(guestWorkspaceId), true);
   assert.equal(state.identityMappings.get(cognitoSubject), guestUserId);
@@ -1357,6 +2915,7 @@ test("completeGuestUpgradeInExecutor with create_new creates and selects a new t
     {
       type: "create_new",
     },
+    DROPPED_ENTITIES_UNSUPPORTED,
   );
 
   assert.equal(result.outcome, "fresh_completion");
@@ -1393,6 +2952,7 @@ test("completeGuestUpgradeInExecutor applies guest scheduler settings when guest
       type: "existing",
       workspaceId: targetWorkspaceId,
     },
+    DROPPED_ENTITIES_UNSUPPORTED,
   );
 
   const targetWorkspace = state.workspaces.get(targetWorkspaceId);
@@ -1426,6 +2986,7 @@ test("completeGuestUpgradeInExecutor leaves target scheduler settings when targe
       type: "existing",
       workspaceId: targetWorkspaceId,
     },
+    DROPPED_ENTITIES_UNSUPPORTED,
   );
 
   const targetWorkspace = state.workspaces.get(targetWorkspaceId);
@@ -1433,7 +2994,7 @@ test("completeGuestUpgradeInExecutor leaves target scheduler settings when targe
   assert.equal(targetWorkspace?.fsrs_last_modified_by_replica_id, "target-replica-existing");
 });
 
-test("completeGuestUpgradeInExecutor replays a revoked guest upgrade for the same subject", async () => {
+test("completeGuestUpgradeInExecutor replays committed history after guest session cleanup", async () => {
   const guestToken = "guest-token-2";
   const guestUserId = "guest-user";
   const guestWorkspaceId = "guest-workspace";
@@ -1466,7 +3027,11 @@ test("completeGuestUpgradeInExecutor replays a revoked guest upgrade for the sam
       type: "existing",
       workspaceId: targetWorkspaceId,
     },
+    DROPPED_ENTITIES_UNSUPPORTED,
   );
+  assert.equal(firstResult.outcome, "fresh_completion");
+  assert.equal(state.guestSession, null);
+
   const secondResult = await completeGuestUpgradeInExecutor(
     executor,
     guestToken,
@@ -1475,13 +3040,146 @@ test("completeGuestUpgradeInExecutor replays a revoked guest upgrade for the sam
       type: "existing",
       workspaceId: targetWorkspaceId,
     },
+    DROPPED_ENTITIES_UNSUPPORTED,
   );
 
-  assert.equal(firstResult.outcome, "fresh_completion");
   assert.equal(secondResult.outcome, "idempotent_replay");
   assert.equal(secondResult.workspace.workspaceId, targetWorkspaceId);
   assert.equal(secondResult.targetUserId, targetUserId);
   assert.equal(state.guestUpgradeHistory.length, 1);
+  assert.equal(state.guestUpgradeHistory[0]?.source_guest_session_secret_hash, hashGuestToken(guestToken));
+  assert.notEqual(state.guestUpgradeHistory[0]?.source_guest_session_secret_hash, guestToken);
+});
+
+test("completeGuestUpgradeInExecutor replays deleted-session history without guest drain when no entities were dropped", async () => {
+  const guestToken = "guest-token-legacy-replay";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const targetSubject = "cognito-subject-legacy-replay";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-legacy-replay",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId: "guest-replica-legacy-replay",
+    installationId: "installation-legacy-replay",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+  await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_UNSUPPORTED,
+  );
+  const result = await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    LEGACY_REPLAY_CAPABILITIES,
+  );
+
+  assert.equal(result.outcome, "idempotent_replay");
+  assert.equal(result.workspace.workspaceId, targetWorkspaceId);
+  assert.equal(result.targetUserId, targetUserId);
+  assert.equal(Object.hasOwn(result, "droppedEntities"), false);
+  assert.equal(state.guestUpgradeHistory.length, 1);
+});
+
+test("completeGuestUpgradeInExecutor rejects missing guest session without replay history", async () => {
+  const guestToken = "guest-token-missing-no-history";
+  const targetWorkspaceId = "target-workspace";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-missing-no-history",
+    guestUserId: "guest-user",
+    guestWorkspaceId: "guest-workspace",
+    targetSubject: "cognito-subject-missing-no-history",
+    targetUserId: "linked-user",
+    targetWorkspaceId,
+    guestReplicaId: "guest-replica-missing-no-history",
+    installationId: "installation-missing-no-history",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.guestSession = null;
+
+  const executor = createGuestUpgradeExecutor(state);
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      guestToken,
+      "cognito-subject-missing-no-history",
+      {
+        type: "existing",
+        workspaceId: targetWorkspaceId,
+      },
+      DROPPED_ENTITIES_UNSUPPORTED,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 401);
+      assert.equal(error.code, "GUEST_AUTH_INVALID");
+      return true;
+    },
+  );
+});
+
+test("completeGuestUpgradeInExecutor rejects deleted-session replay with dropped entities for legacy clients", async () => {
+  const fixture = createReviewEventClientEventDedupMergeFixture();
+  const executor = createGuestUpgradeExecutor(fixture.state);
+  await completeGuestUpgradeInExecutor(
+    executor,
+    fixture.guestToken,
+    fixture.targetSubject,
+    {
+      type: "existing",
+      workspaceId: fixture.targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_SUPPORTED,
+  );
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      fixture.guestToken,
+      fixture.targetSubject,
+      {
+        type: "existing",
+        workspaceId: fixture.targetWorkspaceId,
+      },
+      LEGACY_REPLAY_CAPABILITIES,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "GUEST_UPGRADE_DROPPED_ENTITIES_UNSUPPORTED");
+      return true;
+    },
+  );
+
+  assert.deepEqual(fixture.state.guestUpgradeHistory[0]?.dropped_entities, {
+    cardIds: [],
+    deckIds: [],
+    reviewEventIds: [fixture.guestReviewEventId],
+  });
+  assert.equal(fixture.state.guestSession, null);
 });
 
 test("completeGuestUpgradeInExecutor rejects a replay from a different subject", async () => {
@@ -1517,6 +3215,9 @@ test("completeGuestUpgradeInExecutor rejects a replay from a different subject",
     workspaceMemberships: new Set<string>([
       membershipKey("linked-user", targetWorkspaceId),
     ]),
+    workspaceMembershipRoles: new Map<string, WorkspaceMembershipRole>([
+      [membershipKey("linked-user", targetWorkspaceId), "owner"],
+    ]),
     workspaceReplicas: [],
     installations: new Map<string, InstallationState>(),
     cards: [],
@@ -1527,12 +3228,15 @@ test("completeGuestUpgradeInExecutor rejects a replay from a different subject",
       source_guest_user_id: guestUserId,
       source_guest_workspace_id: "guest-workspace",
       source_guest_session_id: guestSessionId,
+      source_guest_session_secret_hash: hashGuestToken(guestToken),
       target_subject_user_id: "original-subject",
       target_user_id: "linked-user",
       target_workspace_id: targetWorkspaceId,
       selection_type: "existing",
+      dropped_entities: null,
     }],
     guestReplicaAliases: [],
+    hotChanges: [],
   };
 
   const executor = createGuestUpgradeExecutor(state);
@@ -1546,6 +3250,7 @@ test("completeGuestUpgradeInExecutor rejects a replay from a different subject",
         type: "existing",
         workspaceId: targetWorkspaceId,
       },
+      DROPPED_ENTITIES_UNSUPPORTED,
     ),
     (error: unknown) => (
       error instanceof HttpError
@@ -1574,6 +3279,7 @@ test("completeGuestUpgradeInExecutor rejects a revoked guest session without rep
     userSettings: new Map<string, UserSettingsState>(),
     workspaces: new Map<string, WorkspaceState>(),
     workspaceMemberships: new Set<string>(),
+    workspaceMembershipRoles: new Map<string, WorkspaceMembershipRole>(),
     workspaceReplicas: [],
     installations: new Map<string, InstallationState>(),
     cards: [],
@@ -1581,6 +3287,7 @@ test("completeGuestUpgradeInExecutor rejects a revoked guest session without rep
     reviewEvents: [],
     guestUpgradeHistory: [],
     guestReplicaAliases: [],
+    hotChanges: [],
   };
 
   const executor = createGuestUpgradeExecutor(state);
@@ -1593,6 +3300,7 @@ test("completeGuestUpgradeInExecutor rejects a revoked guest session without rep
       {
         type: "create_new",
       },
+      DROPPED_ENTITIES_UNSUPPORTED,
     ),
     (error: unknown) => (
       error instanceof HttpError

--- a/apps/backend/src/guestAuth.test.ts
+++ b/apps/backend/src/guestAuth.test.ts
@@ -8,7 +8,13 @@ import {
   deleteGuestSessionInExecutor,
   prepareGuestUpgradeInExecutor,
 } from "./guestAuth";
+import { cleanupGuestSessionSourceInExecutor } from "./guestAuth/delete";
 import { HttpError } from "./errors";
+import {
+  forkCardIdForWorkspace,
+  forkDeckIdForWorkspace,
+  forkReviewEventIdForWorkspace,
+} from "./sync/fork";
 
 type GuestSessionState = Readonly<{
   session_id: string;
@@ -414,6 +420,39 @@ function createGuestUpgradeExecutor(state: MutableState): DatabaseExecutor {
           workspace_id: workspace.workspace_id,
           name: workspace.name,
           created_at: workspace.created_at,
+        } as unknown as Row];
+        return createQueryResult<Row>(rows);
+      }
+
+      if (
+        text.includes("FROM org.workspace_memberships memberships")
+        && text.includes("memberships.role")
+        && text.includes("AS member_count")
+      ) {
+        const userId = params[0];
+        const workspaceId = params[1];
+        if (typeof userId !== "string" || typeof workspaceId !== "string") {
+          return createQueryResult<Row>([]);
+        }
+
+        if (state.currentUserId !== userId) {
+          return createQueryResult<Row>([]);
+        }
+
+        if (!state.workspaceMemberships.has(membershipKey(userId, workspaceId))) {
+          return createQueryResult<Row>([]);
+        }
+
+        const workspace = state.workspaces.get(workspaceId);
+        const memberCount = [...state.workspaceMemberships]
+          .filter((membership) => membership.endsWith(`:${workspaceId}`))
+          .length;
+        const rows = workspace === undefined ? [] : [{
+          workspace_id: workspace.workspace_id,
+          name: workspace.name,
+          created_at: workspace.created_at,
+          role: "owner",
+          member_count: memberCount,
         } as unknown as Row];
         return createQueryResult<Row>(rows);
       }
@@ -945,6 +984,167 @@ test("completeGuestUpgradeInExecutor reassigns guest installation ownership duri
   assert.equal(targetReplica?.user_id, targetUserId);
 });
 
+test("completeGuestUpgradeInExecutor rejects selecting the guest workspace as the merge target", async () => {
+  const guestToken = "guest-token-same-workspace";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const installationId = "installation-same-workspace";
+  const targetSubject = "cognito-subject-same-workspace";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-same-workspace",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId: "target-workspace",
+    guestReplicaId: "guest-replica-same-workspace",
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.workspaceMemberships.add(membershipKey(targetUserId, guestWorkspaceId));
+
+  const executor = createGuestUpgradeExecutor(state);
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      guestToken,
+      targetSubject,
+      {
+        type: "existing",
+        workspaceId: guestWorkspaceId,
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "GUEST_UPGRADE_TARGET_SAME_AS_SOURCE");
+      return true;
+    },
+  );
+
+  assert.equal(state.guestSession.revoked_at, null);
+  assert.equal(state.guestUpgradeHistory.length, 0);
+  assert.equal(state.installations.get(installationId)?.user_id, guestUserId);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
+});
+
+test("completeGuestUpgradeInExecutor deterministically forks copied ids into a different workspace", async () => {
+  const guestToken = "guest-token-forked-copy";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const guestReplicaId = "guest-replica";
+  const installationId = "installation-forked-copy";
+  const targetSubject = "cognito-subject-forked-copy";
+  const sourceCardId = "11111111-1111-4111-8111-111111111111";
+  const sourceDeckId = "22222222-2222-4222-8222-222222222222";
+  const sourceReviewEventId = "33333333-3333-4333-8333-333333333333";
+
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-forked-copy",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.cards.push({
+    card_id: sourceCardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Front",
+    back_text: "Back",
+    tags: ["tag"],
+    effort_level: "fast",
+    due_at: null,
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+  state.decks.push({
+    deck_id: sourceDeckId,
+    workspace_id: guestWorkspaceId,
+    name: "Deck",
+    filter_definition: {
+      version: 2,
+      effortLevels: ["fast"],
+      tags: ["tag"],
+    },
+    created_at: "2026-04-02T14:00:04.000Z",
+    client_updated_at: "2026-04-02T14:00:05.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-deck-op",
+    updated_at: "2026-04-02T14:00:05.000Z",
+    deleted_at: null,
+  });
+  state.reviewEvents.push({
+    review_event_id: sourceReviewEventId,
+    workspace_id: guestWorkspaceId,
+    card_id: sourceCardId,
+    replica_id: guestReplicaId,
+    client_event_id: "client-event-1",
+    rating: 3,
+    reviewed_at_client: "2026-04-02T14:00:06.000Z",
+    reviewed_at_server: "2026-04-02T14:00:06.000Z",
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+  await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+  );
+
+  const expectedCardId = forkCardIdForWorkspace(guestWorkspaceId, targetWorkspaceId, sourceCardId);
+  const expectedDeckId = forkDeckIdForWorkspace(guestWorkspaceId, targetWorkspaceId, sourceDeckId);
+  const expectedReviewEventId = forkReviewEventIdForWorkspace(
+    guestWorkspaceId,
+    targetWorkspaceId,
+    sourceReviewEventId,
+  );
+
+  const targetCard = state.cards.find((card) => card.workspace_id === targetWorkspaceId);
+  const targetDeck = state.decks.find((deck) => deck.workspace_id === targetWorkspaceId);
+  const targetReviewEvent = state.reviewEvents.find((reviewEvent) => reviewEvent.workspace_id === targetWorkspaceId);
+
+  assert.ok(targetCard);
+  assert.equal(targetCard?.card_id, expectedCardId);
+  assert.notEqual(targetCard?.card_id, sourceCardId);
+
+  assert.ok(targetDeck);
+  assert.equal(targetDeck?.deck_id, expectedDeckId);
+  assert.notEqual(targetDeck?.deck_id, sourceDeckId);
+
+  assert.ok(targetReviewEvent);
+  assert.equal(targetReviewEvent?.review_event_id, expectedReviewEventId);
+  assert.equal(targetReviewEvent?.card_id, expectedCardId);
+  assert.notEqual(targetReviewEvent?.review_event_id, sourceReviewEventId);
+});
+
 test("deleteGuestSessionInExecutor revokes and removes guest server state", async () => {
   const guestToken = "guest-token-delete";
   const guestUserId = "guest-user";
@@ -972,6 +1172,80 @@ test("deleteGuestSessionInExecutor revokes and removes guest server state", asyn
   assert.equal(
     state.workspaceReplicas.some((replica) => replica.workspace_id === guestWorkspaceId),
     false,
+  );
+});
+
+test("cleanupGuestSessionSourceInExecutor re-scopes to the guest user before checking cleanup invariants", async () => {
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const targetUserId = "linked-user";
+  const targetWorkspaceId = "target-workspace";
+  const state = createMergeState({
+    guestToken: "guest-token-cleanup-rescope",
+    guestSessionId: "guest-session-cleanup-rescope",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject: "cognito-subject-cleanup-rescope",
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId: "guest-replica-cleanup-rescope",
+    installationId: "installation-cleanup-rescope",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.currentUserId = targetUserId;
+  state.currentWorkspaceId = targetWorkspaceId;
+
+  const executor = createGuestUpgradeExecutor(state);
+  await cleanupGuestSessionSourceInExecutor(
+    executor,
+    guestUserId,
+    "guest-session-cleanup-rescope",
+    guestWorkspaceId,
+  );
+
+  assert.equal(state.guestSession.revoked_at, "2026-04-02T14:01:16.000Z");
+  assert.equal(state.userSettings.has(guestUserId), false);
+  assert.equal(state.workspaces.has(guestWorkspaceId), false);
+});
+
+test("deleteGuestSessionInExecutor rejects guest cleanup for a shared workspace", async () => {
+  const guestToken = "guest-token-delete-shared";
+  const guestUserId = "guest-user";
+  const guestWorkspaceId = "guest-workspace";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-delete-shared",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject: "cognito-subject-delete-shared",
+    targetUserId: "linked-user",
+    targetWorkspaceId: "target-workspace",
+    guestReplicaId: "guest-replica-delete-shared",
+    installationId: "installation-delete-shared",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.workspaceMemberships.add(membershipKey("shared-user", guestWorkspaceId));
+
+  const executor = createGuestUpgradeExecutor(state);
+
+  await assert.rejects(
+    deleteGuestSessionInExecutor(executor, guestToken),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "WORKSPACE_DELETE_SHARED");
+      return true;
+    },
+  );
+
+  assert.equal(state.guestSession.revoked_at, null);
+  assert.equal(state.userSettings.has(guestUserId), true);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
+  assert.equal(
+    state.workspaceReplicas.some((replica) => replica.workspace_id === guestWorkspaceId),
+    true,
   );
 });
 

--- a/apps/backend/src/guestAuth.ts
+++ b/apps/backend/src/guestAuth.ts
@@ -11,6 +11,7 @@ import {
   prepareGuestUpgradeInExecutor,
 } from "./guestAuth/upgrade";
 import type {
+  GuestUpgradeCompleteCapabilities,
   GuestSessionSnapshot,
   GuestUpgradeCompletion,
   GuestUpgradePreparation,
@@ -18,6 +19,7 @@ import type {
 } from "./guestAuth/types";
 
 export type {
+  GuestUpgradeCompleteCapabilities,
   GuestSessionSnapshot,
   GuestUpgradeCompletion,
   GuestUpgradePreparation,
@@ -49,9 +51,16 @@ export async function completeGuestUpgrade(
   guestToken: string,
   cognitoSubject: string,
   selection: GuestUpgradeSelection,
+  capabilities: GuestUpgradeCompleteCapabilities,
 ): Promise<GuestUpgradeCompletion> {
   return unsafeTransaction(
-    async (executor) => completeGuestUpgradeInExecutor(executor, guestToken, cognitoSubject, selection),
+    async (executor) => completeGuestUpgradeInExecutor(
+      executor,
+      guestToken,
+      cognitoSubject,
+      selection,
+      capabilities,
+    ),
   );
 }
 

--- a/apps/backend/src/guestAuth/delete.ts
+++ b/apps/backend/src/guestAuth/delete.ts
@@ -10,8 +10,8 @@ import {
 } from "../workspaces/shared";
 import {
   deleteUserSettingsInExecutor,
+  deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor,
   hasCognitoIdentityMappingForUserInExecutor,
-  deleteWorkspaceInExecutor as deleteGuestWorkspaceInExecutor,
   loadGuestSessionInExecutor,
   loadGuestWorkspaceIdInExecutor,
   revokeGuestSessionInExecutor,
@@ -38,9 +38,17 @@ export async function cleanupGuestSessionSourceInExecutor(
   guestSessionId: string,
   guestWorkspaceId: string,
 ): Promise<void> {
-  await assertGuestWorkspaceCleanupAllowedInExecutor(executor, guestUserId, guestWorkspaceId);
+  const deletedWorkspace = await deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor(
+    executor,
+    guestUserId,
+    guestWorkspaceId,
+  );
+  if (!deletedWorkspace) {
+    await assertGuestWorkspaceCleanupAllowedInExecutor(executor, guestUserId, guestWorkspaceId);
+    throw new Error(`Guest workspace cleanup delete did not remove workspace ${guestWorkspaceId}`);
+  }
+
   await revokeGuestSessionInExecutor(executor, guestUserId, guestSessionId);
-  await deleteGuestWorkspaceInExecutor(executor, guestUserId, guestWorkspaceId);
   await deleteUserSettingsInExecutor(executor, guestUserId);
 }
 

--- a/apps/backend/src/guestAuth/delete.ts
+++ b/apps/backend/src/guestAuth/delete.ts
@@ -1,13 +1,36 @@
-import type { DatabaseExecutor } from "../db";
+import {
+  applyUserDatabaseScopeInExecutor,
+  type DatabaseExecutor,
+} from "../db";
 import { HttpError } from "../errors";
+import { loadWorkspaceManagementRowInExecutor } from "../workspaces/queries";
+import {
+  assertWorkspaceIsSoleMember,
+  assertWorkspaceOwner,
+} from "../workspaces/shared";
 import {
   deleteUserSettingsInExecutor,
   hasCognitoIdentityMappingForUserInExecutor,
-  deleteWorkspaceInExecutor,
+  deleteWorkspaceInExecutor as deleteGuestWorkspaceInExecutor,
   loadGuestSessionInExecutor,
   loadGuestWorkspaceIdInExecutor,
   revokeGuestSessionInExecutor,
 } from "./store";
+
+async function assertGuestWorkspaceCleanupAllowedInExecutor(
+  executor: DatabaseExecutor,
+  guestUserId: string,
+  guestWorkspaceId: string,
+): Promise<void> {
+  await applyUserDatabaseScopeInExecutor(executor, { userId: guestUserId });
+  const managedWorkspace = await loadWorkspaceManagementRowInExecutor(
+    executor,
+    guestUserId,
+    guestWorkspaceId,
+  );
+  assertWorkspaceOwner(managedWorkspace.role);
+  assertWorkspaceIsSoleMember(managedWorkspace.member_count);
+}
 
 export async function cleanupGuestSessionSourceInExecutor(
   executor: DatabaseExecutor,
@@ -15,8 +38,9 @@ export async function cleanupGuestSessionSourceInExecutor(
   guestSessionId: string,
   guestWorkspaceId: string,
 ): Promise<void> {
+  await assertGuestWorkspaceCleanupAllowedInExecutor(executor, guestUserId, guestWorkspaceId);
   await revokeGuestSessionInExecutor(executor, guestUserId, guestSessionId);
-  await deleteWorkspaceInExecutor(executor, guestUserId, guestWorkspaceId);
+  await deleteGuestWorkspaceInExecutor(executor, guestUserId, guestWorkspaceId);
   await deleteUserSettingsInExecutor(executor, guestUserId);
 }
 

--- a/apps/backend/src/guestAuth/merge.ts
+++ b/apps/backend/src/guestAuth/merge.ts
@@ -1,21 +1,36 @@
 import { randomUUID } from "node:crypto";
-import type { DatabaseExecutor } from "../db";
-import { compareLwwMetadata } from "../lww";
-import { insertSyncChange } from "../syncChanges";
 import {
-  forkCardIdForWorkspace,
-  forkDeckIdForWorkspace,
-  forkReviewEventIdForWorkspace,
-} from "../sync/fork";
+  appendReviewEventSnapshotInExecutor,
+  getInvalidFsrsStateReason,
+  upsertCardSnapshotInExecutor,
+  type CardMutationMetadata,
+  type CardSnapshotInput,
+  type ReviewEvent,
+} from "../cards";
+import {
+  applyWorkspaceDatabaseScopeInExecutor,
+  type DatabaseExecutor,
+} from "../db";
+import {
+  HttpError,
+  type SyncConflictEntityType,
+} from "../errors";
+import {
+  compareLwwMetadata,
+} from "../lww";
+import {
+  upsertDeckSnapshotInExecutor,
+  type DeckMutationMetadata,
+  type DeckSnapshotInput,
+} from "../decks";
+import { insertSyncChange } from "../syncChanges";
 import {
   ensureSystemWorkspaceReplicaInExecutor,
   ensureWorkspaceReplicaInExecutor,
 } from "../syncIdentity";
+import { SYNC_WORKSPACE_FORK_REQUIRED } from "../sync/fork";
 import {
   deleteGuestWorkspaceContentInExecutor,
-  insertGuestCardCopyInExecutor,
-  insertGuestDeckCopyInExecutor,
-  insertGuestReviewEventCopyInExecutor,
   loadGuestCardsInExecutor,
   loadGuestDecksInExecutor,
   loadGuestReplicasInExecutor,
@@ -26,15 +41,29 @@ import {
   updateWorkspaceSchedulerFromGuestInExecutor,
 } from "./store";
 import type {
+  GuestUpgradeDroppedEntities,
   GuestUpgradeHistoryWrite,
   GuestUpgradeSelectionType,
 } from "./types";
 import { toIsoString } from "./shared";
 
-type GuestEntityIdMaps = Readonly<{
-  cardIdMap: ReadonlyMap<string, string>;
-  deckIdMap: ReadonlyMap<string, string>;
-  reviewEventIdMap: ReadonlyMap<string, string>;
+type GuestMergeWriteInput = Readonly<{
+  entityType: SyncConflictEntityType;
+  entityId: string;
+  sourceGuestWorkspaceId: string;
+  targetWorkspaceId: string;
+  supportsDroppedEntities: boolean;
+  write: () => Promise<boolean>;
+}>;
+
+type GuestMergeDroppedEntitiesAccumulator = {
+  cardIds: Array<string>;
+  deckIds: Array<string>;
+  reviewEventIds: Array<string>;
+};
+
+type GuestMergeResult = Readonly<{
+  history: GuestUpgradeHistoryWrite;
 }>;
 
 function schedulerWinnerIsGuest(
@@ -52,40 +81,333 @@ function schedulerWinnerIsGuest(
   }) > 0;
 }
 
-function requireMappedEntityId(
-  entityIdMap: ReadonlyMap<string, string>,
-  sourceEntityId: string,
-  entityType: string,
-): string {
-  const targetEntityId = entityIdMap.get(sourceEntityId);
-  if (targetEntityId === undefined) {
-    throw new Error(`Missing merged ${entityType} id mapping for ${sourceEntityId}`);
-  }
-
-  return targetEntityId;
+function createGuestMutationMetadata(
+  clientUpdatedAt: Date | string,
+  lastModifiedByReplicaId: string,
+  lastOperationId: string,
+): CardMutationMetadata {
+  return {
+    clientUpdatedAt: toIsoString(clientUpdatedAt),
+    lastModifiedByReplicaId,
+    lastOperationId,
+  };
 }
 
-function createGuestEntityIdMaps(
-  sourceWorkspaceId: string,
-  targetWorkspaceId: string,
-  cards: ReadonlyArray<import("./store").GuestCardRecord>,
-  decks: ReadonlyArray<import("./store").GuestDeckRecord>,
-  reviewEvents: ReadonlyArray<import("./store").GuestReviewEventRecord>,
-): GuestEntityIdMaps {
+function createCardSnapshotInput(
+  card: import("./store").GuestCardRecord,
+): CardSnapshotInput {
   return {
-    cardIdMap: new Map(cards.map((card) => ([
-      card.cardId,
-      forkCardIdForWorkspace(sourceWorkspaceId, targetWorkspaceId, card.cardId),
-    ]))),
-    deckIdMap: new Map(decks.map((deck) => ([
-      deck.deckId,
-      forkDeckIdForWorkspace(sourceWorkspaceId, targetWorkspaceId, deck.deckId),
-    ]))),
-    reviewEventIdMap: new Map(reviewEvents.map((reviewEvent) => ([
-      reviewEvent.reviewEventId,
-      forkReviewEventIdForWorkspace(sourceWorkspaceId, targetWorkspaceId, reviewEvent.reviewEventId),
-    ]))),
+    cardId: card.cardId,
+    frontText: card.frontText,
+    backText: card.backText,
+    tags: card.tags,
+    effortLevel: card.effortLevel,
+    dueAt: card.dueAt === null ? null : toIsoString(card.dueAt),
+    createdAt: toIsoString(card.createdAt),
+    reps: card.reps,
+    lapses: card.lapses,
+    fsrsCardState: card.fsrsCardState,
+    fsrsStepIndex: card.fsrsStepIndex,
+    fsrsStability: card.fsrsStability,
+    fsrsDifficulty: card.fsrsDifficulty,
+    fsrsLastReviewedAt: card.fsrsLastReviewedAt === null ? null : toIsoString(card.fsrsLastReviewedAt),
+    fsrsScheduledDays: card.fsrsScheduledDays,
+    deletedAt: card.deletedAt === null ? null : toIsoString(card.deletedAt),
   };
+}
+
+function logGuestMergeFsrsStateReset(
+  workspaceId: string,
+  cardId: string,
+  reason: string,
+): void {
+  console.error(JSON.stringify({
+    domain: "cards",
+    action: "reset_invalid_fsrs_state",
+    workspaceId,
+    cardId,
+    reason,
+    repair: "reset",
+  }));
+}
+
+function repairGuestCardSnapshotInput(
+  workspaceId: string,
+  card: CardSnapshotInput,
+): CardSnapshotInput {
+  const invalidReason = getInvalidFsrsStateReason({
+    due_at: card.dueAt,
+    reps: card.reps,
+    lapses: card.lapses,
+    fsrs_card_state: card.fsrsCardState,
+    fsrs_step_index: card.fsrsStepIndex,
+    fsrs_stability: card.fsrsStability,
+    fsrs_difficulty: card.fsrsDifficulty,
+    fsrs_last_reviewed_at: card.fsrsLastReviewedAt,
+    fsrs_scheduled_days: card.fsrsScheduledDays,
+  });
+  if (invalidReason === null) {
+    return card;
+  }
+
+  logGuestMergeFsrsStateReset(workspaceId, card.cardId, invalidReason);
+  return {
+    ...card,
+    dueAt: null,
+    reps: 0,
+    lapses: 0,
+    fsrsCardState: "new",
+    fsrsStepIndex: null,
+    fsrsStability: null,
+    fsrsDifficulty: null,
+    fsrsLastReviewedAt: null,
+    fsrsScheduledDays: null,
+  };
+}
+
+function createDeckSnapshotInput(
+  deck: import("./store").GuestDeckRecord,
+): DeckSnapshotInput {
+  return {
+    deckId: deck.deckId,
+    name: deck.name,
+    filterDefinition: deck.filterDefinition,
+    createdAt: toIsoString(deck.createdAt),
+    deletedAt: deck.deletedAt === null ? null : toIsoString(deck.deletedAt),
+  };
+}
+
+function createReviewEventSnapshot(
+  workspaceId: string,
+  reviewEvent: import("./store").GuestReviewEventRecord,
+  replicaId: string,
+): ReviewEvent {
+  return {
+    reviewEventId: reviewEvent.reviewEventId,
+    workspaceId,
+    cardId: reviewEvent.cardId,
+    replicaId,
+    clientEventId: reviewEvent.clientEventId,
+    rating: reviewEvent.rating,
+    reviewedAtClient: toIsoString(reviewEvent.reviewedAtClient),
+    reviewedAtServer: toIsoString(reviewEvent.reviewedAtServer),
+  };
+}
+
+function createGuestMergeDroppedEntitiesAccumulator(): GuestMergeDroppedEntitiesAccumulator {
+  return {
+    cardIds: [],
+    deckIds: [],
+    reviewEventIds: [],
+  };
+}
+
+function createGuestMergeSourceCleanupInvariantError(
+  entityType: SyncConflictEntityType,
+  entityId: string,
+  sourceGuestWorkspaceId: string,
+): Error {
+  return new Error(
+    `Guest merge cleanup invariant failed for ${entityType} ${entityId}: `
+    + `source workspace ${sourceGuestWorkspaceId} still owns the conflicting id after cleanup`,
+  );
+}
+
+function recordDroppedGuestMergeEntity(
+  droppedEntities: GuestMergeDroppedEntitiesAccumulator,
+  entityType: SyncConflictEntityType,
+  entityId: string,
+): void {
+  if (entityType === "card") {
+    droppedEntities.cardIds.push(entityId);
+    return;
+  }
+
+  if (entityType === "deck") {
+    droppedEntities.deckIds.push(entityId);
+    return;
+  }
+
+  droppedEntities.reviewEventIds.push(entityId);
+}
+
+function finalizeGuestMergeDroppedEntities(
+  droppedEntities: GuestMergeDroppedEntitiesAccumulator,
+): GuestUpgradeDroppedEntities | undefined {
+  if (
+    droppedEntities.cardIds.length === 0
+    && droppedEntities.deckIds.length === 0
+    && droppedEntities.reviewEventIds.length === 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    cardIds: droppedEntities.cardIds,
+    deckIds: droppedEntities.deckIds,
+    reviewEventIds: droppedEntities.reviewEventIds,
+  };
+}
+
+function createGuestMergeDroppedEntitiesUnsupportedError(
+  entityType: SyncConflictEntityType,
+  entityId: string,
+  conflictingWorkspaceId: string,
+): HttpError {
+  return new HttpError(
+    409,
+    `Guest upgrade cannot drop guest ${entityType} ${entityId} because its id conflicts with another workspace and this client did not declare supportsDroppedEntities. Retry /guest-auth/upgrade/complete with supportsDroppedEntities: true.`,
+    "GUEST_UPGRADE_DROPPED_ENTITIES_UNSUPPORTED",
+    {
+      syncConflict: {
+        phase: "guest_upgrade_merge",
+        entityType,
+        entityId,
+        conflictingWorkspaceId,
+        constraint: null,
+        sqlState: null,
+        table: null,
+        recoverable: true,
+      },
+    },
+  );
+}
+
+function createGuestMergeDroppedReviewEventUnsupportedError(
+  reviewEventId: string,
+  cardId: string,
+): HttpError {
+  return new HttpError(
+    409,
+    `Guest upgrade cannot drop review_event ${reviewEventId} for missing card ${cardId} because this client did not declare supportsDroppedEntities. Retry /guest-auth/upgrade/complete with supportsDroppedEntities: true.`,
+    "GUEST_UPGRADE_DROPPED_ENTITIES_UNSUPPORTED",
+  );
+}
+
+function createGuestMergeDedupedReviewEventUnsupportedError(
+  reviewEventId: string,
+  storedReviewEventId: string,
+): HttpError {
+  return new HttpError(
+    409,
+    `Guest upgrade cannot drop review_event ${reviewEventId} because the target workspace already has review_event ${storedReviewEventId} for the same client event and this client did not declare supportsDroppedEntities. Retry /guest-auth/upgrade/complete with supportsDroppedEntities: true.`,
+    "GUEST_UPGRADE_DROPPED_ENTITIES_UNSUPPORTED",
+  );
+}
+
+function resolveGuestMergeThirdWorkspaceConflict(
+  error: unknown,
+  entityType: SyncConflictEntityType,
+  entityId: string,
+  sourceGuestWorkspaceId: string,
+  targetWorkspaceId: string,
+): string | null {
+  if (!(error instanceof HttpError) || error.code !== SYNC_WORKSPACE_FORK_REQUIRED) {
+    return null;
+  }
+
+  const syncConflict = error.details?.syncConflict ?? null;
+  if (syncConflict === null) {
+    return null;
+  }
+
+  const conflictingWorkspaceId = syncConflict?.conflictingWorkspaceId ?? null;
+  if (conflictingWorkspaceId === null) {
+    return null;
+  }
+
+  if (syncConflict.entityType !== entityType || syncConflict.entityId !== entityId) {
+    throw new Error(
+      `Guest merge conflict metadata mismatch for ${entityType} ${entityId}: `
+      + `${syncConflict.entityType} ${syncConflict.entityId}`,
+    );
+  }
+
+  if (conflictingWorkspaceId === targetWorkspaceId) {
+    return null;
+  }
+
+  if (conflictingWorkspaceId === sourceGuestWorkspaceId) {
+    throw createGuestMergeSourceCleanupInvariantError(
+      entityType,
+      entityId,
+      sourceGuestWorkspaceId,
+    );
+  }
+
+  return conflictingWorkspaceId;
+}
+
+function logGuestMergeDroppedEntity(
+  entityType: SyncConflictEntityType,
+  entityId: string,
+  sourceGuestWorkspaceId: string,
+  targetWorkspaceId: string,
+  conflictingWorkspaceId: string,
+): void {
+  console.error(JSON.stringify({
+    domain: "guest_auth",
+    action: "guest_merge_drop_third_workspace_conflict",
+    entityType,
+    entityId,
+    sourceGuestWorkspaceId,
+    targetWorkspaceId,
+    conflictingWorkspaceId,
+    resolution: "drop_guest_entity",
+  }));
+}
+
+function logGuestMergeDroppedReviewEventForMissingCard(
+  reviewEventId: string,
+  cardId: string,
+  sourceGuestWorkspaceId: string,
+  targetWorkspaceId: string,
+): void {
+  console.error(JSON.stringify({
+    domain: "guest_auth",
+    action: "guest_merge_drop_review_event_missing_target_card",
+    reviewEventId,
+    cardId,
+    sourceGuestWorkspaceId,
+    targetWorkspaceId,
+    resolution: "drop_guest_entity",
+  }));
+}
+
+async function writeGuestEntityIntoTargetInExecutor(
+  input: GuestMergeWriteInput,
+): Promise<boolean> {
+  try {
+    return await input.write();
+  } catch (error) {
+    const conflictingWorkspaceId = resolveGuestMergeThirdWorkspaceConflict(
+      error,
+      input.entityType,
+      input.entityId,
+      input.sourceGuestWorkspaceId,
+      input.targetWorkspaceId,
+    );
+    if (conflictingWorkspaceId === null) {
+      throw error;
+    }
+
+    if (!input.supportsDroppedEntities) {
+      throw createGuestMergeDroppedEntitiesUnsupportedError(
+        input.entityType,
+        input.entityId,
+        conflictingWorkspaceId,
+      );
+    }
+
+    logGuestMergeDroppedEntity(
+      input.entityType,
+      input.entityId,
+      input.sourceGuestWorkspaceId,
+      input.targetWorkspaceId,
+      conflictingWorkspaceId,
+    );
+    return false;
+  }
 }
 
 async function recreateGuestReplicasInExecutor(
@@ -131,109 +453,176 @@ async function recreateGuestReplicasInExecutor(
   return new Map<string, string>(replicaIdMapEntries);
 }
 
-async function insertMergedCardsInExecutor(
+async function mergeCardsIntoTargetInExecutor(
   executor: DatabaseExecutor,
-  sourceWorkspaceId: string,
   targetUserId: string,
   targetWorkspaceId: string,
+  sourceGuestWorkspaceId: string,
   cards: ReadonlyArray<import("./store").GuestCardRecord>,
-  cardIdMap: ReadonlyMap<string, string>,
   replicaIdMap: ReadonlyMap<string, string>,
-  mergeId: string,
-): Promise<void> {
+  supportsDroppedEntities: boolean,
+  droppedEntities: GuestMergeDroppedEntitiesAccumulator,
+): Promise<ReadonlySet<string>> {
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: targetUserId,
+    workspaceId: targetWorkspaceId,
+  });
+
+  const mergedCardIds = new Set<string>();
   for (const card of cards) {
     const targetReplicaId = requireMappedReplicaId(replicaIdMap, card.lastModifiedByReplicaId);
-    const targetCardId = requireMappedEntityId(cardIdMap, card.cardId, "card");
-    const copiedCard: import("./store").GuestCardRecord = {
-      ...card,
-      cardId: targetCardId,
-    };
-    await insertGuestCardCopyInExecutor(
-      executor,
-      targetUserId,
+    const wasWritten = await writeGuestEntityIntoTargetInExecutor({
+      entityType: "card",
+      entityId: card.cardId,
+      sourceGuestWorkspaceId,
       targetWorkspaceId,
-      copiedCard,
-      targetReplicaId,
-    );
-    await insertSyncChange(
-      executor,
-      targetWorkspaceId,
-      "card",
-      targetCardId,
-      "upsert",
-      targetReplicaId,
-      `guest-merge-${mergeId}-card-${sourceWorkspaceId}-${targetCardId}`,
-      toIsoString(card.clientUpdatedAt),
-    );
+      supportsDroppedEntities,
+      write: async (): Promise<boolean> => {
+        await upsertCardSnapshotInExecutor(
+          executor,
+          targetWorkspaceId,
+          repairGuestCardSnapshotInput(
+            targetWorkspaceId,
+            createCardSnapshotInput(card),
+          ),
+          createGuestMutationMetadata(
+            card.clientUpdatedAt,
+            targetReplicaId,
+            card.lastOperationId,
+          ),
+        );
+        return true;
+      },
+    });
+    if (wasWritten) {
+      mergedCardIds.add(card.cardId);
+      continue;
+    }
+
+    recordDroppedGuestMergeEntity(droppedEntities, "card", card.cardId);
   }
+
+  return mergedCardIds;
 }
 
-async function insertMergedDecksInExecutor(
+async function mergeDecksIntoTargetInExecutor(
   executor: DatabaseExecutor,
-  sourceWorkspaceId: string,
   targetUserId: string,
   targetWorkspaceId: string,
+  sourceGuestWorkspaceId: string,
   decks: ReadonlyArray<import("./store").GuestDeckRecord>,
-  deckIdMap: ReadonlyMap<string, string>,
   replicaIdMap: ReadonlyMap<string, string>,
-  mergeId: string,
+  supportsDroppedEntities: boolean,
+  droppedEntities: GuestMergeDroppedEntitiesAccumulator,
 ): Promise<void> {
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: targetUserId,
+    workspaceId: targetWorkspaceId,
+  });
+
   for (const deck of decks) {
     const targetReplicaId = requireMappedReplicaId(replicaIdMap, deck.lastModifiedByReplicaId);
-    const targetDeckId = requireMappedEntityId(deckIdMap, deck.deckId, "deck");
-    const copiedDeck: import("./store").GuestDeckRecord = {
-      ...deck,
-      deckId: targetDeckId,
-    };
-    await insertGuestDeckCopyInExecutor(
-      executor,
-      targetUserId,
-      targetWorkspaceId,
-      copiedDeck,
+    const metadata: DeckMutationMetadata = createGuestMutationMetadata(
+      deck.clientUpdatedAt,
       targetReplicaId,
+      deck.lastOperationId,
     );
-    await insertSyncChange(
-      executor,
+    const wasWritten = await writeGuestEntityIntoTargetInExecutor({
+      entityType: "deck",
+      entityId: deck.deckId,
+      sourceGuestWorkspaceId,
       targetWorkspaceId,
-      "deck",
-      targetDeckId,
-      "upsert",
-      targetReplicaId,
-      `guest-merge-${mergeId}-deck-${sourceWorkspaceId}-${targetDeckId}`,
-      toIsoString(deck.clientUpdatedAt),
-    );
+      supportsDroppedEntities,
+      write: async (): Promise<boolean> => {
+        await upsertDeckSnapshotInExecutor(
+          executor,
+          targetWorkspaceId,
+          createDeckSnapshotInput(deck),
+          metadata,
+        );
+        return true;
+      },
+    });
+    if (!wasWritten) {
+      recordDroppedGuestMergeEntity(droppedEntities, "deck", deck.deckId);
+    }
   }
 }
 
-async function insertMergedReviewEventsInExecutor(
+async function mergeReviewEventsIntoTargetInExecutor(
   executor: DatabaseExecutor,
   targetUserId: string,
   targetWorkspaceId: string,
+  sourceGuestWorkspaceId: string,
   reviewEvents: ReadonlyArray<import("./store").GuestReviewEventRecord>,
-  cardIdMap: ReadonlyMap<string, string>,
-  reviewEventIdMap: ReadonlyMap<string, string>,
   replicaIdMap: ReadonlyMap<string, string>,
+  mergedCardIds: ReadonlySet<string>,
+  supportsDroppedEntities: boolean,
+  droppedEntities: GuestMergeDroppedEntitiesAccumulator,
 ): Promise<void> {
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: targetUserId,
+    workspaceId: targetWorkspaceId,
+  });
+
   for (const reviewEvent of reviewEvents) {
+    if (!mergedCardIds.has(reviewEvent.cardId)) {
+      if (!supportsDroppedEntities) {
+        throw createGuestMergeDroppedReviewEventUnsupportedError(
+          reviewEvent.reviewEventId,
+          reviewEvent.cardId,
+        );
+      }
+
+      logGuestMergeDroppedReviewEventForMissingCard(
+        reviewEvent.reviewEventId,
+        reviewEvent.cardId,
+        sourceGuestWorkspaceId,
+        targetWorkspaceId,
+      );
+      recordDroppedGuestMergeEntity(
+        droppedEntities,
+        "review_event",
+        reviewEvent.reviewEventId,
+      );
+      continue;
+    }
+
     const targetReplicaId = requireMappedReplicaId(replicaIdMap, reviewEvent.replicaId);
-    const targetCardId = requireMappedEntityId(cardIdMap, reviewEvent.cardId, "card");
-    const targetReviewEventId = requireMappedEntityId(
-      reviewEventIdMap,
-      reviewEvent.reviewEventId,
-      "review_event",
-    );
-    const copiedReviewEvent: import("./store").GuestReviewEventRecord = {
-      ...reviewEvent,
-      reviewEventId: targetReviewEventId,
-      cardId: targetCardId,
-    };
-    await insertGuestReviewEventCopyInExecutor(
-      executor,
-      targetUserId,
+    const wasWritten = await writeGuestEntityIntoTargetInExecutor({
+      entityType: "review_event",
+      entityId: reviewEvent.reviewEventId,
+      sourceGuestWorkspaceId,
       targetWorkspaceId,
-      copiedReviewEvent,
-      targetReplicaId,
-    );
+      supportsDroppedEntities,
+      write: async (): Promise<boolean> => {
+        const result = await appendReviewEventSnapshotInExecutor(
+          executor,
+          targetWorkspaceId,
+          createReviewEventSnapshot(targetWorkspaceId, reviewEvent, targetReplicaId),
+          reviewEvent.reviewEventId,
+        );
+        if (result.reviewEvent.reviewEventId === reviewEvent.reviewEventId) {
+          return true;
+        }
+
+        if (!supportsDroppedEntities) {
+          throw createGuestMergeDedupedReviewEventUnsupportedError(
+            reviewEvent.reviewEventId,
+            result.reviewEvent.reviewEventId,
+          );
+        }
+
+        return false;
+      },
+    });
+    if (!wasWritten) {
+      recordDroppedGuestMergeEntity(
+        droppedEntities,
+        "review_event",
+        reviewEvent.reviewEventId,
+      );
+    }
   }
 }
 
@@ -271,25 +660,34 @@ async function maybeApplyGuestSchedulerInExecutor(
 }
 
 /**
- * Merges portable guest workspace state into the selected destination workspace
- * and returns the durable replica alias metadata that must be recorded before
- * the live guest rows are deleted.
+ * Merges already-synced guest cloud workspace state into the selected
+ * destination workspace and returns the durable replica alias metadata that
+ * must be recorded before the live guest rows are deleted.
  *
- * Cards, decks, and review events are deterministically forked into the target
- * workspace so globally keyed entity ids never collide across workspaces.
+ * Cards, decks, and review events keep their existing ids by default. The
+ * source content rows are deleted first inside the same transaction to free
+ * the global ids, then cards/decks reuse normal snapshot LWW behavior in the
+ * target workspace and review events reuse append-only insert-or-no-op
+ * behavior. The backend does not create card/deck/review id aliases or consume
+ * pending client-local outbox rows. If an impossible global-id conflict still
+ * resolves to a true third workspace, the guest entity is dropped only for
+ * clients that declared dropped-entity reconciliation support; older clients
+ * receive a typed error.
  */
 export async function mergeGuestWorkspaceIntoTargetInExecutor(
   executor: DatabaseExecutor,
   params: Readonly<{
     guestSessionId: string;
+    sourceGuestSessionSecretHash: string;
     guestUserId: string;
     guestWorkspaceId: string;
     targetSubjectUserId: string;
     targetUserId: string;
     targetWorkspaceId: string;
     selectionType: GuestUpgradeSelectionType;
+    supportsDroppedEntities: boolean;
   }>,
-): Promise<GuestUpgradeHistoryWrite> {
+): Promise<GuestMergeResult> {
   const upgradeId = randomUUID().toLowerCase();
   const guestReplicas = await loadGuestReplicasInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
   const guestCards = await loadGuestCardsInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
@@ -297,13 +695,7 @@ export async function mergeGuestWorkspaceIntoTargetInExecutor(
   const guestReviewEvents = await loadGuestReviewEventsInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
   const guestScheduler = await loadWorkspaceSchedulerInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
   const targetScheduler = await loadWorkspaceSchedulerInExecutor(executor, params.targetUserId, params.targetWorkspaceId);
-  const guestEntityIdMaps = createGuestEntityIdMaps(
-    params.guestWorkspaceId,
-    params.targetWorkspaceId,
-    guestCards,
-    guestDecks,
-    guestReviewEvents,
-  );
+  const droppedEntities = createGuestMergeDroppedEntitiesAccumulator();
 
   await deleteGuestWorkspaceContentInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
 
@@ -314,34 +706,36 @@ export async function mergeGuestWorkspaceIntoTargetInExecutor(
     params.targetWorkspaceId,
   );
 
-  await insertMergedCardsInExecutor(
+  const mergedCardIds = await mergeCardsIntoTargetInExecutor(
     executor,
-    params.guestWorkspaceId,
     params.targetUserId,
     params.targetWorkspaceId,
+    params.guestWorkspaceId,
     guestCards,
-    guestEntityIdMaps.cardIdMap,
     replicaIdMap,
-    upgradeId,
+    params.supportsDroppedEntities,
+    droppedEntities,
   );
-  await insertMergedDecksInExecutor(
+  await mergeDecksIntoTargetInExecutor(
     executor,
+    params.targetUserId,
+    params.targetWorkspaceId,
     params.guestWorkspaceId,
-    params.targetUserId,
-    params.targetWorkspaceId,
     guestDecks,
-    guestEntityIdMaps.deckIdMap,
     replicaIdMap,
-    upgradeId,
+    params.supportsDroppedEntities,
+    droppedEntities,
   );
-  await insertMergedReviewEventsInExecutor(
+  await mergeReviewEventsIntoTargetInExecutor(
     executor,
     params.targetUserId,
     params.targetWorkspaceId,
+    params.guestWorkspaceId,
     guestReviewEvents,
-    guestEntityIdMaps.cardIdMap,
-    guestEntityIdMaps.reviewEventIdMap,
     replicaIdMap,
+    mergedCardIds,
+    params.supportsDroppedEntities,
+    droppedEntities,
   );
   await maybeApplyGuestSchedulerInExecutor(
     executor,
@@ -353,15 +747,23 @@ export async function mergeGuestWorkspaceIntoTargetInExecutor(
     upgradeId,
   );
 
+  const finalizedDroppedEntities = finalizeGuestMergeDroppedEntities(droppedEntities);
+
   return {
-    upgradeId,
-    sourceGuestUserId: params.guestUserId,
-    sourceGuestWorkspaceId: params.guestWorkspaceId,
-    sourceGuestSessionId: params.guestSessionId,
-    targetSubjectUserId: params.targetSubjectUserId,
-    targetUserId: params.targetUserId,
-    targetWorkspaceId: params.targetWorkspaceId,
-    selectionType: params.selectionType,
-    replicaIdMap,
+    history: {
+      upgradeId,
+      sourceGuestUserId: params.guestUserId,
+      sourceGuestWorkspaceId: params.guestWorkspaceId,
+      sourceGuestSessionId: params.guestSessionId,
+      sourceGuestSessionSecretHash: params.sourceGuestSessionSecretHash,
+      targetSubjectUserId: params.targetSubjectUserId,
+      targetUserId: params.targetUserId,
+      targetWorkspaceId: params.targetWorkspaceId,
+      selectionType: params.selectionType,
+      ...(finalizedDroppedEntities === undefined
+        ? {}
+        : { droppedEntities: finalizedDroppedEntities }),
+      replicaIdMap,
+    },
   };
 }

--- a/apps/backend/src/guestAuth/merge.ts
+++ b/apps/backend/src/guestAuth/merge.ts
@@ -3,6 +3,11 @@ import type { DatabaseExecutor } from "../db";
 import { compareLwwMetadata } from "../lww";
 import { insertSyncChange } from "../syncChanges";
 import {
+  forkCardIdForWorkspace,
+  forkDeckIdForWorkspace,
+  forkReviewEventIdForWorkspace,
+} from "../sync/fork";
+import {
   ensureSystemWorkspaceReplicaInExecutor,
   ensureWorkspaceReplicaInExecutor,
 } from "../syncIdentity";
@@ -26,6 +31,12 @@ import type {
 } from "./types";
 import { toIsoString } from "./shared";
 
+type GuestEntityIdMaps = Readonly<{
+  cardIdMap: ReadonlyMap<string, string>;
+  deckIdMap: ReadonlyMap<string, string>;
+  reviewEventIdMap: ReadonlyMap<string, string>;
+}>;
+
 function schedulerWinnerIsGuest(
   guestScheduler: import("./store").GuestWorkspaceSchedulerRecord,
   targetScheduler: import("./store").GuestWorkspaceSchedulerRecord,
@@ -39,6 +50,42 @@ function schedulerWinnerIsGuest(
     lastModifiedByReplicaId: targetScheduler.lastModifiedByReplicaId,
     lastOperationId: targetScheduler.lastOperationId,
   }) > 0;
+}
+
+function requireMappedEntityId(
+  entityIdMap: ReadonlyMap<string, string>,
+  sourceEntityId: string,
+  entityType: string,
+): string {
+  const targetEntityId = entityIdMap.get(sourceEntityId);
+  if (targetEntityId === undefined) {
+    throw new Error(`Missing merged ${entityType} id mapping for ${sourceEntityId}`);
+  }
+
+  return targetEntityId;
+}
+
+function createGuestEntityIdMaps(
+  sourceWorkspaceId: string,
+  targetWorkspaceId: string,
+  cards: ReadonlyArray<import("./store").GuestCardRecord>,
+  decks: ReadonlyArray<import("./store").GuestDeckRecord>,
+  reviewEvents: ReadonlyArray<import("./store").GuestReviewEventRecord>,
+): GuestEntityIdMaps {
+  return {
+    cardIdMap: new Map(cards.map((card) => ([
+      card.cardId,
+      forkCardIdForWorkspace(sourceWorkspaceId, targetWorkspaceId, card.cardId),
+    ]))),
+    deckIdMap: new Map(decks.map((deck) => ([
+      deck.deckId,
+      forkDeckIdForWorkspace(sourceWorkspaceId, targetWorkspaceId, deck.deckId),
+    ]))),
+    reviewEventIdMap: new Map(reviewEvents.map((reviewEvent) => ([
+      reviewEvent.reviewEventId,
+      forkReviewEventIdForWorkspace(sourceWorkspaceId, targetWorkspaceId, reviewEvent.reviewEventId),
+    ]))),
+  };
 }
 
 async function recreateGuestReplicasInExecutor(
@@ -86,29 +133,36 @@ async function recreateGuestReplicasInExecutor(
 
 async function insertMergedCardsInExecutor(
   executor: DatabaseExecutor,
+  sourceWorkspaceId: string,
   targetUserId: string,
   targetWorkspaceId: string,
   cards: ReadonlyArray<import("./store").GuestCardRecord>,
+  cardIdMap: ReadonlyMap<string, string>,
   replicaIdMap: ReadonlyMap<string, string>,
   mergeId: string,
 ): Promise<void> {
   for (const card of cards) {
     const targetReplicaId = requireMappedReplicaId(replicaIdMap, card.lastModifiedByReplicaId);
+    const targetCardId = requireMappedEntityId(cardIdMap, card.cardId, "card");
+    const copiedCard: import("./store").GuestCardRecord = {
+      ...card,
+      cardId: targetCardId,
+    };
     await insertGuestCardCopyInExecutor(
       executor,
       targetUserId,
       targetWorkspaceId,
-      card,
+      copiedCard,
       targetReplicaId,
     );
     await insertSyncChange(
       executor,
       targetWorkspaceId,
       "card",
-      card.cardId,
+      targetCardId,
       "upsert",
       targetReplicaId,
-      `guest-merge-${mergeId}-card-${card.cardId}`,
+      `guest-merge-${mergeId}-card-${sourceWorkspaceId}-${targetCardId}`,
       toIsoString(card.clientUpdatedAt),
     );
   }
@@ -116,29 +170,36 @@ async function insertMergedCardsInExecutor(
 
 async function insertMergedDecksInExecutor(
   executor: DatabaseExecutor,
+  sourceWorkspaceId: string,
   targetUserId: string,
   targetWorkspaceId: string,
   decks: ReadonlyArray<import("./store").GuestDeckRecord>,
+  deckIdMap: ReadonlyMap<string, string>,
   replicaIdMap: ReadonlyMap<string, string>,
   mergeId: string,
 ): Promise<void> {
   for (const deck of decks) {
     const targetReplicaId = requireMappedReplicaId(replicaIdMap, deck.lastModifiedByReplicaId);
+    const targetDeckId = requireMappedEntityId(deckIdMap, deck.deckId, "deck");
+    const copiedDeck: import("./store").GuestDeckRecord = {
+      ...deck,
+      deckId: targetDeckId,
+    };
     await insertGuestDeckCopyInExecutor(
       executor,
       targetUserId,
       targetWorkspaceId,
-      deck,
+      copiedDeck,
       targetReplicaId,
     );
     await insertSyncChange(
       executor,
       targetWorkspaceId,
       "deck",
-      deck.deckId,
+      targetDeckId,
       "upsert",
       targetReplicaId,
-      `guest-merge-${mergeId}-deck-${deck.deckId}`,
+      `guest-merge-${mergeId}-deck-${sourceWorkspaceId}-${targetDeckId}`,
       toIsoString(deck.clientUpdatedAt),
     );
   }
@@ -149,15 +210,28 @@ async function insertMergedReviewEventsInExecutor(
   targetUserId: string,
   targetWorkspaceId: string,
   reviewEvents: ReadonlyArray<import("./store").GuestReviewEventRecord>,
+  cardIdMap: ReadonlyMap<string, string>,
+  reviewEventIdMap: ReadonlyMap<string, string>,
   replicaIdMap: ReadonlyMap<string, string>,
 ): Promise<void> {
   for (const reviewEvent of reviewEvents) {
     const targetReplicaId = requireMappedReplicaId(replicaIdMap, reviewEvent.replicaId);
+    const targetCardId = requireMappedEntityId(cardIdMap, reviewEvent.cardId, "card");
+    const targetReviewEventId = requireMappedEntityId(
+      reviewEventIdMap,
+      reviewEvent.reviewEventId,
+      "review_event",
+    );
+    const copiedReviewEvent: import("./store").GuestReviewEventRecord = {
+      ...reviewEvent,
+      reviewEventId: targetReviewEventId,
+      cardId: targetCardId,
+    };
     await insertGuestReviewEventCopyInExecutor(
       executor,
       targetUserId,
       targetWorkspaceId,
-      reviewEvent,
+      copiedReviewEvent,
       targetReplicaId,
     );
   }
@@ -198,12 +272,11 @@ async function maybeApplyGuestSchedulerInExecutor(
 
 /**
  * Merges portable guest workspace state into the selected destination workspace
- * and returns the durable alias metadata that must be recorded before the live
- * guest rows are deleted.
+ * and returns the durable replica alias metadata that must be recorded before
+ * the live guest rows are deleted.
  *
- * V1 intentionally preserves only correlation metadata for future debugging.
- * Guest-only chat rows and other cascade-deleted live records still disappear
- * during cleanup and are not copied here.
+ * Cards, decks, and review events are deterministically forked into the target
+ * workspace so globally keyed entity ids never collide across workspaces.
  */
 export async function mergeGuestWorkspaceIntoTargetInExecutor(
   executor: DatabaseExecutor,
@@ -224,6 +297,13 @@ export async function mergeGuestWorkspaceIntoTargetInExecutor(
   const guestReviewEvents = await loadGuestReviewEventsInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
   const guestScheduler = await loadWorkspaceSchedulerInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
   const targetScheduler = await loadWorkspaceSchedulerInExecutor(executor, params.targetUserId, params.targetWorkspaceId);
+  const guestEntityIdMaps = createGuestEntityIdMaps(
+    params.guestWorkspaceId,
+    params.targetWorkspaceId,
+    guestCards,
+    guestDecks,
+    guestReviewEvents,
+  );
 
   await deleteGuestWorkspaceContentInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
 
@@ -236,17 +316,21 @@ export async function mergeGuestWorkspaceIntoTargetInExecutor(
 
   await insertMergedCardsInExecutor(
     executor,
+    params.guestWorkspaceId,
     params.targetUserId,
     params.targetWorkspaceId,
     guestCards,
+    guestEntityIdMaps.cardIdMap,
     replicaIdMap,
     upgradeId,
   );
   await insertMergedDecksInExecutor(
     executor,
+    params.guestWorkspaceId,
     params.targetUserId,
     params.targetWorkspaceId,
     guestDecks,
+    guestEntityIdMaps.deckIdMap,
     replicaIdMap,
     upgradeId,
   );
@@ -255,6 +339,8 @@ export async function mergeGuestWorkspaceIntoTargetInExecutor(
     params.targetUserId,
     params.targetWorkspaceId,
     guestReviewEvents,
+    guestEntityIdMaps.cardIdMap,
+    guestEntityIdMaps.reviewEventIdMap,
     replicaIdMap,
   );
   await maybeApplyGuestSchedulerInExecutor(

--- a/apps/backend/src/guestAuth/store.ts
+++ b/apps/backend/src/guestAuth/store.ts
@@ -3,7 +3,10 @@ import {
   applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
 } from "../db";
+import type { EffortLevel } from "../cards";
+import type { DeckFilterDefinition } from "../decks";
 import { HttpError } from "../errors";
+import type { FsrsCardState } from "../schedule";
 import type {
   SyncClientPlatform,
   WorkspaceReplicaActorKind,
@@ -11,6 +14,7 @@ import type {
 } from "../syncIdentity";
 import type {
   GuestUpgradeCompletion,
+  GuestUpgradeDroppedEntities,
   GuestUpgradeHistoryWrite,
 } from "./types";
 import { hashGuestToken, toIsoString } from "./shared";
@@ -22,9 +26,11 @@ type GuestSessionRow = Readonly<{
 }>;
 
 type GuestUpgradeHistoryReplayRow = Readonly<{
+  source_guest_session_id: string;
   target_subject_user_id: string;
   target_user_id: string;
   target_workspace_id: string;
+  dropped_entities: GuestUpgradeDroppedEntities | null;
 }>;
 
 type GuestWorkspaceRow = Readonly<{
@@ -110,6 +116,10 @@ type WorkspaceSchedulerRow = Readonly<{
   fsrs_updated_at: Date | string;
 }>;
 
+type DeletedGuestWorkspaceRow = Readonly<{
+  workspace_id: string;
+}>;
+
 export type GuestSessionRecord = Readonly<{
   sessionId: string;
   userId: string;
@@ -117,9 +127,11 @@ export type GuestSessionRecord = Readonly<{
 }>;
 
 export type GuestUpgradeReplayRecord = Readonly<{
+  sourceGuestSessionId: string;
   targetSubjectUserId: string;
   targetUserId: string;
   targetWorkspaceId: string;
+  droppedEntities?: GuestUpgradeDroppedEntities;
 }>;
 
 export type GuestReplicaRecord = Readonly<{
@@ -138,12 +150,12 @@ export type GuestCardRecord = Readonly<{
   frontText: string;
   backText: string;
   tags: ReadonlyArray<string>;
-  effortLevel: string;
+  effortLevel: EffortLevel;
   dueAt: Date | string | null;
   createdAt: Date | string;
   reps: number;
   lapses: number;
-  fsrsCardState: string;
+  fsrsCardState: FsrsCardState;
   fsrsStepIndex: number | null;
   fsrsStability: number | null;
   fsrsDifficulty: number | null;
@@ -159,7 +171,7 @@ export type GuestCardRecord = Readonly<{
 export type GuestDeckRecord = Readonly<{
   deckId: string;
   name: string;
-  filterDefinition: Readonly<Record<string, unknown>>;
+  filterDefinition: DeckFilterDefinition;
   createdAt: Date | string;
   clientUpdatedAt: Date | string;
   lastModifiedByReplicaId: string;
@@ -201,9 +213,13 @@ function mapGuestSessionRecord(row: GuestSessionRow): GuestSessionRecord {
 
 function mapGuestUpgradeReplayRecord(row: GuestUpgradeHistoryReplayRow): GuestUpgradeReplayRecord {
   return {
+    sourceGuestSessionId: row.source_guest_session_id,
     targetSubjectUserId: row.target_subject_user_id,
     targetUserId: row.target_user_id,
     targetWorkspaceId: row.target_workspace_id,
+    ...(row.dropped_entities === null
+      ? {}
+      : { droppedEntities: row.dropped_entities }),
   };
 }
 
@@ -226,12 +242,12 @@ function mapGuestCardRecord(row: CardRow): GuestCardRecord {
     frontText: row.front_text,
     backText: row.back_text,
     tags: row.tags,
-    effortLevel: row.effort_level,
+    effortLevel: row.effort_level as EffortLevel,
     dueAt: row.due_at,
     createdAt: row.created_at,
     reps: row.reps,
     lapses: row.lapses,
-    fsrsCardState: row.fsrs_card_state,
+    fsrsCardState: row.fsrs_card_state as FsrsCardState,
     fsrsStepIndex: row.fsrs_step_index,
     fsrsStability: row.fsrs_stability,
     fsrsDifficulty: row.fsrs_difficulty,
@@ -249,7 +265,7 @@ function mapGuestDeckRecord(row: DeckRow): GuestDeckRecord {
   return {
     deckId: row.deck_id,
     name: row.name,
-    filterDefinition: row.filter_definition,
+    filterDefinition: row.filter_definition as DeckFilterDefinition,
     createdAt: row.created_at,
     clientUpdatedAt: row.client_updated_at,
     lastModifiedByReplicaId: row.last_modified_by_replica_id,
@@ -322,14 +338,35 @@ export async function loadGuestUpgradeReplayInExecutor(
   executor: DatabaseExecutor,
   guestSessionId: string,
 ): Promise<GuestUpgradeReplayRecord | null> {
+  // Compatibility read path for released clients that retry
+  // `/guest-auth/upgrade/complete` after the merge committed and the original
+  // guest session was already revoked.
   const result = await executor.query<GuestUpgradeHistoryReplayRow>(
     [
-      "SELECT target_subject_user_id, target_user_id, target_workspace_id",
+      "SELECT source_guest_session_id, target_subject_user_id, target_user_id, target_workspace_id, dropped_entities",
       "FROM auth.guest_upgrade_history",
       "WHERE source_guest_session_id = $1",
       "LIMIT 1",
     ].join(" "),
     [guestSessionId],
+  );
+
+  const row = result.rows[0];
+  return row === undefined ? null : mapGuestUpgradeReplayRecord(row);
+}
+
+export async function loadGuestUpgradeReplayByGuestTokenInExecutor(
+  executor: DatabaseExecutor,
+  guestToken: string,
+): Promise<GuestUpgradeReplayRecord | null> {
+  const result = await executor.query<GuestUpgradeHistoryReplayRow>(
+    [
+      "SELECT source_guest_session_id, target_subject_user_id, target_user_id, target_workspace_id, dropped_entities",
+      "FROM auth.guest_upgrade_history",
+      "WHERE source_guest_session_secret_hash = $1",
+      "LIMIT 1",
+    ].join(" "),
+    [hashGuestToken(guestToken)],
   );
 
   const row = result.rows[0];
@@ -605,130 +642,16 @@ export async function deleteGuestWorkspaceContentInExecutor(
   });
 
   await executor.query(
+    "DELETE FROM content.review_events WHERE workspace_id = $1",
+    [guestWorkspaceId],
+  );
+  await executor.query(
     "DELETE FROM content.decks WHERE workspace_id = $1",
     [guestWorkspaceId],
   );
   await executor.query(
     "DELETE FROM content.cards WHERE workspace_id = $1",
     [guestWorkspaceId],
-  );
-}
-
-export async function insertGuestCardCopyInExecutor(
-  executor: DatabaseExecutor,
-  targetUserId: string,
-  targetWorkspaceId: string,
-  card: GuestCardRecord,
-  replicaId: string,
-): Promise<void> {
-  await applyWorkspaceDatabaseScopeInExecutor(executor, {
-    userId: targetUserId,
-    workspaceId: targetWorkspaceId,
-  });
-
-  await executor.query(
-    [
-      "INSERT INTO content.cards",
-      "(",
-      "card_id, workspace_id, front_text, back_text, tags, effort_level, due_at, reps, lapses,",
-      "updated_at, deleted_at, fsrs_card_state, fsrs_step_index, fsrs_stability, fsrs_difficulty,",
-      "fsrs_last_reviewed_at, fsrs_scheduled_days, client_updated_at, last_modified_by_replica_id, last_operation_id, created_at",
-      ")",
-      "VALUES",
-      "($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",
-    ].join(" "),
-    [
-      card.cardId,
-      targetWorkspaceId,
-      card.frontText,
-      card.backText,
-      card.tags,
-      card.effortLevel,
-      card.dueAt === null ? null : toIsoString(card.dueAt),
-      card.reps,
-      card.lapses,
-      toIsoString(card.updatedAt),
-      card.deletedAt === null ? null : toIsoString(card.deletedAt),
-      card.fsrsCardState,
-      card.fsrsStepIndex,
-      card.fsrsStability,
-      card.fsrsDifficulty,
-      card.fsrsLastReviewedAt === null ? null : toIsoString(card.fsrsLastReviewedAt),
-      card.fsrsScheduledDays,
-      toIsoString(card.clientUpdatedAt),
-      replicaId,
-      card.lastOperationId,
-      toIsoString(card.createdAt),
-    ],
-  );
-}
-
-export async function insertGuestDeckCopyInExecutor(
-  executor: DatabaseExecutor,
-  targetUserId: string,
-  targetWorkspaceId: string,
-  deck: GuestDeckRecord,
-  replicaId: string,
-): Promise<void> {
-  await applyWorkspaceDatabaseScopeInExecutor(executor, {
-    userId: targetUserId,
-    workspaceId: targetWorkspaceId,
-  });
-
-  await executor.query(
-    [
-      "INSERT INTO content.decks",
-      "(",
-      "deck_id, workspace_id, name, filter_definition, created_at, updated_at, deleted_at,",
-      "client_updated_at, last_modified_by_replica_id, last_operation_id",
-      ")",
-      "VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8, $9, $10)",
-    ].join(" "),
-    [
-      deck.deckId,
-      targetWorkspaceId,
-      deck.name,
-      JSON.stringify(deck.filterDefinition),
-      toIsoString(deck.createdAt),
-      toIsoString(deck.updatedAt),
-      deck.deletedAt === null ? null : toIsoString(deck.deletedAt),
-      toIsoString(deck.clientUpdatedAt),
-      replicaId,
-      deck.lastOperationId,
-    ],
-  );
-}
-
-export async function insertGuestReviewEventCopyInExecutor(
-  executor: DatabaseExecutor,
-  targetUserId: string,
-  targetWorkspaceId: string,
-  reviewEvent: GuestReviewEventRecord,
-  replicaId: string,
-): Promise<void> {
-  await applyWorkspaceDatabaseScopeInExecutor(executor, {
-    userId: targetUserId,
-    workspaceId: targetWorkspaceId,
-  });
-
-  await executor.query(
-    [
-      "INSERT INTO content.review_events",
-      "(",
-      "review_event_id, workspace_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server",
-      ")",
-      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-    ].join(" "),
-    [
-      reviewEvent.reviewEventId,
-      targetWorkspaceId,
-      reviewEvent.cardId,
-      replicaId,
-      reviewEvent.clientEventId,
-      reviewEvent.rating,
-      toIsoString(reviewEvent.reviewedAtClient),
-      toIsoString(reviewEvent.reviewedAtServer),
-    ],
   );
 }
 
@@ -780,28 +703,39 @@ export async function recordGuestUpgradeHistoryInExecutor(
   executor: DatabaseExecutor,
   history: GuestUpgradeHistoryWrite,
 ): Promise<void> {
+  // Legacy/idempotency-only audit record. Keep it while old clients can retry
+  // completion after session revocation; it is not a local-outbox replay layer.
   await executor.query(
     [
       "INSERT INTO auth.guest_upgrade_history",
       "(",
       "upgrade_id, source_guest_user_id, source_guest_workspace_id, source_guest_session_id,",
-      "target_subject_user_id, target_user_id, target_workspace_id, selection_type",
+      "source_guest_session_secret_hash, target_subject_user_id, target_user_id, target_workspace_id,",
+      "selection_type, dropped_entities",
       ")",
-      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)",
     ].join(" "),
     [
       history.upgradeId,
       history.sourceGuestUserId,
       history.sourceGuestWorkspaceId,
       history.sourceGuestSessionId,
+      history.sourceGuestSessionSecretHash,
       history.targetSubjectUserId,
       history.targetUserId,
       history.targetWorkspaceId,
       history.selectionType,
+      history.droppedEntities === undefined
+        ? null
+        : JSON.stringify(history.droppedEntities),
     ],
   );
 
   for (const [sourceGuestReplicaId, targetReplicaId] of history.replicaIdMap) {
+    // Replica aliases are the last durable routing bridge for stale shipped
+    // clients that still reference pre-merge guest replica ids. They do not
+    // alias card/deck/review ids. Remove them only together with the rest of
+    // the guest-upgrade compatibility layer.
     await executor.query(
       [
         "INSERT INTO auth.guest_replica_aliases",
@@ -853,6 +787,36 @@ export async function deleteWorkspaceInExecutor(
     "DELETE FROM org.workspaces WHERE workspace_id = $1",
     [guestWorkspaceId],
   );
+}
+
+export async function deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor(
+  executor: DatabaseExecutor,
+  guestUserId: string,
+  guestWorkspaceId: string,
+): Promise<boolean> {
+  await applyUserDatabaseScopeInExecutor(executor, { userId: guestUserId });
+  const result = await executor.query<DeletedGuestWorkspaceRow>(
+    [
+      "DELETE FROM org.workspaces AS workspaces",
+      "WHERE workspaces.workspace_id = $1",
+      "AND EXISTS (",
+      "SELECT 1",
+      "FROM org.workspace_memberships memberships",
+      "WHERE memberships.workspace_id = workspaces.workspace_id",
+      "AND memberships.user_id = $2",
+      "AND memberships.role = 'owner'",
+      ")",
+      "AND 1 = (",
+      "SELECT COUNT(*)::int",
+      "FROM org.workspace_memberships all_memberships",
+      "WHERE all_memberships.workspace_id = workspaces.workspace_id",
+      ")",
+      "RETURNING workspaces.workspace_id",
+    ].join(" "),
+    [guestWorkspaceId, guestUserId],
+  );
+
+  return result.rows[0] !== undefined;
 }
 
 export async function deleteUserSettingsInExecutor(

--- a/apps/backend/src/guestAuth/types.ts
+++ b/apps/backend/src/guestAuth/types.ts
@@ -19,6 +19,18 @@ export type GuestUpgradeSelection =
     type: "create_new";
   }>;
 
+export type GuestUpgradeCompleteCapabilities = Readonly<{
+  guestWorkspaceSyncedAndOutboxDrained: boolean;
+  requiresGuestWorkspaceSyncedAndOutboxDrained: boolean;
+  supportsDroppedEntities: boolean;
+}>;
+
+export type GuestUpgradeDroppedEntities = Readonly<{
+  cardIds: ReadonlyArray<string>;
+  deckIds: ReadonlyArray<string>;
+  reviewEventIds: ReadonlyArray<string>;
+}>;
+
 export type GuestUpgradeCompletion = Readonly<{
   workspace: Readonly<{
     workspaceId: string;
@@ -31,6 +43,7 @@ export type GuestUpgradeCompletion = Readonly<{
   targetSubjectUserId: string;
   targetUserId: string;
   targetWorkspaceId: string;
+  droppedEntities?: GuestUpgradeDroppedEntities;
 }>;
 
 export type GuestUpgradeSelectionType = GuestUpgradeSelection["type"];
@@ -40,10 +53,12 @@ export type GuestUpgradeHistoryWrite = Readonly<{
   sourceGuestUserId: string;
   sourceGuestWorkspaceId: string;
   sourceGuestSessionId: string;
+  sourceGuestSessionSecretHash: string;
   targetSubjectUserId: string;
   targetUserId: string;
   targetWorkspaceId: string;
   selectionType: GuestUpgradeSelectionType;
+  droppedEntities?: GuestUpgradeDroppedEntities;
   replicaIdMap: ReadonlyMap<string, string>;
 }>;
 

--- a/apps/backend/src/guestAuth/upgrade.ts
+++ b/apps/backend/src/guestAuth/upgrade.ts
@@ -11,6 +11,7 @@ import {
   bindIdentityMappingInExecutor,
   loadGuestSessionInExecutor,
   loadGuestSessionRecordInExecutor,
+  loadGuestUpgradeReplayByGuestTokenInExecutor,
   loadGuestUpgradeReplayInExecutor,
   loadGuestWorkspaceIdInExecutor,
   loadIdentityMappingInExecutor,
@@ -20,16 +21,49 @@ import {
   selectWorkspaceForUserInExecutor,
   updateUserEmailInExecutor,
 } from "./store";
+import { hashGuestToken } from "./shared";
 import type {
+  GuestUpgradeCompleteCapabilities,
   GuestUpgradeCompletion,
   GuestUpgradePreparation,
+  GuestUpgradeDroppedEntities,
   GuestUpgradeResolution,
   GuestUpgradeSelection,
 } from "./types";
 
+function createDroppedEntitiesUnsupportedReplayError(): HttpError {
+  return new HttpError(
+    409,
+    "Guest upgrade replay includes dropped entities, but this client did not declare supportsDroppedEntities. Retry /guest-auth/upgrade/complete with supportsDroppedEntities: true.",
+    "GUEST_UPGRADE_DROPPED_ENTITIES_UNSUPPORTED",
+  );
+}
+
+function createGuestWorkspaceNotDrainedError(): HttpError {
+  return new HttpError(
+    409,
+    "Guest upgrade merge requires the current guest workspace to be fully synced and the local guest outbox to be empty. Sync the guest workspace, wait until the guest outbox is empty, then retry /guest-auth/upgrade/complete with guestWorkspaceSyncedAndOutboxDrained: true.",
+    "GUEST_UPGRADE_GUEST_SYNC_NOT_DRAINED",
+  );
+}
+
+function assertGuestWorkspaceSyncedAndOutboxDrained(
+  capabilities: GuestUpgradeCompleteCapabilities,
+): void {
+  if (
+    capabilities.requiresGuestWorkspaceSyncedAndOutboxDrained &&
+    !capabilities.guestWorkspaceSyncedAndOutboxDrained
+  ) {
+    throw createGuestWorkspaceNotDrainedError();
+  }
+}
+
 function logSuspiciousGuestUpgradeReplay(
-  reason: "revoked_session_without_history" | "revoked_session_subject_mismatch",
-  guestSessionId: string,
+  reason:
+    | "deleted_session_subject_mismatch"
+    | "revoked_session_without_history"
+    | "revoked_session_subject_mismatch",
+  guestSessionId: string | null,
   targetSubjectUserId: string,
   historyTargetSubjectUserId: string | null,
 ): void {
@@ -43,10 +77,60 @@ function logSuspiciousGuestUpgradeReplay(
   }));
 }
 
+async function createGuestUpgradeReplayCompletionInExecutor(
+  executor: DatabaseExecutor,
+  replay: Readonly<{
+    sourceGuestSessionId: string;
+    targetSubjectUserId: string;
+    targetUserId: string;
+    targetWorkspaceId: string;
+    droppedEntities?: GuestUpgradeDroppedEntities;
+  }>,
+  capabilities: GuestUpgradeCompleteCapabilities,
+): Promise<GuestUpgradeCompletion> {
+  if (replay.droppedEntities !== undefined && !capabilities.supportsDroppedEntities) {
+    throw createDroppedEntitiesUnsupportedReplayError();
+  }
+
+  return {
+    workspace: await loadWorkspaceSummaryInExecutor(
+      executor,
+      replay.targetUserId,
+      replay.targetWorkspaceId,
+    ),
+    outcome: "idempotent_replay",
+    guestSessionId: replay.sourceGuestSessionId,
+    targetSubjectUserId: replay.targetSubjectUserId,
+    targetUserId: replay.targetUserId,
+    targetWorkspaceId: replay.targetWorkspaceId,
+    ...(replay.droppedEntities === undefined
+      ? {}
+      : { droppedEntities: replay.droppedEntities }),
+  };
+}
+
+/**
+ * Replays the post-merge completion payload after the original guest session
+ * has already been revoked.
+ *
+ * This is a temporary backend compatibility path for already released clients
+ * that can retry `/guest-auth/upgrade/complete` after the server committed the
+ * merge but before the client received the first 200 response. It replays only
+ * the already-committed cloud-state merge result; it never accepts client local
+ * outbox rows. Remove this path only after the minimum supported client
+ * versions no longer rely on revoked-session replay semantics, and update the
+ * related compatibility notes in the same change.
+ *
+ * Because this path only returns stored merge history and never accepts local
+ * outbox rows, it intentionally does not require the fresh-merge guest drain
+ * assertion. The only replay-time client capability gate is whether the stored
+ * result includes dropped entities the caller must be able to handle.
+ */
 async function resolveRevokedGuestUpgradeReplayInExecutor(
   executor: DatabaseExecutor,
   guestSessionId: string,
   cognitoSubject: string,
+  capabilities: GuestUpgradeCompleteCapabilities,
 ): Promise<GuestUpgradeCompletion> {
   const replay = await loadGuestUpgradeReplayInExecutor(executor, guestSessionId);
   if (replay === null) {
@@ -69,18 +153,35 @@ async function resolveRevokedGuestUpgradeReplayInExecutor(
     throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
   }
 
-  return {
-    workspace: await loadWorkspaceSummaryInExecutor(
-      executor,
-      replay.targetUserId,
-      replay.targetWorkspaceId,
-    ),
-    outcome: "idempotent_replay",
-    guestSessionId,
-    targetSubjectUserId: replay.targetSubjectUserId,
-    targetUserId: replay.targetUserId,
-    targetWorkspaceId: replay.targetWorkspaceId,
-  };
+  return createGuestUpgradeReplayCompletionInExecutor(executor, replay, capabilities);
+}
+
+/**
+ * Replays committed merge history when the source guest user cleanup has
+ * already cascaded away the original auth.guest_sessions row.
+ */
+async function resolveDeletedGuestUpgradeReplayInExecutor(
+  executor: DatabaseExecutor,
+  guestToken: string,
+  cognitoSubject: string,
+  capabilities: GuestUpgradeCompleteCapabilities,
+): Promise<GuestUpgradeCompletion> {
+  const replay = await loadGuestUpgradeReplayByGuestTokenInExecutor(executor, guestToken);
+  if (replay === null) {
+    throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
+  }
+
+  if (replay.targetSubjectUserId !== cognitoSubject) {
+    logSuspiciousGuestUpgradeReplay(
+      "deleted_session_subject_mismatch",
+      replay.sourceGuestSessionId,
+      cognitoSubject,
+      replay.targetSubjectUserId,
+    );
+    throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
+  }
+
+  return createGuestUpgradeReplayCompletionInExecutor(executor, replay, capabilities);
 }
 
 async function resolveGuestUpgradeTargetInExecutor(
@@ -159,20 +260,33 @@ export async function prepareGuestUpgradeInExecutor(
 /**
  * Completes one guest upgrade attempt using the already-open executor.
  *
- * For `merge_required`, the backend deterministically forks globally keyed
- * entities into the destination workspace before the live guest rows are
- * deleted. Durable history still keeps replica aliases for idempotent replay.
+ * For `merge_required`, the backend moves guest content into the destination
+ * workspace from already-synced guest cloud rows without rekeying cards,
+ * decks, or review events. Clients must sync the guest workspace and drain the
+ * local guest outbox before calling this endpoint; pending local outbox rows are
+ * never carried through this merge.
+ *
+ * The durable replay/history layer below is intentionally narrower than the
+ * old V1 alias model from `main`, but it is still legacy compatibility code.
+ * Keep it only until released clients no longer depend on idempotent replay
+ * after session revocation or stale-client replica routing.
  */
 export async function completeGuestUpgradeInExecutor(
   executor: DatabaseExecutor,
   guestToken: string,
   cognitoSubject: string,
   selection: GuestUpgradeSelection,
+  capabilities: GuestUpgradeCompleteCapabilities,
 ): Promise<GuestUpgradeCompletion> {
   // Phase 1: load and lock the guest session.
   const guestSession = await loadGuestSessionRecordInExecutor(executor, guestToken, true);
   if (guestSession === null) {
-    throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
+    return resolveDeletedGuestUpgradeReplayInExecutor(
+      executor,
+      guestToken,
+      cognitoSubject,
+      capabilities,
+    );
   }
 
   // Phase 2: resolve the mapped target user.
@@ -183,10 +297,21 @@ export async function completeGuestUpgradeInExecutor(
 
   // Phase 3: short-circuit revoked-session replay.
   if (guestSession.revokedAt !== null) {
-    return resolveRevokedGuestUpgradeReplayInExecutor(executor, guestSession.sessionId, cognitoSubject);
+    return resolveRevokedGuestUpgradeReplayInExecutor(
+      executor,
+      guestSession.sessionId,
+      cognitoSubject,
+      capabilities,
+    );
   }
 
   // Phase 4: short-circuit same-user bound completion.
+  // In this invariant the Cognito subject is already bound to the guest user,
+  // so there is no cross-account merge and no guest source deletion. Keep this
+  // path before the drain-capability check for released clients that completed
+  // the bound flow before those merge-only capabilities existed; there are no
+  // dropped entities to report because all rows already belong to the final
+  // user/workspace.
   if (targetUserId === guestSession.userId) {
     const guestWorkspaceId = await loadGuestWorkspaceIdInExecutor(executor, guestSession.userId);
     return {
@@ -199,7 +324,12 @@ export async function completeGuestUpgradeInExecutor(
     };
   }
 
-  // Phase 5: resolve explicit source and destination workspace ids.
+  // Phase 5: enforce the merge precondition for clients that declare the new
+  // drain protocol. Omitted capability fields are the legacy shipped-client
+  // route shape and must remain compatible until those clients are out of support.
+  assertGuestWorkspaceSyncedAndOutboxDrained(capabilities);
+
+  // Phase 6: resolve explicit source and destination workspace ids.
   const guestUpgradeResolution = await resolveGuestUpgradeTargetInExecutor(
     executor,
     guestSession.userId,
@@ -207,31 +337,37 @@ export async function completeGuestUpgradeInExecutor(
     selection,
   );
 
-  // Phase 6: merge guest workspace state into the destination workspace.
-  const guestUpgradeHistory = await mergeGuestWorkspaceIntoTargetInExecutor(
+  // Phase 7: merge already-synced guest cloud state into the destination workspace.
+  const guestUpgradeMerge = await mergeGuestWorkspaceIntoTargetInExecutor(
     executor,
     {
       guestSessionId: guestSession.sessionId,
+      sourceGuestSessionSecretHash: hashGuestToken(guestToken),
       guestUserId: guestSession.userId,
       guestWorkspaceId: guestUpgradeResolution.guestWorkspaceId,
       targetSubjectUserId: cognitoSubject,
       targetUserId: guestUpgradeResolution.targetUserId,
       targetWorkspaceId: guestUpgradeResolution.targetWorkspaceId,
       selectionType: selection.type,
+      supportsDroppedEntities: capabilities.supportsDroppedEntities,
     },
   );
 
-  // Phase 7: record durable merge history and replica aliases.
-  await recordGuestUpgradeHistoryInExecutor(executor, guestUpgradeHistory);
+  // Phase 8: record durable merge history and replica aliases.
+  // This is legacy/idempotency-only compatibility for shipped clients that can
+  // replay completion or resend stale replica-bound operations after the guest
+  // session is gone. Remove only after those clients are explicitly out of
+  // support.
+  await recordGuestUpgradeHistoryInExecutor(executor, guestUpgradeMerge.history);
 
-  // Phase 8: persist the selected target workspace.
+  // Phase 9: persist the selected target workspace.
   await persistGuestUpgradeTargetSelectionInExecutor(
     executor,
     guestUpgradeResolution.targetUserId,
     guestUpgradeResolution.targetWorkspaceId,
   );
 
-  // Phase 9: revoke and delete guest source rows.
+  // Phase 10: revoke and delete guest source rows.
   await cleanupGuestSessionSourceInExecutor(
     executor,
     guestSession.userId,
@@ -239,7 +375,7 @@ export async function completeGuestUpgradeInExecutor(
     guestUpgradeResolution.guestWorkspaceId,
   );
 
-  // Phase 10: load the final workspace summary for the response.
+  // Phase 11: load the final workspace summary for the response.
   return {
     workspace: await loadWorkspaceSummaryInExecutor(
       executor,
@@ -251,5 +387,8 @@ export async function completeGuestUpgradeInExecutor(
     targetSubjectUserId: cognitoSubject,
     targetUserId: guestUpgradeResolution.targetUserId,
     targetWorkspaceId: guestUpgradeResolution.targetWorkspaceId,
+    ...(guestUpgradeMerge.history.droppedEntities === undefined
+      ? {}
+      : { droppedEntities: guestUpgradeMerge.history.droppedEntities }),
   };
 }

--- a/apps/backend/src/guestAuth/upgrade.ts
+++ b/apps/backend/src/guestAuth/upgrade.ts
@@ -90,6 +90,13 @@ async function resolveGuestUpgradeTargetInExecutor(
   selection: GuestUpgradeSelection,
 ): Promise<GuestUpgradeResolution> {
   const guestWorkspaceId = await loadGuestWorkspaceIdInExecutor(executor, guestUserId);
+  if (selection.type === "existing" && selection.workspaceId === guestWorkspaceId) {
+    throw new HttpError(
+      409,
+      "Choose a different destination workspace. The guest workspace cannot be merged into itself.",
+      "GUEST_UPGRADE_TARGET_SAME_AS_SOURCE",
+    );
+  }
   const targetWorkspaceId = selection.type === "existing"
     ? selection.workspaceId
     : await (async (): Promise<string> => {
@@ -152,9 +159,9 @@ export async function prepareGuestUpgradeInExecutor(
 /**
  * Completes one guest upgrade attempt using the already-open executor.
  *
- * For `merge_required`, V1 records durable guest/user/device aliases before the
- * live guest rows are deleted. Server-side guest chat rows still disappear via
- * cascade and are intentionally not copied in this version.
+ * For `merge_required`, the backend deterministically forks globally keyed
+ * entities into the destination workspace before the live guest rows are
+ * deleted. Durable history still keeps replica aliases for idempotent replay.
  */
 export async function completeGuestUpgradeInExecutor(
   executor: DatabaseExecutor,

--- a/apps/backend/src/routes/guestAuth.test.ts
+++ b/apps/backend/src/routes/guestAuth.test.ts
@@ -6,10 +6,21 @@ import type { AppEnv } from "../app";
 import type { AuthResult } from "../auth";
 import { AuthError } from "../auth";
 import { HttpError } from "../errors";
+import type {
+  GuestUpgradeCompleteCapabilities,
+  GuestUpgradeCompletion,
+  GuestUpgradeSelection,
+} from "../guestAuth";
 import { createGuestAuthRoutes } from "./guestAuth";
 
 type GuestAuthTestAppOptions = Readonly<{
   authResult: AuthResult;
+  onCompleteGuestUpgrade?: (
+    guestToken: string,
+    subjectUserId: string,
+    selection: GuestUpgradeSelection,
+    capabilities: GuestUpgradeCompleteCapabilities,
+  ) => Promise<GuestUpgradeCompletion>;
   onDeleteGuestSession?: (guestToken: string) => Promise<void>;
 }>;
 
@@ -47,6 +58,7 @@ function createGuestAuthTestApp(options: GuestAuthTestAppOptions): Hono<AppEnv> 
   });
   app.route("/", createGuestAuthRoutes({
     authenticateRequestFn: async () => options.authResult,
+    completeGuestUpgradeFn: options.onCompleteGuestUpgrade,
     deleteGuestSessionFn: async (guestToken) => {
       await options.onDeleteGuestSession?.(guestToken);
     },
@@ -136,5 +148,226 @@ test("POST /guest-auth/session/delete returns 409 for a guest session already li
     error: "Guest session is already linked to a signed-in account. Use /me/delete from that account instead.",
     requestId: "request-1",
     code: "GUEST_SESSION_DELETE_LINKED_ACCOUNT",
+  });
+});
+
+test("POST /guest-auth/upgrade/complete returns droppedEntities when merge drops guest rows", async () => {
+  let receivedSelection: GuestUpgradeSelection | null = null;
+  let receivedCapabilities: GuestUpgradeCompleteCapabilities | null = null;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("bearer"),
+    onCompleteGuestUpgrade: async (_guestToken, subjectUserId, selection, capabilities) => {
+      receivedSelection = selection;
+      receivedCapabilities = capabilities;
+      return {
+        workspace: {
+          workspaceId: "target-workspace",
+          name: "Target workspace",
+          createdAt: "2026-04-02T13:00:00.000Z",
+          isSelected: true,
+        },
+        outcome: "fresh_completion",
+        guestSessionId: "guest-session-upgrade-complete",
+        targetSubjectUserId: subjectUserId,
+        targetUserId: "linked-user",
+        targetWorkspaceId: "target-workspace",
+        droppedEntities: {
+          cardIds: ["card-drop-1"],
+          deckIds: ["deck-drop-1"],
+          reviewEventIds: ["review-drop-1", "review-drop-2"],
+        },
+      };
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/upgrade/complete", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt-token",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      guestToken: "guest-token-upgrade-complete",
+      selection: {
+        type: "existing",
+        workspaceId: "target-workspace",
+      },
+      guestWorkspaceSyncedAndOutboxDrained: true,
+      supportsDroppedEntities: true,
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(receivedSelection, {
+    type: "existing",
+    workspaceId: "target-workspace",
+  });
+  assert.deepEqual(receivedCapabilities, {
+    guestWorkspaceSyncedAndOutboxDrained: true,
+    requiresGuestWorkspaceSyncedAndOutboxDrained: true,
+    supportsDroppedEntities: true,
+  });
+  assert.deepEqual(await response.json(), {
+    workspace: {
+      workspaceId: "target-workspace",
+      name: "Target workspace",
+      createdAt: "2026-04-02T13:00:00.000Z",
+      isSelected: true,
+    },
+    droppedEntities: {
+      cardIds: ["card-drop-1"],
+      deckIds: ["deck-drop-1"],
+      reviewEventIds: ["review-drop-1", "review-drop-2"],
+    },
+  });
+});
+
+test("POST /guest-auth/upgrade/complete allows omitted droppedEntities support after guest drain assertion", async () => {
+  let receivedCapabilities: GuestUpgradeCompleteCapabilities | null = null;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("bearer"),
+    onCompleteGuestUpgrade: async (_guestToken, subjectUserId, _selection, capabilities) => {
+      receivedCapabilities = capabilities;
+      return {
+        workspace: {
+          workspaceId: "target-workspace",
+          name: "Target workspace",
+          createdAt: "2026-04-02T13:00:00.000Z",
+          isSelected: true,
+        },
+        outcome: "fresh_completion",
+        guestSessionId: "guest-session-upgrade-complete",
+        targetSubjectUserId: subjectUserId,
+        targetUserId: "linked-user",
+        targetWorkspaceId: "target-workspace",
+      };
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/upgrade/complete", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt-token",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      guestToken: "guest-token-upgrade-complete",
+      selection: {
+        type: "existing",
+        workspaceId: "target-workspace",
+      },
+      guestWorkspaceSyncedAndOutboxDrained: true,
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(receivedCapabilities, {
+    guestWorkspaceSyncedAndOutboxDrained: true,
+    requiresGuestWorkspaceSyncedAndOutboxDrained: true,
+    supportsDroppedEntities: false,
+  });
+  assert.deepEqual(await response.json(), {
+    workspace: {
+      workspaceId: "target-workspace",
+      name: "Target workspace",
+      createdAt: "2026-04-02T13:00:00.000Z",
+      isSelected: true,
+    },
+  });
+});
+
+test("POST /guest-auth/upgrade/complete preserves legacy clients that omit new capability fields", async () => {
+  let receivedCapabilities: GuestUpgradeCompleteCapabilities | null = null;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("bearer"),
+    onCompleteGuestUpgrade: async (_guestToken, subjectUserId, _selection, capabilities) => {
+      receivedCapabilities = capabilities;
+      return {
+        workspace: {
+          workspaceId: "target-workspace",
+          name: "Target workspace",
+          createdAt: "2026-04-02T13:00:00.000Z",
+          isSelected: true,
+        },
+        outcome: "fresh_completion",
+        guestSessionId: "guest-session-upgrade-complete",
+        targetSubjectUserId: subjectUserId,
+        targetUserId: "linked-user",
+        targetWorkspaceId: "target-workspace",
+      };
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/upgrade/complete", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt-token",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      guestToken: "guest-token-upgrade-complete",
+      selection: {
+        type: "existing",
+        workspaceId: "target-workspace",
+      },
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(receivedCapabilities, {
+    guestWorkspaceSyncedAndOutboxDrained: false,
+    requiresGuestWorkspaceSyncedAndOutboxDrained: false,
+    supportsDroppedEntities: false,
+  });
+  assert.deepEqual(await response.json(), {
+    workspace: {
+      workspaceId: "target-workspace",
+      name: "Target workspace",
+      createdAt: "2026-04-02T13:00:00.000Z",
+      isSelected: true,
+    },
+  });
+});
+
+test("POST /guest-auth/upgrade/complete reports typed drain rejection for stale clients", async () => {
+  let receivedCapabilities: GuestUpgradeCompleteCapabilities | null = null;
+  const app = createGuestAuthTestApp({
+    authResult: createAuthResult("bearer"),
+    onCompleteGuestUpgrade: async (_guestToken, _subjectUserId, _selection, capabilities) => {
+      receivedCapabilities = capabilities;
+      throw new HttpError(
+        409,
+        "Guest upgrade merge requires the current guest workspace to be fully synced and the local guest outbox to be empty. Sync the guest workspace, wait until the guest outbox is empty, then retry /guest-auth/upgrade/complete with guestWorkspaceSyncedAndOutboxDrained: true.",
+        "GUEST_UPGRADE_GUEST_SYNC_NOT_DRAINED",
+      );
+    },
+  });
+
+  const response = await app.request("http://localhost/guest-auth/upgrade/complete", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt-token",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      guestToken: "guest-token-upgrade-complete",
+      selection: {
+        type: "existing",
+        workspaceId: "target-workspace",
+      },
+      supportsDroppedEntities: true,
+    }),
+  });
+
+  assert.equal(response.status, 409);
+  assert.deepEqual(receivedCapabilities, {
+    guestWorkspaceSyncedAndOutboxDrained: false,
+    requiresGuestWorkspaceSyncedAndOutboxDrained: true,
+    supportsDroppedEntities: true,
+  });
+  assert.deepEqual(await response.json(), {
+    error: "Guest upgrade merge requires the current guest workspace to be fully synced and the local guest outbox to be empty. Sync the guest workspace, wait until the guest outbox is empty, then retry /guest-auth/upgrade/complete with guestWorkspaceSyncedAndOutboxDrained: true.",
+    requestId: "request-1",
+    code: "GUEST_UPGRADE_GUEST_SYNC_NOT_DRAINED",
   });
 });

--- a/apps/backend/src/routes/guestAuth.ts
+++ b/apps/backend/src/routes/guestAuth.ts
@@ -6,9 +6,11 @@ import {
   createGuestSession,
   deleteGuestSession,
   prepareGuestUpgrade,
+  type GuestUpgradeCompleteCapabilities,
   type GuestUpgradeSelection,
 } from "../guestAuth";
 import {
+  expectBoolean,
   expectNonEmptyString,
   expectRecord,
   parseJsonBody,
@@ -34,10 +36,16 @@ type GuestUpgradeCompleteEnvelope = Readonly<{
     createdAt: string;
     isSelected: true;
   }>;
+  droppedEntities?: Readonly<{
+    cardIds: ReadonlyArray<string>;
+    deckIds: ReadonlyArray<string>;
+    reviewEventIds: ReadonlyArray<string>;
+  }>;
 }>;
 
 type GuestAuthRoutesOptions = Readonly<{
   authenticateRequestFn?: typeof authenticateRequest;
+  completeGuestUpgradeFn?: typeof completeGuestUpgrade;
   deleteGuestSessionFn?: typeof deleteGuestSession;
 }>;
 
@@ -58,6 +66,33 @@ function parseGuestUpgradeSelection(value: unknown): GuestUpgradeSelection {
   throw new HttpError(400, "selection.type is invalid", "GUEST_UPGRADE_SELECTION_INVALID");
 }
 
+function parseGuestUpgradeCompleteCapabilities(
+  body: Readonly<Record<string, unknown>>,
+): GuestUpgradeCompleteCapabilities {
+  const hasGuestDrainCapability = body.guestWorkspaceSyncedAndOutboxDrained !== undefined;
+  const hasDroppedEntitiesCapability = body.supportsDroppedEntities !== undefined;
+  const guestWorkspaceSyncedAndOutboxDrained = !hasGuestDrainCapability
+    ? false
+    : expectBoolean(
+      body.guestWorkspaceSyncedAndOutboxDrained,
+      "guestWorkspaceSyncedAndOutboxDrained",
+    );
+
+  if (!hasDroppedEntitiesCapability) {
+    return {
+      guestWorkspaceSyncedAndOutboxDrained,
+      requiresGuestWorkspaceSyncedAndOutboxDrained: hasGuestDrainCapability,
+      supportsDroppedEntities: false,
+    };
+  }
+
+  return {
+    guestWorkspaceSyncedAndOutboxDrained,
+    requiresGuestWorkspaceSyncedAndOutboxDrained: true,
+    supportsDroppedEntities: expectBoolean(body.supportsDroppedEntities, "supportsDroppedEntities"),
+  };
+}
+
 function expectGuestAuthorizationToken(authorizationHeader: string | undefined): string {
   if (authorizationHeader === undefined || !authorizationHeader.startsWith("Guest ")) {
     throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
@@ -74,6 +109,7 @@ function expectGuestAuthorizationToken(authorizationHeader: string | undefined):
 export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const authenticateRequestFn = options.authenticateRequestFn ?? authenticateRequest;
+  const completeGuestUpgradeFn = options.completeGuestUpgradeFn ?? completeGuestUpgrade;
   const deleteGuestSessionFn = options.deleteGuestSessionFn ?? deleteGuestSession;
 
   app.post("/guest-auth/session", async (context) => {
@@ -125,14 +161,20 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
     const body = expectRecord(await parseJsonBody(context.req.raw));
     const guestToken = expectNonEmptyString(body.guestToken, "guestToken");
     const selection = parseGuestUpgradeSelection(body.selection);
+    // Merge completion consumes already-synced guest cloud rows only. Clients
+    // must drain their local guest outbox before calling this route.
+    const capabilities = parseGuestUpgradeCompleteCapabilities(body);
 
     try {
-      const result = await completeGuestUpgrade(guestToken, auth.subjectUserId, selection);
+      const result = await completeGuestUpgradeFn(guestToken, auth.subjectUserId, selection, capabilities);
       logCloudRouteEvent("guest_upgrade_complete", {
         requestId,
         route: context.req.path,
         statusCode: 200,
         selectionType: selection.type,
+        guestWorkspaceSyncedAndOutboxDrained: capabilities.guestWorkspaceSyncedAndOutboxDrained,
+        requiresGuestWorkspaceSyncedAndOutboxDrained: capabilities.requiresGuestWorkspaceSyncedAndOutboxDrained,
+        supportsDroppedEntities: capabilities.supportsDroppedEntities,
         targetSubjectUserId: result.targetSubjectUserId,
         guestSessionId: result.guestSessionId,
         targetUserId: result.targetUserId,
@@ -140,15 +182,24 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
         completionKind: result.outcome,
       }, false);
 
-      return context.json({
-        workspace: result.workspace,
-      } satisfies GuestUpgradeCompleteEnvelope);
+      const response: GuestUpgradeCompleteEnvelope = result.droppedEntities === undefined
+        ? {
+          workspace: result.workspace,
+        }
+        : {
+          workspace: result.workspace,
+          droppedEntities: result.droppedEntities,
+        };
+      return context.json(response);
     } catch (error) {
       logCloudRouteEvent("guest_upgrade_complete_error", {
         requestId,
         route: context.req.path,
         statusCode: error instanceof HttpError ? error.statusCode : 500,
         selectionType: selection.type,
+        guestWorkspaceSyncedAndOutboxDrained: capabilities.guestWorkspaceSyncedAndOutboxDrained,
+        requiresGuestWorkspaceSyncedAndOutboxDrained: capabilities.requiresGuestWorkspaceSyncedAndOutboxDrained,
+        supportsDroppedEntities: capabilities.supportsDroppedEntities,
         targetSubjectUserId: auth.subjectUserId,
         code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
         message: error instanceof Error ? error.message : String(error),

--- a/apps/backend/src/routes/sync.ts
+++ b/apps/backend/src/routes/sync.ts
@@ -34,6 +34,30 @@ function getInternalErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function getSyncConflictLogContext(error: HttpError | unknown): Record<string, unknown> {
+  if (!(error instanceof HttpError)) {
+    return {};
+  }
+
+  const syncConflict = error.details?.syncConflict;
+  if (syncConflict === undefined) {
+    return {};
+  }
+
+  return {
+    syncConflictPhase: syncConflict.phase,
+    syncConflictEntityType: syncConflict.entityType,
+    syncConflictEntityId: syncConflict.entityId,
+    conflictingWorkspaceId: syncConflict.conflictingWorkspaceId,
+    constraint: syncConflict.constraint,
+    sqlState: syncConflict.sqlState,
+    table: syncConflict.table,
+    entryIndex: syncConflict.entryIndex ?? null,
+    reviewEventIndex: syncConflict.reviewEventIndex ?? null,
+    syncConflictRecoverable: syncConflict.recoverable,
+  };
+}
+
 export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
 
@@ -54,6 +78,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         operationsCount: input.operations.length,
         entityTypes,
       }, false);
@@ -66,11 +92,14 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         operationsCount: input.operations.length,
         entityTypes,
         code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
         message: getInternalErrorMessage(error),
         validationIssues: summarizeValidationIssues(error),
+        ...getSyncConflictLogContext(error),
       }, true);
       throw error;
     }
@@ -92,6 +121,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         afterHotChangeId: input.afterHotChangeId,
         nextHotChangeId: result.nextHotChangeId,
         changesCount: result.changes.length,
@@ -105,6 +136,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         afterHotChangeId: input.afterHotChangeId,
         code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
         message: getInternalErrorMessage(error),
@@ -130,6 +163,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         mode: input.mode,
       }, false);
       return context.json(result);
@@ -141,10 +176,13 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         mode: input.mode,
         code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
         message: getInternalErrorMessage(error),
         validationIssues: summarizeValidationIssues(error),
+        ...getSyncConflictLogContext(error),
       }, true);
       throw error;
     }
@@ -166,6 +204,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         afterReviewSequenceId: input.afterReviewSequenceId,
         nextReviewSequenceId: result.nextReviewSequenceId,
         reviewEventsCount: result.reviewEvents.length,
@@ -179,6 +219,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         afterReviewSequenceId: input.afterReviewSequenceId,
         code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
         message: getInternalErrorMessage(error),
@@ -204,6 +246,8 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         reviewEventsCount: input.reviewEvents.length,
         importedCount: result.importedCount,
         duplicateCount: result.duplicateCount,
@@ -217,10 +261,13 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         userId: requestContext.userId,
         workspaceId,
         installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
         reviewEventsCount: input.reviewEvents.length,
         code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
         message: getInternalErrorMessage(error),
         validationIssues: summarizeValidationIssues(error),
+        ...getSyncConflictLogContext(error),
       }, true);
       throw error;
     }

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -158,11 +158,12 @@ export function logAdminQueryEvent(
 export function summarizeValidationIssues(
   error: HttpError | unknown,
 ): ReadonlyArray<Readonly<{ path: string; code: string }>> {
-  if (!(error instanceof HttpError) || error.details === null) {
+  if (!(error instanceof HttpError)) {
     return [];
   }
 
-  return error.details.validationIssues.map((issue) => ({
+  const validationIssues = error.details?.validationIssues ?? [];
+  return validationIssues.map((issue) => ({
     path: issue.path,
     code: issue.code,
   }));

--- a/apps/backend/src/sync/bootstrap.ts
+++ b/apps/backend/src/sync/bootstrap.ts
@@ -11,6 +11,7 @@ import {
 } from "../pagination";
 import { ensureWorkspaceReplica } from "../syncIdentity";
 import { ensureWorkspaceSyncMetadataInExecutor } from "../syncChanges";
+import { annotateSyncConflictHttpError } from "./fork";
 import { applyWorkspaceSchedulerSettingsSnapshotInExecutor } from "../workspaceSchedulerSettings";
 import {
   cardPayloadSchema,
@@ -164,48 +165,56 @@ export async function processSyncBootstrap(
       }
 
       let appliedEntriesCount = 0;
-      for (const entry of input.entries) {
-        if (entry.entityType === "card") {
-          await upsertCardSnapshotInExecutor(
+      for (const [entryIndex, entry] of input.entries.entries()) {
+        try {
+          if (entry.entityType === "card") {
+            await upsertCardSnapshotInExecutor(
+              executor,
+              workspaceId,
+              toCardSnapshotInput(entry.payload),
+              toCardMutationMetadata({
+                clientUpdatedAt: entry.payload.clientUpdatedAt,
+                lastModifiedByReplicaId: replicaId,
+                lastOperationId: entry.payload.lastOperationId,
+              }),
+            );
+            appliedEntriesCount += 1;
+            continue;
+          }
+
+          if (entry.entityType === "deck") {
+            await upsertDeckSnapshotInExecutor(
+              executor,
+              workspaceId,
+              toDeckSnapshotInput(entry.payload),
+              toDeckMutationMetadata({
+                clientUpdatedAt: entry.payload.clientUpdatedAt,
+                lastModifiedByReplicaId: replicaId,
+                lastOperationId: entry.payload.lastOperationId,
+              }),
+            );
+            appliedEntriesCount += 1;
+            continue;
+          }
+
+          await applyWorkspaceSchedulerSettingsSnapshotInExecutor(
             executor,
             workspaceId,
-            toCardSnapshotInput(entry.payload),
-            toCardMutationMetadata({
+            toWorkspaceSchedulerSettingsSnapshotInput(entry.payload),
+            toWorkspaceSchedulerSettingsMutationMetadata({
               clientUpdatedAt: entry.payload.clientUpdatedAt,
               lastModifiedByReplicaId: replicaId,
               lastOperationId: entry.payload.lastOperationId,
             }),
           );
           appliedEntriesCount += 1;
-          continue;
+        } catch (error) {
+          const annotatedError = annotateSyncConflictHttpError(error, {
+            phase: "bootstrap",
+            entryIndex,
+          });
+          throw annotatedError ?? error;
         }
-
-        if (entry.entityType === "deck") {
-          await upsertDeckSnapshotInExecutor(
-            executor,
-            workspaceId,
-            toDeckSnapshotInput(entry.payload),
-            toDeckMutationMetadata({
-              clientUpdatedAt: entry.payload.clientUpdatedAt,
-              lastModifiedByReplicaId: replicaId,
-              lastOperationId: entry.payload.lastOperationId,
-            }),
-          );
-          appliedEntriesCount += 1;
-          continue;
-        }
-
-        await applyWorkspaceSchedulerSettingsSnapshotInExecutor(
-          executor,
-          workspaceId,
-          toWorkspaceSchedulerSettingsSnapshotInput(entry.payload),
-          toWorkspaceSchedulerSettingsMutationMetadata({
-            clientUpdatedAt: entry.payload.clientUpdatedAt,
-            lastModifiedByReplicaId: replicaId,
-            lastOperationId: entry.payload.lastOperationId,
-          }),
-        );
-        appliedEntriesCount += 1;
       }
 
       return {

--- a/apps/backend/src/sync/fork.ts
+++ b/apps/backend/src/sync/fork.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { type DatabaseExecutor } from "../db";
 import {
   HttpError,
@@ -8,10 +7,6 @@ import {
 } from "../errors";
 
 export const SYNC_WORKSPACE_FORK_REQUIRED = "SYNC_WORKSPACE_FORK_REQUIRED";
-
-const CARD_FORK_NAMESPACE = "5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1";
-const DECK_FORK_NAMESPACE = "98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4";
-const REVIEW_EVENT_FORK_NAMESPACE = "3a214a3e-9c89-426d-a21f-11a5f5c1d6e8";
 
 type ConflictWorkspaceRow = Readonly<{
   workspace_id: string;
@@ -39,44 +34,6 @@ type SyncConflictAnnotation = Readonly<{
   entryIndex?: number;
   reviewEventIndex?: number;
 }>;
-
-function toUuidBytes(value: string): Buffer {
-  const normalizedValue = value.replace(/-/g, "").toLowerCase();
-  if (!/^[0-9a-f]{32}$/.test(normalizedValue)) {
-    throw new Error(`Invalid UUID namespace: ${value}`);
-  }
-
-  return Buffer.from(normalizedValue, "hex");
-}
-
-function toUuidString(bytes: Buffer): string {
-  const hex = bytes.toString("hex");
-  return [
-    hex.slice(0, 8),
-    hex.slice(8, 12),
-    hex.slice(12, 16),
-    hex.slice(16, 20),
-    hex.slice(20, 32),
-  ].join("-");
-}
-
-function createDeterministicUuidV5(namespaceId: string, name: string): string {
-  const hash = createHash("sha1");
-  hash.update(toUuidBytes(namespaceId));
-  hash.update(Buffer.from(name, "utf8"));
-  const bytes = hash.digest().subarray(0, 16);
-  bytes[6] = (bytes[6] & 0x0f) | 0x50;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-  return toUuidString(bytes);
-}
-
-function createForkName(
-  sourceWorkspaceId: string,
-  targetWorkspaceId: string,
-  entityId: string,
-): string {
-  return `${sourceWorkspaceId}:${targetWorkspaceId}:${entityId}`;
-}
 
 function createSyncConflictDetails(input: SyncConflictErrorInput): SyncConflictDetails {
   return {
@@ -140,49 +97,4 @@ export function annotateSyncConflictHttpError(
   };
 
   return new HttpError(error.statusCode, error.message, error.code ?? undefined, details);
-}
-
-export function forkCardIdForWorkspace(
-  sourceWorkspaceId: string,
-  targetWorkspaceId: string,
-  cardId: string,
-): string {
-  if (sourceWorkspaceId === targetWorkspaceId) {
-    return cardId;
-  }
-
-  return createDeterministicUuidV5(
-    CARD_FORK_NAMESPACE,
-    createForkName(sourceWorkspaceId, targetWorkspaceId, cardId),
-  );
-}
-
-export function forkDeckIdForWorkspace(
-  sourceWorkspaceId: string,
-  targetWorkspaceId: string,
-  deckId: string,
-): string {
-  if (sourceWorkspaceId === targetWorkspaceId) {
-    return deckId;
-  }
-
-  return createDeterministicUuidV5(
-    DECK_FORK_NAMESPACE,
-    createForkName(sourceWorkspaceId, targetWorkspaceId, deckId),
-  );
-}
-
-export function forkReviewEventIdForWorkspace(
-  sourceWorkspaceId: string,
-  targetWorkspaceId: string,
-  reviewEventId: string,
-): string {
-  if (sourceWorkspaceId === targetWorkspaceId) {
-    return reviewEventId;
-  }
-
-  return createDeterministicUuidV5(
-    REVIEW_EVENT_FORK_NAMESPACE,
-    createForkName(sourceWorkspaceId, targetWorkspaceId, reviewEventId),
-  );
 }

--- a/apps/backend/src/sync/fork.ts
+++ b/apps/backend/src/sync/fork.ts
@@ -1,0 +1,188 @@
+import { createHash } from "node:crypto";
+import { type DatabaseExecutor } from "../db";
+import {
+  HttpError,
+  type HttpErrorDetails,
+  type SyncConflictDetails,
+  type SyncConflictEntityType,
+} from "../errors";
+
+export const SYNC_WORKSPACE_FORK_REQUIRED = "SYNC_WORKSPACE_FORK_REQUIRED";
+
+const CARD_FORK_NAMESPACE = "5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1";
+const DECK_FORK_NAMESPACE = "98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4";
+const REVIEW_EVENT_FORK_NAMESPACE = "3a214a3e-9c89-426d-a21f-11a5f5c1d6e8";
+
+type ConflictWorkspaceRow = Readonly<{
+  workspace_id: string;
+}>;
+
+type SyncConflictLookupInput = Readonly<{
+  entityType: SyncConflictEntityType;
+  entityId: string;
+}>;
+
+type SyncConflictErrorInput = Readonly<{
+  phase: string;
+  entityType: SyncConflictEntityType;
+  entityId: string;
+  conflictingWorkspaceId: string;
+  constraint: string | null;
+  sqlState: string | null;
+  table: string | null;
+  entryIndex?: number;
+  reviewEventIndex?: number;
+}>;
+
+type SyncConflictAnnotation = Readonly<{
+  phase: string;
+  entryIndex?: number;
+  reviewEventIndex?: number;
+}>;
+
+function toUuidBytes(value: string): Buffer {
+  const normalizedValue = value.replace(/-/g, "").toLowerCase();
+  if (!/^[0-9a-f]{32}$/.test(normalizedValue)) {
+    throw new Error(`Invalid UUID namespace: ${value}`);
+  }
+
+  return Buffer.from(normalizedValue, "hex");
+}
+
+function toUuidString(bytes: Buffer): string {
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+function createDeterministicUuidV5(namespaceId: string, name: string): string {
+  const hash = createHash("sha1");
+  hash.update(toUuidBytes(namespaceId));
+  hash.update(Buffer.from(name, "utf8"));
+  const bytes = hash.digest().subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  return toUuidString(bytes);
+}
+
+function createForkName(
+  sourceWorkspaceId: string,
+  targetWorkspaceId: string,
+  entityId: string,
+): string {
+  return `${sourceWorkspaceId}:${targetWorkspaceId}:${entityId}`;
+}
+
+function createSyncConflictDetails(input: SyncConflictErrorInput): SyncConflictDetails {
+  return {
+    phase: input.phase,
+    entityType: input.entityType,
+    entityId: input.entityId,
+    conflictingWorkspaceId: input.conflictingWorkspaceId,
+    constraint: input.constraint,
+    sqlState: input.sqlState,
+    table: input.table,
+    ...(input.entryIndex === undefined ? {} : { entryIndex: input.entryIndex }),
+    ...(input.reviewEventIndex === undefined ? {} : { reviewEventIndex: input.reviewEventIndex }),
+    recoverable: true,
+  };
+}
+
+export async function findSyncConflictWorkspaceIdInExecutor(
+  executor: DatabaseExecutor,
+  input: SyncConflictLookupInput,
+): Promise<string | null> {
+  const result = await executor.query<ConflictWorkspaceRow>(
+    "SELECT workspace_id FROM sync.find_conflicting_workspace_id($1, $2) LIMIT 1",
+    [input.entityType, input.entityId],
+  );
+
+  return result.rows[0]?.workspace_id ?? null;
+}
+
+export function createSyncConflictHttpError(input: SyncConflictErrorInput): HttpError {
+  return new HttpError(
+    409,
+    "Sync detected content copied from another workspace. Retry after forking ids.",
+    SYNC_WORKSPACE_FORK_REQUIRED,
+    {
+      syncConflict: createSyncConflictDetails(input),
+    },
+  );
+}
+
+export function annotateSyncConflictHttpError(
+  error: unknown,
+  annotation: SyncConflictAnnotation,
+): HttpError | null {
+  if (!(error instanceof HttpError) || error.code !== SYNC_WORKSPACE_FORK_REQUIRED) {
+    return null;
+  }
+
+  const syncConflict = error.details?.syncConflict;
+  if (syncConflict === undefined) {
+    return null;
+  }
+
+  const details: HttpErrorDetails = {
+    ...error.details,
+    syncConflict: {
+      ...syncConflict,
+      phase: annotation.phase,
+      ...(annotation.entryIndex === undefined ? {} : { entryIndex: annotation.entryIndex }),
+      ...(annotation.reviewEventIndex === undefined ? {} : { reviewEventIndex: annotation.reviewEventIndex }),
+    },
+  };
+
+  return new HttpError(error.statusCode, error.message, error.code ?? undefined, details);
+}
+
+export function forkCardIdForWorkspace(
+  sourceWorkspaceId: string,
+  targetWorkspaceId: string,
+  cardId: string,
+): string {
+  if (sourceWorkspaceId === targetWorkspaceId) {
+    return cardId;
+  }
+
+  return createDeterministicUuidV5(
+    CARD_FORK_NAMESPACE,
+    createForkName(sourceWorkspaceId, targetWorkspaceId, cardId),
+  );
+}
+
+export function forkDeckIdForWorkspace(
+  sourceWorkspaceId: string,
+  targetWorkspaceId: string,
+  deckId: string,
+): string {
+  if (sourceWorkspaceId === targetWorkspaceId) {
+    return deckId;
+  }
+
+  return createDeterministicUuidV5(
+    DECK_FORK_NAMESPACE,
+    createForkName(sourceWorkspaceId, targetWorkspaceId, deckId),
+  );
+}
+
+export function forkReviewEventIdForWorkspace(
+  sourceWorkspaceId: string,
+  targetWorkspaceId: string,
+  reviewEventId: string,
+): string {
+  if (sourceWorkspaceId === targetWorkspaceId) {
+    return reviewEventId;
+  }
+
+  return createDeterministicUuidV5(
+    REVIEW_EVENT_FORK_NAMESPACE,
+    createForkName(sourceWorkspaceId, targetWorkspaceId, reviewEventId),
+  );
+}

--- a/apps/backend/src/sync/reviewHistory.ts
+++ b/apps/backend/src/sync/reviewHistory.ts
@@ -6,6 +6,7 @@ import {
 } from "../db";
 import { HttpError } from "../errors";
 import { ensureWorkspaceReplica } from "../syncIdentity";
+import { annotateSyncConflictHttpError } from "./fork";
 import type {
   SyncReviewHistoryImportInput,
   SyncReviewHistoryPullInput,
@@ -73,27 +74,35 @@ export async function processSyncReviewHistoryImportInExecutor(
   let importedCount = 0;
   let duplicateCount = 0;
 
-  for (const reviewEvent of input.reviewEvents) {
-    const mutation = await appendReviewEventSnapshotInExecutor(
-      executor,
-      workspaceId,
-      {
-        reviewEventId: reviewEvent.reviewEventId,
+  for (const [reviewEventIndex, reviewEvent] of input.reviewEvents.entries()) {
+    try {
+      const mutation = await appendReviewEventSnapshotInExecutor(
+        executor,
         workspaceId,
-        cardId: reviewEvent.cardId,
-        replicaId,
-        clientEventId: reviewEvent.clientEventId,
-        rating: reviewEvent.rating,
-        reviewedAtClient: reviewEvent.reviewedAtClient,
-        reviewedAtServer: reviewEvent.reviewedAtServer,
-      },
-      reviewEvent.reviewEventId,
-    );
+        {
+          reviewEventId: reviewEvent.reviewEventId,
+          workspaceId,
+          cardId: reviewEvent.cardId,
+          replicaId,
+          clientEventId: reviewEvent.clientEventId,
+          rating: reviewEvent.rating,
+          reviewedAtClient: reviewEvent.reviewedAtClient,
+          reviewedAtServer: reviewEvent.reviewedAtServer,
+        },
+        reviewEvent.reviewEventId,
+      );
 
-    if (mutation.applied) {
-      importedCount += 1;
-    } else {
-      duplicateCount += 1;
+      if (mutation.applied) {
+        importedCount += 1;
+      } else {
+        duplicateCount += 1;
+      }
+    } catch (error) {
+      const annotatedError = annotateSyncConflictHttpError(error, {
+        phase: "review_history_import",
+        reviewEventIndex,
+      });
+      throw annotatedError ?? error;
     }
   }
 

--- a/apps/backend/src/syncConflict.test.ts
+++ b/apps/backend/src/syncConflict.test.ts
@@ -1,0 +1,373 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import { createPublicHttpErrorBody } from "./app";
+import { upsertCardSnapshotInExecutor } from "./cards";
+import type { DatabaseExecutor } from "./db";
+import { upsertDeckSnapshotInExecutor } from "./decks";
+import { HttpError } from "./errors";
+import {
+  annotateSyncConflictHttpError,
+  createSyncConflictHttpError,
+  findSyncConflictWorkspaceIdInExecutor,
+  SYNC_WORKSPACE_FORK_REQUIRED,
+} from "./sync/fork";
+import { processSyncReviewHistoryImportInExecutor } from "./sync/reviewHistory";
+
+type EntityType = "card" | "deck" | "review_event";
+
+type RecordedQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<string | number | boolean | Date | null | ReadonlyArray<string>>;
+}>;
+
+type ConflictExecutorOptions = Readonly<{
+  currentUserId: string;
+  currentWorkspaceId: string;
+  conflictingWorkspaceId: string;
+  entityType: EntityType;
+}>;
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createConflictExecutor(
+  options: ConflictExecutorOptions,
+): Readonly<{
+  executor: DatabaseExecutor;
+  recordedQueries: Array<RecordedQuery>;
+}> {
+  const recordedQueries: Array<RecordedQuery> = [];
+  let currentUserId = options.currentUserId;
+  let currentWorkspaceId = options.currentWorkspaceId;
+
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<string | number | boolean | Date | null | ReadonlyArray<string>>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+
+      if (text.includes("set_config('app.user_id'")) {
+        currentUserId = typeof params[0] === "string" ? params[0] : currentUserId;
+        currentWorkspaceId = typeof params[1] === "string" && params[1] !== ""
+          ? params[1]
+          : currentWorkspaceId;
+        return createQueryResult<Row>([]);
+      }
+
+      if (text === "SELECT security.current_user_id() AS user_id") {
+        return createQueryResult<Row>([{
+          user_id: currentUserId,
+        } as unknown as Row]);
+      }
+
+      if (text === "SELECT workspace_id FROM sync.find_conflicting_workspace_id($1, $2) LIMIT 1") {
+        return createQueryResult<Row>([{
+          workspace_id: options.conflictingWorkspaceId,
+        } as unknown as Row]);
+      }
+
+      if (
+        options.entityType === "card"
+        && text.includes("FROM content.cards")
+        && text.includes("WHERE workspace_id = $1 AND card_id = $2")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        options.entityType === "card"
+        && text.includes("INSERT INTO content.cards")
+        && text.includes("ON CONFLICT DO NOTHING")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        options.entityType === "deck"
+        && text.includes("FROM content.decks")
+        && text.includes("WHERE workspace_id = $1 AND deck_id = $2")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        options.entityType === "deck"
+        && text.includes("INSERT INTO content.decks")
+        && text.includes("ON CONFLICT DO NOTHING")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        options.entityType === "review_event"
+        && text.includes("INSERT INTO content.review_events")
+        && text.includes("ON CONFLICT DO NOTHING")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  return {
+    executor,
+    recordedQueries,
+  };
+}
+
+test("findSyncConflictWorkspaceIdInExecutor resolves conflicts without membership probing", async () => {
+  const { executor, recordedQueries } = createConflictExecutor({
+    currentUserId: "user-1",
+    currentWorkspaceId: "workspace-current",
+    conflictingWorkspaceId: "workspace-hidden",
+    entityType: "card",
+  });
+
+  const conflictingWorkspaceId = await findSyncConflictWorkspaceIdInExecutor(executor, {
+    entityType: "card",
+    entityId: "card-conflict-hidden",
+  });
+
+  assert.equal(conflictingWorkspaceId, "workspace-hidden");
+  assert.equal(
+    recordedQueries.some((query) => query.text.includes("FROM org.workspace_memberships")),
+    false,
+  );
+});
+
+test("upsertCardSnapshotInExecutor returns a typed cross-workspace fork error", async () => {
+  const cardId = "card-conflict-1";
+  const { executor, recordedQueries } = createConflictExecutor({
+    currentUserId: "user-1",
+    currentWorkspaceId: "workspace-current",
+    conflictingWorkspaceId: "workspace-other",
+    entityType: "card",
+  });
+
+  await assert.rejects(
+    upsertCardSnapshotInExecutor(
+      executor,
+      "workspace-current",
+      {
+        cardId,
+        frontText: "Front",
+        backText: "Back",
+        tags: ["tag"],
+        effortLevel: "fast",
+        dueAt: null,
+        createdAt: "2026-04-24T10:00:00.000Z",
+        reps: 0,
+        lapses: 0,
+        fsrsCardState: "new",
+        fsrsStepIndex: null,
+        fsrsStability: null,
+        fsrsDifficulty: null,
+        fsrsLastReviewedAt: null,
+        fsrsScheduledDays: null,
+        deletedAt: null,
+      },
+      {
+        clientUpdatedAt: "2026-04-24T10:00:00.000Z",
+        lastModifiedByReplicaId: "replica-1",
+        lastOperationId: "op-1",
+      },
+    ),
+    (error: unknown): boolean => {
+      if (!(error instanceof HttpError)) {
+        return false;
+      }
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, SYNC_WORKSPACE_FORK_REQUIRED);
+      assert.deepEqual(error.details?.syncConflict, {
+        phase: "sync_write",
+        entityType: "card",
+        entityId: cardId,
+        conflictingWorkspaceId: "workspace-other",
+        constraint: "cards_pkey",
+        sqlState: "23505",
+        table: "cards",
+        recoverable: true,
+      });
+      return true;
+    },
+  );
+
+  assert.ok(recordedQueries.some((query) => query.text.includes("INSERT INTO content.cards")));
+});
+
+test("upsertDeckSnapshotInExecutor returns a typed cross-workspace fork error", async () => {
+  const deckId = "deck-conflict-1";
+  const { executor } = createConflictExecutor({
+    currentUserId: "user-1",
+    currentWorkspaceId: "workspace-current",
+    conflictingWorkspaceId: "workspace-other",
+    entityType: "deck",
+  });
+
+  await assert.rejects(
+    upsertDeckSnapshotInExecutor(
+      executor,
+      "workspace-current",
+      {
+        deckId,
+        name: "Deck",
+        filterDefinition: {
+          version: 2,
+          effortLevels: ["fast"],
+          tags: ["tag"],
+        },
+        createdAt: "2026-04-24T10:00:00.000Z",
+        deletedAt: null,
+      },
+      {
+        clientUpdatedAt: "2026-04-24T10:00:00.000Z",
+        lastModifiedByReplicaId: "replica-1",
+        lastOperationId: "op-1",
+      },
+    ),
+    (error: unknown): boolean => {
+      if (!(error instanceof HttpError)) {
+        return false;
+      }
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, SYNC_WORKSPACE_FORK_REQUIRED);
+      assert.deepEqual(error.details?.syncConflict, {
+        phase: "sync_write",
+        entityType: "deck",
+        entityId: deckId,
+        conflictingWorkspaceId: "workspace-other",
+        constraint: "decks_pkey",
+        sqlState: "23505",
+        table: "decks",
+        recoverable: true,
+      });
+      return true;
+    },
+  );
+});
+
+test("processSyncReviewHistoryImportInExecutor annotates fork errors with the review event index", async () => {
+  const reviewEventId = "review-event-conflict-1";
+  const { executor } = createConflictExecutor({
+    currentUserId: "user-1",
+    currentWorkspaceId: "workspace-current",
+    conflictingWorkspaceId: "workspace-other",
+    entityType: "review_event",
+  });
+
+  await assert.rejects(
+    processSyncReviewHistoryImportInExecutor(
+      executor,
+      "workspace-current",
+      "replica-current",
+      {
+        installationId: "installation-1",
+        platform: "ios",
+        appVersion: "1.2.3",
+        reviewEvents: [{
+          reviewEventId,
+          workspaceId: "workspace-current",
+          cardId: "card-1",
+          clientEventId: "client-event-1",
+          rating: 3,
+          reviewedAtClient: "2026-04-24T10:00:00.000Z",
+          reviewedAtServer: "2026-04-24T10:00:00.000Z",
+        }],
+      },
+    ),
+    (error: unknown): boolean => {
+      if (!(error instanceof HttpError)) {
+        return false;
+      }
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, SYNC_WORKSPACE_FORK_REQUIRED);
+      assert.deepEqual(error.details?.syncConflict, {
+        phase: "review_history_import",
+        entityType: "review_event",
+        entityId: reviewEventId,
+        conflictingWorkspaceId: "workspace-other",
+        constraint: "review_events_pkey",
+        sqlState: "23505",
+        table: "review_events",
+        reviewEventIndex: 0,
+        recoverable: true,
+      });
+      return true;
+    },
+  );
+});
+
+test("annotateSyncConflictHttpError adds bootstrap entry metadata", () => {
+  const error = createSyncConflictHttpError({
+    phase: "sync_write",
+    entityType: "card",
+    entityId: "card-1",
+    conflictingWorkspaceId: "workspace-other",
+    constraint: "cards_pkey",
+    sqlState: "23505",
+    table: "cards",
+  });
+
+  const annotatedError = annotateSyncConflictHttpError(error, {
+    phase: "bootstrap",
+    entryIndex: 3,
+  });
+
+  assert.notEqual(annotatedError, null);
+  if (annotatedError === null) {
+    throw new Error("Expected sync conflict annotation to preserve the HttpError");
+  }
+  assert.deepEqual(annotatedError.details?.syncConflict, {
+    phase: "bootstrap",
+    entityType: "card",
+    entityId: "card-1",
+    conflictingWorkspaceId: "workspace-other",
+    constraint: "cards_pkey",
+    sqlState: "23505",
+    table: "cards",
+    entryIndex: 3,
+    recoverable: true,
+  });
+});
+
+test("createPublicHttpErrorBody includes optional HttpError details", () => {
+  const error = createSyncConflictHttpError({
+    phase: "bootstrap",
+    entityType: "deck",
+    entityId: "deck-1",
+    conflictingWorkspaceId: "workspace-other",
+    constraint: "decks_pkey",
+    sqlState: "23505",
+    table: "decks",
+  });
+
+  const body = createPublicHttpErrorBody(error, "request-1");
+
+  assert.deepEqual(body, {
+    error: "Sync detected content copied from another workspace. Retry after forking ids.",
+    requestId: "request-1",
+    code: SYNC_WORKSPACE_FORK_REQUIRED,
+    details: {
+      syncConflict: {
+        phase: "bootstrap",
+        entityType: "deck",
+        entityId: "deck-1",
+        conflictingWorkspaceId: "workspace-other",
+        constraint: "decks_pkey",
+        sqlState: "23505",
+        table: "decks",
+        recoverable: true,
+      },
+    },
+  });
+});

--- a/apps/backend/src/syncConflict.test.ts
+++ b/apps/backend/src/syncConflict.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import test from "node:test";
 import type pg from "pg";
 import { createPublicHttpErrorBody } from "./app";
@@ -143,6 +145,20 @@ test("findSyncConflictWorkspaceIdInExecutor resolves conflicts without membershi
     recordedQueries.some((query) => query.text.includes("FROM org.workspace_memberships")),
     false,
   );
+});
+
+test("0048 sync conflict lookup casts target ids once and compares UUID columns directly", () => {
+  const migration = readFileSync(
+    join(__dirname, "../../../db/migrations/0048_sync_conflict_lookup.sql"),
+    "utf8",
+  );
+
+  assert.match(migration, /target_entity_uuid UUID/);
+  assert.match(migration, /target_entity_uuid := target_entity_id::UUID/);
+  assert.doesNotMatch(migration, /::text\s*=\s*target_entity_id/);
+  assert.match(migration, /cards\.card_id = target_entity_uuid/);
+  assert.match(migration, /decks\.deck_id = target_entity_uuid/);
+  assert.match(migration, /review_events\.review_event_id = target_entity_uuid/);
 });
 
 test("upsertCardSnapshotInExecutor returns a typed cross-workspace fork error", async () => {
@@ -340,7 +356,7 @@ test("annotateSyncConflictHttpError adds bootstrap entry metadata", () => {
   });
 });
 
-test("createPublicHttpErrorBody includes optional HttpError details", () => {
+test("createPublicHttpErrorBody includes safe sync conflict details", () => {
   const error = createSyncConflictHttpError({
     phase: "bootstrap",
     entityType: "deck",
@@ -350,6 +366,8 @@ test("createPublicHttpErrorBody includes optional HttpError details", () => {
     sqlState: "23505",
     table: "decks",
   });
+
+  assert.equal(error.details?.syncConflict?.conflictingWorkspaceId, "workspace-other");
 
   const body = createPublicHttpErrorBody(error, "request-1");
 
@@ -362,12 +380,12 @@ test("createPublicHttpErrorBody includes optional HttpError details", () => {
         phase: "bootstrap",
         entityType: "deck",
         entityId: "deck-1",
-        conflictingWorkspaceId: "workspace-other",
-        constraint: "decks_pkey",
-        sqlState: "23505",
-        table: "decks",
         recoverable: true,
       },
     },
   });
+  assert.equal(JSON.stringify(body).includes("workspace-other"), false);
+  assert.equal(JSON.stringify(body).includes("conflictingWorkspaceId"), false);
+  assert.equal(JSON.stringify(body).includes("decks_pkey"), false);
+  assert.equal(JSON.stringify(body).includes("23505"), false);
 });

--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsTypes.swift
@@ -665,6 +665,7 @@ struct CloudSyncTrigger: Hashable, Sendable {
 struct CloudSyncResult: Hashable, Sendable {
     let appliedPullChangeCount: Int
     let changedEntityTypes: Set<SyncEntityType>
+    let localIdRepairEntityTypes: Set<SyncEntityType>
     let acknowledgedOperationCount: Int
     let acknowledgedReviewEventOperationCount: Int
     let cleanedUpOperationCount: Int
@@ -673,6 +674,7 @@ struct CloudSyncResult: Hashable, Sendable {
     static let noChanges = CloudSyncResult(
         appliedPullChangeCount: 0,
         changedEntityTypes: [],
+        localIdRepairEntityTypes: [],
         acknowledgedOperationCount: 0,
         acknowledgedReviewEventOperationCount: 0,
         cleanedUpOperationCount: 0,
@@ -690,6 +692,10 @@ struct CloudSyncResult: Hashable, Sendable {
             || self.changedEntityTypes.contains(.reviewEvent)
     }
 
+    var repairedLocalDeckId: Bool {
+        self.localIdRepairEntityTypes.contains(.deck)
+    }
+
     var reviewProgressDataChanged: Bool {
         self.changedEntityTypes.contains(.reviewEvent)
             || self.acknowledgedReviewEventOperationCount > 0
@@ -705,6 +711,7 @@ struct CloudSyncResult: Hashable, Sendable {
         CloudSyncResult(
             appliedPullChangeCount: self.appliedPullChangeCount + other.appliedPullChangeCount,
             changedEntityTypes: self.changedEntityTypes.union(other.changedEntityTypes),
+            localIdRepairEntityTypes: self.localIdRepairEntityTypes.union(other.localIdRepairEntityTypes),
             acknowledgedOperationCount: self.acknowledgedOperationCount + other.acknowledgedOperationCount,
             acknowledgedReviewEventOperationCount: self.acknowledgedReviewEventOperationCount + other.acknowledgedReviewEventOperationCount,
             cleanedUpOperationCount: self.cleanedUpOperationCount + other.cleanedUpOperationCount,

--- a/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
@@ -2,6 +2,11 @@ import Foundation
 
 @MainActor
 extension FlashcardsStore {
+    private func requireLocalOutboxMutationContext() throws -> LocalMutationContext {
+        try self.assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade()
+        return try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+    }
+
     private func localMutationCloudSyncTrigger(now: Date) -> CloudSyncTrigger {
         CloudSyncTrigger(
             source: .localMutation,
@@ -13,7 +18,7 @@ extension FlashcardsStore {
     }
 
     func saveCard(input: CardEditorInput, editingCardId: String?) throws {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         _ = try context.database.saveCard(
             workspaceId: context.workspaceId,
@@ -25,7 +30,7 @@ extension FlashcardsStore {
     }
 
     func createCards(inputs: [CardEditorInput]) throws -> [Card] {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         let createdCards = try context.database.createCards(workspaceId: context.workspaceId, inputs: inputs)
         try self.reload()
@@ -34,7 +39,7 @@ extension FlashcardsStore {
     }
 
     func deleteCard(cardId: String) throws {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         _ = try context.database.deleteCard(workspaceId: context.workspaceId, cardId: cardId)
         self.refreshLocalReadModels(now: now)
@@ -42,7 +47,7 @@ extension FlashcardsStore {
     }
 
     func updateCards(updates: [CardUpdateInput]) throws -> [Card] {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         let updatedCards = try context.database.updateCards(workspaceId: context.workspaceId, updates: updates)
         try self.reload()
@@ -51,7 +56,7 @@ extension FlashcardsStore {
     }
 
     func deleteCards(cardIds: [String]) throws -> BulkDeleteCardsResult {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         let result = try context.database.deleteCards(workspaceId: context.workspaceId, cardIds: cardIds)
         try self.reload()
@@ -60,7 +65,7 @@ extension FlashcardsStore {
     }
 
     func createDeck(input: DeckEditorInput) throws {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         _ = try context.database.createDeck(workspaceId: context.workspaceId, input: input)
         self.refreshLocalReadModels(now: now)
@@ -68,7 +73,7 @@ extension FlashcardsStore {
     }
 
     func updateDeck(deckId: String, input: DeckEditorInput) throws {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         _ = try context.database.updateDeck(
             workspaceId: context.workspaceId,
@@ -80,7 +85,7 @@ extension FlashcardsStore {
     }
 
     func deleteDeck(deckId: String) throws {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         _ = try context.database.deleteDeck(workspaceId: context.workspaceId, deckId: deckId)
         self.refreshLocalReadModels(now: now)
@@ -88,7 +93,7 @@ extension FlashcardsStore {
     }
 
     func submitReview(cardId: String, rating: ReviewRating) throws {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         _ = try context.database.submitReview(
             workspaceId: context.workspaceId,
@@ -107,6 +112,7 @@ extension FlashcardsStore {
         guard self.dependencies.reviewSubmissionExecutor != nil else {
             throw self.reviewRuntime.reviewSubmissionExecutorUnavailableError()
         }
+        try self.assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade()
 
         let workspaceId = try requireWorkspaceId(workspace: self.workspace)
         let nextReviewState = try self.reviewRuntime.enqueueReviewSubmission(
@@ -135,7 +141,7 @@ extension FlashcardsStore {
         maximumIntervalDays: Int,
         enableFuzz: Bool
     ) throws {
-        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        let context = try self.requireLocalOutboxMutationContext()
         try context.database.updateWorkspaceSchedulerSettings(
             workspaceId: context.workspaceId,
             desiredRetention: desiredRetention,

--- a/apps/ios/Flashcards/Flashcards/Cloud/CloudApiErrorSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/CloudApiErrorSupport.swift
@@ -4,12 +4,42 @@ private struct CloudApiErrorEnvelope: Decodable {
     let error: String?
     let requestId: String?
     let code: String?
+    let details: CloudApiErrorPublicDetails?
+
+    enum CodingKeys: String, CodingKey {
+        case error
+        case requestId
+        case code
+        case details
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.error = try container.decodeIfPresent(String.self, forKey: .error)
+        self.requestId = try container.decodeIfPresent(String.self, forKey: .requestId)
+        self.code = try container.decodeIfPresent(String.self, forKey: .code)
+        self.details = try? container.decodeIfPresent(CloudApiErrorPublicDetails.self, forKey: .details)
+    }
+}
+
+private struct CloudApiErrorPublicDetails: Decodable {
+    let syncConflict: CloudSyncConflictDetails?
+}
+
+struct CloudSyncConflictDetails: Codable, Hashable {
+    let phase: String
+    let entityType: SyncEntityType
+    let entityId: String
+    let entryIndex: Int?
+    let reviewEventIndex: Int?
+    let recoverable: Bool
 }
 
 struct CloudApiErrorDetails: Hashable {
     let message: String
     let requestId: String?
     let code: String?
+    let syncConflict: CloudSyncConflictDetails?
 }
 
 func decodeCloudApiErrorDetails(data: Data, requestId: String?) -> CloudApiErrorDetails {
@@ -20,14 +50,16 @@ func decodeCloudApiErrorDetails(data: Data, requestId: String?) -> CloudApiError
         return CloudApiErrorDetails(
             message: message,
             requestId: envelope.requestId ?? requestId,
-            code: envelope.code
+            code: envelope.code,
+            syncConflict: envelope.details?.syncConflict
         )
     }
 
     return CloudApiErrorDetails(
         message: String(data: data, encoding: .utf8) ?? "<non-utf8-body>",
         requestId: requestId,
-        code: nil
+        code: nil,
+        syncConflict: nil
     )
 }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/CloudSessionRuntime.swift
@@ -1,9 +1,15 @@
 import Foundation
 
 @MainActor
+struct CloudSyncOperationState {
+    let id: String
+    let task: Task<CloudSyncResult, Error>
+}
+
+@MainActor
 struct CloudSessionRuntimeState {
     var activeCloudSession: CloudLinkedSession?
-    var activeCloudSyncTask: Task<CloudSyncResult, Error>?
+    var activeCloudSyncTask: CloudSyncOperationState?
     var pendingCloudResync: Bool
     var activeCloudLinkTask: CloudLinkTransitionState?
     var activeWorkspaceCompletionTask: CloudWorkspaceCompletionState?
@@ -249,6 +255,20 @@ final class CloudSessionRuntime {
         return true
     }
 
+    func waitForActiveCloudCompletionIfNeeded() async throws -> Bool {
+        if let activeWorkspaceCompletionTask = self.state.activeWorkspaceCompletionTask {
+            _ = try await activeWorkspaceCompletionTask.task.value
+            return true
+        }
+
+        if let activeCloudLinkTask = self.state.activeCloudLinkTask {
+            try await activeCloudLinkTask.task.value
+            return true
+        }
+
+        return false
+    }
+
     func storedLinkedSession(
         cloudSettings: CloudSettings?,
         configuration: CloudServiceConfiguration,
@@ -305,28 +325,59 @@ final class CloudSessionRuntime {
 
     func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
         let cloudSyncService = try requireCloudSyncService(cloudSyncService: self.cloudSyncService)
+        return try await self.runCloudSyncTask {
+            try await cloudSyncService.runLinkedSync(linkedSession: linkedSession)
+        }
+    }
 
+    func runFreshLinkedSyncAfterActiveSyncSettles(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        let cloudSyncService = try requireCloudSyncService(cloudSyncService: self.cloudSyncService)
+        try await self.waitForActiveCloudSyncToSettle()
+        return try await self.startCloudSyncTask {
+            try await cloudSyncService.runLinkedSync(linkedSession: linkedSession)
+        }
+    }
+
+    private func runCloudSyncTask(
+        operation: @escaping @MainActor () async throws -> CloudSyncResult
+    ) async throws -> CloudSyncResult {
         if let activeCloudSyncTask = self.state.activeCloudSyncTask {
             self.state.pendingCloudResync = true
-            return try await activeCloudSyncTask.value
+            return try await activeCloudSyncTask.task.value
         }
 
+        return try await self.startCloudSyncTask(operation: operation)
+    }
+
+    private func startCloudSyncTask(
+        operation: @escaping @MainActor () async throws -> CloudSyncResult
+    ) async throws -> CloudSyncResult {
+        let syncOperation = CloudSyncOperationState(
+            id: UUID().uuidString.lowercased(),
+            task: Task { @MainActor in
+                try await self.runCloudSyncLoop(operation: operation)
+            }
+        )
+        self.state.activeCloudSyncTask = syncOperation
+
+        do {
+            let syncResult = try await syncOperation.task.value
+            self.clearActiveCloudSyncTaskIfCurrent(id: syncOperation.id)
+            return syncResult
+        } catch {
+            self.clearActiveCloudSyncTaskIfCurrent(id: syncOperation.id)
+            throw error
+        }
+    }
+
+    private func runCloudSyncLoop(
+        operation: @escaping @MainActor () async throws -> CloudSyncResult
+    ) async throws -> CloudSyncResult {
         var accumulatedResult = CloudSyncResult.noChanges
         while true {
             self.state.pendingCloudResync = false
-            let syncTask = Task { @MainActor in
-                try await cloudSyncService.runLinkedSync(linkedSession: linkedSession)
-            }
-            self.state.activeCloudSyncTask = syncTask
-
-            do {
-                let syncResult = try await syncTask.value
-                accumulatedResult = accumulatedResult.merging(syncResult)
-                self.state.activeCloudSyncTask = nil
-            } catch {
-                self.state.activeCloudSyncTask = nil
-                throw error
-            }
+            let syncResult = try await operation()
+            accumulatedResult = accumulatedResult.merging(syncResult)
 
             if self.state.pendingCloudResync == false {
                 break
@@ -334,6 +385,32 @@ final class CloudSessionRuntime {
         }
 
         return accumulatedResult
+    }
+
+    private func waitForActiveCloudSyncToSettle() async {
+        while let activeCloudSyncTask = self.state.activeCloudSyncTask {
+            do {
+                _ = try await activeCloudSyncTask.task.value
+            } catch {
+                logFlashcardsError(
+                    domain: "cloud",
+                    action: "active_sync_settled_before_fresh_sync",
+                    metadata: [
+                        "message": Flashcards.errorMessage(error: error),
+                    ]
+                )
+            }
+            self.clearActiveCloudSyncTaskIfCurrent(id: activeCloudSyncTask.id)
+        }
+    }
+
+    private func clearActiveCloudSyncTaskIfCurrent(id: String) {
+        guard self.state.activeCloudSyncTask?.id == id else {
+            return
+        }
+
+        self.state.activeCloudSyncTask = nil
+        self.state.pendingCloudResync = false
     }
 
     func isCloudAuthorizationError(_ error: Error) -> Bool {
@@ -366,7 +443,7 @@ final class CloudSessionRuntime {
     }
 
     func cancelForWorkspaceSwitch() {
-        self.state.activeCloudSyncTask?.cancel()
+        self.state.activeCloudSyncTask?.task.cancel()
         self.state.activeCloudSyncTask = nil
         self.state.pendingCloudResync = false
         self.state.activeAIChatSessionPreparation?.task.cancel()
@@ -376,7 +453,7 @@ final class CloudSessionRuntime {
     func cancelForAccountDeletion() {
         self.state.activeCloudLinkTask?.task.cancel()
         self.state.activeCloudLinkTask = nil
-        self.state.activeCloudSyncTask?.cancel()
+        self.state.activeCloudSyncTask?.task.cancel()
         self.state.activeCloudSyncTask = nil
         self.state.pendingCloudResync = false
         self.state.activeAIChatSessionPreparation?.task.cancel()

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudIdentity.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudIdentity.swift
@@ -24,6 +24,7 @@ extension FlashcardsStore {
         self.pendingStrictRemindersReconcileRequest = nil
         try self.cloudRuntime.clearCredentials()
         try self.dependencies.guestCredentialStore.clearGuestSession()
+        self.clearPendingGuestUpgradeStateAndUnblockMutations()
         rotateStrictReminderNotificationScope(userDefaults: self.userDefaults)
         clearPendingAppNotificationTap(userDefaults: self.userDefaults)
         self.removeStrictReminderNotificationsForCloudIdentityReset(

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudLink.swift
@@ -1,5 +1,311 @@
 import Foundation
 
+let pendingGuestUpgradeUserDefaultsKey: String = "pending-guest-upgrade"
+private let pendingGuestUpgradeSchemaVersion: Int = 5
+private let supportedPendingGuestUpgradeSchemaVersions: Set<Int> = [pendingGuestUpgradeSchemaVersion, 4, 3, 2]
+
+private enum PendingGuestUpgradePhase: String, Codable, Hashable {
+    case inFlight = "in_flight"
+    case completed
+}
+
+private enum PendingGuestUpgradeSelection: Codable, Hashable {
+    case existing(workspaceId: String)
+    case createNew
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case workspaceId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "existing":
+            self = .existing(workspaceId: try container.decode(String.self, forKey: .workspaceId))
+        case "create_new":
+            self = .createNew
+        default:
+            throw LocalStoreError.database("Unsupported pending guest upgrade selection type: \(type)")
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .existing(let workspaceId):
+            try container.encode("existing", forKey: .type)
+            try container.encode(workspaceId, forKey: .workspaceId)
+        case .createNew:
+            try container.encode("create_new", forKey: .type)
+        }
+    }
+}
+
+private struct PendingGuestUpgradeCommonState: Hashable {
+    let schemaVersion: Int
+    let apiBaseUrl: String
+    let configurationMode: CloudServiceConfigurationMode
+    let userId: String
+    let email: String?
+}
+
+private struct PendingGuestUpgradeGuestIdentityState: Hashable {
+    let userId: String
+    let workspaceId: String
+}
+
+private struct PendingGuestUpgradeInFlightState: Hashable {
+    let common: PendingGuestUpgradeCommonState
+    let guestIdentity: PendingGuestUpgradeGuestIdentityState
+    let selection: PendingGuestUpgradeSelection
+    let supportsDroppedEntities: Bool
+}
+
+private struct PendingGuestUpgradeCompletedState: Hashable {
+    let common: PendingGuestUpgradeCommonState
+    let workspace: CloudWorkspaceSummary
+}
+
+/// UserDefaults stores only the resumable guest-upgrade checkpoint: target
+/// cloud identity plus either replay inputs or the completed workspace. The
+/// bearer token and guest token stay in secure credential stores and are never
+/// persisted in this plaintext payload.
+private enum PendingGuestUpgradeState: Codable, Hashable {
+    case inFlight(PendingGuestUpgradeInFlightState)
+    case completed(PendingGuestUpgradeCompletedState)
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case phase
+        case apiBaseUrl
+        case configurationMode
+        case userId
+        case email
+        case guestUserId
+        case guestWorkspaceId
+        case selection
+        case supportsDroppedEntities
+        case workspace
+    }
+
+    var common: PendingGuestUpgradeCommonState {
+        switch self {
+        case .inFlight(let state):
+            return state.common
+        case .completed(let state):
+            return state.common
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        guard supportedPendingGuestUpgradeSchemaVersions.contains(schemaVersion) else {
+            throw LocalStoreError.database(
+                "Unsupported pending guest upgrade schema version: \(schemaVersion)"
+            )
+        }
+
+        let common = PendingGuestUpgradeCommonState(
+            schemaVersion: schemaVersion,
+            apiBaseUrl: try container.decode(String.self, forKey: .apiBaseUrl),
+            configurationMode: try container.decode(
+                CloudServiceConfigurationMode.self,
+                forKey: .configurationMode
+            ),
+            userId: try container.decode(String.self, forKey: .userId),
+            email: try container.decodeIfPresent(String.self, forKey: .email)
+        )
+        // Schema versions 2 and 3 only persisted completed checkpoints and did
+        // not include a phase field, so missing phase normalizes to completed.
+        let phase = try container.decodeIfPresent(PendingGuestUpgradePhase.self, forKey: .phase) ?? .completed
+        switch phase {
+        case .inFlight:
+            guard let selection = try container.decodeIfPresent(
+                PendingGuestUpgradeSelection.self,
+                forKey: .selection
+            ) else {
+                throw LocalStoreError.database("In-flight pending guest upgrade is missing workspace selection")
+            }
+            guard let guestUserId = try container.decodeIfPresent(String.self, forKey: .guestUserId),
+                  let guestWorkspaceId = try container.decodeIfPresent(String.self, forKey: .guestWorkspaceId) else {
+                throw LocalStoreError.database(
+                    "In-flight pending guest upgrade is missing guest identity fields. Restart the account upgrade from the original guest workspace before retrying recovery."
+                )
+            }
+            guard let supportsDroppedEntities = try container.decodeIfPresent(
+                Bool.self,
+                forKey: .supportsDroppedEntities
+            ) else {
+                throw LocalStoreError.database("In-flight pending guest upgrade is missing capability flags")
+            }
+            self = .inFlight(
+                PendingGuestUpgradeInFlightState(
+                    common: common,
+                    guestIdentity: PendingGuestUpgradeGuestIdentityState(
+                        userId: guestUserId,
+                        workspaceId: guestWorkspaceId
+                    ),
+                    selection: selection,
+                    supportsDroppedEntities: supportsDroppedEntities
+                )
+            )
+        case .completed:
+            guard let workspace = try container.decodeIfPresent(CloudWorkspaceSummary.self, forKey: .workspace) else {
+                throw LocalStoreError.database("Completed pending guest upgrade is missing linked workspace")
+            }
+            self = .completed(
+                PendingGuestUpgradeCompletedState(
+                    common: common,
+                    workspace: workspace
+                )
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        let common = self.common
+        try container.encode(common.schemaVersion, forKey: .schemaVersion)
+        try container.encode(common.apiBaseUrl, forKey: .apiBaseUrl)
+        try container.encode(common.configurationMode, forKey: .configurationMode)
+        try container.encode(common.userId, forKey: .userId)
+        try container.encodeIfPresent(common.email, forKey: .email)
+
+        switch self {
+        case .inFlight(let state):
+            try container.encode(PendingGuestUpgradePhase.inFlight, forKey: .phase)
+            try container.encode(state.guestIdentity.userId, forKey: .guestUserId)
+            try container.encode(state.guestIdentity.workspaceId, forKey: .guestWorkspaceId)
+            try container.encode(state.selection, forKey: .selection)
+            try container.encode(state.supportsDroppedEntities, forKey: .supportsDroppedEntities)
+        case .completed(let state):
+            try container.encode(PendingGuestUpgradePhase.completed, forKey: .phase)
+            try container.encode(state.workspace, forKey: .workspace)
+        }
+    }
+}
+
+enum CloudGuestUpgradeDrainError: LocalizedError {
+    case workspaceMismatch(localWorkspaceId: String, guestWorkspaceId: String)
+    case pendingGuestOutboxEntries(workspaceId: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .workspaceMismatch(let localWorkspaceId, let guestWorkspaceId):
+            return "Guest upgrade expected workspace \(guestWorkspaceId), but the active local workspace is \(localWorkspaceId)."
+        case .pendingGuestOutboxEntries(let workspaceId):
+            return "Guest upgrade is waiting for local changes in workspace \(workspaceId) to finish syncing. Try again after cloud sync completes."
+        }
+    }
+}
+
+enum PendingGuestUpgradeLocalMutationError: LocalizedError {
+    case blocked
+
+    var errorDescription: String? {
+        switch self {
+        case .blocked:
+            return "Account upgrade is finishing. Wait for the upgrade to complete before making more local changes."
+        }
+    }
+}
+
+func assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade(
+    isGuestUpgradeLocalOutboxMutationBlocked: Bool,
+    userDefaults: UserDefaults
+) throws {
+    guard isGuestUpgradeLocalOutboxMutationBlocked == false else {
+        throw PendingGuestUpgradeLocalMutationError.blocked
+    }
+    guard userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey) == nil else {
+        throw PendingGuestUpgradeLocalMutationError.blocked
+    }
+}
+
+private func clearPendingGuestUpgradeState(userDefaults: UserDefaults) {
+    userDefaults.removeObject(forKey: pendingGuestUpgradeUserDefaultsKey)
+}
+
+private func cloudGuestUpgradeSelection(selection: CloudWorkspaceLinkSelection) -> CloudGuestUpgradeSelection {
+    switch selection {
+    case .existing(let workspaceId):
+        return .existing(workspaceId: workspaceId)
+    case .createNew:
+        return .createNew
+    }
+}
+
+private func pendingGuestUpgradeSelection(selection: CloudWorkspaceLinkSelection) -> PendingGuestUpgradeSelection {
+    switch selection {
+    case .existing(let workspaceId):
+        return .existing(workspaceId: workspaceId)
+    case .createNew:
+        return .createNew
+    }
+}
+
+private func cloudGuestUpgradeSelection(selection: PendingGuestUpgradeSelection) -> CloudGuestUpgradeSelection {
+    switch selection {
+    case .existing(let workspaceId):
+        return .existing(workspaceId: workspaceId)
+    case .createNew:
+        return .createNew
+    }
+}
+
+private func pendingGuestUpgradeInFlightState(
+    linkContext: CloudWorkspaceLinkContext,
+    configuration: CloudServiceConfiguration,
+    guestSession: StoredGuestCloudSession,
+    selection: CloudWorkspaceLinkSelection,
+    supportsDroppedEntities: Bool
+) -> PendingGuestUpgradeState {
+    .inFlight(
+        PendingGuestUpgradeInFlightState(
+            common: PendingGuestUpgradeCommonState(
+                schemaVersion: pendingGuestUpgradeSchemaVersion,
+                apiBaseUrl: linkContext.apiBaseUrl,
+                configurationMode: configuration.mode,
+                userId: linkContext.userId,
+                email: linkContext.email
+            ),
+            guestIdentity: PendingGuestUpgradeGuestIdentityState(
+                userId: guestSession.userId,
+                workspaceId: guestSession.workspaceId
+            ),
+            selection: pendingGuestUpgradeSelection(selection: selection),
+            supportsDroppedEntities: supportsDroppedEntities
+        )
+    )
+}
+
+private func pendingGuestUpgradeCompletedState(
+    state: PendingGuestUpgradeInFlightState,
+    workspace: CloudWorkspaceSummary
+) -> PendingGuestUpgradeCompletedState {
+    PendingGuestUpgradeCompletedState(
+        common: state.common,
+        workspace: workspace
+    )
+}
+
+private func cloudLinkedSession(
+    state: PendingGuestUpgradeCompletedState,
+    credentials: StoredCloudCredentials
+) -> CloudLinkedSession {
+    CloudLinkedSession(
+        userId: state.common.userId,
+        workspaceId: state.workspace.workspaceId,
+        email: state.common.email,
+        configurationMode: state.common.configurationMode,
+        apiBaseUrl: state.common.apiBaseUrl,
+        authorization: .bearer(credentials.idToken)
+    )
+}
+
 enum CloudBootstrapEligibilityError: LocalizedError {
     case remoteWorkspaceIsNotEmpty
 
@@ -13,6 +319,13 @@ enum CloudBootstrapEligibilityError: LocalizedError {
 
 @MainActor
 extension FlashcardsStore {
+    func assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade() throws {
+        try Flashcards.assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade(
+            isGuestUpgradeLocalOutboxMutationBlocked: self.isGuestUpgradeLocalOutboxMutationBlocked,
+            userDefaults: self.userDefaults
+        )
+    }
+
     func validateCustomCloudServer(customOrigin: String) async throws -> CloudServiceConfiguration {
         let configuration = try makeCustomCloudServiceConfiguration(customOrigin: customOrigin)
         try await self.cloudServiceConfigurationValidator.validate(configuration: configuration)
@@ -128,39 +441,236 @@ extension FlashcardsStore {
             guard let guestSession = try self.loadGuestSessionForCurrentConfiguration() else {
                 throw LocalStoreError.uninitialized("Guest AI session is unavailable")
             }
-
-            let guestSelection: CloudGuestUpgradeSelection
-            switch selection {
-            case .existing(let workspaceId):
-                guestSelection = .existing(workspaceId: workspaceId)
-            case .createNew:
-                guestSelection = .createNew
+            guard let guestUpgradeMode = linkContext.guestUpgradeMode else {
+                throw LocalStoreError.uninitialized("Guest upgrade context is unavailable")
             }
 
-            let linkedWorkspace = try await self.dependencies.guestCloudAuthService.completeGuestUpgrade(
-                apiBaseUrl: linkContext.apiBaseUrl,
-                bearerToken: linkContext.credentials.idToken,
-                guestToken: guestSession.guestToken,
-                selection: guestSelection
-            )
-
-            try self.cloudRuntime.saveCredentials(credentials: linkContext.credentials)
             let configuration = try self.currentCloudServiceConfiguration()
-            try await self.finishCloudLink(
-                linkedSession: CloudLinkedSession(
-                    userId: linkContext.userId,
-                    workspaceId: linkedWorkspace.workspaceId,
-                    email: linkContext.email,
-                    configurationMode: configuration.mode,
-                    apiBaseUrl: linkContext.apiBaseUrl,
-                    authorization: .bearer(linkContext.credentials.idToken)
-                ),
-                trigger: self.manualCloudSyncTrigger(now: Date())
+            let trigger = self.manualCloudSyncTrigger(now: Date())
+            await self.blockGuestUpgradeLocalOutboxMutationsBeforeDrain()
+            do {
+                // Guest upgrade completion only merges already-synced cloud state.
+                // Drain normal guest sync first so no pending guest outbox is carried
+                // into the linked workspace.
+            try await self.drainGuestWorkspaceBeforeUpgrade(
+                guestSession: guestSession,
+                configuration: configuration,
+                trigger: trigger
             )
-            try self.clearGuestSessionIfNeeded()
-            self.globalErrorMessage = ""
-            return linkedWorkspace
+                try self.cloudRuntime.saveCredentials(credentials: linkContext.credentials)
+                let inFlightState = pendingGuestUpgradeInFlightState(
+                    linkContext: linkContext,
+                    configuration: configuration,
+                    guestSession: guestSession,
+                    selection: selection,
+                    supportsDroppedEntities: guestUpgradeMode == .mergeRequired
+                )
+                try self.savePendingGuestUpgradeState(state: inFlightState)
+
+                let completionState = try await self.completePendingGuestUpgradeIfNeeded(state: inFlightState)
+                try await self.finalizePendingGuestUpgradeCompletion(
+                    state: completionState,
+                    trigger: trigger
+                )
+                self.unblockGuestUpgradeLocalOutboxMutationsIfPossible()
+                return completionState.workspace
+            } catch {
+                self.unblockGuestUpgradeLocalOutboxMutationsIfPossible()
+                throw error
+            }
         }
+    }
+
+    func resumePendingGuestUpgradeIfNeeded(trigger: CloudSyncTrigger) async throws -> Bool {
+        guard try self.loadPendingGuestUpgradeState() != nil else {
+            return false
+        }
+
+        _ = try await self.cloudRuntime.runWorkspaceCompletion { [weak self] in
+            guard let self else {
+                throw LocalStoreError.uninitialized("Flashcards store is unavailable")
+            }
+
+            return try await self.performPendingGuestUpgradeResume(trigger: trigger)
+        }
+        return true
+    }
+
+    private func performPendingGuestUpgradeResume(trigger: CloudSyncTrigger) async throws -> CloudWorkspaceSummary {
+        guard let pendingState = try self.loadPendingGuestUpgradeState() else {
+            throw LocalStoreError.uninitialized("Pending guest upgrade state is unavailable")
+        }
+
+        let completionState = try await self.completePendingGuestUpgradeIfNeeded(state: pendingState)
+        try await self.finalizePendingGuestUpgradeCompletion(state: completionState, trigger: trigger)
+        return completionState.workspace
+    }
+
+    private func drainGuestWorkspaceBeforeUpgrade(
+        guestSession: StoredGuestCloudSession,
+        configuration: CloudServiceConfiguration,
+        trigger: CloudSyncTrigger
+    ) async throws {
+        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+        guard context.workspaceId == guestSession.workspaceId else {
+            throw CloudGuestUpgradeDrainError.workspaceMismatch(
+                localWorkspaceId: context.workspaceId,
+                guestWorkspaceId: guestSession.workspaceId
+            )
+        }
+
+        let linkedSession = CloudLinkedSession(
+            userId: guestSession.userId,
+            workspaceId: guestSession.workspaceId,
+            email: nil,
+            configurationMode: configuration.mode,
+            apiBaseUrl: configuration.apiBaseUrl,
+            authorization: .guest(guestSession.guestToken)
+        )
+
+        self.cloudRuntime.setActiveCloudSession(linkedSession: linkedSession)
+        self.syncStatus = .syncing
+        do {
+            let syncResult = try await self.runFreshLinkedSyncAfterActiveSyncSettles(
+                linkedSession: linkedSession
+            )
+            try await self.applySyncResultWithoutBlockingReset(
+                syncResult: syncResult,
+                now: Date(),
+                trigger: trigger
+            )
+            let database = try requireLocalDatabase(database: self.database)
+            let remainingOutboxEntries = try database.loadOutboxEntries(
+                workspaceId: guestSession.workspaceId,
+                limit: 1
+            )
+            if remainingOutboxEntries.isEmpty == false {
+                throw CloudGuestUpgradeDrainError.pendingGuestOutboxEntries(
+                    workspaceId: guestSession.workspaceId
+                )
+            }
+        } catch {
+            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
+            if trigger.surfacesGlobalErrorMessage {
+                self.globalErrorMessage = Flashcards.errorMessage(error: error)
+            }
+            throw error
+        }
+    }
+
+    private func finalizePendingGuestUpgradeCompletion(
+        state: PendingGuestUpgradeCompletedState,
+        trigger: CloudSyncTrigger
+    ) async throws {
+        let credentials = try await self.loadPendingGuestUpgradeCredentials(commonState: state.common)
+        let linkedSession = cloudLinkedSession(state: state, credentials: credentials)
+
+        try await self.finishCompletedGuestCloudLink(
+            linkedSession: linkedSession,
+            workspace: state.workspace,
+            trigger: trigger
+        )
+
+        try self.clearGuestSessionIfNeeded()
+        self.clearPendingGuestUpgradeStateAndUnblockMutations()
+        self.globalErrorMessage = ""
+    }
+
+    private func blockGuestUpgradeLocalOutboxMutationsBeforeDrain() async {
+        self.isGuestUpgradeLocalOutboxMutationBlocked = true
+        await self.reviewSubmissionOutboxMutationGate.blockNewReviewSubmissionsAndWaitForActiveSubmissions()
+    }
+
+    private func unblockGuestUpgradeLocalOutboxMutationsIfPossible() {
+        if self.userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey) == nil {
+            self.reviewSubmissionOutboxMutationGate.unblockReviewSubmissions()
+        }
+        self.isGuestUpgradeLocalOutboxMutationBlocked = false
+    }
+
+    func clearPendingGuestUpgradeStateAndUnblockMutations() {
+        clearPendingGuestUpgradeState(userDefaults: self.userDefaults)
+        self.isGuestUpgradeLocalOutboxMutationBlocked = false
+        self.reviewSubmissionOutboxMutationGate.unblockReviewSubmissions()
+    }
+
+    private func completePendingGuestUpgradeIfNeeded(
+        state: PendingGuestUpgradeState
+    ) async throws -> PendingGuestUpgradeCompletedState {
+        switch state {
+        case .completed(let completedState):
+            return completedState
+        case .inFlight(let inFlightState):
+            let credentials = try await self.loadPendingGuestUpgradeCredentials(commonState: inFlightState.common)
+            let guestSession = try self.loadPendingGuestUpgradeGuestSession(state: inFlightState)
+            let workspace = try await self.dependencies.guestCloudAuthService.completeGuestUpgrade(
+                apiBaseUrl: inFlightState.common.apiBaseUrl,
+                bearerToken: credentials.idToken,
+                guestToken: guestSession.guestToken,
+                selection: cloudGuestUpgradeSelection(selection: inFlightState.selection),
+                supportsDroppedEntities: inFlightState.supportsDroppedEntities,
+                guestWorkspaceSyncedAndOutboxDrained: true
+            )
+            let completionState = pendingGuestUpgradeCompletedState(
+                state: inFlightState,
+                workspace: workspace
+            )
+            try self.savePendingGuestUpgradeState(state: .completed(completionState))
+            return completionState
+        }
+    }
+
+    private func loadPendingGuestUpgradeCredentials(
+        commonState: PendingGuestUpgradeCommonState
+    ) async throws -> StoredCloudCredentials {
+        let configuration = try self.currentCloudServiceConfiguration()
+        guard configuration.apiBaseUrl == commonState.apiBaseUrl && configuration.mode == commonState.configurationMode else {
+            throw LocalStoreError.database(
+                "Pending guest upgrade cloud configuration mismatch: pendingApiBaseUrl=\(commonState.apiBaseUrl) currentApiBaseUrl=\(configuration.apiBaseUrl) pendingMode=\(commonState.configurationMode.rawValue) currentMode=\(configuration.mode.rawValue)"
+            )
+        }
+
+        return try await self.refreshCloudCredentials(forceRefresh: false)
+    }
+
+    private func loadPendingGuestUpgradeGuestSession(
+        state: PendingGuestUpgradeInFlightState
+    ) throws -> StoredGuestCloudSession {
+        // Only in-flight replay needs the guest token. Completed checkpoints
+        // already have the linked workspace and must not require guest storage.
+        guard let guestSession = try self.dependencies.guestCredentialStore.loadGuestSession() else {
+            throw LocalStoreError.database(
+                "In-flight pending guest upgrade cannot replay backend completion because the guest credential is missing from secure storage. Restore the guest session on this device or contact support before resetting local data."
+            )
+        }
+        guard guestSession.apiBaseUrl == state.common.apiBaseUrl
+            && guestSession.configurationMode == state.common.configurationMode else {
+            throw LocalStoreError.database(
+                "In-flight pending guest upgrade credential mismatch: pendingApiBaseUrl=\(state.common.apiBaseUrl) credentialApiBaseUrl=\(guestSession.apiBaseUrl) pendingMode=\(state.common.configurationMode.rawValue) credentialMode=\(guestSession.configurationMode.rawValue)"
+            )
+        }
+        guard guestSession.userId == state.guestIdentity.userId
+            && guestSession.workspaceId == state.guestIdentity.workspaceId else {
+            throw LocalStoreError.database(
+                "In-flight pending guest upgrade guest identity mismatch: pendingGuestUserId=\(state.guestIdentity.userId) credentialGuestUserId=\(guestSession.userId) pendingGuestWorkspaceId=\(state.guestIdentity.workspaceId) credentialGuestWorkspaceId=\(guestSession.workspaceId). Restore the original guest session for this pending upgrade before retrying recovery."
+            )
+        }
+
+        return guestSession
+    }
+
+    private func savePendingGuestUpgradeState(state: PendingGuestUpgradeState) throws {
+        let data = try self.encoder.encode(state)
+        self.userDefaults.set(data, forKey: pendingGuestUpgradeUserDefaultsKey)
+    }
+
+    private func loadPendingGuestUpgradeState() throws -> PendingGuestUpgradeState? {
+        guard let data = self.userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey) else {
+            return nil
+        }
+
+        let state = try self.decoder.decode(PendingGuestUpgradeState.self, from: data)
+        return state
     }
 
     func finishCloudLink(linkedSession: CloudLinkedSession, trigger: CloudSyncTrigger) async throws {
@@ -236,6 +746,109 @@ extension FlashcardsStore {
                 targetWorkspaceId: linkedSession.workspaceId,
                 migrationKind: migrationKind,
                 remoteWorkspaceIsEmpty: remoteWorkspaceIsEmpty
+            )
+            let syncResult = try await self.runLinkedSync(linkedSession: linkedSession)
+            try await self.applySyncResultWithoutBlockingReset(
+                syncResult: syncResult,
+                now: Date(),
+                trigger: trigger
+            )
+            self.userDefaults.removeObject(forKey: pendingCloudServerBootstrapUserDefaultsKey)
+            logCloudFlowPhase(
+                phase: .linkedSync,
+                outcome: "success",
+                workspaceId: linkedSession.workspaceId,
+                installationId: self.cloudSettings?.installationId
+            )
+            try self.reload()
+        } catch {
+            if didCompleteLocalLink == false {
+                logCloudFlowPhase(
+                    phase: .linkLocalWorkspace,
+                    outcome: "failure",
+                    workspaceId: linkedSession.workspaceId,
+                    installationId: self.cloudSettings?.installationId,
+                    sourceWorkspaceId: context.workspaceId,
+                    targetWorkspaceId: linkedSession.workspaceId,
+                    errorMessage: Flashcards.errorMessage(error: error)
+                )
+            }
+            logCloudFlowPhase(
+                phase: .linkedSync,
+                outcome: "failure",
+                workspaceId: linkedSession.workspaceId,
+                installationId: self.cloudSettings?.installationId,
+                errorMessage: Flashcards.errorMessage(error: error)
+            )
+            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
+            if trigger.surfacesGlobalErrorMessage {
+                self.globalErrorMessage = Flashcards.errorMessage(error: error)
+            }
+            throw error
+        }
+    }
+
+    private func finishCompletedGuestCloudLink(
+        linkedSession: CloudLinkedSession,
+        workspace: CloudWorkspaceSummary,
+        trigger: CloudSyncTrigger
+    ) async throws {
+        try await self.cloudRuntime.runCloudLinkTransition { [weak self] in
+            guard let self else {
+                throw LocalStoreError.uninitialized("Flashcards store is unavailable")
+            }
+
+            try await self.performCompletedGuestCloudLink(
+                linkedSession: linkedSession,
+                workspace: workspace,
+                trigger: trigger
+            )
+        }
+    }
+
+    private func performCompletedGuestCloudLink(
+        linkedSession: CloudLinkedSession,
+        workspace: CloudWorkspaceSummary,
+        trigger: CloudSyncTrigger
+    ) async throws {
+        let context = try requireLocalMutationContext(database: self.database, workspace: self.workspace)
+
+        self.cloudRuntime.cancelForWorkspaceSwitch()
+        self.syncStatus = .syncing
+        var didCompleteLocalLink = false
+        let migrationKind = "guest_upgrade_hydrate_remote"
+        do {
+            logCloudFlowPhase(
+                phase: .linkLocalWorkspace,
+                outcome: "start",
+                workspaceId: linkedSession.workspaceId,
+                installationId: self.cloudSettings?.installationId,
+                sourceWorkspaceId: context.workspaceId,
+                targetWorkspaceId: linkedSession.workspaceId,
+                migrationKind: migrationKind,
+                remoteWorkspaceIsEmpty: nil
+            )
+            // Backend completion already merged drained guest cloud state.
+            // Do not migrate any local guest outbox; switch locally and hydrate
+            // the linked workspace from remote instead.
+            try context.database.switchGuestUpgradeToLinkedWorkspaceFromRemote(
+                localWorkspaceId: context.workspaceId,
+                linkedSession: linkedSession,
+                workspace: workspace
+            )
+
+            self.cloudRuntime.setActiveCloudSession(linkedSession: linkedSession)
+            try self.reload()
+            didCompleteLocalLink = true
+            logCloudFlowPhase(
+                phase: .linkLocalWorkspace,
+                outcome: "success",
+                workspaceId: linkedSession.workspaceId,
+                installationId: self.cloudSettings?.installationId,
+                sourceWorkspaceId: context.workspaceId,
+                targetWorkspaceId: linkedSession.workspaceId,
+                migrationKind: migrationKind,
+                remoteWorkspaceIsEmpty: nil
             )
             let syncResult = try await self.runLinkedSync(linkedSession: linkedSession)
             try await self.applySyncResultWithoutBlockingReset(
@@ -373,6 +986,7 @@ extension FlashcardsStore {
         self.cloudRuntime.cancelForAccountDeletion()
         try self.cloudRuntime.clearCredentials()
         try self.dependencies.guestCredentialStore.clearGuestSession()
+        self.clearPendingGuestUpgradeStateAndUnblockMutations()
         try context.database.clearCloudSyncState(workspaceId: context.workspaceId)
         try context.database.updateCloudSettings(
             cloudState: .disconnected,

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudSync.swift
@@ -7,7 +7,8 @@ private enum PersistedCloudStateReconciliationOutcome {
 
 private let blockedCloudIdentityConflictCodes: Set<String> = [
     "SYNC_INSTALLATION_PLATFORM_MISMATCH",
-    "SYNC_REPLICA_CONFLICT"
+    "SYNC_REPLICA_CONFLICT",
+    "SYNC_WORKSPACE_FORK_REQUIRED"
 ]
 
 @MainActor
@@ -27,6 +28,12 @@ extension FlashcardsStore {
     }
 
     func syncCloudNow(trigger: CloudSyncTrigger) async throws {
+        if try await self.resumePendingGuestUpgradeIfNeeded(trigger: trigger) {
+            return
+        }
+        if try await self.cloudRuntime.waitForActiveCloudCompletionIfNeeded() {
+            return
+        }
         if case .blocked(let message) = self.syncStatus {
             throw LocalStoreError.validation(message)
         }
@@ -66,27 +73,47 @@ extension FlashcardsStore {
                 trigger: trigger
             )
         } catch {
+            let failureError: Error
+            do {
+                failureError = try self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
+                    error: error,
+                    now: Date()
+                )
+            } catch {
+                self.syncStatus = self.syncStatusForCloudFailure(
+                    error: error,
+                    fallbackCloudState: failureStateCloudState
+                )
+                if trigger.surfacesGlobalErrorMessage {
+                    self.globalErrorMessage = Flashcards.errorMessage(error: error)
+                }
+                throw error
+            }
             self.syncStatus = self.syncStatusForCloudFailure(
-                error: error,
+                error: failureError,
                 fallbackCloudState: failureStateCloudState
             )
             if trigger.surfacesGlobalErrorMessage {
-                self.globalErrorMessage = Flashcards.errorMessage(error: error)
+                self.globalErrorMessage = Flashcards.errorMessage(error: failureError)
             }
-            throw error
+            throw failureError
         }
     }
 
     func syncCloudIfLinked(trigger: CloudSyncTrigger) async {
-        if self.isCloudSyncBlocked {
-            return
-        }
         if self.userDefaults.bool(forKey: accountDeletionPendingUserDefaultsKey) {
             await self.resumePendingAccountDeletionIfNeeded()
             return
         }
 
         do {
+            if try await self.resumePendingGuestUpgradeIfNeeded(trigger: trigger) {
+                return
+            }
+            if self.isCloudSyncBlocked {
+                return
+            }
+
             let reconciliationOutcome = try await self.reconcilePersistedCloudStateBeforeSync(trigger: trigger)
             let hasStoredCredentials: Bool
             let hasStoredGuestSession: Bool
@@ -98,7 +125,7 @@ extension FlashcardsStore {
                 return
             }
 
-            if try await self.cloudRuntime.waitForActiveCloudLinkTransitionIfNeeded() {
+            if try await self.cloudRuntime.waitForActiveCloudCompletionIfNeeded() {
                 return
             }
 
@@ -219,7 +246,12 @@ extension FlashcardsStore {
         trigger: CloudSyncTrigger
     ) async throws {
         let bootstrapRefreshOutcome = try self.refreshBootstrapSnapshotWithoutReset(now: now)
-        let shouldRefreshReviewState = syncResult.reviewDataChanged || bootstrapRefreshOutcome.cardsChanged
+        let didResetVolatileReviewSelection = self.resetVolatileReviewSelectionAfterLocalIdRepairIfNeeded(
+            syncResult: syncResult,
+            now: now
+        )
+        let shouldRefreshReviewState = didResetVolatileReviewSelection == false
+            && (syncResult.reviewDataChanged || bootstrapRefreshOutcome.cardsChanged)
         let didRefreshReviewState: Bool
         if shouldRefreshReviewState {
             let reviewRefreshMode: ReviewRefreshMode
@@ -234,7 +266,10 @@ extension FlashcardsStore {
             )
             self.reconcileStrictReminders(trigger: .reviewHistoryImported, now: now)
         } else {
-            didRefreshReviewState = false
+            didRefreshReviewState = didResetVolatileReviewSelection
+            if didResetVolatileReviewSelection {
+                self.reconcileStrictReminders(trigger: .reviewHistoryImported, now: now)
+            }
         }
         if trigger.allowsVisibleChangeBanner {
             self.enqueueBackgroundSyncVisibleChangeBannerIfNeeded(
@@ -251,6 +286,58 @@ extension FlashcardsStore {
         self.lastSuccessfulCloudSyncAt = nowIsoTimestamp()
         self.syncStatus = .idle
         self.globalErrorMessage = ""
+    }
+
+    private func failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
+        error: Error,
+        now: Date
+    ) throws -> Error {
+        guard let localIdRepairFailure = error as? CloudSyncLocalIdRepairFailure else {
+            return error
+        }
+
+        try self.applyLocalIdRepairSideEffectsAfterSyncFailure(
+            syncResult: localIdRepairFailure.syncResult,
+            now: now
+        )
+        return localIdRepairFailure.underlyingError
+    }
+
+    private func applyLocalIdRepairSideEffectsAfterSyncFailure(
+        syncResult: CloudSyncResult,
+        now: Date
+    ) throws {
+        let bootstrapRefreshOutcome = try self.refreshBootstrapSnapshotWithoutReset(now: now)
+        let didResetVolatileReviewSelection = self.resetVolatileReviewSelectionAfterLocalIdRepairIfNeeded(
+            syncResult: syncResult,
+            now: now
+        )
+        if didResetVolatileReviewSelection {
+            self.reconcileStrictReminders(trigger: .reviewHistoryImported, now: now)
+        }
+        if bootstrapRefreshOutcome.didChange || didResetVolatileReviewSelection {
+            self.localReadVersion += 1
+        }
+    }
+
+    /**
+     Local re-id recovery can invalidate volatile review filters and selections
+     that store entity ids. Reset broadly to All Cards instead of preserving
+     individual filters with fragile per-entity repair logic.
+     */
+    private func resetVolatileReviewSelectionAfterLocalIdRepairIfNeeded(
+        syncResult: CloudSyncResult,
+        now: Date
+    ) -> Bool {
+        guard syncResult.localIdRepairEntityTypes.isEmpty == false else {
+            return false
+        }
+
+        self.selectedReviewFilter = .allCards
+        self.persistSelectedReviewFilter(reviewFilter: .allCards)
+        self.startReviewLoad(reviewFilter: .allCards, now: now)
+        self.reconcileReviewNotifications(trigger: .filterChanged, now: now)
+        return true
     }
 
     func isCloudAuthorizationError(_ error: Error) -> Bool {
@@ -305,7 +392,25 @@ extension FlashcardsStore {
     }
 
     func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
-        try await self.cloudRuntime.runLinkedSync(linkedSession: linkedSession)
+        do {
+            return try await self.cloudRuntime.runLinkedSync(linkedSession: linkedSession)
+        } catch {
+            throw try self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
+                error: error,
+                now: Date()
+            )
+        }
+    }
+
+    func runFreshLinkedSyncAfterActiveSyncSettles(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        do {
+            return try await self.cloudRuntime.runFreshLinkedSyncAfterActiveSyncSettles(linkedSession: linkedSession)
+        } catch {
+            throw try self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
+                error: error,
+                now: Date()
+            )
+        }
     }
 
     func triggerCloudSyncIfLinked(trigger: CloudSyncTrigger) {

--- a/apps/ios/Flashcards/Flashcards/Cloud/GuestCloudAuthService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/GuestCloudAuthService.swift
@@ -46,6 +46,8 @@ private struct GuestUpgradeCompleteRequest: Encodable {
 
     let guestToken: String
     let selection: Selection
+    let guestWorkspaceSyncedAndOutboxDrained: Bool
+    let supportsDroppedEntities: Bool
 }
 
 private struct GuestUpgradeCompleteEnvelope: Decodable {
@@ -159,7 +161,9 @@ final class GuestCloudAuthService {
         apiBaseUrl: String,
         bearerToken: String,
         guestToken: String,
-        selection: CloudGuestUpgradeSelection
+        selection: CloudGuestUpgradeSelection,
+        supportsDroppedEntities: Bool,
+        guestWorkspaceSyncedAndOutboxDrained: Bool
     ) async throws -> CloudWorkspaceSummary {
         let requestSelection: GuestUpgradeCompleteRequest.Selection
         switch selection {
@@ -182,7 +186,9 @@ final class GuestCloudAuthService {
             method: "POST",
             body: GuestUpgradeCompleteRequest(
                 guestToken: guestToken,
-                selection: requestSelection
+                selection: requestSelection,
+                guestWorkspaceSyncedAndOutboxDrained: guestWorkspaceSyncedAndOutboxDrained,
+                supportsDroppedEntities: supportsDroppedEntities,
             )
         )
         return response.workspace

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
@@ -1,8 +1,46 @@
+import Foundation
+
 /*
  Keep the iOS sync runner flow aligned with:
  - apps/backend/src/sync.ts
  - apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/CloudRepositories.kt
  */
+
+private let syncWorkspaceForkRequiredErrorCode: String = "SYNC_WORKSPACE_FORK_REQUIRED"
+private let maxPublicWorkspaceForkRecoveriesPerSync: Int = 10
+
+private struct PublicWorkspaceForkRecoveryKey: Hashable {
+    let entityType: SyncEntityType
+    let entityId: String
+}
+
+private struct PublicWorkspaceForkRecoveryResult: Hashable {
+    let key: PublicWorkspaceForkRecoveryKey
+    let entityType: SyncEntityType
+}
+
+private struct InitialHotStateSyncResult: Hashable {
+    let syncResult: CloudSyncResult
+    let requiresPostPushHotHydration: Bool
+}
+
+struct CloudSyncLocalIdRepairFailure: LocalizedError, @unchecked Sendable {
+    let syncResult: CloudSyncResult
+    let underlyingError: Error
+
+    var errorDescription: String? {
+        if let errorDescription = (self.underlyingError as? LocalizedError)?.errorDescription {
+            return errorDescription
+        }
+
+        return self.underlyingError.localizedDescription
+    }
+}
+
+private struct PendingLocalHotEntityKey: Hashable {
+    let entityType: SyncEntityType
+    let entityId: String
+}
 
 struct CloudSyncRunner {
     private let database: LocalDatabase
@@ -17,66 +55,249 @@ struct CloudSyncRunner {
         let cloudSettings = try self.database.loadBootstrapSnapshot().cloudSettings
         let workspaceId = linkedSession.workspaceId
         let syncBasePath = "/workspaces/\(workspaceId)/sync"
-        var syncResult = CloudSyncResult.noChanges
+        var repairedPublicWorkspaceForkConflicts: Set<PublicWorkspaceForkRecoveryKey> = []
+        var publicWorkspaceForkRepairEntityTypes: Set<SyncEntityType> = []
 
-        let removedReviewEventCount = try self.database.deleteStaleReviewEventOutboxEntries(workspaceId: workspaceId)
-        if removedReviewEventCount > 0 {
-            syncResult = syncResult.merging(
-                CloudSyncResult(
-                    appliedPullChangeCount: 0,
-                    changedEntityTypes: [],
-                    acknowledgedOperationCount: 0,
-                    acknowledgedReviewEventOperationCount: 0,
-                    cleanedUpOperationCount: removedReviewEventCount,
-                    cleanedUpReviewEventOperationCount: removedReviewEventCount
-                )
-            )
-            logCloudFlowPhase(
-                phase: .initialPush,
-                outcome: "self_heal",
-                workspaceId: workspaceId,
-                installationId: cloudSettings.installationId,
-                operationsCount: removedReviewEventCount
-            )
-        }
-
-        if try self.database.hasHydratedHotState(workspaceId: workspaceId) == false {
-            syncResult = syncResult.merging(
-                try await self.performInitialHotStateSync(
+        while true {
+            do {
+                let syncResult = try await self.runLinkedSyncOnce(
                     linkedSession: linkedSession,
                     workspaceId: workspaceId,
                     installationId: cloudSettings.installationId,
                     syncBasePath: syncBasePath
                 )
+
+                guard publicWorkspaceForkRepairEntityTypes.isEmpty == false else {
+                    return syncResult
+                }
+
+                return syncResult.merging(
+                    self.makeLocalIdRepairSyncResult(changedEntityTypes: publicWorkspaceForkRepairEntityTypes)
+                )
+            } catch {
+                do {
+                    if let recovery = try self.repairPublicWorkspaceForkConflictIfNeeded(
+                        linkedSession: linkedSession,
+                        workspaceId: workspaceId,
+                        error: error,
+                        repairedConflicts: repairedPublicWorkspaceForkConflicts
+                    ) {
+                        repairedPublicWorkspaceForkConflicts.insert(recovery.key)
+                        publicWorkspaceForkRepairEntityTypes.insert(recovery.entityType)
+                        continue
+                    }
+                } catch {
+                    throw self.wrapFailureAfterLocalIdRepairIfNeeded(
+                        error: error,
+                        changedEntityTypes: publicWorkspaceForkRepairEntityTypes
+                    )
+                }
+
+                throw self.wrapFailureAfterLocalIdRepairIfNeeded(
+                    error: error,
+                    changedEntityTypes: publicWorkspaceForkRepairEntityTypes
+                )
+            }
+        }
+    }
+
+    private func runLinkedSyncOnce(
+        linkedSession: CloudLinkedSession,
+        workspaceId: String,
+        installationId: String,
+        syncBasePath: String
+    ) async throws -> CloudSyncResult {
+        var syncResult = try self.cleanupStaleReviewEventOutboxEntries(
+            workspaceId: workspaceId,
+            installationId: installationId
+        )
+        let initialHotStateSyncResult: InitialHotStateSyncResult?
+
+        if try self.database.hasHydratedHotState(workspaceId: workspaceId) == false {
+            let hotStateSyncResult = try await self.performInitialHotStateSync(
+                linkedSession: linkedSession,
+                workspaceId: workspaceId,
+                installationId: installationId,
+                syncBasePath: syncBasePath
             )
+            syncResult = syncResult.merging(hotStateSyncResult.syncResult)
+            initialHotStateSyncResult = hotStateSyncResult
+        } else {
+            initialHotStateSyncResult = nil
         }
 
         syncResult = syncResult.merging(
             try await self.pushOutboxBatches(
                 linkedSession: linkedSession,
                 workspaceId: workspaceId,
-                installationId: cloudSettings.installationId,
+                installationId: installationId,
                 syncBasePath: syncBasePath
             )
         )
-        syncResult = syncResult.merging(
-            try await self.pullHotChanges(
+        let hotPullResult: CloudSyncResult
+        if initialHotStateSyncResult?.requiresPostPushHotHydration == true {
+            hotPullResult = try await self.pullHotChangesCompletingInitialHotStateHydration(
                 linkedSession: linkedSession,
                 workspaceId: workspaceId,
-                installationId: cloudSettings.installationId,
+                installationId: installationId,
                 syncBasePath: syncBasePath
             )
-        )
+        } else {
+            hotPullResult = try await self.pullHotChanges(
+                linkedSession: linkedSession,
+                workspaceId: workspaceId,
+                installationId: installationId,
+                syncBasePath: syncBasePath
+            )
+        }
+        syncResult = syncResult.merging(hotPullResult)
         syncResult = syncResult.merging(
             try await self.pullReviewHistory(
                 linkedSession: linkedSession,
                 workspaceId: workspaceId,
-                installationId: cloudSettings.installationId,
+                installationId: installationId,
                 syncBasePath: syncBasePath
             )
         )
 
         return syncResult
+    }
+
+    private func repairPublicWorkspaceForkConflictIfNeeded(
+        linkedSession: CloudLinkedSession,
+        workspaceId: String,
+        error: Error,
+        repairedConflicts: Set<PublicWorkspaceForkRecoveryKey>
+    ) throws -> PublicWorkspaceForkRecoveryResult? {
+        guard linkedSession.authorization.isGuest == false else {
+            return nil
+        }
+        guard let syncError = error as? CloudSyncError else {
+            return nil
+        }
+        guard case .invalidResponse(let details, let statusCode) = syncError else {
+            return nil
+        }
+        guard details.code == syncWorkspaceForkRequiredErrorCode else {
+            return nil
+        }
+        guard let syncConflict = details.syncConflict, syncConflict.recoverable else {
+            return nil
+        }
+        let recoveryKey = PublicWorkspaceForkRecoveryKey(
+            entityType: syncConflict.entityType,
+            entityId: syncConflict.entityId
+        )
+        guard repairedConflicts.contains(recoveryKey) == false else {
+            let conflictDescription = "\(syncConflict.entityType.rawValue) \(syncConflict.entityId)"
+            throw self.makePublicWorkspaceForkRecoveryBlockedError(
+                details: details,
+                statusCode: statusCode,
+                reason: "automatic local id repair already repaired \(conflictDescription) in this sync attempt and the backend still reports the same conflict"
+            )
+        }
+        guard repairedConflicts.count < maxPublicWorkspaceForkRecoveriesPerSync else {
+            throw self.makePublicWorkspaceForkRecoveryBlockedError(
+                details: details,
+                statusCode: statusCode,
+                reason: "automatic local id repair reached the limit of \(maxPublicWorkspaceForkRecoveriesPerSync) distinct conflicts in this sync attempt"
+            )
+        }
+
+        do {
+            let recovery = try self.database.repairLocalIdForPublicSyncConflict(
+                workspaceId: workspaceId,
+                syncConflict: syncConflict
+            )
+            return PublicWorkspaceForkRecoveryResult(
+                key: recoveryKey,
+                entityType: recovery.entityType
+            )
+        } catch {
+            let repairErrorMessage: String = (error as? LocalizedError)?.errorDescription ?? String(describing: error)
+            throw self.makePublicWorkspaceForkRecoveryBlockedError(
+                details: details,
+                statusCode: statusCode,
+                reason: "local id repair failed: \(repairErrorMessage)"
+            )
+        }
+    }
+
+    private func makePublicWorkspaceForkRecoveryBlockedError(
+        details: CloudApiErrorDetails,
+        statusCode: Int,
+        reason: String
+    ) -> CloudSyncError {
+        let entityDescription: String
+        if let syncConflict = details.syncConflict {
+            entityDescription = "\(syncConflict.entityType.rawValue) \(syncConflict.entityId)"
+        } else {
+            entityDescription = "the conflicting local entity"
+        }
+
+        return .invalidResponse(
+            CloudApiErrorDetails(
+                message: "Cloud sync is blocked because automatic local id repair for \(entityDescription) could not complete: \(reason).",
+                requestId: details.requestId,
+                code: syncWorkspaceForkRequiredErrorCode,
+                syncConflict: details.syncConflict
+            ),
+            statusCode
+        )
+    }
+
+    private func makeLocalIdRepairSyncResult(changedEntityTypes: Set<SyncEntityType>) -> CloudSyncResult {
+        CloudSyncResult(
+            appliedPullChangeCount: 0,
+            changedEntityTypes: changedEntityTypes,
+            localIdRepairEntityTypes: changedEntityTypes,
+            acknowledgedOperationCount: 0,
+            acknowledgedReviewEventOperationCount: 0,
+            cleanedUpOperationCount: 0,
+            cleanedUpReviewEventOperationCount: 0
+        )
+    }
+
+    private func wrapFailureAfterLocalIdRepairIfNeeded(
+        error: Error,
+        changedEntityTypes: Set<SyncEntityType>
+    ) -> Error {
+        guard changedEntityTypes.isEmpty == false else {
+            return error
+        }
+
+        return CloudSyncLocalIdRepairFailure(
+            syncResult: self.makeLocalIdRepairSyncResult(changedEntityTypes: changedEntityTypes),
+            underlyingError: error
+        )
+    }
+
+    private func cleanupStaleReviewEventOutboxEntries(
+        workspaceId: String,
+        installationId: String
+    ) throws -> CloudSyncResult {
+        let removedReviewEventCount = try self.database.deleteStaleReviewEventOutboxEntries(workspaceId: workspaceId)
+        if removedReviewEventCount == 0 {
+            return .noChanges
+        }
+
+        logCloudFlowPhase(
+            phase: .initialPush,
+            outcome: "self_heal",
+            workspaceId: workspaceId,
+            installationId: installationId,
+            operationsCount: removedReviewEventCount
+        )
+
+        return CloudSyncResult(
+            appliedPullChangeCount: 0,
+            changedEntityTypes: [],
+            localIdRepairEntityTypes: [],
+            acknowledgedOperationCount: 0,
+            acknowledgedReviewEventOperationCount: 0,
+            cleanedUpOperationCount: removedReviewEventCount,
+            cleanedUpReviewEventOperationCount: removedReviewEventCount
+        )
     }
 
     /// Bootstraps the blocking mutable current state first.
@@ -94,7 +315,7 @@ struct CloudSyncRunner {
         workspaceId: String,
         installationId: String,
         syncBasePath: String
-    ) async throws -> CloudSyncResult {
+    ) async throws -> InitialHotStateSyncResult {
         let firstPage: RemoteBootstrapPullResponseEnvelope = try await self.transport.request(
             apiBaseUrl: linkedSession.apiBaseUrl,
             authorizationHeader: linkedSession.authorization.headerValue,
@@ -111,44 +332,88 @@ struct CloudSyncRunner {
         )
 
         if firstPage.remoteIsEmpty {
-            return try await self.bootstrapEmptyRemoteWorkspace(
-                linkedSession: linkedSession,
-                workspaceId: workspaceId,
-                installationId: installationId,
-                syncBasePath: syncBasePath
+            return InitialHotStateSyncResult(
+                syncResult: try await self.bootstrapEmptyRemoteWorkspace(
+                    linkedSession: linkedSession,
+                    workspaceId: workspaceId,
+                    installationId: installationId,
+                    syncBasePath: syncBasePath
+                ),
+                requiresPostPushHotHydration: false
             )
         }
 
+        return try await self.bootstrapNonEmptyRemoteWorkspace(
+            firstPage: firstPage,
+            linkedSession: linkedSession,
+            workspaceId: workspaceId,
+            installationId: installationId,
+            syncBasePath: syncBasePath
+        )
+    }
+
+    private func bootstrapNonEmptyRemoteWorkspace(
+        firstPage: RemoteBootstrapPullResponseEnvelope,
+        linkedSession: CloudLinkedSession,
+        workspaceId: String,
+        installationId: String,
+        syncBasePath: String
+    ) async throws -> InitialHotStateSyncResult {
         var appliedPullChangeCount = 0
         var changedEntityTypes = Set<SyncEntityType>()
         var currentPage = firstPage
+        var pendingLocalHotEntityKeys = Set<PendingLocalHotEntityKey>()
+        var appliedBootstrapHotEntityKeys = Set<PendingLocalHotEntityKey>()
+        var requiresPostPushHotHydration = false
 
         while true {
+            let latestPendingLocalHotEntityKeys = try self.loadPendingLocalHotEntityKeys(workspaceId: workspaceId)
+            if latestPendingLocalHotEntityKeys.isDisjoint(with: appliedBootstrapHotEntityKeys) == false {
+                requiresPostPushHotHydration = true
+            }
+            pendingLocalHotEntityKeys.formUnion(latestPendingLocalHotEntityKeys)
+
             for entry in currentPage.entries {
+                let entryKey = self.makePendingLocalHotEntityKey(
+                    entityType: entry.entityType,
+                    entityId: entry.entityId
+                )
+                if let entryKey, pendingLocalHotEntityKeys.contains(entryKey) {
+                    requiresPostPushHotHydration = true
+                    continue
+                }
+
                 try self.database.applySyncBootstrapEntry(
                     workspaceId: workspaceId,
                     entry: CloudSyncMapper.makeSyncBootstrapEntry(workspaceId: workspaceId, entry: entry)
                 )
+                if let entryKey {
+                    appliedBootstrapHotEntityKeys.insert(entryKey)
+                }
                 appliedPullChangeCount += 1
                 changedEntityTypes.insert(entry.entityType)
             }
 
             if currentPage.hasMore == false {
-                try self.database.setLastAppliedHotChangeId(
-                    workspaceId: workspaceId,
-                    changeId: currentPage.bootstrapHotChangeId
-                )
-                try self.database.setHasHydratedHotState(
-                    workspaceId: workspaceId,
-                    hasHydratedHotState: true
-                )
-                return CloudSyncResult(
-                    appliedPullChangeCount: appliedPullChangeCount,
-                    changedEntityTypes: changedEntityTypes,
-                    acknowledgedOperationCount: 0,
-                    acknowledgedReviewEventOperationCount: 0,
-                    cleanedUpOperationCount: 0,
-                    cleanedUpReviewEventOperationCount: 0
+                if requiresPostPushHotHydration == false {
+                    requiresPostPushHotHydration = try self.finalizeBootstrapHotStateIfClean(
+                        workspaceId: workspaceId,
+                        bootstrapHotChangeId: currentPage.bootstrapHotChangeId,
+                        appliedBootstrapHotEntityKeys: appliedBootstrapHotEntityKeys
+                    )
+                }
+
+                return InitialHotStateSyncResult(
+                    syncResult: CloudSyncResult(
+                        appliedPullChangeCount: appliedPullChangeCount,
+                        changedEntityTypes: changedEntityTypes,
+                        localIdRepairEntityTypes: [],
+                        acknowledgedOperationCount: 0,
+                        acknowledgedReviewEventOperationCount: 0,
+                        cleanedUpOperationCount: 0,
+                        cleanedUpReviewEventOperationCount: 0
+                    ),
+                    requiresPostPushHotHydration: requiresPostPushHotHydration
                 )
             }
 
@@ -173,6 +438,48 @@ struct CloudSyncRunner {
         }
     }
 
+    private func finalizeBootstrapHotStateIfClean(
+        workspaceId: String,
+        bootstrapHotChangeId: Int64,
+        appliedBootstrapHotEntityKeys: Set<PendingLocalHotEntityKey>
+    ) throws -> Bool {
+        try self.database.core.inTransaction {
+            let latestPendingLocalHotEntityKeys = try self.loadPendingLocalHotEntityKeys(workspaceId: workspaceId)
+            guard latestPendingLocalHotEntityKeys.isDisjoint(with: appliedBootstrapHotEntityKeys) else {
+                return true
+            }
+
+            try self.database.setLastAppliedHotChangeId(
+                workspaceId: workspaceId,
+                changeId: bootstrapHotChangeId
+            )
+            try self.database.setHasHydratedHotState(
+                workspaceId: workspaceId,
+                hasHydratedHotState: true
+            )
+            return false
+        }
+    }
+
+    private func pullHotChangesCompletingInitialHotStateHydration(
+        linkedSession: CloudLinkedSession,
+        workspaceId: String,
+        installationId: String,
+        syncBasePath: String
+    ) async throws -> CloudSyncResult {
+        let syncResult = try await self.pullHotChanges(
+            linkedSession: linkedSession,
+            workspaceId: workspaceId,
+            installationId: installationId,
+            syncBasePath: syncBasePath
+        )
+        try self.database.setHasHydratedHotState(
+            workspaceId: workspaceId,
+            hasHydratedHotState: true
+        )
+        return syncResult
+    }
+
     private func bootstrapEmptyRemoteWorkspace(
         linkedSession: CloudLinkedSession,
         workspaceId: String,
@@ -189,31 +496,26 @@ struct CloudSyncRunner {
 
         var bootstrapHotChangeId: Int64 = 0
         if bootstrapEntries.isEmpty == false {
-            var startIndex = 0
-            while startIndex < bootstrapEntries.count {
-                let endIndex = min(startIndex + 200, bootstrapEntries.count)
-                let response: RemoteBootstrapPushResponseEnvelope = try await self.transport.request(
-                    apiBaseUrl: linkedSession.apiBaseUrl,
-                    authorizationHeader: linkedSession.authorization.headerValue,
-                    path: "\(syncBasePath)/bootstrap",
-                    method: "POST",
-                    body: BootstrapPushRequest(
-                        mode: "push",
-                        installationId: installationId,
-                        platform: "ios",
-                        appVersion: self.transport.appVersion(),
-                        entries: bootstrapEntries[startIndex..<endIndex].map { entry in
-                            SyncBootstrapEntryEnvelope(entry: entry)
-                        }
-                    )
+            let response: RemoteBootstrapPushResponseEnvelope = try await self.transport.request(
+                apiBaseUrl: linkedSession.apiBaseUrl,
+                authorizationHeader: linkedSession.authorization.headerValue,
+                path: "\(syncBasePath)/bootstrap",
+                method: "POST",
+                body: BootstrapPushRequest(
+                    mode: "push",
+                    installationId: installationId,
+                    platform: "ios",
+                    appVersion: self.transport.appVersion(),
+                    entries: bootstrapEntries.map { entry in
+                        SyncBootstrapEntryEnvelope(entry: entry)
+                    }
                 )
-                guard let responseHotChangeId = response.bootstrapHotChangeId else {
-                    throw LocalStoreError.validation("Bootstrap push response is missing bootstrapHotChangeId")
-                }
-
-                bootstrapHotChangeId = responseHotChangeId
-                startIndex = endIndex
+            )
+            guard let responseHotChangeId = response.bootstrapHotChangeId else {
+                throw LocalStoreError.validation("Bootstrap push response is missing bootstrapHotChangeId")
             }
+
+            bootstrapHotChangeId = responseHotChangeId
         }
 
         var nextReviewSequenceId: Int64 = 0
@@ -268,6 +570,7 @@ struct CloudSyncRunner {
         return CloudSyncResult(
             appliedPullChangeCount: 0,
             changedEntityTypes: changedEntityTypes,
+            localIdRepairEntityTypes: [],
             acknowledgedOperationCount: 0,
             acknowledgedReviewEventOperationCount: 0,
             cleanedUpOperationCount: pendingOutboxCount,
@@ -290,6 +593,7 @@ struct CloudSyncRunner {
                 return CloudSyncResult(
                     appliedPullChangeCount: 0,
                     changedEntityTypes: [],
+                    localIdRepairEntityTypes: [],
                     acknowledgedOperationCount: acknowledgedOperationCount,
                     acknowledgedReviewEventOperationCount: acknowledgedReviewEventOperationCount,
                     cleanedUpOperationCount: 0,
@@ -359,6 +663,30 @@ struct CloudSyncRunner {
         }
     }
 
+    private func loadPendingLocalHotEntityKeys(workspaceId: String) throws -> Set<PendingLocalHotEntityKey> {
+        let outboxEntries = try self.database.loadOutboxEntries(workspaceId: workspaceId, limit: Int.max)
+        return Set(
+            outboxEntries.compactMap { entry in
+                self.makePendingLocalHotEntityKey(
+                    entityType: entry.operation.entityType,
+                    entityId: entry.operation.entityId
+                )
+            }
+        )
+    }
+
+    private func makePendingLocalHotEntityKey(
+        entityType: SyncEntityType,
+        entityId: String
+    ) -> PendingLocalHotEntityKey? {
+        switch entityType {
+        case .card, .deck, .workspaceSchedulerSettings:
+            return PendingLocalHotEntityKey(entityType: entityType, entityId: entityId)
+        case .reviewEvent:
+            return nil
+        }
+    }
+
     private func pullHotChanges(
         linkedSession: CloudLinkedSession,
         workspaceId: String,
@@ -403,6 +731,7 @@ struct CloudSyncRunner {
                 return CloudSyncResult(
                     appliedPullChangeCount: appliedPullChangeCount,
                     changedEntityTypes: changedEntityTypes,
+                    localIdRepairEntityTypes: [],
                     acknowledgedOperationCount: 0,
                     acknowledgedReviewEventOperationCount: 0,
                     cleanedUpOperationCount: 0,
@@ -461,6 +790,7 @@ struct CloudSyncRunner {
                 return CloudSyncResult(
                     appliedPullChangeCount: appliedReviewEventCount,
                     changedEntityTypes: appliedReviewEventCount == 0 ? [] : [.reviewEvent],
+                    localIdRepairEntityTypes: [],
                     acknowledgedOperationCount: 0,
                     acknowledgedReviewEventOperationCount: 0,
                     cleanedUpOperationCount: 0,

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+WorkspaceLinking.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+WorkspaceLinking.swift
@@ -1,4 +1,216 @@
+import CryptoKit
 import Foundation
+
+private let cardIdentityForkNamespace: UUID = UUID(uuidString: "5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1")!
+private let deckIdentityForkNamespace: UUID = UUID(uuidString: "98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4")!
+private let reviewEventIdentityForkNamespace: UUID = UUID(uuidString: "3a214a3e-9c89-426d-a21f-11a5f5c1d6e8")!
+private let workspaceForkReviewEventSelectBatchSize: Int = 500
+private let publicSyncConflictReIdMaxAttempts: Int = 5
+
+struct PublicSyncConflictReIdRecovery: Hashable {
+    let entityType: SyncEntityType
+    let sourceEntityId: String
+    let replacementEntityId: String
+}
+
+private struct WorkspaceForkIdMappings {
+    let cardIdsBySourceId: [String: String]
+    let deckIdsBySourceId: [String: String]
+    let reviewEventIdsBySourceId: [String: String]
+}
+
+private struct WorkspaceForkReviewEventRow {
+    let sourceReviewEventId: String
+    let sourceCardId: String
+    let replicaId: String
+    let clientEventId: String
+    let rating: Int64
+    let reviewedAtClient: String
+    let reviewedAtServer: String
+}
+
+private struct WorkspaceForkOutboxRow {
+    let operationId: String
+    let entityType: SyncEntityType
+    let entityId: String
+    let payloadJson: String
+}
+
+private enum WorkspaceForkJSONValue: Codable, Equatable {
+    case object([String: WorkspaceForkJSONValue])
+    case array([WorkspaceForkJSONValue])
+    case string(String)
+    case integer(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .integer(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([WorkspaceForkJSONValue].self) {
+            self = .array(value)
+        } else {
+            self = .object(try container.decode([String: WorkspaceForkJSONValue].self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .integer(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
+func forkedCardIdForWorkspace(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceCardId: String
+) -> String {
+    forkedWorkspaceEntityId(
+        namespace: cardIdentityForkNamespace,
+        sourceWorkspaceId: sourceWorkspaceId,
+        destinationWorkspaceId: destinationWorkspaceId,
+        sourceEntityId: sourceCardId
+    )
+}
+
+func forkedDeckIdForWorkspace(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceDeckId: String
+) -> String {
+    forkedWorkspaceEntityId(
+        namespace: deckIdentityForkNamespace,
+        sourceWorkspaceId: sourceWorkspaceId,
+        destinationWorkspaceId: destinationWorkspaceId,
+        sourceEntityId: sourceDeckId
+    )
+}
+
+func forkedReviewEventIdForWorkspace(
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceReviewEventId: String
+) -> String {
+    forkedWorkspaceEntityId(
+        namespace: reviewEventIdentityForkNamespace,
+        sourceWorkspaceId: sourceWorkspaceId,
+        destinationWorkspaceId: destinationWorkspaceId,
+        sourceEntityId: sourceReviewEventId
+    )
+}
+
+private func forkedWorkspaceEntityId(
+    namespace: UUID,
+    sourceWorkspaceId: String,
+    destinationWorkspaceId: String,
+    sourceEntityId: String
+) -> String {
+    if sourceWorkspaceId == destinationWorkspaceId {
+        return sourceEntityId
+    }
+
+    let name = "\(sourceWorkspaceId):\(destinationWorkspaceId):\(sourceEntityId)"
+    return uuidV5(namespace: namespace, name: name).uuidString.lowercased()
+}
+
+private func uuidV5(namespace: UUID, name: String) -> UUID {
+    let hashInput = namespace.bigEndianBytes + Array(name.utf8)
+    var hash = Array(Insecure.SHA1.hash(data: Data(hashInput)))
+    hash[6] = (hash[6] & 0x0f) | 0x50
+    hash[8] = (hash[8] & 0x3f) | 0x80
+    return UUID(uuid: (
+        hash[0],
+        hash[1],
+        hash[2],
+        hash[3],
+        hash[4],
+        hash[5],
+        hash[6],
+        hash[7],
+        hash[8],
+        hash[9],
+        hash[10],
+        hash[11],
+        hash[12],
+        hash[13],
+        hash[14],
+        hash[15]
+    ))
+}
+
+private extension UUID {
+    var bigEndianBytes: [UInt8] {
+        [
+            self.uuid.0,
+            self.uuid.1,
+            self.uuid.2,
+            self.uuid.3,
+            self.uuid.4,
+            self.uuid.5,
+            self.uuid.6,
+            self.uuid.7,
+            self.uuid.8,
+            self.uuid.9,
+            self.uuid.10,
+            self.uuid.11,
+            self.uuid.12,
+            self.uuid.13,
+            self.uuid.14,
+            self.uuid.15,
+        ]
+    }
+}
+
+private extension Dictionary where Key == String, Value == String {
+    func requireMappedId(entityType: String, sourceId: String) throws -> String {
+        guard let mappedId = self[sourceId] else {
+            throw LocalStoreError.database(
+                "Workspace identity fork is missing mapped \(entityType) id for source id '\(sourceId)'"
+            )
+        }
+
+        return mappedId
+    }
+}
+
+private extension Dictionary where Key == String, Value == WorkspaceForkJSONValue {
+    func requireString(fieldName: String, context: String) throws -> String {
+        guard let value = self[fieldName] else {
+            throw LocalStoreError.database("Workspace identity fork payload is missing \(fieldName) for \(context)")
+        }
+
+        guard case .string(let stringValue) = value else {
+            throw LocalStoreError.database("Workspace identity fork payload field \(fieldName) is not a string for \(context)")
+        }
+
+        return stringValue
+    }
+}
 
 extension LocalDatabase {
     func updateCloudSettings(
@@ -90,6 +302,96 @@ extension LocalDatabase {
         }
     }
 
+    /**
+     Switches local storage after backend guest-upgrade completion.
+
+     Backend completion only merges guest cloud state that was already synced,
+     so this path never migrates pending guest outbox rows into the linked
+     workspace. Remaining local hydration comes from ordinary linked sync.
+     */
+    func switchGuestUpgradeToLinkedWorkspaceFromRemote(
+        localWorkspaceId: String,
+        linkedSession: CloudLinkedSession,
+        workspace: CloudWorkspaceSummary
+    ) throws {
+        guard linkedSession.workspaceId == workspace.workspaceId else {
+            throw LocalStoreError.database(
+                "Guest upgrade linked session workspace does not match selected workspace: session=\(linkedSession.workspaceId) selected=\(workspace.workspaceId)"
+            )
+        }
+
+        try self.core.inTransaction {
+            if localWorkspaceId == workspace.workspaceId {
+                try self.ensureLinkedWorkspaceShell(workspace: workspace)
+                try self.updateAccountWorkspaceReference(workspaceId: workspace.workspaceId)
+            } else {
+                try self.assertNoPendingOutboxEntriesBeforeGuestWorkspaceDelete(workspaceId: localWorkspaceId)
+                try self.deleteWorkspaceIfExists(workspaceId: workspace.workspaceId)
+                try self.ensureLinkedWorkspaceShell(workspace: workspace)
+                try self.resetSyncState(workspaceId: workspace.workspaceId)
+                try self.updateAccountWorkspaceReference(workspaceId: workspace.workspaceId)
+                try self.deleteWorkspaceIfExists(workspaceId: localWorkspaceId)
+            }
+            try self.deleteOtherWorkspaces(exceptWorkspaceId: workspace.workspaceId)
+            try self.assertSingleWorkspaceInvariant(expectedWorkspaceId: workspace.workspaceId)
+            try self.workspaceSettingsStore.updateCloudSettings(
+                cloudState: .linked,
+                linkedUserId: linkedSession.userId,
+                linkedWorkspaceId: workspace.workspaceId,
+                activeWorkspaceId: workspace.workspaceId,
+                linkedEmail: linkedSession.email
+            )
+        }
+    }
+
+    func repairLocalIdForPublicSyncConflict(
+        workspaceId: String,
+        syncConflict: CloudSyncConflictDetails
+    ) throws -> PublicSyncConflictReIdRecovery {
+        guard syncConflict.recoverable else {
+            throw LocalStoreError.validation(
+                "Public sync conflict is not recoverable for \(syncConflict.entityType.rawValue) \(syncConflict.entityId)"
+            )
+        }
+
+        return try self.core.inTransaction {
+            let replacementEntityId: String = try self.makeFreshPublicSyncConflictEntityId(
+                entityType: syncConflict.entityType
+            )
+
+            switch syncConflict.entityType {
+            case .card:
+                try self.rewriteLocalCardIdForPublicSyncConflict(
+                    workspaceId: workspaceId,
+                    sourceCardId: syncConflict.entityId,
+                    replacementCardId: replacementEntityId
+                )
+            case .deck:
+                try self.rewriteLocalDeckIdForPublicSyncConflict(
+                    workspaceId: workspaceId,
+                    sourceDeckId: syncConflict.entityId,
+                    replacementDeckId: replacementEntityId
+                )
+            case .reviewEvent:
+                try self.rewriteLocalReviewEventIdForPublicSyncConflict(
+                    workspaceId: workspaceId,
+                    sourceReviewEventId: syncConflict.entityId,
+                    replacementReviewEventId: replacementEntityId
+                )
+            case .workspaceSchedulerSettings:
+                throw LocalStoreError.validation(
+                    "Public sync conflict recovery cannot re-id workspace scheduler settings for workspace \(workspaceId)"
+                )
+            }
+
+            return PublicSyncConflictReIdRecovery(
+                entityType: syncConflict.entityType,
+                sourceEntityId: syncConflict.entityId,
+                replacementEntityId: replacementEntityId
+            )
+        }
+    }
+
     func replaceLocalWorkspaceAfterRemoteDelete(
         localWorkspaceId: String,
         replacementWorkspace: CloudWorkspaceSummary,
@@ -115,6 +417,18 @@ extension LocalDatabase {
 
     func resetForAccountDeletion() throws {
         try self.core.resetForAccountDeletion()
+    }
+
+    private func assertNoPendingOutboxEntriesBeforeGuestWorkspaceDelete(workspaceId: String) throws {
+        let pendingOutboxCount = try self.core.scalarInt(
+            sql: "SELECT COUNT(*) FROM outbox WHERE workspace_id = ?",
+            values: [.text(workspaceId)]
+        )
+        guard pendingOutboxCount == 0 else {
+            throw LocalStoreError.database(
+                "Guest upgrade cannot delete workspace \(workspaceId) because \(pendingOutboxCount) pending guest outbox entries remain."
+            )
+        }
     }
 
     private func insertWorkspaceFromLocalSettings(
@@ -260,6 +574,253 @@ extension LocalDatabase {
         try self.ensureSyncStateExists(workspaceId: workspaceId)
     }
 
+    private func makeFreshPublicSyncConflictEntityId(entityType: SyncEntityType) throws -> String {
+        var attemptIndex: Int = 0
+        while attemptIndex < publicSyncConflictReIdMaxAttempts {
+            let candidateId: String = UUID().uuidString.lowercased()
+            if try self.publicSyncConflictEntityExists(entityType: entityType, entityId: candidateId) == false {
+                return candidateId
+            }
+
+            attemptIndex += 1
+        }
+
+        throw LocalStoreError.database(
+            "Failed to generate a fresh local id for \(entityType.rawValue) after \(publicSyncConflictReIdMaxAttempts) attempts"
+        )
+    }
+
+    private func publicSyncConflictEntityExists(entityType: SyncEntityType, entityId: String) throws -> Bool {
+        switch entityType {
+        case .card:
+            return try self.core.scalarInt(
+                sql: "SELECT COUNT(*) FROM cards WHERE card_id = ?",
+                values: [.text(entityId)]
+            ) > 0
+        case .deck:
+            return try self.core.scalarInt(
+                sql: "SELECT COUNT(*) FROM decks WHERE deck_id = ?",
+                values: [.text(entityId)]
+            ) > 0
+        case .reviewEvent:
+            return try self.core.scalarInt(
+                sql: "SELECT COUNT(*) FROM review_events WHERE review_event_id = ?",
+                values: [.text(entityId)]
+            ) > 0
+        case .workspaceSchedulerSettings:
+            return try self.core.scalarInt(
+                sql: "SELECT COUNT(*) FROM workspaces WHERE workspace_id = ?",
+                values: [.text(entityId)]
+            ) > 0
+        }
+    }
+
+    private func rewriteLocalCardIdForPublicSyncConflict(
+        workspaceId: String,
+        sourceCardId: String,
+        replacementCardId: String
+    ) throws {
+        let insertedRows: Int = try self.core.execute(
+            sql: """
+            INSERT INTO cards (
+                card_id,
+                workspace_id,
+                front_text,
+                back_text,
+                tags_json,
+                effort_level,
+                due_at,
+                created_at,
+                reps,
+                lapses,
+                fsrs_card_state,
+                fsrs_step_index,
+                fsrs_stability,
+                fsrs_difficulty,
+                fsrs_last_reviewed_at,
+                fsrs_scheduled_days,
+                client_updated_at,
+                last_modified_by_replica_id,
+                last_operation_id,
+                updated_at,
+                deleted_at
+            )
+            SELECT
+                ?,
+                workspace_id,
+                front_text,
+                back_text,
+                tags_json,
+                effort_level,
+                due_at,
+                created_at,
+                reps,
+                lapses,
+                fsrs_card_state,
+                fsrs_step_index,
+                fsrs_stability,
+                fsrs_difficulty,
+                fsrs_last_reviewed_at,
+                fsrs_scheduled_days,
+                client_updated_at,
+                last_modified_by_replica_id,
+                last_operation_id,
+                updated_at,
+                deleted_at
+            FROM cards
+            WHERE workspace_id = ? AND card_id = ?
+            """,
+            values: [
+                .text(replacementCardId),
+                .text(workspaceId),
+                .text(sourceCardId)
+            ]
+        )
+        guard insertedRows == 1 else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery could not find local card \(sourceCardId) in workspace \(workspaceId)"
+            )
+        }
+
+        _ = try self.core.execute(
+            sql: """
+            UPDATE card_tags
+            SET card_id = ?
+            WHERE workspace_id = ? AND card_id = ?
+            """,
+            values: [
+                .text(replacementCardId),
+                .text(workspaceId),
+                .text(sourceCardId)
+            ]
+        )
+        _ = try self.core.execute(
+            sql: """
+            UPDATE review_events
+            SET card_id = ?
+            WHERE workspace_id = ? AND card_id = ?
+            """,
+            values: [
+                .text(replacementCardId),
+                .text(workspaceId),
+                .text(sourceCardId)
+            ]
+        )
+        try self.rewriteOutboxForCardPublicSyncConflict(
+            workspaceId: workspaceId,
+            sourceCardId: sourceCardId,
+            replacementCardId: replacementCardId
+        )
+
+        let deletedRows: Int = try self.core.execute(
+            sql: "DELETE FROM cards WHERE workspace_id = ? AND card_id = ?",
+            values: [
+                .text(workspaceId),
+                .text(sourceCardId)
+            ]
+        )
+        guard deletedRows == 1 else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery could not remove source card \(sourceCardId) in workspace \(workspaceId)"
+            )
+        }
+    }
+
+    private func rewriteLocalDeckIdForPublicSyncConflict(
+        workspaceId: String,
+        sourceDeckId: String,
+        replacementDeckId: String
+    ) throws {
+        let insertedRows: Int = try self.core.execute(
+            sql: """
+            INSERT INTO decks (
+                deck_id,
+                workspace_id,
+                name,
+                filter_definition_json,
+                created_at,
+                client_updated_at,
+                last_modified_by_replica_id,
+                last_operation_id,
+                updated_at,
+                deleted_at
+            )
+            SELECT
+                ?,
+                workspace_id,
+                name,
+                filter_definition_json,
+                created_at,
+                client_updated_at,
+                last_modified_by_replica_id,
+                last_operation_id,
+                updated_at,
+                deleted_at
+            FROM decks
+            WHERE workspace_id = ? AND deck_id = ?
+            """,
+            values: [
+                .text(replacementDeckId),
+                .text(workspaceId),
+                .text(sourceDeckId)
+            ]
+        )
+        guard insertedRows == 1 else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery could not find local deck \(sourceDeckId) in workspace \(workspaceId)"
+            )
+        }
+
+        try self.rewriteOutboxForDeckPublicSyncConflict(
+            workspaceId: workspaceId,
+            sourceDeckId: sourceDeckId,
+            replacementDeckId: replacementDeckId
+        )
+
+        let deletedRows: Int = try self.core.execute(
+            sql: "DELETE FROM decks WHERE workspace_id = ? AND deck_id = ?",
+            values: [
+                .text(workspaceId),
+                .text(sourceDeckId)
+            ]
+        )
+        guard deletedRows == 1 else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery could not remove source deck \(sourceDeckId) in workspace \(workspaceId)"
+            )
+        }
+    }
+
+    private func rewriteLocalReviewEventIdForPublicSyncConflict(
+        workspaceId: String,
+        sourceReviewEventId: String,
+        replacementReviewEventId: String
+    ) throws {
+        let updatedRows: Int = try self.core.execute(
+            sql: """
+            UPDATE review_events
+            SET review_event_id = ?
+            WHERE workspace_id = ? AND review_event_id = ?
+            """,
+            values: [
+                .text(replacementReviewEventId),
+                .text(workspaceId),
+                .text(sourceReviewEventId)
+            ]
+        )
+        guard updatedRows == 1 else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery could not find local review_event \(sourceReviewEventId) in workspace \(workspaceId)"
+            )
+        }
+
+        try self.rewriteOutboxForReviewEventPublicSyncConflict(
+            workspaceId: workspaceId,
+            sourceReviewEventId: sourceReviewEventId,
+            replacementReviewEventId: replacementReviewEventId
+        )
+    }
+
     private func updateAccountWorkspaceReference(workspaceId: String) throws {
         _ = try self.core.execute(
             sql: """
@@ -270,28 +831,16 @@ extension LocalDatabase {
         )
     }
 
-    private func updateWorkspaceReferences(
-        tableNames: [String],
-        sourceWorkspaceId: String,
-        destinationWorkspaceId: String
-    ) throws {
-        for tableName in tableNames {
-            _ = try self.core.execute(
-                sql: "UPDATE \(tableName) SET workspace_id = ? WHERE workspace_id = ?",
-                values: [
-                    .text(destinationWorkspaceId),
-                    .text(sourceWorkspaceId)
-                ]
-            )
-        }
-    }
-
     private func preserveLocalDataForEmptyRemoteWorkspace(
         sourceWorkspaceId: String,
         destinationWorkspaceId: String
     ) throws {
         let localWorkspace = try self.workspaceSettingsStore.loadWorkspace()
         let currentSettings = try self.workspaceSettingsStore.loadWorkspaceSchedulerSettings(workspaceId: sourceWorkspaceId)
+        let forkMappings = try self.loadWorkspaceForkIdMappings(
+            sourceWorkspaceId: sourceWorkspaceId,
+            destinationWorkspaceId: destinationWorkspaceId
+        )
 
         try self.deleteWorkspaceIfExists(workspaceId: destinationWorkspaceId)
         try self.insertWorkspaceFromLocalSettings(
@@ -301,16 +850,679 @@ extension LocalDatabase {
             settings: currentSettings
         )
 
-        let workspaceScopedTables: [String] = ["user_settings", "cards", "decks", "review_events", "outbox", "card_tags"]
-        try self.updateWorkspaceReferences(
-            tableNames: workspaceScopedTables,
+        try self.insertForkedCards(
             sourceWorkspaceId: sourceWorkspaceId,
-            destinationWorkspaceId: destinationWorkspaceId
+            destinationWorkspaceId: destinationWorkspaceId,
+            forkMappings: forkMappings
+        )
+        try self.insertForkedDecks(
+            sourceWorkspaceId: sourceWorkspaceId,
+            destinationWorkspaceId: destinationWorkspaceId,
+            forkMappings: forkMappings
+        )
+        try self.insertForkedCardTags(
+            sourceWorkspaceId: sourceWorkspaceId,
+            destinationWorkspaceId: destinationWorkspaceId,
+            forkMappings: forkMappings
+        )
+        try self.insertForkedReviewEvents(
+            sourceWorkspaceId: sourceWorkspaceId,
+            destinationWorkspaceId: destinationWorkspaceId,
+            forkMappings: forkMappings
+        )
+        try self.rewriteOutboxForWorkspaceFork(
+            sourceWorkspaceId: sourceWorkspaceId,
+            destinationWorkspaceId: destinationWorkspaceId,
+            forkMappings: forkMappings
         )
 
         try self.updateAccountWorkspaceReference(workspaceId: destinationWorkspaceId)
         try self.deleteWorkspaceIfExists(workspaceId: sourceWorkspaceId)
         try self.resetSyncState(workspaceId: destinationWorkspaceId)
+    }
+
+    private func loadWorkspaceForkIdMappings(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String
+    ) throws -> WorkspaceForkIdMappings {
+        let cardIds = try self.loadEntityIds(
+            sql: "SELECT card_id FROM cards WHERE workspace_id = ? ORDER BY card_id ASC",
+            workspaceId: sourceWorkspaceId
+        )
+        let deckIds = try self.loadEntityIds(
+            sql: "SELECT deck_id FROM decks WHERE workspace_id = ? ORDER BY deck_id ASC",
+            workspaceId: sourceWorkspaceId
+        )
+        let reviewEventIds = try self.loadEntityIds(
+            sql: "SELECT review_event_id FROM review_events WHERE workspace_id = ? ORDER BY review_event_id ASC",
+            workspaceId: sourceWorkspaceId
+        )
+
+        return WorkspaceForkIdMappings(
+            cardIdsBySourceId: Dictionary(uniqueKeysWithValues: cardIds.map { cardId in
+                (
+                    cardId,
+                    forkedCardIdForWorkspace(
+                        sourceWorkspaceId: sourceWorkspaceId,
+                        destinationWorkspaceId: destinationWorkspaceId,
+                        sourceCardId: cardId
+                    )
+                )
+            }),
+            deckIdsBySourceId: Dictionary(uniqueKeysWithValues: deckIds.map { deckId in
+                (
+                    deckId,
+                    forkedDeckIdForWorkspace(
+                        sourceWorkspaceId: sourceWorkspaceId,
+                        destinationWorkspaceId: destinationWorkspaceId,
+                        sourceDeckId: deckId
+                    )
+                )
+            }),
+            reviewEventIdsBySourceId: Dictionary(uniqueKeysWithValues: reviewEventIds.map { reviewEventId in
+                (
+                    reviewEventId,
+                    forkedReviewEventIdForWorkspace(
+                        sourceWorkspaceId: sourceWorkspaceId,
+                        destinationWorkspaceId: destinationWorkspaceId,
+                        sourceReviewEventId: reviewEventId
+                    )
+                )
+            })
+        )
+    }
+
+    private func loadEntityIds(sql: String, workspaceId: String) throws -> [String] {
+        try self.core.query(
+            sql: sql,
+            values: [.text(workspaceId)]
+        ) { statement in
+            DatabaseCore.columnText(statement: statement, index: 0)
+        }
+    }
+
+    private func insertForkedCards(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws {
+        for (sourceCardId, destinationCardId) in forkMappings.cardIdsBySourceId {
+            try self.core.execute(
+                sql: """
+                INSERT INTO cards (
+                    card_id,
+                    workspace_id,
+                    front_text,
+                    back_text,
+                    tags_json,
+                    effort_level,
+                    due_at,
+                    created_at,
+                    reps,
+                    lapses,
+                    fsrs_card_state,
+                    fsrs_step_index,
+                    fsrs_stability,
+                    fsrs_difficulty,
+                    fsrs_last_reviewed_at,
+                    fsrs_scheduled_days,
+                    client_updated_at,
+                    last_modified_by_replica_id,
+                    last_operation_id,
+                    updated_at,
+                    deleted_at
+                )
+                SELECT
+                    ?,
+                    ?,
+                    front_text,
+                    back_text,
+                    tags_json,
+                    effort_level,
+                    due_at,
+                    created_at,
+                    reps,
+                    lapses,
+                    fsrs_card_state,
+                    fsrs_step_index,
+                    fsrs_stability,
+                    fsrs_difficulty,
+                    fsrs_last_reviewed_at,
+                    fsrs_scheduled_days,
+                    client_updated_at,
+                    last_modified_by_replica_id,
+                    last_operation_id,
+                    updated_at,
+                    deleted_at
+                FROM cards
+                WHERE workspace_id = ? AND card_id = ?
+                """,
+                values: [
+                    .text(destinationCardId),
+                    .text(destinationWorkspaceId),
+                    .text(sourceWorkspaceId),
+                    .text(sourceCardId)
+                ]
+            )
+        }
+    }
+
+    private func insertForkedDecks(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws {
+        for (sourceDeckId, destinationDeckId) in forkMappings.deckIdsBySourceId {
+            try self.core.execute(
+                sql: """
+                INSERT INTO decks (
+                    deck_id,
+                    workspace_id,
+                    name,
+                    filter_definition_json,
+                    created_at,
+                    client_updated_at,
+                    last_modified_by_replica_id,
+                    last_operation_id,
+                    updated_at,
+                    deleted_at
+                )
+                SELECT
+                    ?,
+                    ?,
+                    name,
+                    filter_definition_json,
+                    created_at,
+                    client_updated_at,
+                    last_modified_by_replica_id,
+                    last_operation_id,
+                    updated_at,
+                    deleted_at
+                FROM decks
+                WHERE workspace_id = ? AND deck_id = ?
+                """,
+                values: [
+                    .text(destinationDeckId),
+                    .text(destinationWorkspaceId),
+                    .text(sourceWorkspaceId),
+                    .text(sourceDeckId)
+                ]
+            )
+        }
+    }
+
+    private func insertForkedCardTags(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws {
+        let cardTags = try self.core.query(
+            sql: """
+            SELECT card_id, tag
+            FROM card_tags
+            WHERE workspace_id = ?
+            ORDER BY card_id ASC, tag ASC
+            """,
+            values: [.text(sourceWorkspaceId)]
+        ) { statement in
+            (
+                DatabaseCore.columnText(statement: statement, index: 0),
+                DatabaseCore.columnText(statement: statement, index: 1)
+            )
+        }
+
+        for (sourceCardId, tag) in cardTags {
+            try self.core.execute(
+                sql: """
+                INSERT INTO card_tags (workspace_id, card_id, tag)
+                VALUES (?, ?, ?)
+                """,
+                values: [
+                    .text(destinationWorkspaceId),
+                    .text(try forkMappings.cardIdsBySourceId.requireMappedId(entityType: "card", sourceId: sourceCardId)),
+                    .text(tag)
+                ]
+            )
+        }
+    }
+
+    private func insertForkedReviewEvents(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws {
+        let sourceReviewEventIds: [String] = forkMappings.reviewEventIdsBySourceId.keys.sorted()
+        let sourceReviewEvents: [WorkspaceForkReviewEventRow] = try self.loadWorkspaceForkReviewEvents(
+            sourceWorkspaceId: sourceWorkspaceId,
+            sourceReviewEventIds: sourceReviewEventIds
+        )
+
+        for sourceReviewEvent in sourceReviewEvents {
+            let destinationReviewEventId: String = try forkMappings.reviewEventIdsBySourceId.requireMappedId(
+                entityType: "review_event",
+                sourceId: sourceReviewEvent.sourceReviewEventId
+            )
+            let destinationCardId: String = try forkMappings.cardIdsBySourceId.requireMappedId(
+                entityType: "card",
+                sourceId: sourceReviewEvent.sourceCardId
+            )
+            try self.core.execute(
+                sql: """
+                INSERT INTO review_events (
+                    review_event_id,
+                    workspace_id,
+                    card_id,
+                    replica_id,
+                    client_event_id,
+                    rating,
+                    reviewed_at_client,
+                    reviewed_at_server
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                values: [
+                    .text(destinationReviewEventId),
+                    .text(destinationWorkspaceId),
+                    .text(destinationCardId),
+                    .text(sourceReviewEvent.replicaId),
+                    .text(sourceReviewEvent.clientEventId),
+                    .integer(sourceReviewEvent.rating),
+                    .text(sourceReviewEvent.reviewedAtClient),
+                    .text(sourceReviewEvent.reviewedAtServer)
+                ]
+            )
+        }
+    }
+
+    private func loadWorkspaceForkReviewEvents(
+        sourceWorkspaceId: String,
+        sourceReviewEventIds: [String]
+    ) throws -> [WorkspaceForkReviewEventRow] {
+        guard sourceReviewEventIds.isEmpty == false else {
+            return []
+        }
+
+        var rows: [WorkspaceForkReviewEventRow] = []
+        var batchStartIndex: Int = 0
+        while batchStartIndex < sourceReviewEventIds.count {
+            let batchEndIndex: Int = min(
+                batchStartIndex + workspaceForkReviewEventSelectBatchSize,
+                sourceReviewEventIds.count
+            )
+            let batchReviewEventIds: [String] = Array(sourceReviewEventIds[batchStartIndex..<batchEndIndex])
+            rows.append(contentsOf: try self.loadWorkspaceForkReviewEventBatch(
+                sourceWorkspaceId: sourceWorkspaceId,
+                sourceReviewEventIds: batchReviewEventIds
+            ))
+            batchStartIndex = batchEndIndex
+        }
+
+        return rows
+    }
+
+    private func loadWorkspaceForkReviewEventBatch(
+        sourceWorkspaceId: String,
+        sourceReviewEventIds: [String]
+    ) throws -> [WorkspaceForkReviewEventRow] {
+        guard sourceReviewEventIds.isEmpty == false else {
+            return []
+        }
+
+        let placeholders: String = sourceReviewEventIds.map { _ in "?" }.joined(separator: ", ")
+        let rows: [WorkspaceForkReviewEventRow] = try self.core.query(
+            sql: """
+            SELECT review_event_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server
+            FROM review_events
+            WHERE workspace_id = ? AND review_event_id IN (\(placeholders))
+            ORDER BY review_event_id ASC
+            """,
+            values: [.text(sourceWorkspaceId)] + sourceReviewEventIds.map { sourceReviewEventId in
+                .text(sourceReviewEventId)
+            }
+        ) { statement in
+            WorkspaceForkReviewEventRow(
+                sourceReviewEventId: DatabaseCore.columnText(statement: statement, index: 0),
+                sourceCardId: DatabaseCore.columnText(statement: statement, index: 1),
+                replicaId: DatabaseCore.columnText(statement: statement, index: 2),
+                clientEventId: DatabaseCore.columnText(statement: statement, index: 3),
+                rating: DatabaseCore.columnInt64(statement: statement, index: 4),
+                reviewedAtClient: DatabaseCore.columnText(statement: statement, index: 5),
+                reviewedAtServer: DatabaseCore.columnText(statement: statement, index: 6)
+            )
+        }
+
+        let loadedReviewEventIds: Set<String> = Set(rows.map(\.sourceReviewEventId))
+        let missingReviewEventIds: [String] = sourceReviewEventIds.filter { sourceReviewEventId in
+            loadedReviewEventIds.contains(sourceReviewEventId) == false
+        }
+        guard missingReviewEventIds.isEmpty else {
+            throw LocalStoreError.database(
+                "Workspace identity fork is missing source review_event rows: \(missingReviewEventIds.joined(separator: ", "))"
+            )
+        }
+
+        return rows
+    }
+
+    private func rewriteOutboxForWorkspaceFork(
+        sourceWorkspaceId: String,
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws {
+        let rows = try self.loadWorkspaceForkOutboxRows(workspaceId: sourceWorkspaceId)
+        for row in rows {
+            let rewrittenEntityId = try self.rewrittenWorkspaceForkOutboxEntityId(
+                row: row,
+                destinationWorkspaceId: destinationWorkspaceId,
+                forkMappings: forkMappings
+            )
+            let rewrittenPayloadJson = try self.rewrittenWorkspaceForkOutboxPayloadJson(
+                row: row,
+                forkMappings: forkMappings
+            )
+            try self.core.execute(
+                sql: """
+                UPDATE outbox
+                SET workspace_id = ?, entity_id = ?, payload_json = ?
+                WHERE operation_id = ?
+                """,
+                values: [
+                    .text(destinationWorkspaceId),
+                    .text(rewrittenEntityId),
+                    .text(rewrittenPayloadJson),
+                    .text(row.operationId)
+                ]
+            )
+        }
+    }
+
+    private func loadWorkspaceForkOutboxRows(workspaceId: String) throws -> [WorkspaceForkOutboxRow] {
+        try self.core.query(
+            sql: """
+            SELECT operation_id, entity_type, entity_id, payload_json
+            FROM outbox
+            WHERE workspace_id = ?
+            ORDER BY created_at ASC, operation_id ASC
+            """,
+            values: [.text(workspaceId)]
+        ) { statement in
+            let entityTypeRaw = DatabaseCore.columnText(statement: statement, index: 1)
+            guard let entityType = SyncEntityType(rawValue: entityTypeRaw) else {
+                throw LocalStoreError.database("Stored outbox entity type is invalid during workspace fork: \(entityTypeRaw)")
+            }
+            return WorkspaceForkOutboxRow(
+                operationId: DatabaseCore.columnText(statement: statement, index: 0),
+                entityType: entityType,
+                entityId: DatabaseCore.columnText(statement: statement, index: 2),
+                payloadJson: DatabaseCore.columnText(statement: statement, index: 3)
+            )
+        }
+    }
+
+    private func rewrittenWorkspaceForkOutboxEntityId(
+        row: WorkspaceForkOutboxRow,
+        destinationWorkspaceId: String,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws -> String {
+        switch row.entityType {
+        case .card:
+            return try forkMappings.cardIdsBySourceId.requireMappedId(entityType: "card", sourceId: row.entityId)
+        case .deck:
+            return try forkMappings.deckIdsBySourceId.requireMappedId(entityType: "deck", sourceId: row.entityId)
+        case .workspaceSchedulerSettings:
+            return destinationWorkspaceId
+        case .reviewEvent:
+            return try forkMappings.reviewEventIdsBySourceId.requireMappedId(
+                entityType: "review_event",
+                sourceId: row.entityId
+            )
+        }
+    }
+
+    private func rewrittenWorkspaceForkOutboxPayloadJson(
+        row: WorkspaceForkOutboxRow,
+        forkMappings: WorkspaceForkIdMappings
+    ) throws -> String {
+        var payload = try self.core.decoder.decode(
+            [String: WorkspaceForkJSONValue].self,
+            from: Data(row.payloadJson.utf8)
+        )
+
+        switch row.entityType {
+        case .card:
+            let sourceCardId = try payload.requireString(fieldName: "cardId", context: "fork.outbox.card.cardId")
+            payload["cardId"] = .string(
+                try forkMappings.cardIdsBySourceId.requireMappedId(entityType: "card", sourceId: sourceCardId)
+            )
+        case .deck:
+            let sourceDeckId = try payload.requireString(fieldName: "deckId", context: "fork.outbox.deck.deckId")
+            payload["deckId"] = .string(
+                try forkMappings.deckIdsBySourceId.requireMappedId(entityType: "deck", sourceId: sourceDeckId)
+            )
+        case .workspaceSchedulerSettings:
+            break
+        case .reviewEvent:
+            let sourceReviewEventId = try payload.requireString(
+                fieldName: "reviewEventId",
+                context: "fork.outbox.reviewEvent.reviewEventId"
+            )
+            let sourceCardId = try payload.requireString(
+                fieldName: "cardId",
+                context: "fork.outbox.reviewEvent.cardId"
+            )
+            payload["reviewEventId"] = .string(
+                try forkMappings.reviewEventIdsBySourceId.requireMappedId(
+                    entityType: "review_event",
+                    sourceId: sourceReviewEventId
+                )
+            )
+            payload["cardId"] = .string(
+                try forkMappings.cardIdsBySourceId.requireMappedId(entityType: "card", sourceId: sourceCardId)
+            )
+        }
+
+        return try self.core.encodeJsonString(value: payload)
+    }
+
+    private func rewriteOutboxForCardPublicSyncConflict(
+        workspaceId: String,
+        sourceCardId: String,
+        replacementCardId: String
+    ) throws {
+        let rows: [WorkspaceForkOutboxRow] = try self.loadWorkspaceForkOutboxRows(workspaceId: workspaceId)
+        for row in rows {
+            switch row.entityType {
+            case .card:
+                try self.rewriteCardOutboxRowForPublicSyncConflict(
+                    row: row,
+                    sourceCardId: sourceCardId,
+                    replacementCardId: replacementCardId
+                )
+            case .reviewEvent:
+                try self.rewriteReviewEventOutboxCardReferenceForPublicSyncConflict(
+                    row: row,
+                    sourceCardId: sourceCardId,
+                    replacementCardId: replacementCardId
+                )
+            case .deck, .workspaceSchedulerSettings:
+                break
+            }
+        }
+    }
+
+    private func rewriteOutboxForDeckPublicSyncConflict(
+        workspaceId: String,
+        sourceDeckId: String,
+        replacementDeckId: String
+    ) throws {
+        let rows: [WorkspaceForkOutboxRow] = try self.loadWorkspaceForkOutboxRows(workspaceId: workspaceId)
+        for row in rows {
+            guard row.entityType == .deck else {
+                continue
+            }
+
+            try self.rewriteDeckOutboxRowForPublicSyncConflict(
+                row: row,
+                sourceDeckId: sourceDeckId,
+                replacementDeckId: replacementDeckId
+            )
+        }
+    }
+
+    private func rewriteOutboxForReviewEventPublicSyncConflict(
+        workspaceId: String,
+        sourceReviewEventId: String,
+        replacementReviewEventId: String
+    ) throws {
+        let rows: [WorkspaceForkOutboxRow] = try self.loadWorkspaceForkOutboxRows(workspaceId: workspaceId)
+        for row in rows {
+            guard row.entityType == .reviewEvent else {
+                continue
+            }
+
+            try self.rewriteReviewEventOutboxRowForPublicSyncConflict(
+                row: row,
+                sourceReviewEventId: sourceReviewEventId,
+                replacementReviewEventId: replacementReviewEventId
+            )
+        }
+    }
+
+    private func rewriteCardOutboxRowForPublicSyncConflict(
+        row: WorkspaceForkOutboxRow,
+        sourceCardId: String,
+        replacementCardId: String
+    ) throws {
+        var payload: [String: WorkspaceForkJSONValue] = try self.decodeWorkspaceForkOutboxPayload(row: row)
+        let payloadCardId: String = try payload.requireString(
+            fieldName: "cardId",
+            context: "publicSyncConflict.outbox.card.cardId"
+        )
+        let rowReferencesSource: Bool = row.entityId == sourceCardId
+        let payloadReferencesSource: Bool = payloadCardId == sourceCardId
+        guard rowReferencesSource == payloadReferencesSource else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery found mismatched card outbox ids for operation \(row.operationId): entityId=\(row.entityId) payload.cardId=\(payloadCardId)"
+            )
+        }
+        guard rowReferencesSource else {
+            return
+        }
+
+        payload["cardId"] = .string(replacementCardId)
+        try self.updatePublicSyncConflictOutboxRow(
+            operationId: row.operationId,
+            entityId: replacementCardId,
+            payload: payload
+        )
+    }
+
+    private func rewriteDeckOutboxRowForPublicSyncConflict(
+        row: WorkspaceForkOutboxRow,
+        sourceDeckId: String,
+        replacementDeckId: String
+    ) throws {
+        var payload: [String: WorkspaceForkJSONValue] = try self.decodeWorkspaceForkOutboxPayload(row: row)
+        let payloadDeckId: String = try payload.requireString(
+            fieldName: "deckId",
+            context: "publicSyncConflict.outbox.deck.deckId"
+        )
+        let rowReferencesSource: Bool = row.entityId == sourceDeckId
+        let payloadReferencesSource: Bool = payloadDeckId == sourceDeckId
+        guard rowReferencesSource == payloadReferencesSource else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery found mismatched deck outbox ids for operation \(row.operationId): entityId=\(row.entityId) payload.deckId=\(payloadDeckId)"
+            )
+        }
+        guard rowReferencesSource else {
+            return
+        }
+
+        payload["deckId"] = .string(replacementDeckId)
+        try self.updatePublicSyncConflictOutboxRow(
+            operationId: row.operationId,
+            entityId: replacementDeckId,
+            payload: payload
+        )
+    }
+
+    private func rewriteReviewEventOutboxCardReferenceForPublicSyncConflict(
+        row: WorkspaceForkOutboxRow,
+        sourceCardId: String,
+        replacementCardId: String
+    ) throws {
+        var payload: [String: WorkspaceForkJSONValue] = try self.decodeWorkspaceForkOutboxPayload(row: row)
+        let payloadCardId: String = try payload.requireString(
+            fieldName: "cardId",
+            context: "publicSyncConflict.outbox.reviewEvent.cardId"
+        )
+        guard payloadCardId == sourceCardId else {
+            return
+        }
+
+        payload["cardId"] = .string(replacementCardId)
+        try self.updatePublicSyncConflictOutboxRow(
+            operationId: row.operationId,
+            entityId: row.entityId,
+            payload: payload
+        )
+    }
+
+    private func rewriteReviewEventOutboxRowForPublicSyncConflict(
+        row: WorkspaceForkOutboxRow,
+        sourceReviewEventId: String,
+        replacementReviewEventId: String
+    ) throws {
+        var payload: [String: WorkspaceForkJSONValue] = try self.decodeWorkspaceForkOutboxPayload(row: row)
+        let payloadReviewEventId: String = try payload.requireString(
+            fieldName: "reviewEventId",
+            context: "publicSyncConflict.outbox.reviewEvent.reviewEventId"
+        )
+        let rowReferencesSource: Bool = row.entityId == sourceReviewEventId
+        let payloadReferencesSource: Bool = payloadReviewEventId == sourceReviewEventId
+        guard rowReferencesSource == payloadReferencesSource else {
+            throw LocalStoreError.database(
+                "Public sync conflict recovery found mismatched review_event outbox ids for operation \(row.operationId): entityId=\(row.entityId) payload.reviewEventId=\(payloadReviewEventId)"
+            )
+        }
+        guard rowReferencesSource else {
+            return
+        }
+
+        payload["reviewEventId"] = .string(replacementReviewEventId)
+        try self.updatePublicSyncConflictOutboxRow(
+            operationId: row.operationId,
+            entityId: replacementReviewEventId,
+            payload: payload
+        )
+    }
+
+    private func decodeWorkspaceForkOutboxPayload(
+        row: WorkspaceForkOutboxRow
+    ) throws -> [String: WorkspaceForkJSONValue] {
+        try self.core.decoder.decode(
+            [String: WorkspaceForkJSONValue].self,
+            from: Data(row.payloadJson.utf8)
+        )
+    }
+
+    private func updatePublicSyncConflictOutboxRow(
+        operationId: String,
+        entityId: String,
+        payload: [String: WorkspaceForkJSONValue]
+    ) throws {
+        try self.core.execute(
+            sql: """
+            UPDATE outbox
+            SET entity_id = ?, payload_json = ?, last_error = NULL
+            WHERE operation_id = ?
+            """,
+            values: [
+                .text(entityId),
+                .text(try self.core.encodeJsonString(value: payload)),
+                .text(operationId)
+            ]
+        )
     }
 
     private func replaceLocalShellForNonEmptyRemoteWorkspace(

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
@@ -101,8 +101,10 @@ final class FlashcardsStore {
     @ObservationIgnored let decoder: JSONDecoder
     @ObservationIgnored var cloudServiceConfigurationValidator: any CloudServiceConfigurationValidating
     @ObservationIgnored var reviewRuntime: ReviewQueueRuntime
+    @ObservationIgnored var reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate
     @ObservationIgnored var cloudRuntime: CloudSessionRuntime
     @ObservationIgnored var isAccountDeletionRunning: Bool
+    @ObservationIgnored var isGuestUpgradeLocalOutboxMutationBlocked: Bool
     @ObservationIgnored var cachedAIChatStore: AIChatStore?
     @ObservationIgnored var currentVisibleTab: AppTab
     @ObservationIgnored var lastImmediateCloudSyncTriggerAt: Date?
@@ -187,8 +189,12 @@ final class FlashcardsStore {
         guestCredentialStore: GuestCloudCredentialStore,
         initialGlobalErrorMessage: String
     ) {
+        let reviewSubmissionOutboxMutationGate = ReviewSubmissionOutboxMutationGate()
         let reviewSubmissionExecutor: ReviewSubmissionExecuting? = database.map { initializedDatabase in
-            ReviewSubmissionExecutor(databaseURL: initializedDatabase.databaseURL)
+            ReviewSubmissionExecutor(
+                databaseURL: initializedDatabase.databaseURL,
+                outboxMutationGate: reviewSubmissionOutboxMutationGate
+            )
         }
         self.init(
             userDefaults: userDefaults,
@@ -199,6 +205,7 @@ final class FlashcardsStore {
             credentialStore: credentialStore,
             guestCloudAuthService: guestCloudAuthService,
             guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: reviewSubmissionOutboxMutationGate,
             reviewSubmissionExecutor: reviewSubmissionExecutor,
             reviewHeadLoader: defaultReviewHeadLoader,
             reviewCountsLoader: defaultReviewCountsLoader,
@@ -218,6 +225,7 @@ final class FlashcardsStore {
         credentialStore: CloudCredentialStore,
         guestCloudAuthService: GuestCloudAuthService,
         guestCredentialStore: GuestCloudCredentialStore,
+        reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate,
         reviewSubmissionExecutor: ReviewSubmissionExecuting?,
         reviewHeadLoader: @escaping ReviewHeadLoader,
         reviewCountsLoader: @escaping ReviewCountsLoader,
@@ -240,6 +248,7 @@ final class FlashcardsStore {
             credentialStore: credentialStore,
             guestCloudAuthService: guestCloudAuthService,
             guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: reviewSubmissionOutboxMutationGate,
             reviewSubmissionExecutor: reviewSubmissionExecutor,
             reviewHeadLoader: reviewHeadLoader,
             reviewCountsLoader: reviewCountsLoader,
@@ -260,6 +269,7 @@ final class FlashcardsStore {
         credentialStore: CloudCredentialStore,
         guestCloudAuthService: GuestCloudAuthService,
         guestCredentialStore: GuestCloudCredentialStore,
+        reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate,
         reviewSubmissionExecutor: ReviewSubmissionExecuting?,
         reviewHeadLoader: @escaping ReviewHeadLoader,
         reviewCountsLoader: @escaping ReviewCountsLoader,
@@ -350,12 +360,14 @@ final class FlashcardsStore {
             reviewSeedQueueSize: reviewSeedQueueSize,
             reviewQueueReplenishmentThreshold: reviewQueueReplenishmentThreshold
         )
+        self.reviewSubmissionOutboxMutationGate = reviewSubmissionOutboxMutationGate
         self.cloudRuntime = CloudSessionRuntime(
             cloudAuthService: dependencies.cloudAuthService,
             cloudSyncService: dependencies.cloudSyncService,
             credentialStore: dependencies.credentialStore
         )
         self.isAccountDeletionRunning = false
+        self.isGuestUpgradeLocalOutboxMutationBlocked = false
         self.currentVisibleTab = .review
         self.lastImmediateCloudSyncTriggerAt = nil
         self.activeReviewNotificationsRescheduleTask = nil

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStoreSupport.swift
@@ -111,7 +111,9 @@ protocol GuestCloudAuthServing {
         apiBaseUrl: String,
         bearerToken: String,
         guestToken: String,
-        selection: CloudGuestUpgradeSelection
+        selection: CloudGuestUpgradeSelection,
+        supportsDroppedEntities: Bool,
+        guestWorkspaceSyncedAndOutboxDrained: Bool
     ) async throws -> CloudWorkspaceSummary
 }
 

--- a/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+Review.swift
@@ -275,6 +275,7 @@ extension FlashcardsStore {
         }
 
         do {
+            try self.assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade()
             _ = try await reviewSubmissionExecutor.submitReview(
                 workspaceId: request.workspaceId,
                 submission: ReviewSubmission(

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewSubmissionExecutor.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewSubmissionExecutor.swift
@@ -6,19 +6,122 @@ protocol ReviewSubmissionExecuting: Sendable {
     func submitReview(workspaceId: String, submission: ReviewSubmission) async throws -> Card
 }
 
+final class ReviewSubmissionOutboxMutationGate: @unchecked Sendable {
+    private let lock: NSLock
+    private var isBlockedForGuestUpgrade: Bool
+    private var activeReviewSubmissionCount: Int
+    private var activeReviewSubmissionWaiters: [CheckedContinuation<Void, Never>]
+
+    init() {
+        self.lock = NSLock()
+        self.isBlockedForGuestUpgrade = false
+        self.activeReviewSubmissionCount = 0
+        self.activeReviewSubmissionWaiters = []
+    }
+
+    func beginReviewSubmission() throws {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        guard self.isBlockedForGuestUpgrade == false else {
+            throw PendingGuestUpgradeLocalMutationError.blocked
+        }
+
+        self.activeReviewSubmissionCount += 1
+    }
+
+    func finishReviewSubmission() {
+        let waiters: [CheckedContinuation<Void, Never>]
+
+        self.lock.lock()
+        guard self.activeReviewSubmissionCount > 0 else {
+            self.lock.unlock()
+            preconditionFailure("Review submission gate finished without an active submission")
+        }
+
+        self.activeReviewSubmissionCount -= 1
+        if self.activeReviewSubmissionCount == 0 {
+            waiters = self.activeReviewSubmissionWaiters
+            self.activeReviewSubmissionWaiters = []
+        } else {
+            waiters = []
+        }
+        self.lock.unlock()
+
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func blockNewReviewSubmissionsAndWaitForActiveSubmissions() async {
+        let hasActiveReviewSubmissions = self.blockNewReviewSubmissions()
+        guard hasActiveReviewSubmissions else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            if self.appendActiveReviewSubmissionWaiterOrShouldResumeImmediately(continuation: continuation) {
+                continuation.resume()
+            }
+        }
+    }
+
+    func unblockReviewSubmissions() {
+        self.lock.lock()
+        self.isBlockedForGuestUpgrade = false
+        self.lock.unlock()
+    }
+
+    private func blockNewReviewSubmissions() -> Bool {
+        self.lock.lock()
+        self.isBlockedForGuestUpgrade = true
+        let hasActiveReviewSubmissions = self.activeReviewSubmissionCount > 0
+        self.lock.unlock()
+        return hasActiveReviewSubmissions
+    }
+
+    private func appendActiveReviewSubmissionWaiterOrShouldResumeImmediately(
+        continuation: CheckedContinuation<Void, Never>
+    ) -> Bool {
+        self.lock.lock()
+        defer {
+            self.lock.unlock()
+        }
+
+        if self.activeReviewSubmissionCount == 0 {
+            return true
+        }
+
+        self.activeReviewSubmissionWaiters.append(continuation)
+        return false
+    }
+}
+
 /// Default review submission worker backed by the local SQLite database.
 actor ReviewSubmissionExecutor: ReviewSubmissionExecuting {
     private let databaseURL: URL
+    private let outboxMutationGate: ReviewSubmissionOutboxMutationGate
     private var database: LocalDatabase?
 
-    init(databaseURL: URL) {
+    init(databaseURL: URL, outboxMutationGate: ReviewSubmissionOutboxMutationGate) {
         self.databaseURL = databaseURL
+        self.outboxMutationGate = outboxMutationGate
         self.database = nil
     }
 
     func submitReview(workspaceId: String, submission: ReviewSubmission) async throws -> Card {
-        let database = try self.resolvedDatabase()
-        return try database.submitReview(workspaceId: workspaceId, reviewSubmission: submission)
+        try self.outboxMutationGate.beginReviewSubmission()
+        do {
+            let database = try self.resolvedDatabase()
+            let card = try database.submitReview(workspaceId: workspaceId, reviewSubmission: submission)
+            self.outboxMutationGate.finishReviewSubmission()
+            return card
+        } catch {
+            self.outboxMutationGate.finishReviewSubmission()
+            throw error
+        }
     }
 
     private func resolvedDatabase() throws -> LocalDatabase {

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatResumeDiagnosticsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatResumeDiagnosticsTests.swift
@@ -412,7 +412,8 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
             errorDetails: CloudApiErrorDetails(
                 message: "AI live stream request is missing runId.",
                 requestId: "request-400",
-                code: "CHAT_LIVE_RUN_ID_REQUIRED"
+                code: "CHAT_LIVE_RUN_ID_REQUIRED",
+                syncConflict: nil
             ),
             configurationMode: .official
         )

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStartTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStartTests.swift
@@ -881,7 +881,8 @@ private func makeGuestQuotaError() -> AIChatServiceError {
         CloudApiErrorDetails(
             message: "Guest AI limit reached.",
             requestId: "request-guest-limit",
-            code: "GUEST_AI_LIMIT_REACHED"
+            code: "GUEST_AI_LIMIT_REACHED",
+            syncConflict: nil
         ),
         "Guest AI limit reached.",
         AIChatFailureDiagnostics(

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
@@ -48,6 +48,7 @@ enum AIChatStoreTestSupport {
                     bundle: .main,
                     userDefaults: userDefaults
                 ),
+                reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
                 reviewSubmissionExecutor: nil,
                 reviewHeadLoader: defaultReviewHeadLoader,
                 reviewCountsLoader: defaultReviewCountsLoader,
@@ -497,6 +498,7 @@ enum AIChatStoreTestSupport {
             return CloudSyncResult(
                 appliedPullChangeCount: 0,
                 changedEntityTypes: [],
+                localIdRepairEntityTypes: [],
                 acknowledgedOperationCount: 0,
                 acknowledgedReviewEventOperationCount: 0,
                 cleanedUpOperationCount: 0,

--- a/apps/ios/Flashcards/FlashcardsTests/CloudAuthInlineErrorPresentationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/CloudAuthInlineErrorPresentationTests.swift
@@ -43,7 +43,8 @@ final class CloudAuthInlineErrorPresentationTests: XCTestCase {
             CloudApiErrorDetails(
                 message: "upstream failure",
                 requestId: "req-123",
-                code: "OTP_SEND_FAILED"
+                code: "OTP_SEND_FAILED",
+                syncConflict: nil
             ),
             500
         )
@@ -59,4 +60,1802 @@ final class CloudAuthInlineErrorPresentationTests: XCTestCase {
         )
         XCTAssertNil(presentation.technicalDetails)
     }
+
+    func testCloudApiErrorDetailsDecodePublicSyncConflictWithoutPrivateWorkspaceId() throws {
+        let data = try XCTUnwrap(
+            """
+            {
+              "error": "Sync detected content copied from another workspace. Retry after forking ids.",
+              "requestId": "request-fork",
+              "code": "SYNC_WORKSPACE_FORK_REQUIRED",
+              "details": {
+                "syncConflict": {
+                  "phase": "push",
+                  "entityType": "card",
+                  "entityId": "card-conflict",
+                  "entryIndex": 2,
+                  "recoverable": true
+                }
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let details = decodeCloudApiErrorDetails(data: data, requestId: nil)
+
+        XCTAssertEqual("SYNC_WORKSPACE_FORK_REQUIRED", details.code)
+        XCTAssertEqual("request-fork", details.requestId)
+        XCTAssertEqual(.card, details.syncConflict?.entityType)
+        XCTAssertEqual("card-conflict", details.syncConflict?.entityId)
+        XCTAssertEqual(2, details.syncConflict?.entryIndex)
+        XCTAssertEqual(true, details.syncConflict?.recoverable)
+    }
+}
+
+@MainActor
+final class CloudSyncIdentityConflictStatusTests: XCTestCase {
+    func testOrdinaryLinkedSyncBlocksWorkspaceForkRequiredError() async throws {
+        let suiteName: String = "linked-sync-fork-required-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        let credentialStore: CloudCredentialStore = CloudCredentialStore(
+            encoder: encoder,
+            decoder: decoder,
+            service: "tests-\(suiteName)-cloud-auth",
+            account: "primary"
+        )
+        let guestCredentialStore: GuestCloudCredentialStore = GuestCloudCredentialStore(
+            encoder: encoder,
+            decoder: decoder,
+            service: "tests-\(suiteName)-guest-auth",
+            account: "primary",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let cloudAuthService: CloudAuthService = CloudAuthService(
+            encoder: encoder,
+            decoder: makeFlashcardsRemoteJSONDecoder(),
+            session: nil,
+            cookieStorage: HTTPCookieStorage()
+        )
+        let guestCloudAuthService: GuestCloudAuthService = GuestCloudAuthService(
+            encoder: encoder,
+            decoder: makeFlashcardsRemoteJSONDecoder(),
+            session: URLSession(configuration: URLSessionConfiguration.ephemeral)
+        )
+        let store: FlashcardsStore = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: nil,
+            cloudAuthService: cloudAuthService,
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let expectedMessage: String = "Sync detected content copied from another workspace. Retry after forking ids. Reference: request-fork"
+        cloudSyncService.runLinkedSyncHandler = { (linkedSession: CloudLinkedSession) in
+            XCTAssertEqual(.bearer("id-token-fresh"), linkedSession.authorization)
+            throw CloudSyncError.invalidResponse(
+                CloudApiErrorDetails(
+                    message: "Sync detected content copied from another workspace. Retry after forking ids.",
+                    requestId: "request-fork",
+                    code: "SYNC_WORKSPACE_FORK_REQUIRED",
+                    syncConflict: nil
+                ),
+                409
+            )
+        }
+        try credentialStore.saveCredentials(
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token-fresh",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            )
+        )
+        store.cloudSettings = CloudSettings(
+            installationId: "installation-1",
+            cloudState: .linked,
+            linkedUserId: "linked-user",
+            linkedWorkspaceId: "workspace-linked",
+            activeWorkspaceId: "workspace-linked",
+            linkedEmail: "user@example.com",
+            onboardingCompleted: true,
+            updatedAt: "2026-04-25T00:00:00.000Z"
+        )
+        store.cloudRuntime.setActiveCloudSession(
+            linkedSession: CloudLinkedSession(
+                userId: "linked-user",
+                workspaceId: "workspace-linked",
+                email: "user@example.com",
+                configurationMode: .custom,
+                apiBaseUrl: "https://example.test/v1",
+                authorization: .bearer("id-token-stale")
+            )
+        )
+
+        do {
+            try await store.syncCloudNow(trigger: store.manualCloudSyncTrigger(now: Date(timeIntervalSince1970: 0)))
+            XCTFail("Expected typed workspace fork conflict to block ordinary linked sync.")
+        } catch let error as CloudSyncError {
+            guard case .invalidResponse(let details, let statusCode) = error else {
+                XCTFail("Expected invalid response error.")
+                return
+            }
+            XCTAssertEqual("SYNC_WORKSPACE_FORK_REQUIRED", details.code)
+            XCTAssertEqual(409, statusCode)
+        } catch {
+            XCTFail("Unexpected sync error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(.blocked(message: expectedMessage), store.syncStatus)
+        XCTAssertEqual(expectedMessage, store.globalErrorMessage)
+    }
+}
+
+@MainActor
+final class GuestCloudAuthServiceCapabilityTests: XCTestCase {
+    override func tearDown() {
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+        super.tearDown()
+    }
+
+    func testCompleteGuestUpgradeSendsExplicitCapabilitiesAndDrainAssertion() async throws {
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            let body = try guestCloudAuthServiceTestRequestBody(request: request)
+            let requestBody = try JSONDecoder().decode(
+                GuestUpgradeCompleteRequestBody.self,
+                from: body
+            )
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues.append(
+                requestBody.supportsDroppedEntities
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues.append(
+                requestBody.guestWorkspaceSyncedAndOutboxDrained
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestTokens.append(requestBody.guestToken)
+
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            let responseBody = Data(
+                """
+                {
+                  "workspace": {
+                    "workspaceId": "workspace-linked",
+                    "name": "Personal",
+                    "createdAt": "2026-04-01T00:00:00.000Z",
+                    "isSelected": true
+                  }
+                }
+                """.utf8
+            )
+            return (response, responseBody)
+        }
+
+        let service = GuestCloudAuthService(session: self.makeSession())
+        _ = try await service.completeGuestUpgrade(
+            apiBaseUrl: "https://api.example.test/v1",
+            bearerToken: "id-token",
+            guestToken: "guest-token",
+            selection: .createNew,
+            supportsDroppedEntities: false,
+            guestWorkspaceSyncedAndOutboxDrained: true
+        )
+        _ = try await service.completeGuestUpgrade(
+            apiBaseUrl: "https://api.example.test/v1",
+            bearerToken: "id-token",
+            guestToken: "guest-token",
+            selection: .createNew,
+            supportsDroppedEntities: true,
+            guestWorkspaceSyncedAndOutboxDrained: true
+        )
+
+        XCTAssertEqual(
+            [false, true],
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues
+        )
+        XCTAssertEqual(
+            [true, true],
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues
+        )
+        XCTAssertEqual(
+            ["guest-token", "guest-token"],
+            GuestCloudAuthServiceTestURLProtocol.guestTokens
+        )
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
+@MainActor
+final class GuestCloudUpgradeDrainTests: XCTestCase {
+    func testPendingGuestUpgradeResumeReplaysBackendCompleteWithoutGuestDrainAfterLostResponse() async throws {
+        let suiteName = "guest-upgrade-replay-\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guest-upgrade-replay-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("sqlite")
+        let database = try LocalDatabase(databaseURL: databaseURL)
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let urlSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        let guestCloudAuthService = GuestCloudAuthService(session: URLSession(configuration: urlSessionConfiguration))
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            let body = try guestCloudAuthServiceTestRequestBody(request: request)
+            let requestBody = try JSONDecoder().decode(
+                GuestUpgradeCompleteRequestBody.self,
+                from: body
+            )
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues.append(
+                requestBody.supportsDroppedEntities
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues.append(
+                requestBody.guestWorkspaceSyncedAndOutboxDrained
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestTokens.append(requestBody.guestToken)
+
+            if GuestCloudAuthServiceTestURLProtocol.requestCount == 1 {
+                let replayUserDefaults = UserDefaults(suiteName: suiteName)
+                GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete =
+                    replayUserDefaults?.data(forKey: pendingGuestUpgradeUserDefaultsKey) != nil
+                throw URLError(.networkConnectionLost)
+            }
+
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            let responseBody = Data(
+                """
+                {
+                  "workspace": {
+                    "workspaceId": "workspace-linked",
+                    "name": "Personal",
+                    "createdAt": "2026-04-01T00:00:00.000Z",
+                    "isSelected": true
+                  }
+                }
+                """.utf8
+            )
+            return (response, responseBody)
+        }
+        let store = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? database.close()
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+            GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let configuration = try makeCustomCloudServiceConfiguration(customOrigin: "https://example.test")
+        let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
+        let guestSession = StoredGuestCloudSession(
+            guestToken: "guest-token-initial",
+            userId: "guest-user",
+            workspaceId: localWorkspace.workspaceId,
+            configurationMode: configuration.mode,
+            apiBaseUrl: configuration.apiBaseUrl
+        )
+        try guestCredentialStore.saveGuestSession(session: guestSession)
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: guestSession.userId,
+            linkedWorkspaceId: guestSession.workspaceId,
+            activeWorkspaceId: guestSession.workspaceId,
+            linkedEmail: nil
+        )
+        try store.reload()
+
+        let linkContext = CloudWorkspaceLinkContext(
+            userId: "linked-user",
+            email: "user@example.com",
+            apiBaseUrl: configuration.apiBaseUrl,
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            ),
+            workspaces: [],
+            guestUpgradeMode: .mergeRequired
+        )
+
+        do {
+            try await store.completeGuestCloudLink(linkContext: linkContext, selection: .createNew)
+            XCTFail("Guest upgrade should preserve pending replay state when backend response is lost.")
+        } catch let error as URLError {
+            XCTAssertEqual(.networkConnectionLost, error.code)
+        } catch {
+            XCTFail("Unexpected guest upgrade replay setup error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertTrue(GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete)
+        let pendingData = try XCTUnwrap(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        let pendingPayload = String(decoding: pendingData, as: UTF8.self)
+        XCTAssertFalse(pendingPayload.contains("guestToken"))
+        XCTAssertFalse(pendingPayload.contains("guest-token-initial"))
+        XCTAssertTrue(pendingPayload.contains("\"guestUserId\""))
+        XCTAssertTrue(pendingPayload.contains("\"guestWorkspaceId\""))
+        XCTAssertTrue(pendingPayload.contains("guest-user"))
+        XCTAssertTrue(pendingPayload.contains(localWorkspace.workspaceId))
+        XCTAssertEqual([.guest("guest-token-initial")], cloudSyncService.runLinkedSyncAuthorizations)
+
+        try guestCredentialStore.saveGuestSession(
+            session: StoredGuestCloudSession(
+                guestToken: "guest-token-replay",
+                userId: guestSession.userId,
+                workspaceId: guestSession.workspaceId,
+                configurationMode: guestSession.configurationMode,
+                apiBaseUrl: guestSession.apiBaseUrl
+            )
+        )
+
+        let didResume = try await store.resumePendingGuestUpgradeIfNeeded(
+            trigger: store.manualCloudSyncTrigger(now: Date())
+        )
+
+        XCTAssertTrue(didResume)
+        XCTAssertNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertNil(try guestCredentialStore.loadGuestSession())
+        XCTAssertEqual(.linked, try database.workspaceSettingsStore.loadCloudSettings().cloudState)
+        XCTAssertEqual("workspace-linked", try database.workspaceSettingsStore.loadWorkspace().workspaceId)
+        XCTAssertEqual([.guest("guest-token-initial"), .bearer("id-token")], cloudSyncService.runLinkedSyncAuthorizations)
+        XCTAssertEqual(2, GuestCloudAuthServiceTestURLProtocol.requestCount)
+        XCTAssertEqual(
+            ["guest-token-initial", "guest-token-replay"],
+            GuestCloudAuthServiceTestURLProtocol.guestTokens
+        )
+        XCTAssertEqual(
+            [true, true],
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues
+        )
+        XCTAssertEqual(
+            [true, true],
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues
+        )
+    }
+
+    func testCompleteGuestCloudLinkRunsFreshGuestDrainAfterAlreadyActiveSync() async throws {
+        let suiteName: String = "guest-upgrade-fresh-drain-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let databaseURL: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guest-upgrade-fresh-drain-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("sqlite")
+        let database: LocalDatabase = try LocalDatabase(databaseURL: databaseURL)
+        let credentialStore: CloudCredentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore: GuestCloudCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let urlSessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        let guestCloudAuthService: GuestCloudAuthService = GuestCloudAuthService(
+            session: URLSession(configuration: urlSessionConfiguration)
+        )
+        let activeSyncStarted: XCTestExpectation = expectation(description: "active guest sync started")
+        let freshDrainStarted: XCTestExpectation = expectation(description: "fresh guest drain started")
+        let allowActiveSync: GuestUpgradeAsyncGate = GuestUpgradeAsyncGate()
+        cloudSyncService.runLinkedSyncHandler = { linkedSession in
+            if linkedSession.authorization.isGuest {
+                if cloudSyncService.runLinkedSyncCallCount == 1 {
+                    activeSyncStarted.fulfill()
+                    await allowActiveSync.wait()
+                } else if cloudSyncService.runLinkedSyncCallCount == 2 {
+                    freshDrainStarted.fulfill()
+                }
+            }
+
+            return .noChanges
+        }
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            let body: Data = try guestCloudAuthServiceTestRequestBody(request: request)
+            let requestBody: GuestUpgradeCompleteRequestBody = try JSONDecoder().decode(
+                GuestUpgradeCompleteRequestBody.self,
+                from: body
+            )
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues.append(
+                requestBody.supportsDroppedEntities
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues.append(
+                requestBody.guestWorkspaceSyncedAndOutboxDrained
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestTokens.append(requestBody.guestToken)
+
+            let response: HTTPURLResponse = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            let responseBody: Data = Data(
+                """
+                {
+                  "workspace": {
+                    "workspaceId": "workspace-linked",
+                    "name": "Personal",
+                    "createdAt": "2026-04-01T00:00:00.000Z",
+                    "isSelected": true
+                  }
+                }
+                """.utf8
+            )
+            return (response, responseBody)
+        }
+        let store: FlashcardsStore = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? database.close()
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+            GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let configuration: CloudServiceConfiguration = try makeCustomCloudServiceConfiguration(
+            customOrigin: "https://example.test"
+        )
+        let localWorkspace: Workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let guestSession: StoredGuestCloudSession = StoredGuestCloudSession(
+            guestToken: "guest-token",
+            userId: "guest-user",
+            workspaceId: localWorkspace.workspaceId,
+            configurationMode: configuration.mode,
+            apiBaseUrl: configuration.apiBaseUrl
+        )
+        try guestCredentialStore.saveGuestSession(session: guestSession)
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: guestSession.userId,
+            linkedWorkspaceId: guestSession.workspaceId,
+            activeWorkspaceId: guestSession.workspaceId,
+            linkedEmail: nil
+        )
+        try store.reload()
+        let guestLinkedSession: CloudLinkedSession = CloudLinkedSession(
+            userId: guestSession.userId,
+            workspaceId: guestSession.workspaceId,
+            email: nil,
+            configurationMode: configuration.mode,
+            apiBaseUrl: configuration.apiBaseUrl,
+            authorization: .guest(guestSession.guestToken)
+        )
+        store.cloudRuntime.setActiveCloudSession(linkedSession: guestLinkedSession)
+
+        let activeSyncTask: Task<Void, Error> = Task { @MainActor in
+            try await store.syncCloudNow(trigger: store.manualCloudSyncTrigger(now: Date()))
+        }
+        await fulfillment(of: [activeSyncStarted], timeout: 2)
+
+        let linkContext: CloudWorkspaceLinkContext = CloudWorkspaceLinkContext(
+            userId: "linked-user",
+            email: "user@example.com",
+            apiBaseUrl: configuration.apiBaseUrl,
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            ),
+            workspaces: [],
+            guestUpgradeMode: .mergeRequired
+        )
+        let upgradeTask: Task<Void, Error> = Task { @MainActor in
+            try await store.completeGuestCloudLink(linkContext: linkContext, selection: .createNew)
+        }
+
+        XCTAssertEqual([.guest("guest-token")], cloudSyncService.runLinkedSyncAuthorizations)
+        await allowActiveSync.open()
+        try await activeSyncTask.value
+        await fulfillment(of: [freshDrainStarted], timeout: 2)
+        try await upgradeTask.value
+
+        XCTAssertEqual(
+            [.guest("guest-token"), .guest("guest-token"), .bearer("id-token")],
+            cloudSyncService.runLinkedSyncAuthorizations
+        )
+        XCTAssertNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertNil(try guestCredentialStore.loadGuestSession())
+        XCTAssertEqual("workspace-linked", try database.workspaceSettingsStore.loadWorkspace().workspaceId)
+        XCTAssertEqual([true], GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues)
+        XCTAssertEqual([true], GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues)
+        XCTAssertEqual(["guest-token"], GuestCloudAuthServiceTestURLProtocol.guestTokens)
+    }
+
+    func testPendingGuestUpgradeResumeRejectsMismatchedSecureStoreGuestSession() async throws {
+        let suiteName: String = "guest-upgrade-replay-identity-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let credentialStore: CloudCredentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore: GuestCloudCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let urlSessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        let guestCloudAuthService: GuestCloudAuthService = GuestCloudAuthService(
+            session: URLSession(configuration: urlSessionConfiguration)
+        )
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            _ = request
+            throw LocalStoreError.database("In-flight guest upgrade replay should reject the guest session before backend complete")
+        }
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+        let store: FlashcardsStore = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: nil,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+            GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let configuration: CloudServiceConfiguration = try makeCustomCloudServiceConfiguration(
+            customOrigin: "https://example.test"
+        )
+        try credentialStore.saveCredentials(
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            )
+        )
+        try guestCredentialStore.saveGuestSession(
+            session: StoredGuestCloudSession(
+                guestToken: "guest-token-replaced",
+                userId: "guest-user-replaced",
+                workspaceId: "workspace-replaced",
+                configurationMode: configuration.mode,
+                apiBaseUrl: configuration.apiBaseUrl
+            )
+        )
+
+        let pendingData: Data = self.inFlightPendingGuestUpgradePayload(
+            apiBaseUrl: configuration.apiBaseUrl,
+            guestUserId: "guest-user-original",
+            guestWorkspaceId: "workspace-original"
+        )
+        let pendingPayload: String = String(decoding: pendingData, as: UTF8.self)
+        XCTAssertFalse(pendingPayload.contains("guestToken"))
+        XCTAssertFalse(pendingPayload.contains("guest-token-replaced"))
+        userDefaults.set(pendingData, forKey: pendingGuestUpgradeUserDefaultsKey)
+
+        do {
+            _ = try await store.resumePendingGuestUpgradeIfNeeded(
+                trigger: store.manualCloudSyncTrigger(now: Date())
+            )
+            XCTFail("Pending guest upgrade replay should reject a replaced secure-store guest session.")
+        } catch let error as LocalStoreError {
+            XCTAssertEqual(
+                "In-flight pending guest upgrade guest identity mismatch: pendingGuestUserId=guest-user-original credentialGuestUserId=guest-user-replaced pendingGuestWorkspaceId=workspace-original credentialGuestWorkspaceId=workspace-replaced. Restore the original guest session for this pending upgrade before retrying recovery.",
+                Flashcards.errorMessage(error: error)
+            )
+        } catch {
+            XCTFail("Unexpected guest identity validation error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertNotNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertNotNil(try guestCredentialStore.loadGuestSession())
+        XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
+        XCTAssertEqual(0, cloudSyncService.runLinkedSyncCallCount)
+    }
+
+    func testPendingGuestUpgradeResumeFinalizesCompletedStatesWithoutGuestCredential() async throws {
+        try await self.verifyCompletedPendingGuestUpgradeResume(schemaVersion: 2, phase: nil)
+        try await self.verifyCompletedPendingGuestUpgradeResume(schemaVersion: 3, phase: nil)
+        try await self.verifyCompletedPendingGuestUpgradeResume(schemaVersion: 4, phase: "completed")
+        try await self.verifyCompletedPendingGuestUpgradeResume(schemaVersion: 5, phase: "completed")
+    }
+
+    func testCompleteGuestCloudLinkBlocksLocalOutboxMutationsFromDrainStartUntilFinalizationCompletes() async throws {
+        let suiteName = "guest-upgrade-mutation-block-\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guest-upgrade-mutation-block-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("sqlite")
+        let database = try LocalDatabase(databaseURL: databaseURL)
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let urlSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        let guestCloudAuthService = GuestCloudAuthService(session: URLSession(configuration: urlSessionConfiguration))
+        let guestDrainStarted = expectation(description: "guest drain started")
+        let allowGuestDrain = GuestUpgradeAsyncGate()
+        let backendCompleteStarted = expectation(description: "backend complete started")
+        let allowBackendComplete = DispatchSemaphore(value: 0)
+        cloudSyncService.runLinkedSyncHandler = { linkedSession in
+            if linkedSession.authorization.isGuest {
+                guestDrainStarted.fulfill()
+                await allowGuestDrain.wait()
+            }
+            return .noChanges
+        }
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            let body = try guestCloudAuthServiceTestRequestBody(request: request)
+            let requestBody = try JSONDecoder().decode(
+                GuestUpgradeCompleteRequestBody.self,
+                from: body
+            )
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues.append(
+                requestBody.supportsDroppedEntities
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues.append(
+                requestBody.guestWorkspaceSyncedAndOutboxDrained
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestTokens.append(requestBody.guestToken)
+            let replayUserDefaults = UserDefaults(suiteName: suiteName)
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete =
+                replayUserDefaults?.data(forKey: pendingGuestUpgradeUserDefaultsKey) != nil
+            backendCompleteStarted.fulfill()
+            if allowBackendComplete.wait(timeout: .now() + 5) == .timedOut {
+                throw URLError(.timedOut)
+            }
+
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            let responseBody = Data(
+                """
+                {
+                  "workspace": {
+                    "workspaceId": "workspace-linked",
+                    "name": "Personal",
+                    "createdAt": "2026-04-01T00:00:00.000Z",
+                    "isSelected": true
+                  }
+                }
+                """.utf8
+            )
+            return (response, responseBody)
+        }
+        let store = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            allowBackendComplete.signal()
+            store.shutdownForTests()
+            try? database.close()
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+            GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let configuration = try makeCustomCloudServiceConfiguration(customOrigin: "https://example.test")
+        let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
+        let guestSession = StoredGuestCloudSession(
+            guestToken: "guest-token",
+            userId: "guest-user",
+            workspaceId: localWorkspace.workspaceId,
+            configurationMode: configuration.mode,
+            apiBaseUrl: configuration.apiBaseUrl
+        )
+        try guestCredentialStore.saveGuestSession(session: guestSession)
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: guestSession.userId,
+            linkedWorkspaceId: guestSession.workspaceId,
+            activeWorkspaceId: guestSession.workspaceId,
+            linkedEmail: nil
+        )
+        try store.reload()
+
+        let linkContext = CloudWorkspaceLinkContext(
+            userId: "linked-user",
+            email: "user@example.com",
+            apiBaseUrl: configuration.apiBaseUrl,
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            ),
+            workspaces: [],
+            guestUpgradeMode: .mergeRequired
+        )
+
+        let upgradeTask = Task { @MainActor in
+            try await store.completeGuestCloudLink(linkContext: linkContext, selection: .createNew)
+        }
+        await fulfillment(of: [guestDrainStarted], timeout: 2)
+
+        XCTAssertNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertThrowsError(
+            try store.saveCard(
+                input: CardEditorInput(
+                    frontText: "Blocked before drain finishes",
+                    backText: "Blocked answer",
+                    tags: [],
+                    effortLevel: .medium
+                ),
+                editingCardId: nil
+            )
+        ) { error in
+            XCTAssertEqual(
+                "Account upgrade is finishing. Wait for the upgrade to complete before making more local changes.",
+                Flashcards.errorMessage(error: error)
+            )
+        }
+        XCTAssertTrue(try database.loadOutboxEntries(workspaceId: localWorkspace.workspaceId, limit: 1).isEmpty)
+
+        await allowGuestDrain.open()
+        await fulfillment(of: [backendCompleteStarted], timeout: 2)
+
+        XCTAssertTrue(GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete)
+        XCTAssertNotNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertThrowsError(
+            try store.saveCard(
+                input: CardEditorInput(
+                    frontText: "Blocked question",
+                    backText: "Blocked answer",
+                    tags: [],
+                    effortLevel: .medium
+                ),
+                editingCardId: nil
+            )
+        ) { error in
+            XCTAssertEqual(
+                "Account upgrade is finishing. Wait for the upgrade to complete before making more local changes.",
+                Flashcards.errorMessage(error: error)
+            )
+        }
+        XCTAssertTrue(try database.loadOutboxEntries(workspaceId: localWorkspace.workspaceId, limit: 1).isEmpty)
+
+        allowBackendComplete.signal()
+        try await upgradeTask.value
+
+        XCTAssertNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertNil(try guestCredentialStore.loadGuestSession())
+        XCTAssertEqual("workspace-linked", try database.workspaceSettingsStore.loadWorkspace().workspaceId)
+        XCTAssertEqual([.guest("guest-token"), .bearer("id-token")], cloudSyncService.runLinkedSyncAuthorizations)
+        XCTAssertEqual([true], GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues)
+        XCTAssertEqual([true], GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues)
+        XCTAssertEqual(["guest-token"], GuestCloudAuthServiceTestURLProtocol.guestTokens)
+
+        try store.saveCard(
+            input: CardEditorInput(
+                frontText: "Linked question",
+                backText: "Linked answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            editingCardId: nil
+        )
+        XCTAssertEqual(1, try database.loadOutboxEntries(workspaceId: "workspace-linked", limit: Int.max).count)
+    }
+
+    func testActiveReviewSubmissionCannotAppendGuestOutboxAfterDrainBlockStarts() async throws {
+        let suiteName = "guest-upgrade-review-race-\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guest-upgrade-review-race-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("sqlite")
+        let database = try LocalDatabase(databaseURL: databaseURL)
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let urlSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        let guestCloudAuthService = GuestCloudAuthService(session: URLSession(configuration: urlSessionConfiguration))
+        let reviewSubmissionOutboxMutationGate = ReviewSubmissionOutboxMutationGate()
+        let reviewSubmissionExecutor = ReviewSubmissionExecutor(
+            databaseURL: databaseURL,
+            outboxMutationGate: reviewSubmissionOutboxMutationGate
+        )
+        let guestDrainStarted = expectation(description: "guest drain started")
+        let allowGuestDrain = GuestUpgradeAsyncGate()
+        cloudSyncService.runLinkedSyncHandler = { linkedSession in
+            if linkedSession.authorization.isGuest {
+                guestDrainStarted.fulfill()
+                await allowGuestDrain.wait()
+            }
+            return .noChanges
+        }
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            let body = try guestCloudAuthServiceTestRequestBody(request: request)
+            let requestBody = try JSONDecoder().decode(
+                GuestUpgradeCompleteRequestBody.self,
+                from: body
+            )
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues.append(
+                requestBody.supportsDroppedEntities
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues.append(
+                requestBody.guestWorkspaceSyncedAndOutboxDrained
+            )
+            GuestCloudAuthServiceTestURLProtocol.guestTokens.append(requestBody.guestToken)
+
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )
+            )
+            let responseBody = Data(
+                """
+                {
+                  "workspace": {
+                    "workspaceId": "workspace-linked",
+                    "name": "Personal",
+                    "createdAt": "2026-04-01T00:00:00.000Z",
+                    "isSelected": true
+                  }
+                }
+                """.utf8
+            )
+            return (response, responseBody)
+        }
+        let store = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: reviewSubmissionOutboxMutationGate,
+            reviewSubmissionExecutor: reviewSubmissionExecutor,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? database.close()
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+            GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let configuration = try makeCustomCloudServiceConfiguration(customOrigin: "https://example.test")
+        let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
+        let guestSession = StoredGuestCloudSession(
+            guestToken: "guest-token",
+            userId: "guest-user",
+            workspaceId: localWorkspace.workspaceId,
+            configurationMode: configuration.mode,
+            apiBaseUrl: configuration.apiBaseUrl
+        )
+        try guestCredentialStore.saveGuestSession(session: guestSession)
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: guestSession.userId,
+            linkedWorkspaceId: guestSession.workspaceId,
+            activeWorkspaceId: guestSession.workspaceId,
+            linkedEmail: nil
+        )
+        let card = try database.saveCard(
+            workspaceId: localWorkspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        let setupOutboxEntries = try database.loadOutboxEntries(
+            workspaceId: localWorkspace.workspaceId,
+            limit: Int.max
+        )
+        try database.deleteOutboxEntries(operationIds: setupOutboxEntries.map(\.operationId))
+        try store.reload()
+
+        let linkContext = CloudWorkspaceLinkContext(
+            userId: "linked-user",
+            email: "user@example.com",
+            apiBaseUrl: configuration.apiBaseUrl,
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            ),
+            workspaces: [],
+            guestUpgradeMode: .mergeRequired
+        )
+        let upgradeTask = Task { @MainActor in
+            try await store.completeGuestCloudLink(linkContext: linkContext, selection: .createNew)
+        }
+        await fulfillment(of: [guestDrainStarted], timeout: 2)
+
+        XCTAssertTrue(try database.loadOutboxEntries(workspaceId: localWorkspace.workspaceId, limit: 1).isEmpty)
+
+        do {
+            _ = try await reviewSubmissionExecutor.submitReview(
+                workspaceId: localWorkspace.workspaceId,
+                submission: ReviewSubmission(
+                    cardId: card.cardId,
+                    rating: .good,
+                    reviewedAtClient: "2026-04-25T12:00:00.000Z"
+                )
+            )
+            XCTFail("Review submission executor should block guest outbox writes after guest upgrade drain starts.")
+        } catch PendingGuestUpgradeLocalMutationError.blocked {
+        } catch {
+            XCTFail("Unexpected review submission gate error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertTrue(try database.loadOutboxEntries(workspaceId: localWorkspace.workspaceId, limit: 1).isEmpty)
+
+        await allowGuestDrain.open()
+        try await upgradeTask.value
+
+        XCTAssertNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertNil(try guestCredentialStore.loadGuestSession())
+        XCTAssertEqual("workspace-linked", try database.workspaceSettingsStore.loadWorkspace().workspaceId)
+        XCTAssertEqual([.guest("guest-token"), .bearer("id-token")], cloudSyncService.runLinkedSyncAuthorizations)
+        XCTAssertEqual([true], GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues)
+        XCTAssertEqual([true], GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues)
+        XCTAssertEqual(["guest-token"], GuestCloudAuthServiceTestURLProtocol.guestTokens)
+    }
+
+    func testCloudIdentityResetClearsPendingGuestUpgradeAndUnblocksMutationGates() async throws {
+        let suiteName: String = "guest-upgrade-reset-cleanup-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        let databaseURL: URL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guest-upgrade-reset-cleanup-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("sqlite")
+        let database: LocalDatabase = try LocalDatabase(databaseURL: databaseURL)
+        let credentialStore: CloudCredentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore: GuestCloudCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate = ReviewSubmissionOutboxMutationGate()
+        let store: FlashcardsStore = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: GuestUpgradeDrainCloudSyncService(),
+            credentialStore: credentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: reviewSubmissionOutboxMutationGate,
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? database.close()
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        userDefaults.set(Data("pending".utf8), forKey: pendingGuestUpgradeUserDefaultsKey)
+        store.isGuestUpgradeLocalOutboxMutationBlocked = true
+        await reviewSubmissionOutboxMutationGate.blockNewReviewSubmissionsAndWaitForActiveSubmissions()
+
+        XCTAssertThrowsError(try store.assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade()) { error in
+            XCTAssertEqual(
+                "Account upgrade is finishing. Wait for the upgrade to complete before making more local changes.",
+                Flashcards.errorMessage(error: error)
+            )
+        }
+        XCTAssertThrowsError(try reviewSubmissionOutboxMutationGate.beginReviewSubmission()) { error in
+            XCTAssertEqual(
+                "Account upgrade is finishing. Wait for the upgrade to complete before making more local changes.",
+                Flashcards.errorMessage(error: error)
+            )
+        }
+
+        try store.resetLocalStateForCloudIdentityChange()
+
+        XCTAssertNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertFalse(store.isGuestUpgradeLocalOutboxMutationBlocked)
+        XCTAssertNoThrow(try store.assertLocalOutboxMutationAllowedDuringPendingGuestUpgrade())
+        do {
+            try reviewSubmissionOutboxMutationGate.beginReviewSubmission()
+            reviewSubmissionOutboxMutationGate.finishReviewSubmission()
+        } catch {
+            XCTFail("Review submission gate should be unblocked after identity reset: \(Flashcards.errorMessage(error: error))")
+        }
+    }
+
+    func testCompleteGuestCloudLinkStopsBeforeBackendWhenGuestOutboxRemainsAfterSync() async throws {
+        let suiteName = "guest-upgrade-drain-\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guest-upgrade-drain-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("sqlite")
+        let database = try LocalDatabase(databaseURL: databaseURL)
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let urlSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        let guestCloudAuthService = GuestCloudAuthService(session: URLSession(configuration: urlSessionConfiguration))
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        let store = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? database.close()
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+            GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+            GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let configuration = try makeCustomCloudServiceConfiguration(customOrigin: "https://example.test")
+        let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
+        let guestSession = StoredGuestCloudSession(
+            guestToken: "guest-token",
+            userId: "guest-user",
+            workspaceId: localWorkspace.workspaceId,
+            configurationMode: configuration.mode,
+            apiBaseUrl: configuration.apiBaseUrl
+        )
+        try guestCredentialStore.saveGuestSession(session: guestSession)
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: guestSession.userId,
+            linkedWorkspaceId: guestSession.workspaceId,
+            activeWorkspaceId: guestSession.workspaceId,
+            linkedEmail: nil
+        )
+        _ = try database.saveCard(
+            workspaceId: localWorkspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        try store.reload()
+
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            _ = request
+            throw LocalStoreError.database("Guest upgrade backend complete should not be called")
+        }
+
+        let linkContext = CloudWorkspaceLinkContext(
+            userId: "linked-user",
+            email: "user@example.com",
+            apiBaseUrl: configuration.apiBaseUrl,
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            ),
+            workspaces: [],
+            guestUpgradeMode: .mergeRequired
+        )
+
+        do {
+            try await store.completeGuestCloudLink(linkContext: linkContext, selection: .createNew)
+            XCTFail("Guest upgrade should fail before backend complete when guest outbox remains.")
+        } catch CloudGuestUpgradeDrainError.pendingGuestOutboxEntries(let workspaceId) {
+            XCTAssertEqual(localWorkspace.workspaceId, workspaceId)
+        } catch {
+            XCTFail("Unexpected guest upgrade drain error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
+        XCTAssertEqual(.guest, try database.workspaceSettingsStore.loadCloudSettings().cloudState)
+        XCTAssertGreaterThan(try database.loadOutboxEntries(workspaceId: localWorkspace.workspaceId, limit: 1).count, 0)
+        XCTAssertNil(try credentialStore.loadCredentials())
+    }
+
+    private func verifyCompletedPendingGuestUpgradeResume(
+        schemaVersion: Int,
+        phase: String?
+    ) async throws {
+        let suiteName = "guest-upgrade-completed-\(schemaVersion)-\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guest-upgrade-completed-\(schemaVersion)-\(UUID().uuidString.lowercased())")
+            .appendingPathExtension("sqlite")
+        let database = try LocalDatabase(databaseURL: databaseURL)
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        let cloudSyncService = GuestUpgradeDrainCloudSyncService()
+        let urlSessionConfiguration = URLSessionConfiguration.ephemeral
+        urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
+        let guestCloudAuthService = GuestCloudAuthService(session: URLSession(configuration: urlSessionConfiguration))
+        GuestCloudAuthServiceTestURLProtocol.requestHandler = { request in
+            _ = request
+            throw LocalStoreError.database("Completed pending guest upgrade should not call backend guest completion")
+        }
+        GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+        GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+        GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+        GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+        let store = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: guestCloudAuthService,
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: defaultReviewCountsLoader,
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: defaultReviewQueueWindowLoader,
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        defer {
+            store.shutdownForTests()
+            try? database.close()
+            try? FileManager.default.removeItem(at: databaseURL)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            GuestCloudAuthServiceTestURLProtocol.requestHandler = nil
+            GuestCloudAuthServiceTestURLProtocol.requestCount = 0
+            GuestCloudAuthServiceTestURLProtocol.supportsDroppedEntitiesValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestWorkspaceSyncedAndOutboxDrainedValues = []
+            GuestCloudAuthServiceTestURLProtocol.guestTokens = []
+            GuestCloudAuthServiceTestURLProtocol.pendingGuestUpgradeStateWasSavedBeforeComplete = false
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let configuration = try makeCustomCloudServiceConfiguration(customOrigin: "https://example.test")
+        let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: "guest-user",
+            linkedWorkspaceId: localWorkspace.workspaceId,
+            activeWorkspaceId: localWorkspace.workspaceId,
+            linkedEmail: nil
+        )
+        try credentialStore.saveCredentials(
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token-\(schemaVersion)",
+                idToken: "id-token-\(schemaVersion)",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            )
+        )
+        try store.reload()
+
+        let pendingData = self.completedPendingGuestUpgradePayload(
+            schemaVersion: schemaVersion,
+            phase: phase,
+            apiBaseUrl: configuration.apiBaseUrl
+        )
+        let pendingPayload = String(decoding: pendingData, as: UTF8.self)
+        XCTAssertFalse(pendingPayload.contains("guestToken"))
+        XCTAssertFalse(pendingPayload.contains("guest-token"))
+        userDefaults.set(pendingData, forKey: pendingGuestUpgradeUserDefaultsKey)
+        XCTAssertNil(try guestCredentialStore.loadGuestSession())
+
+        let didResume = try await store.resumePendingGuestUpgradeIfNeeded(
+            trigger: store.manualCloudSyncTrigger(now: Date())
+        )
+
+        XCTAssertTrue(didResume)
+        XCTAssertNil(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        XCTAssertNil(try guestCredentialStore.loadGuestSession())
+        XCTAssertEqual(.linked, try database.workspaceSettingsStore.loadCloudSettings().cloudState)
+        XCTAssertEqual("workspace-linked-\(schemaVersion)", try database.workspaceSettingsStore.loadWorkspace().workspaceId)
+        XCTAssertEqual([.bearer("id-token-\(schemaVersion)")], cloudSyncService.runLinkedSyncAuthorizations)
+        XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
+    }
+
+    private func completedPendingGuestUpgradePayload(
+        schemaVersion: Int,
+        phase: String?,
+        apiBaseUrl: String
+    ) -> Data {
+        let phaseLine: String
+        if let phase {
+            phaseLine = "  \"phase\": \"\(phase)\",\n"
+        } else {
+            phaseLine = ""
+        }
+
+        return Data(
+            """
+            {
+              "schemaVersion": \(schemaVersion),
+            \(phaseLine)  "apiBaseUrl": "\(apiBaseUrl)",
+              "configurationMode": "custom",
+              "userId": "linked-user-\(schemaVersion)",
+              "email": "user-\(schemaVersion)@example.com",
+              "workspace": {
+                "workspaceId": "workspace-linked-\(schemaVersion)",
+                "name": "Personal",
+                "createdAt": "2026-04-01T00:00:00.000Z",
+                "isSelected": true
+              }
+            }
+            """.utf8
+        )
+    }
+
+    private func inFlightPendingGuestUpgradePayload(
+        apiBaseUrl: String,
+        guestUserId: String,
+        guestWorkspaceId: String
+    ) -> Data {
+        Data(
+            """
+            {
+              "schemaVersion": 5,
+              "phase": "in_flight",
+              "apiBaseUrl": "\(apiBaseUrl)",
+              "configurationMode": "custom",
+              "userId": "linked-user",
+              "email": "user@example.com",
+              "guestUserId": "\(guestUserId)",
+              "guestWorkspaceId": "\(guestWorkspaceId)",
+              "selection": {
+                "type": "create_new"
+              },
+              "supportsDroppedEntities": true
+            }
+            """.utf8
+        )
+    }
+}
+
+private final class GuestCloudAuthServiceTestURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requestCount: Int = 0
+    nonisolated(unsafe) static var supportsDroppedEntitiesValues: [Bool] = []
+    nonisolated(unsafe) static var guestWorkspaceSyncedAndOutboxDrainedValues: [Bool] = []
+    nonisolated(unsafe) static var guestTokens: [String] = []
+    nonisolated(unsafe) static var pendingGuestUpgradeStateWasSavedBeforeComplete: Bool = false
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        _ = request
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestCount += 1
+        guard let requestHandler = Self.requestHandler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+    }
+}
+
+private struct GuestUpgradeCompleteRequestBody: Decodable {
+    let guestToken: String
+    let guestWorkspaceSyncedAndOutboxDrained: Bool
+    let supportsDroppedEntities: Bool
+}
+
+private actor GuestUpgradeAsyncGate {
+    private var isOpen: Bool = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        if self.isOpen {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+}
+
+@MainActor
+private final class GuestUpgradeDrainCloudSyncService: CloudSyncServing {
+    private(set) var runLinkedSyncCallCount: Int = 0
+    private(set) var runLinkedSyncAuthorizations: [CloudAuthorization] = []
+    var runLinkedSyncHandler: ((CloudLinkedSession) async throws -> CloudSyncResult)?
+
+    func fetchCloudAccount(apiBaseUrl: String, bearerToken: String) async throws -> CloudAccountSnapshot {
+        _ = apiBaseUrl
+        _ = bearerToken
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func loadProgressSummary(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        timeZone: String
+    ) async throws -> UserProgressSummary {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        return UserProgressSummary(
+            timeZone: timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 0,
+                hasReviewedToday: false,
+                lastReviewedOn: nil,
+                activeReviewDays: 0
+            ),
+            generatedAt: "2026-04-25T00:00:00.000Z"
+        )
+    }
+
+    func loadProgressSeries(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        timeZone: String,
+        from: String,
+        to: String
+    ) async throws -> UserProgressSeries {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        return UserProgressSeries(
+            timeZone: timeZone,
+            from: from,
+            to: to,
+            dailyReviews: [],
+            summary: ProgressSummary(
+                currentStreakDays: 0,
+                hasReviewedToday: false,
+                lastReviewedOn: nil,
+                activeReviewDays: 0
+            ),
+            generatedAt: "2026-04-25T00:00:00.000Z"
+        )
+    }
+
+    func createWorkspace(apiBaseUrl: String, bearerToken: String, name: String) async throws -> CloudWorkspaceSummary {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = name
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func renameWorkspace(
+        apiBaseUrl: String,
+        bearerToken: String,
+        workspaceId: String,
+        name: String
+    ) async throws -> CloudWorkspaceSummary {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = workspaceId
+        _ = name
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func loadWorkspaceDeletePreview(
+        apiBaseUrl: String,
+        bearerToken: String,
+        workspaceId: String
+    ) async throws -> CloudWorkspaceDeletePreview {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = workspaceId
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func loadWorkspaceResetProgressPreview(
+        apiBaseUrl: String,
+        bearerToken: String,
+        workspaceId: String
+    ) async throws -> CloudWorkspaceResetProgressPreview {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = workspaceId
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func deleteWorkspace(
+        apiBaseUrl: String,
+        bearerToken: String,
+        workspaceId: String,
+        confirmationText: String
+    ) async throws -> CloudWorkspaceDeleteResult {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = workspaceId
+        _ = confirmationText
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func resetWorkspaceProgress(
+        apiBaseUrl: String,
+        bearerToken: String,
+        workspaceId: String,
+        confirmationText: String
+    ) async throws -> CloudWorkspaceResetProgressResult {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = workspaceId
+        _ = confirmationText
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func selectWorkspace(
+        apiBaseUrl: String,
+        bearerToken: String,
+        workspaceId: String
+    ) async throws -> CloudWorkspaceSummary {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = workspaceId
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func listAgentApiKeys(
+        apiBaseUrl: String,
+        bearerToken: String
+    ) async throws -> ([AgentApiKeyConnection], String) {
+        _ = apiBaseUrl
+        _ = bearerToken
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func revokeAgentApiKey(
+        apiBaseUrl: String,
+        bearerToken: String,
+        connectionId: String
+    ) async throws -> (AgentApiKeyConnection, String) {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = connectionId
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func isWorkspaceEmptyForBootstrap(
+        apiBaseUrl: String,
+        authorizationHeader: String,
+        workspaceId: String,
+        installationId: String
+    ) async throws -> Bool {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        _ = workspaceId
+        _ = installationId
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func deleteAccount(apiBaseUrl: String, bearerToken: String, confirmationText: String) async throws {
+        _ = apiBaseUrl
+        _ = bearerToken
+        _ = confirmationText
+        fatalError("Not used in GuestCloudUpgradeDrainTests.")
+    }
+
+    func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        self.runLinkedSyncCallCount += 1
+        self.runLinkedSyncAuthorizations.append(linkedSession.authorization)
+        if let runLinkedSyncHandler {
+            return try await runLinkedSyncHandler(linkedSession)
+        }
+        return .noChanges
+    }
+}
+
+private func guestCloudAuthServiceTestRequestBody(request: URLRequest) throws -> Data {
+    if let httpBody = request.httpBody {
+        return httpBody
+    }
+
+    guard let stream = request.httpBodyStream else {
+        throw LocalStoreError.database("Guest auth service test request is missing HTTP body")
+    }
+
+    stream.open()
+    defer {
+        stream.close()
+    }
+
+    let bufferSize: Int = 1024
+    var data = Data()
+    var buffer = [UInt8](repeating: 0, count: bufferSize)
+    while stream.hasBytesAvailable {
+        let readCount = stream.read(&buffer, maxLength: buffer.count)
+        if readCount < 0 {
+            throw LocalStoreError.database("Guest auth service test request body stream failed")
+        }
+        if readCount == 0 {
+            break
+        }
+        data.append(buffer, count: readCount)
+    }
+    return data
 }

--- a/apps/ios/Flashcards/FlashcardsTests/LocalWorkspaceLinkMigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalWorkspaceLinkMigrationTests.swift
@@ -15,7 +15,35 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
         }
         self.database = nil
         self.databaseURL = nil
+        CloudSyncRunnerTestURLProtocol.reset()
         try super.tearDownWithError()
+    }
+
+    func testWorkspaceIdentityForkUsesStableBackendCompatibleUuidV5Inputs() {
+        XCTAssertEqual(
+            "6cab5f77-fe75-5774-a07e-965887d8c4bd",
+            forkedCardIdForWorkspace(
+                sourceWorkspaceId: "workspace-local",
+                destinationWorkspaceId: "workspace-linked",
+                sourceCardId: "card-source"
+            )
+        )
+        XCTAssertEqual(
+            "55b8435f-64d5-5381-8dbb-f5a736616156",
+            forkedDeckIdForWorkspace(
+                sourceWorkspaceId: "workspace-local",
+                destinationWorkspaceId: "workspace-linked",
+                sourceDeckId: "deck-source"
+            )
+        )
+        XCTAssertEqual(
+            "c2d996b4-d588-5afe-b062-300de5d03dd4",
+            forkedReviewEventIdForWorkspace(
+                sourceWorkspaceId: "workspace-local",
+                destinationWorkspaceId: "workspace-linked",
+                sourceReviewEventId: "review-source"
+            )
+        )
     }
 
     func testMigrateLocalWorkspaceToLinkedWorkspaceReplacesLocalShellForNonEmptyRemoteWorkspace() throws {
@@ -70,7 +98,7 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
         )
     }
 
-    func testMigrateLocalWorkspaceToLinkedWorkspacePreservesLocalDataForEmptyRemoteWorkspaceButResetsSyncState() throws {
+    func testMigrateLocalWorkspaceToLinkedWorkspaceForksLocalDataForEmptyRemoteWorkspaceAndResetsSyncState() throws {
         let database = try self.makeDatabase()
         let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
         let savedCard = try database.saveCard(
@@ -83,6 +111,13 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
             ),
             cardId: nil
         )
+        let savedDeck = try database.createDeck(
+            workspaceId: localWorkspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [], tags: ["tag"])
+            )
+        )
         _ = try database.submitReview(
             workspaceId: localWorkspace.workspaceId,
             reviewSubmission: ReviewSubmission(
@@ -91,11 +126,35 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
                 reviewedAtClient: "2026-04-02T15:50:57.000Z"
             )
         )
+        try database.updateWorkspaceSchedulerSettings(
+            workspaceId: localWorkspace.workspaceId,
+            desiredRetention: 0.9,
+            learningStepsMinutes: [1, 10],
+            relearningStepsMinutes: [10],
+            maximumIntervalDays: 36500,
+            enableFuzz: true
+        )
+        let sourceReviewEvent = try XCTUnwrap(try database.loadReviewEvents(workspaceId: localWorkspace.workspaceId).first)
         try self.updateSyncState(
             database: database,
             workspaceId: localWorkspace.workspaceId,
             hotChangeId: 123,
             reviewSequenceId: 456
+        )
+        let expectedForkedCardId = forkedCardIdForWorkspace(
+            sourceWorkspaceId: localWorkspace.workspaceId,
+            destinationWorkspaceId: "workspace-linked",
+            sourceCardId: savedCard.cardId
+        )
+        let expectedForkedDeckId = forkedDeckIdForWorkspace(
+            sourceWorkspaceId: localWorkspace.workspaceId,
+            destinationWorkspaceId: "workspace-linked",
+            sourceDeckId: savedDeck.deckId
+        )
+        let expectedForkedReviewEventId = forkedReviewEventIdForWorkspace(
+            sourceWorkspaceId: localWorkspace.workspaceId,
+            destinationWorkspaceId: "workspace-linked",
+            sourceReviewEventId: sourceReviewEvent.reviewEventId
         )
 
         try database.migrateLocalWorkspaceToLinkedWorkspace(
@@ -108,11 +167,58 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
         let migratedReviewEvents = try database.loadReviewEvents(workspaceId: "workspace-linked")
         let migratedCard = try XCTUnwrap(migratedCards.first)
         let migratedReviewEvent = try XCTUnwrap(migratedReviewEvents.first)
+        let migratedDeck = try XCTUnwrap(try database.loadActiveDecks(workspaceId: "workspace-linked").first)
+        let outboxRows = try self.loadOutboxRows(database: database)
+        let cardOutboxRows = outboxRows.filter { row in
+            row.entityType == SyncEntityType.card.rawValue
+        }
+        let deckOutboxRows = outboxRows.filter { row in
+            row.entityType == SyncEntityType.deck.rawValue
+        }
+        let reviewEventOutboxRows = outboxRows.filter { row in
+            row.entityType == SyncEntityType.reviewEvent.rawValue
+        }
+        let schedulerOutboxRows = outboxRows.filter { row in
+            row.entityType == SyncEntityType.workspaceSchedulerSettings.rawValue
+        }
+
         XCTAssertEqual(1, try self.loadWorkspaceIds(database: database).count)
-        XCTAssertEqual(savedCard.cardId, migratedCard.cardId)
+        XCTAssertEqual(expectedForkedCardId, migratedCard.cardId)
         XCTAssertEqual("workspace-linked", migratedCard.workspaceId)
+        XCTAssertEqual(["tag"], migratedCard.tags)
+        XCTAssertEqual(expectedForkedDeckId, migratedDeck.deckId)
         XCTAssertEqual(1, migratedReviewEvents.count)
+        XCTAssertEqual(expectedForkedReviewEventId, migratedReviewEvent.reviewEventId)
         XCTAssertEqual("workspace-linked", migratedReviewEvent.workspaceId)
+        XCTAssertEqual(expectedForkedCardId, migratedReviewEvent.cardId)
+        XCTAssertTrue(outboxRows.allSatisfy { row in row.workspaceId == "workspace-linked" })
+        XCTAssertFalse(outboxRows.contains { row in row.entityId == savedCard.cardId })
+        XCTAssertFalse(outboxRows.contains { row in row.entityId == savedDeck.deckId })
+        XCTAssertFalse(outboxRows.contains { row in row.entityId == sourceReviewEvent.reviewEventId })
+        XCTAssertTrue(
+            try cardOutboxRows.allSatisfy { row in
+                let payload = try JSONDecoder().decode(CardOutboxPayload.self, from: Data(row.payloadJson.utf8))
+                return row.entityId == expectedForkedCardId && payload.cardId == expectedForkedCardId
+            }
+        )
+        XCTAssertTrue(
+            try deckOutboxRows.allSatisfy { row in
+                let payload = try JSONDecoder().decode(DeckOutboxPayload.self, from: Data(row.payloadJson.utf8))
+                return row.entityId == expectedForkedDeckId && payload.deckId == expectedForkedDeckId
+            }
+        )
+        XCTAssertTrue(
+            try reviewEventOutboxRows.allSatisfy { row in
+                let payload = try JSONDecoder().decode(
+                    ReviewEventOutboxPayload.self,
+                    from: Data(row.payloadJson.utf8)
+                )
+                return row.entityId == expectedForkedReviewEventId
+                    && payload.reviewEventId == expectedForkedReviewEventId
+                    && payload.cardId == expectedForkedCardId
+            }
+        )
+        XCTAssertEqual(["workspace-linked"], schedulerOutboxRows.map(\.entityId))
         XCTAssertGreaterThan(try self.loadOutboxCount(database: database), 0)
         XCTAssertNil(try self.loadSyncState(database: database, workspaceId: localWorkspace.workspaceId))
         XCTAssertEqual(
@@ -122,6 +228,990 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
                 lastAppliedReviewSequenceId: 0,
                 hasHydratedHotState: false,
                 hasHydratedReviewHistory: false
+            ),
+            try self.loadSyncState(database: database, workspaceId: "workspace-linked")
+        )
+    }
+
+    func testRepairLocalIdForPublicCardSyncConflictRewritesCardReferencesAndOutbox() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: ["tag"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: savedCard.cardId,
+                rating: .good,
+                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+            )
+        )
+
+        let recovery = try database.repairLocalIdForPublicSyncConflict(
+            workspaceId: workspace.workspaceId,
+            syncConflict: CloudSyncConflictDetails(
+                phase: "push",
+                entityType: .card,
+                entityId: savedCard.cardId,
+                entryIndex: nil,
+                reviewEventIndex: nil,
+                recoverable: true
+            )
+        )
+
+        let replacementCardId = recovery.replacementEntityId
+        let cards = try database.loadActiveCards(workspaceId: workspace.workspaceId)
+        let reviewEvents = try database.loadReviewEvents(workspaceId: workspace.workspaceId)
+        let outboxRows = try self.loadOutboxRows(database: database)
+        XCTAssertEqual(.card, recovery.entityType)
+        XCTAssertEqual(savedCard.cardId, recovery.sourceEntityId)
+        XCTAssertNotEqual(savedCard.cardId, replacementCardId)
+        XCTAssertNotNil(UUID(uuidString: replacementCardId))
+        XCTAssertFalse(cards.contains { card in card.cardId == savedCard.cardId })
+        XCTAssertTrue(cards.contains { card in card.cardId == replacementCardId })
+        XCTAssertEqual(0, try self.loadCardTagCount(database: database, cardId: savedCard.cardId))
+        XCTAssertEqual(1, try self.loadCardTagCount(database: database, cardId: replacementCardId))
+        XCTAssertTrue(reviewEvents.allSatisfy { reviewEvent in reviewEvent.cardId == replacementCardId })
+        XCTAssertFalse(outboxRows.contains { row in row.entityId == savedCard.cardId })
+        XCTAssertTrue(
+            try outboxRows
+                .filter { row in row.entityType == SyncEntityType.card.rawValue }
+                .allSatisfy { row in
+                    let payload = try JSONDecoder().decode(CardOutboxPayload.self, from: Data(row.payloadJson.utf8))
+                    return row.entityId == replacementCardId && payload.cardId == replacementCardId
+                }
+        )
+        XCTAssertTrue(
+            try outboxRows
+                .filter { row in row.entityType == SyncEntityType.reviewEvent.rawValue }
+                .allSatisfy { row in
+                    let payload = try JSONDecoder().decode(
+                        ReviewEventOutboxPayload.self,
+                        from: Data(row.payloadJson.utf8)
+                    )
+                    return payload.cardId == replacementCardId
+                }
+        )
+    }
+
+    func testRepairLocalIdForPublicReviewEventSyncConflictRewritesReviewEventAndOutbox() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: savedCard.cardId,
+                rating: .easy,
+                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+            )
+        )
+        let sourceReviewEvent = try XCTUnwrap(try database.loadReviewEvents(workspaceId: workspace.workspaceId).first)
+
+        let recovery = try database.repairLocalIdForPublicSyncConflict(
+            workspaceId: workspace.workspaceId,
+            syncConflict: CloudSyncConflictDetails(
+                phase: "review_history_import",
+                entityType: .reviewEvent,
+                entityId: sourceReviewEvent.reviewEventId,
+                entryIndex: nil,
+                reviewEventIndex: 0,
+                recoverable: true
+            )
+        )
+
+        let replacementReviewEventId = recovery.replacementEntityId
+        let reviewEvents = try database.loadReviewEvents(workspaceId: workspace.workspaceId)
+        let outboxRows = try self.loadOutboxRows(database: database).filter { row in
+            row.entityType == SyncEntityType.reviewEvent.rawValue
+        }
+        XCTAssertEqual(.reviewEvent, recovery.entityType)
+        XCTAssertEqual(sourceReviewEvent.reviewEventId, recovery.sourceEntityId)
+        XCTAssertNotEqual(sourceReviewEvent.reviewEventId, replacementReviewEventId)
+        XCTAssertNotNil(UUID(uuidString: replacementReviewEventId))
+        XCTAssertFalse(reviewEvents.contains { reviewEvent in reviewEvent.reviewEventId == sourceReviewEvent.reviewEventId })
+        XCTAssertTrue(reviewEvents.contains { reviewEvent in
+            reviewEvent.reviewEventId == replacementReviewEventId && reviewEvent.cardId == savedCard.cardId
+        })
+        XCTAssertTrue(
+            try outboxRows.allSatisfy { row in
+                let payload = try JSONDecoder().decode(
+                    ReviewEventOutboxPayload.self,
+                    from: Data(row.payloadJson.utf8)
+                )
+                return row.entityId == replacementReviewEventId
+                    && payload.reviewEventId == replacementReviewEventId
+                    && payload.cardId == savedCard.cardId
+            }
+        )
+    }
+
+    func testRepairLocalIdForPublicDeckSyncConflictRewritesDeckAndOutbox() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedDeck = try database.createDeck(
+            workspaceId: workspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [.medium], tags: ["tag"])
+            )
+        )
+
+        let recovery = try database.repairLocalIdForPublicSyncConflict(
+            workspaceId: workspace.workspaceId,
+            syncConflict: CloudSyncConflictDetails(
+                phase: "bootstrap",
+                entityType: .deck,
+                entityId: savedDeck.deckId,
+                entryIndex: 0,
+                reviewEventIndex: nil,
+                recoverable: true
+            )
+        )
+
+        let replacementDeckId = recovery.replacementEntityId
+        let decks = try database.loadActiveDecks(workspaceId: workspace.workspaceId)
+        let deckOutboxRows = try self.loadOutboxRows(database: database).filter { row in
+            row.entityType == SyncEntityType.deck.rawValue
+        }
+        XCTAssertEqual(.deck, recovery.entityType)
+        XCTAssertEqual(savedDeck.deckId, recovery.sourceEntityId)
+        XCTAssertNotEqual(savedDeck.deckId, replacementDeckId)
+        XCTAssertNotNil(UUID(uuidString: replacementDeckId))
+        XCTAssertFalse(decks.contains { deck in deck.deckId == savedDeck.deckId })
+        XCTAssertTrue(decks.contains { deck in deck.deckId == replacementDeckId })
+        XCTAssertTrue(
+            try deckOutboxRows.allSatisfy { row in
+                let payload = try JSONDecoder().decode(DeckOutboxPayload.self, from: Data(row.payloadJson.utf8))
+                return row.entityId == replacementDeckId && payload.deckId == replacementDeckId
+            }
+        )
+    }
+
+    func testLinkedSyncRetriesAfterPublicCardSyncConflictRecovery() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: ["tag"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try Self.handleLinkedSyncRetryTestRequest(
+                request: request,
+                sourceCardId: savedCard.cardId
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let cards = try database.loadActiveCards(workspaceId: workspace.workspaceId)
+        let pushCardIds = CloudSyncRunnerTestURLProtocol.bootstrapPushCardIds
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.card))
+        XCTAssertEqual(2, pushCardIds.count)
+        XCTAssertEqual(savedCard.cardId, pushCardIds.first)
+        XCTAssertNotEqual(savedCard.cardId, pushCardIds.last)
+        XCTAssertFalse(cards.contains { card in card.cardId == savedCard.cardId })
+        XCTAssertTrue(cards.contains { card in card.cardId == pushCardIds.last })
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+    }
+
+    func testLinkedSyncEmptyRemoteBootstrapPushesMoreThanTwoHundredHotEntriesInOneRequest() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cardCount: Int = 201
+        let expectedEntryCount: Int = cardCount + 1
+
+        for cardIndex in 0..<cardCount {
+            _ = try database.saveCard(
+                workspaceId: workspace.workspaceId,
+                input: CardEditorInput(
+                    frontText: "Question \(cardIndex)",
+                    backText: "Answer \(cardIndex)",
+                    tags: [],
+                    effortLevel: .medium
+                ),
+                cardId: nil
+            )
+        }
+        XCTAssertEqual(cardCount, try self.loadOutboxCount(database: database))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try Self.handleLargeEmptyRemoteBootstrapRequest(
+                request: request,
+                expectedEntryCount: expectedEntryCount
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
+        XCTAssertEqual([expectedEntryCount], CloudSyncRunnerTestURLProtocol.bootstrapPushEntryCounts)
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.card))
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.workspaceSchedulerSettings))
+        XCTAssertEqual(cardCount, syncResult.cleanedUpOperationCount)
+        XCTAssertEqual(77, syncState.lastAppliedHotChangeId)
+        XCTAssertTrue(syncState.hasHydratedHotState)
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+    }
+
+    func testLinkedSyncReturnsDeckChangeAfterPublicDeckPushConflictRecovery() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedDeck = try database.createDeck(
+            workspaceId: workspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [.medium], tags: ["tag"])
+            )
+        )
+        try self.updateSyncState(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            hotChangeId: 1,
+            reviewSequenceId: 1
+        )
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try Self.handleLinkedSyncPushRetryTestRequest(
+                request: request,
+                sourceEntityType: .deck,
+                sourceEntityId: savedDeck.deckId
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let decks = try database.loadActiveDecks(workspaceId: workspace.workspaceId)
+        let pushEntityIds = CloudSyncRunnerTestURLProtocol.pushEntityIds
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.deck))
+        XCTAssertTrue(syncResult.localIdRepairEntityTypes.contains(.deck))
+        XCTAssertTrue(syncResult.reviewDataChanged)
+        XCTAssertEqual(2, pushEntityIds.count)
+        XCTAssertEqual(savedDeck.deckId, pushEntityIds.first)
+        XCTAssertNotEqual(savedDeck.deckId, pushEntityIds.last)
+        XCTAssertFalse(decks.contains { deck in deck.deckId == savedDeck.deckId })
+        XCTAssertTrue(decks.contains { deck in deck.deckId == pushEntityIds.last })
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+    }
+
+    func testLinkedSyncRepairsMultipleDistinctPublicPushConflictsInOneAttempt() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: ["tag"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        let savedDeck = try database.createDeck(
+            workspaceId: workspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [.medium], tags: ["tag"])
+            )
+        )
+        try self.updateSyncState(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            hotChangeId: 1,
+            reviewSequenceId: 1
+        )
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try Self.handleLinkedSyncMultiConflictPushRetryTestRequest(
+                request: request,
+                sourceCardId: savedCard.cardId,
+                sourceDeckId: savedDeck.deckId
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let cards = try database.loadActiveCards(workspaceId: workspace.workspaceId)
+        let decks = try database.loadActiveDecks(workspaceId: workspace.workspaceId)
+        let pushSnapshots = CloudSyncRunnerTestURLProtocol.pushEntitySnapshots
+        XCTAssertTrue(syncResult.localIdRepairEntityTypes.contains(.card))
+        XCTAssertTrue(syncResult.localIdRepairEntityTypes.contains(.deck))
+        XCTAssertEqual(3, pushSnapshots.count)
+        XCTAssertEqual(savedCard.cardId, pushSnapshots[0][SyncEntityType.card.rawValue])
+        XCTAssertEqual(savedDeck.deckId, pushSnapshots[0][SyncEntityType.deck.rawValue])
+        XCTAssertNotEqual(savedCard.cardId, pushSnapshots[1][SyncEntityType.card.rawValue])
+        XCTAssertEqual(savedDeck.deckId, pushSnapshots[1][SyncEntityType.deck.rawValue])
+        XCTAssertEqual(pushSnapshots[1][SyncEntityType.card.rawValue], pushSnapshots[2][SyncEntityType.card.rawValue])
+        XCTAssertNotEqual(savedDeck.deckId, pushSnapshots[2][SyncEntityType.deck.rawValue])
+        XCTAssertFalse(cards.contains { card in card.cardId == savedCard.cardId })
+        XCTAssertFalse(decks.contains { deck in deck.deckId == savedDeck.deckId })
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+    }
+
+    func testLinkedSyncBootstrapSkipsPendingLocalHotOutboxEntries() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Local dirty question",
+                backText: "Local dirty answer",
+                tags: ["local"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        let savedDeck = try database.createDeck(
+            workspaceId: workspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Local dirty deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [.medium], tags: ["local"])
+            )
+        )
+        try database.updateWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId,
+            desiredRetention: 0.91,
+            learningStepsMinutes: [1, 10],
+            relearningStepsMinutes: [10],
+            maximumIntervalDays: 36500,
+            enableFuzz: true
+        )
+        XCTAssertEqual(3, try self.loadOutboxCount(database: database))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try Self.handleDirtyBootstrapProtectionRequest(
+                request: request,
+                workspaceId: workspace.workspaceId,
+                dirtyCardId: savedCard.cardId,
+                dirtyDeckId: savedDeck.deckId
+            )
+        }
+
+        _ = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let cards = try database.loadActiveCards(workspaceId: workspace.workspaceId)
+        let dirtyCard = try XCTUnwrap(cards.first { card in card.cardId == savedCard.cardId })
+        let cleanRemoteCard = try XCTUnwrap(cards.first { card in card.cardId == "remote-clean-card" })
+        let dirtyDeck = try XCTUnwrap(
+            try database.loadActiveDecks(workspaceId: workspace.workspaceId).first { deck in
+                deck.deckId == savedDeck.deckId
+            }
+        )
+        let schedulerSettings = try database.workspaceSettingsStore.loadWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId
+        )
+        XCTAssertEqual("Local dirty question", dirtyCard.frontText)
+        XCTAssertEqual("Clean remote question", cleanRemoteCard.frontText)
+        XCTAssertEqual("Local dirty deck", dirtyDeck.name)
+        XCTAssertEqual(0.91, schedulerSettings.desiredRetention, accuracy: 0.0001)
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+    }
+
+    func testLinkedSyncBootstrapReplaysSkippedDirtyRowsWhenPushIsIgnored() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Local dirty question",
+                backText: "Local dirty answer",
+                tags: ["local"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        XCTAssertEqual(1, try self.loadOutboxCount(database: database))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try Self.handleIgnoredDirtyBootstrapProtectionRequest(
+                request: request,
+                dirtyCardId: savedCard.cardId
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let cards = try database.loadActiveCards(workspaceId: workspace.workspaceId)
+        let dirtyCard = try XCTUnwrap(cards.first { card in card.cardId == savedCard.cardId })
+        let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
+        XCTAssertEqual("Remote winning question", dirtyCard.frontText)
+        XCTAssertEqual(["remote"], dirtyCard.tags)
+        XCTAssertEqual(1, syncResult.acknowledgedOperationCount)
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+        XCTAssertEqual([0], CloudSyncRunnerTestURLProtocol.pullAfterHotChangeIds)
+        XCTAssertEqual(20, syncState.lastAppliedHotChangeId)
+        XCTAssertTrue(syncState.hasHydratedHotState)
+    }
+
+    func testLinkedSyncBootstrapRechecksFinalPageDirtyHotOutboxBeforeHydrating() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let dirtyCardId = "remote-final-page-card"
+        try self.installFinalBootstrapDirtyOutboxTrigger(database: database, cardId: dirtyCardId)
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try Self.handleIgnoredDirtyBootstrapProtectionRequest(
+                request: request,
+                dirtyCardId: dirtyCardId
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let cards = try database.loadActiveCards(workspaceId: workspace.workspaceId)
+        let dirtyCard = try XCTUnwrap(cards.first { card in card.cardId == dirtyCardId })
+        let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
+        XCTAssertEqual("Remote winning question", dirtyCard.frontText)
+        XCTAssertEqual(["remote"], dirtyCard.tags)
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.card))
+        XCTAssertEqual(1, syncResult.acknowledgedOperationCount)
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+        XCTAssertEqual([0], CloudSyncRunnerTestURLProtocol.pullAfterHotChangeIds)
+        XCTAssertEqual(20, syncState.lastAppliedHotChangeId)
+        XCTAssertTrue(syncState.hasHydratedHotState)
+    }
+
+    @MainActor
+    func testApplySyncResultBroadlyResetsReviewSelectionAfterLocalIdRepair() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: ["tag"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        let suiteName = "review-selection-recovery-\(UUID().uuidString.lowercased())"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let credentialStore = CloudCredentialStore(service: "tests-deck-filter-\(UUID().uuidString.lowercased())")
+        defer {
+            try? credentialStore.clearCredentials()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let store = self.makeReviewFilterRecoveryStore(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore,
+            cloudSyncService: nil
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+
+        store.workspace = workspace
+        store.schedulerSettings = try database.workspaceSettingsStore.loadWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId
+        )
+        store.cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        store.selectedReviewFilter = .tag(tag: "tag")
+        store.reviewQueue = [savedCard]
+        store.presentedReviewCardId = savedCard.cardId
+        store.persistSelectedReviewFilter(reviewFilter: .tag(tag: "tag"))
+        XCTAssertEqual(.tag(tag: "tag"), store.selectedReviewFilter)
+        XCTAssertEqual(
+            .tag(tag: "tag"),
+            FlashcardsStore.loadSelectedReviewFilter(
+                userDefaults: userDefaults,
+                decoder: JSONDecoder(),
+                workspaceId: workspace.workspaceId
+            )
+        )
+
+        _ = try database.repairLocalIdForPublicSyncConflict(
+            workspaceId: workspace.workspaceId,
+            syncConflict: CloudSyncConflictDetails(
+                phase: "push",
+                entityType: .card,
+                entityId: savedCard.cardId,
+                entryIndex: 0,
+                reviewEventIndex: nil,
+                recoverable: true
+            )
+        )
+
+        try await store.applySyncResultWithoutBlockingReset(
+            syncResult: CloudSyncResult(
+                appliedPullChangeCount: 0,
+                changedEntityTypes: [.card],
+                localIdRepairEntityTypes: [.card],
+                acknowledgedOperationCount: 0,
+                acknowledgedReviewEventOperationCount: 0,
+                cleanedUpOperationCount: 0,
+                cleanedUpReviewEventOperationCount: 0
+            ),
+            now: now,
+            trigger: self.makeManualSyncTrigger(now: now)
+        )
+
+        XCTAssertEqual(.allCards, store.selectedReviewFilter)
+        XCTAssertNil(store.presentedReviewCardId)
+        XCTAssertTrue(store.reviewQueue.isEmpty)
+        XCTAssertEqual(
+            .allCards,
+            FlashcardsStore.loadSelectedReviewFilter(
+                userDefaults: userDefaults,
+                decoder: JSONDecoder(),
+                workspaceId: workspace.workspaceId
+            )
+        )
+    }
+
+    @MainActor
+    func testSyncCloudNowResetsReviewSelectionWhenLocalIdRepairFailureThrows() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: ["tag"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        try database.updateCloudSettings(
+            cloudState: .linked,
+            linkedUserId: "user-1",
+            linkedWorkspaceId: workspace.workspaceId,
+            activeWorkspaceId: workspace.workspaceId,
+            linkedEmail: "user@example.com"
+        )
+        let suiteName = "review-selection-recovery-failure-\(UUID().uuidString.lowercased())"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let credentialStore = CloudCredentialStore(service: "tests-deck-filter-\(UUID().uuidString.lowercased())")
+        defer {
+            try? credentialStore.clearCredentials()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        try credentialStore.saveCredentials(
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token",
+                idToken: "id-token",
+                idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+            )
+        )
+        let cloudSyncService = AIChatStoreTestSupport.CloudSyncService()
+        cloudSyncService.runLinkedSyncErrors = [
+            CloudSyncLocalIdRepairFailure(
+                syncResult: CloudSyncResult(
+                    appliedPullChangeCount: 0,
+                    changedEntityTypes: [.card],
+                    localIdRepairEntityTypes: [.card],
+                    acknowledgedOperationCount: 0,
+                    acknowledgedReviewEventOperationCount: 0,
+                    cleanedUpOperationCount: 0,
+                    cleanedUpReviewEventOperationCount: 0
+                ),
+                underlyingError: LocalStoreError.validation("terminal sync failure after repair")
+            )
+        ]
+        let store = self.makeReviewFilterRecoveryStore(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore,
+            cloudSyncService: cloudSyncService
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+
+        store.workspace = workspace
+        store.schedulerSettings = try database.workspaceSettingsStore.loadWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId
+        )
+        store.cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        store.cloudRuntime.setActiveCloudSession(linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId))
+        store.selectedReviewFilter = .tag(tag: "tag")
+        store.reviewQueue = [savedCard]
+        store.presentedReviewCardId = savedCard.cardId
+        store.persistSelectedReviewFilter(reviewFilter: .tag(tag: "tag"))
+
+        do {
+            try await store.syncCloudNow(trigger: self.makeManualSyncTrigger(now: now))
+            XCTFail("Expected sync failure after local id repair")
+        } catch {
+            XCTAssertTrue(Flashcards.errorMessage(error: error).contains("terminal sync failure after repair"))
+        }
+
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(.allCards, store.selectedReviewFilter)
+        XCTAssertNil(store.presentedReviewCardId)
+        XCTAssertTrue(store.reviewQueue.isEmpty)
+        XCTAssertEqual(
+            .allCards,
+            FlashcardsStore.loadSelectedReviewFilter(
+                userDefaults: userDefaults,
+                decoder: JSONDecoder(),
+                workspaceId: workspace.workspaceId
+            )
+        )
+        XCTAssertNil(store.lastSuccessfulCloudSyncAt)
+        guard case .failed(let message) = store.syncStatus else {
+            XCTFail("Expected failed sync status after sync failure")
+            return
+        }
+        XCTAssertTrue(message.contains("terminal sync failure after repair"))
+    }
+
+    @MainActor
+    func testRunLinkedSyncResetsReviewSelectionWhenLocalIdRepairFailureThrows() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: ["tag"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        let suiteName = "review-selection-run-linked-recovery-\(UUID().uuidString.lowercased())"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let credentialStore = CloudCredentialStore(service: "tests-deck-filter-\(UUID().uuidString.lowercased())")
+        defer {
+            try? credentialStore.clearCredentials()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let cloudSyncService = AIChatStoreTestSupport.CloudSyncService()
+        cloudSyncService.runLinkedSyncErrors = [
+            CloudSyncLocalIdRepairFailure(
+                syncResult: CloudSyncResult(
+                    appliedPullChangeCount: 0,
+                    changedEntityTypes: [.card],
+                    localIdRepairEntityTypes: [.card],
+                    acknowledgedOperationCount: 0,
+                    acknowledgedReviewEventOperationCount: 0,
+                    cleanedUpOperationCount: 0,
+                    cleanedUpReviewEventOperationCount: 0
+                ),
+                underlyingError: LocalStoreError.validation("terminal sync failure after repair")
+            )
+        ]
+        let store = self.makeReviewFilterRecoveryStore(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore,
+            cloudSyncService: cloudSyncService
+        )
+        defer {
+            store.shutdownForTests()
+        }
+
+        store.workspace = workspace
+        store.schedulerSettings = try database.workspaceSettingsStore.loadWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId
+        )
+        store.cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        store.selectedReviewFilter = .tag(tag: "tag")
+        store.reviewQueue = [savedCard]
+        store.presentedReviewCardId = savedCard.cardId
+        store.persistSelectedReviewFilter(reviewFilter: .tag(tag: "tag"))
+
+        do {
+            _ = try await store.runLinkedSync(
+                linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+            )
+            XCTFail("Expected sync failure after local id repair")
+        } catch {
+            XCTAssertTrue(Flashcards.errorMessage(error: error).contains("terminal sync failure after repair"))
+        }
+
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(.allCards, store.selectedReviewFilter)
+        XCTAssertNil(store.presentedReviewCardId)
+        XCTAssertTrue(store.reviewQueue.isEmpty)
+        XCTAssertEqual(
+            .allCards,
+            FlashcardsStore.loadSelectedReviewFilter(
+                userDefaults: userDefaults,
+                decoder: JSONDecoder(),
+                workspaceId: workspace.workspaceId
+            )
+        )
+        XCTAssertNil(store.lastSuccessfulCloudSyncAt)
+    }
+
+    @MainActor
+    func testApplySyncResultPreservesSelectedDeckReviewFilterForNormalDeckChange() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedDeck = try database.createDeck(
+            workspaceId: workspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [.medium], tags: [])
+            )
+        )
+        let suiteName = "deck-filter-normal-change-\(UUID().uuidString.lowercased())"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let credentialStore = CloudCredentialStore(service: "tests-deck-filter-\(UUID().uuidString.lowercased())")
+        defer {
+            try? credentialStore.clearCredentials()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let store = self.makeReviewFilterRecoveryStore(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore,
+            cloudSyncService: nil
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+
+        store.workspace = workspace
+        store.schedulerSettings = try database.workspaceSettingsStore.loadWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId
+        )
+        store.cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        store.selectedReviewFilter = .deck(deckId: savedDeck.deckId)
+        store.persistSelectedReviewFilter(reviewFilter: .deck(deckId: savedDeck.deckId))
+        _ = try database.updateDeck(
+            workspaceId: workspace.workspaceId,
+            deckId: savedDeck.deckId,
+            input: DeckEditorInput(
+                name: "Renamed deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [.medium], tags: [])
+            )
+        )
+
+        try await store.applySyncResultWithoutBlockingReset(
+            syncResult: CloudSyncResult(
+                appliedPullChangeCount: 1,
+                changedEntityTypes: [.deck],
+                localIdRepairEntityTypes: [],
+                acknowledgedOperationCount: 0,
+                acknowledgedReviewEventOperationCount: 0,
+                cleanedUpOperationCount: 0,
+                cleanedUpReviewEventOperationCount: 0
+            ),
+            now: now,
+            trigger: self.makeManualSyncTrigger(now: now)
+        )
+
+        XCTAssertEqual(.deck(deckId: savedDeck.deckId), store.selectedReviewFilter)
+        XCTAssertEqual(
+            .deck(deckId: savedDeck.deckId),
+            FlashcardsStore.loadSelectedReviewFilter(
+                userDefaults: userDefaults,
+                decoder: JSONDecoder(),
+                workspaceId: workspace.workspaceId
+            )
+        )
+    }
+
+    func testSwitchGuestUpgradeToLinkedWorkspaceFromRemoteRejectsPendingGuestOutboxBeforeDeletingGuestWorkspace() throws {
+        let database = try self.makeDatabase()
+        let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: localWorkspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: ["guest"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.createDeck(
+            workspaceId: localWorkspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [], tags: ["guest"])
+            )
+        )
+        try database.updateWorkspaceSchedulerSettings(
+            workspaceId: localWorkspace.workspaceId,
+            desiredRetention: 0.91,
+            learningStepsMinutes: [1, 10],
+            relearningStepsMinutes: [10],
+            maximumIntervalDays: 36500,
+            enableFuzz: true
+        )
+        try self.updateSyncState(
+            database: database,
+            workspaceId: localWorkspace.workspaceId,
+            hotChangeId: 123,
+            reviewSequenceId: 456
+        )
+        XCTAssertGreaterThan(try self.loadOutboxCount(database: database), 0)
+
+        XCTAssertThrowsError(
+            try database.switchGuestUpgradeToLinkedWorkspaceFromRemote(
+                localWorkspaceId: localWorkspace.workspaceId,
+                linkedSession: self.makeLinkedSession(workspaceId: "workspace-linked"),
+                workspace: CloudWorkspaceSummary(
+                    workspaceId: "workspace-linked",
+                    name: "Existing workspace",
+                    createdAt: "2026-04-01T00:00:00.000Z",
+                    isSelected: true
+                )
+            )
+        ) { error in
+            XCTAssertTrue(Flashcards.errorMessage(error: error).contains("pending guest outbox entries remain"))
+        }
+
+        XCTAssertEqual(localWorkspace.workspaceId, try database.workspaceSettingsStore.loadWorkspace().workspaceId)
+        XCTAssertEqual(1, try self.loadWorkspaceIds(database: database).count)
+        XCTAssertTrue(try database.loadActiveCards(workspaceId: localWorkspace.workspaceId).contains { card in
+            card.cardId == savedCard.cardId
+        })
+        XCTAssertGreaterThan(try self.loadOutboxCount(database: database), 0)
+        XCTAssertEqual(
+            SyncStateSnapshot(
+                workspaceId: localWorkspace.workspaceId,
+                lastAppliedHotChangeId: 123,
+                lastAppliedReviewSequenceId: 456,
+                hasHydratedHotState: true,
+                hasHydratedReviewHistory: true
+            ),
+            try self.loadSyncState(database: database, workspaceId: localWorkspace.workspaceId)
+        )
+    }
+
+    func testSwitchGuestUpgradeToLinkedWorkspaceFromRemotePreservesLinkedOutboxOnResume() throws {
+        let database = try self.makeDatabase()
+        let localWorkspace = try database.workspaceSettingsStore.loadWorkspace()
+        let linkedSession = self.makeLinkedSession(workspaceId: "workspace-linked")
+        let linkedWorkspace = CloudWorkspaceSummary(
+            workspaceId: "workspace-linked",
+            name: "Existing workspace",
+            createdAt: "2026-04-01T00:00:00.000Z",
+            isSelected: true
+        )
+
+        try database.switchGuestUpgradeToLinkedWorkspaceFromRemote(
+            localWorkspaceId: localWorkspace.workspaceId,
+            linkedSession: linkedSession,
+            workspace: linkedWorkspace
+        )
+        try self.updateSyncState(
+            database: database,
+            workspaceId: "workspace-linked",
+            hotChangeId: 789,
+            reviewSequenceId: 987
+        )
+        let savedLinkedCard = try database.saveCard(
+            workspaceId: "workspace-linked",
+            input: CardEditorInput(
+                frontText: "Linked question",
+                backText: "Linked answer",
+                tags: ["linked"],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        let outboxRowsBeforeResume = try self.loadOutboxRows(database: database)
+        XCTAssertTrue(outboxRowsBeforeResume.contains { row in row.entityId == savedLinkedCard.cardId })
+
+        try database.switchGuestUpgradeToLinkedWorkspaceFromRemote(
+            localWorkspaceId: "workspace-linked",
+            linkedSession: linkedSession,
+            workspace: linkedWorkspace
+        )
+
+        let outboxRowsAfterResume = try self.loadOutboxRows(database: database)
+        XCTAssertEqual(outboxRowsBeforeResume.count, outboxRowsAfterResume.count)
+        XCTAssertTrue(outboxRowsAfterResume.contains { row in row.entityId == savedLinkedCard.cardId })
+        XCTAssertEqual(1, try database.loadActiveCards(workspaceId: "workspace-linked").count)
+        XCTAssertEqual(
+            SyncStateSnapshot(
+                workspaceId: "workspace-linked",
+                lastAppliedHotChangeId: 789,
+                lastAppliedReviewSequenceId: 987,
+                hasHydratedHotState: true,
+                hasHydratedReviewHistory: true
             ),
             try self.loadSyncState(database: database, workspaceId: "workspace-linked")
         )
@@ -145,6 +1235,874 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
             configurationMode: .official,
             apiBaseUrl: "https://api.flashcards-open-source-app.com/v1",
             authorization: .bearer("id-token")
+        )
+    }
+
+    private func installFinalBootstrapDirtyOutboxTrigger(database: LocalDatabase, cardId: String) throws {
+        let payloadJson: String = """
+        {"cardId":"\(cardId)","frontText":"Local final-page dirty question","backText":"Local final-page dirty answer","tags":["local"],"effortLevel":"medium","dueAt":null,"createdAt":"2026-04-01T00:00:00.000Z","reps":0,"lapses":0,"fsrsCardState":"new","fsrsStepIndex":null,"fsrsStability":null,"fsrsDifficulty":null,"fsrsLastReviewedAt":null,"fsrsScheduledDays":null,"deletedAt":null}
+        """
+        let cardIdLiteral: String = self.sqliteTextLiteral(value: cardId)
+        let payloadJsonLiteral: String = self.sqliteTextLiteral(value: payloadJson)
+
+        try database.core.execute(
+            sql: """
+            CREATE TRIGGER final_bootstrap_dirty_outbox_after_card_insert
+            AFTER INSERT ON cards
+            WHEN NEW.card_id = \(cardIdLiteral)
+            BEGIN
+                UPDATE cards
+                SET
+                    front_text = 'Local final-page dirty question',
+                    back_text = 'Local final-page dirty answer',
+                    tags_json = '["local"]',
+                    client_updated_at = '2030-01-01T00:00:00.000Z',
+                    last_modified_by_replica_id = 'local-final-page-race',
+                    last_operation_id = 'final-page-race-operation',
+                    updated_at = '2030-01-01T00:00:00.000Z'
+                WHERE workspace_id = NEW.workspace_id AND card_id = NEW.card_id;
+
+                DELETE FROM card_tags
+                WHERE workspace_id = NEW.workspace_id AND card_id = NEW.card_id;
+
+                INSERT INTO card_tags (workspace_id, card_id, tag)
+                VALUES (NEW.workspace_id, NEW.card_id, 'local');
+
+                INSERT INTO outbox (
+                    operation_id,
+                    workspace_id,
+                    installation_id,
+                    entity_type,
+                    entity_id,
+                    operation_type,
+                    payload_json,
+                    client_updated_at,
+                    created_at,
+                    attempt_count,
+                    last_error
+                )
+                VALUES (
+                    'final-page-race-operation',
+                    NEW.workspace_id,
+                    'test-installation',
+                    'card',
+                    NEW.card_id,
+                    'upsert',
+                    \(payloadJsonLiteral),
+                    '2030-01-01T00:00:00.000Z',
+                    '2030-01-01T00:00:00.000Z',
+                    0,
+                    NULL
+                );
+            END
+            """,
+            values: []
+        )
+    }
+
+    private func sqliteTextLiteral(value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "''"))'"
+    }
+
+    private static func handleLinkedSyncRetryTestRequest(
+        request: URLRequest,
+        sourceCardId: String
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/bootstrap") {
+            let body = try self.jsonObjectBody(request: request)
+            let mode = try XCTUnwrap(body["mode"] as? String)
+            if mode == "pull" {
+                return try self.jsonResponse(
+                    request: request,
+                    statusCode: 200,
+                    body: """
+                    {
+                      "entries": [],
+                      "nextCursor": null,
+                      "hasMore": false,
+                      "bootstrapHotChangeId": 0,
+                      "remoteIsEmpty": true
+                    }
+                    """
+                )
+            }
+
+            let entries = try XCTUnwrap(body["entries"] as? [[String: Any]])
+            let cardEntry = try XCTUnwrap(entries.first { entry in
+                entry["entityType"] as? String == SyncEntityType.card.rawValue
+            })
+            let cardEntityId = try XCTUnwrap(cardEntry["entityId"] as? String)
+            CloudSyncRunnerTestURLProtocol.bootstrapPushCardIds.append(cardEntityId)
+            if CloudSyncRunnerTestURLProtocol.bootstrapPushCardIds.count == 1 {
+                return try self.jsonResponse(
+                    request: request,
+                    statusCode: 409,
+                    body: """
+                    {
+                      "error": "Sync detected content copied from another workspace. Retry after forking ids.",
+                      "requestId": "request-fork",
+                      "code": "SYNC_WORKSPACE_FORK_REQUIRED",
+                      "details": {
+                        "syncConflict": {
+                          "phase": "bootstrap",
+                          "entityType": "card",
+                          "entityId": "\(sourceCardId)",
+                          "entryIndex": 0,
+                          "recoverable": true
+                        }
+                      }
+                    }
+                    """
+                )
+            }
+
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "appliedEntriesCount": 2,
+                  "bootstrapHotChangeId": 1
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [],
+                  "nextHotChangeId": 1,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [],
+                  "nextReviewSequenceId": 0,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
+    private static func handleLargeEmptyRemoteBootstrapRequest(
+        request: URLRequest,
+        expectedEntryCount: Int
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/bootstrap") {
+            let body = try self.jsonObjectBody(request: request)
+            let mode = try XCTUnwrap(body["mode"] as? String)
+            if mode == "pull" {
+                return try self.jsonResponse(
+                    request: request,
+                    statusCode: 200,
+                    body: """
+                    {
+                      "entries": [],
+                      "nextCursor": null,
+                      "hasMore": false,
+                      "bootstrapHotChangeId": 0,
+                      "remoteIsEmpty": true
+                    }
+                    """
+                )
+            }
+
+            XCTAssertEqual("push", mode)
+            let entries = try XCTUnwrap(body["entries"] as? [[String: Any]])
+            CloudSyncRunnerTestURLProtocol.bootstrapPushEntryCounts.append(entries.count)
+            XCTAssertEqual(expectedEntryCount, entries.count)
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "appliedEntriesCount": \(entries.count),
+                  "bootstrapHotChangeId": 77
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [],
+                  "nextHotChangeId": 77,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [],
+                  "nextReviewSequenceId": 0,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
+    private static func handleLinkedSyncPushRetryTestRequest(
+        request: URLRequest,
+        sourceEntityType: SyncEntityType,
+        sourceEntityId: String
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/push") {
+            let body = try JSONDecoder().decode(PushRetryRequestBody.self, from: self.requestBodyData(request: request))
+            let conflictingOperation = try XCTUnwrap(body.operations.first { operation in
+                operation.entityType == sourceEntityType
+            })
+            let entityId = conflictingOperation.entityId
+            CloudSyncRunnerTestURLProtocol.pushEntityIds.append(entityId)
+
+            if CloudSyncRunnerTestURLProtocol.pushEntityIds.count == 1 {
+                return try self.jsonResponse(
+                    request: request,
+                    statusCode: 409,
+                    body: """
+                    {
+                      "error": "Sync detected content copied from another workspace. Retry after forking ids.",
+                      "requestId": "request-fork",
+                      "code": "SYNC_WORKSPACE_FORK_REQUIRED",
+                      "details": {
+                        "syncConflict": {
+                          "phase": "push",
+                          "entityType": "\(sourceEntityType.rawValue)",
+                          "entityId": "\(sourceEntityId)",
+                          "entryIndex": 0,
+                          "recoverable": true
+                        }
+                      }
+                    }
+                    """
+                )
+            }
+
+            let operationResults = body.operations.map { operation -> String in
+                return """
+                {
+                  "operationId": "\(operation.operationId)",
+                  "entityType": "\(operation.entityType.rawValue)",
+                  "entityId": "\(operation.entityId)",
+                  "status": "applied",
+                  "resultingHotChangeId": 2,
+                  "error": null
+                }
+                """
+            }.joined(separator: ",")
+
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "operations": [\(operationResults)]
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [],
+                  "nextHotChangeId": 2,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [],
+                  "nextReviewSequenceId": 1,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
+    private static func handleLinkedSyncMultiConflictPushRetryTestRequest(
+        request: URLRequest,
+        sourceCardId: String,
+        sourceDeckId: String
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/push") {
+            let body = try JSONDecoder().decode(PushRetryRequestBody.self, from: self.requestBodyData(request: request))
+            let entityIdsByType: [String: String] = body.operations.reduce(into: [:]) { result, operation in
+                result[operation.entityType.rawValue] = operation.entityId
+            }
+            CloudSyncRunnerTestURLProtocol.pushEntitySnapshots.append(entityIdsByType)
+
+            if CloudSyncRunnerTestURLProtocol.pushEntitySnapshots.count == 1 {
+                return try self.workspaceForkRequiredJsonResponse(
+                    request: request,
+                    requestId: "request-fork-card",
+                    entityType: .card,
+                    entityId: sourceCardId
+                )
+            }
+
+            if CloudSyncRunnerTestURLProtocol.pushEntitySnapshots.count == 2 {
+                return try self.workspaceForkRequiredJsonResponse(
+                    request: request,
+                    requestId: "request-fork-deck",
+                    entityType: .deck,
+                    entityId: sourceDeckId
+                )
+            }
+
+            let operationResults = body.operations.map { operation -> String in
+                return """
+                {
+                  "operationId": "\(operation.operationId)",
+                  "entityType": "\(operation.entityType.rawValue)",
+                  "entityId": "\(operation.entityId)",
+                  "status": "applied",
+                  "resultingHotChangeId": 2,
+                  "error": null
+                }
+                """
+            }.joined(separator: ",")
+
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "operations": [\(operationResults)]
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [],
+                  "nextHotChangeId": 2,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [],
+                  "nextReviewSequenceId": 1,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
+    private static func handleDirtyBootstrapProtectionRequest(
+        request: URLRequest,
+        workspaceId: String,
+        dirtyCardId: String,
+        dirtyDeckId: String
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/bootstrap") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "entries": [
+                    {
+                      "entityType": "card",
+                      "entityId": "\(dirtyCardId)",
+                      "action": "upsert",
+                      "payload": {
+                        "cardId": "\(dirtyCardId)",
+                        "frontText": "Remote bootstrap question",
+                        "backText": "Remote bootstrap answer",
+                        "tags": ["remote"],
+                        "effortLevel": "medium",
+                        "dueAt": null,
+                        "createdAt": "2026-04-01T00:00:00.000Z",
+                        "reps": 0,
+                        "lapses": 0,
+                        "fsrsCardState": "new",
+                        "fsrsStepIndex": null,
+                        "fsrsStability": null,
+                        "fsrsDifficulty": null,
+                        "fsrsLastReviewedAt": null,
+                        "fsrsScheduledDays": null,
+                        "clientUpdatedAt": "2030-01-01T00:00:00.000Z",
+                        "lastModifiedByReplicaId": "remote-replica",
+                        "lastOperationId": "remote-card-operation",
+                        "updatedAt": "2030-01-01T00:00:00.000Z",
+                        "deletedAt": null
+                      }
+                    },
+                    {
+                      "entityType": "card",
+                      "entityId": "remote-clean-card",
+                      "action": "upsert",
+                      "payload": {
+                        "cardId": "remote-clean-card",
+                        "frontText": "Clean remote question",
+                        "backText": "Clean remote answer",
+                        "tags": ["remote"],
+                        "effortLevel": "medium",
+                        "dueAt": null,
+                        "createdAt": "2026-04-01T00:00:00.000Z",
+                        "reps": 0,
+                        "lapses": 0,
+                        "fsrsCardState": "new",
+                        "fsrsStepIndex": null,
+                        "fsrsStability": null,
+                        "fsrsDifficulty": null,
+                        "fsrsLastReviewedAt": null,
+                        "fsrsScheduledDays": null,
+                        "clientUpdatedAt": "2030-01-01T00:00:00.000Z",
+                        "lastModifiedByReplicaId": "remote-replica",
+                        "lastOperationId": "remote-clean-card-operation",
+                        "updatedAt": "2030-01-01T00:00:00.000Z",
+                        "deletedAt": null
+                      }
+                    },
+                    {
+                      "entityType": "deck",
+                      "entityId": "\(dirtyDeckId)",
+                      "action": "upsert",
+                      "payload": {
+                        "deckId": "\(dirtyDeckId)",
+                        "name": "Remote bootstrap deck",
+                        "filterDefinition": {
+                          "version": 2,
+                          "effortLevels": ["medium"],
+                          "tags": ["remote"]
+                        },
+                        "createdAt": "2026-04-01T00:00:00.000Z",
+                        "clientUpdatedAt": "2030-01-01T00:00:00.000Z",
+                        "lastModifiedByReplicaId": "remote-replica",
+                        "lastOperationId": "remote-deck-operation",
+                        "updatedAt": "2030-01-01T00:00:00.000Z",
+                        "deletedAt": null
+                      }
+                    },
+                    {
+                      "entityType": "workspace_scheduler_settings",
+                      "entityId": "\(workspaceId)",
+                      "action": "upsert",
+                      "payload": {
+                        "algorithm": "fsrs-6",
+                        "desiredRetention": 0.5,
+                        "learningStepsMinutes": [5],
+                        "relearningStepsMinutes": [5],
+                        "maximumIntervalDays": 30,
+                        "enableFuzz": false,
+                        "clientUpdatedAt": "2030-01-01T00:00:00.000Z",
+                        "lastModifiedByReplicaId": "remote-replica",
+                        "lastOperationId": "remote-settings-operation",
+                        "updatedAt": "2030-01-01T00:00:00.000Z"
+                      }
+                    }
+                  ],
+                  "nextCursor": null,
+                  "hasMore": false,
+                  "bootstrapHotChangeId": 20,
+                  "remoteIsEmpty": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/push") {
+            let body = try JSONDecoder().decode(PushRetryRequestBody.self, from: self.requestBodyData(request: request))
+            let operationResults = body.operations.map { operation -> String in
+                return """
+                {
+                  "operationId": "\(operation.operationId)",
+                  "entityType": "\(operation.entityType.rawValue)",
+                  "entityId": "\(operation.entityId)",
+                  "status": "applied",
+                  "resultingHotChangeId": 21,
+                  "error": null
+                }
+                """
+            }.joined(separator: ",")
+
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "operations": [\(operationResults)]
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [],
+                  "nextHotChangeId": 21,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [],
+                  "nextReviewSequenceId": 0,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
+    private static func handleIgnoredDirtyBootstrapProtectionRequest(
+        request: URLRequest,
+        dirtyCardId: String
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/bootstrap") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "entries": [
+                    {
+                      "entityType": "card",
+                      "entityId": "\(dirtyCardId)",
+                      "action": "upsert",
+                      "payload": {
+                        "cardId": "\(dirtyCardId)",
+                        "frontText": "Remote winning question",
+                        "backText": "Remote winning answer",
+                        "tags": ["remote"],
+                        "effortLevel": "medium",
+                        "dueAt": null,
+                        "createdAt": "2026-04-01T00:00:00.000Z",
+                        "reps": 0,
+                        "lapses": 0,
+                        "fsrsCardState": "new",
+                        "fsrsStepIndex": null,
+                        "fsrsStability": null,
+                        "fsrsDifficulty": null,
+                        "fsrsLastReviewedAt": null,
+                        "fsrsScheduledDays": null,
+                        "clientUpdatedAt": "2030-01-01T00:00:00.000Z",
+                        "lastModifiedByReplicaId": "remote-replica",
+                        "lastOperationId": "remote-card-operation",
+                        "updatedAt": "2030-01-01T00:00:00.000Z",
+                        "deletedAt": null
+                      }
+                    }
+                  ],
+                  "nextCursor": null,
+                  "hasMore": false,
+                  "bootstrapHotChangeId": 20,
+                  "remoteIsEmpty": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/push") {
+            let body = try JSONDecoder().decode(PushRetryRequestBody.self, from: self.requestBodyData(request: request))
+            let operationResults = body.operations.map { operation -> String in
+                return """
+                {
+                  "operationId": "\(operation.operationId)",
+                  "entityType": "\(operation.entityType.rawValue)",
+                  "entityId": "\(operation.entityId)",
+                  "status": "ignored",
+                  "resultingHotChangeId": null,
+                  "error": null
+                }
+                """
+            }.joined(separator: ",")
+
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "operations": [\(operationResults)]
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/pull") {
+            let body = try self.jsonObjectBody(request: request)
+            let afterHotChangeId = try XCTUnwrap(body["afterHotChangeId"] as? NSNumber).int64Value
+            CloudSyncRunnerTestURLProtocol.pullAfterHotChangeIds.append(afterHotChangeId)
+            let changes: String
+            if afterHotChangeId == 0 {
+                changes = """
+                    {
+                      "changeId": 20,
+                      "entityType": "card",
+                      "entityId": "\(dirtyCardId)",
+                      "action": "upsert",
+                      "payload": {
+                        "cardId": "\(dirtyCardId)",
+                        "frontText": "Remote winning question",
+                        "backText": "Remote winning answer",
+                        "tags": ["remote"],
+                        "effortLevel": "medium",
+                        "dueAt": null,
+                        "createdAt": "2026-04-01T00:00:00.000Z",
+                        "reps": 0,
+                        "lapses": 0,
+                        "fsrsCardState": "new",
+                        "fsrsStepIndex": null,
+                        "fsrsStability": null,
+                        "fsrsDifficulty": null,
+                        "fsrsLastReviewedAt": null,
+                        "fsrsScheduledDays": null,
+                        "clientUpdatedAt": "2030-01-01T00:00:00.000Z",
+                        "lastModifiedByReplicaId": "remote-replica",
+                        "lastOperationId": "remote-card-operation",
+                        "updatedAt": "2030-01-01T00:00:00.000Z",
+                        "deletedAt": null
+                      }
+                    }
+                """
+            } else {
+                changes = ""
+            }
+
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [\(changes)],
+                  "nextHotChangeId": 20,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            return try self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [],
+                  "nextReviewSequenceId": 0,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
+    private static func workspaceForkRequiredJsonResponse(
+        request: URLRequest,
+        requestId: String,
+        entityType: SyncEntityType,
+        entityId: String
+    ) throws -> (HTTPURLResponse, Data) {
+        try self.jsonResponse(
+            request: request,
+            statusCode: 409,
+            body: """
+            {
+              "error": "Sync detected content copied from another workspace. Retry after forking ids.",
+              "requestId": "\(requestId)",
+              "code": "SYNC_WORKSPACE_FORK_REQUIRED",
+              "details": {
+                "syncConflict": {
+                  "phase": "push",
+                  "entityType": "\(entityType.rawValue)",
+                  "entityId": "\(entityId)",
+                  "entryIndex": 0,
+                  "recoverable": true
+                }
+              }
+            }
+            """
+        )
+    }
+
+    private static func jsonObjectBody(request: URLRequest) throws -> [String: Any] {
+        let data = try self.requestBodyData(request: request)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    private static func requestBodyData(request: URLRequest) throws -> Data {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+
+        let stream = try XCTUnwrap(request.httpBodyStream)
+        stream.open()
+        defer {
+            stream.close()
+        }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let readCount = stream.read(&buffer, maxLength: buffer.count)
+            if readCount > 0 {
+                data.append(buffer, count: readCount)
+            } else if readCount == 0 {
+                return data
+            } else {
+                throw stream.streamError ?? URLError(.cannotDecodeRawData)
+            }
+        }
+    }
+
+    private static func jsonResponse(
+        request: URLRequest,
+        statusCode: Int,
+        body: String
+    ) throws -> (HTTPURLResponse, Data) {
+        let url = try XCTUnwrap(request.url)
+        let response = try XCTUnwrap(
+            HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )
+        )
+        return (response, Data(body.utf8))
+    }
+
+    @MainActor
+    private func makeReviewFilterRecoveryStore(
+        database: LocalDatabase,
+        userDefaults: UserDefaults,
+        credentialStore: CloudCredentialStore,
+        cloudSyncService: (any CloudSyncServing)?
+    ) -> FlashcardsStore {
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-deck-filter-guest-\(UUID().uuidString.lowercased())",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+
+        let store = FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: JSONEncoder(),
+            decoder: JSONDecoder(),
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: cloudSyncService,
+            credentialStore: credentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: { _, _, resolvedReviewFilter, _, _, _ in
+                ReviewHeadLoadState(
+                    resolvedReviewFilter: resolvedReviewFilter,
+                    seedReviewQueue: [],
+                    hasMoreCards: false
+                )
+            },
+            reviewCountsLoader: { _, _, _, _ in
+                ReviewCounts(dueCount: 0, totalCount: 0)
+            },
+            reviewQueueChunkLoader: { _, _, _, _, _, _ in
+                ReviewQueueChunkLoadState(reviewQueueChunk: [], hasMoreCards: false)
+            },
+            reviewQueueWindowLoader: { _, _, _, _, _ in
+                ReviewQueueWindowLoadState(reviewQueue: [], hasMoreCards: false)
+            },
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+        store.updateCurrentVisibleTab(tab: .cards)
+        return store
+    }
+
+    private func makeManualSyncTrigger(now: Date) -> CloudSyncTrigger {
+        CloudSyncTrigger(
+            source: .manualSyncNow,
+            now: now,
+            extendsFastPolling: false,
+            allowsVisibleChangeBanner: false,
+            surfacesGlobalErrorMessage: false
         )
     }
 
@@ -190,6 +2148,31 @@ final class LocalWorkspaceLinkMigrationTests: XCTestCase {
         ))
     }
 
+    private func loadCardTagCount(database: LocalDatabase, cardId: String) throws -> Int {
+        Int(try database.core.scalarInt(
+            sql: "SELECT COUNT(*) FROM card_tags WHERE card_id = ?",
+            values: [.text(cardId)]
+        ))
+    }
+
+    private func loadOutboxRows(database: LocalDatabase) throws -> [OutboxRow] {
+        try database.core.query(
+            sql: """
+            SELECT workspace_id, entity_type, entity_id, payload_json
+            FROM outbox
+            ORDER BY created_at ASC, operation_id ASC
+            """,
+            values: []
+        ) { statement in
+            OutboxRow(
+                workspaceId: DatabaseCore.columnText(statement: statement, index: 0),
+                entityType: DatabaseCore.columnText(statement: statement, index: 1),
+                entityId: DatabaseCore.columnText(statement: statement, index: 2),
+                payloadJson: DatabaseCore.columnText(statement: statement, index: 3)
+            )
+        }
+    }
+
     private func loadSyncState(database: LocalDatabase, workspaceId: String) throws -> SyncStateSnapshot? {
         try database.core.query(
             sql: """
@@ -222,4 +2205,80 @@ private struct SyncStateSnapshot: Equatable {
     let lastAppliedReviewSequenceId: Int64
     let hasHydratedHotState: Bool
     let hasHydratedReviewHistory: Bool
+}
+
+private struct OutboxRow {
+    let workspaceId: String
+    let entityType: String
+    let entityId: String
+    let payloadJson: String
+}
+
+private struct CardOutboxPayload: Decodable {
+    let cardId: String
+}
+
+private struct DeckOutboxPayload: Decodable {
+    let deckId: String
+}
+
+private struct ReviewEventOutboxPayload: Decodable {
+    let reviewEventId: String
+    let cardId: String
+}
+
+private struct PushRetryRequestBody: Decodable {
+    let operations: [PushRetryOperationBody]
+}
+
+private struct PushRetryOperationBody: Decodable {
+    let operationId: String
+    let entityType: SyncEntityType
+    let entityId: String
+}
+
+private final class CloudSyncRunnerTestURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var bootstrapPushCardIds: [String] = []
+    nonisolated(unsafe) static var bootstrapPushEntryCounts: [Int] = []
+    nonisolated(unsafe) static var pushEntityIds: [String] = []
+    nonisolated(unsafe) static var pushEntitySnapshots: [[String: String]] = []
+    nonisolated(unsafe) static var pullAfterHotChangeIds: [Int64] = []
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        _ = request
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {
+    }
+
+    static func reset() {
+        self.requestHandler = nil
+        self.bootstrapPushCardIds = []
+        self.bootstrapPushEntryCounts = []
+        self.pushEntityIds = []
+        self.pushEntitySnapshots = []
+        self.pullAfterHotChangeIds = []
+    }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/ProgressMergeTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/ProgressMergeTests.swift
@@ -715,6 +715,7 @@ final class ProgressMergeTests: XCTestCase {
             syncResult: CloudSyncResult(
                 appliedPullChangeCount: 0,
                 changedEntityTypes: [],
+                localIdRepairEntityTypes: [],
                 acknowledgedOperationCount: 1,
                 acknowledgedReviewEventOperationCount: 0,
                 cleanedUpOperationCount: 0,
@@ -796,6 +797,7 @@ final class ProgressMergeTests: XCTestCase {
             syncResult: CloudSyncResult(
                 appliedPullChangeCount: 0,
                 changedEntityTypes: [],
+                localIdRepairEntityTypes: [],
                 acknowledgedOperationCount: 1,
                 acknowledgedReviewEventOperationCount: 1,
                 cleanedUpOperationCount: 0,
@@ -880,6 +882,7 @@ final class ProgressMergeTests: XCTestCase {
             syncResult: CloudSyncResult(
                 appliedPullChangeCount: 1,
                 changedEntityTypes: [.reviewEvent],
+                localIdRepairEntityTypes: [],
                 acknowledgedOperationCount: 0,
                 acknowledgedReviewEventOperationCount: 0,
                 cleanedUpOperationCount: 0,
@@ -967,6 +970,7 @@ final class ProgressMergeTests: XCTestCase {
             syncResult: CloudSyncResult(
                 appliedPullChangeCount: 0,
                 changedEntityTypes: [],
+                localIdRepairEntityTypes: [],
                 acknowledgedOperationCount: 0,
                 acknowledgedReviewEventOperationCount: 0,
                 cleanedUpOperationCount: 1,
@@ -1051,6 +1055,7 @@ final class ProgressMergeTests: XCTestCase {
             syncResult: CloudSyncResult(
                 appliedPullChangeCount: 1,
                 changedEntityTypes: [.reviewEvent],
+                localIdRepairEntityTypes: [],
                 acknowledgedOperationCount: 0,
                 acknowledgedReviewEventOperationCount: 0,
                 cleanedUpOperationCount: 0,
@@ -1722,6 +1727,7 @@ final class ProgressMergeTests: XCTestCase {
             credentialStore: credentialStore,
             guestCloudAuthService: GuestCloudAuthService(),
             guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
             reviewSubmissionExecutor: nil,
             reviewHeadLoader: defaultReviewHeadLoader,
             reviewCountsLoader: { _, _, _, _ in
@@ -1921,6 +1927,7 @@ final class ProgressMergeTests: XCTestCase {
             credentialStore: credentialStore,
             guestCloudAuthService: GuestCloudAuthService(),
             guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
             reviewSubmissionExecutor: nil,
             reviewHeadLoader: defaultReviewHeadLoader,
             reviewCountsLoader: defaultReviewCountsLoader,

--- a/db/migrations/0048_sync_conflict_lookup.sql
+++ b/db/migrations/0048_sync_conflict_lookup.sql
@@ -13,14 +13,29 @@ RETURNS TABLE (
 LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
-SET search_path = pg_catalog, public
+SET search_path = pg_catalog
 AS $$
+DECLARE
+  target_entity_uuid UUID;
 BEGIN
+  IF target_entity_type NOT IN ('card', 'deck', 'review_event') THEN
+    RAISE EXCEPTION 'Unsupported sync conflict entity type: %', target_entity_type
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  BEGIN
+    target_entity_uuid := target_entity_id::UUID;
+  EXCEPTION
+    WHEN invalid_text_representation THEN
+      RAISE EXCEPTION 'Invalid sync conflict entity id for %: %', target_entity_type, target_entity_id
+        USING ERRCODE = '22P02';
+  END;
+
   IF target_entity_type = 'card' THEN
     RETURN QUERY
     SELECT cards.workspace_id
     FROM content.cards AS cards
-    WHERE cards.card_id::text = target_entity_id
+    WHERE cards.card_id = target_entity_uuid
     LIMIT 1;
     RETURN;
   END IF;
@@ -29,7 +44,7 @@ BEGIN
     RETURN QUERY
     SELECT decks.workspace_id
     FROM content.decks AS decks
-    WHERE decks.deck_id::text = target_entity_id
+    WHERE decks.deck_id = target_entity_uuid
     LIMIT 1;
     RETURN;
   END IF;
@@ -38,13 +53,10 @@ BEGIN
     RETURN QUERY
     SELECT review_events.workspace_id
     FROM content.review_events AS review_events
-    WHERE review_events.review_event_id::text = target_entity_id
+    WHERE review_events.review_event_id = target_entity_uuid
     LIMIT 1;
     RETURN;
   END IF;
-
-  RAISE EXCEPTION 'Unsupported sync conflict entity type: %', target_entity_type
-    USING ERRCODE = 'P0001';
 END;
 $$;
 

--- a/db/migrations/0048_sync_conflict_lookup.sql
+++ b/db/migrations/0048_sync_conflict_lookup.sql
@@ -1,0 +1,55 @@
+-- Migration status: Current / canonical.
+-- Introduces: a narrow cross-workspace sync conflict lookup helper for globally keyed entities.
+-- Current guidance: typed sync fork errors must not depend on the caller's visible memberships.
+-- See also: docs/sync-identity-model.md, db/migrations/0035_sync_installations_and_workspace_replicas.sql.
+
+CREATE OR REPLACE FUNCTION sync.find_conflicting_workspace_id(
+  target_entity_type TEXT,
+  target_entity_id TEXT
+)
+RETURNS TABLE (
+  workspace_id UUID
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF target_entity_type = 'card' THEN
+    RETURN QUERY
+    SELECT cards.workspace_id
+    FROM content.cards AS cards
+    WHERE cards.card_id::text = target_entity_id
+    LIMIT 1;
+    RETURN;
+  END IF;
+
+  IF target_entity_type = 'deck' THEN
+    RETURN QUERY
+    SELECT decks.workspace_id
+    FROM content.decks AS decks
+    WHERE decks.deck_id::text = target_entity_id
+    LIMIT 1;
+    RETURN;
+  END IF;
+
+  IF target_entity_type = 'review_event' THEN
+    RETURN QUERY
+    SELECT review_events.workspace_id
+    FROM content.review_events AS review_events
+    WHERE review_events.review_event_id::text = target_entity_id
+    LIMIT 1;
+    RETURN;
+  END IF;
+
+  RAISE EXCEPTION 'Unsupported sync conflict entity type: %', target_entity_type
+    USING ERRCODE = 'P0001';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION sync.find_conflicting_workspace_id(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION sync.find_conflicting_workspace_id(TEXT, TEXT) TO backend_app;
+
+COMMENT ON FUNCTION sync.find_conflicting_workspace_id(TEXT, TEXT) IS
+  'Returns the owning workspace for one globally keyed sync entity id without depending on caller-visible workspace memberships.';

--- a/db/migrations/0049_guest_upgrade_dropped_entities.sql
+++ b/db/migrations/0049_guest_upgrade_dropped_entities.sql
@@ -1,0 +1,8 @@
+-- Migration status: Current / canonical.
+-- Introduces: durable guest-upgrade dropped-entity replay metadata.
+
+ALTER TABLE auth.guest_upgrade_history
+  ADD COLUMN IF NOT EXISTS dropped_entities JSONB;
+
+COMMENT ON COLUMN auth.guest_upgrade_history.dropped_entities IS
+  'Optional replay/audit/reconciliation metadata listing exceptional guest-merge omissions, including entities intentionally dropped after conflicts, dependent review events skipped after card drops, and review events deduplicated to an existing target client event.';

--- a/db/migrations/0050_guest_upgrade_replay_secret_hash.sql
+++ b/db/migrations/0050_guest_upgrade_replay_secret_hash.sql
@@ -1,0 +1,18 @@
+-- Migration status: Current / canonical.
+-- Introduces: durable guest-upgrade replay lookup after guest session cleanup.
+
+ALTER TABLE auth.guest_upgrade_history
+  ADD COLUMN IF NOT EXISTS source_guest_session_secret_hash TEXT;
+
+UPDATE auth.guest_upgrade_history AS history
+SET source_guest_session_secret_hash = sessions.session_secret_hash
+FROM auth.guest_sessions AS sessions
+WHERE history.source_guest_session_id = sessions.session_id
+  AND history.source_guest_session_secret_hash IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_guest_upgrade_history_source_session_secret_hash_unique
+  ON auth.guest_upgrade_history(source_guest_session_secret_hash)
+  WHERE source_guest_session_secret_hash IS NOT NULL;
+
+COMMENT ON COLUMN auth.guest_upgrade_history.source_guest_session_secret_hash IS
+  'SHA-256 hash of the guest session token used only to replay a committed upgrade after auth.guest_sessions is removed by guest user cleanup. The raw guest token is never stored.';

--- a/docs/sync-identity-model.md
+++ b/docs/sync-identity-model.md
@@ -55,9 +55,13 @@ The new model fixes that by keeping:
 
 This lets one physical installation switch users, switch workspaces, return later, upgrade guest sessions, and delete workspaces without rewriting historical actor ownership.
 
-## Workspace Identity Forking
+## Entity Id Rules
 
-Copying cards, decks, or review history into a different workspace must deterministically fork every globally keyed entity id. Reusing the original ids across workspaces is invalid because these tables are keyed globally, not by `(workspace_id, entity_id)`.
+Cards, decks, and review events use globally keyed ids. Guest upgrade and true workspace copy/fork flows handle those ids differently.
+
+Guest upgrade preserves ids and merges already-synced guest cloud state into the selected destination workspace. Before calling `/guest-auth/upgrade/complete`, clients fully sync the guest workspace with guest authentication and verify that the local guest outbox is empty. Completion does not carry pending local operations through linked migration, does not depend on entity-id alias mappings, and clients must not fork guest ids before or after linked sync. After upgrade, clients continue syncing the same card, deck, and review event ids.
+
+True workspace copy/fork flows create a separate copy of the data and must deterministically fork every globally keyed entity id. Reusing the original ids in an independent workspace copy is invalid because these tables are keyed globally, not by `(workspace_id, entity_id)`.
 
 - Fork card ids with UUID v5 namespace `5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1`
 - Fork deck ids with UUID v5 namespace `98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4`
@@ -65,4 +69,4 @@ Copying cards, decks, or review history into a different workspace must determin
 
 When review events are copied into another workspace, their `cardId` references must be rewritten to the forked card ids from the same copy operation.
 
-Destructive guest-upgrade merges use the same deterministic fork rule when they copy guest cloud state into the selected destination workspace. Native clients must apply the same source-workspace-to-target-workspace mapping to any still-local unsynced guest state before the next linked sync.
+If guest upgrade encounters an impossible conflict where a guest entity id belongs to a third workspace, the backend may drop the conflicting guest entity only for clients that send request capability `supportsDroppedEntities`; otherwise it rejects completion. When a guest card does not merge, the backend also drops dependent guest review events for that card, even if the review event ids do not conflict. `droppedEntities` is durable replay, audit, and reconciliation metadata that lets capable clients understand exceptional server-side drops. Current Android and iOS merge-required recovery discards or switches away from the local guest workspace shell, then hydrates the target workspace from remote state instead of requiring per-row deletion of matching local rows. Because completion requires an empty local guest outbox, `droppedEntities` is not a pending-outbox migration path.

--- a/docs/sync-identity-model.md
+++ b/docs/sync-identity-model.md
@@ -54,3 +54,15 @@ The new model fixes that by keeping:
 - replicas immutable and workspace-scoped
 
 This lets one physical installation switch users, switch workspaces, return later, upgrade guest sessions, and delete workspaces without rewriting historical actor ownership.
+
+## Workspace Identity Forking
+
+Copying cards, decks, or review history into a different workspace must deterministically fork every globally keyed entity id. Reusing the original ids across workspaces is invalid because these tables are keyed globally, not by `(workspace_id, entity_id)`.
+
+- Fork card ids with UUID v5 namespace `5b0c7f2e-6f2a-4b7e-9e1b-2b5f0a4a91b1`
+- Fork deck ids with UUID v5 namespace `98e66f2c-d3c7-4e3f-a7df-55d8e19ad2b4`
+- Fork review event ids with UUID v5 namespace `3a214a3e-9c89-426d-a21f-11a5f5c1d6e8`
+
+When review events are copied into another workspace, their `cardId` references must be rewritten to the forked card ids from the same copy operation.
+
+Destructive guest-upgrade merges use the same deterministic fork rule when they copy guest cloud state into the selected destination workspace. Native clients must apply the same source-workspace-to-target-workspace mapping to any still-local unsynced guest state before the next linked sync.


### PR DESCRIPTION
## Summary

- Add typed sync conflict recovery and guest-upgrade compatibility handling across backend, Android, and iOS.
- Preserve legacy guest-upgrade completion semantics while adding drained-workspace recovery for current clients.
- Harden Android/iOS bootstrap cursor handling so dirty local outbox rows and remote-winning rows are reconciled predictably.
- Document droppedEntities as replay/audit/reconciliation metadata and add related migrations/API schema updates.

## Validation

- Android: `:data:local:compileDebugKotlin`, `:data:local:compileDebugAndroidTestKotlin`, scoped `diff --check`.
- iOS: targeted `LocalWorkspaceLinkMigrationTests` via `xcodebuild`, scoped `diff --check`.
- Backend/API: backend lint, API lint, targeted `node --test` suites.
- Review: Android, iOS, backend/db/docs, and cross-contract subagent reviews approved.