### PR TITLE
Fix Android release test fake

### DIFF
--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -319,11 +319,23 @@ private class FakeReviewLogDao(
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }
 
+    override suspend fun loadReviewLog(reviewLogId: String): ReviewLogEntity? {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
     override suspend fun loadReviewLogs(workspaceId: String): List<ReviewLogEntity> {
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }
 
     override suspend fun insertReviewLogs(reviewLogs: List<ReviewLogEntity>) {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
+    override suspend fun reassignReviewLogsToCard(workspaceId: String, oldCardId: String, newCardId: String) {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
+    override suspend fun deleteReviewLogs(reviewLogIds: List<String>) {
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }
 


### PR DESCRIPTION
## Summary

- Update the strict reminders test `FakeReviewLogDao` to implement the current `ReviewLogDao` contract.
- Keep the newly required unused DAO methods explicitly failing if a test unexpectedly calls them.

## Root cause

PR #32 added `ReviewLogDao` methods used by sync recovery, but this app unit-test fake was not updated. Android Release then failed during `:app:compileDebugUnitTestKotlin` before Firebase or Play jobs could start.

## Validation

- `ANDROID_VERSION_CODE=9969337 ./gradlew --no-daemon :app:compileDebugUnitTestKotlin`
- `ANDROID_VERSION_CODE=9969337 bash scripts/run-android-ci.sh`