### PR TITLE
Fix Android data local sync expectation

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalCloudAccountRepositoryCloudIdentityTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/LocalCloudAccountRepositoryCloudIdentityTest.kt
@@ -1171,7 +1171,15 @@ class LocalCloudAccountRepositoryCloudIdentityTest {
         assertEquals(listOf(true), remoteGateway.completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained)
         assertEquals(listOf(true), remoteGateway.completeGuestUpgradeSupportsDroppedEntities)
         assertEquals(
-            listOf("push", "pull", "pull_review_history", "bootstrap_pull", "pull", "pull_review_history"),
+            listOf(
+                "push",
+                "pull",
+                "pull_review_history",
+                "bootstrap_pull",
+                "pull_review_history",
+                "pull",
+                "pull_review_history"
+            ),
             remoteGateway.syncRequestEvents
         )
     }


### PR DESCRIPTION
## Summary
- Update the data-local instrumentation expectation for guest upgrade sync ordering after bootstrap hydration.
- Keep the test aligned with the current CloudSyncRunner flow, where review history hydration happens immediately after bootstrap_pull before the next pull.

## Validation
- ANDROID_VERSION_CODE=9970418 ./gradlew --no-daemon :data:local:compileDebugAndroidTestKotlin
- ANDROID_VERSION_CODE=9970418 bash scripts/run-android-ci.sh