### PR TITLE
Use non-deprecated Google Play tracks input

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -564,7 +564,7 @@ jobs:
           serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
           packageName: ${{ vars.ANDROID_PLAY_PACKAGE_NAME }}
           releaseFiles: apps/android/app/build/outputs/bundle/release/app-release.aab
-          track: production
+          tracks: production
           status: draft
           releaseName: ${{ env.ANDROID_PLAY_RELEASE_NAME }}
 


### PR DESCRIPTION
## Summary
- Replace the deprecated r0adkll/upload-google-play track input with tracks for the production draft upload.

## Validation
- Parsed .github/workflows/android-release.yml with Ruby YAML loader.
- git --no-pager diff --check.