### PR TITLE
[codex] Fix auth API root gateway integration

### DIFF
--- a/infra/aws/lib/auth-gateway.ts
+++ b/infra/aws/lib/auth-gateway.ts
@@ -133,10 +133,8 @@ export function authGateway(scope: Construct, props: AuthGatewayProps): AuthGate
   });
 
   const integration = new apigw.LambdaIntegration(authFn);
-  restApi.root.addProxy({
-    defaultIntegration: integration,
-    anyMethod: true,
-  });
+  restApi.root.addMethod("ANY", integration);
+  restApi.root.addResource("{proxy+}").addMethod("ANY", integration);
 
   if (props.authCertificateArn) {
     const authDomainName = `auth.${props.baseDomain}`;


### PR DESCRIPTION
## Summary
- route the auth API root method to the auth Lambda instead of the CDK-generated mock integration
- keep the catch-all proxy route on the same Lambda integration

## Why
The auth API root path `/` could return an API Gateway-generated 500 before Lambda was invoked, which caused false 5xx alarms when public scanners hit `auth.flashcards-open-source-app.com/`.

## Validation
- `npm run build` in `infra/aws`
- `npm test` in `infra/aws`