### PR TITLE
[codex] Fix progress refresh error race

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+Progress.swift
@@ -52,7 +52,7 @@ extension FlashcardsStore {
                 return
             }
 
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
         }
     }
 
@@ -101,7 +101,7 @@ extension FlashcardsStore {
                 return
             }
 
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
         }
     }
 
@@ -129,7 +129,7 @@ extension FlashcardsStore {
                 return
             }
 
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
         }
     }
 
@@ -150,7 +150,7 @@ extension FlashcardsStore {
             try self.publishReviewProgressBadgeState(scopeKey: scopeKey)
 
             guard let progressSnapshot = self.progressSnapshot else {
-                self.progressErrorMessage = ""
+                self.clearProgressErrorMessage()
                 return
             }
 
@@ -160,9 +160,9 @@ extension FlashcardsStore {
                 reviewedAtClient: reviewedAtClient
             )
             self.applyProgressSnapshot(snapshot: patchedSnapshot)
-            self.progressErrorMessage = ""
+            self.clearProgressErrorMessage()
         } catch {
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
         }
     }
 
@@ -205,7 +205,7 @@ extension FlashcardsStore {
                 return
             }
 
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
         }
     }
 
@@ -213,7 +213,7 @@ extension FlashcardsStore {
         do {
             try self.prepareProgressForCurrentVisibleTabState(now: now)
         } catch {
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
             self.applyProgressSnapshot(snapshot: nil)
         }
     }
@@ -229,7 +229,7 @@ extension FlashcardsStore {
                 await self.refreshVisibleProgressIfNeeded(now: now)
             }
         } catch {
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
             self.applyProgressSnapshot(snapshot: nil)
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+ProgressErrorState.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+ProgressErrorState.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+@MainActor
+extension FlashcardsStore {
+    func clearProgressErrorMessage() {
+        self.applyProgressErrorState(state: makeEmptyProgressErrorState())
+    }
+
+    func replaceProgressErrorMessage(message: String) {
+        self.applyProgressErrorState(
+            state: progressErrorStateWithOnlyGeneralMessage(message: message)
+        )
+    }
+
+    func beginProgressSummaryRefreshErrorScope() {
+        self.applyProgressErrorState(
+            state: progressErrorStateClearingGeneralAndSummaryRefreshMessages(
+                state: self.progressErrorState
+            )
+        )
+    }
+
+    func beginProgressSeriesRefreshErrorScope() {
+        self.applyProgressErrorState(
+            state: progressErrorStateClearingGeneralAndSeriesRefreshMessages(
+                state: self.progressErrorState
+            )
+        )
+    }
+
+    func clearProgressSummaryRefreshErrorMessage() {
+        self.applyProgressErrorState(
+            state: progressErrorStateClearingSummaryRefreshMessage(
+                state: self.progressErrorState
+            )
+        )
+    }
+
+    func clearProgressSeriesRefreshErrorMessage() {
+        self.applyProgressErrorState(
+            state: progressErrorStateClearingSeriesRefreshMessage(
+                state: self.progressErrorState
+            )
+        )
+    }
+
+    func replaceProgressSummaryRefreshErrorMessage(message: String) {
+        self.applyProgressErrorState(
+            state: progressErrorStateWithSummaryRefreshMessage(
+                state: self.progressErrorState,
+                message: message
+            )
+        )
+    }
+
+    func replaceProgressSeriesRefreshErrorMessage(message: String) {
+        self.applyProgressErrorState(
+            state: progressErrorStateWithSeriesRefreshMessage(
+                state: self.progressErrorState,
+                message: message
+            )
+        )
+    }
+
+    private func applyProgressErrorState(state: ProgressErrorState) {
+        self.progressErrorState = state
+        let message = progressErrorDisplayMessage(state: state)
+        if self.progressErrorMessage != message {
+            self.progressErrorMessage = message
+        }
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+ProgressRefresh.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+ProgressRefresh.swift
@@ -16,7 +16,7 @@ extension FlashcardsStore {
         self.progressActiveSummaryRefreshToken = refreshToken
         self.isProgressSummaryRefreshing = true
         self.updateProgressRefreshingState()
-        self.progressErrorMessage = ""
+        self.beginProgressSummaryRefreshErrorScope()
 
         defer {
             if self.progressActiveSummaryRefreshScopeKey == scopeKey,
@@ -46,6 +46,7 @@ extension FlashcardsStore {
             try self.persistProgressSummaryServerBase(serverBase: persistedServerBase)
             self.progressSummaryServerBaseCache = persistedServerBase
             self.progressSummaryInvalidatedScopeKeys.remove(scopeKey)
+            self.clearProgressSummaryRefreshErrorMessage()
 
             guard let observedScopeKey = self.progressObservedScopeKey,
                   progressSummaryScopeKey(seriesScopeKey: observedScopeKey) == scopeKey else {
@@ -58,7 +59,6 @@ extension FlashcardsStore {
             }
 
             try self.publishProgressSnapshot(scopeKey: observedScopeKey)
-            self.progressErrorMessage = ""
         } catch {
             if isRequestCancellationError(error: error) {
                 return
@@ -68,7 +68,7 @@ extension FlashcardsStore {
                 return
             }
 
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressSummaryRefreshErrorMessage(message: Flashcards.errorMessage(error: error))
         }
     }
 
@@ -86,7 +86,7 @@ extension FlashcardsStore {
         self.progressActiveSeriesRefreshToken = refreshToken
         self.isProgressSeriesRefreshing = true
         self.updateProgressRefreshingState()
-        self.progressErrorMessage = ""
+        self.beginProgressSeriesRefreshErrorScope()
 
         defer {
             if self.progressActiveSeriesRefreshScopeKey == scopeKey,
@@ -116,8 +116,8 @@ extension FlashcardsStore {
             try self.persistProgressSeriesServerBase(serverBase: persistedServerBase)
             self.progressSeriesServerBaseCache = persistedServerBase
             self.progressSeriesInvalidatedScopeKeys.remove(scopeKey)
+            self.clearProgressSeriesRefreshErrorMessage()
             try self.publishProgressSnapshot(scopeKey: scopeKey)
-            self.progressErrorMessage = ""
         } catch {
             if isRequestCancellationError(error: error) {
                 return
@@ -127,7 +127,7 @@ extension FlashcardsStore {
                 return
             }
 
-            self.progressErrorMessage = Flashcards.errorMessage(error: error)
+            self.replaceProgressSeriesRefreshErrorMessage(message: Flashcards.errorMessage(error: error))
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+ProgressSnapshot.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+ProgressSnapshot.swift
@@ -12,7 +12,7 @@ extension FlashcardsStore {
                 scopeKey: progressSummaryScopeKey(seriesScopeKey: scopeKey)
             )
             self.progressSeriesServerBaseCache = self.loadPersistedProgressSeriesServerBase(scopeKey: scopeKey)
-            self.progressErrorMessage = ""
+            self.clearProgressErrorMessage()
             if previousScopeKey != nil {
                 self.invalidateProgress(
                     scopeKey: scopeKey,

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
@@ -116,6 +116,7 @@ final class FlashcardsStore {
     @ObservationIgnored var progressSummaryServerBaseCache: PersistedProgressSummaryServerBase?
     @ObservationIgnored var progressSeriesServerBaseCache: PersistedProgressSeriesServerBase?
     @ObservationIgnored var progressObservedScopeKey: ProgressScopeKey?
+    @ObservationIgnored var progressErrorState: ProgressErrorState
     @ObservationIgnored var progressSummaryInvalidatedScopeKeys: Set<ProgressSummaryScopeKey>
     @ObservationIgnored var progressSeriesInvalidatedScopeKeys: Set<ProgressScopeKey>
     @ObservationIgnored var progressSummaryRefreshToken: Int
@@ -378,6 +379,7 @@ final class FlashcardsStore {
         self.progressSummaryServerBaseCache = nil
         self.progressSeriesServerBaseCache = nil
         self.progressObservedScopeKey = nil
+        self.progressErrorState = makeEmptyProgressErrorState()
         self.progressSummaryInvalidatedScopeKeys = []
         self.progressSeriesInvalidatedScopeKeys = []
         self.progressSummaryRefreshToken = 0

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressErrorState.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressErrorState.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct ProgressErrorState: Equatable, Sendable {
+    let generalMessage: String
+    let summaryRefreshMessage: String
+    let seriesRefreshMessage: String
+}
+
+func makeEmptyProgressErrorState() -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: "",
+        summaryRefreshMessage: "",
+        seriesRefreshMessage: ""
+    )
+}
+
+func progressErrorStateWithOnlyGeneralMessage(message: String) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: message,
+        summaryRefreshMessage: "",
+        seriesRefreshMessage: ""
+    )
+}
+
+func progressErrorStateClearingGeneralAndSummaryRefreshMessages(state: ProgressErrorState) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: "",
+        summaryRefreshMessage: "",
+        seriesRefreshMessage: state.seriesRefreshMessage
+    )
+}
+
+func progressErrorStateClearingGeneralAndSeriesRefreshMessages(state: ProgressErrorState) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: "",
+        summaryRefreshMessage: state.summaryRefreshMessage,
+        seriesRefreshMessage: ""
+    )
+}
+
+func progressErrorStateClearingSummaryRefreshMessage(state: ProgressErrorState) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: state.generalMessage,
+        summaryRefreshMessage: "",
+        seriesRefreshMessage: state.seriesRefreshMessage
+    )
+}
+
+func progressErrorStateClearingSeriesRefreshMessage(state: ProgressErrorState) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: state.generalMessage,
+        summaryRefreshMessage: state.summaryRefreshMessage,
+        seriesRefreshMessage: ""
+    )
+}
+
+func progressErrorStateWithSummaryRefreshMessage(
+    state: ProgressErrorState,
+    message: String
+) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: "",
+        summaryRefreshMessage: message,
+        seriesRefreshMessage: state.seriesRefreshMessage
+    )
+}
+
+func progressErrorStateWithSeriesRefreshMessage(
+    state: ProgressErrorState,
+    message: String
+) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: "",
+        summaryRefreshMessage: state.summaryRefreshMessage,
+        seriesRefreshMessage: message
+    )
+}
+
+func progressErrorDisplayMessage(state: ProgressErrorState) -> String {
+    [
+        state.generalMessage,
+        state.summaryRefreshMessage,
+        state.seriesRefreshMessage,
+    ]
+        .filter { message in
+            message.isEmpty == false
+        }
+        .joined(separator: "\n")
+}


### PR DESCRIPTION
## Summary
- split progress error handling into general, summary-refresh, and series-refresh slots
- keep `progressErrorMessage` as the single UI-facing projection
- prevent a successful parallel summary refresh from clearing a series refresh failure, and vice versa

## Root cause
Xcode Cloud build 311 exposed a race in `ProgressMergeTests`: summary and series refreshes run concurrently, but both mutated the same `progressErrorMessage`. A later successful refresh could clear an earlier failure from the other refresh path.

## Validation
- `git --no-pager diff --check`
- `xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'platform=iOS Simulator,id=441AC3A5-B086-4E0F-A00E-DCD3AAA41F8F' -only-testing:'Flashcards Open Source App Tests/ProgressMergeTests' test`
- subagent review: 3 independent review agents approved with no P0/P1/P2 findings
