### PR TITLE
Fix Android review session completion

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -202,6 +202,7 @@ class ReviewViewModel(
         )
         val emptyState = resolveReviewEmptyState(
             selectedFilter = sessionSnapshot.selectedFilter,
+            remainingCount = sessionSnapshot.remainingCount,
             totalCount = sessionSnapshot.totalCount,
             workspaceCardCount = appMetadata.cardCount
         )
@@ -918,11 +919,16 @@ private fun applyResolvedReviewFilter(
 
 private fun resolveReviewEmptyState(
     selectedFilter: ReviewFilter,
+    remainingCount: Int,
     totalCount: Int,
     workspaceCardCount: Int
 ): ReviewEmptyState? {
-    if (totalCount > 0) {
+    if (remainingCount > 0) {
         return null
+    }
+
+    if (totalCount > 0) {
+        return ReviewEmptyState.SESSION_COMPLETE
     }
 
     if (workspaceCardCount == 0) {


### PR DESCRIPTION
## Summary
- Fix Android review empty-state resolution so a completed non-empty session shows the session-complete state when remaining cards reaches zero.
- Keep no-cards and filter-empty states scoped to genuinely empty review queues.

## Verification
- Worker ran `cd apps/android && ./gradlew :feature:review:compileDebugKotlin` and reported `BUILD SUCCESSFUL`.
- Parent checked `git diff --check`.
- Subagent review approved the final diff with no findings.