### PR TITLE
[codex] Fix AI live smoke assistant text detection

### DIFF
--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeAiObservations.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeAiObservations.swift
@@ -4,7 +4,7 @@ extension LiveSmokeTestCase {
     @MainActor
     func visibleAssistantRowTexts(ignoredExactLabels: Set<String>) -> [String] {
         self.elements(
-            query: self.app.otherElements
+            query: self.app.descendants(matching: .any)
                 .matching(identifier: LiveSmokeIdentifier.aiAssistantVisibleText)
         )
         .compactMap { element in


### PR DESCRIPTION
## Summary
- fix iOS live smoke assistant text observation to include static text accessibility nodes
- keep reset-flow completion detection aligned with Xcode Cloud snapshots

## Verification
- git --no-pager diff --check
- inspected Xcode Cloud build 312 API issues, testResults, and log artifacts
