### PR TITLE
[codex] Increase chat worker Lambda memory

### DIFF
--- a/infra/aws/lib/api-gateway.ts
+++ b/infra/aws/lib/api-gateway.ts
@@ -62,6 +62,7 @@ interface BackendFunctionProps {
   demoEmailDostip: string | undefined;
   guestAiWeightedMonthlyTokenCap: string | undefined;
   globalMetricsConfig: GlobalMetricsConfig | undefined;
+  memorySize: number;
 }
 
 interface GlobalMetricsConfig {
@@ -176,7 +177,7 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
     handler: "handler",
     runtime: lambda.Runtime.NODEJS_24_X,
     timeout: cdk.Duration.minutes(15),
-    memorySize: 256,
+    memorySize: props.memorySize,
     vpc: props.vpc,
     vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
     securityGroups: [props.lambdaSg],
@@ -306,6 +307,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       snapshotBucket: props.globalMetricsSnapshotBucket,
       snapshotObjectKey: props.globalMetricsSnapshotObjectKey,
     },
+    memorySize: 256,
   });
   const chatWorkerFn = createBackendFunction(scope, {
     constructId: "ChatRunWorkerHandler",
@@ -329,6 +331,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
+    memorySize: 512,
   });
   const chatLiveFn = createBackendFunction(scope, {
     constructId: "ChatLiveHandler",
@@ -352,6 +355,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
+    memorySize: 256,
   });
   const chatLiveFunctionUrl = chatLiveFn.addFunctionUrl({
     authType: lambda.FunctionUrlAuthType.NONE,


### PR DESCRIPTION
## Summary

Raise the detached chat worker Lambda memory from 256 MB to 512 MB while keeping the public backend handler and chat live stream handler at 256 MB.

## Reason

CloudWatch reported Runtime.OutOfMemory for ChatRunWorkerHandler at the previous 256 MB limit. The chat worker has a heavier runtime profile than the request/stream handlers because it runs the OpenAI worker loop and accumulates chat/tool state during a run.

## Validation

- npm ci in infra/aws
- npm run build in infra/aws

No local AWS deploy was run; this should apply through the repository CI/CD deployment flow.