### PR TITLE
Propagate OpenAI safety identifiers

### DIFF
--- a/apps/backend/src/chat/composerSuggestions.test.ts
+++ b/apps/backend/src/chat/composerSuggestions.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type OpenAI from "openai";
+import {
+  generateFollowUpChatComposerSuggestionsWithDependencies,
+  type ChatComposerSuggestionsDependencies,
+} from "./composerSuggestions";
+import { buildOpenAISafetyIdentifier } from "./openai/safetyIdentifier";
+
+test("generateFollowUpChatComposerSuggestions sends the hashed safety identifier to OpenAI", async () => {
+  const capturedRequests: Array<OpenAI.Responses.ResponseCreateParams> = [];
+  const dependencies: ChatComposerSuggestionsDependencies = {
+    getOpenAIClient: () => ({
+      responses: {
+        create: async (request: OpenAI.Responses.ResponseCreateParams): Promise<OpenAI.Responses.Response> => {
+          capturedRequests.push(request);
+          return {
+            output_text: "{\"suggestions\":[\"Review this card\",\"Show an example\"]}",
+          } as OpenAI.Responses.Response;
+        },
+      },
+    } as unknown as OpenAI),
+  };
+
+  const suggestions = await generateFollowUpChatComposerSuggestionsWithDependencies(
+    "user-1",
+    [{ type: "text", text: "What is spaced repetition?" }],
+    [{ type: "text", text: "A scheduling method for durable memory." }],
+    "assistant-item-1",
+    "en-US",
+    dependencies,
+  );
+
+  assert.equal(capturedRequests.length, 1);
+  assert.equal(capturedRequests[0].safety_identifier, buildOpenAISafetyIdentifier("user-1"));
+  assert.equal(Object.hasOwn(capturedRequests[0], "user"), false);
+  assert.deepEqual(
+    suggestions.map((suggestion) => suggestion.text),
+    ["Review this card", "Show an example"],
+  );
+});

--- a/apps/backend/src/chat/composerSuggestions.ts
+++ b/apps/backend/src/chat/composerSuggestions.ts
@@ -6,6 +6,7 @@
 import { z } from "zod";
 import { CHAT_MODEL_ID } from "./config";
 import { getOpenAIClient } from "./openai/client";
+import { buildOpenAISafetyIdentifier } from "./openai/safetyIdentifier";
 import type { ContentPart } from "./types";
 
 export type ChatComposerSuggestionSource = "initial" | "assistant_follow_up";
@@ -22,6 +23,14 @@ export type ChatComposerSuggestion = Readonly<{
   source: ChatComposerSuggestionSource;
   assistantItemId: string | null;
 }>;
+
+export type ChatComposerSuggestionsDependencies = Readonly<{
+  getOpenAIClient: typeof getOpenAIClient;
+}>;
+
+const DEFAULT_CHAT_COMPOSER_SUGGESTIONS_DEPENDENCIES: ChatComposerSuggestionsDependencies = {
+  getOpenAIClient,
+};
 
 const MAX_CHAT_COMPOSER_SUGGESTIONS = 2;
 
@@ -578,10 +587,29 @@ export function parsePersistedChatComposerSuggestions(
  * Generates follow-up suggestions from the latest completed assistant reply.
  */
 export async function generateFollowUpChatComposerSuggestions(
+  userId: string,
   userContent: ReadonlyArray<ContentPart>,
   assistantContent: ReadonlyArray<ContentPart>,
   assistantItemId: string,
   uiLocale: string | null | undefined,
+): Promise<ReadonlyArray<ChatComposerSuggestion>> {
+  return generateFollowUpChatComposerSuggestionsWithDependencies(
+    userId,
+    userContent,
+    assistantContent,
+    assistantItemId,
+    uiLocale,
+    DEFAULT_CHAT_COMPOSER_SUGGESTIONS_DEPENDENCIES,
+  );
+}
+
+export async function generateFollowUpChatComposerSuggestionsWithDependencies(
+  userId: string,
+  userContent: ReadonlyArray<ContentPart>,
+  assistantContent: ReadonlyArray<ContentPart>,
+  assistantItemId: string,
+  uiLocale: string | null | undefined,
+  dependencies: ChatComposerSuggestionsDependencies,
 ): Promise<ReadonlyArray<ChatComposerSuggestion>> {
   const userMessage = extractPlainText(userContent);
   const assistantReply = extractPlainText(assistantContent);
@@ -591,9 +619,10 @@ export async function generateFollowUpChatComposerSuggestions(
 
   const normalizedUiLocale = normalizeChatComposerSuggestionsUiLocale(uiLocale);
 
-  const response = await getOpenAIClient().responses.create({
+  const response = await dependencies.getOpenAIClient().responses.create({
     model: CHAT_MODEL_ID,
     store: false,
+    safety_identifier: buildOpenAISafetyIdentifier(userId),
     input: [{
       type: "message",
       role: "system",

--- a/apps/backend/src/chat/openai/loop.test.ts
+++ b/apps/backend/src/chat/openai/loop.test.ts
@@ -7,8 +7,12 @@ import {
   type OpenAILoopEventSink,
   type StartOpenAILoopParams,
 } from "./loop";
+import { buildOpenAISafetyIdentifier } from "./safetyIdentifier";
 
 type OpenAILoopDependencies = Parameters<typeof startOpenAILoopWithDeps>[2];
+type OpenAIResponseStream = AsyncIterable<OpenAI.Responses.ResponseStreamEvent> & Readonly<{
+  finalResponse: () => Promise<OpenAI.Responses.Response>;
+}>;
 
 function createParams(
   overrides: Partial<StartOpenAILoopParams> = {},
@@ -142,16 +146,14 @@ function createResponseStream(
 }
 
 function createDependencies(
-  streamFactory: () => AsyncIterable<OpenAI.Responses.ResponseStreamEvent> & Readonly<{
-    finalResponse: () => Promise<OpenAI.Responses.Response>;
-  }>,
+  streamFactory: (request: OpenAI.Responses.ResponseCreateParams) => OpenAIResponseStream,
   runOneToolCall: OpenAILoopDependencies["runOneToolCall"],
 ): OpenAILoopDependencies {
   return {
     buildChatCompletionInput: async () => [],
     getObservedOpenAIClient: () => ({
       responses: {
-        stream: () => streamFactory(),
+        stream: (request: OpenAI.Responses.ResponseCreateParams) => streamFactory(request),
       },
     } as unknown as OpenAI),
     runOneToolCall,
@@ -171,6 +173,30 @@ function collectEvents(): Readonly<{
     events,
   };
 }
+
+test("startOpenAILoopWithDeps sends a hashed safety identifier on the initial model request", async () => {
+  const requests: Array<OpenAI.Responses.ResponseCreateParams> = [];
+  const messageItem = createAssistantMessageItem("done");
+
+  await startOpenAILoopWithDeps(
+    createParams(),
+    async (): Promise<void> => undefined,
+    createDependencies(
+      (request) => {
+        requests.push(request);
+        return createResponseStream([], createResponse([messageItem], "done"));
+      },
+      async () => {
+        throw new Error("runOneToolCall should not be called");
+      },
+    ),
+  );
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].safety_identifier, buildOpenAISafetyIdentifier("user-1"));
+  assert.equal(requests[0].prompt_cache_key, "session-1");
+  assert.equal(Object.hasOwn(requests[0], "user"), false);
+});
 
 test("startOpenAILoopWithDeps stops before the next tool call when requested", async () => {
   let stopBeforeNextStep = false;
@@ -333,6 +359,7 @@ test("startOpenAILoopWithDeps reports model phase transitions for the tool-limit
   let streamCallCount = 0;
   let toolCallCount = 0;
   const phases: Array<string> = [];
+  const requests: Array<OpenAI.Responses.ResponseCreateParams> = [];
 
   const result = await startOpenAILoopWithDeps(
     createParams({
@@ -342,7 +369,8 @@ test("startOpenAILoopWithDeps reports model phase transitions for the tool-limit
     }),
     async (): Promise<void> => undefined,
     createDependencies(
-      () => {
+      (request) => {
+        requests.push(request);
         streamCallCount += 1;
         if (streamCallCount <= CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS) {
           return createResponseStream(
@@ -370,6 +398,15 @@ test("startOpenAILoopWithDeps reports model phase transitions for the tool-limit
   assert.equal(result.terminationReason, "completed");
   assert.equal(streamCallCount, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1);
   assert.equal(toolCallCount, CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS);
+  assert.deepEqual(
+    requests.map((request) => request.safety_identifier),
+    Array.from(
+      { length: CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1 },
+      () => buildOpenAISafetyIdentifier("user-1"),
+    ),
+  );
+  assert.equal(requests[1].safety_identifier, buildOpenAISafetyIdentifier("user-1"));
+  assert.equal(requests[CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS].tools?.length, 0);
   assert.equal(
     phases.filter((phase) => phase === "model").length,
     CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS + 1,

--- a/apps/backend/src/chat/openai/loop.ts
+++ b/apps/backend/src/chat/openai/loop.ts
@@ -27,6 +27,7 @@ import {
   OPENAI_CHAT_TOOLS,
   type ExecutedChatToolCall,
 } from "./tools";
+import { buildOpenAISafetyIdentifier } from "./safetyIdentifier";
 import type { ChatStreamEvent, ContentPart } from "../types";
 import {
   CHAT_MODEL_ID,
@@ -77,6 +78,16 @@ type OpenAIResponsesRequest = Readonly<{
     summary: typeof CHAT_MODEL_REASONING_SUMMARY;
   }>;
   prompt_cache_key: string;
+  safety_identifier: string;
+}>;
+
+type BuildOpenAIResponsesRequestParams = Readonly<{
+  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
+  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>;
+  userId: string;
+  sessionId: string;
+  extraInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>;
+  tools: ReadonlyArray<OpenAI.Responses.Tool>;
 }>;
 
 export type StartOpenAILoopParams = Readonly<{
@@ -279,24 +290,19 @@ export function buildPromptCacheKey(sessionId: string): string {
   return sessionId;
 }
 
-function buildOpenAIResponsesRequest(
-  baseInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem>,
-  continuationItems: ReadonlyArray<StoredOpenAIReplayItem>,
-  sessionId: string,
-  extraInput: ReadonlyArray<OpenAI.Responses.ResponseInputItem> = [],
-  tools: ReadonlyArray<OpenAI.Responses.Tool> = OPENAI_CHAT_TOOLS,
-): OpenAIResponsesRequest {
+function buildOpenAIResponsesRequest(params: BuildOpenAIResponsesRequestParams): OpenAIResponsesRequest {
   return {
     model: CHAT_MODEL_ID,
     store: false,
     include: ["reasoning.encrypted_content"],
-    tools: [...tools],
-    input: buildOpenAIInput(baseInput, continuationItems, extraInput),
+    tools: [...params.tools],
+    input: buildOpenAIInput(params.baseInput, params.continuationItems, params.extraInput),
     reasoning: {
       effort: CHAT_MODEL_REASONING_EFFORT,
       summary: CHAT_MODEL_REASONING_SUMMARY,
     },
-    prompt_cache_key: buildPromptCacheKey(sessionId),
+    prompt_cache_key: buildPromptCacheKey(params.sessionId),
+    safety_identifier: buildOpenAISafetyIdentifier(params.userId),
   };
 }
 
@@ -480,13 +486,14 @@ async function completeToolLimitSummaryTurn(
     client,
     params,
     onEvent,
-    buildOpenAIResponsesRequest(
+    buildOpenAIResponsesRequest({
       baseInput,
       continuationItems,
-      params.sessionId,
-      [buildToolLimitSummaryInstruction(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)],
-      [],
-    ),
+      userId: params.userId,
+      sessionId: params.sessionId,
+      extraInput: [buildToolLimitSummaryInstruction(CHAT_RUN_MAX_TOOL_CALL_MODEL_CALLS)],
+      tools: [],
+    }),
     summaryCallIndex,
   );
 
@@ -544,7 +551,14 @@ async function runLoopWithDeps(
       client,
       params,
       onEvent,
-      buildOpenAIResponsesRequest(baseInput, continuationItems, params.sessionId),
+      buildOpenAIResponsesRequest({
+        baseInput,
+        continuationItems,
+        userId: params.userId,
+        sessionId: params.sessionId,
+        extraInput: [],
+        tools: OPENAI_CHAT_TOOLS,
+      }),
       callIndex,
     );
 

--- a/apps/backend/src/chat/openai/safetyIdentifier.test.ts
+++ b/apps/backend/src/chat/openai/safetyIdentifier.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildOpenAISafetyIdentifier } from "./safetyIdentifier";
+
+test("buildOpenAISafetyIdentifier hashes a normal app user id deterministically", () => {
+  const identifier = buildOpenAISafetyIdentifier("user-1");
+
+  assert.equal(identifier, "v1_xsKJ5J6cBbIUWGA4e3O8sY30P7CaHkpKlxPHbIi7VBs");
+  assert.equal(identifier.length <= 64, true);
+});
+
+test("buildOpenAISafetyIdentifier hashes a guest-style uuid deterministically", () => {
+  const identifier = buildOpenAISafetyIdentifier("f47ac10b-58cc-4372-a567-0e02b2c3d479");
+
+  assert.equal(identifier, "v1_j0AMJXYR7V0wwOZgesYQdDB9-iTPcKjpLD6BR9Z9LHA");
+  assert.equal(identifier.length <= 64, true);
+});
+
+test("buildOpenAISafetyIdentifier rejects empty user ids", () => {
+  assert.throws(
+    () => buildOpenAISafetyIdentifier("   "),
+    /OpenAI safety identifier source userId must not be empty/,
+  );
+});

--- a/apps/backend/src/chat/openai/safetyIdentifier.ts
+++ b/apps/backend/src/chat/openai/safetyIdentifier.ts
@@ -1,0 +1,16 @@
+import { createHash } from "node:crypto";
+
+const OPENAI_SAFETY_IDENTIFIER_PREFIX = "v1_";
+
+export function buildOpenAISafetyIdentifier(userId: string): string {
+  const normalizedUserId = userId.trim();
+  if (normalizedUserId === "") {
+    throw new Error("OpenAI safety identifier source userId must not be empty");
+  }
+
+  const digest = createHash("sha256")
+    .update(normalizedUserId, "utf8")
+    .digest("base64url");
+
+  return `${OPENAI_SAFETY_IDENTIFIER_PREFIX}${digest}`;
+}

--- a/apps/backend/src/chat/runtime.ts
+++ b/apps/backend/src/chat/runtime.ts
@@ -393,6 +393,7 @@ async function generateTerminalComposerSuggestions(
 ): Promise<ReadonlyArray<ChatComposerSuggestion>> {
   try {
     return await dependencies.generateFollowUpChatComposerSuggestions(
+      params.userId,
       params.turnInput,
       assistantContent,
       params.assistantItemId,

--- a/apps/backend/src/chat/tests/chat-runtime.test.ts
+++ b/apps/backend/src/chat/tests/chat-runtime.test.ts
@@ -932,6 +932,7 @@ test("runPersistedChatSessionWithDeps exits without failing when the claimed run
 
 test("runPersistedChatSessionWithDeps completes a successful run and persists completion once", async () => {
   let completedPersistCount = 0;
+  let composerSuggestionUserId: string | null = null;
   let composerSuggestionUiLocale: string | null | undefined = undefined;
 
   const logs = await withCapturedLogs(async () => {
@@ -956,11 +957,13 @@ test("runPersistedChatSessionWithDeps completes a successful run and persists co
           };
         },
         generateFollowUpChatComposerSuggestions: async (
+          userId,
           _userContent,
           _assistantContent,
           _assistantItemId,
           uiLocale,
         ) => {
+          composerSuggestionUserId = userId;
           composerSuggestionUiLocale = uiLocale;
           return [];
         },
@@ -979,6 +982,7 @@ test("runPersistedChatSessionWithDeps completes a successful run and persists co
   });
 
   assert.equal(completedPersistCount, 1);
+  assert.equal(composerSuggestionUserId, "user-1");
   assert.equal(composerSuggestionUiLocale, "es-MX");
   assert.equal(findLog(logs, "chat_worker_terminal_state_persisted")?.runStatus, "completed");
 });

--- a/docs/web-localization.md
+++ b/docs/web-localization.md
@@ -66,10 +66,10 @@ When adding a new web locale, inspect all of these places:
 12. [apps/web/src/chat/sessionController/context.tsx](../apps/web/src/chat/sessionController/context.tsx)
 13. [apps/web/src/chat/useChatHistory.ts](../apps/web/src/chat/useChatHistory.ts)
 14. [apps/web/src/chat/chatMessageContent.tsx](../apps/web/src/chat/chatMessageContent.tsx)
-15. [apps/web/src/screens/reviewSpeech.ts](../apps/web/src/screens/reviewSpeech.ts)
-16. [apps/web/src/screens/useReviewCardEditor.ts](../apps/web/src/screens/useReviewCardEditor.ts)
-17. [apps/web/src/screens/ThisDeviceSettingsScreen.tsx](../apps/web/src/screens/ThisDeviceSettingsScreen.tsx)
-18. [apps/web/src/screens/AccessPermissionDetailScreen.tsx](../apps/web/src/screens/AccessPermissionDetailScreen.tsx)
+15. [apps/web/src/screens/review/reviewSpeech.ts](../apps/web/src/screens/review/reviewSpeech.ts)
+16. [apps/web/src/screens/review/useReviewCardEditor.ts](../apps/web/src/screens/review/useReviewCardEditor.ts)
+17. [apps/web/src/screens/settings/ThisDeviceSettingsScreen.tsx](../apps/web/src/screens/settings/ThisDeviceSettingsScreen.tsx)
+18. [apps/web/src/screens/settings/access/AccessPermissionDetailScreen.tsx](../apps/web/src/screens/settings/access/AccessPermissionDetailScreen.tsx)
 19. [apps/web/src/i18n/runtime.test.ts](../apps/web/src/i18n/runtime.test.ts)
 20. [apps/web/src/api.test.ts](../apps/web/src/api.test.ts)
 21. [apps/web/e2e/live-smoke/](../apps/web/e2e/live-smoke/)
@@ -166,7 +166,7 @@ The new locale should still flow through:
 
 ### 6. Update the browser-local language override screen
 
-Review [apps/web/src/screens/ThisDeviceSettingsScreen.tsx](../apps/web/src/screens/ThisDeviceSettingsScreen.tsx) carefully.
+Review [apps/web/src/screens/settings/ThisDeviceSettingsScreen.tsx](../apps/web/src/screens/settings/ThisDeviceSettingsScreen.tsx) carefully.
 
 This is an easy place to miss required work because it does more than render translated labels:
 
@@ -200,10 +200,10 @@ These files are required audit points for a new locale:
 - [apps/web/src/chat/chatMessageContent.tsx](../apps/web/src/chat/chatMessageContent.tsx)
   Tool labels, copy buttons, attachment labels, reasoning/tool-call status text, clipboard failure alerts.
 
-- [apps/web/src/screens/useReviewCardEditor.ts](../apps/web/src/screens/useReviewCardEditor.ts)
+- [apps/web/src/screens/review/useReviewCardEditor.ts](../apps/web/src/screens/review/useReviewCardEditor.ts)
   Delete-confirmation dialog and editor-specific error copy.
 
-- [apps/web/src/screens/AccessPermissionDetailScreen.tsx](../apps/web/src/screens/AccessPermissionDetailScreen.tsx)
+- [apps/web/src/screens/settings/access/AccessPermissionDetailScreen.tsx](../apps/web/src/screens/settings/access/AccessPermissionDetailScreen.tsx)
   Permission-state labels, guidance text, mapped browser media errors, and secure-context/access failures.
 
 The goal is not just to translate the happy path.
@@ -211,7 +211,7 @@ It is to make sure loading, retry, denied-permission, interrupted-run, and dialo
 
 ### 8. Review speech support if the locale should sound correct when spoken
 
-Review [apps/web/src/screens/reviewSpeech.ts](../apps/web/src/screens/reviewSpeech.ts).
+Review [apps/web/src/screens/review/reviewSpeech.ts](../apps/web/src/screens/review/reviewSpeech.ts).
 
 Adding a UI locale does not automatically make speech output feel correct. The current web behavior should follow this rule:
 


### PR DESCRIPTION
## Summary
- add hashed OpenAI Responses safety identifiers for backend chat model calls
- pass the canonical app user id into composer suggestion requests
- update stale web localization docs links after screen moves

## Verification
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend
- subagent review confirmed the docs link finding is resolved