### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.2.0"
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 ksp = "2.3.7"
 coreKtx = "1.18.0"
 splashscreen = "1.2.0"

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -19,7 +19,7 @@
         "@opentelemetry/sdk-node": "^0.214.0",
         "aws-jwt-verify": "^5.1.1",
         "hono": "^4.12.15",
-        "openai": "^6.34.0",
+        "openai": "^6.35.0",
         "pg": "^8.20.0",
         "zod": "^4.3.6"
       },
@@ -3230,9 +3230,9 @@
       "license": "MIT"
     },
     "node_modules/openai": {
-      "version": "6.34.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.34.0.tgz",
-      "integrity": "sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==",
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
+      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "@opentelemetry/sdk-node": "^0.214.0",
     "aws-jwt-verify": "^5.1.1",
     "hono": "^4.12.15",
-    "openai": "^6.34.0",
+    "openai": "^6.35.0",
     "pg": "^8.20.0",
     "zod": "^4.3.6"
   },


### PR DESCRIPTION
## What changed
- bump Android Kotlin plugin version from `2.3.20` to `2.3.21`
- bump backend `openai` from `6.34.0` to `6.35.0`
- refresh the backend lockfile for the `openai` patch update

## Why
These were the two safe dependency drift updates identified in the current audit. Everything else either already matched latest stable or required a larger major-version validation pass.

## Validation
- `npx -y node@24 $(command -v npm) run lint --prefix apps/backend`
- `npx -y node@24 $(command -v npm) run build --prefix apps/backend`
- `cd apps/android && ./gradlew --no-daemon :app:assembleDebug`
