### PR TITLE
Refactor chat panel composer ownership

### DIFF
--- a/apps/web/src/chat/ChatPanel.new-chat.test.tsx
+++ b/apps/web/src/chat/ChatPanel.new-chat.test.tsx
@@ -32,7 +32,6 @@ const {
   setLocalePreference,
   unmountChatPanel,
   clickNewConversation,
-  clickAddAttachment,
   sendMessage,
 } = setupChatPanelTest();
 
@@ -108,14 +107,12 @@ describe("ChatPanel new chat", () => {
     expect(textarea).not.toBeNull();
 
     await setTextareaValue(textarea as HTMLTextAreaElement, "pending draft");
-    await clickAddAttachment();
     await flushAsync();
 
     const draftsBeforeNew = loadChatDraftWorkspaceState("workspace-1");
     const draftSessionIdsBeforeNew = Object.keys(draftsBeforeNew);
     expect(draftSessionIdsBeforeNew).toHaveLength(0);
     expect(textarea?.value).toBe("pending draft");
-    expect(getContainer().textContent).toContain("attached.txt");
 
     await clickNewConversation();
     await flushAsync();
@@ -126,7 +123,6 @@ describe("ChatPanel new chat", () => {
     expect(Object.keys(draftsAfterNew)).toHaveLength(0);
     expect(createNewChatSessionMock.mock.calls[1]?.[0]).toMatch(UUID_PATTERN);
     expect(textarea?.value).toBe("");
-    expect(getContainer().textContent).not.toContain("attached.txt");
   });
 
   it("clears a stale pending post-run sync flag when starting a new conversation", async () => {
@@ -397,6 +393,7 @@ describe("ChatPanel new chat", () => {
 
     expect(createNewChatSessionMock).toHaveBeenCalledWith(
       expect.any(String),
+      "workspace-1",
       "es-MX",
     );
   });
@@ -432,7 +429,7 @@ describe("ChatPanel new chat", () => {
         messages: [],
       },
     }));
-    createNewChatSessionMock.mockImplementation((sessionId: string, uiLocale: string) => {
+    createNewChatSessionMock.mockImplementation((sessionId: string, _workspaceId: string, uiLocale: string) => {
       if (uiLocale === "en") {
         return Promise.resolve({
           ok: true,
@@ -461,7 +458,7 @@ describe("ChatPanel new chat", () => {
 
     expect(createNewChatSessionMock).toHaveBeenCalledTimes(2);
     expect(createNewChatSessionMock.mock.calls[0]?.[0]).toBe(createNewChatSessionMock.mock.calls[1]?.[0]);
-    expect(createNewChatSessionMock.mock.calls[1]?.[1]).toBe("es-MX");
+    expect(createNewChatSessionMock.mock.calls[1]?.[2]).toBe("es-MX");
     expect(getContainer().textContent).not.toContain("Study with spaced repetition");
     expect(secondRequestResolved).toBe(false);
 
@@ -496,7 +493,7 @@ describe("ChatPanel new chat", () => {
         messages: [],
       },
     }));
-    createNewChatSessionMock.mockImplementation((sessionId: string, uiLocale: string) => {
+    createNewChatSessionMock.mockImplementation((sessionId: string, _workspaceId: string, uiLocale: string) => {
       if (uiLocale === "en") {
         return Promise.resolve({
           ok: true,
@@ -551,7 +548,7 @@ describe("ChatPanel new chat", () => {
       chatConfig: ReturnType<typeof createChatSnapshot>["chatConfig"];
     }) => void) | null = null;
 
-    createNewChatSessionMock.mockImplementation((sessionId: string, uiLocale: string) => {
+    createNewChatSessionMock.mockImplementation((sessionId: string, _workspaceId: string, uiLocale: string) => {
       if (uiLocale === "en") {
         if (createNewChatSessionMock.mock.calls.length === 1) {
           return Promise.resolve({
@@ -586,7 +583,7 @@ describe("ChatPanel new chat", () => {
     expect(createNewChatSessionMock).toHaveBeenCalledTimes(3);
     expect(createNewChatSessionMock.mock.calls[1]?.[0]).toBe(freshSessionId);
     expect(createNewChatSessionMock.mock.calls[2]?.[0]).toBe(freshSessionId);
-    expect(createNewChatSessionMock.mock.calls[2]?.[1]).toBe("es-MX");
+    expect(createNewChatSessionMock.mock.calls[2]?.[2]).toBe("es-MX");
 
     resolveSpanishRequest?.({
       ok: true,

--- a/apps/web/src/chat/ChatPanel.post-run-sync.test.tsx
+++ b/apps/web/src/chat/ChatPanel.post-run-sync.test.tsx
@@ -239,12 +239,12 @@ describe("ChatPanel post-run sync", () => {
       runSync: runSyncMock,
       setErrorMessage: vi.fn(),
     }));
-    consumeChatLiveStreamMock.mockImplementation(async ({ onEvent }) => {
+    consumeChatLiveStreamMock.mockImplementation(async ({ onEvent, runId, sessionId }) => {
       onEvent({
         type: "assistant_tool_call",
-        sessionId: "session-1",
-        conversationScopeId: "session-1",
-        runId: "run-1",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId,
         sequenceNumber: 1,
         streamEpoch: "epoch-1",
         cursor: "cursor-1",
@@ -259,9 +259,9 @@ describe("ChatPanel post-run sync", () => {
       });
       onEvent({
         type: "run_terminal",
-        sessionId: "session-1",
-        conversationScopeId: "session-1",
-        runId: "run-1",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId,
         sequenceNumber: 2,
         streamEpoch: "epoch-1",
         cursor: null,
@@ -288,12 +288,12 @@ describe("ChatPanel post-run sync", () => {
       runSync: runSyncMock,
       setErrorMessage: vi.fn(),
     }));
-    consumeChatLiveStreamMock.mockImplementation(async ({ onEvent }) => {
+    consumeChatLiveStreamMock.mockImplementation(async ({ onEvent, runId, sessionId }) => {
       onEvent({
         type: "assistant_tool_call",
-        sessionId: "session-1",
-        conversationScopeId: "session-1",
-        runId: "run-1",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId,
         sequenceNumber: 1,
         streamEpoch: "epoch-1",
         cursor: "cursor-1",
@@ -308,9 +308,9 @@ describe("ChatPanel post-run sync", () => {
       });
       onEvent({
         type: "assistant_message_done",
-        sessionId: "session-1",
-        conversationScopeId: "session-1",
-        runId: "run-1",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId,
         sequenceNumber: 2,
         streamEpoch: "epoch-1",
         cursor: "cursor-2",
@@ -324,9 +324,9 @@ describe("ChatPanel post-run sync", () => {
       });
       onEvent({
         type: "run_terminal",
-        sessionId: "session-1",
-        conversationScopeId: "session-1",
-        runId: "run-1",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId,
         sequenceNumber: 3,
         streamEpoch: "epoch-1",
         cursor: "cursor-3",

--- a/apps/web/src/chat/ChatPanel.send-lifecycle.test.tsx
+++ b/apps/web/src/chat/ChatPanel.send-lifecycle.test.tsx
@@ -20,7 +20,7 @@ import {
   transcribeChatAudioMock,
   useAppDataMock,
 } from "./ChatPanelTestSupport";
-import { getChatComposerCapabilities } from "./ChatPanel";
+import { getChatComposerCapabilities } from "./chatComposerState";
 import {
   createUnverifiedWorkspaceAppDataMock,
   createVerifiedWorkspaceAppDataMock,
@@ -160,7 +160,7 @@ describe("ChatPanel send lifecycle", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-local-fresh");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-local-fresh", "workspace-1");
   });
 
   it("opens a stale warm-start session as a fresh local chat without loading the stale session", async () => {
@@ -238,7 +238,7 @@ describe("ChatPanel send lifecycle", () => {
     await renderChatPanel();
     await flushAsync();
 
-    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-assistant-only");
+    expect(getChatSnapshotMock).toHaveBeenCalledWith("session-assistant-only", "workspace-1");
     expect(createNewChatSessionMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/chat/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel.tsx
@@ -1,209 +1,35 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  type DragEvent,
-  type KeyboardEvent,
-  type MutableRefObject,
-  type ReactElement,
-} from "react";
-import { transcribeChatAudio } from "../api";
+import { useRef, type ReactElement } from "react";
 import { useAppData } from "../appData";
 import { useI18n } from "../i18n";
-import { listOutboxRecords } from "../localDb/outbox";
-import {
-  explainBrowserMediaPermissionError,
-  queryBrowserPermissionState,
-} from "../access/browserAccess";
-import { useChatDraft, type ChatComposerSendPhase } from "./ChatDraftContext";
+import { useChatDraft } from "./ChatDraftContext";
 import { useChatLayout } from "./ChatLayoutContext";
 import {
-  checkFileSize,
-  EXTRA_AGGRESSIVE_IMAGE_COMPRESSION,
   FileAttachment,
   isBinaryPendingAttachment,
-  prepareAttachment,
-  recompressImageAttachment,
-  type PendingAttachment,
 } from "./FileAttachment";
 import { formatCardAttachmentLabel } from "./chatCardParts";
 import {
-  ATTACHMENT_PAYLOAD_LIMIT_BYTES,
-  IMAGE_MEDIA_TYPE_PREFIX,
-  MAX_WIDTH,
-  MIN_WIDTH,
   USER_VISIBLE_ATTACHMENT_LIMIT_MB,
-  buildContentParts,
-  calculateSidebarWidthFromPointer,
-  toRequestBodySizeBytes,
 } from "./chatHelpers";
+import {
+  getCanSendPendingMessage,
+  getCanShowComposerSuggestions,
+  getChatComposerCapabilities,
+  getChatComposerState,
+  hasChatDraftContent,
+} from "./chatComposerState";
 import { renderStoredMessageContent } from "./chatMessageContent";
 import { useChatAutoScroll } from "./useChatAutoScroll";
-import {
-  insertDictationTranscriptIntoDraft,
-  type ChatDraftSelection,
-  type ChatDictationState,
-} from "./chatDictation";
 import { useChatSession } from "./sessionController";
-import type { ChatComposerAction } from "./sessionController/runState";
+import { useChatAttachments } from "./useChatAttachments";
+import { useChatComposerKeyboard } from "./useChatComposerKeyboard";
+import { useChatComposerSend } from "./useChatComposerSend";
+import { useChatDictationCapture } from "./useChatDictationCapture";
+import { useChatSidebarResize } from "./useChatSidebarResize";
 
 type Props = Readonly<{
   mode: "sidebar" | "fullscreen";
 }>;
-
-type ChatComposerState = "idle" | "preparingSend" | "startingRun" | "running" | "stopping";
-type ChatComposerCapabilities = Readonly<{
-  canAttachDraftFiles: boolean;
-  canStartDictation: boolean;
-  isDictationButtonDisabled: boolean;
-  isDraftInputBlocked: boolean;
-}>;
-const MOBILE_CHAT_BREAKPOINT_QUERY = "(max-width: 768px)";
-
-function getChatComposerState(params: Readonly<{
-  composerAction: ChatComposerAction;
-  isAssistantRunActive: boolean;
-  isStopping: boolean;
-  sendPhase: ChatComposerSendPhase;
-}>): ChatComposerState {
-  const {
-    composerAction,
-    isAssistantRunActive,
-    isStopping,
-    sendPhase,
-  } = params;
-
-  if (sendPhase === "preparingSend") {
-    return "preparingSend";
-  }
-
-  if (sendPhase === "startingRun") {
-    return "startingRun";
-  }
-
-  if (isStopping) {
-    return "stopping";
-  }
-
-  if (composerAction === "stop" || isAssistantRunActive) {
-    return "running";
-  }
-
-  return "idle";
-}
-
-export function getChatComposerCapabilities(params: Readonly<{
-  areAttachmentsEnabled: boolean;
-  dictationState: ChatDictationState;
-  isChatActionLocked: boolean;
-  isChatConversationReadyForAttachments: boolean;
-  isDictationEnabled: boolean;
-  isStopping: boolean;
-  sendPhase: ChatComposerSendPhase;
-}>): ChatComposerCapabilities {
-  const {
-    areAttachmentsEnabled,
-    dictationState,
-    isChatActionLocked,
-    isChatConversationReadyForAttachments,
-    isDictationEnabled,
-    isStopping,
-    sendPhase,
-  } = params;
-  const canPrepareDraft = sendPhase === "idle" && !isStopping;
-  const canStartDictation = isDictationEnabled
-    && dictationState === "idle"
-    && canPrepareDraft
-    && !isChatActionLocked;
-
-  return {
-    canAttachDraftFiles: areAttachmentsEnabled
-      && dictationState === "idle"
-      && canPrepareDraft
-      && !isChatActionLocked
-      && isChatConversationReadyForAttachments,
-    canStartDictation,
-    isDictationButtonDisabled: dictationState === "recording" ? false : !canStartDictation,
-    isDraftInputBlocked: dictationState !== "idle" || !canPrepareDraft,
-  };
-}
-
-function matchesMobileChatBreakpoint(): boolean {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-    return false;
-  }
-
-  return window.matchMedia(MOBILE_CHAT_BREAKPOINT_QUERY).matches;
-}
-
-function stopMediaStream(stream: MediaStream | null): void {
-  if (stream === null) {
-    return;
-  }
-
-  for (const track of stream.getTracks()) {
-    track.stop();
-  }
-}
-
-function chooseSupportedRecordingMimeType(): string | null {
-  if (typeof MediaRecorder.isTypeSupported !== "function") {
-    return null;
-  }
-
-  const supportedMimeTypes = [
-    "audio/webm;codecs=opus",
-    "audio/webm",
-    "audio/mp4",
-  ];
-
-  for (const mimeType of supportedMimeTypes) {
-    if (MediaRecorder.isTypeSupported(mimeType)) {
-      return mimeType;
-    }
-  }
-
-  return null;
-}
-
-function cleanupDictationResources(
-  mediaRecorderRef: MutableRefObject<MediaRecorder | null>,
-  mediaStreamRef: MutableRefObject<MediaStream | null>,
-  recordedChunksRef: MutableRefObject<Array<Blob>>,
-): void {
-  stopMediaStream(mediaStreamRef.current);
-  mediaRecorderRef.current = null;
-  mediaStreamRef.current = null;
-  recordedChunksRef.current = [];
-}
-
-function stopMediaRecorder(
-  recorder: MediaRecorder,
-  recordedChunksRef: MutableRefObject<Array<Blob>>,
-): Promise<Blob> {
-  return new Promise((resolve, reject) => {
-    function handleStop(): void {
-      recorder.removeEventListener("error", handleError as EventListener);
-      resolve(new Blob(recordedChunksRef.current, {
-        type: recorder.mimeType === "" ? "audio/webm" : recorder.mimeType,
-      }));
-    }
-
-    function handleError(event: Event): void {
-      recorder.removeEventListener("stop", handleStop);
-      if (event instanceof ErrorEvent && event.error instanceof Error) {
-        reject(event.error);
-        return;
-      }
-
-      reject(new Error("MICROPHONE_RECORDING_FAILED"));
-    }
-
-    recorder.addEventListener("stop", handleStop, { once: true });
-    recorder.addEventListener("error", handleError as EventListener, { once: true });
-    recorder.stop();
-  });
-}
 
 export function ChatPanel(props: Props): ReactElement {
   const { mode } = props;
@@ -220,16 +46,8 @@ export function ChatPanel(props: Props): ReactElement {
     replaceComposerSendPhase: setSendPhase,
   } = useChatDraft();
   const { setIsOpen, chatWidth, setChatWidth } = useChatLayout();
-  const [localWidth, setLocalWidth] = useState<number>(chatWidth);
-  const [isDragging, setIsDragging] = useState<boolean>(false);
-  const [isDragOver, setIsDragOver] = useState<boolean>(false);
-  const [dictationState, setDictationState] = useState<ChatDictationState>("idle");
-  const [isDraftOptimisticallyClearedForSend, setIsDraftOptimisticallyClearedForSend] = useState<boolean>(false);
-  const [isMobileChatLayout, setIsMobileChatLayout] = useState<boolean>(matchesMobileChatBreakpoint);
   const draftInputText = draft.inputText;
   const draftPendingAttachments = draft.pendingAttachments;
-  const inputText = isDraftOptimisticallyClearedForSend ? "" : draftInputText;
-  const pendingAttachments = isDraftOptimisticallyClearedForSend ? [] : draftPendingAttachments;
 
   const activeWorkspaceId = appData.activeWorkspace?.workspaceId ?? null;
   const {
@@ -254,20 +72,6 @@ export function ChatPanel(props: Props): ReactElement {
   const messagesRef = useRef<HTMLDivElement>(null);
   const messagesContentRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const pendingAttachmentsRef = useRef<ReadonlyArray<PendingAttachment>>([]);
-  const dragCounterRef = useRef<number>(0);
-  const dragWidthRef = useRef<number>(chatWidth);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const mediaStreamRef = useRef<MediaStream | null>(null);
-  const recordedChunksRef = useRef<Array<Blob>>([]);
-  const currentSessionIdRef = useRef<string | null>(currentSessionId);
-  const draftSelectionRef = useRef<ChatDraftSelection | null>(null);
-  const pendingTextareaSelectionRef = useRef<ChatDraftSelection | null>(null);
-  const pendingComposerFocusRestoreRef = useRef<boolean>(false);
-  const shouldRestoreTextareaFocusAfterDictationRef = useRef<boolean>(false);
-  const isMountedRef = useRef<boolean>(true);
-  const sendLifecycleRequestSequenceRef = useRef<number>(0);
-  const canAttachDraftFilesRef = useRef<boolean>(false);
 
   const { handleMessagesScroll } = useChatAutoScroll({
     isHydrated: isHistoryLoaded,
@@ -277,563 +81,67 @@ export function ChatPanel(props: Props): ReactElement {
     messagesContentRef,
   });
   const isInitialHistoryLoading = !isHistoryLoaded && messages.length === 0;
-
-  function setPendingAttachmentsState(nextAttachments: ReadonlyArray<PendingAttachment>): void {
-    pendingAttachmentsRef.current = nextAttachments;
-    replacePendingAttachments(nextAttachments);
-  }
-
-  function buildDraftRequestBodyForAttachments(
-    attachments: ReadonlyArray<PendingAttachment>,
-    timezone: string,
-  ): Readonly<{
-    sessionId?: string;
-    content: ReturnType<typeof buildContentParts>;
-    timezone: string;
-  }> | null {
-    const draftContentParts = buildContentParts(draftInputText, attachments);
-    if (draftContentParts.length === 0) {
-      return null;
-    }
-
-    return {
-      sessionId: currentSessionId ?? undefined,
-      content: draftContentParts,
-      timezone,
-    };
-  }
-
-  useEffect(() => {
-    setLocalWidth(chatWidth);
-    dragWidthRef.current = chatWidth;
-  }, [chatWidth]);
-
-  useEffect(() => {
-    pendingAttachmentsRef.current = pendingAttachments;
-  }, [pendingAttachments]);
-
-  useEffect(() => {
-    currentSessionIdRef.current = currentSessionId;
-  }, [currentSessionId]);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
-    }
-
-    const mediaQueryList = window.matchMedia(MOBILE_CHAT_BREAKPOINT_QUERY);
-    const handleChange = (event: MediaQueryListEvent): void => {
-      setIsMobileChatLayout(event.matches);
-    };
-
-    setIsMobileChatLayout(mediaQueryList.matches);
-    mediaQueryList.addEventListener("change", handleChange);
-    return () => mediaQueryList.removeEventListener("change", handleChange);
-  }, []);
-
-  useEffect(() => {
-    if (pendingComposerFocusRestoreRef.current === false || dictationState !== "idle") {
-      return;
-    }
-
-    const textarea = textareaRef.current;
-    if (textarea === null) {
-      return;
-    }
-
-    pendingComposerFocusRestoreRef.current = false;
-    textarea.focus();
+  const attachmentLimitMessage = t("chatPanel.alerts.attachmentLimit", {
+    count: formatNumber(USER_VISIBLE_ATTACHMENT_LIMIT_MB),
   });
-
-  useEffect(() => {
-    if (dictationState !== "idle") {
-      return;
-    }
-
-    textareaRef.current?.focus();
-  }, [dictationState, focusComposerRequestVersion]);
-
-  useEffect(() => {
-    if (dictationState !== "idle") {
-      return;
-    }
-
-    const textarea = textareaRef.current;
-    const pendingSelection = pendingTextareaSelectionRef.current;
-    if (textarea === null || pendingSelection === null) {
-      return;
-    }
-
-    const start = Math.max(0, Math.min(pendingSelection.start, textarea.value.length));
-    const end = Math.max(0, Math.min(pendingSelection.end, textarea.value.length));
-
-    if (shouldRestoreTextareaFocusAfterDictationRef.current) {
-      textarea.focus();
-    }
-
-    textarea.setSelectionRange(start, end);
-    draftSelectionRef.current = { start, end };
-    pendingTextareaSelectionRef.current = null;
-    shouldRestoreTextareaFocusAfterDictationRef.current = false;
-  }, [dictationState, inputText]);
-
-  useEffect(() => {
-    return () => {
-      isMountedRef.current = false;
-      const recorder = mediaRecorderRef.current;
-      if (recorder !== null && recorder.state !== "inactive") {
-        recorder.stop();
-      }
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-    };
-  }, []);
-
-  function updateTrackedDraftSelection(textarea: HTMLTextAreaElement): void {
-    draftSelectionRef.current = {
-      start: textarea.selectionStart,
-      end: textarea.selectionEnd,
-    };
-  }
-
-  function requestComposerFocusRestore(): void {
-    pendingComposerFocusRestoreRef.current = true;
-  }
-
-  function clearComposerForPendingSend(): void {
-    setIsDraftOptimisticallyClearedForSend(true);
-    pendingAttachmentsRef.current = [];
-    draftSelectionRef.current = null;
-    pendingTextareaSelectionRef.current = null;
-  }
-
-  function restoreComposerAfterPendingSend(
-    nextAttachments: ReadonlyArray<PendingAttachment>,
-  ): void {
-    setIsDraftOptimisticallyClearedForSend(false);
-    pendingAttachmentsRef.current = nextAttachments;
-  }
-
-  function finalizeAcceptedSend(
-    sourceSessionId: string | null,
-    resultSessionId: string | null,
-  ): void {
-    clearDraftForSession(sourceSessionId);
-    if (resultSessionId !== null && resultSessionId !== sourceSessionId) {
-      clearDraftForSession(resultSessionId);
-    }
-    pendingAttachmentsRef.current = [];
-    draftSelectionRef.current = null;
-    pendingTextareaSelectionRef.current = null;
-    setIsDraftOptimisticallyClearedForSend(false);
-    requestComposerFocusRestore();
-  }
-
-  function invalidateSendLifecycleRequests(): number {
-    const nextSequence = sendLifecycleRequestSequenceRef.current + 1;
-    sendLifecycleRequestSequenceRef.current = nextSequence;
-    return nextSequence;
-  }
-
-  function isSendLifecycleRequestCurrent(requestSequence: number): boolean {
-    return sendLifecycleRequestSequenceRef.current === requestSequence;
-  }
-
-  useEffect(() => {
-    if (!isDragging) {
-      return;
-    }
-
-    function handleMouseMove(event: MouseEvent): void {
-      const sidebarElement = rootRef.current;
-      if (sidebarElement === null) {
-        return;
-      }
-
-      const sidebarBounds = sidebarElement.getBoundingClientRect();
-      const nextWidth = calculateSidebarWidthFromPointer(
-        event.clientX,
-        sidebarBounds.left,
-        MIN_WIDTH,
-        MAX_WIDTH,
-      );
-
-      dragWidthRef.current = nextWidth;
-      setLocalWidth(nextWidth);
-    }
-
-    function handleMouseUp(): void {
-      setIsDragging(false);
-      setChatWidth(dragWidthRef.current);
-    }
-
-    document.addEventListener("mousemove", handleMouseMove);
-    document.addEventListener("mouseup", handleMouseUp);
-    document.body.style.cursor = "col-resize";
-    document.body.style.userSelect = "none";
-
-    return () => {
-      document.removeEventListener("mousemove", handleMouseMove);
-      document.removeEventListener("mouseup", handleMouseUp);
-      document.body.style.cursor = "";
-      document.body.style.userSelect = "";
-    };
-  }, [isDragging, setChatWidth]);
-
-  async function handleAttach(attachment: PendingAttachment): Promise<void> {
-    if (!canAttachDraftFilesRef.current) {
-      return;
-    }
-
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    let finalAttachment = attachment;
-    let candidateAttachments = [...pendingAttachmentsRef.current, finalAttachment];
-    let projectedRequestBody = buildDraftRequestBodyForAttachments(candidateAttachments, timezone);
-    let projectedSizeBytes = projectedRequestBody === null ? 0 : toRequestBodySizeBytes(projectedRequestBody);
-
-    if (
-      projectedSizeBytes > ATTACHMENT_PAYLOAD_LIMIT_BYTES
-      && isBinaryPendingAttachment(attachment)
-      && attachment.mediaType.startsWith(IMAGE_MEDIA_TYPE_PREFIX)
-    ) {
-      try {
-        finalAttachment = await recompressImageAttachment(
-          attachment,
-          EXTRA_AGGRESSIVE_IMAGE_COMPRESSION,
-        );
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        window.alert(message);
-        return;
-      }
-
-      candidateAttachments = [...pendingAttachmentsRef.current, finalAttachment];
-      projectedRequestBody = buildDraftRequestBodyForAttachments(candidateAttachments, timezone);
-      projectedSizeBytes = projectedRequestBody === null ? 0 : toRequestBodySizeBytes(projectedRequestBody);
-    }
-
-    if (!canAttachDraftFilesRef.current) {
-      return;
-    }
-
-    if (projectedSizeBytes > ATTACHMENT_PAYLOAD_LIMIT_BYTES) {
-      window.alert(t("chatPanel.alerts.attachmentLimit", {
-        count: formatNumber(USER_VISIBLE_ATTACHMENT_LIMIT_MB),
-      }));
-      return;
-    }
-
-    setPendingAttachmentsState(candidateAttachments);
-  }
-
-  function removeAttachment(index: number): void {
-    const currentAttachments = pendingAttachmentsRef.current;
-    setPendingAttachmentsState([
-      ...currentAttachments.slice(0, index),
-      ...currentAttachments.slice(index + 1),
-    ]);
-  }
-
-  function discardDictation(): void {
-    const recorder = mediaRecorderRef.current;
-    if (recorder !== null && recorder.state !== "inactive") {
-      recorder.stop();
-    }
-
-    cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-    draftSelectionRef.current = null;
-    pendingTextareaSelectionRef.current = null;
-    shouldRestoreTextareaFocusAfterDictationRef.current = false;
-    if (isMountedRef.current) {
-      setDictationState("idle");
-    }
-  }
-
-  async function startDictation(): Promise<void> {
-    if (dictationState !== "idle") {
-      return;
-    }
-
-    const textarea = textareaRef.current;
-    const shouldRestoreFocus = textarea !== null && document.activeElement === textarea;
-    shouldRestoreTextareaFocusAfterDictationRef.current = shouldRestoreFocus;
-    draftSelectionRef.current = shouldRestoreFocus && textarea !== null
-      ? {
-        start: textarea.selectionStart,
-        end: textarea.selectionEnd,
-      }
-      : null;
-
-    if (typeof MediaRecorder === "undefined") {
-      window.alert(t("chatPanel.alerts.microphoneUnavailable"));
-      return;
-    }
-
-    const mediaDevices = navigator.mediaDevices;
-    if (mediaDevices === undefined || typeof mediaDevices.getUserMedia !== "function") {
-      window.alert(t("chatPanel.alerts.microphoneUnavailable"));
-      return;
-    }
-
-    setDictationState("requesting_permission");
-
-    let stream: MediaStream | null = null;
-    try {
-      stream = await mediaDevices.getUserMedia({ audio: true, video: false });
-      const recorderMimeType = chooseSupportedRecordingMimeType();
-      const recorder = recorderMimeType === null
-        ? new MediaRecorder(stream)
-        : new MediaRecorder(stream, { mimeType: recorderMimeType });
-      recordedChunksRef.current = [];
-      recorder.addEventListener("dataavailable", (event: BlobEvent) => {
-        if (event.data.size > 0) {
-          recordedChunksRef.current.push(event.data);
-        }
-      });
-      recorder.start();
-      mediaRecorderRef.current = recorder;
-      mediaStreamRef.current = stream;
-      if (isMountedRef.current) {
-        setDictationState("recording");
-      }
-    } catch (error) {
-      stopMediaStream(stream);
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-      const permissionState = await queryBrowserPermissionState("microphone");
-      if (isMountedRef.current) {
-        window.alert(explainBrowserMediaPermissionError("microphone", error, permissionState, t));
-        setDictationState("idle");
-      }
-    }
-  }
-
-  async function stopDictation(): Promise<void> {
-    const recorder = mediaRecorderRef.current;
-    if (recorder === null || recorder.state === "inactive") {
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-      setDictationState("idle");
-      return;
-    }
-
-    setDictationState("transcribing");
-
-    try {
-      const audioBlob = await stopMediaRecorder(recorder, recordedChunksRef);
-      stopMediaStream(mediaStreamRef.current);
-      if (audioBlob.size <= 0) {
-        if (isMountedRef.current) {
-          setDictationState("idle");
-        }
-        return;
-      }
-
-      if (activeWorkspaceId === null) {
-        throw new Error(t("chatPanel.transientErrors.workspaceRequired"));
-      }
-
-      const sessionId = await ensureRemoteSession();
-      const transcription = await transcribeChatAudio(
-        audioBlob,
-        "web",
-        sessionId,
-        activeWorkspaceId,
-      );
-      if (transcription.sessionId !== sessionId) {
-        throw new Error(t("chatPanel.errors.transcriptionUnexpectedSessionId"));
-      }
-
-      if (currentSessionIdRef.current !== sessionId) {
-        return;
-      }
-
-      if (isMountedRef.current) {
-        updateInputText((currentText) => {
-          const insertionResult = insertDictationTranscriptIntoDraft(
-            currentText,
-            transcription.text,
-            draftSelectionRef.current,
-          );
-          const nextSelection = shouldRestoreTextareaFocusAfterDictationRef.current
-            ? insertionResult.selection
-            : null;
-          draftSelectionRef.current = nextSelection;
-          pendingTextareaSelectionRef.current = nextSelection;
-          return insertionResult.text;
-        });
-      }
-    } catch (error) {
-      if (isMountedRef.current) {
-        const message = error instanceof Error && error.message === "MICROPHONE_RECORDING_FAILED"
-          ? t("chatPanel.alerts.microphoneUnavailable")
-          : error instanceof Error
-            ? error.message
-            : String(error);
-        window.alert(message);
-      }
-    } finally {
-      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
-      if (isMountedRef.current) {
-        setDictationState("idle");
-      }
-    }
-  }
-
-  async function handleMicrophoneClick(): Promise<void> {
-    if (dictationState === "recording") {
-      await stopDictation();
-      return;
-    }
-
-    if (!canStartDictation) {
-      return;
-    }
-
-    await startDictation();
-  }
-
-  async function handleDrop(event: DragEvent<HTMLDivElement>): Promise<void> {
-    event.preventDefault();
-    dragCounterRef.current = 0;
-    setIsDragOver(false);
-
-    if (!canAttachDraftFiles) {
-      return;
-    }
-
-    const files = event.dataTransfer.files;
-    for (let index = 0; index < files.length; index += 1) {
-      const file = files[index];
-      const sizeError = checkFileSize(file);
-      if (sizeError !== null) {
-        window.alert(sizeError);
-        continue;
-      }
-
-      try {
-        await handleAttach(await prepareAttachment(file));
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        window.alert(message);
-      }
-    }
-  }
-
-  async function sendPendingMessage(): Promise<void> {
-    if (dictationState !== "idle" || composerAction !== "send" || sendPhase !== "idle") {
-      return;
-    }
-
-    if (appData.isSessionVerified === false) {
-      appData.setErrorMessage(t("chatPanel.transientErrors.sessionRestoring"));
-      return;
-    }
-
-    if (activeWorkspaceId === null) {
-      appData.setErrorMessage(t("chatPanel.transientErrors.workspaceRequired"));
-      return;
-    }
-
-    const nextText = draftInputText;
-    const nextAttachments = pendingAttachmentsRef.current;
-    const sourceSessionId = currentSessionId;
-    const contentParts = buildContentParts(nextText, nextAttachments);
-    if (contentParts.length === 0) {
-      return;
-    }
-
-    const requestBody = {
-      sessionId: currentSessionId ?? undefined,
-      content: contentParts,
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    };
-    if (toRequestBodySizeBytes(requestBody) > ATTACHMENT_PAYLOAD_LIMIT_BYTES) {
-      window.alert(t("chatPanel.alerts.attachmentLimit", {
-        count: formatNumber(USER_VISIBLE_ATTACHMENT_LIMIT_MB),
-      }));
-      return;
-    }
-
-    const requestSequence = sendLifecycleRequestSequenceRef.current;
-    clearComposerForPendingSend();
-    setSendPhase("preparingSend");
-
-    try {
-      await appData.runSync();
-      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
-        return;
-      }
-
-      const outboxRecords = await listOutboxRecords(activeWorkspaceId);
-      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
-        return;
-      }
-
-      if (outboxRecords.length > 0) {
-        restoreComposerAfterPendingSend(nextAttachments);
-        appData.setErrorMessage(t("chatPanel.transientErrors.pendingSync"));
-        setSendPhase("idle");
-        return;
-      }
-    } catch (error) {
-      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
-        return;
-      }
-
-      restoreComposerAfterPendingSend(nextAttachments);
-      appData.setErrorMessage(error instanceof Error ? error.message : String(error));
-      setSendPhase("idle");
-      return;
-    }
-
-    if (isSendLifecycleRequestCurrent(requestSequence) === false) {
-      return;
-    }
-
-    setSendPhase("startingRun");
-
-    try {
-      const result = await sendChatMessage({
-        clientRequestId: crypto.randomUUID().toLowerCase(),
-        text: nextText,
-        attachments: nextAttachments,
-      });
-      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
-        return;
-      }
-
-      if (result.accepted) {
-        finalizeAcceptedSend(sourceSessionId, result.sessionId);
-      } else {
-        restoreComposerAfterPendingSend(nextAttachments);
-      }
-    } finally {
-      if (isSendLifecycleRequestCurrent(requestSequence)) {
-        setSendPhase("idle");
-      }
-    }
-  }
-
-  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>): void {
-    if (event.key !== "Enter") {
-      return;
-    }
-
-    if (isMobileChatLayout || event.shiftKey || event.repeat) {
-      return;
-    }
-
-    event.preventDefault();
-
-    if (composerAction === "stop") {
-      void stopMessage();
-      return;
-    }
-
-    void sendPendingMessage();
-  }
-
+  const {
+    beginResizeDrag,
+    isDragging,
+    localWidth,
+  } = useChatSidebarResize({
+    chatWidth,
+    rootRef,
+    setChatWidth,
+  });
+  const {
+    clearTrackedDraftSelection,
+    dictationState,
+    discardDictation,
+    handleMicrophoneClick,
+    requestComposerFocusRestore,
+    updateTrackedDraftSelection,
+  } = useChatDictationCapture({
+    activeWorkspaceId,
+    currentSessionId,
+    ensureRemoteSession,
+    focusComposerRequestVersion,
+    inputText: draftInputText,
+    t,
+    textareaRef,
+    updateInputText,
+  });
+  const {
+    finishNewConversationComposerReset,
+    inputText,
+    pendingAttachments,
+    pendingAttachmentsRef,
+    sendPendingMessage,
+    setPendingAttachmentsState,
+    startNewConversationComposerReset,
+  } = useChatComposerSend({
+    activeWorkspaceId,
+    attachmentLimitMessage,
+    clearDraftForSession,
+    clearTrackedDraftSelection,
+    composerAction,
+    currentSessionId,
+    dictationState,
+    draftInputText,
+    draftPendingAttachments,
+    isSessionVerified: appData.isSessionVerified,
+    pendingSyncMessage: t("chatPanel.transientErrors.pendingSync"),
+    replacePendingAttachments,
+    requestComposerFocusRestore,
+    runSync: appData.runSync,
+    sendChatMessage,
+    sendPhase,
+    sessionRestoringMessage: t("chatPanel.transientErrors.sessionRestoring"),
+    setErrorMessage: appData.setErrorMessage,
+    setSendPhase,
+    workspaceRequiredMessage: t("chatPanel.transientErrors.workspaceRequired"),
+  });
   const rootClassName = mode === "sidebar" ? "chat-sidebar" : "chat-sidebar-fullscreen";
   const isDictationVisible = dictationState !== "idle";
-  const isComposerTransientBusy = sendPhase !== "idle";
   const isChatActionLocked = appData.isSessionVerified === false;
   const areAttachmentsEnabled = chatConfig.features.attachmentsEnabled;
   const isDictationEnabled = chatConfig.features.dictationEnabled;
@@ -852,31 +160,55 @@ export function ChatPanel(props: Props): ReactElement {
     isStopping,
     sendPhase,
   });
-  canAttachDraftFilesRef.current = canAttachDraftFiles;
-  const hasDraftContent = inputText.trim().length > 0 || pendingAttachments.length > 0;
+  const {
+    handleAttach,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDrop,
+    isDragOver,
+    removeAttachment,
+  } = useChatAttachments({
+    attachmentLimitMessage,
+    canAttachDraftFiles,
+    currentSessionId,
+    draftInputText,
+    pendingAttachmentsRef,
+    setPendingAttachmentsState,
+  });
+  const { handleKeyDown } = useChatComposerKeyboard({
+    composerAction,
+    sendPendingMessage,
+    stopMessage,
+  });
+  const hasDraftContent = hasChatDraftContent(inputText, pendingAttachments);
   const composerState = getChatComposerState({
     composerAction,
     isAssistantRunActive,
     isStopping,
     sendPhase,
   });
-  const canSendPendingMessage = isHistoryLoaded
-    && composerAction === "send"
-    && sendPhase === "idle"
-    && !isStopping
-    && !isChatActionLocked
-    && dictationState === "idle"
-    && hasDraftContent;
-  const canShowComposerSuggestions = isHistoryLoaded
-    && composerAction === "send"
-    && sendPhase === "idle"
-    && !isAssistantRunActive
-    && !isStopping
-    && !isChatActionLocked
-    && dictationState === "idle"
-    && pendingAttachments.length === 0
-    && inputText.trim().length === 0
-    && composerSuggestions.length > 0;
+  const canSendPendingMessage = getCanSendPendingMessage({
+    composerAction,
+    dictationState,
+    hasDraftContent,
+    isChatActionLocked,
+    isHistoryLoaded,
+    isStopping,
+    sendPhase,
+  });
+  const canShowComposerSuggestions = getCanShowComposerSuggestions({
+    composerAction,
+    composerSuggestionsCount: composerSuggestions.length,
+    dictationState,
+    inputText,
+    isAssistantRunActive,
+    isChatActionLocked,
+    isHistoryLoaded,
+    isStopping,
+    pendingAttachmentCount: pendingAttachments.length,
+    sendPhase,
+  });
   const microphoneAriaLabel = dictationState === "recording" ? t("chatPanel.dictation.stop") : t("chatPanel.dictation.start");
   const dictationStatusLabel = dictationState === "requesting_permission"
     ? t("chatPanel.dictation.waitingForPermission")
@@ -890,37 +222,9 @@ export function ChatPanel(props: Props): ReactElement {
       className={rootClassName}
       data-testid="chat-panel"
       style={mode === "sidebar" ? { width: localWidth } : undefined}
-      onDragEnter={(event) => {
-        event.preventDefault();
-        event.dataTransfer.dropEffect = canAttachDraftFiles ? "copy" : "none";
-        if (!canAttachDraftFiles) {
-          dragCounterRef.current = 0;
-          setIsDragOver(false);
-          return;
-        }
-
-        dragCounterRef.current += 1;
-        if (dragCounterRef.current === 1) {
-          setIsDragOver(true);
-        }
-      }}
-      onDragLeave={(event) => {
-        event.preventDefault();
-        if (!canAttachDraftFiles) {
-          dragCounterRef.current = 0;
-          setIsDragOver(false);
-          return;
-        }
-
-        dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
-        if (dragCounterRef.current === 0) {
-          setIsDragOver(false);
-        }
-      }}
-      onDragOver={(event) => {
-        event.preventDefault();
-        event.dataTransfer.dropEffect = canAttachDraftFiles ? "copy" : "none";
-      }}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
       onDrop={(event) => void handleDrop(event)}
     >
       {isDragOver && canAttachDraftFiles ? <div className="chat-drop-overlay">{t("chatPanel.dropFiles")}</div> : null}
@@ -929,8 +233,7 @@ export function ChatPanel(props: Props): ReactElement {
           className={`chat-resize-handle${isDragging ? " dragging" : ""}`}
           onMouseDown={(event) => {
             event.preventDefault();
-            dragWidthRef.current = localWidth;
-            setIsDragging(true);
+            beginResizeDrag();
           }}
         />
       ) : null}
@@ -945,21 +248,10 @@ export function ChatPanel(props: Props): ReactElement {
             type="button"
             className="chat-close-btn"
             onClick={() => {
-              invalidateSendLifecycleRequests();
-              setIsDraftOptimisticallyClearedForSend(false);
-              setSendPhase("idle");
+              startNewConversationComposerReset(currentSessionId);
               discardDictation();
-              if (currentSessionId === null) {
-                clearDraftForSession(null);
-              }
               void clearConversation()
-                .then((nextSessionId) => {
-                  clearDraftForSession(nextSessionId);
-                  pendingAttachmentsRef.current = [];
-                  draftSelectionRef.current = null;
-                  pendingTextareaSelectionRef.current = null;
-                  requestComposerFocusRestore();
-                });
+                .then((nextSessionId) => finishNewConversationComposerReset(nextSessionId));
             }}
             disabled={isStopping || isChatActionLocked}
             data-testid="chat-new-button"
@@ -1128,7 +420,7 @@ export function ChatPanel(props: Props): ReactElement {
               type="button"
               className={`chat-mic-btn${dictationState === "recording" ? " chat-mic-btn-recording" : ""}`}
               aria-label={microphoneAriaLabel}
-              onClick={() => void handleMicrophoneClick()}
+              onClick={() => void handleMicrophoneClick(canStartDictation)}
               disabled={isDictationButtonDisabled}
             >
               {dictationState === "recording" ? (

--- a/apps/web/src/chat/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanelTestSupport.ts
@@ -472,7 +472,11 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
       chatConfig: defaultChatConfig,
       activeRun: createChatActiveRun(),
     }));
-    createNewChatSessionMock.mockImplementation(async (sessionId: string, _uiLocale: Locale) => ({
+    createNewChatSessionMock.mockImplementation(async (
+      sessionId: string,
+      _workspaceId: string,
+      _uiLocale: Locale,
+    ) => ({
       ok: true,
       sessionId,
       composerSuggestions: [],

--- a/apps/web/src/chat/chatComposerState.ts
+++ b/apps/web/src/chat/chatComposerState.ts
@@ -1,0 +1,153 @@
+import type { ChatComposerSendPhase } from "./ChatDraftContext";
+import type { PendingAttachment } from "./FileAttachment";
+import type { ChatDictationState } from "./chatDictation";
+import type { ChatComposerAction } from "./sessionController/runState";
+
+export type ChatComposerState = "idle" | "preparingSend" | "startingRun" | "running" | "stopping";
+
+export type ChatComposerCapabilities = Readonly<{
+  canAttachDraftFiles: boolean;
+  canStartDictation: boolean;
+  isDictationButtonDisabled: boolean;
+  isDraftInputBlocked: boolean;
+}>;
+
+export function getChatComposerState(params: Readonly<{
+  composerAction: ChatComposerAction;
+  isAssistantRunActive: boolean;
+  isStopping: boolean;
+  sendPhase: ChatComposerSendPhase;
+}>): ChatComposerState {
+  const {
+    composerAction,
+    isAssistantRunActive,
+    isStopping,
+    sendPhase,
+  } = params;
+
+  if (sendPhase === "preparingSend") {
+    return "preparingSend";
+  }
+
+  if (sendPhase === "startingRun") {
+    return "startingRun";
+  }
+
+  if (isStopping) {
+    return "stopping";
+  }
+
+  if (composerAction === "stop" || isAssistantRunActive) {
+    return "running";
+  }
+
+  return "idle";
+}
+
+export function getChatComposerCapabilities(params: Readonly<{
+  areAttachmentsEnabled: boolean;
+  dictationState: ChatDictationState;
+  isChatActionLocked: boolean;
+  isChatConversationReadyForAttachments: boolean;
+  isDictationEnabled: boolean;
+  isStopping: boolean;
+  sendPhase: ChatComposerSendPhase;
+}>): ChatComposerCapabilities {
+  const {
+    areAttachmentsEnabled,
+    dictationState,
+    isChatActionLocked,
+    isChatConversationReadyForAttachments,
+    isDictationEnabled,
+    isStopping,
+    sendPhase,
+  } = params;
+  const canPrepareDraft = sendPhase === "idle" && !isStopping;
+  const canStartDictation = isDictationEnabled
+    && dictationState === "idle"
+    && canPrepareDraft
+    && !isChatActionLocked;
+
+  return {
+    canAttachDraftFiles: areAttachmentsEnabled
+      && dictationState === "idle"
+      && canPrepareDraft
+      && !isChatActionLocked
+      && isChatConversationReadyForAttachments,
+    canStartDictation,
+    isDictationButtonDisabled: dictationState === "recording" ? false : !canStartDictation,
+    isDraftInputBlocked: dictationState !== "idle" || !canPrepareDraft,
+  };
+}
+
+export function hasChatDraftContent(
+  inputText: string,
+  pendingAttachments: ReadonlyArray<PendingAttachment>,
+): boolean {
+  return inputText.trim().length > 0 || pendingAttachments.length > 0;
+}
+
+export function getCanSendPendingMessage(params: Readonly<{
+  composerAction: ChatComposerAction;
+  dictationState: ChatDictationState;
+  hasDraftContent: boolean;
+  isChatActionLocked: boolean;
+  isHistoryLoaded: boolean;
+  isStopping: boolean;
+  sendPhase: ChatComposerSendPhase;
+}>): boolean {
+  const {
+    composerAction,
+    dictationState,
+    hasDraftContent,
+    isChatActionLocked,
+    isHistoryLoaded,
+    isStopping,
+    sendPhase,
+  } = params;
+
+  return isHistoryLoaded
+    && composerAction === "send"
+    && sendPhase === "idle"
+    && !isStopping
+    && !isChatActionLocked
+    && dictationState === "idle"
+    && hasDraftContent;
+}
+
+export function getCanShowComposerSuggestions(params: Readonly<{
+  composerAction: ChatComposerAction;
+  composerSuggestionsCount: number;
+  dictationState: ChatDictationState;
+  inputText: string;
+  isAssistantRunActive: boolean;
+  isChatActionLocked: boolean;
+  isHistoryLoaded: boolean;
+  isStopping: boolean;
+  pendingAttachmentCount: number;
+  sendPhase: ChatComposerSendPhase;
+}>): boolean {
+  const {
+    composerAction,
+    composerSuggestionsCount,
+    dictationState,
+    inputText,
+    isAssistantRunActive,
+    isChatActionLocked,
+    isHistoryLoaded,
+    isStopping,
+    pendingAttachmentCount,
+    sendPhase,
+  } = params;
+
+  return isHistoryLoaded
+    && composerAction === "send"
+    && sendPhase === "idle"
+    && !isAssistantRunActive
+    && !isStopping
+    && !isChatActionLocked
+    && dictationState === "idle"
+    && pendingAttachmentCount === 0
+    && inputText.trim().length === 0
+    && composerSuggestionsCount > 0;
+}

--- a/apps/web/src/chat/useChatAttachments.ts
+++ b/apps/web/src/chat/useChatAttachments.ts
@@ -1,0 +1,220 @@
+import { useRef, useState, type DragEvent, type MutableRefObject } from "react";
+import {
+  ATTACHMENT_PAYLOAD_LIMIT_BYTES,
+  IMAGE_MEDIA_TYPE_PREFIX,
+  buildContentParts,
+  toRequestBodySizeBytes,
+} from "./chatHelpers";
+import {
+  EXTRA_AGGRESSIVE_IMAGE_COMPRESSION,
+  checkFileSize,
+  isBinaryPendingAttachment,
+  prepareAttachment,
+  recompressImageAttachment,
+  type PendingAttachment,
+} from "./FileAttachment";
+
+type DraftAttachmentRequestBody = Readonly<{
+  content: ReturnType<typeof buildContentParts>;
+  sessionId?: string;
+  timezone: string;
+}>;
+
+type UseChatAttachmentsParams = Readonly<{
+  attachmentLimitMessage: string;
+  canAttachDraftFiles: boolean;
+  currentSessionId: string | null;
+  draftInputText: string;
+  pendingAttachmentsRef: MutableRefObject<ReadonlyArray<PendingAttachment>>;
+  setPendingAttachmentsState: (nextAttachments: ReadonlyArray<PendingAttachment>) => void;
+}>;
+
+export type ChatAttachmentControls = Readonly<{
+  handleAttach: (attachment: PendingAttachment) => Promise<void>;
+  handleDragEnter: (event: DragEvent<HTMLDivElement>) => void;
+  handleDragLeave: (event: DragEvent<HTMLDivElement>) => void;
+  handleDragOver: (event: DragEvent<HTMLDivElement>) => void;
+  handleDrop: (event: DragEvent<HTMLDivElement>) => Promise<void>;
+  isDragOver: boolean;
+  removeAttachment: (index: number) => void;
+}>;
+
+function buildDraftRequestBodyForAttachments(params: Readonly<{
+  attachments: ReadonlyArray<PendingAttachment>;
+  currentSessionId: string | null;
+  draftInputText: string;
+  timezone: string;
+}>): DraftAttachmentRequestBody | null {
+  const {
+    attachments,
+    currentSessionId,
+    draftInputText,
+    timezone,
+  } = params;
+  const draftContentParts = buildContentParts(draftInputText, attachments);
+  if (draftContentParts.length === 0) {
+    return null;
+  }
+
+  return {
+    sessionId: currentSessionId ?? undefined,
+    content: draftContentParts,
+    timezone,
+  };
+}
+
+function measureDraftRequestBodySize(params: Readonly<{
+  attachments: ReadonlyArray<PendingAttachment>;
+  currentSessionId: string | null;
+  draftInputText: string;
+  timezone: string;
+}>): number {
+  const projectedRequestBody = buildDraftRequestBodyForAttachments(params);
+  return projectedRequestBody === null ? 0 : toRequestBodySizeBytes(projectedRequestBody);
+}
+
+export function useChatAttachments(params: UseChatAttachmentsParams): ChatAttachmentControls {
+  const {
+    attachmentLimitMessage,
+    canAttachDraftFiles,
+    currentSessionId,
+    draftInputText,
+    pendingAttachmentsRef,
+    setPendingAttachmentsState,
+  } = params;
+  const [isDragOver, setIsDragOver] = useState<boolean>(false);
+  const dragCounterRef = useRef<number>(0);
+  const canAttachDraftFilesRef = useRef<boolean>(false);
+  canAttachDraftFilesRef.current = canAttachDraftFiles;
+
+  async function handleAttach(attachment: PendingAttachment): Promise<void> {
+    if (!canAttachDraftFilesRef.current) {
+      return;
+    }
+
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    let finalAttachment = attachment;
+    let candidateAttachments = [...pendingAttachmentsRef.current, finalAttachment];
+    let projectedSizeBytes = measureDraftRequestBodySize({
+      attachments: candidateAttachments,
+      currentSessionId,
+      draftInputText,
+      timezone,
+    });
+
+    if (
+      projectedSizeBytes > ATTACHMENT_PAYLOAD_LIMIT_BYTES
+      && isBinaryPendingAttachment(attachment)
+      && attachment.mediaType.startsWith(IMAGE_MEDIA_TYPE_PREFIX)
+    ) {
+      try {
+        finalAttachment = await recompressImageAttachment(
+          attachment,
+          EXTRA_AGGRESSIVE_IMAGE_COMPRESSION,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        window.alert(message);
+        return;
+      }
+
+      candidateAttachments = [...pendingAttachmentsRef.current, finalAttachment];
+      projectedSizeBytes = measureDraftRequestBodySize({
+        attachments: candidateAttachments,
+        currentSessionId,
+        draftInputText,
+        timezone,
+      });
+    }
+
+    if (!canAttachDraftFilesRef.current) {
+      return;
+    }
+
+    if (projectedSizeBytes > ATTACHMENT_PAYLOAD_LIMIT_BYTES) {
+      window.alert(attachmentLimitMessage);
+      return;
+    }
+
+    setPendingAttachmentsState(candidateAttachments);
+  }
+
+  function removeAttachment(index: number): void {
+    const currentAttachments = pendingAttachmentsRef.current;
+    setPendingAttachmentsState([
+      ...currentAttachments.slice(0, index),
+      ...currentAttachments.slice(index + 1),
+    ]);
+  }
+
+  function handleDragEnter(event: DragEvent<HTMLDivElement>): void {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = canAttachDraftFiles ? "copy" : "none";
+    if (!canAttachDraftFiles) {
+      dragCounterRef.current = 0;
+      setIsDragOver(false);
+      return;
+    }
+
+    dragCounterRef.current += 1;
+    if (dragCounterRef.current === 1) {
+      setIsDragOver(true);
+    }
+  }
+
+  function handleDragLeave(event: DragEvent<HTMLDivElement>): void {
+    event.preventDefault();
+    if (!canAttachDraftFiles) {
+      dragCounterRef.current = 0;
+      setIsDragOver(false);
+      return;
+    }
+
+    dragCounterRef.current = Math.max(0, dragCounterRef.current - 1);
+    if (dragCounterRef.current === 0) {
+      setIsDragOver(false);
+    }
+  }
+
+  function handleDragOver(event: DragEvent<HTMLDivElement>): void {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = canAttachDraftFiles ? "copy" : "none";
+  }
+
+  async function handleDrop(event: DragEvent<HTMLDivElement>): Promise<void> {
+    event.preventDefault();
+    dragCounterRef.current = 0;
+    setIsDragOver(false);
+
+    if (!canAttachDraftFiles) {
+      return;
+    }
+
+    const files = event.dataTransfer.files;
+    for (let index = 0; index < files.length; index += 1) {
+      const file = files[index];
+      const sizeError = checkFileSize(file);
+      if (sizeError !== null) {
+        window.alert(sizeError);
+        continue;
+      }
+
+      try {
+        await handleAttach(await prepareAttachment(file));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        window.alert(message);
+      }
+    }
+  }
+
+  return {
+    handleAttach,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDrop,
+    isDragOver,
+    removeAttachment,
+  };
+}

--- a/apps/web/src/chat/useChatComposerKeyboard.ts
+++ b/apps/web/src/chat/useChatComposerKeyboard.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState, type KeyboardEvent } from "react";
+import type { ChatComposerAction } from "./sessionController/runState";
+
+const MOBILE_CHAT_BREAKPOINT_QUERY = "(max-width: 768px)";
+
+type UseChatComposerKeyboardParams = Readonly<{
+  composerAction: ChatComposerAction;
+  sendPendingMessage: () => Promise<void>;
+  stopMessage: () => Promise<void>;
+}>;
+
+export type ChatComposerKeyboard = Readonly<{
+  handleKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
+  isMobileChatLayout: boolean;
+}>;
+
+function matchesMobileChatBreakpoint(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia(MOBILE_CHAT_BREAKPOINT_QUERY).matches;
+}
+
+export function useChatComposerKeyboard(params: UseChatComposerKeyboardParams): ChatComposerKeyboard {
+  const {
+    composerAction,
+    sendPendingMessage,
+    stopMessage,
+  } = params;
+  const [isMobileChatLayout, setIsMobileChatLayout] = useState<boolean>(matchesMobileChatBreakpoint);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(MOBILE_CHAT_BREAKPOINT_QUERY);
+    const handleChange = (event: MediaQueryListEvent): void => {
+      setIsMobileChatLayout(event.matches);
+    };
+
+    setIsMobileChatLayout(mediaQueryList.matches);
+    mediaQueryList.addEventListener("change", handleChange);
+    return () => mediaQueryList.removeEventListener("change", handleChange);
+  }, []);
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>): void {
+    if (event.key !== "Enter") {
+      return;
+    }
+
+    if (isMobileChatLayout || event.shiftKey || event.repeat) {
+      return;
+    }
+
+    event.preventDefault();
+
+    if (composerAction === "stop") {
+      void stopMessage();
+      return;
+    }
+
+    void sendPendingMessage();
+  }
+
+  return {
+    handleKeyDown,
+    isMobileChatLayout,
+  };
+}

--- a/apps/web/src/chat/useChatComposerSend.ts
+++ b/apps/web/src/chat/useChatComposerSend.ts
@@ -1,0 +1,243 @@
+import { useEffect, useRef, useState, type MutableRefObject } from "react";
+import { listOutboxRecords } from "../localDb/outbox";
+import type { ChatComposerSendPhase } from "./ChatDraftContext";
+import type { PendingAttachment } from "./FileAttachment";
+import {
+  ATTACHMENT_PAYLOAD_LIMIT_BYTES,
+  buildContentParts,
+  toRequestBodySizeBytes,
+} from "./chatHelpers";
+import type { ChatDictationState } from "./chatDictation";
+import type {
+  SendChatMessageParams,
+  SendChatMessageResult,
+} from "./sessionController";
+import type { ChatComposerAction } from "./sessionController/runState";
+
+type UseChatComposerSendParams = Readonly<{
+  activeWorkspaceId: string | null;
+  attachmentLimitMessage: string;
+  clearDraftForSession: (sessionId: string | null) => void;
+  clearTrackedDraftSelection: () => void;
+  composerAction: ChatComposerAction;
+  currentSessionId: string | null;
+  dictationState: ChatDictationState;
+  draftInputText: string;
+  draftPendingAttachments: ReadonlyArray<PendingAttachment>;
+  isSessionVerified: boolean;
+  pendingSyncMessage: string;
+  replacePendingAttachments: (nextPendingAttachments: ReadonlyArray<PendingAttachment>) => void;
+  requestComposerFocusRestore: () => void;
+  runSync: () => Promise<void>;
+  sendChatMessage: (params: SendChatMessageParams) => Promise<SendChatMessageResult>;
+  sendPhase: ChatComposerSendPhase;
+  sessionRestoringMessage: string;
+  setErrorMessage: (message: string) => void;
+  setSendPhase: (nextSendPhase: ChatComposerSendPhase) => void;
+  workspaceRequiredMessage: string;
+}>;
+
+export type ChatComposerSend = Readonly<{
+  finishNewConversationComposerReset: (nextSessionId: string | null) => void;
+  inputText: string;
+  pendingAttachments: ReadonlyArray<PendingAttachment>;
+  pendingAttachmentsRef: MutableRefObject<ReadonlyArray<PendingAttachment>>;
+  sendPendingMessage: () => Promise<void>;
+  setPendingAttachmentsState: (nextAttachments: ReadonlyArray<PendingAttachment>) => void;
+  startNewConversationComposerReset: (sourceSessionId: string | null) => void;
+}>;
+
+export function useChatComposerSend(params: UseChatComposerSendParams): ChatComposerSend {
+  const {
+    activeWorkspaceId,
+    attachmentLimitMessage,
+    clearDraftForSession,
+    clearTrackedDraftSelection,
+    composerAction,
+    currentSessionId,
+    dictationState,
+    draftInputText,
+    draftPendingAttachments,
+    isSessionVerified,
+    pendingSyncMessage,
+    replacePendingAttachments,
+    requestComposerFocusRestore,
+    runSync,
+    sendChatMessage,
+    sendPhase,
+    sessionRestoringMessage,
+    setErrorMessage,
+    setSendPhase,
+    workspaceRequiredMessage,
+  } = params;
+  const [isDraftOptimisticallyClearedForSend, setIsDraftOptimisticallyClearedForSend] = useState<boolean>(false);
+  const sendLifecycleRequestSequenceRef = useRef<number>(0);
+  const pendingAttachmentsRef = useRef<ReadonlyArray<PendingAttachment>>([]);
+  const inputText = isDraftOptimisticallyClearedForSend ? "" : draftInputText;
+  const pendingAttachments = isDraftOptimisticallyClearedForSend ? [] : draftPendingAttachments;
+
+  useEffect(() => {
+    pendingAttachmentsRef.current = pendingAttachments;
+  }, [pendingAttachments]);
+
+  function setPendingAttachmentsState(nextAttachments: ReadonlyArray<PendingAttachment>): void {
+    pendingAttachmentsRef.current = nextAttachments;
+    replacePendingAttachments(nextAttachments);
+  }
+
+  function invalidateSendLifecycleRequests(): number {
+    const nextSequence = sendLifecycleRequestSequenceRef.current + 1;
+    sendLifecycleRequestSequenceRef.current = nextSequence;
+    return nextSequence;
+  }
+
+  function isSendLifecycleRequestCurrent(requestSequence: number): boolean {
+    return sendLifecycleRequestSequenceRef.current === requestSequence;
+  }
+
+  function clearComposerForPendingSend(): void {
+    setIsDraftOptimisticallyClearedForSend(true);
+    pendingAttachmentsRef.current = [];
+    clearTrackedDraftSelection();
+  }
+
+  function restoreComposerAfterPendingSend(
+    nextAttachments: ReadonlyArray<PendingAttachment>,
+  ): void {
+    setIsDraftOptimisticallyClearedForSend(false);
+    pendingAttachmentsRef.current = nextAttachments;
+  }
+
+  function finalizeAcceptedSend(
+    sourceSessionId: string | null,
+    resultSessionId: string | null,
+  ): void {
+    clearDraftForSession(sourceSessionId);
+    if (resultSessionId !== null && resultSessionId !== sourceSessionId) {
+      clearDraftForSession(resultSessionId);
+    }
+    pendingAttachmentsRef.current = [];
+    clearTrackedDraftSelection();
+    setIsDraftOptimisticallyClearedForSend(false);
+    requestComposerFocusRestore();
+  }
+
+  function startNewConversationComposerReset(sourceSessionId: string | null): void {
+    invalidateSendLifecycleRequests();
+    setIsDraftOptimisticallyClearedForSend(false);
+    setSendPhase("idle");
+    if (sourceSessionId === null) {
+      clearDraftForSession(null);
+    }
+  }
+
+  function finishNewConversationComposerReset(nextSessionId: string | null): void {
+    clearDraftForSession(nextSessionId);
+    pendingAttachmentsRef.current = [];
+    clearTrackedDraftSelection();
+    requestComposerFocusRestore();
+  }
+
+  async function sendPendingMessage(): Promise<void> {
+    if (dictationState !== "idle" || composerAction !== "send" || sendPhase !== "idle") {
+      return;
+    }
+
+    if (isSessionVerified === false) {
+      setErrorMessage(sessionRestoringMessage);
+      return;
+    }
+
+    if (activeWorkspaceId === null) {
+      setErrorMessage(workspaceRequiredMessage);
+      return;
+    }
+
+    const nextText = draftInputText;
+    const nextAttachments = pendingAttachmentsRef.current;
+    const sourceSessionId = currentSessionId;
+    const contentParts = buildContentParts(nextText, nextAttachments);
+    if (contentParts.length === 0) {
+      return;
+    }
+
+    const requestBody = {
+      sessionId: currentSessionId ?? undefined,
+      content: contentParts,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+    if (toRequestBodySizeBytes(requestBody) > ATTACHMENT_PAYLOAD_LIMIT_BYTES) {
+      window.alert(attachmentLimitMessage);
+      return;
+    }
+
+    const requestSequence = sendLifecycleRequestSequenceRef.current;
+    clearComposerForPendingSend();
+    setSendPhase("preparingSend");
+
+    try {
+      await runSync();
+      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
+        return;
+      }
+
+      const outboxRecords = await listOutboxRecords(activeWorkspaceId);
+      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
+        return;
+      }
+
+      if (outboxRecords.length > 0) {
+        restoreComposerAfterPendingSend(nextAttachments);
+        setErrorMessage(pendingSyncMessage);
+        setSendPhase("idle");
+        return;
+      }
+    } catch (error) {
+      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
+        return;
+      }
+
+      restoreComposerAfterPendingSend(nextAttachments);
+      setErrorMessage(error instanceof Error ? error.message : String(error));
+      setSendPhase("idle");
+      return;
+    }
+
+    if (isSendLifecycleRequestCurrent(requestSequence) === false) {
+      return;
+    }
+
+    setSendPhase("startingRun");
+
+    try {
+      const result = await sendChatMessage({
+        clientRequestId: crypto.randomUUID().toLowerCase(),
+        text: nextText,
+        attachments: nextAttachments,
+      });
+      if (isSendLifecycleRequestCurrent(requestSequence) === false) {
+        return;
+      }
+
+      if (result.accepted) {
+        finalizeAcceptedSend(sourceSessionId, result.sessionId);
+      } else {
+        restoreComposerAfterPendingSend(nextAttachments);
+      }
+    } finally {
+      if (isSendLifecycleRequestCurrent(requestSequence)) {
+        setSendPhase("idle");
+      }
+    }
+  }
+
+  return {
+    finishNewConversationComposerReset,
+    inputText,
+    pendingAttachments,
+    pendingAttachmentsRef,
+    sendPendingMessage,
+    setPendingAttachmentsState,
+    startNewConversationComposerReset,
+  };
+}

--- a/apps/web/src/chat/useChatDictationCapture.ts
+++ b/apps/web/src/chat/useChatDictationCapture.ts
@@ -1,0 +1,369 @@
+import { useEffect, useRef, useState, type MutableRefObject, type RefObject } from "react";
+import { transcribeChatAudio } from "../api";
+import {
+  explainBrowserMediaPermissionError,
+  queryBrowserPermissionState,
+} from "../access/browserAccess";
+import type { TranslationKey, TranslationValues } from "../i18n";
+import {
+  insertDictationTranscriptIntoDraft,
+  type ChatDictationState,
+  type ChatDraftSelection,
+} from "./chatDictation";
+
+type Translate = (key: TranslationKey, values?: TranslationValues) => string;
+
+type UseChatDictationCaptureParams = Readonly<{
+  activeWorkspaceId: string | null;
+  currentSessionId: string | null;
+  ensureRemoteSession: () => Promise<string>;
+  focusComposerRequestVersion: number;
+  inputText: string;
+  t: Translate;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  updateInputText: (updateDraftText: (currentInputText: string) => string) => void;
+}>;
+
+export type ChatDictationCapture = Readonly<{
+  clearTrackedDraftSelection: () => void;
+  dictationState: ChatDictationState;
+  discardDictation: () => void;
+  handleMicrophoneClick: (canStartDictation: boolean) => Promise<void>;
+  requestComposerFocusRestore: () => void;
+  updateTrackedDraftSelection: (textarea: HTMLTextAreaElement) => void;
+}>;
+
+function stopMediaStream(stream: MediaStream | null): void {
+  if (stream === null) {
+    return;
+  }
+
+  for (const track of stream.getTracks()) {
+    track.stop();
+  }
+}
+
+function chooseSupportedRecordingMimeType(): string | null {
+  if (typeof MediaRecorder.isTypeSupported !== "function") {
+    return null;
+  }
+
+  const supportedMimeTypes = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/mp4",
+  ];
+
+  for (const mimeType of supportedMimeTypes) {
+    if (MediaRecorder.isTypeSupported(mimeType)) {
+      return mimeType;
+    }
+  }
+
+  return null;
+}
+
+function cleanupDictationResources(
+  mediaRecorderRef: MutableRefObject<MediaRecorder | null>,
+  mediaStreamRef: MutableRefObject<MediaStream | null>,
+  recordedChunksRef: MutableRefObject<Array<Blob>>,
+): void {
+  stopMediaStream(mediaStreamRef.current);
+  mediaRecorderRef.current = null;
+  mediaStreamRef.current = null;
+  recordedChunksRef.current = [];
+}
+
+function stopMediaRecorder(
+  recorder: MediaRecorder,
+  recordedChunksRef: MutableRefObject<Array<Blob>>,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    function handleStop(): void {
+      recorder.removeEventListener("error", handleError as EventListener);
+      resolve(new Blob(recordedChunksRef.current, {
+        type: recorder.mimeType === "" ? "audio/webm" : recorder.mimeType,
+      }));
+    }
+
+    function handleError(event: Event): void {
+      recorder.removeEventListener("stop", handleStop);
+      if (event instanceof ErrorEvent && event.error instanceof Error) {
+        reject(event.error);
+        return;
+      }
+
+      reject(new Error("MICROPHONE_RECORDING_FAILED"));
+    }
+
+    recorder.addEventListener("stop", handleStop, { once: true });
+    recorder.addEventListener("error", handleError as EventListener, { once: true });
+    recorder.stop();
+  });
+}
+
+export function useChatDictationCapture(params: UseChatDictationCaptureParams): ChatDictationCapture {
+  const {
+    activeWorkspaceId,
+    currentSessionId,
+    ensureRemoteSession,
+    focusComposerRequestVersion,
+    inputText,
+    t,
+    textareaRef,
+    updateInputText,
+  } = params;
+  const [dictationState, setDictationState] = useState<ChatDictationState>("idle");
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const recordedChunksRef = useRef<Array<Blob>>([]);
+  const currentSessionIdRef = useRef<string | null>(currentSessionId);
+  const draftSelectionRef = useRef<ChatDraftSelection | null>(null);
+  const pendingTextareaSelectionRef = useRef<ChatDraftSelection | null>(null);
+  const pendingComposerFocusRestoreRef = useRef<boolean>(false);
+  const shouldRestoreTextareaFocusAfterDictationRef = useRef<boolean>(false);
+  const isMountedRef = useRef<boolean>(true);
+
+  useEffect(() => {
+    currentSessionIdRef.current = currentSessionId;
+  }, [currentSessionId]);
+
+  useEffect(() => {
+    if (pendingComposerFocusRestoreRef.current === false || dictationState !== "idle") {
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    if (textarea === null) {
+      return;
+    }
+
+    pendingComposerFocusRestoreRef.current = false;
+    textarea.focus();
+  });
+
+  useEffect(() => {
+    if (dictationState !== "idle") {
+      return;
+    }
+
+    textareaRef.current?.focus();
+  }, [dictationState, focusComposerRequestVersion, textareaRef]);
+
+  useEffect(() => {
+    if (dictationState !== "idle") {
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    const pendingSelection = pendingTextareaSelectionRef.current;
+    if (textarea === null || pendingSelection === null) {
+      return;
+    }
+
+    const start = Math.max(0, Math.min(pendingSelection.start, textarea.value.length));
+    const end = Math.max(0, Math.min(pendingSelection.end, textarea.value.length));
+
+    if (shouldRestoreTextareaFocusAfterDictationRef.current) {
+      textarea.focus();
+    }
+
+    textarea.setSelectionRange(start, end);
+    draftSelectionRef.current = { start, end };
+    pendingTextareaSelectionRef.current = null;
+    shouldRestoreTextareaFocusAfterDictationRef.current = false;
+  }, [dictationState, inputText, textareaRef]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      const recorder = mediaRecorderRef.current;
+      if (recorder !== null && recorder.state !== "inactive") {
+        recorder.stop();
+      }
+      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+    };
+  }, []);
+
+  function updateTrackedDraftSelection(textarea: HTMLTextAreaElement): void {
+    draftSelectionRef.current = {
+      start: textarea.selectionStart,
+      end: textarea.selectionEnd,
+    };
+  }
+
+  function clearTrackedDraftSelection(): void {
+    draftSelectionRef.current = null;
+    pendingTextareaSelectionRef.current = null;
+  }
+
+  function requestComposerFocusRestore(): void {
+    pendingComposerFocusRestoreRef.current = true;
+  }
+
+  function discardDictation(): void {
+    const recorder = mediaRecorderRef.current;
+    if (recorder !== null && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+
+    cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+    draftSelectionRef.current = null;
+    pendingTextareaSelectionRef.current = null;
+    shouldRestoreTextareaFocusAfterDictationRef.current = false;
+    if (isMountedRef.current) {
+      setDictationState("idle");
+    }
+  }
+
+  async function startDictation(): Promise<void> {
+    if (dictationState !== "idle") {
+      return;
+    }
+
+    const textarea = textareaRef.current;
+    const shouldRestoreFocus = textarea !== null && document.activeElement === textarea;
+    shouldRestoreTextareaFocusAfterDictationRef.current = shouldRestoreFocus;
+    draftSelectionRef.current = shouldRestoreFocus && textarea !== null
+      ? {
+        start: textarea.selectionStart,
+        end: textarea.selectionEnd,
+      }
+      : null;
+
+    if (typeof MediaRecorder === "undefined") {
+      window.alert(t("chatPanel.alerts.microphoneUnavailable"));
+      return;
+    }
+
+    const mediaDevices = navigator.mediaDevices;
+    if (mediaDevices === undefined || typeof mediaDevices.getUserMedia !== "function") {
+      window.alert(t("chatPanel.alerts.microphoneUnavailable"));
+      return;
+    }
+
+    setDictationState("requesting_permission");
+
+    let stream: MediaStream | null = null;
+    try {
+      stream = await mediaDevices.getUserMedia({ audio: true, video: false });
+      const recorderMimeType = chooseSupportedRecordingMimeType();
+      const recorder = recorderMimeType === null
+        ? new MediaRecorder(stream)
+        : new MediaRecorder(stream, { mimeType: recorderMimeType });
+      recordedChunksRef.current = [];
+      recorder.addEventListener("dataavailable", (event: BlobEvent) => {
+        if (event.data.size > 0) {
+          recordedChunksRef.current.push(event.data);
+        }
+      });
+      recorder.start();
+      mediaRecorderRef.current = recorder;
+      mediaStreamRef.current = stream;
+      if (isMountedRef.current) {
+        setDictationState("recording");
+      }
+    } catch (error) {
+      stopMediaStream(stream);
+      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+      const permissionState = await queryBrowserPermissionState("microphone");
+      if (isMountedRef.current) {
+        window.alert(explainBrowserMediaPermissionError("microphone", error, permissionState, t));
+        setDictationState("idle");
+      }
+    }
+  }
+
+  async function stopDictation(): Promise<void> {
+    const recorder = mediaRecorderRef.current;
+    if (recorder === null || recorder.state === "inactive") {
+      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+      setDictationState("idle");
+      return;
+    }
+
+    setDictationState("transcribing");
+
+    try {
+      const audioBlob = await stopMediaRecorder(recorder, recordedChunksRef);
+      stopMediaStream(mediaStreamRef.current);
+      if (audioBlob.size <= 0) {
+        if (isMountedRef.current) {
+          setDictationState("idle");
+        }
+        return;
+      }
+
+      if (activeWorkspaceId === null) {
+        throw new Error(t("chatPanel.transientErrors.workspaceRequired"));
+      }
+
+      const sessionId = await ensureRemoteSession();
+      const transcription = await transcribeChatAudio(
+        audioBlob,
+        "web",
+        sessionId,
+        activeWorkspaceId,
+      );
+      if (transcription.sessionId !== sessionId) {
+        throw new Error(t("chatPanel.errors.transcriptionUnexpectedSessionId"));
+      }
+
+      if (currentSessionIdRef.current !== sessionId) {
+        return;
+      }
+
+      if (isMountedRef.current) {
+        updateInputText((currentText) => {
+          const insertionResult = insertDictationTranscriptIntoDraft(
+            currentText,
+            transcription.text,
+            draftSelectionRef.current,
+          );
+          const nextSelection = shouldRestoreTextareaFocusAfterDictationRef.current
+            ? insertionResult.selection
+            : null;
+          draftSelectionRef.current = nextSelection;
+          pendingTextareaSelectionRef.current = nextSelection;
+          return insertionResult.text;
+        });
+      }
+    } catch (error) {
+      if (isMountedRef.current) {
+        const message = error instanceof Error && error.message === "MICROPHONE_RECORDING_FAILED"
+          ? t("chatPanel.alerts.microphoneUnavailable")
+          : error instanceof Error
+            ? error.message
+            : String(error);
+        window.alert(message);
+      }
+    } finally {
+      cleanupDictationResources(mediaRecorderRef, mediaStreamRef, recordedChunksRef);
+      if (isMountedRef.current) {
+        setDictationState("idle");
+      }
+    }
+  }
+
+  async function handleMicrophoneClick(canStartDictation: boolean): Promise<void> {
+    if (dictationState === "recording") {
+      await stopDictation();
+      return;
+    }
+
+    if (!canStartDictation) {
+      return;
+    }
+
+    await startDictation();
+  }
+
+  return {
+    clearTrackedDraftSelection,
+    dictationState,
+    discardDictation,
+    handleMicrophoneClick,
+    requestComposerFocusRestore,
+    updateTrackedDraftSelection,
+  };
+}

--- a/apps/web/src/chat/useChatSidebarResize.ts
+++ b/apps/web/src/chat/useChatSidebarResize.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+import {
+  MAX_WIDTH,
+  MIN_WIDTH,
+  calculateSidebarWidthFromPointer,
+} from "./chatHelpers";
+
+type UseChatSidebarResizeParams = Readonly<{
+  chatWidth: number;
+  rootRef: RefObject<HTMLDivElement | null>;
+  setChatWidth: (width: number) => void;
+}>;
+
+export type ChatSidebarResize = Readonly<{
+  beginResizeDrag: () => void;
+  isDragging: boolean;
+  localWidth: number;
+}>;
+
+export function useChatSidebarResize(params: UseChatSidebarResizeParams): ChatSidebarResize {
+  const {
+    chatWidth,
+    rootRef,
+    setChatWidth,
+  } = params;
+  const [localWidth, setLocalWidth] = useState<number>(chatWidth);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const dragWidthRef = useRef<number>(chatWidth);
+
+  useEffect(() => {
+    setLocalWidth(chatWidth);
+    dragWidthRef.current = chatWidth;
+  }, [chatWidth]);
+
+  useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+
+    function handleMouseMove(event: MouseEvent): void {
+      const sidebarElement = rootRef.current;
+      if (sidebarElement === null) {
+        return;
+      }
+
+      const sidebarBounds = sidebarElement.getBoundingClientRect();
+      const nextWidth = calculateSidebarWidthFromPointer(
+        event.clientX,
+        sidebarBounds.left,
+        MIN_WIDTH,
+        MAX_WIDTH,
+      );
+
+      dragWidthRef.current = nextWidth;
+      setLocalWidth(nextWidth);
+    }
+
+    function handleMouseUp(): void {
+      setIsDragging(false);
+      setChatWidth(dragWidthRef.current);
+    }
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isDragging, rootRef, setChatWidth]);
+
+  function beginResizeDrag(): void {
+    dragWidthRef.current = localWidth;
+    setIsDragging(true);
+  }
+
+  return {
+    beginResizeDrag,
+    isDragging,
+    localWidth,
+  };
+}


### PR DESCRIPTION
## Summary

Refactor the web chat composer ownership out of `ChatPanel.tsx` into focused internal hooks/helpers while preserving existing user-visible behavior and session-controller contracts.

## Changes

- Move composer state/capability selectors into `chatComposerState.ts`.
- Extract sidebar resize, attachments, dictation capture, send orchestration, and keyboard handling into dedicated hooks.
- Keep `ChatPanel.tsx` as the composition/rendering shell and preserve existing markup/class names.
- Update focused chat tests and test support imports for the new helper boundary.

## Validation

- `git --no-pager diff --check`
- `npm --prefix apps/web exec vitest run src/chat/ChatPanel.send-lifecycle.test.tsx src/chat/ChatPanel.new-chat.test.tsx src/chat/ChatPanel.post-run-sync.test.tsx`
- `npm --prefix apps/web run build`

Note: the stale `docs/web-localization.md` moved-screen links from the prior review are already present on current `origin/main`, so this branch only contains the chat composer refactor.