### PR TITLE
Move cloud identity android tests

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudGuestSessionCoordinatorTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityResetCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityResetCoordinatorTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestEnvironment.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestEnvironment.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import android.content.Context
 import androidx.room.Room

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestFixtures.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import android.content.Context
 import com.flashcardsopensourceapp.data.local.database.SyncStateEntity

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/FakeCloudRemoteGateway.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositoryCloudIdentityTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositoryCloudIdentityTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import androidx.room.withTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalSyncRepositoryCloudIdentityTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalSyncRepositoryCloudIdentityTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteGateway


### PR DESCRIPTION
## Summary
- move cloud-identity androidTest files into a dedicated cloudidentity package
- keep shared cloud-identity test support colocated with that cluster
- leave root data.local androidTest package for database tests

## Validation
- ./gradlew :data:local:assembleDebugAndroidTest
- subagent code review: approved by two reviewers with no findings