### PR TITLE
Move backend agent modules

### DIFF
--- a/apps/backend/src/agent/apiKeys.ts
+++ b/apps/backend/src/agent/apiKeys.ts
@@ -1,14 +1,14 @@
 import { createHash, timingSafeEqual } from "node:crypto";
-import { queryWithUserScope } from "./db";
-import { unsafeQuery } from "./dbUnsafe";
-import { HttpError } from "./errors";
+import { queryWithUserScope } from "../db";
+import { unsafeQuery } from "../dbUnsafe";
+import { HttpError } from "../errors";
 import {
   decodeOpaqueCursor,
   encodeOpaqueCursor,
   type CursorPageInput,
-} from "./pagination";
-import { normalizeCrockfordToken } from "./crockford";
-import { ensureApiKeyWorkspaceSelection } from "./workspaces";
+} from "../pagination";
+import { normalizeCrockfordToken } from "../crockford";
+import { ensureApiKeyWorkspaceSelection } from "../workspaces";
 
 const AGENT_API_KEY_PREFIX = "fca";
 const AGENT_API_KEY_ID_LENGTH = 8;

--- a/apps/backend/src/agent/discovery.ts
+++ b/apps/backend/src/agent/discovery.ts
@@ -1,4 +1,4 @@
-import { getPublicAgentDocs, getPublicApiBaseUrl } from "./publicUrls";
+import { getPublicAgentDocs, getPublicApiBaseUrl } from "../publicUrls";
 
 type AgentDiscoveryEnvelope = Readonly<{
   ok: true;

--- a/apps/backend/src/agent/envelope.ts
+++ b/apps/backend/src/agent/envelope.ts
@@ -1,5 +1,5 @@
-import type { PublicHttpErrorDetails } from "./errors";
-import { getPublicAgentDocs } from "./publicUrls";
+import type { PublicHttpErrorDetails } from "../errors";
+import { getPublicAgentDocs } from "../publicUrls";
 
 export type AgentDocs = Readonly<{
   openapiUrl: string;

--- a/apps/backend/src/agent/setup.ts
+++ b/apps/backend/src/agent/setup.ts
@@ -1,15 +1,15 @@
-import type { AgentApiKeyConnection } from "./agentApiKeys";
+import type { AgentApiKeyConnection } from "./apiKeys";
 import {
   createAgentEnvelope,
   createAgentErrorEnvelope,
   type AgentEnvelope,
   type AgentErrorEnvelope,
-} from "./agentEnvelope";
-import type { AuthTransport } from "./auth";
-import type { PublicHttpErrorDetails } from "./errors";
-import { getPublicApiBaseUrl } from "./publicUrls";
-import type { RequestContext } from "./server/requestContext";
-import type { WorkspaceSummary } from "./workspaces";
+} from "./envelope";
+import type { AuthTransport } from "../auth";
+import type { PublicHttpErrorDetails } from "../errors";
+import { getPublicApiBaseUrl } from "../publicUrls";
+import type { RequestContext } from "../server/requestContext";
+import type { WorkspaceSummary } from "../workspaces";
 
 type AccountData = Readonly<{
   userId: string;

--- a/apps/backend/src/agent/syncIdentity.ts
+++ b/apps/backend/src/agent/syncIdentity.ts
@@ -1,4 +1,4 @@
-import { ensureSystemWorkspaceReplica } from "./syncIdentity";
+import { ensureSystemWorkspaceReplica } from "../syncIdentity";
 
 /**
  * External AI-agent writes must still emit sync-aware metadata so first-party

--- a/apps/backend/src/aiTools/agentToolOperations.ts
+++ b/apps/backend/src/aiTools/agentToolOperations.ts
@@ -42,7 +42,7 @@ import {
   type UpdateDeckInput,
 } from "../decks";
 import { HttpError } from "../errors";
-import { ensureAgentSyncReplica } from "../agentSyncIdentity";
+import { ensureAgentSyncReplica } from "../agent/syncIdentity";
 import {
   getWorkspaceSchedulerSettings,
   type WorkspaceSchedulerSettings,

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -17,7 +17,7 @@ import { createWorkspaceRoutes } from "./routes/workspaces";
 import {
   createAgentConnectionManagementErrorEnvelope,
   createAgentSetupErrorEnvelope,
-} from "./agentSetup";
+} from "./agent/setup";
 import { getGuestAiWeightedMonthlyTokenCap } from "./guestAiQuotaConfig";
 import { logRequestError } from "./server/logging";
 import { getAllowedOrigins } from "./server/requestContext";

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -8,7 +8,7 @@ import {
   JwtParseError,
   JwtWithoutValidKidError,
 } from "aws-jwt-verify/error";
-import { authenticateAgentApiKey } from "./agentApiKeys";
+import { authenticateAgentApiKey } from "./agent/apiKeys";
 import { getAuthConfig } from "./authConfig";
 import { unsafeQuery } from "./dbUnsafe";
 import { authenticateGuestSession } from "./guestAuth";

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -1,10 +1,10 @@
 import { Hono } from "hono";
-import { createAgentEnvelope } from "../agentEnvelope";
+import { createAgentEnvelope } from "../agent/envelope";
 import {
   createAgentAccountEnvelope,
   createAgentWorkspaceReadyEnvelope,
   createAgentWorkspacesEnvelope,
-} from "../agentSetup";
+} from "../agent/setup";
 import { executeAgentSql } from "../aiTools/agentSql";
 import { loadOpenApiDocument } from "../openapi";
 import { parseOptionalCursorQuery, parseRequiredPageLimit } from "../pagination";

--- a/apps/backend/src/routes/system.ts
+++ b/apps/backend/src/routes/system.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
 import { authenticateRequest } from "../auth";
 import { deleteAccountForAuthenticatedUser } from "../accountDeletion";
-import { createAgentDiscoveryEnvelope } from "../agentDiscovery";
-import { createAgentAccountEnvelope, shouldUseAgentSetupEnvelope } from "../agentSetup";
+import { createAgentDiscoveryEnvelope } from "../agent/discovery";
+import { createAgentAccountEnvelope, shouldUseAgentSetupEnvelope } from "../agent/setup";
 import { HttpError } from "../errors";
 import {
   loadUserProgressSeries,

--- a/apps/backend/src/routes/workspaces.ts
+++ b/apps/backend/src/routes/workspaces.ts
@@ -6,12 +6,12 @@ import {
   createAgentWorkspaceReadyEnvelope,
   createAgentWorkspacesEnvelope,
   shouldUseAgentSetupEnvelope,
-} from "../agentSetup";
+} from "../agent/setup";
 import {
   type AgentApiKeyConnection,
   listAgentApiKeyConnectionsPageForUser,
   revokeAgentApiKeyConnectionForUser,
-} from "../agentApiKeys";
+} from "../agent/apiKeys";
 import { parseOptionalCursorQuery, parseRequiredPageLimit } from "../pagination";
 import {
   createWorkspaceForApiKeyConnection,


### PR DESCRIPTION
## Summary

- move backend machine-agent modules from flat root files into `apps/backend/src/agent/`
- update backend import paths for agent routes, setup envelopes, API key auth, and sync replica wiring
- keep `routes/agent.ts` and `aiTools/agentSql.ts` in their existing adapter/tool locations

## Validation

- `npm run lint --prefix apps/backend`
- `npm test --prefix apps/backend` (139 passing)

## Review

- subagent review verdict: APPROVE, confidence HIGH, no findings
