### PR TITLE
[codex] Fix web smoke workspace delete race

### DIFF
--- a/apps/web/e2e/live-smoke.actions.ts
+++ b/apps/web/e2e/live-smoke.actions.ts
@@ -242,27 +242,47 @@ export async function trackedWaitForDeleteWorkspaceRetryTransition(
 export async function observeDeleteWorkspaceDialogState(
   dialog: Locator,
 ): Promise<DeleteWorkspaceDialogObservation> {
-  const confirmationInput = dialog.locator("#delete-workspace-confirmation");
-  const confirmationPhrase = dialog.locator(".settings-delete-phrase");
-  const retryButton = dialog.locator(".screen-actions .primary-btn").first();
-  const errorBanner = dialog.locator(".error-banner").first();
+  const snapshot = await dialog.evaluate((dialogElement): Omit<DeleteWorkspaceDialogObservation, "state"> => {
+    const isElementVisible = (selector: string): boolean => {
+      const element = dialogElement.querySelector(selector);
+      if (element === null) {
+        return false;
+      }
 
-  const isConfirmationInputVisible = await confirmationInput.isVisible().catch(() => false);
-  const isConfirmationPhraseVisible = await confirmationPhrase.isVisible().catch(() => false);
-  const isRetryVisible = await retryButton.isVisible().catch(() => false);
-  const isLoadingVisible = await errorBanner.isVisible().catch(() => false) === false && isConfirmationInputVisible === false;
+      const style = window.getComputedStyle(element);
+      return style.display !== "none"
+        && style.visibility !== "hidden"
+        && element.getClientRects().length > 0;
+    };
 
-  const state: DeleteWorkspaceDialogState = isConfirmationInputVisible && isConfirmationPhraseVisible
+    const isConfirmationInputVisible = isElementVisible("#delete-workspace-confirmation");
+    const isConfirmationPhraseVisible = isElementVisible(".settings-delete-phrase");
+    const isRetryVisible = isElementVisible(".screen-actions .primary-btn");
+    const isErrorVisible = isElementVisible(".error-banner");
+    const isLoadingVisible = isErrorVisible === false && isConfirmationInputVisible === false;
+
+    return {
+      isLoadingVisible,
+      isRetryVisible,
+      isConfirmationPhraseVisible,
+      isConfirmationInputVisible,
+    };
+  });
+
+  const state: DeleteWorkspaceDialogState = snapshot.isConfirmationInputVisible && snapshot.isConfirmationPhraseVisible
     ? "confirmation"
-    : isRetryVisible && isLoadingVisible === false && isConfirmationInputVisible === false && isConfirmationPhraseVisible === false
+    : snapshot.isRetryVisible
+      && snapshot.isLoadingVisible === false
+      && snapshot.isConfirmationInputVisible === false
+      && snapshot.isConfirmationPhraseVisible === false
       ? "retry"
       : "loading";
 
   return {
     state,
-    isLoadingVisible,
-    isRetryVisible,
-    isConfirmationPhraseVisible,
-    isConfirmationInputVisible,
+    isLoadingVisible: snapshot.isLoadingVisible,
+    isRetryVisible: snapshot.isRetryVisible,
+    isConfirmationPhraseVisible: snapshot.isConfirmationPhraseVisible,
+    isConfirmationInputVisible: snapshot.isConfirmationInputVisible,
   };
 }

--- a/apps/web/e2e/live-smoke/observations/workspace-delete.ts
+++ b/apps/web/e2e/live-smoke/observations/workspace-delete.ts
@@ -2,12 +2,14 @@ import { type Locator, type Page } from "@playwright/test";
 
 import {
   observeDeleteWorkspaceDialogState,
-  trackedClick,
   trackedWaitForDeleteWorkspaceConfirmationState,
   trackedWaitForDeleteWorkspaceRetryTransition,
+  type DeleteWorkspaceDialogObservation,
 } from "../../live-smoke.actions";
 import type { LiveSmokeDiagnostics } from "../../live-smoke.diagnostics";
 import { externalUiTimeoutMs, localUiTimeoutMs } from "../config";
+
+type DeleteWorkspaceRetryActionResult = "confirmation" | "retryClicked";
 
 export async function waitForDeleteWorkspaceConfirmation(
   page: Page,
@@ -26,11 +28,11 @@ export async function waitForDeleteWorkspaceConfirmation(
     return;
   }
 
-  await trackedClick(
-    diagnostics,
-    "retry delete workspace details fetch",
-    dialog.locator(".screen-actions .primary-btn").first(),
-  );
+  const retryActionResult = await retryDeleteWorkspaceDetailsFetch(diagnostics, dialog);
+  if (retryActionResult === "confirmation") {
+    return;
+  }
+
   await trackedWaitForDeleteWorkspaceRetryTransition(
     page,
     diagnostics,
@@ -58,4 +60,46 @@ export async function waitForDeleteWorkspaceConfirmation(
     + `confirmationPhraseVisible=${finalObservation.isConfirmationPhraseVisible}, `
     + `confirmationInputVisible=${finalObservation.isConfirmationInputVisible})`,
   );
+}
+
+async function retryDeleteWorkspaceDetailsFetch(
+  diagnostics: LiveSmokeDiagnostics,
+  dialog: Locator,
+): Promise<DeleteWorkspaceRetryActionResult> {
+  return diagnostics.runAction("retry delete workspace details fetch", async () => {
+    const retryButton = dialog.locator(".screen-actions .primary-btn").first();
+    const observationBeforeClick = await observeDeleteWorkspaceDialogState(dialog);
+
+    if (observationBeforeClick.state === "confirmation") {
+      return "confirmation";
+    }
+
+    if (observationBeforeClick.state !== "retry") {
+      throw new Error(
+        "Delete workspace retry was requested while the dialog was not in retry state "
+        + formatDeleteWorkspaceDialogObservation(observationBeforeClick),
+      );
+    }
+
+    try {
+      await retryButton.click({ timeout: localUiTimeoutMs });
+      return "retryClicked";
+    } catch (error) {
+      const observationAfterFailedClick = await observeDeleteWorkspaceDialogState(dialog);
+      if (observationAfterFailedClick.state === "confirmation") {
+        return "confirmation";
+      }
+
+      throw error;
+    }
+  });
+}
+
+function formatDeleteWorkspaceDialogObservation(
+  observation: DeleteWorkspaceDialogObservation,
+): string {
+  return `(state=${observation.state}, loadingVisible=${observation.isLoadingVisible}, `
+    + `retryVisible=${observation.isRetryVisible}, `
+    + `confirmationPhraseVisible=${observation.isConfirmationPhraseVisible}, `
+    + `confirmationInputVisible=${observation.isConfirmationInputVisible})`;
 }


### PR DESCRIPTION
## Summary

Fixes the Web post-deploy smoke cleanup race where the delete-workspace dialog could transition from retry to confirmation before the smoke helper clicked the retry button.

## Changes

- Observe the delete-workspace dialog state from one atomic DOM snapshot.
- Re-check confirmation state before retry click and after retry click failure so the smoke continues when the confirmation UI is already present.

## Validation

- `npm run build --prefix apps/web`
- `FLASHCARDS_E2E_TARGET=prod npx playwright test`
- `git --no-pager diff --check`
- Two subagent code reviews approved with no findings.