### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -8,10 +8,10 @@
       "name": "flashcards-auth",
       "version": "1.2.2",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1039.0",
+        "@aws-sdk/client-secrets-manager": "^3.1040.0",
         "@hono/node-server": "^1.19.14",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.15",
+        "hono": "^4.12.16",
         "pg": "^8.20.0"
       },
       "devDependencies": {
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1039.0.tgz",
-      "integrity": "sha512-Ew0tUX3tKpzGIMMX+RyRyxR4FHcPTEPMjE9YSemyau3NyNFjlpHQjeTNwFvplLEl/LPCC9A5gk58LcaHtySk7A==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1040.0.tgz",
+      "integrity": "sha512-qszI/6MUy57rSqA2eSN3jbdjU1RFUDkayw7HbSX02jRmP896mSssWM0BC+mwYXuY7d3s1QntxmMKiNwXEXRdWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1864,9 +1864,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -10,10 +10,10 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1039.0",
+    "@aws-sdk/client-secrets-manager": "^3.1040.0",
     "@hono/node-server": "^1.19.14",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.15",
+    "hono": "^4.12.16",
     "pg": "^8.20.0"
   },
   "devDependencies": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -8,17 +8,17 @@
       "name": "flashcards-open-source-app-backend",
       "version": "1.2.2",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.1039.0",
-        "@aws-sdk/client-lambda": "^3.1039.0",
-        "@aws-sdk/client-s3": "^3.1039.0",
-        "@aws-sdk/client-secrets-manager": "^3.1039.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.1040.0",
+        "@aws-sdk/client-lambda": "^3.1040.0",
+        "@aws-sdk/client-s3": "^3.1040.0",
+        "@aws-sdk/client-secrets-manager": "^3.1040.0",
         "@hono/node-server": "^1.19.14",
         "@langfuse/openai": "^5.2.0",
         "@langfuse/otel": "^5.2.0",
         "@langfuse/tracing": "^5.2.0",
         "@opentelemetry/sdk-node": "^0.214.0",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.15",
+        "hono": "^4.12.16",
         "openai": "^6.35.0",
         "pg": "^8.20.0",
         "zod": "^4.4.1"
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1039.0.tgz",
-      "integrity": "sha512-no06PhN+f69tjxnFbpT90Ci8+fJUBGsqDdFo9Cb/oGV4ALGOUc/7vrb/H3okMmrq9IbNOKaGomCIBbH5rsx1eg==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1040.0.tgz",
+      "integrity": "sha512-dRbOFYylraM5dedzc3g9Z4AxNVC2Churiqp1rJmz8O5BK2Le98OZwq1mzsqfqJ8uLOiZ3WYXXV3aTXavub5fag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1039.0.tgz",
-      "integrity": "sha512-G6k9MYrrvINhGhHDNheF9NcJlVQ4vbtyLD6pjsgL+vDwugQB84OR95T7bNI9If5DlOxKrLx9s6BGid1YoWQKYA==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1040.0.tgz",
+      "integrity": "sha512-QEpUqgsKVYZXfNmZs0vREVcxDKVvT1FKYH788s3JkPa6zCmT2wBEgCqqIgKS0QdbFMMTPDYIPkIInmIFu3YWjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1039.0.tgz",
-      "integrity": "sha512-PVH9v0pHYBQnBADSR/m88NgcuJcYqPXfpmkcME66vRF75Y4swwbEVVFbTBFuvxu0YcZiLFXu3lw0FDK00vEa3A==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1040.0.tgz",
+      "integrity": "sha512-Ldfby1xDrlZwNY2NxP9pwdVrf8sqHbGBKP1UkoG/oWcePGlGhjY8iVwy8hRy9f1EQfHVFWIFunwHaPQxhYTnWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1039.0.tgz",
-      "integrity": "sha512-Ew0tUX3tKpzGIMMX+RyRyxR4FHcPTEPMjE9YSemyau3NyNFjlpHQjeTNwFvplLEl/LPCC9A5gk58LcaHtySk7A==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1040.0.tgz",
+      "integrity": "sha512-qszI/6MUy57rSqA2eSN3jbdjU1RFUDkayw7HbSX02jRmP896mSssWM0BC+mwYXuY7d3s1QntxmMKiNwXEXRdWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -3173,9 +3173,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,17 +10,17 @@
     "test": "npm run bundle --prefix ../../api && node --test --import tsx src/*.test.ts src/**/*.test.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.1039.0",
-    "@aws-sdk/client-lambda": "^3.1039.0",
-    "@aws-sdk/client-s3": "^3.1039.0",
-    "@aws-sdk/client-secrets-manager": "^3.1039.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1040.0",
+    "@aws-sdk/client-lambda": "^3.1040.0",
+    "@aws-sdk/client-s3": "^3.1040.0",
+    "@aws-sdk/client-secrets-manager": "^3.1040.0",
     "@hono/node-server": "^1.19.14",
     "@langfuse/openai": "^5.2.0",
     "@langfuse/otel": "^5.2.0",
     "@langfuse/tracing": "^5.2.0",
     "@opentelemetry/sdk-node": "^0.214.0",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.15",
+    "hono": "^4.12.16",
     "openai": "^6.35.0",
     "pg": "^8.20.0",
     "zod": "^4.4.1"

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.2.2",
       "dependencies": {
         "@aws-crypto/client-node": "^4.2.2",
-        "@aws-sdk/client-cloudwatch": "^3.1039.0",
-        "@aws-sdk/client-s3": "^3.1039.0",
-        "aws-cdk-lib": "^2.251.0",
+        "@aws-sdk/client-cloudwatch": "^3.1040.0",
+        "@aws-sdk/client-s3": "^3.1040.0",
+        "aws-cdk-lib": "^2.252.0",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1039.0.tgz",
-      "integrity": "sha512-spU8MUEvoaBweA4NxyfIpwhK1wk8g9mEjiCLEtTjCJWDZZrDv+vQYEsYhc2mUKW4EhZXcOZVxLFs4K6czkqN9Q==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1040.0.tgz",
+      "integrity": "sha512-oB2Dcsu686+Q1kG8XWVN1DAEeylRnLgqU6An0Krje9nxV7cccxRgHpL5TYCaOJf7EaxQEshnqr32u9ERJkf37g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -656,9 +656,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1039.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1039.0.tgz",
-      "integrity": "sha512-PVH9v0pHYBQnBADSR/m88NgcuJcYqPXfpmkcME66vRF75Y4swwbEVVFbTBFuvxu0YcZiLFXu3lw0FDK00vEa3A==",
+      "version": "3.1040.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1040.0.tgz",
+      "integrity": "sha512-Ldfby1xDrlZwNY2NxP9pwdVrf8sqHbGBKP1UkoG/oWcePGlGhjY8iVwy8hRy9f1EQfHVFWIFunwHaPQxhYTnWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -2619,9 +2619,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.251.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.251.0.tgz",
-      "integrity": "sha512-H1Jfz2Oyejn+yG24i+By9fZpYfg+E3h1XnFCF2wnt/MyGOTIePRph7MRGkX73ap10ERSpmd0Ly58OLVykFoSQA==",
+      "version": "2.252.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.252.0.tgz",
+      "integrity": "sha512-bRLyTtJxhVgsx2JrL2B/KYYWf+Rg0s68UgQp+VRZK0h5fXeaPqDVEJGPMr7FiOgrmYwEadjfbxsTsZKNAloAvg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -2678,25 +2678,6 @@
       },
       "peerDependencies": {
         "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -13,9 +13,9 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "^4.2.2",
-    "@aws-sdk/client-cloudwatch": "^3.1039.0",
-    "@aws-sdk/client-s3": "^3.1039.0",
-    "aws-cdk-lib": "^2.251.0",
+    "@aws-sdk/client-cloudwatch": "^3.1040.0",
+    "@aws-sdk/client-s3": "^3.1040.0",
+    "aws-cdk-lib": "^2.252.0",
     "constructs": "^10.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed

Updated the remaining patch-level dependency drift in the auth, backend, and AWS infra workspaces.

- `apps/auth`: `@aws-sdk/client-secrets-manager` `3.1039.0 -> 3.1040.0`, `hono` `4.12.15 -> 4.12.16`
- `apps/backend`: `@aws-sdk/client-cognito-identity-provider`, `@aws-sdk/client-lambda`, `@aws-sdk/client-s3`, `@aws-sdk/client-secrets-manager` `3.1039.0 -> 3.1040.0`, `hono` `4.12.15 -> 4.12.16`
- `infra/aws`: `@aws-sdk/client-cloudwatch` `3.1039.0 -> 3.1040.0`, `@aws-sdk/client-s3` `3.1039.0 -> 3.1040.0`, `aws-cdk-lib` `2.251.0 -> 2.252.0`

## Why

These were the remaining safe patch-level updates from the dependency drift audit. The goal was to align the repo to current stable patch releases without pulling in major or behavior-risking upgrades.

## Impact

Low-risk dependency refresh only. No runtime, API surface, or deployment flow changes were included.

## Validation

- `npx -y node@24 "$(command -v npm)" run build --prefix apps/auth`
- `npx -y node@24 "$(command -v npm)" run test --prefix apps/auth`
- `npx -y node@24 "$(command -v npm)" run lint --prefix api`
- `npx -y node@24 "$(command -v npm)" run lint --prefix apps/backend`
- `npx -y node@24 "$(command -v npm)" run build --prefix apps/backend`
- `npx -y node@24 "$(command -v npm)" run test --prefix apps/backend`
- `npx -y node@24 "$(command -v npm)" run build --prefix infra/aws`
- `npx -y node@24 "$(command -v npm)" run test --prefix infra/aws`
