### PR TITLE
[codex] Group guest auth backend tests

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -7,7 +7,7 @@
     "build": "npm run bundle --prefix ../../api && tsc",
     "start": "node dist/index.js",
     "lint": "tsc --noEmit",
-    "test": "npm run bundle --prefix ../../api && node --test --import tsx src/*.test.ts src/**/*.test.ts"
+    "test": "npm run bundle --prefix ../../api && node scripts/run-tests.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.1040.0",

--- a/apps/backend/scripts/run-tests.mjs
+++ b/apps/backend/scripts/run-tests.mjs
@@ -1,0 +1,68 @@
+import { spawnSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const BACKEND_ROOT = dirname(SCRIPT_DIR);
+const SOURCE_ROOT = join(BACKEND_ROOT, "src");
+
+function listTestFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        return listTestFiles(entryPath);
+      }
+
+      if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+        return [relative(BACKEND_ROOT, entryPath)];
+      }
+
+      return [];
+    });
+}
+
+const testFiles = listTestFiles(SOURCE_ROOT).sort();
+
+if (testFiles.length === 0) {
+  console.error("No backend test files found.", {
+    sourceRoot: SOURCE_ROOT,
+  });
+  process.exit(1);
+}
+
+const testProcess = spawnSync(
+  process.execPath,
+  [
+    "--test",
+    "--import",
+    "tsx",
+    ...testFiles,
+  ],
+  {
+    cwd: BACKEND_ROOT,
+    stdio: "inherit",
+    shell: false,
+  },
+);
+
+if (testProcess.error !== undefined) {
+  console.error("Backend test runner failed to start.", {
+    backendRoot: BACKEND_ROOT,
+    sourceRoot: SOURCE_ROOT,
+    errorMessage: testProcess.error.message,
+  });
+  throw testProcess.error;
+}
+
+if (testProcess.signal !== null) {
+  console.error("Backend test runner terminated by signal.", {
+    backendRoot: BACKEND_ROOT,
+    signal: testProcess.signal,
+  });
+  process.exit(1);
+}
+
+process.exit(testProcess.status ?? 1);

--- a/apps/backend/src/guestAuth.testHarness.ts
+++ b/apps/backend/src/guestAuth.testHarness.ts
@@ -1,1 +1,0 @@
-export * from "./guestAuthTestHarness";

--- a/apps/backend/src/guestAuth/tests/cleanup.test.ts
+++ b/apps/backend/src/guestAuth/tests/cleanup.test.ts
@@ -1,17 +1,17 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { HttpError } from "./errors";
+import { HttpError } from "../../errors";
 import {
   deleteGuestSessionInExecutor,
   prepareGuestUpgradeInExecutor,
-} from "./guestAuth";
-import { cleanupGuestSessionSourceInExecutor } from "./guestAuth/delete";
+} from "../../guestAuth";
+import { cleanupGuestSessionSourceInExecutor } from "../delete";
 import {
   addWorkspaceMembership,
   createGuestUpgradeExecutor,
   createMergeState,
   membershipKey,
-} from "./guestAuth.testHarness";
+} from "../../guestAuthTestHarness";
 
 test("deleteGuestSessionInExecutor revokes and removes guest server state", async () => {
   const guestToken = "guest-token-delete";

--- a/apps/backend/src/guestAuth/tests/merge.test.ts
+++ b/apps/backend/src/guestAuth/tests/merge.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type pg from "pg";
-import type { DatabaseExecutor } from "./db";
-import { HttpError } from "./errors";
-import { completeGuestUpgradeInExecutor } from "./guestAuth";
+import type { DatabaseExecutor } from "../../db";
+import { HttpError } from "../../errors";
+import { completeGuestUpgradeInExecutor } from "../../guestAuth";
 import {
   addWorkspaceMembership,
   createGuestUpgradeExecutor,
@@ -13,7 +13,7 @@ import {
   isGuestUpgradeMergeOnlyExecutorQuery,
   membershipKey,
   type GuestUpgradeExecutorParam,
-} from "./guestAuth.testHarness";
+} from "../../guestAuthTestHarness";
 
 test("completeGuestUpgradeInExecutor reassigns guest installation ownership during merge", async () => {
   const guestToken = "guest-token-1";

--- a/apps/backend/src/guestAuth/tests/mergeConflicts.test.ts
+++ b/apps/backend/src/guestAuth/tests/mergeConflicts.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { DatabaseExecutor } from "./db";
-import { HttpError } from "./errors";
-import { completeGuestUpgradeInExecutor } from "./guestAuth";
+import type { DatabaseExecutor } from "../../db";
+import { HttpError } from "../../errors";
+import { completeGuestUpgradeInExecutor } from "../../guestAuth";
 import {
   addWorkspaceMembership,
   createGuestUpgradeExecutor,
@@ -13,7 +13,7 @@ import {
   createWorkspaceState,
   DROPPED_ENTITIES_SUPPORTED,
   DROPPED_ENTITIES_UNSUPPORTED,
-} from "./guestAuth.testHarness";
+} from "../../guestAuthTestHarness";
 
 test("completeGuestUpgradeInExecutor resolves same-id merge conflicts with LWW cards and idempotent review events", async () => {
   const guestToken = "guest-token-same-id-conflicts";

--- a/apps/backend/src/guestAuth/tests/prepare.test.ts
+++ b/apps/backend/src/guestAuth/tests/prepare.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { prepareGuestUpgradeInExecutor } from "./guestAuth";
+import { prepareGuestUpgradeInExecutor } from "../../guestAuth";
 import {
   createGuestUpgradeExecutor,
   createMergeState,
-} from "./guestAuth.testHarness";
+} from "../../guestAuthTestHarness";
 
 test("prepareGuestUpgradeInExecutor binds a new cognito subject to the guest user and updates email", async () => {
   const guestToken = "guest-token-prepare-bound";

--- a/apps/backend/src/guestAuth/tests/replay.test.ts
+++ b/apps/backend/src/guestAuth/tests/replay.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { HttpError } from "./errors";
-import { completeGuestUpgradeInExecutor } from "./guestAuth";
+import { HttpError } from "../../errors";
+import { completeGuestUpgradeInExecutor } from "../../guestAuth";
 import {
   createGuestUpgradeExecutor,
   createMergeState,
@@ -18,7 +18,7 @@ import {
   type UserSettingsState,
   type WorkspaceMembershipRole,
   type WorkspaceState,
-} from "./guestAuth.testHarness";
+} from "../../guestAuthTestHarness";
 
 test("completeGuestUpgradeInExecutor replays committed history after guest session cleanup", async () => {
   const guestToken = "guest-token-2";

--- a/apps/backend/src/guestAuth/tests/scheduler.test.ts
+++ b/apps/backend/src/guestAuth/tests/scheduler.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { completeGuestUpgradeInExecutor } from "./guestAuth";
+import { completeGuestUpgradeInExecutor } from "../../guestAuth";
 import {
   createGuestUpgradeExecutor,
   createMergeState,
   DROPPED_ENTITIES_UNSUPPORTED,
-} from "./guestAuth.testHarness";
+} from "../../guestAuthTestHarness";
 
 test("completeGuestUpgradeInExecutor applies guest scheduler settings when guest metadata wins", async () => {
   const guestToken = "guest-token-scheduler-win";


### PR DESCRIPTION
## Summary
- move guest-auth backend suites from root `apps/backend/src` into `apps/backend/src/guestAuth/tests`
- remove the root guest-auth test harness shim and import the shared harness directly
- replace shell-expanded backend test globs with a recursive Node test runner

## Why
The guest-auth implementation and harness already live in domain folders, while these tests were the remaining root-level mismatch. Moving them exposed that the old `npm test` glob was shell-dependent and skipped deeper nested tests under `/bin/sh`, so the test runner now discovers `.test.ts` files recursively without relying on shell glob expansion.

## Validation
- `npm --prefix apps/backend run lint`
- `npm --prefix apps/backend test` (214 tests)