### PR TITLE
Harden chat stop with run ids

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteService.kt
@@ -22,6 +22,7 @@ import com.flashcardsopensourceapp.data.local.model.AiChatServerConfig
 import com.flashcardsopensourceapp.data.local.model.AiChatToolCall
 import com.flashcardsopensourceapp.data.local.model.AiChatToolCallStatus
 import com.flashcardsopensourceapp.data.local.model.AiChatStartRunRequest
+import com.flashcardsopensourceapp.data.local.model.AiChatStopRunRequest
 import com.flashcardsopensourceapp.data.local.model.AiToolCallRequest
 import com.flashcardsopensourceapp.data.local.model.AiChatBootstrapResponse
 import com.flashcardsopensourceapp.data.local.model.AiChatLiveEvent
@@ -249,8 +250,7 @@ class AiChatRemoteService(
     suspend fun stopRun(
         apiBaseUrl: String,
         authorizationHeader: String,
-        sessionId: String,
-        workspaceId: String?
+        request: AiChatStopRunRequest
     ): AiChatStopRunResponse = withContext(dispatchers.io) {
         val connection = openConnection(
             apiBaseUrl = apiBaseUrl,
@@ -264,11 +264,7 @@ class AiChatRemoteService(
             connection.doOutput = true
             connection.outputStream.use { outputStream ->
                 outputStream.write(
-                    putOptionalWorkspaceId(
-                        payload = JSONObject()
-                            .put("sessionId", sessionId),
-                        workspaceId = workspaceId
-                    ).toString().toByteArray(StandardCharsets.UTF_8)
+                    encodeStopRunRequest(request = request).toString().toByteArray(StandardCharsets.UTF_8)
                 )
             }
             val responseBody = readResponseBody(connection = connection)
@@ -395,12 +391,35 @@ class AiChatRemoteService(
         )
     }
 
+    private fun encodeStopRunRequest(request: AiChatStopRunRequest): JSONObject {
+        val payload: JSONObject = JSONObject()
+            .put("sessionId", request.sessionId)
+
+        return putOptionalRunId(
+            payload = putOptionalWorkspaceId(
+                payload = payload,
+                workspaceId = request.workspaceId
+            ),
+            runId = request.runId
+        )
+    }
+
     private fun putOptionalWorkspaceId(
         payload: JSONObject,
         workspaceId: String?
     ): JSONObject {
         workspaceId?.takeIf { value -> value.isNotBlank() }?.let { resolvedWorkspaceId ->
             payload.put("workspaceId", resolvedWorkspaceId)
+        }
+        return payload
+    }
+
+    private fun putOptionalRunId(
+        payload: JSONObject,
+        runId: String?
+    ): JSONObject {
+        runId?.takeIf { value -> value.isNotBlank() }?.let { resolvedRunId ->
+            payload.put("runId", resolvedRunId)
         }
         return payload
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/AiChatModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/AiChatModels.kt
@@ -306,6 +306,13 @@ data class AiChatNewSessionRequest(
     val uiLocale: String?,
 )
 
+data class AiChatStopRunRequest(
+    val sessionId: String,
+    val workspaceId: String?,
+    // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+    val runId: String?,
+)
+
 data class AiToolCallRequest(
     val toolCallId: String,
     val name: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/AiRepositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/AiRepositories.kt
@@ -16,6 +16,7 @@ import com.flashcardsopensourceapp.data.local.model.AiChatNewSessionRequest
 import com.flashcardsopensourceapp.data.local.model.AiChatResumeDiagnostics
 import com.flashcardsopensourceapp.data.local.model.AiChatSessionProvisioningResult
 import com.flashcardsopensourceapp.data.local.model.AiChatSessionSnapshot
+import com.flashcardsopensourceapp.data.local.model.AiChatStopRunRequest
 import com.flashcardsopensourceapp.data.local.model.AiChatStopRunResponse
 import com.flashcardsopensourceapp.data.local.model.AiChatStartRunRequest
 import com.flashcardsopensourceapp.data.local.model.AiChatStartRunResponse
@@ -338,14 +339,17 @@ class LocalAiChatRepository(
         }
     }
 
-    override suspend fun stopRun(workspaceId: String?, sessionId: String): AiChatStopRunResponse {
+    override suspend fun stopRun(workspaceId: String?, sessionId: String, runId: String?): AiChatStopRunResponse {
         val remoteWorkspaceId = requireRemoteWorkspaceId(workspaceId = workspaceId)
         val session = authorizedSession(workspaceId = remoteWorkspaceId)
         return aiChatRemoteService.stopRun(
             apiBaseUrl = session.apiBaseUrl,
             authorizationHeader = session.authorizationHeader,
-            sessionId = sessionId,
-            workspaceId = remoteWorkspaceId
+            request = AiChatStopRunRequest(
+                sessionId = sessionId,
+                workspaceId = remoteWorkspaceId,
+                runId = runId
+            )
         )
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -206,5 +206,5 @@ interface AiChatRepository {
         afterCursor: String?,
         resumeDiagnostics: AiChatResumeDiagnostics?
     ): Flow<AiChatLiveEvent>
-    suspend fun stopRun(workspaceId: String?, sessionId: String): AiChatStopRunResponse
+    suspend fun stopRun(workspaceId: String?, sessionId: String, runId: String?): AiChatStopRunResponse
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteWireTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteWireTest.kt
@@ -8,6 +8,7 @@ import com.flashcardsopensourceapp.data.local.model.AiChatNewSessionRequest
 import com.flashcardsopensourceapp.data.local.model.AiChatResumeDiagnostics
 import com.flashcardsopensourceapp.data.local.model.AiChatRunTerminalOutcome
 import com.flashcardsopensourceapp.data.local.model.AiChatStartRunRequest
+import com.flashcardsopensourceapp.data.local.model.AiChatStopRunRequest
 import com.flashcardsopensourceapp.data.local.model.AiChatWireContentPart
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.sun.net.httpserver.HttpServer
@@ -437,7 +438,7 @@ class AiChatRemoteWireTest {
     }
 
     @Test
-    fun stopRunIncludesWorkspaceIdWhenPresent() = runBlocking {
+    fun stopRunIncludesWorkspaceIdAndRunIdWhenPresent() = runBlocking {
         val requestBodyRef = AtomicReference("")
         val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
         server.createContext("/chat/stop") { exchange ->
@@ -459,13 +460,56 @@ class AiChatRemoteWireTest {
             service.stopRun(
                 apiBaseUrl = "http://127.0.0.1:${server.address.port}",
                 authorizationHeader = "Bearer token-1",
-                sessionId = "session-1",
-                workspaceId = testWorkspaceId
+                request = AiChatStopRunRequest(
+                    sessionId = "session-1",
+                    workspaceId = testWorkspaceId,
+                    runId = "run-1"
+                )
             )
 
             val requestBody = JSONObject(requestBodyRef.get())
             assertEquals("session-1", requestBody.getString("sessionId"))
             assertEquals(testWorkspaceId, requestBody.getString("workspaceId"))
+            assertEquals("run-1", requestBody.getString("runId"))
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun stopRunOmitsBlankRunId() = runBlocking {
+        val requestBodyRef = AtomicReference("")
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/chat/stop") { exchange ->
+            requestBodyRef.set(exchange.requestBody.bufferedReader().use { reader -> reader.readText() })
+            val body = """
+                {
+                  "sessionId": "session-1",
+                  "stopped": true,
+                  "stillRunning": false
+                }
+            """.trimIndent().toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { outputStream -> outputStream.write(body) }
+        }
+        server.start()
+
+        try {
+            val service = makeRemoteService()
+            service.stopRun(
+                apiBaseUrl = "http://127.0.0.1:${server.address.port}",
+                authorizationHeader = "Bearer token-1",
+                request = AiChatStopRunRequest(
+                    sessionId = "session-1",
+                    workspaceId = testWorkspaceId,
+                    runId = ""
+                )
+            )
+
+            val requestBody = JSONObject(requestBodyRef.get())
+            assertEquals("session-1", requestBody.getString("sessionId"))
+            assertEquals(testWorkspaceId, requestBody.getString("workspaceId"))
+            assertFalse(requestBody.has("runId"))
         } finally {
             server.stop(0)
         }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatLiveStreamCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatLiveStreamCoordinator.kt
@@ -98,6 +98,24 @@ internal class AiChatLiveStreamCoordinator(
         context.persistCurrentState()
     }
 
+    fun reconcileConversationAfterStopNoop() {
+        context.activeLiveJob?.cancel(
+            cause = CancellationException("AI live attach cancelled because the stop response did not stop the active run.")
+        )
+        context.activeLiveJob = null
+        context.runtimeStateMutable.update { state ->
+            state.copy(
+                activeRun = null,
+                isLiveAttached = false,
+                composerPhase = AiComposerPhase.IDLE,
+                repairStatus = null,
+                errorMessage = ""
+            )
+        }
+        context.persistCurrentState()
+        restartConversationBootstrap(true, null)
+    }
+
     private fun attachLiveStream(
         workspaceId: String?,
         sessionId: String,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSendCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSendCoordinator.kt
@@ -174,12 +174,14 @@ internal class AiChatSendCoordinator(
     }
 
     fun stopStreaming() {
-        if (context.runtimeStateMutable.value.composerPhase != AiComposerPhase.RUNNING) {
+        val currentState: AiChatRuntimeState = context.runtimeStateMutable.value
+        if (currentState.composerPhase != AiComposerPhase.RUNNING) {
             return
         }
 
-        val sessionId = context.runtimeStateMutable.value.persistedState.chatSessionId
-        val workspaceId = context.runtimeStateMutable.value.workspaceId
+        val sessionId: String = currentState.persistedState.chatSessionId
+        val workspaceId: String? = currentState.workspaceId
+        val runId: String? = currentState.activeRun?.runId?.ifBlank { null }
 
         context.runtimeStateMutable.update { state ->
             state.copy(
@@ -196,8 +198,13 @@ internal class AiChatSendCoordinator(
                 if (sessionId.isNotBlank()) {
                     val response = context.aiChatRepository.stopRun(
                         workspaceId = workspaceId,
-                        sessionId = sessionId
+                        sessionId = sessionId,
+                        runId = runId
                     )
+                    if (response.stopped.not()) {
+                        liveStreamCoordinator.reconcileConversationAfterStopNoop()
+                        return@launch
+                    }
                     if (response.stopped && response.stillRunning.not()) {
                         liveStreamCoordinator.finalizeStoppedConversation()
                         return@launch

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeBootstrapAndLiveStreamTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeBootstrapAndLiveStreamTest.kt
@@ -3,9 +3,10 @@ package com.flashcardsopensourceapp.feature.ai.runtime
 import com.flashcardsopensourceapp.data.local.model.AiChatAttachment
 import com.flashcardsopensourceapp.data.local.model.AiChatContentPart
 import com.flashcardsopensourceapp.data.local.model.AiChatLiveEvent
+import com.flashcardsopensourceapp.data.local.model.AiChatRunTerminalOutcome
+import com.flashcardsopensourceapp.data.local.model.AiChatStopRunResponse
 import com.flashcardsopensourceapp.data.local.model.AiChatToolCall
 import com.flashcardsopensourceapp.data.local.model.AiChatToolCallStatus
-import com.flashcardsopensourceapp.data.local.model.AiChatRunTerminalOutcome
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.makeDefaultAiChatPersistedState
 import com.flashcardsopensourceapp.feature.ai.AiEntryPrefill
@@ -280,6 +281,76 @@ class AiChatRuntimeBootstrapAndLiveStreamTest {
 
         assertEquals(listOf("run-1"), repository.attachRunIds)
         assertEquals("run-1", runtime.state.value.activeRun?.runId)
+        assertTrue(runtime.state.value.isLiveAttached)
+
+        runtime.onScreenHidden()
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun stopStreamingSendsActiveRunIdWhenKnown() = runTest {
+        val repository = FakeAiChatRepository()
+        val liveEvents = MutableSharedFlow<AiChatLiveEvent>()
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = makeActiveRun(runId = "run-1", cursor = "5")
+        )
+        repository.liveFlows["run-1"] = liveEvents
+        val runtime = makeRuntime(scope = this, repository = repository)
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
+        assertEquals(AiComposerPhase.RUNNING, runtime.state.value.composerPhase)
+
+        runtime.stopStreaming()
+        advanceUntilIdle()
+
+        assertEquals(listOf(defaultTestWorkspaceId), repository.stopRunWorkspaceIds)
+        assertEquals(listOf("session-1"), repository.stopRunSessionIds)
+        assertEquals(listOf("run-1"), repository.stopRunIds)
+
+        runtime.onScreenHidden()
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun stopStreamingReloadsBootstrapWhenStopRunReturnsNoop() = runTest {
+        val repository = FakeAiChatRepository()
+        val liveEvents = MutableSharedFlow<AiChatLiveEvent>()
+        val replacementLiveEvents = MutableSharedFlow<AiChatLiveEvent>()
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = makeActiveRun(runId = "run-1", cursor = "5")
+        )
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = makeActiveRun(runId = "run-2", cursor = "8")
+        )
+        repository.liveFlows["run-1"] = liveEvents
+        repository.liveFlows["run-2"] = replacementLiveEvents
+        repository.stopRunResponse = AiChatStopRunResponse(
+            sessionId = "session-1",
+            stopped = false,
+            stillRunning = true
+        )
+        val runtime = makeRuntime(scope = this, repository = repository)
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
+        assertEquals(AiComposerPhase.RUNNING, runtime.state.value.composerPhase)
+        assertEquals("run-1", runtime.state.value.activeRun?.runId)
+
+        runtime.stopStreaming()
+        advanceUntilIdle()
+
+        assertEquals(listOf("ensured-session-1", "session-1"), repository.loadBootstrapSessionIds)
+        assertEquals(listOf("run-1", "run-2"), repository.attachRunIds)
+        assertEquals(AiComposerPhase.RUNNING, runtime.state.value.composerPhase)
+        assertEquals("run-2", runtime.state.value.activeRun?.runId)
         assertTrue(runtime.state.value.isLiveAttached)
 
         runtime.onScreenHidden()

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeTestSupport.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeTestSupport.kt
@@ -225,6 +225,9 @@ internal class FakeAiChatRepository : AiChatRepository {
     val ensureSessionRequests: MutableList<String> = mutableListOf()
     val transcribeAudioWorkspaceIds: MutableList<String?> = mutableListOf()
     val transcribeAudioSessionIds: MutableList<String> = mutableListOf()
+    val stopRunWorkspaceIds: MutableList<String?> = mutableListOf()
+    val stopRunSessionIds: MutableList<String> = mutableListOf()
+    val stopRunIds: MutableList<String?> = mutableListOf()
     var nextEnsureSessionId: String = "ensured-session-1"
     var transcribeAudioResponse: AiChatTranscriptionResult = AiChatTranscriptionResult(
         text = "transcribed speech",
@@ -237,6 +240,7 @@ internal class FakeAiChatRepository : AiChatRepository {
     var startRunCalls: Int = 0
     var lastStartRunState: AiChatPersistedState? = null
     var lastStartRunUiLocale: String? = null
+    var stopRunResponse: AiChatStopRunResponse? = null
     var startRunResponse: AiChatStartRunResponse = AiChatAcceptedConversationEnvelope(
         accepted = true,
         sessionId = "session-1",
@@ -443,7 +447,14 @@ internal class FakeAiChatRepository : AiChatRepository {
         return liveFlows[runId] ?: emptyFlow()
     }
 
-    override suspend fun stopRun(workspaceId: String?, sessionId: String): AiChatStopRunResponse {
+    override suspend fun stopRun(workspaceId: String?, sessionId: String, runId: String?): AiChatStopRunResponse {
+        stopRunWorkspaceIds += workspaceId
+        stopRunSessionIds += sessionId
+        stopRunIds += runId
+        val configuredResponse: AiChatStopRunResponse? = stopRunResponse
+        if (configuredResponse != null) {
+            return configuredResponse
+        }
         return AiChatStopRunResponse(
             sessionId = sessionId,
             stopped = true,

--- a/apps/backend/src/chat/runs/finalization.ts
+++ b/apps/backend/src/chat/runs/finalization.ts
@@ -12,8 +12,11 @@ import {
   INTERRUPTED_TOOL_CALL_OUTPUT,
   listChatMessagesWithExecutor,
   updateChatItemWithExecutor,
+  updateChatSessionRunStateForActiveRunWithExecutor,
   updateChatSessionRunStateWithExecutor,
+  type ChatSessionRunState,
 } from "../store";
+import type { ChatComposerSuggestionInvalidationReason } from "../composerSuggestions";
 import { isChatRunHeartbeatStale } from "../workerLease";
 import {
   createChatRunStatusUpdateFromRow,
@@ -28,6 +31,35 @@ function findAssistantItem(
   assistantItemId: string,
 ): PersistedChatMessageItem | null {
   return messages.find((message) => message.itemId === assistantItemId) ?? null;
+}
+
+async function finalizeSessionRunStateForActiveRunWithExecutor(
+  executor: DatabaseExecutor,
+  scope: WorkspaceDatabaseScope,
+  run: ChatRunRow,
+  runState: ChatSessionRunState,
+  invalidationReason: ChatComposerSuggestionInvalidationReason,
+): Promise<void> {
+  const updated = await updateChatSessionRunStateForActiveRunWithExecutor(
+    executor,
+    scope,
+    run.session_id,
+    runState,
+    null,
+    null,
+    run.run_id,
+  );
+
+  if (!updated) {
+    return;
+  }
+
+  await clearActiveChatComposerSuggestionGenerationWithExecutor(
+    executor,
+    scope,
+    run.session_id,
+    invalidationReason,
+  );
 }
 
 export async function finalizeCancelledRunWithExecutor(
@@ -58,18 +90,11 @@ export async function finalizeCancelledRunWithExecutor(
     }),
   );
 
-  await updateChatSessionRunStateWithExecutor(
+  await finalizeSessionRunStateForActiveRunWithExecutor(
     executor,
     scope,
-    run.session_id,
+    run,
     "idle",
-    null,
-    null,
-  );
-  await clearActiveChatComposerSuggestionGenerationWithExecutor(
-    executor,
-    scope,
-    run.session_id,
     "run_cancelled",
   );
 }
@@ -122,18 +147,11 @@ export async function finalizeInterruptedRunWithExecutor(
     }),
   );
 
-  await updateChatSessionRunStateWithExecutor(
+  await finalizeSessionRunStateForActiveRunWithExecutor(
     executor,
     scope,
-    run.session_id,
+    run,
     "interrupted",
-    null,
-    null,
-  );
-  await clearActiveChatComposerSuggestionGenerationWithExecutor(
-    executor,
-    scope,
-    run.session_id,
     "run_interrupted",
   );
 }

--- a/apps/backend/src/chat/runs/lifecycleService.test.ts
+++ b/apps/backend/src/chat/runs/lifecycleService.test.ts
@@ -1,9 +1,32 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue, WorkspaceDatabaseScope } from "../../db";
 import { ChatRunRowNotFoundError } from "../errors";
 import type { ChatSessionRow } from "../store/repository";
-import { assertClaimedRunStillActive } from "./lifecycleService";
+import { finalizeInterruptedRunWithExecutor } from "./finalization";
+import { assertClaimedRunStillActive, requestChatRunCancellationWithExecutor } from "./lifecycleService";
 import type { ChatRunRow } from "./repository";
+
+type RecordedQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<SqlValue>;
+}>;
+
+const scope: WorkspaceDatabaseScope = {
+  userId: "user-1",
+  workspaceId: "workspace-1",
+};
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    rows: [...rows],
+    fields: [],
+  };
+}
 
 function createRunRow(
   overrides: Partial<ChatRunRow> = {},
@@ -80,4 +103,108 @@ test("assertClaimedRunStillActive rejects non-running terminal state", () => {
       "fail",
     );
   }, ChatRunRowNotFoundError);
+});
+
+test("requestChatRunCancellationWithExecutor no-ops when the expected run is no longer active", async () => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+
+      if (text.includes("set_config('app.user_id'")) {
+        return createQueryResult<pg.QueryResultRow>([]) as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("FROM ai.chat_sessions") && text.includes("FOR UPDATE OF chat_sessions")) {
+        return createQueryResult<ChatSessionRow>([
+          createSessionRow({
+            active_run_id: "run-2",
+          }),
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const stopState = await requestChatRunCancellationWithExecutor(
+    executor,
+    scope,
+    "session-1",
+    "run-1",
+  );
+
+  assert.deepEqual(stopState, {
+    sessionId: "session-1",
+    stopped: false,
+    stillRunning: true,
+    runId: "run-2",
+  });
+  assert.equal(recordedQueries.some((query) => query.text.includes("FROM ai.chat_runs")), false);
+  assert.equal(recordedQueries.some((query) => query.text.includes("UPDATE ai.chat_runs")), false);
+});
+
+test("finalizeInterruptedRunWithExecutor does not clear a session that no longer owns the run", async () => {
+  let guardedSessionUpdateCount = 0;
+  const run = createRunRow({
+    status: "queued",
+  });
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text.includes("set_config('app.user_id'")) {
+        return createQueryResult<pg.QueryResultRow>([]) as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("FROM ai.chat_items")) {
+        return createQueryResult<pg.QueryResultRow>([]) as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("UPDATE ai.chat_runs")) {
+        return createQueryResult<ChatRunRow>([
+          createRunRow({
+            status: "interrupted",
+            finished_at: "2026-04-16T00:00:00.000Z",
+            last_error_message: "worker dispatch failed",
+          }),
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("UPDATE ai.chat_sessions") && text.includes("AND active_run_id = $5")) {
+        guardedSessionUpdateCount += 1;
+        assert.deepEqual(params, [
+          "session-1",
+          "interrupted",
+          null,
+          null,
+          "run-1",
+        ]);
+        return createQueryResult<ChatSessionRow>([]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("UPDATE ai.chat_sessions")) {
+        throw new Error("Unexpected unguarded chat session update");
+      }
+
+      if (text.includes("UPDATE ai.chat_composer_suggestion_generations")) {
+        throw new Error("Unexpected composer suggestion invalidation");
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  await finalizeInterruptedRunWithExecutor(
+    executor,
+    scope,
+    run,
+    "worker dispatch failed",
+  );
+
+  assert.equal(guardedSessionUpdateCount, 1);
 });

--- a/apps/backend/src/chat/runs/lifecycleService.ts
+++ b/apps/backend/src/chat/runs/lifecycleService.ts
@@ -540,75 +540,109 @@ export async function interruptPreparedChatRun(
 /**
  * Requests cancellation for the active run of a session and returns whether the run stopped immediately.
  */
+function createInactiveChatRunStopState(sessionId: string): ChatRunStopState {
+  return {
+    sessionId,
+    stopped: false,
+    stillRunning: false,
+    runId: null,
+  };
+}
+
+function createExpectedRunMismatchStopState(session: ChatSessionRow): ChatRunStopState {
+  if (session.active_run_id !== null && session.status === "running") {
+    return {
+      sessionId: session.session_id,
+      stopped: false,
+      stillRunning: true,
+      runId: session.active_run_id,
+    };
+  }
+
+  return createInactiveChatRunStopState(session.session_id);
+}
+
+export async function requestChatRunCancellationWithExecutor(
+  executor: DatabaseExecutor,
+  scope: WorkspaceDatabaseScope,
+  sessionId: string,
+  expectedRunId: string | null,
+): Promise<ChatRunStopState> {
+  const session = await selectSessionForUpdateWithExecutor(executor, scope, sessionId);
+  if (session.active_run_id === null || session.status !== "running") {
+    return createInactiveChatRunStopState(sessionId);
+  }
+
+  if (expectedRunId !== null && session.active_run_id !== expectedRunId) {
+    return createExpectedRunMismatchStopState(session);
+  }
+
+  const run = await selectChatRunForUpdateWithExecutor(executor, scope, session.active_run_id);
+  if (run === null) {
+    await updateChatSessionRunStateWithExecutor(executor, scope, sessionId, "interrupted", null, null);
+    await clearActiveChatComposerSuggestionGenerationWithExecutor(
+      executor,
+      scope,
+      sessionId,
+      "run_interrupted",
+    );
+    return {
+      sessionId,
+      stopped: true,
+      stillRunning: false,
+      runId: session.active_run_id,
+    };
+  }
+
+  if (run.status === "queued") {
+    await finalizeCancelledRunWithExecutor(executor, scope, run);
+    return {
+      sessionId,
+      stopped: true,
+      stillRunning: false,
+      runId: run.run_id,
+    };
+  }
+
+  if (run.status !== "running") {
+    return {
+      sessionId,
+      stopped: false,
+      stillRunning: false,
+      runId: run.run_id,
+    };
+  }
+
+  await updateChatRunStatusWithExecutor(
+    executor,
+    scope,
+    createChatRunStatusUpdateFromRow(run, {
+      status: "running",
+      cancelRequestedAt: new Date(),
+      finishedAt: null,
+      lastErrorMessage: null,
+    }),
+  );
+
+  return {
+    sessionId,
+    stopped: true,
+    stillRunning: true,
+    runId: run.run_id,
+  };
+}
+
 export async function requestChatRunCancellation(
   userId: string,
   workspaceId: string,
   sessionId: string,
+  expectedRunId: string | null,
 ): Promise<ChatRunStopState> {
-  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
-    const scope = { userId, workspaceId };
-    const session = await selectSessionForUpdateWithExecutor(executor, scope, sessionId);
-    if (session.active_run_id === null || session.status !== "running") {
-      return {
-        sessionId,
-        stopped: false,
-        stillRunning: false,
-        runId: null,
-      };
-    }
-
-    const run = await selectChatRunForUpdateWithExecutor(executor, scope, session.active_run_id);
-    if (run === null) {
-      await updateChatSessionRunStateWithExecutor(executor, scope, sessionId, "interrupted", null, null);
-      await clearActiveChatComposerSuggestionGenerationWithExecutor(
-        executor,
-        scope,
-        sessionId,
-        "run_interrupted",
-      );
-      return {
-        sessionId,
-        stopped: true,
-        stillRunning: false,
-        runId: session.active_run_id,
-      };
-    }
-
-    if (run.status === "queued") {
-      await finalizeCancelledRunWithExecutor(executor, scope, run);
-      return {
-        sessionId,
-        stopped: true,
-        stillRunning: false,
-        runId: run.run_id,
-      };
-    }
-
-    if (run.status !== "running") {
-      return {
-        sessionId,
-        stopped: false,
-        stillRunning: false,
-        runId: run.run_id,
-      };
-    }
-
-    await updateChatRunStatusWithExecutor(
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) =>
+    requestChatRunCancellationWithExecutor(
       executor,
-      scope,
-      createChatRunStatusUpdateFromRow(run, {
-        status: "running",
-        cancelRequestedAt: new Date(),
-        finishedAt: null,
-        lastErrorMessage: null,
-      }),
-    );
-
-    return {
+      { userId, workspaceId },
       sessionId,
-      stopped: true,
-      stillRunning: true,
-      runId: run.run_id,
-    };
-  });
+      expectedRunId,
+    ));
 }

--- a/apps/backend/src/chat/store.ts
+++ b/apps/backend/src/chat/store.ts
@@ -51,6 +51,7 @@ export {
   selectRequestedChatSessionWithExecutor,
   touchChatSessionHeartbeat,
   touchChatSessionHeartbeatWithExecutor,
+  updateChatSessionRunStateForActiveRunWithExecutor,
   updateChatSessionRunStateWithExecutor,
 } from "./store/sessionService";
 

--- a/apps/backend/src/chat/store/repository.ts
+++ b/apps/backend/src/chat/store/repository.ts
@@ -277,6 +277,26 @@ const UPDATE_CHAT_SESSION_STATUS_SQL = `
     updated_at
 `;
 
+const UPDATE_CHAT_SESSION_STATUS_FOR_ACTIVE_RUN_SQL = `
+  UPDATE ai.chat_sessions
+  SET status = $2,
+      active_run_id = $3,
+      active_run_heartbeat_at = $4,
+      updated_at = now()
+  WHERE session_id = $1
+    AND active_run_id = $5
+  RETURNING
+    session_id,
+    status,
+    active_run_id,
+    active_run_heartbeat_at,
+    composer_suggestions,
+    active_composer_suggestion_generation_id,
+    NULL::jsonb AS active_generation_suggestions,
+    main_content_invalidation_version,
+    updated_at
+`;
+
 const INSERT_CHAT_COMPOSER_SUGGESTION_GENERATION_SQL = `
   INSERT INTO ai.chat_composer_suggestion_generations (
     session_id,
@@ -611,6 +631,27 @@ export async function updateChatSessionStatusRowWithExecutor(
       activeRunHeartbeatAt?.toISOString() ?? null,
     ]);
     return requireSessionRow(rows[0], "update");
+  });
+}
+
+export async function updateChatSessionStatusForActiveRunRowWithExecutor(
+  executor: DatabaseExecutor,
+  scope: WorkspaceDatabaseScope,
+  sessionId: string,
+  runState: ChatSessionRunState,
+  activeRunId: string | null,
+  activeRunHeartbeatAt: Date | null,
+  expectedActiveRunId: string,
+): Promise<ChatSessionRow | null> {
+  return withScopedExecutor(executor, scope, async () => {
+    const rows = await executeQuery<ChatSessionRow>(executor, UPDATE_CHAT_SESSION_STATUS_FOR_ACTIVE_RUN_SQL, [
+      sessionId,
+      runState,
+      activeRunId,
+      activeRunHeartbeatAt?.toISOString() ?? null,
+      expectedActiveRunId,
+    ]);
+    return rows[0] ?? null;
   });
 }
 

--- a/apps/backend/src/chat/store/sessionService.ts
+++ b/apps/backend/src/chat/store/sessionService.ts
@@ -15,6 +15,7 @@ import {
   insertRequestedChatSessionRowWithExecutor,
   selectLatestChatSessionRowWithExecutor,
   selectRequestedChatSessionRowWithExecutor,
+  updateChatSessionStatusForActiveRunRowWithExecutor,
   updateChatSessionStatusRowWithExecutor,
   type ChatSessionRow,
 } from "./repository";
@@ -185,6 +186,27 @@ export const updateChatSessionRunStateWithExecutor = async (
     activeRunId,
     activeRunHeartbeatAt,
   );
+};
+
+export const updateChatSessionRunStateForActiveRunWithExecutor = async (
+  executor: DatabaseExecutor,
+  scope: WorkspaceDatabaseScope,
+  sessionId: string,
+  runState: ChatSessionRunState,
+  activeRunId: string | null,
+  activeRunHeartbeatAt: Date | null,
+  expectedActiveRunId: string,
+): Promise<boolean> => {
+  const row = await updateChatSessionStatusForActiveRunRowWithExecutor(
+    executor,
+    scope,
+    sessionId,
+    runState,
+    activeRunId,
+    activeRunHeartbeatAt,
+    expectedActiveRunId,
+  );
+  return row !== null;
 };
 
 export const getChatSessionId = async (

--- a/apps/backend/src/chat/tests/chat-routes.test.ts
+++ b/apps/backend/src/chat/tests/chat-routes.test.ts
@@ -14,6 +14,7 @@ import type { RequestContext } from "../../server/requestContext";
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
 const SESSION_TWO = "22222222-2222-4222-8222-222222222222";
 const EXPLICIT_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
+const RUN_ONE = "44444444-4444-4444-8444-444444444444";
 const LEGACY_WORKSPACE_ID = "workspace-legacy";
 
 function createRequestContext(): RequestContext {
@@ -1375,8 +1376,9 @@ test("POST /chat/stop uses an explicit workspaceId from JSON before the legacy s
       requestedWorkspaceIds.push(workspaceId);
       return SESSION_ONE;
     },
-    requestChatRunCancellationFn: async (_userId, workspaceId, sessionId) => {
+    requestChatRunCancellationFn: async (_userId, workspaceId, sessionId, expectedRunId) => {
       requestedWorkspaceIds.push(workspaceId);
+      assert.equal(expectedRunId, null);
       return {
         sessionId,
         runId: "run-stop-1",
@@ -1405,5 +1407,47 @@ test("POST /chat/stop uses an explicit workspaceId from JSON before the legacy s
     runId: "run-stop-1",
     stopped: true,
     stillRunning: false,
+  });
+});
+
+test("POST /chat/stop passes the expected runId when the client provides it", async () => {
+  let requestedRunId: string | null = null;
+  const app = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    getChatSessionIdFn: async () => SESSION_ONE,
+    requestChatRunCancellationFn: async (_userId, _workspaceId, sessionId, expectedRunId) => {
+      requestedRunId = expectedRunId;
+      return {
+        sessionId,
+        runId: expectedRunId,
+        stopped: true,
+        stillRunning: true,
+      };
+    },
+  });
+
+  const response = await app.request("http://localhost/chat/stop", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sessionId: SESSION_ONE,
+      runId: RUN_ONE,
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(requestedRunId, RUN_ONE);
+  assert.deepEqual(await response.json(), {
+    sessionId: SESSION_ONE,
+    conversationScopeId: SESSION_ONE,
+    runId: RUN_ONE,
+    stopped: true,
+    stillRunning: true,
   });
 });

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -141,6 +141,8 @@ type NewChatRequestBody = Readonly<{
 
 type StopChatRequestBody = Readonly<{
   sessionId: string;
+  // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+  runId?: string;
   // Optional explicit routing during the workspaceId client migration. Older
   // released clients still rely on the server-side selected-workspace
   // fallback until every supported build sends workspaceId.
@@ -380,6 +382,9 @@ export function parseStopChatRequestBody(value: unknown): StopChatRequestBody {
 
   return {
     sessionId: expectUuidString(body.sessionId, "sessionId"),
+    runId: body.runId === undefined
+      ? undefined
+      : expectUuidString(body.runId, "runId"),
     workspaceId: parseOptionalWorkspaceIdField(body.workspaceId),
   };
 }
@@ -1050,6 +1055,7 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
       requestContext.userId,
       workspaceId,
       sessionId,
+      body.runId ?? null,
     );
 
     return context.json({

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatContentModels.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatContentModels.swift
@@ -10,6 +10,15 @@ func makeAIChatSessionId() -> String {
     UUID().uuidString.lowercased()
 }
 
+func aiChatNonEmptyRunId(runId: String?) -> String? {
+    guard let trimmedRunId: String = runId?.trimmingCharacters(in: .whitespacesAndNewlines),
+          trimmedRunId.isEmpty == false else {
+        return nil
+    }
+
+    return trimmedRunId
+}
+
 func aiChatResolvedSessionId(
     workspaceId: String?,
     sessionId: String

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatConversationModels.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatConversationModels.swift
@@ -196,6 +196,8 @@ struct AIChatStopRunResponse: Decodable, Hashable, Sendable {
 
 struct AIChatStopRunRequestBody: Codable, Hashable, Sendable {
     let sessionId: String
+    // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+    let runId: String?
     // Keep this additive field optional while older client and backend builds roll out independently.
     let workspaceId: String?
 }

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatRuntimeContracts.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatRuntimeContracts.swift
@@ -174,7 +174,8 @@ protocol AIChatSessionServicing: Sendable {
 
     func stopRun(
         session: CloudLinkedSession,
-        sessionId: String
+        sessionId: String,
+        runId: String?
     ) async throws -> AIChatStopRunResponse
 }
 

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatService.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatService.swift
@@ -314,7 +314,8 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
 
     func stopRun(
         session: CloudLinkedSession,
-        sessionId: String
+        sessionId: String,
+        runId: String?
     ) async throws -> AIChatStopRunResponse {
         let clientRequestId = UUID().uuidString.lowercased()
         let urlRequest = try self.makeJsonRequest(
@@ -323,6 +324,7 @@ final class AIChatService: AIChatSessionServicing, @unchecked Sendable {
             method: "POST",
             body: AIChatStopRunRequestBody(
                 sessionId: sessionId,
+                runId: aiChatNonEmptyRunId(runId: runId),
                 workspaceId: session.workspaceId
             ),
             clientRequestId: clientRequestId

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
@@ -132,12 +132,13 @@ extension AIChatStore {
     }
 
     func cancelStreaming() {
+        let stopRunId: String? = aiChatNonEmptyRunId(runId: self.activeRunId)
         self.activeSendTask?.cancel()
         self.activeSendTask = nil
         Task {
             await self.runtime.detach()
         }
-        self.transitionToStopping(runId: self.activeRunId)
+        self.transitionToStopping(runId: stopRunId)
         self.repairStatus = nil
         self.clearOptimisticAssistantStatusIfNeeded()
 
@@ -162,7 +163,16 @@ extension AIChatStore {
             }
             do {
                 let session = try await self.flashcardsStore.cloudSessionForAI()
-                let stopResponse = try await self.chatService.stopRun(session: session, sessionId: sessionId)
+                let stopResponse = try await self.chatService.stopRun(
+                    session: session,
+                    sessionId: sessionId,
+                    runId: stopRunId
+                )
+                if stopResponse.stopped == false {
+                    self.transitionToIdle()
+                    self.startLinkedBootstrap(forceReloadState: true, resumeAttemptDiagnostics: nil)
+                    return
+                }
                 if stopResponse.stopped, stopResponse.stillRunning == false {
                     self.finalizeStoppedAssistantMessageIfNeeded()
                     self.activeStreamingMessageId = nil

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatResumeDiagnosticsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatResumeDiagnosticsTests.swift
@@ -237,7 +237,7 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
         await self.fulfillment(of: [expectation], timeout: 1.0)
     }
 
-    func testStopRunEncodesWorkspaceIdInRequestBody() async throws {
+    func testStopRunEncodesWorkspaceAndRunIdInRequestBody() async throws {
         let expectation = XCTestExpectation(description: "Stop run request captured")
         let service = AIChatService(
             session: self.makeURLSession(),
@@ -250,6 +250,7 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
             let body = try XCTUnwrap(aiChatRequestBodyData(request: request))
             let payload = try JSONDecoder().decode(AIChatEncodedStopRunRequest.self, from: body)
             XCTAssertEqual(payload.sessionId, "session-1")
+            XCTAssertEqual(payload.runId, "run-1")
             XCTAssertEqual(payload.workspaceId, "workspace-1")
             expectation.fulfill()
             return (
@@ -265,7 +266,8 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
 
         let response = try await service.stopRun(
             session: self.makeLinkedSession(),
-            sessionId: "session-1"
+            sessionId: "session-1",
+            runId: "run-1"
         )
 
         XCTAssertEqual(response.sessionId, "session-1")
@@ -352,6 +354,7 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
         let stopRunData = try encoder.encode(
             AIChatStopRunRequestBody(
                 sessionId: "session-1",
+                runId: nil,
                 workspaceId: nil
             )
         )
@@ -364,6 +367,7 @@ final class AIChatResumeDiagnosticsTests: XCTestCase {
         XCTAssertFalse(startRunPayload.contains("\"workspaceId\""))
         XCTAssertFalse(newSessionPayload.contains("\"uiLocale\""))
         XCTAssertFalse(newSessionPayload.contains("\"workspaceId\""))
+        XCTAssertFalse(stopRunPayload.contains("\"runId\""))
         XCTAssertFalse(stopRunPayload.contains("\"workspaceId\""))
     }
 
@@ -568,6 +572,7 @@ private struct AIChatEncodedNewSessionRequest: Decodable {
 
 private struct AIChatEncodedStopRunRequest: Decodable {
     let sessionId: String
+    let runId: String?
     let workspaceId: String?
 }
 

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import Flashcards
+
+@MainActor
+final class AIChatStoreRunStopTests: XCTestCase {
+    func testNoopStopClearsStoppingAndReloadsBootstrap() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        let activeRun = AIChatStoreTestSupport.makeActiveRun()
+        let replacementRun = AIChatActiveRun(
+            runId: "run-2",
+            status: activeRun.status,
+            live: activeRun.live,
+            lastHeartbeatAt: nil
+        )
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.transitionToStreaming(
+            activeRun: AIChatActiveRunSession(
+                sessionId: "session-1",
+                conversationScopeId: "session-1",
+                runId: activeRun.runId,
+                liveStream: activeRun.live.stream,
+                liveCursor: activeRun.live.cursor,
+                streamEpoch: nil
+            )
+        )
+        store.persistStateSynchronously(state: store.currentPersistedState())
+        context.chatService.stopRunHandler = { sessionId, runId in
+            XCTAssertEqual(sessionId, "session-1")
+            XCTAssertEqual(runId, "run-1")
+            return AIChatStopRunResponse(
+                sessionId: sessionId,
+                stopped: false,
+                stillRunning: true
+            )
+        }
+        context.chatService.loadBootstrapHandler = { sessionId in
+            XCTAssertEqual(sessionId, "session-1")
+            return AIChatStoreTestSupport.makeConversationEnvelope(
+                sessionId: "session-1",
+                messages: [],
+                activeRun: replacementRun
+            )
+        }
+
+        store.cancelStreaming()
+
+        let didSettle = await AIChatStoreTestSupport.waitForCondition(
+            description: "noop stop bootstrap reconciliation",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.chatService.stopRunRequests.count == 1
+                    && context.chatService.loadBootstrapSessionIds == ["session-1"]
+                    && store.composerPhase == .running
+                    && store.activeRunId == "run-2"
+            }
+        )
+
+        XCTAssertTrue(didSettle)
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.runId }, ["run-1"])
+        XCTAssertEqual(store.composerPhase, .running)
+        XCTAssertEqual(store.activeRunId, "run-2")
+    }
+}

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
@@ -216,9 +216,11 @@ enum AIChatStoreTestSupport {
         var loadBootstrapGate: AsyncGate?
         var startRunRequests: [AIChatStartRunRequestBody]
         var createNewSessionRequests: [AIChatNewSessionRequestBody]
+        var stopRunRequests: [(sessionId: String, runId: String?)]
         var loadBootstrapHandler: ((String?) throws -> AIChatBootstrapResponse)?
         var startRunHandler: ((AIChatStartRunRequestBody) throws -> AIChatStartRunResponse)?
         var createNewSessionHandler: ((AIChatNewSessionRequestBody) throws -> AIChatNewSessionResponse)?
+        var stopRunHandler: ((String, String?) throws -> AIChatStopRunResponse)?
 
         var createNewSessionSessionIds: [String?] {
             self.createNewSessionRequests.map(\.sessionId)
@@ -231,9 +233,11 @@ enum AIChatStoreTestSupport {
             self.loadBootstrapGate = nil
             self.startRunRequests = []
             self.createNewSessionRequests = []
+            self.stopRunRequests = []
             self.loadBootstrapHandler = nil
             self.startRunHandler = nil
             self.createNewSessionHandler = nil
+            self.stopRunHandler = nil
         }
 
         func loadSnapshot(
@@ -307,9 +311,15 @@ enum AIChatStoreTestSupport {
 
         func stopRun(
             session: CloudLinkedSession,
-            sessionId: String
+            sessionId: String,
+            runId: String?
         ) async throws -> AIChatStopRunResponse {
             _ = session
+            self.events.append("stopRun:\(sessionId):\(runId ?? "nil")")
+            self.stopRunRequests.append((sessionId: sessionId, runId: runId))
+            if let stopRunHandler {
+                return try stopRunHandler(sessionId, runId)
+            }
             return AIChatStopRunResponse(
                 sessionId: sessionId,
                 stopped: false,

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -656,7 +656,7 @@ describe("AI chat transport", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await getSession();
-    await expect(stopChatRun("session-1", "workspace-1")).resolves.toEqual({
+    await expect(stopChatRun("session-1", "workspace-1", null)).resolves.toEqual({
       sessionId: "session-1",
       stopped: true,
       stillRunning: false,
@@ -666,6 +666,27 @@ describe("AI chat transport", () => {
     expect(chatRequestInit?.body).toBe(JSON.stringify({
       sessionId: "session-1",
       workspaceId: "workspace-1",
+    }));
+  });
+
+  it("includes runId in POST /chat/stop requests when known", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createSessionResponse())
+      .mockResolvedValueOnce(createStopChatRunResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getSession();
+    await expect(stopChatRun("session-1", "workspace-1", "run-1")).resolves.toEqual({
+      sessionId: "session-1",
+      stopped: true,
+      stillRunning: false,
+    });
+
+    const chatRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
+    expect(chatRequestInit?.body).toBe(JSON.stringify({
+      sessionId: "session-1",
+      workspaceId: "workspace-1",
+      runId: "run-1",
     }));
   });
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -831,11 +831,21 @@ export async function createNewChatSession(
   }, allowAuthRecovery), "POST /chat/new");
 }
 
-export async function stopChatRun(sessionId: string, workspaceId: string): Promise<StopChatRunResponse> {
-  const requestBody: StopChatRunRequestBody = {
-    sessionId,
-    workspaceId,
-  };
+export async function stopChatRun(
+  sessionId: string,
+  workspaceId: string,
+  runId: string | null,
+): Promise<StopChatRunResponse> {
+  const requestBody: StopChatRunRequestBody = runId === null
+    ? {
+      sessionId,
+      workspaceId,
+    }
+    : {
+      sessionId,
+      workspaceId,
+      runId,
+    };
 
   return parseStopChatRunResponse(await requestJson("/chat/stop", {
     method: "POST",

--- a/apps/web/src/chat/ChatPanel/ChatPanel.send-lifecycle.test.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.send-lifecycle.test.tsx
@@ -611,6 +611,62 @@ describe("ChatPanel send lifecycle", () => {
     expect(sendButton).toBeNull();
   });
 
+  it("passes the accepted active run id when stopping a sent message", async () => {
+    await renderChatPanel();
+    await flushAsync();
+    await sendMessage("hello");
+    await flushAsync();
+    await flushAsync();
+
+    await clickStop();
+    await flushAsync();
+
+    expect(stopChatRunMock).toHaveBeenCalledWith(expect.any(String), "workspace-1", "run-1");
+  });
+
+  it("clears stopping and reconciles the snapshot when stop returns a no-op", async () => {
+    let resolveReconcileSnapshot: ((snapshot: ReturnType<typeof createChatSnapshot>) => void) | null = null;
+    getChatSnapshotMock
+      .mockResolvedValueOnce(createChatSnapshot({
+        activeRun: createChatActiveRun(),
+      }))
+      .mockImplementation(() => new Promise((resolve) => {
+        resolveReconcileSnapshot = resolve;
+      }));
+    stopChatRunMock.mockResolvedValue({
+      sessionId: "session-1",
+      stopped: false,
+      stillRunning: true,
+    });
+
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    await clickStop();
+    await flushAsync();
+    await flushAsync();
+
+    const composerState = getContainer().querySelector('[data-testid="chat-composer-state"]') as HTMLDivElement | null;
+    const stopButton = getContainer().querySelector('.chat-stop-btn[aria-label="Stop response"]') as HTMLButtonElement | null;
+    expect(stopChatRunMock).toHaveBeenCalledWith("session-1", "workspace-1", "run-1");
+    expect(getChatSnapshotMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(composerState?.getAttribute("data-stopping")).toBe("false");
+    expect(composerState?.getAttribute("data-composer-state")).toBe("running");
+    expect(stopButton).not.toBeNull();
+    expect(stopButton?.disabled).toBe(false);
+
+    await clickStop();
+    await flushAsync();
+
+    expect(stopChatRunMock.mock.calls[1]).toEqual(["session-1", "workspace-1", null]);
+
+    resolveReconcileSnapshot?.(createChatSnapshot({
+      activeRun: createChatActiveRun({ runId: "run-2" }),
+    }));
+    await flushAsync();
+  });
+
   it("keeps draft preparation controls enabled while an assistant run is active", async () => {
     getChatSnapshotMock.mockResolvedValue(createChatSnapshot({
       activeRun: createChatActiveRun(),
@@ -672,6 +728,8 @@ describe("ChatPanel send lifecycle", () => {
 
     await clickStop();
     await flushAsync();
+
+    expect(stopChatRunMock).toHaveBeenCalledWith("session-1", "workspace-1", "run-1");
 
     const composerState = getContainer().querySelector('[data-testid="chat-composer-state"]') as HTMLDivElement | null;
     const textarea = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;

--- a/apps/web/src/chat/sessionController/useActions.ts
+++ b/apps/web/src/chat/sessionController/useActions.ts
@@ -80,6 +80,7 @@ export function useChatSessionActions(
     reconcileTerminalSnapshot,
     resetSnapshotTracking,
     runtimeRefs,
+    setKnownActiveRunId,
     setKnownLiveCursor,
     startActiveRunLiveStream,
   } = snapshotSync;
@@ -438,6 +439,7 @@ export function useChatSessionActions(
         chatConfig: response.chatConfig,
       });
       storeChatConfig(response.chatConfig);
+      setKnownActiveRunId(response.activeRun?.runId ?? null);
       setKnownLiveCursor(response.activeRun?.live.cursor ?? null);
       if (response.activeRun === null) {
         reconcileTerminalSnapshot();
@@ -478,6 +480,7 @@ export function useChatSessionActions(
     markRunHadToolCallsFromSnapshot,
     reconcileTerminalSnapshot,
     runtimeRefs,
+    setKnownActiveRunId,
     setKnownLiveCursor,
     startActiveRunLiveStream,
     startAssistantMessage,
@@ -497,12 +500,23 @@ export function useChatSessionActions(
     }
 
     dispatch({ type: "stop_requested" });
+    const activeRunId = runtimeRefs.activeRunIdRef.current;
     try {
       if (workspaceId === null) {
         throw createRemoteSessionProvisioningError(uiMessages.workspaceRequired);
       }
 
-      const response = await stopChatRun(state.currentSessionId, workspaceId);
+      const response = await stopChatRun(state.currentSessionId, workspaceId, activeRunId);
+      if (response.stopped === false) {
+        setKnownActiveRunId(null);
+        reconcileTerminalSnapshot();
+        dispatch({
+          type: "stop_finished",
+          runState: response.stillRunning ? "running" : "idle",
+        });
+        return;
+      }
+
       if (response.stopped && response.stillRunning === false && hasActiveLiveConnection() === false) {
         reconcileTerminalSnapshot();
         dispatch({
@@ -529,10 +543,13 @@ export function useChatSessionActions(
     hasActiveLiveConnection,
     reconcileTerminalSnapshot,
     runtimeRefs.runStateRef,
+    runtimeRefs.activeRunIdRef,
+    setKnownActiveRunId,
     state.currentSessionId,
     state.isStopping,
     state.runState,
     uiMessages,
+    workspaceId,
   ]);
 
   const clearConversation = useCallback(async (): Promise<string | null> => {

--- a/apps/web/src/chat/sessionController/useSnapshotSync.ts
+++ b/apps/web/src/chat/sessionController/useSnapshotSync.ts
@@ -46,6 +46,7 @@ export type ChatSessionSnapshotRuntimeRefs = Readonly<{
   currentWorkspaceIdRef: MutableRefObject<string | null>;
   currentSessionIdRef: MutableRefObject<string | null>;
   runStateRef: MutableRefObject<ChatSessionControllerState["runState"]>;
+  activeRunIdRef: MutableRefObject<string | null>;
   messagesRef: MutableRefObject<ChatHistoryState["messages"]>;
   chatConfigRef: MutableRefObject<ChatSessionControllerState["chatConfig"]>;
   lastSnapshotUpdatedAtRef: MutableRefObject<number | null>;
@@ -67,6 +68,7 @@ export type ChatSessionSnapshotSync = Readonly<{
   ) => Promise<ChatSessionSnapshot | null>;
   resetSnapshotTracking: (updatedAt: number | null) => void;
   runtimeRefs: ChatSessionSnapshotRuntimeRefs;
+  setKnownActiveRunId: (runId: string | null) => void;
   setKnownLiveCursor: (cursor: string | null) => void;
   startActiveRunLiveStream: (
     sessionId: string,
@@ -292,6 +294,7 @@ export function useChatSessionSnapshotSync(
   const currentWorkspaceIdRef = useRef<string | null>(workspaceId);
   const currentSessionIdRef = useRef<string | null>(state.currentSessionId);
   const runStateRef = useRef<ChatSessionControllerState["runState"]>(state.runState);
+  const activeRunIdRef = useRef<string | null>(null);
   const messagesRef = useRef<ChatHistoryState["messages"]>(messages);
   const chatConfigRef = useRef<ChatSessionControllerState["chatConfig"]>(state.chatConfig);
   const lastSnapshotUpdatedAtRef = useRef<number | null>(initialLastSnapshotUpdatedAt);
@@ -307,6 +310,7 @@ export function useChatSessionSnapshotSync(
     currentWorkspaceIdRef,
     currentSessionIdRef,
     runStateRef,
+    activeRunIdRef,
     messagesRef,
     chatConfigRef,
     lastSnapshotUpdatedAtRef,
@@ -346,12 +350,17 @@ export function useChatSessionSnapshotSync(
     liveCursorRef.current = cursor;
   }, []);
 
+  const setKnownActiveRunId = useCallback((runId: string | null): void => {
+    activeRunIdRef.current = runId;
+  }, []);
+
   const invalidatePendingSnapshotRequests = useCallback((): void => {
     snapshotRequestVersionRef.current += 1;
   }, []);
 
   const resetSnapshotTracking = useCallback((updatedAt: number | null): void => {
     lastSnapshotUpdatedAtRef.current = updatedAt;
+    activeRunIdRef.current = null;
     liveCursorRef.current = null;
   }, []);
 
@@ -488,6 +497,8 @@ export function useChatSessionSnapshotSync(
       return;
     }
 
+    setKnownActiveRunId(null);
+
     if (event.outcome === "reset_required") {
       reconcileTerminalSnapshotRef.current();
       return;
@@ -514,6 +525,7 @@ export function useChatSessionSnapshotSync(
     state.mainContentInvalidationVersion,
     triggerToolRunPostSyncIfNeeded,
     uiMessages,
+    setKnownActiveRunId,
     setKnownLiveCursor,
     upsertAssistantReasoningSummary,
     upsertAssistantToolCall,
@@ -688,6 +700,7 @@ export function useChatSessionSnapshotSync(
         );
       }
 
+      setKnownActiveRunId(snapshot.activeRun?.runId ?? null);
       dispatch({
         type: "snapshot_applied",
         sessionId: snapshot.sessionId,
@@ -748,6 +761,7 @@ export function useChatSessionSnapshotSync(
     replaceMessages,
     triggerToolRunPostSyncIfNeeded,
     uiMessages,
+    setKnownActiveRunId,
     setKnownLiveCursor,
     workspaceId,
   ]);
@@ -757,6 +771,7 @@ export function useChatSessionSnapshotSync(
     activeRun: ChatActiveRun,
     resumeAttemptId: number | null,
   ): void => {
+    setKnownActiveRunId(activeRun.runId);
     startLiveStream(
       sessionId,
       activeRun.runId,
@@ -764,7 +779,7 @@ export function useChatSessionSnapshotSync(
       activeRun.live.cursor,
       resumeAttemptId,
     );
-  }, [startLiveStream]);
+  }, [setKnownActiveRunId, startLiveStream]);
 
   const startSnapshotLiveStream = useCallback((
     snapshot: ChatSessionSnapshot,
@@ -838,6 +853,7 @@ export function useChatSessionSnapshotSync(
     loadAndApplySnapshot,
     resetSnapshotTracking,
     runtimeRefs,
+    setKnownActiveRunId,
     setKnownLiveCursor,
     startActiveRunLiveStream,
     startSnapshotLiveStream,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -303,6 +303,8 @@ export type StopChatRunRequestBody = Readonly<{
   sessionId: string;
   // Optional on the wire so older backend/client contract phases keep working.
   workspaceId?: string;
+  // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+  runId?: string;
 }>;
 
 /** Mirrors the iOS local workspace payload used by local AI tools. */


### PR DESCRIPTION
## Summary
- add optional runId to AI chat stop while preserving legacy session-scoped clients
- make backend stop/finalization run-scoped so stale runs cannot cancel or clear newer active runs
- pass active run ids from web, iOS, and Android and reconcile cleanly on stop no-op responses

## Verification
- backend targeted chat route/lifecycle tests passed
- backend lint passed
- web targeted Vitest send lifecycle/API tests passed
- web TypeScript build passed
- Android targeted Gradle tests passed
- iOS build-for-testing and targeted stop test passed
- git diff check passed