### PR TITLE
Prioritize recent due review cards

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseTest.kt
@@ -10,6 +10,8 @@ import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.CardEntity
+import com.flashcardsopensourceapp.data.local.database.CardTagEntity
+import com.flashcardsopensourceapp.data.local.database.TagEntity
 import com.flashcardsopensourceapp.data.local.model.CardDraft
 import com.flashcardsopensourceapp.data.local.model.CardFilter
 import com.flashcardsopensourceapp.data.local.model.DeckDraft
@@ -44,6 +46,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -247,7 +250,8 @@ class AppDatabaseTest {
 
         val allCardsSnapshot = reviewRepository.observeReviewSession(
             selectedFilter = ReviewFilter.Deck(deckId = "missing-deck"),
-            pendingReviewedCards = emptySet()
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
         ).first()
         val pendingSnapshot = reviewRepository.observeReviewSession(
             selectedFilter = ReviewFilter.AllCards,
@@ -256,15 +260,18 @@ class AppDatabaseTest {
                     cardId = orderedCards.first().cardId,
                     updatedAtMillis = orderedCards.first().updatedAtMillis
                 )
-            )
+            ),
+            presentedCardId = null
         ).first()
         val tagSnapshot = reviewRepository.observeReviewSession(
             selectedFilter = ReviewFilter.Tag(tag = "ui"),
-            pendingReviewedCards = emptySet()
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
         ).first()
         val effortSnapshot = reviewRepository.observeReviewSession(
             selectedFilter = ReviewFilter.Effort(effortLevel = EffortLevel.FAST),
-            pendingReviewedCards = emptySet()
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
         ).first()
 
         assertEquals(ReviewFilter.AllCards, allCardsSnapshot.selectedFilter)
@@ -337,78 +344,62 @@ class AppDatabaseTest {
     }
 
     @Test
-    fun reviewQueuePrioritizesTimedDueCardsBeforeNewCardsAndFutureCards(): Unit = runBlocking {
+    fun reviewQueuePrioritizesRecentDueCardsBeforeOldDueNewCardsAndFutureCards(): Unit = runBlocking {
         val nowMillis = System.currentTimeMillis()
+        val fiveMinutesMillis = 5 * 60 * 1_000L
+        val fortyFiveMinutesMillis = 45 * 60 * 1_000L
         val oneDayMillis = 86_400_000L
-        val oneYearMillis = 31_536_000_000L
         val workspaceId = bootstrapLocalWorkspace(currentTimeMillis = nowMillis)
         val reviewRepository = makeReviewRepository()
 
         database.cardDao().insertCards(
             listOf(
-                CardEntity(
-                    cardId = "timed-due-card",
+                makeDueReviewOrderingCardEntity(
+                    cardId = "old-due-card",
                     workspaceId = workspaceId,
-                    frontText = "Timed due",
-                    backText = "Back",
                     effortLevel = EffortLevel.FAST,
                     dueAtMillis = nowMillis - oneDayMillis,
                     createdAtMillis = nowMillis - (2 * oneDayMillis),
-                    updatedAtMillis = nowMillis - (2 * oneDayMillis),
-                    reps = 1,
-                    lapses = 0,
-                    fsrsCardState = FsrsCardState.REVIEW,
-                    fsrsStepIndex = null,
-                    fsrsStability = 1.0,
-                    fsrsDifficulty = 1.0,
-                    fsrsLastReviewedAtMillis = nowMillis - oneDayMillis,
-                    fsrsScheduledDays = 1,
-                    deletedAtMillis = null
+                    updatedAtMillis = nowMillis - (2 * oneDayMillis)
                 ),
-                CardEntity(
+                makeNewReviewOrderingCardEntity(
                     cardId = "new-card",
                     workspaceId = workspaceId,
-                    frontText = "New card",
-                    backText = "Back",
                     effortLevel = EffortLevel.FAST,
-                    dueAtMillis = null,
                     createdAtMillis = nowMillis - oneDayMillis,
-                    updatedAtMillis = nowMillis - oneDayMillis,
-                    reps = 0,
-                    lapses = 0,
-                    fsrsCardState = FsrsCardState.NEW,
-                    fsrsStepIndex = null,
-                    fsrsStability = null,
-                    fsrsDifficulty = null,
-                    fsrsLastReviewedAtMillis = null,
-                    fsrsScheduledDays = null,
-                    deletedAtMillis = null
+                    updatedAtMillis = nowMillis - oneDayMillis
                 ),
-                CardEntity(
+                makeDueReviewOrderingCardEntity(
                     cardId = "future-card",
                     workspaceId = workspaceId,
-                    frontText = "Future card",
-                    backText = "Back",
                     effortLevel = EffortLevel.FAST,
-                    dueAtMillis = nowMillis + oneYearMillis,
+                    dueAtMillis = nowMillis + oneDayMillis,
                     createdAtMillis = nowMillis - oneDayMillis,
-                    updatedAtMillis = nowMillis - oneDayMillis,
-                    reps = 1,
-                    lapses = 0,
-                    fsrsCardState = FsrsCardState.REVIEW,
-                    fsrsStepIndex = null,
-                    fsrsStability = 1.0,
-                    fsrsDifficulty = 1.0,
-                    fsrsLastReviewedAtMillis = nowMillis - oneDayMillis,
-                    fsrsScheduledDays = 1,
-                    deletedAtMillis = null
+                    updatedAtMillis = nowMillis - oneDayMillis
+                ),
+                makeDueReviewOrderingCardEntity(
+                    cardId = "recent-due-1115-card",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.FAST,
+                    dueAtMillis = nowMillis - fortyFiveMinutesMillis,
+                    createdAtMillis = nowMillis - fortyFiveMinutesMillis,
+                    updatedAtMillis = nowMillis - fortyFiveMinutesMillis
+                ),
+                makeDueReviewOrderingCardEntity(
+                    cardId = "recent-due-1155-card",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.FAST,
+                    dueAtMillis = nowMillis - fiveMinutesMillis,
+                    createdAtMillis = nowMillis - fiveMinutesMillis,
+                    updatedAtMillis = nowMillis - fiveMinutesMillis
                 )
             )
         )
 
         val sessionSnapshot = reviewRepository.observeReviewSession(
             selectedFilter = ReviewFilter.AllCards,
-            pendingReviewedCards = emptySet()
+            pendingReviewedCards = emptySet(),
+            presentedCardId = null
         ).first()
         val timelinePage = reviewRepository.loadReviewTimelinePage(
             selectedFilter = ReviewFilter.AllCards,
@@ -421,9 +412,136 @@ class AppDatabaseTest {
             nowMillis = nowMillis
         )
 
-        assertEquals(listOf("timed-due-card", "new-card"), sessionSnapshot.cards.map { card -> card.cardId })
-        assertEquals(listOf("timed-due-card", "new-card", "future-card"), timelinePage.cards.map { card -> card.cardId })
-        assertEquals("timed-due-card", topReviewCard?.cardId)
+        assertEquals(
+            listOf("recent-due-1115-card", "recent-due-1155-card", "old-due-card", "new-card"),
+            sessionSnapshot.cards.map { card -> card.cardId }
+        )
+        assertEquals(
+            listOf("recent-due-1115-card", "recent-due-1155-card", "old-due-card", "new-card", "future-card"),
+            timelinePage.cards.map { card -> card.cardId }
+        )
+        assertEquals("recent-due-1115-card", topReviewCard?.cardId)
+    }
+
+    @Test
+    fun topReviewCardQueriesUseRecentDueBoundariesAndFilters(): Unit = runBlocking {
+        val nowMillis = 12 * 60 * 60 * 1_000L
+        val oneHourMillis = 60 * 60 * 1_000L
+        val workspaceId = bootstrapLocalWorkspace(currentTimeMillis = nowMillis)
+        val priorityTag = TagEntity(
+            tagId = "tag-priority",
+            workspaceId = workspaceId,
+            name = "Priority"
+        )
+        val futureTag = TagEntity(
+            tagId = "tag-future-only",
+            workspaceId = workspaceId,
+            name = "Future Only"
+        )
+
+        database.cardDao().insertCards(
+            listOf(
+                makeDueReviewOrderingCardEntity(
+                    cardId = "recent-cutoff-a",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.FAST,
+                    dueAtMillis = nowMillis - oneHourMillis,
+                    createdAtMillis = 300L,
+                    updatedAtMillis = 300L
+                ),
+                makeDueReviewOrderingCardEntity(
+                    cardId = "recent-cutoff-b",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.FAST,
+                    dueAtMillis = nowMillis - oneHourMillis,
+                    createdAtMillis = 300L,
+                    updatedAtMillis = 300L
+                ),
+                makeDueReviewOrderingCardEntity(
+                    cardId = "recent-cutoff-older-created",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.FAST,
+                    dueAtMillis = nowMillis - oneHourMillis,
+                    createdAtMillis = 200L,
+                    updatedAtMillis = 200L
+                ),
+                makeDueReviewOrderingCardEntity(
+                    cardId = "old-boundary-card",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.LONG,
+                    dueAtMillis = nowMillis - oneHourMillis - 1L,
+                    createdAtMillis = 400L,
+                    updatedAtMillis = 400L
+                ),
+                makeDueReviewOrderingCardEntity(
+                    cardId = "due-now-card",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.MEDIUM,
+                    dueAtMillis = nowMillis,
+                    createdAtMillis = 500L,
+                    updatedAtMillis = 500L
+                ),
+                makeNewReviewOrderingCardEntity(
+                    cardId = "new-medium-card",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.MEDIUM,
+                    createdAtMillis = 600L,
+                    updatedAtMillis = 600L
+                ),
+                makeDueReviewOrderingCardEntity(
+                    cardId = "future-card",
+                    workspaceId = workspaceId,
+                    effortLevel = EffortLevel.FAST,
+                    dueAtMillis = nowMillis + 1L,
+                    createdAtMillis = 700L,
+                    updatedAtMillis = 700L
+                )
+            )
+        )
+        database.tagDao().insertTags(tags = listOf(priorityTag, futureTag))
+        database.tagDao().insertCardTags(
+            cardTags = listOf(
+                CardTagEntity(cardId = "recent-cutoff-a", tagId = priorityTag.tagId),
+                CardTagEntity(cardId = "recent-cutoff-b", tagId = priorityTag.tagId),
+                CardTagEntity(cardId = "recent-cutoff-older-created", tagId = priorityTag.tagId),
+                CardTagEntity(cardId = "old-boundary-card", tagId = priorityTag.tagId),
+                CardTagEntity(cardId = "due-now-card", tagId = priorityTag.tagId),
+                CardTagEntity(cardId = "new-medium-card", tagId = priorityTag.tagId),
+                CardTagEntity(cardId = "future-card", tagId = futureTag.tagId)
+            )
+        )
+
+        val allCardsTop = database.cardDao().loadTopReviewCard(
+            workspaceId = workspaceId,
+            nowMillis = nowMillis
+        )
+        val effortTop = database.cardDao().loadTopReviewCardByEffortLevels(
+            workspaceId = workspaceId,
+            nowMillis = nowMillis,
+            effortLevels = listOf(EffortLevel.FAST)
+        )
+        val tagTop = database.cardDao().loadTopReviewCardByAnyTags(
+            workspaceId = workspaceId,
+            nowMillis = nowMillis,
+            normalizedTagNames = listOf("priority")
+        )
+        val effortAndTagTop = database.cardDao().loadTopReviewCardByEffortLevelsAndAnyTags(
+            workspaceId = workspaceId,
+            nowMillis = nowMillis,
+            effortLevels = listOf(EffortLevel.MEDIUM),
+            normalizedTagNames = listOf("priority")
+        )
+        val futureOnlyTagTop = database.cardDao().loadTopReviewCardByAnyTags(
+            workspaceId = workspaceId,
+            nowMillis = nowMillis,
+            normalizedTagNames = listOf("future only")
+        )
+
+        assertEquals("recent-cutoff-a", allCardsTop?.cardId)
+        assertEquals("recent-cutoff-a", effortTop?.cardId)
+        assertEquals("recent-cutoff-a", tagTop?.cardId)
+        assertEquals("due-now-card", effortAndTagTop?.cardId)
+        assertNull(futureOnlyTagTop)
     }
 
     @Test
@@ -692,6 +810,63 @@ class AppDatabaseTest {
                 database = database,
                 timeProvider = SystemProgressTimeProvider
             )
+        )
+    }
+
+    private fun makeDueReviewOrderingCardEntity(
+        cardId: String,
+        workspaceId: String,
+        effortLevel: EffortLevel,
+        dueAtMillis: Long,
+        createdAtMillis: Long,
+        updatedAtMillis: Long
+    ): CardEntity {
+        return CardEntity(
+            cardId = cardId,
+            workspaceId = workspaceId,
+            frontText = cardId,
+            backText = "Back",
+            effortLevel = effortLevel,
+            dueAtMillis = dueAtMillis,
+            createdAtMillis = createdAtMillis,
+            updatedAtMillis = updatedAtMillis,
+            reps = 1,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.REVIEW,
+            fsrsStepIndex = null,
+            fsrsStability = 1.0,
+            fsrsDifficulty = 1.0,
+            fsrsLastReviewedAtMillis = createdAtMillis,
+            fsrsScheduledDays = 1,
+            deletedAtMillis = null
+        )
+    }
+
+    private fun makeNewReviewOrderingCardEntity(
+        cardId: String,
+        workspaceId: String,
+        effortLevel: EffortLevel,
+        createdAtMillis: Long,
+        updatedAtMillis: Long
+    ): CardEntity {
+        return CardEntity(
+            cardId = cardId,
+            workspaceId = workspaceId,
+            frontText = cardId,
+            backText = "Back",
+            effortLevel = effortLevel,
+            dueAtMillis = null,
+            createdAtMillis = createdAtMillis,
+            updatedAtMillis = updatedAtMillis,
+            reps = 0,
+            lapses = 0,
+            fsrsCardState = FsrsCardState.NEW,
+            fsrsStepIndex = null,
+            fsrsStability = null,
+            fsrsDifficulty = null,
+            fsrsLastReviewedAtMillis = null,
+            fsrsScheduledDays = null,
+            deletedAtMillis = null
         )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
@@ -159,9 +159,10 @@ interface CardDao {
             AND (dueAtMillis IS NULL OR dueAtMillis <= :nowMillis)
         ORDER BY
             CASE
-                WHEN dueAtMillis <= :nowMillis THEN 0
-                WHEN dueAtMillis IS NULL THEN 1
-                ELSE 2
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis >= :nowMillis - 3600000 AND dueAtMillis <= :nowMillis THEN 0
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis < :nowMillis - 3600000 THEN 1
+                WHEN dueAtMillis IS NULL THEN 2
+                ELSE 3
             END ASC,
             dueAtMillis ASC,
             createdAtMillis DESC,
@@ -180,9 +181,10 @@ interface CardDao {
             AND effortLevel IN (:effortLevels)
         ORDER BY
             CASE
-                WHEN dueAtMillis <= :nowMillis THEN 0
-                WHEN dueAtMillis IS NULL THEN 1
-                ELSE 2
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis >= :nowMillis - 3600000 AND dueAtMillis <= :nowMillis THEN 0
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis < :nowMillis - 3600000 THEN 1
+                WHEN dueAtMillis IS NULL THEN 2
+                ELSE 3
             END ASC,
             dueAtMillis ASC,
             createdAtMillis DESC,
@@ -212,9 +214,10 @@ interface CardDao {
             )
         ORDER BY
             CASE
-                WHEN dueAtMillis <= :nowMillis THEN 0
-                WHEN dueAtMillis IS NULL THEN 1
-                ELSE 2
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis >= :nowMillis - 3600000 AND dueAtMillis <= :nowMillis THEN 0
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis < :nowMillis - 3600000 THEN 1
+                WHEN dueAtMillis IS NULL THEN 2
+                ELSE 3
             END ASC,
             dueAtMillis ASC,
             createdAtMillis DESC,
@@ -245,9 +248,10 @@ interface CardDao {
         )
         ORDER BY
             CASE
-                WHEN dueAtMillis <= :nowMillis THEN 0
-                WHEN dueAtMillis IS NULL THEN 1
-                ELSE 2
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis >= :nowMillis - 3600000 AND dueAtMillis <= :nowMillis THEN 0
+                WHEN dueAtMillis IS NOT NULL AND dueAtMillis < :nowMillis - 3600000 THEN 1
+                WHEN dueAtMillis IS NULL THEN 2
+                ELSE 3
             END ASC,
             dueAtMillis ASC,
             createdAtMillis DESC,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
@@ -494,6 +494,7 @@ data class ReviewSessionSnapshot(
     val cards: List<ReviewCard>,
     val answerOptions: List<ReviewAnswerOption>,
     val nextAnswerOptions: List<ReviewAnswerOption>,
+    val answerOptionsByCardId: Map<String, List<ReviewAnswerOption>>,
     val remainingCount: Int,
     val totalCount: Int,
     val availableDeckFilters: List<ReviewDeckFilterOption>,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ReviewSupport.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ReviewSupport.kt
@@ -1,17 +1,23 @@
 package com.flashcardsopensourceapp.data.local.model
 
 // Keep review queue ordering aligned with:
-// - apps/ios/Flashcards/Flashcards/ReviewQuerySupport.swift::compareCardsForReviewOrder
+// - apps/ios/Flashcards/Flashcards/Review/ReviewQuerySupport.swift::compareCardsForReviewOrder
 // - apps/ios/Flashcards/Flashcards/Database/CardStore+ReadSQL.swift review queue ORDER BY
 // - apps/web/src/appData/domain.ts::compareCardsForReviewOrder
-// Ordering contract: timed due cards first, then null due/new cards, then future cards,
-// followed by earlier dueAt, newer createdAt, then cardId ascending.
+// Ordering contract: recent due cards within the inclusive one-hour window first,
+// then older due cards, then null due/new cards, then future cards, followed by earlier dueAt,
+// newer createdAt, then cardId ascending.
 // If this changes, mirror the same change across all three clients in the same change.
+private const val recentDuePriorityWindowMillis: Long = 60L * 60L * 1_000L
+
 private fun reviewOrderRank(card: CardSummary, nowMillis: Long): Int {
+    val dueAtMillis = card.dueAtMillis
+    val recentDueCutoffMillis = nowMillis - recentDuePriorityWindowMillis
     return when {
-        card.dueAtMillis != null && card.dueAtMillis <= nowMillis -> 0
-        card.dueAtMillis == null -> 1
-        else -> 2
+        dueAtMillis != null && dueAtMillis >= recentDueCutoffMillis && dueAtMillis <= nowMillis -> 0
+        dueAtMillis != null && dueAtMillis < recentDueCutoffMillis -> 1
+        dueAtMillis == null -> 2
+        else -> 3
     }
 }
 
@@ -140,6 +146,20 @@ private fun cardsMatchingReviewFilter(
     }
 }
 
+private fun buildReviewAnswerOptionsByCardId(
+    cards: List<CardSummary>,
+    settings: WorkspaceSchedulerSettings,
+    reviewedAtMillis: Long
+): Map<String, List<ReviewAnswerOption>> {
+    return cards.associate { card ->
+        card.cardId to makeReviewAnswerOptions(
+            card = card,
+            settings = settings,
+            reviewedAtMillis = reviewedAtMillis
+        )
+    }
+}
+
 fun buildReviewDeckFilterOptions(decks: List<DeckSummary>): List<ReviewDeckFilterOption> {
     return decks.map { deck ->
         ReviewDeckFilterOption(
@@ -203,6 +223,7 @@ fun buildReviewTagFilterOptions(cards: List<CardSummary>, reviewedAtMillis: Long
 fun buildReviewSessionSnapshot(
     selectedFilter: ReviewFilter,
     pendingReviewedCards: Set<PendingReviewedCard>,
+    presentedCardId: String?,
     decks: List<DeckSummary>,
     cards: List<CardSummary>,
     tagsSummary: WorkspaceTagsSummary,
@@ -228,6 +249,23 @@ fun buildReviewSessionSnapshot(
     }
     val currentCard = remainingCards.firstOrNull()
     val nextCard = remainingCards.getOrNull(index = 1)
+    val presentedCard = presentedCardId?.let { cardId ->
+        remainingCards.firstOrNull { card ->
+            card.cardId == cardId
+        }
+    }
+    val answerOptionCards = listOfNotNull(
+        currentCard,
+        nextCard,
+        presentedCard
+    ).distinctBy { card ->
+        card.cardId
+    }
+    val answerOptionsByCardId = buildReviewAnswerOptionsByCardId(
+        cards = answerOptionCards,
+        settings = settings,
+        reviewedAtMillis = reviewedAtMillis
+    )
 
     return ReviewSessionSnapshot(
         selectedFilter = resolvedFilter,
@@ -237,19 +275,12 @@ fun buildReviewSessionSnapshot(
         ),
         cards = remainingCards.map(::toReviewCard),
         answerOptions = currentCard?.let { card ->
-            makeReviewAnswerOptions(
-                card = card,
-                settings = settings,
-                reviewedAtMillis = reviewedAtMillis
-            )
+            answerOptionsByCardId[card.cardId]
         } ?: emptyList(),
         nextAnswerOptions = nextCard?.let { card ->
-            makeReviewAnswerOptions(
-                card = card,
-                settings = settings,
-                reviewedAtMillis = reviewedAtMillis
-            )
+            answerOptionsByCardId[card.cardId]
         } ?: emptyList(),
+        answerOptionsByCardId = answerOptionsByCardId,
         remainingCount = remainingCards.size,
         totalCount = matchingCards.size,
         availableDeckFilters = buildReviewDeckFilterOptions(decks = decks),

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalRepositories.kt
@@ -522,7 +522,8 @@ class LocalReviewRepository(
 ) : ReviewRepository {
     override fun observeReviewSession(
         selectedFilter: ReviewFilter,
-        pendingReviewedCards: Set<com.flashcardsopensourceapp.data.local.model.PendingReviewedCard>
+        pendingReviewedCards: Set<com.flashcardsopensourceapp.data.local.model.PendingReviewedCard>,
+        presentedCardId: String?
     ): Flow<ReviewSessionSnapshot> {
         return combine(
             observeCurrentWorkspace(
@@ -568,6 +569,7 @@ class LocalReviewRepository(
             buildReviewSessionSnapshot(
                 selectedFilter = selectedFilter,
                 pendingReviewedCards = pendingReviewedCards,
+                presentedCardId = presentedCardId,
                 decks = deckSummaries,
                 cards = cardSummaries,
                 tagsSummary = makeWorkspaceTagsSummary(cards = cardSummaries),

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -87,7 +87,8 @@ interface WorkspaceRepository {
 interface ReviewRepository {
     fun observeReviewSession(
         selectedFilter: ReviewFilter,
-        pendingReviewedCards: Set<PendingReviewedCard>
+        pendingReviewedCards: Set<PendingReviewedCard>,
+        presentedCardId: String?
     ): Flow<ReviewSessionSnapshot>
 
     suspend fun loadReviewTimelinePage(

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -111,7 +111,8 @@ class ReviewViewModel(
     private val reviewSessionState = draftState.flatMapLatest { state ->
         reviewRepository.observeReviewSession(
             selectedFilter = state.requestedFilter,
-            pendingReviewedCards = state.pendingReviewedCards
+            pendingReviewedCards = state.pendingReviewedCards,
+            presentedCardId = state.presentedCardId
         ).map { sessionSnapshot ->
             ObservedReviewSessionState(
                 requestedFilter = state.requestedFilter,
@@ -179,9 +180,7 @@ class ReviewViewModel(
         )
         val sessionPreparedCurrentCard = prepareDisplayedSessionCardPresentation(
             displayedCard = displayedCurrentCard,
-            sessionCards = sessionSnapshot.cards,
-            headAnswerOptions = sessionSnapshot.answerOptions,
-            secondAnswerOptions = sessionSnapshot.nextAnswerOptions,
+            answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId,
             textProvider = textProvider
         )
         val currentPreparedCard = if (
@@ -195,9 +194,7 @@ class ReviewViewModel(
         val displayedNextCard = displayedQueue.getOrNull(index = 1)
         val preparedNextCard = prepareDisplayedSessionCardPresentation(
             displayedCard = displayedNextCard,
-            sessionCards = sessionSnapshot.cards,
-            headAnswerOptions = sessionSnapshot.answerOptions,
-            secondAnswerOptions = sessionSnapshot.nextAnswerOptions,
+            answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId,
             textProvider = textProvider
         )
         val emptyState = resolveReviewEmptyState(
@@ -760,9 +757,7 @@ class ReviewViewModel(
         )
         val preparedCurrentCardAfterSync = prepareDisplayedSessionCardPresentation(
             displayedCard = displayedCurrentCardAfterSync,
-            sessionCards = sessionSnapshot.cards,
-            headAnswerOptions = sessionSnapshot.answerOptions,
-            secondAnswerOptions = sessionSnapshot.nextAnswerOptions,
+            answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId,
             textProvider = textProvider
         )
         val didReviewQueueChange = reviewCardIdsBeforeSync != reviewCardIdsAfterSync
@@ -953,6 +948,7 @@ private fun loadingReviewSessionSnapshot(textProvider: ReviewTextProvider): Revi
         cards = emptyList(),
         answerOptions = emptyList(),
         nextAnswerOptions = emptyList(),
+        answerOptionsByCardId = emptyMap(),
         remainingCount = 0,
         totalCount = 0,
         availableDeckFilters = emptyList(),
@@ -976,7 +972,7 @@ private fun resolvePresentedCardId(
     return sessionCards.firstOrNull()?.cardId
 }
 
-private fun resolveDisplayedCurrentCard(
+internal fun resolveDisplayedCurrentCard(
     sessionCards: List<ReviewCard>,
     presentedCardId: String?
 ): ReviewCard? {
@@ -985,7 +981,7 @@ private fun resolveDisplayedCurrentCard(
     } ?: sessionCards.firstOrNull()
 }
 
-private fun buildDisplayedReviewQueue(
+internal fun buildDisplayedReviewQueue(
     sessionCards: List<ReviewCard>,
     displayedCurrentCardId: String?
 ): List<ReviewCard> {
@@ -1007,22 +1003,30 @@ private fun buildDisplayedReviewQueue(
     }
 }
 
+internal fun resolveDisplayedSessionAnswerOptions(
+    displayedCard: ReviewCard?,
+    answerOptionsByCardId: Map<String, List<ReviewAnswerOption>>
+): List<ReviewAnswerOption>? {
+    val card = displayedCard ?: return null
+    return answerOptionsByCardId[card.cardId]
+}
+
 private fun prepareDisplayedSessionCardPresentation(
     displayedCard: ReviewCard?,
-    sessionCards: List<ReviewCard>,
-    headAnswerOptions: List<ReviewAnswerOption>,
-    secondAnswerOptions: List<ReviewAnswerOption>,
+    answerOptionsByCardId: Map<String, List<ReviewAnswerOption>>,
     textProvider: ReviewTextProvider
 ): PreparedReviewCardPresentation? {
     val card = displayedCard ?: return null
-    val cardIndex = sessionCards.indexOfFirst { sessionCard ->
-        sessionCard.cardId == card.cardId
+    val answerOptions = requireNotNull(
+        resolveDisplayedSessionAnswerOptions(
+            displayedCard = card,
+            answerOptionsByCardId = answerOptionsByCardId
+        )
+    ) {
+        "Review answer options are missing for displayed card: ${card.cardId}"
     }
-
-    val answerOptions = when (cardIndex) {
-        0 -> headAnswerOptions
-        1 -> secondAnswerOptions
-        else -> return null
+    require(answerOptions.isNotEmpty()) {
+        "Review answer options are empty for displayed card: ${card.cardId}"
     }
 
     return prepareReviewCardPresentation(

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewPinnedCurrentCardPresentationTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewPinnedCurrentCardPresentationTest.kt
@@ -1,0 +1,181 @@
+package com.flashcardsopensourceapp.feature.review
+
+import com.flashcardsopensourceapp.data.local.model.CardSummary
+import com.flashcardsopensourceapp.data.local.model.EffortLevel
+import com.flashcardsopensourceapp.data.local.model.FsrsCardState
+import com.flashcardsopensourceapp.data.local.model.PendingReviewedCard
+import com.flashcardsopensourceapp.data.local.model.ReviewFilter
+import com.flashcardsopensourceapp.data.local.model.ReviewRating
+import com.flashcardsopensourceapp.data.local.model.ReviewSessionSnapshot
+import com.flashcardsopensourceapp.data.local.model.WorkspaceTagsSummary
+import com.flashcardsopensourceapp.data.local.model.buildReviewSessionSnapshot
+import com.flashcardsopensourceapp.data.local.model.makeDefaultWorkspaceSchedulerSettings
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+private const val pinnedReviewWorkspaceId: String = "workspace-review-pinned-current"
+private const val pinnedReviewNowMillis: Long = 3_600_000L
+private const val pinnedReviewOneHourMillis: Long = 60L * 60L * 1_000L
+private const val pinnedReviewOneDayMillis: Long = 24L * 60L * 60L * 1_000L
+
+class ReviewPinnedCurrentCardPresentationTest {
+    @Test
+    fun pinnedCurrentCardStaysOptionBearingWhenCanonicalQueueMovesItBehindRecentDueCards() {
+        val pinnedCard = makePinnedReviewCardSummary(
+            cardId = "pinned-old-card",
+            dueAtMillis = pinnedReviewNowMillis - pinnedReviewOneHourMillis - 1L,
+            createdAtMillis = 400L,
+            updatedAtMillis = 400L
+        )
+        val cards = listOf(
+            pinnedCard,
+            makePinnedReviewCardSummary(
+                cardId = "recent-due-1115-card",
+                dueAtMillis = pinnedReviewNowMillis - (45L * 60L * 1_000L),
+                createdAtMillis = 100L,
+                updatedAtMillis = 100L
+            ),
+            makePinnedReviewCardSummary(
+                cardId = "recent-due-1155-card",
+                dueAtMillis = pinnedReviewNowMillis - (5L * 60L * 1_000L),
+                createdAtMillis = 200L,
+                updatedAtMillis = 200L
+            ),
+            makePinnedReviewCardSummary(
+                cardId = "null-due-card",
+                dueAtMillis = null,
+                createdAtMillis = 300L,
+                updatedAtMillis = 300L
+            )
+        )
+        val sessionSnapshot = makePinnedReviewSessionSnapshot(
+            cards = cards,
+            pendingReviewedCards = emptySet(),
+            presentedCardId = pinnedCard.cardId
+        )
+
+        assertEquals(
+            listOf("recent-due-1115-card", "recent-due-1155-card", "pinned-old-card", "null-due-card"),
+            sessionSnapshot.cards.map { card -> card.cardId }
+        )
+        assertEquals(
+            setOf("recent-due-1115-card", "recent-due-1155-card", "pinned-old-card"),
+            sessionSnapshot.answerOptionsByCardId.keys
+        )
+
+        val displayedCurrentCard = requireNotNull(
+            resolveDisplayedCurrentCard(
+                sessionCards = sessionSnapshot.cards,
+                presentedCardId = pinnedCard.cardId
+            )
+        )
+        val displayedQueue = buildDisplayedReviewQueue(
+            sessionCards = sessionSnapshot.cards,
+            displayedCurrentCardId = displayedCurrentCard.cardId
+        )
+        assertEquals(
+            listOf("pinned-old-card", "recent-due-1115-card", "recent-due-1155-card", "null-due-card"),
+            displayedQueue.map { card -> card.cardId }
+        )
+
+        val pinnedAnswerOptions = requireNotNull(
+            resolveDisplayedSessionAnswerOptions(
+                displayedCard = displayedCurrentCard,
+                answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId
+            )
+        )
+        assertEquals(
+            listOf(ReviewRating.AGAIN, ReviewRating.HARD, ReviewRating.GOOD, ReviewRating.EASY),
+            pinnedAnswerOptions.map { option -> option.rating }
+        )
+
+        val preparedNextAnswerOptions = requireNotNull(
+            resolveDisplayedSessionAnswerOptions(
+                displayedCard = displayedQueue[1],
+                answerOptionsByCardId = sessionSnapshot.answerOptionsByCardId
+            )
+        )
+        assertEquals(sessionSnapshot.answerOptions, preparedNextAnswerOptions)
+
+        val afterAnswerSnapshot = makePinnedReviewSessionSnapshot(
+            cards = cards,
+            pendingReviewedCards = setOf(
+                PendingReviewedCard(
+                    cardId = pinnedCard.cardId,
+                    updatedAtMillis = pinnedCard.updatedAtMillis
+                )
+            ),
+            presentedCardId = displayedQueue[1].cardId
+        )
+        val displayedCardAfterAnswer = requireNotNull(
+            resolveDisplayedCurrentCard(
+                sessionCards = afterAnswerSnapshot.cards,
+                presentedCardId = displayedQueue[1].cardId
+            )
+        )
+        val answerOptionsAfterAnswer = requireNotNull(
+            resolveDisplayedSessionAnswerOptions(
+                displayedCard = displayedCardAfterAnswer,
+                answerOptionsByCardId = afterAnswerSnapshot.answerOptionsByCardId
+            )
+        )
+
+        assertEquals("recent-due-1115-card", displayedCardAfterAnswer.cardId)
+        assertEquals(
+            setOf("recent-due-1115-card", "recent-due-1155-card"),
+            afterAnswerSnapshot.answerOptionsByCardId.keys
+        )
+        assertEquals(afterAnswerSnapshot.answerOptions, answerOptionsAfterAnswer)
+    }
+}
+
+private fun makePinnedReviewSessionSnapshot(
+    cards: List<CardSummary>,
+    pendingReviewedCards: Set<PendingReviewedCard>,
+    presentedCardId: String?
+): ReviewSessionSnapshot {
+    return buildReviewSessionSnapshot(
+        selectedFilter = ReviewFilter.AllCards,
+        pendingReviewedCards = pendingReviewedCards,
+        presentedCardId = presentedCardId,
+        decks = emptyList(),
+        cards = cards,
+        tagsSummary = WorkspaceTagsSummary(
+            tags = emptyList(),
+            totalCards = cards.size
+        ),
+        settings = makeDefaultWorkspaceSchedulerSettings(
+            workspaceId = pinnedReviewWorkspaceId,
+            updatedAtMillis = pinnedReviewNowMillis
+        ),
+        reviewedAtMillis = pinnedReviewNowMillis
+    )
+}
+
+private fun makePinnedReviewCardSummary(
+    cardId: String,
+    dueAtMillis: Long?,
+    createdAtMillis: Long,
+    updatedAtMillis: Long
+): CardSummary {
+    return CardSummary(
+        cardId = cardId,
+        workspaceId = pinnedReviewWorkspaceId,
+        frontText = "Front $cardId",
+        backText = "Back $cardId",
+        tags = emptyList(),
+        effortLevel = EffortLevel.FAST,
+        dueAtMillis = dueAtMillis,
+        createdAtMillis = createdAtMillis,
+        updatedAtMillis = updatedAtMillis,
+        reps = 2,
+        lapses = 0,
+        fsrsCardState = FsrsCardState.REVIEW,
+        fsrsStepIndex = null,
+        fsrsStability = 2.5,
+        fsrsDifficulty = 5.0,
+        fsrsLastReviewedAtMillis = pinnedReviewNowMillis - pinnedReviewOneDayMillis,
+        fsrsScheduledDays = 1,
+        deletedAtMillis = null
+    )
+}

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore+Read.swift
@@ -179,7 +179,7 @@ extension CardStore {
                 COALESCE(
                     SUM(
                         CASE
-                            WHEN due_at IS NULL OR due_at <= ? THEN 1
+                            WHEN \(cardStoreActiveReviewDueEligibilitySQL) THEN 1
                             ELSE 0
                         END
                     ),
@@ -296,6 +296,8 @@ extension CardStore {
         precondition(offset >= 0, "Review timeline page offset must not be negative")
 
         let querySQL = try self.makeReviewQuerySQL(reviewQueryDefinition: reviewQueryDefinition)
+        let nowText = formatIsoTimestamp(date: now)
+        let cutoffText = formatIsoTimestamp(date: now.addingTimeInterval(-recentDuePriorityWindow))
         let pageRows = try self.core.query(
             sql: """
             SELECT
@@ -304,17 +306,24 @@ extension CardStore {
             WHERE workspace_id = ? AND deleted_at IS NULL\(querySQL.clause)
             ORDER BY
                 CASE
-                    WHEN due_at <= ? THEN 0
-                    WHEN due_at IS NULL THEN 1
-                    ELSE 2
+                    WHEN due_at IS NULL THEN 2
+                    WHEN NOT \(cardStoreSupportedIsoDueAtSQL) THEN 4
+                    WHEN \(cardStoreDueAtSortKeySQL) >= ? AND \(cardStoreDueAtSortKeySQL) <= ? THEN 0
+                    WHEN \(cardStoreDueAtSortKeySQL) < ? THEN 1
+                    ELSE 3
                 END ASC,
-                due_at ASC,
+                CASE
+                    WHEN \(cardStoreSupportedIsoDueAtSQL) THEN \(cardStoreDueAtSortKeySQL)
+                    ELSE NULL
+                END ASC,
                 created_at DESC,
                 card_id ASC
             LIMIT ? OFFSET ?
             """,
             values: [.text(workspaceId)] + querySQL.values + [
-                .text(formatIsoTimestamp(date: now)),
+                .text(cutoffText),
+                .text(nowText),
+                .text(cutoffText),
                 .integer(Int64(limit + 1)),
                 .integer(Int64(offset))
             ]

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore+ReadSQL.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore+ReadSQL.swift
@@ -24,6 +24,244 @@ let cardStoreSelectColumnsSQL: String = """
     deleted_at
 """
 
+let cardStoreIsoSecondPrefixShapeSQL: String = """
+substr(due_at, 1, 19) GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]'
+"""
+
+// TODO: migrate review queue filtering and ordering to an indexed numeric due timestamp
+// so SQLite does not have to mirror Swift ISO calendar validation for due_at text.
+let cardStoreIsoDateTimeComponentRangeSQL: String = """
+(
+    substr(due_at, 6, 2) BETWEEN '01' AND '12'
+    AND substr(due_at, 9, 2) BETWEEN '01' AND '31'
+    AND CAST(substr(due_at, 9, 2) AS INTEGER) <= CASE
+        WHEN substr(due_at, 6, 2) IN ('01', '03', '05', '07', '08', '10', '12') THEN 31
+        WHEN substr(due_at, 6, 2) IN ('04', '06', '09', '11') THEN 30
+        WHEN substr(due_at, 6, 2) = '02'
+            AND (
+                CAST(substr(due_at, 1, 4) AS INTEGER) % 400 = 0
+                OR (
+                    CAST(substr(due_at, 1, 4) AS INTEGER) % 4 = 0
+                    AND CAST(substr(due_at, 1, 4) AS INTEGER) % 100 != 0
+                )
+            ) THEN 29
+        WHEN substr(due_at, 6, 2) = '02' THEN 28
+        ELSE 0
+    END
+    AND substr(due_at, 12, 2) BETWEEN '00' AND '23'
+    AND substr(due_at, 15, 2) BETWEEN '00' AND '59'
+    AND substr(due_at, 18, 2) BETWEEN '00' AND '59'
+)
+"""
+
+let cardStoreCanonicalDueAtSQL: String = """
+(
+    length(due_at) = 24
+    AND due_at GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9].[0-9][0-9][0-9]Z'
+    AND \(cardStoreIsoDateTimeComponentRangeSQL)
+)
+"""
+
+let cardStoreSupportedIsoDueAtSQL: String = """
+(
+    \(cardStoreCanonicalDueAtSQL)
+    OR (
+        length(due_at) = 20
+        AND due_at GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z'
+        AND \(cardStoreIsoDateTimeComponentRangeSQL)
+    )
+    OR (
+        length(due_at) > 21
+        AND \(cardStoreIsoSecondPrefixShapeSQL)
+        AND \(cardStoreIsoDateTimeComponentRangeSQL)
+        AND substr(due_at, 20, 1) = '.'
+        AND substr(due_at, length(due_at), 1) = 'Z'
+        AND substr(due_at, 21, length(due_at) - 21) NOT GLOB '*[^0-9]*'
+    )
+)
+"""
+
+let cardStoreNonCanonicalSupportedIsoDueAtSQL: String = """
+(
+    \(cardStoreSupportedIsoDueAtSQL)
+    AND NOT \(cardStoreCanonicalDueAtSQL)
+)
+"""
+
+let cardStoreDueAtSortKeySQL: String = """
+CASE
+    WHEN due_at IS NULL THEN NULL
+    WHEN length(due_at) = 20
+        AND due_at GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z'
+        THEN substr(due_at, 1, 19) || '.000Z'
+    WHEN \(cardStoreSupportedIsoDueAtSQL)
+        THEN substr(due_at, 1, 20) || substr(substr(due_at, 21, length(due_at) - 21) || '000', 1, 3) || 'Z'
+    ELSE NULL
+END
+"""
+
+let cardStoreActiveReviewDueEligibilitySQL: String = """
+(
+    due_at IS NULL
+    OR (
+        due_at IS NOT NULL
+        AND \(cardStoreSupportedIsoDueAtSQL)
+        AND \(cardStoreDueAtSortKeySQL) <= ?
+    )
+)
+"""
+
+let cardStoreActiveDueBucketOrderSQL: String = "due_at ASC, created_at DESC, card_id ASC"
+
+private enum ActiveReviewQueueSQLBucket {
+    case recentDue(cutoff: String, now: String, lowerBound: String, upperBound: String)
+    case oldDue(cutoff: String, upperBound: String)
+    case new
+}
+
+private func makeIsoTimestampSecondPrefix(date: Date) -> String {
+    String(formatIsoTimestamp(date: date).prefix(19))
+}
+
+private func makeIsoTimestampSecondUpperBound(date: Date) -> String {
+    "\(makeIsoTimestampSecondPrefix(date: date))Z"
+}
+
+private func makeActiveReviewQueueCanonicalBucketSQL(bucket: ActiveReviewQueueSQLBucket) -> ReviewQuerySQL {
+    switch bucket {
+    case .recentDue(let cutoff, let now, _, _):
+        return ReviewQuerySQL(
+            clause: """
+             AND due_at IS NOT NULL
+             AND \(cardStoreCanonicalDueAtSQL)
+             AND due_at >= ?
+             AND due_at <= ?
+            """,
+            values: [
+                .text(cutoff),
+                .text(now)
+            ]
+        )
+    case .oldDue(let cutoff, _):
+        return ReviewQuerySQL(
+            clause: """
+             AND due_at IS NOT NULL
+             AND \(cardStoreCanonicalDueAtSQL)
+             AND due_at < ?
+            """,
+            values: [.text(cutoff)]
+        )
+    case .new:
+        return ReviewQuerySQL(
+            clause: " AND due_at IS NULL",
+            values: []
+        )
+    }
+}
+
+private func makeActiveReviewQueueNonCanonicalCandidateUpperSortKey(
+    canonicalRows: [Card],
+    limit: Int
+) -> String? {
+    guard canonicalRows.count == limit else {
+        return nil
+    }
+
+    return canonicalRows.last?.dueAt
+}
+
+private func makeActiveReviewQueueNonCanonicalBucketSQL(
+    bucket: ActiveReviewQueueSQLBucket,
+    candidateUpperSortKey: String?
+) -> ReviewQuerySQL? {
+    let candidateUpperSortKeyClause: String
+    let candidateUpperSortKeyValues: [SQLiteValue]
+    if let candidateUpperSortKey {
+        candidateUpperSortKeyClause = """
+
+             AND \(cardStoreDueAtSortKeySQL) <= ?
+        """
+        candidateUpperSortKeyValues = [.text(candidateUpperSortKey)]
+    } else {
+        candidateUpperSortKeyClause = ""
+        candidateUpperSortKeyValues = []
+    }
+
+    switch bucket {
+    case .recentDue(let cutoff, let now, let lowerBound, let upperBound):
+        return ReviewQuerySQL(
+            clause: """
+             AND due_at IS NOT NULL
+             AND \(cardStoreNonCanonicalSupportedIsoDueAtSQL)
+             AND due_at >= ?
+             AND due_at <= ?
+             AND \(cardStoreDueAtSortKeySQL) >= ?
+             AND \(cardStoreDueAtSortKeySQL) <= ?\(candidateUpperSortKeyClause)
+            """,
+            values: [
+                .text(lowerBound),
+                .text(upperBound),
+                .text(cutoff),
+                .text(now)
+            ] + candidateUpperSortKeyValues
+        )
+    case .oldDue(let cutoff, let upperBound):
+        return ReviewQuerySQL(
+            clause: """
+             AND due_at IS NOT NULL
+             AND \(cardStoreNonCanonicalSupportedIsoDueAtSQL)
+             AND due_at <= ?
+             AND \(cardStoreDueAtSortKeySQL) < ?\(candidateUpperSortKeyClause)
+            """,
+            values: [
+                .text(upperBound),
+                .text(cutoff)
+            ] + candidateUpperSortKeyValues
+        )
+    case .new:
+        return nil
+    }
+}
+
+private func makeActiveReviewQueueCanonicalBucketOrderSQL(bucket: ActiveReviewQueueSQLBucket) -> String {
+    switch bucket {
+    case .recentDue, .oldDue:
+        return cardStoreActiveDueBucketOrderSQL
+    case .new:
+        return "created_at DESC, card_id ASC"
+    }
+}
+
+private func makeActiveReviewQueueNonCanonicalBucketOrderSQL() -> String {
+    "\(cardStoreDueAtSortKeySQL) ASC, created_at DESC, card_id ASC"
+}
+
+private func shouldLoadNonCanonicalActiveBucketRows(bucket: ActiveReviewQueueSQLBucket) -> Bool {
+    switch bucket {
+    case .recentDue, .oldDue:
+        return true
+    case .new:
+        return false
+    }
+}
+
+private func mergeActiveReviewQueueDueBucketRows(
+    canonicalRows: [Card],
+    nonCanonicalRows: [Card],
+    now: Date,
+    limit: Int
+) -> [Card] {
+    guard nonCanonicalRows.isEmpty == false else {
+        return canonicalRows
+    }
+
+    let sortedRows = (canonicalRows + nonCanonicalRows).sorted { leftCard, rightCard in
+        compareCardsForReviewOrder(leftCard: leftCard, rightCard: rightCard, now: now)
+    }
+
+    return Array(sortedRows.prefix(limit))
+}
+
 extension CardStore {
     func makeReviewQuerySQL(reviewQueryDefinition: ReviewQueryDefinition) throws -> ReviewQuerySQL {
         switch reviewQueryDefinition {
@@ -197,36 +435,125 @@ extension CardStore {
         }
 
         // Keep review queue ordering aligned with:
-        // - apps/ios/Flashcards/Flashcards/ReviewQuerySupport.swift::compareCardsForReviewOrder
+        // - apps/ios/Flashcards/Flashcards/Review/ReviewQuerySupport.swift::compareCardsForReviewOrder
         // - apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ReviewSupport.kt::sortCardsForReviewQueue
         // - apps/web/src/appData/domain.ts::compareCardsForReviewOrder
-        // Ordering contract: timed due cards first, then nil dueAt new cards, then future cards.
+        // Ordering contract: recent due cards within the inclusive one-hour window first, then older due cards,
+        // then nil dueAt new cards. Future and malformed dueAt values are excluded from the active queue.
         // If this changes, mirror the same change across all three clients in the same change.
+        let targetLimit = limit + 1
+        let nowText = formatIsoTimestamp(date: now)
+        let cutoffText = formatIsoTimestamp(date: now.addingTimeInterval(-recentDuePriorityWindow))
+        var rows: [Card] = []
+
+        for bucket in [
+            ActiveReviewQueueSQLBucket.recentDue(
+                cutoff: cutoffText,
+                now: nowText,
+                lowerBound: makeIsoTimestampSecondPrefix(date: now.addingTimeInterval(-recentDuePriorityWindow)),
+                upperBound: makeIsoTimestampSecondUpperBound(date: now)
+            ),
+            ActiveReviewQueueSQLBucket.oldDue(
+                cutoff: cutoffText,
+                upperBound: makeIsoTimestampSecondUpperBound(date: now.addingTimeInterval(-recentDuePriorityWindow))
+            ),
+            ActiveReviewQueueSQLBucket.new
+        ] {
+            let remainingLimit = targetLimit - rows.count
+            guard remainingLimit > 0 else {
+                break
+            }
+
+            rows += try self.loadActiveReviewQueueBucketRows(
+                workspaceId: workspaceId,
+                querySQL: querySQL,
+                excludedCardIdsClause: excludedCardIdsClause,
+                excludedCardValues: excludedCardValues,
+                bucket: bucket,
+                now: now,
+                limit: remainingLimit
+            )
+        }
+
+        return rows
+    }
+
+    private func loadActiveReviewQueueBucketRows(
+        workspaceId: String,
+        querySQL: ReviewQuerySQL,
+        excludedCardIdsClause: String,
+        excludedCardValues: [SQLiteValue],
+        bucket: ActiveReviewQueueSQLBucket,
+        now: Date,
+        limit: Int
+    ) throws -> [Card] {
+        let canonicalBucketSQL = makeActiveReviewQueueCanonicalBucketSQL(bucket: bucket)
+        let canonicalRows = try self.loadActiveReviewQueueRowsMatchingBucketSQL(
+            workspaceId: workspaceId,
+            querySQL: querySQL,
+            excludedCardIdsClause: excludedCardIdsClause,
+            excludedCardValues: excludedCardValues,
+            bucketSQL: canonicalBucketSQL,
+            orderSQL: makeActiveReviewQueueCanonicalBucketOrderSQL(bucket: bucket),
+            limit: limit
+        )
+
+        guard shouldLoadNonCanonicalActiveBucketRows(bucket: bucket) else {
+            return canonicalRows
+        }
+
+        let nonCanonicalCandidateUpperSortKey = makeActiveReviewQueueNonCanonicalCandidateUpperSortKey(
+            canonicalRows: canonicalRows,
+            limit: limit
+        )
+        guard let nonCanonicalBucketSQL = makeActiveReviewQueueNonCanonicalBucketSQL(
+            bucket: bucket,
+            candidateUpperSortKey: nonCanonicalCandidateUpperSortKey
+        ) else {
+            return canonicalRows
+        }
+
+        let nonCanonicalRows = try self.loadActiveReviewQueueRowsMatchingBucketSQL(
+            workspaceId: workspaceId,
+            querySQL: querySQL,
+            excludedCardIdsClause: excludedCardIdsClause,
+            excludedCardValues: excludedCardValues,
+            bucketSQL: nonCanonicalBucketSQL,
+            orderSQL: makeActiveReviewQueueNonCanonicalBucketOrderSQL(),
+            limit: limit
+        )
+
+        return mergeActiveReviewQueueDueBucketRows(
+            canonicalRows: canonicalRows,
+            nonCanonicalRows: nonCanonicalRows,
+            now: now,
+            limit: limit
+        )
+    }
+
+    private func loadActiveReviewQueueRowsMatchingBucketSQL(
+        workspaceId: String,
+        querySQL: ReviewQuerySQL,
+        excludedCardIdsClause: String,
+        excludedCardValues: [SQLiteValue],
+        bucketSQL: ReviewQuerySQL,
+        orderSQL: String,
+        limit: Int
+    ) throws -> [Card] {
         return try self.core.query(
             sql: """
             SELECT
             \(cardStoreSelectColumnsSQL)
             FROM cards
             WHERE workspace_id = ?
-                AND deleted_at IS NULL
-                AND (due_at IS NULL OR due_at <= ?)\(querySQL.clause)\(excludedCardIdsClause)
-            ORDER BY
-                CASE
-                    WHEN due_at <= ? THEN 0
-                    WHEN due_at IS NULL THEN 1
-                    ELSE 2
-                END ASC,
-                due_at ASC,
-                created_at DESC,
-                card_id ASC
+                AND deleted_at IS NULL\(bucketSQL.clause)\(querySQL.clause)\(excludedCardIdsClause)
+            ORDER BY \(orderSQL)
             LIMIT ?
             """,
             values: [
-                .text(workspaceId),
-                .text(formatIsoTimestamp(date: now))
-            ] + querySQL.values + excludedCardValues + [
-                .text(formatIsoTimestamp(date: now)),
-                .integer(Int64(limit + 1))
+                .text(workspaceId)
+            ] + bucketSQL.values + querySQL.values + excludedCardValues + [
+                .integer(Int64(limit))
             ]
         ) { statement in
             try self.mapCard(statement: statement)

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
@@ -177,6 +177,7 @@ extension FlashcardsStore {
     func applyReviewPublishedState(reviewState: ReviewQueuePublishedState) {
         self.selectedReviewFilter = reviewState.selectedReviewFilter
         self.reviewQueue = reviewState.reviewQueue
+        self.reviewQueueCanonicalCount = reviewState.reviewQueueCanonicalCount
         self.presentedReviewCardId = reviewState.presentedCardId
         self.reviewCounts = reviewState.reviewCounts
         self.isReviewHeadLoading = reviewState.isReviewHeadLoading
@@ -190,6 +191,7 @@ extension FlashcardsStore {
         ReviewQueuePublishedState(
             selectedReviewFilter: self.selectedReviewFilter,
             reviewQueue: self.reviewQueue,
+            reviewQueueCanonicalCount: self.reviewQueueCanonicalCount,
             presentedCardId: self.presentedReviewCardId,
             reviewCounts: self.reviewCounts,
             isReviewHeadLoading: self.isReviewHeadLoading,

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
@@ -64,6 +64,7 @@ final class FlashcardsStore {
     var deckItems: [DeckListItem]
     var selectedReviewFilter: ReviewFilter
     var reviewQueue: [Card]
+    var reviewQueueCanonicalCount: Int
     var presentedReviewCardId: String?
     var reviewCounts: ReviewCounts
     var isReviewHeadLoading: Bool
@@ -310,6 +311,7 @@ final class FlashcardsStore {
         self.deckItems = []
         self.selectedReviewFilter = initialReviewPublishedState.selectedReviewFilter
         self.reviewQueue = initialReviewPublishedState.reviewQueue
+        self.reviewQueueCanonicalCount = initialReviewPublishedState.reviewQueueCanonicalCount
         self.presentedReviewCardId = initialReviewPublishedState.presentedCardId
         self.reviewCounts = initialReviewPublishedState.reviewCounts
         self.isReviewHeadLoading = initialReviewPublishedState.isReviewHeadLoading

--- a/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+Review.swift
@@ -379,7 +379,7 @@ extension FlashcardsStore {
         let databaseURL = database.databaseURL
         let reviewCountsLoader = self.dependencies.reviewCountsLoader
         let reviewQueueWindowLoader = self.dependencies.reviewQueueWindowLoader
-        let reviewQueueWindowLimit = max(currentReviewState.reviewQueue.count, reviewSeedQueueSize)
+        let reviewQueueWindowLimit = max(currentReviewState.reviewQueueCanonicalCount, reviewSeedQueueSize)
 
         async let reviewCountsTask = reviewCountsLoader(
             databaseURL,
@@ -404,16 +404,25 @@ extension FlashcardsStore {
         guard resolvedReviewQuery.reviewFilter == self.selectedReviewFilter else {
             return false
         }
+        let refreshedReviewQueue = reviewQueuePreservingPresentedCard(
+            reviewQueue: reviewQueueWindowState.reviewQueue,
+            presentedCardId: currentCardId,
+            pendingReviewCardIds: currentReviewState.pendingReviewCardIds,
+            resolvedReviewFilter: resolvedReviewQuery.reviewFilter,
+            decks: self.decks,
+            cards: self.cards,
+            now: now
+        )
 
         let nextSignature = makeReviewSessionSignature(
             selectedReviewFilter: resolvedReviewQuery.reviewFilter,
-            reviewQueue: reviewQueueWindowState.reviewQueue,
+            reviewQueue: refreshedReviewQueue,
             schedulerSettings: self.schedulerSettings,
             seedQueueSize: reviewSeedQueueSize
         )
         let didChangeReviewSession = currentSignature != nextSignature
         let didChangeReviewCounts = currentReviewState.reviewCounts != reviewCounts
-        let didChangeLoadedReviewQueue = currentReviewState.reviewQueue != reviewQueueWindowState.reviewQueue
+        let didChangeLoadedReviewQueue = currentReviewState.reviewQueue != refreshedReviewQueue
 
         guard didChangeReviewSession || didChangeReviewCounts || didChangeLoadedReviewQueue else {
             return false
@@ -423,7 +432,8 @@ extension FlashcardsStore {
             publishedState: currentReviewState,
             selectedReviewFilter: resolvedReviewQuery.reviewFilter,
             reviewCounts: reviewCounts,
-            reviewQueue: reviewQueueWindowState.reviewQueue,
+            reviewQueue: refreshedReviewQueue,
+            reviewQueueCanonicalCount: reviewQueueWindowState.reviewQueue.count,
             hasMoreCards: reviewQueueWindowState.hasMoreCards
         )
         self.applyReviewPublishedState(reviewState: nextReviewState)

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewQuerySupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewQuerySupport.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+let recentDuePriorityWindow: TimeInterval = 60 * 60
+
 struct ResolvedReviewQuery: Hashable, Sendable {
     let reviewFilter: ReviewFilter
     let queryDefinition: ReviewQueryDefinition
@@ -32,16 +34,47 @@ struct ReviewQueueWindowLoadState: Hashable, Sendable {
     let hasMoreCards: Bool
 }
 
-private func reviewOrderDueAtRank(card: Card) -> Int {
+enum ReviewOrderBucket: Int, Hashable, Sendable {
+    case recentDue = 0
+    case oldDue = 1
+    case new = 2
+    case future = 3
+    case malformed = 4
+}
+
+struct ReviewOrderRank: Hashable, Sendable {
+    let bucket: ReviewOrderBucket
+    let dueAt: Date?
+}
+
+func makeReviewOrderRank(card: Card, now: Date) -> ReviewOrderRank {
     guard let dueAt = card.dueAt else {
-        return 1
+        return ReviewOrderRank(bucket: .new, dueAt: nil)
     }
 
-    guard parseIsoTimestamp(value: dueAt) != nil else {
-        return 2
+    guard let dueDate = parseIsoTimestamp(value: dueAt) else {
+        return ReviewOrderRank(bucket: .malformed, dueAt: nil)
     }
 
-    return 0
+    if dueDate > now {
+        return ReviewOrderRank(bucket: .future, dueAt: dueDate)
+    }
+
+    let recentCutoff = now.addingTimeInterval(-recentDuePriorityWindow)
+    if dueDate >= recentCutoff {
+        return ReviewOrderRank(bucket: .recentDue, dueAt: dueDate)
+    }
+
+    return ReviewOrderRank(bucket: .oldDue, dueAt: dueDate)
+}
+
+func isActiveReviewOrderBucket(bucket: ReviewOrderBucket) -> Bool {
+    switch bucket {
+    case .recentDue, .oldDue, .new:
+        return true
+    case .future, .malformed:
+        return false
+    }
 }
 
 private func hasActiveTag(tag: String, cards: [Card]) -> Bool {
@@ -54,24 +87,19 @@ private func hasActiveTag(tag: String, cards: [Card]) -> Bool {
 // - apps/ios/Flashcards/Flashcards/Database/CardStore+ReadSQL.swift review queue ORDER BY
 // - apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ReviewSupport.kt::sortCardsForReviewQueue
 // - apps/web/src/appData/domain.ts::compareCardsForReviewOrder
-// Ordering contract: timed due cards first, then nil dueAt new cards, then future cards, then malformed dueAt values last.
+// Ordering contract: recent due cards within the inclusive one-hour window first, then older due cards,
+// then nil dueAt new cards, then future cards, then malformed dueAt values last.
 // If this changes, mirror the same change across all three clients in the same change.
 func compareCardsForReviewOrder(leftCard: Card, rightCard: Card, now: Date) -> Bool {
-    let leftIsDue = isCardDue(card: leftCard, now: now)
-    let rightIsDue = isCardDue(card: rightCard, now: now)
-    if leftIsDue != rightIsDue {
-        return leftIsDue
-    }
-
-    let leftDueRank = reviewOrderDueAtRank(card: leftCard)
-    let rightDueRank = reviewOrderDueAtRank(card: rightCard)
-    if leftDueRank != rightDueRank {
-        return leftDueRank < rightDueRank
+    let leftRank = makeReviewOrderRank(card: leftCard, now: now)
+    let rightRank = makeReviewOrderRank(card: rightCard, now: now)
+    if leftRank.bucket != rightRank.bucket {
+        return leftRank.bucket.rawValue < rightRank.bucket.rawValue
     }
 
     if
-        let leftDueDate = leftCard.dueAt.flatMap(parseIsoTimestamp),
-        let rightDueDate = rightCard.dueAt.flatMap(parseIsoTimestamp),
+        let leftDueDate = leftRank.dueAt,
+        let rightDueDate = rightRank.dueAt,
         leftDueDate != rightDueDate
     {
         return leftDueDate < rightDueDate
@@ -88,7 +116,7 @@ func compareCardsForReviewOrder(leftCard: Card, rightCard: Card, now: Date) -> B
 
 func sortCardsForReviewQueue(cards: [Card], now: Date) -> [Card] {
     cards.filter { card in
-        card.deletedAt == nil && isCardDue(card: card, now: now)
+        card.deletedAt == nil && isActiveReviewOrderBucket(bucket: makeReviewOrderRank(card: card, now: now).bucket)
     }.sorted { leftCard, rightCard in
         compareCardsForReviewOrder(leftCard: leftCard, rightCard: rightCard, now: now)
     }
@@ -187,6 +215,64 @@ func makeReviewQueue(reviewFilter: ReviewFilter, decks: [Deck], cards: [Card], n
         cards: cardsMatchingReviewFilter(reviewFilter: reviewFilter, decks: decks, cards: cards),
         now: now
     )
+}
+
+private func cardMatchesResolvedReviewFilter(reviewFilter: ReviewFilter, decks: [Deck], card: Card) -> Bool {
+    guard card.deletedAt == nil else {
+        return false
+    }
+
+    switch reviewFilter {
+    case .allCards:
+        return true
+    case .deck(let deckId):
+        guard let deck = decks.first(where: { candidateDeck in
+            candidateDeck.deckId == deckId
+        }) else {
+            return false
+        }
+
+        return matchesDeckFilterDefinition(filterDefinition: deck.filterDefinition, card: card)
+    case .effort(let level):
+        return card.effortLevel == level
+    case .tag(let tag):
+        return card.tags.contains(tag)
+    }
+}
+
+func reviewQueuePreservingPresentedCard(
+    reviewQueue: [Card],
+    presentedCardId: String?,
+    pendingReviewCardIds: Set<String>,
+    resolvedReviewFilter: ReviewFilter,
+    decks: [Deck],
+    cards: [Card],
+    now: Date
+) -> [Card] {
+    guard let presentedCardId else {
+        return reviewQueue
+    }
+    guard reviewQueue.contains(where: { card in
+        card.cardId == presentedCardId
+    }) == false else {
+        return reviewQueue
+    }
+    guard pendingReviewCardIds.contains(presentedCardId) == false else {
+        return reviewQueue
+    }
+    guard let presentedCard = cards.first(where: { card in
+        card.cardId == presentedCardId
+    }) else {
+        return reviewQueue
+    }
+    guard cardMatchesResolvedReviewFilter(reviewFilter: resolvedReviewFilter, decks: decks, card: presentedCard) else {
+        return reviewQueue
+    }
+    guard isActiveReviewOrderBucket(bucket: makeReviewOrderRank(card: presentedCard, now: now).bucket) else {
+        return reviewQueue
+    }
+
+    return reviewQueue + [presentedCard]
 }
 
 private func insertReviewQueueCandidate(
@@ -293,7 +379,10 @@ func makeReviewQueueChunkLoadState(
         guard excludedCardIds.contains(card.cardId) == false else {
             return
         }
-        guard card.deletedAt == nil && isCardDue(card: card, now: now) else {
+        guard card.deletedAt == nil else {
+            return
+        }
+        guard isActiveReviewOrderBucket(bucket: makeReviewOrderRank(card: card, now: now).bucket) else {
             return
         }
 

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewQueueRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewQueueRuntime.swift
@@ -3,6 +3,7 @@ import Foundation
 struct ReviewQueuePublishedState: Hashable {
     let selectedReviewFilter: ReviewFilter
     let reviewQueue: [Card]
+    let reviewQueueCanonicalCount: Int
     let presentedCardId: String?
     let reviewCounts: ReviewCounts
     let isReviewHeadLoading: Bool
@@ -95,6 +96,7 @@ struct ReviewQueueRuntime {
         ReviewQueuePublishedState(
             selectedReviewFilter: selectedReviewFilter,
             reviewQueue: [],
+            reviewQueueCanonicalCount: 0,
             presentedCardId: nil,
             reviewCounts: ReviewCounts(dueCount: 0, totalCount: 0),
             isReviewHeadLoading: false,
@@ -176,6 +178,7 @@ struct ReviewQueueRuntime {
         let nextPublishedState = ReviewQueuePublishedState(
             selectedReviewFilter: resolvedReviewQuery.reviewFilter,
             reviewQueue: [],
+            reviewQueueCanonicalCount: 0,
             presentedCardId: nil,
             reviewCounts: ReviewCounts(dueCount: 0, totalCount: 0),
             isReviewHeadLoading: true,
@@ -235,6 +238,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: reviewHeadState.resolvedReviewFilter,
             reviewQueue: reviewHeadState.seedReviewQueue,
+            reviewQueueCanonicalCount: reviewHeadState.seedReviewQueue.count,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: reviewHeadState.seedReviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
@@ -264,6 +268,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: publishedState.reviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
@@ -302,6 +307,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: publishedState.reviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
@@ -329,6 +335,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: publishedState.reviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
@@ -348,6 +355,7 @@ struct ReviewQueueRuntime {
         selectedReviewFilter: ReviewFilter,
         reviewCounts: ReviewCounts,
         reviewQueue: [Card],
+        reviewQueueCanonicalCount: Int,
         hasMoreCards: Bool
     ) -> ReviewQueuePublishedState {
         self.state.hasMoreReviewQueueCards = hasMoreCards
@@ -355,6 +363,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: selectedReviewFilter,
             reviewQueue: reviewQueue,
+            reviewQueueCanonicalCount: reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: reviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
@@ -413,6 +422,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: publishedState.reviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
@@ -445,11 +455,18 @@ struct ReviewQueueRuntime {
         self.state.hasMoreReviewQueueCards = queueChunkLoadState.hasMoreCards
         self.clearActiveReviewQueueChunkLoad(requestId: requestId)
 
+        let canonicalCount = min(max(publishedState.reviewQueueCanonicalCount, 0), publishedState.reviewQueue.count)
+        let canonicalQueue = Array(publishedState.reviewQueue.prefix(canonicalCount))
+        let preservedTailQueue = Array(publishedState.reviewQueue.dropFirst(canonicalCount))
+        let nextReviewQueue = canonicalQueue + queueChunkLoadState.reviewQueueChunk + preservedTailQueue
+        let nextReviewQueueCanonicalCount = canonicalCount + queueChunkLoadState.reviewQueueChunk.count
+
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
-            reviewQueue: publishedState.reviewQueue + queueChunkLoadState.reviewQueueChunk,
+            reviewQueue: nextReviewQueue,
+            reviewQueueCanonicalCount: nextReviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
-                reviewQueue: publishedState.reviewQueue + queueChunkLoadState.reviewQueueChunk,
+                reviewQueue: nextReviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
                 preferredPresentedCardId: publishedState.presentedCardId
             ),
@@ -475,6 +492,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: publishedState.reviewQueue,
                 pendingReviewCardIds: publishedState.pendingReviewCardIds,
@@ -513,6 +531,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: publishedState.reviewQueue,
                 pendingReviewCardIds: pendingReviewCardIds,
@@ -567,6 +586,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: self.resolvePresentedCardId(
                 reviewQueue: publishedState.reviewQueue,
                 pendingReviewCardIds: pendingReviewCardIds,
@@ -596,6 +616,7 @@ struct ReviewQueueRuntime {
         return ReviewQueuePublishedState(
             selectedReviewFilter: publishedState.selectedReviewFilter,
             reviewQueue: publishedState.reviewQueue,
+            reviewQueueCanonicalCount: publishedState.reviewQueueCanonicalCount,
             presentedCardId: presentedCardId,
             reviewCounts: publishedState.reviewCounts,
             isReviewHeadLoading: publishedState.isReviewHeadLoading,

--- a/apps/ios/Flashcards/FlashcardsTests/FsrsReviewPresentationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/FsrsReviewPresentationTests.swift
@@ -229,6 +229,113 @@ final class FsrsReviewPresentationTests: XCTestCase {
         )
     }
 
+    func testMakeReviewQueuePrioritizesRecentDueWindowBeforeOldDueAndNewCards() throws {
+        XCTAssertEqual(recentDuePriorityWindow, 60 * 60)
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+        let cards = [
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "new-card",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: nil,
+                updatedAt: "2026-03-09T09:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "old-earlier",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T07:00:00.000Z",
+                updatedAt: "2026-03-09T08:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "old-tie-older",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T07:30:00.000Z",
+                updatedAt: "2026-03-09T06:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "old-tie-newer",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T07:30:00.000Z",
+                updatedAt: "2026-03-09T07:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "recent-cutoff",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T08:00:00.000Z",
+                updatedAt: "2026-03-09T05:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "recent-tie-older",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T08:30:00.000Z",
+                updatedAt: "2026-03-09T04:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "recent-tie-newer",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T08:30:00.000Z",
+                updatedAt: "2026-03-09T04:30:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "recent-now",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T09:00:00.000Z",
+                updatedAt: "2026-03-09T03:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "future-one-millisecond",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "2026-03-09T09:00:00.001Z",
+                updatedAt: "2026-03-09T02:00:00.000Z"
+            ),
+            FsrsSchedulerTestSupport.makeTestCard(
+                cardId: "malformed-due",
+                tags: [],
+                effortLevel: .fast,
+                dueAt: "not-an-iso-date",
+                updatedAt: "2026-03-09T01:00:00.000Z"
+            )
+        ]
+
+        XCTAssertEqual(
+            makeReviewQueue(reviewFilter: .allCards, decks: [], cards: cards, now: now).map(\.cardId),
+            [
+                "recent-cutoff",
+                "recent-tie-newer",
+                "recent-tie-older",
+                "recent-now",
+                "old-earlier",
+                "old-tie-newer",
+                "old-tie-older",
+                "new-card"
+            ]
+        )
+        XCTAssertEqual(
+            makeReviewTimeline(reviewFilter: .allCards, decks: [], cards: cards, now: now).map(\.cardId),
+            [
+                "recent-cutoff",
+                "recent-tie-newer",
+                "recent-tie-older",
+                "recent-now",
+                "old-earlier",
+                "old-tie-newer",
+                "old-tie-older",
+                "new-card",
+                "future-one-millisecond",
+                "malformed-due"
+            ]
+        )
+    }
+
     func testMakeReviewQueueDoesNotTreatFutureNewCardsAsDue() throws {
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
         let cards = [

--- a/apps/ios/Flashcards/FlashcardsTests/ReviewBackgroundReconcileTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/ReviewBackgroundReconcileTests.swift
@@ -83,6 +83,7 @@ final class ReviewBackgroundReconcileTests: ProgressStoreTestCase {
             reviewState: ReviewQueuePublishedState(
                 selectedReviewFilter: .allCards,
                 reviewQueue: currentQueue,
+                reviewQueueCanonicalCount: currentQueue.count,
                 presentedCardId: currentQueue[3].cardId,
                 reviewCounts: ReviewCounts(dueCount: currentQueue.count, totalCount: currentQueue.count),
                 isReviewHeadLoading: false,
@@ -105,4 +106,245 @@ final class ReviewBackgroundReconcileTests: ProgressStoreTestCase {
         XCTAssertEqual(store.reviewCounts, expectedCounts)
         XCTAssertFalse(store.isReviewQueueChunkLoading)
     }
+
+    @MainActor
+    func testBackgroundReviewReconcilePreservesPresentedCardMissingFromBoundedWindow() async throws {
+        let database = try self.makeDatabase()
+        let bootstrapSnapshot = try database.loadBootstrapSnapshot()
+        let suiteName = "review-reconcile-pin-\(UUID().uuidString.lowercased())"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+        }
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T10:00:00.000Z"))
+        let presentedCard = makePinnedRefreshCard(
+            cardId: "old-presented",
+            dueAt: "2026-04-18T07:00:00.000Z",
+            updatedAt: "2026-04-18T08:00:00.000Z"
+        )
+        let currentQueue = [presentedCard] + (1...7).map { index in
+            makePinnedRefreshCard(
+                cardId: "old-tail-\(index)",
+                dueAt: "2026-04-18T07:0\(index):00.000Z",
+                updatedAt: "2026-04-18T08:0\(index):00.000Z"
+            )
+        }
+        let refreshedWindow = (1...8).map { index in
+            makePinnedRefreshCard(
+                cardId: "recent-\(index)",
+                dueAt: String(format: "2026-04-18T09:%02d:00.000Z", 10 + index),
+                updatedAt: String(format: "2026-04-18T09:%02d:00.000Z", 10 + index)
+            )
+        }
+        let expectedCounts = ReviewCounts(
+            dueCount: refreshedWindow.count + 1,
+            totalCount: refreshedWindow.count + 1
+        )
+        let windowLimitRecorder = ReviewWindowLimitRecorder()
+        let store = self.makeStoreForBackgroundReconcileTest(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            reviewCounts: expectedCounts,
+            expectedWindowLimit: currentQueue.count,
+            windowLimitRecorder: windowLimitRecorder,
+            refreshedWindow: refreshedWindow,
+            hasMoreCards: true
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        store.workspace = bootstrapSnapshot.workspace
+        store.schedulerSettings = bootstrapSnapshot.schedulerSettings
+        store.cards = refreshedWindow + currentQueue
+        store.applyReviewPublishedState(
+            reviewState: ReviewQueuePublishedState(
+                selectedReviewFilter: .allCards,
+                reviewQueue: currentQueue,
+                reviewQueueCanonicalCount: currentQueue.count,
+                presentedCardId: presentedCard.cardId,
+                reviewCounts: ReviewCounts(dueCount: currentQueue.count, totalCount: currentQueue.count),
+                isReviewHeadLoading: false,
+                isReviewCountsLoading: false,
+                isReviewQueueChunkLoading: false,
+                pendingReviewCardIds: [],
+                reviewSubmissionFailure: nil
+            )
+        )
+
+        let didRefresh = try await store.refreshReviewState(now: now, mode: .backgroundReconcileSilently)
+        let didRefreshAgain = try await store.refreshReviewState(now: now, mode: .backgroundReconcileSilently)
+
+        let expectedStoredQueue = refreshedWindow + [presentedCard]
+        XCTAssertTrue(didRefresh)
+        XCTAssertFalse(didRefreshAgain)
+        XCTAssertEqual(store.reviewQueue.map(\.cardId), expectedStoredQueue.map(\.cardId))
+        XCTAssertEqual(store.reviewQueueCanonicalCount, refreshedWindow.count)
+        XCTAssertEqual(store.presentedReviewCardId, presentedCard.cardId)
+        XCTAssertEqual(store.effectiveReviewQueue.first?.cardId, presentedCard.cardId)
+        XCTAssertEqual(store.effectiveReviewQueue.dropFirst().first?.cardId, refreshedWindow[0].cardId)
+        XCTAssertEqual(store.reviewCounts, expectedCounts)
+        XCTAssertFalse(store.isReviewQueueChunkLoading)
+        let recordedWindowLimits = await windowLimitRecorder.snapshot()
+        XCTAssertEqual(recordedWindowLimits, [currentQueue.count, currentQueue.count])
+    }
+
+    @MainActor
+    func testBackgroundReviewReconcileDoesNotPreservePresentedCardMissingFromLatestCards() async throws {
+        let database = try self.makeDatabase()
+        let bootstrapSnapshot = try database.loadBootstrapSnapshot()
+        let suiteName = "review-reconcile-pin-missing-\(UUID().uuidString.lowercased())"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        let credentialStore = CloudCredentialStore(service: "tests-\(suiteName)-cloud-auth")
+        let guestCredentialStore = GuestCloudCredentialStore(
+            service: "tests-\(suiteName)-guest-auth",
+            bundle: .main,
+            userDefaults: userDefaults
+        )
+        defer {
+            userDefaults.removePersistentDomain(forName: suiteName)
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+        }
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T10:00:00.000Z"))
+        let presentedCard = makePinnedRefreshCard(
+            cardId: "missing-presented",
+            dueAt: "2026-04-18T07:00:00.000Z",
+            updatedAt: "2026-04-18T08:00:00.000Z"
+        )
+        let currentQueue = [
+            presentedCard,
+            makePinnedRefreshCard(
+                cardId: "old-tail",
+                dueAt: "2026-04-18T07:01:00.000Z",
+                updatedAt: "2026-04-18T08:01:00.000Z"
+            )
+        ]
+        let refreshedWindow = (1...8).map { index in
+            makePinnedRefreshCard(
+                cardId: "latest-\(index)",
+                dueAt: String(format: "2026-04-18T09:%02d:00.000Z", 20 + index),
+                updatedAt: String(format: "2026-04-18T09:%02d:00.000Z", 20 + index)
+            )
+        }
+        let expectedCounts = ReviewCounts(
+            dueCount: refreshedWindow.count,
+            totalCount: refreshedWindow.count
+        )
+        let store = self.makeStoreForBackgroundReconcileTest(
+            database: database,
+            userDefaults: userDefaults,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            reviewCounts: expectedCounts,
+            expectedWindowLimit: reviewSeedQueueSize,
+            windowLimitRecorder: nil,
+            refreshedWindow: refreshedWindow,
+            hasMoreCards: false
+        )
+        defer {
+            store.shutdownForTests()
+        }
+        store.workspace = bootstrapSnapshot.workspace
+        store.schedulerSettings = bootstrapSnapshot.schedulerSettings
+        store.cards = refreshedWindow
+        store.applyReviewPublishedState(
+            reviewState: ReviewQueuePublishedState(
+                selectedReviewFilter: .allCards,
+                reviewQueue: currentQueue,
+                reviewQueueCanonicalCount: currentQueue.count,
+                presentedCardId: presentedCard.cardId,
+                reviewCounts: ReviewCounts(dueCount: currentQueue.count, totalCount: currentQueue.count),
+                isReviewHeadLoading: false,
+                isReviewCountsLoading: false,
+                isReviewQueueChunkLoading: false,
+                pendingReviewCardIds: [],
+                reviewSubmissionFailure: nil
+            )
+        )
+
+        let didRefresh = try await store.refreshReviewState(now: now, mode: .backgroundReconcileSilently)
+
+        XCTAssertTrue(didRefresh)
+        XCTAssertEqual(store.reviewQueue.map(\.cardId), refreshedWindow.map(\.cardId))
+        XCTAssertEqual(store.presentedReviewCardId, refreshedWindow[0].cardId)
+        XCTAssertEqual(store.effectiveReviewQueue.first?.cardId, refreshedWindow[0].cardId)
+        XCTAssertEqual(store.reviewCounts, expectedCounts)
+        XCTAssertFalse(store.isReviewQueueChunkLoading)
+    }
+
+    @MainActor
+    private func makeStoreForBackgroundReconcileTest(
+        database: LocalDatabase,
+        userDefaults: UserDefaults,
+        credentialStore: CloudCredentialStore,
+        guestCredentialStore: GuestCloudCredentialStore,
+        reviewCounts: ReviewCounts,
+        expectedWindowLimit: Int,
+        windowLimitRecorder: ReviewWindowLimitRecorder?,
+        refreshedWindow: [Card],
+        hasMoreCards: Bool
+    ) -> FlashcardsStore {
+        FlashcardsStore(
+            userDefaults: userDefaults,
+            encoder: JSONEncoder(),
+            decoder: JSONDecoder(),
+            database: database,
+            cloudAuthService: CloudAuthService(),
+            cloudSyncService: nil,
+            credentialStore: credentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            guestCredentialStore: guestCredentialStore,
+            reviewSubmissionOutboxMutationGate: ReviewSubmissionOutboxMutationGate(),
+            reviewSubmissionExecutor: nil,
+            reviewHeadLoader: defaultReviewHeadLoader,
+            reviewCountsLoader: { _, _, _, _ in
+                reviewCounts
+            },
+            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueWindowLoader: { _, _, _, _, limit in
+                await windowLimitRecorder?.record(limit: limit)
+                XCTAssertEqual(expectedWindowLimit, limit)
+                return ReviewQueueWindowLoadState(
+                    reviewQueue: refreshedWindow,
+                    hasMoreCards: hasMoreCards
+                )
+            },
+            reviewTimelinePageLoader: defaultReviewTimelinePageLoader,
+            initialGlobalErrorMessage: ""
+        )
+    }
+}
+
+private actor ReviewWindowLimitRecorder {
+    private var limits: [Int] = []
+
+    func record(limit: Int) {
+        self.limits.append(limit)
+    }
+
+    func snapshot() -> [Int] {
+        self.limits
+    }
+}
+
+private func makePinnedRefreshCard(cardId: String, dueAt: String, updatedAt: String) -> Card {
+    FsrsSchedulerTestSupport.makeTestCard(
+        cardId: cardId,
+        tags: [],
+        effortLevel: .fast,
+        dueAt: dueAt,
+        updatedAt: updatedAt
+    )
 }

--- a/apps/ios/Flashcards/FlashcardsTests/ReviewQueueRuntimeTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/ReviewQueueRuntimeTests.swift
@@ -21,6 +21,7 @@ final class ReviewQueueRuntimeTests: XCTestCase {
         )
         let publishedState = makePublishedState(
             reviewQueue: [newlyDueHead, displayedCurrent, trailingCard],
+            reviewQueueCanonicalCount: 3,
             presentedCardId: displayedCurrent.cardId,
             pendingReviewCardIds: []
         )
@@ -50,6 +51,7 @@ final class ReviewQueueRuntimeTests: XCTestCase {
         )
         let currentState = makePublishedState(
             reviewQueue: [previousHead, displayedCurrent],
+            reviewQueueCanonicalCount: 2,
             presentedCardId: displayedCurrent.cardId,
             pendingReviewCardIds: []
         )
@@ -64,6 +66,7 @@ final class ReviewQueueRuntimeTests: XCTestCase {
             selectedReviewFilter: reviewHeadState.resolvedReviewFilter,
             reviewCounts: ReviewCounts(dueCount: 3, totalCount: 3),
             reviewQueue: reviewHeadState.seedReviewQueue,
+            reviewQueueCanonicalCount: reviewHeadState.seedReviewQueue.count,
             hasMoreCards: reviewHeadState.hasMoreCards
         )
 
@@ -93,6 +96,7 @@ final class ReviewQueueRuntimeTests: XCTestCase {
         )
         let currentState = makePublishedState(
             reviewQueue: [seedHead, secondSeedCard, preservedTailCard],
+            reviewQueueCanonicalCount: 2,
             presentedCardId: seedHead.cardId,
             pendingReviewCardIds: []
         )
@@ -107,6 +111,7 @@ final class ReviewQueueRuntimeTests: XCTestCase {
             selectedReviewFilter: reviewHeadState.resolvedReviewFilter,
             reviewCounts: ReviewCounts(dueCount: 3, totalCount: 3),
             reviewQueue: currentState.reviewQueue,
+            reviewQueueCanonicalCount: reviewHeadState.seedReviewQueue.count,
             hasMoreCards: reviewHeadState.hasMoreCards
         )
         let request = runtime.makeReviewQueueChunkLoadRequestIfNeeded(
@@ -123,6 +128,69 @@ final class ReviewQueueRuntimeTests: XCTestCase {
         )
     }
 
+    func testReviewQueueChunkLoadInsertsChunkBeforePreservedTail() throws {
+        var runtime = makeRuntime()
+        let canonicalHead = makeCard(
+            cardId: "canonical-head",
+            dueAt: "2026-03-09T07:30:00.000Z",
+            updatedAt: "2026-03-09T07:00:00.000Z"
+        )
+        let canonicalSecond = makeCard(
+            cardId: "canonical-second",
+            dueAt: "2026-03-09T08:00:00.000Z",
+            updatedAt: "2026-03-09T08:00:00.000Z"
+        )
+        let preservedTailCard = makeCard(
+            cardId: "preserved-tail-card",
+            dueAt: nil,
+            updatedAt: "2026-03-09T09:00:00.000Z"
+        )
+        let chunkHead = makeCard(
+            cardId: "chunk-head",
+            dueAt: nil,
+            updatedAt: "2026-03-09T09:01:00.000Z"
+        )
+        let chunkSecond = makeCard(
+            cardId: "chunk-second",
+            dueAt: nil,
+            updatedAt: "2026-03-09T09:02:00.000Z"
+        )
+        let currentState = makePublishedState(
+            reviewQueue: [canonicalHead, canonicalSecond, preservedTailCard],
+            reviewQueueCanonicalCount: 2,
+            presentedCardId: preservedTailCard.cardId,
+            pendingReviewCardIds: []
+        )
+        let loadingState = runtime.markReviewQueueChunkLoading(
+            publishedState: currentState,
+            requestId: "chunk-1"
+        )
+
+        let nextState = try XCTUnwrap(runtime.applyReviewQueueChunkLoadSuccess(
+            publishedState: loadingState,
+            queueChunkLoadState: ReviewQueueChunkLoadState(
+                reviewQueueChunk: [chunkHead, chunkSecond],
+                hasMoreCards: false
+            ),
+            requestId: "chunk-1",
+            sourceVersion: 0
+        ))
+
+        XCTAssertEqual(
+            nextState.reviewQueue.map(\.cardId),
+            [
+                canonicalHead.cardId,
+                canonicalSecond.cardId,
+                chunkHead.cardId,
+                chunkSecond.cardId,
+                preservedTailCard.cardId
+            ]
+        )
+        XCTAssertEqual(nextState.reviewQueueCanonicalCount, 4)
+        XCTAssertEqual(nextState.presentedCardId, preservedTailCard.cardId)
+        XCTAssertEqual(runtime.effectiveReviewQueue(publishedState: nextState).first?.cardId, preservedTailCard.cardId)
+    }
+
     func testEnqueueReviewSubmissionAdvancesPresentedCardToNextVisibleCard() throws {
         var runtime = makeRuntime()
         let currentCard = makeCard(
@@ -137,6 +205,7 @@ final class ReviewQueueRuntimeTests: XCTestCase {
         )
         let publishedState = makePublishedState(
             reviewQueue: [currentCard, nextCard],
+            reviewQueueCanonicalCount: 2,
             presentedCardId: currentCard.cardId,
             pendingReviewCardIds: []
         )
@@ -166,6 +235,7 @@ final class ReviewQueueRuntimeTests: XCTestCase {
         )
         let publishedState = makePublishedState(
             reviewQueue: [currentCard, nextCard],
+            reviewQueueCanonicalCount: 2,
             presentedCardId: nextCard.cardId,
             pendingReviewCardIds: [currentCard.cardId]
         )
@@ -201,12 +271,14 @@ private func makeRuntime() -> ReviewQueueRuntime {
 
 private func makePublishedState(
     reviewQueue: [Card],
+    reviewQueueCanonicalCount: Int,
     presentedCardId: String?,
     pendingReviewCardIds: Set<String>
 ) -> ReviewQueuePublishedState {
     ReviewQueuePublishedState(
         selectedReviewFilter: .allCards,
         reviewQueue: reviewQueue,
+        reviewQueueCanonicalCount: reviewQueueCanonicalCount,
         presentedCardId: presentedCardId,
         reviewCounts: ReviewCounts(dueCount: reviewQueue.count, totalCount: reviewQueue.count),
         isReviewHeadLoading: false,

--- a/apps/ios/Flashcards/FlashcardsTests/ReviewSQLiteOrderingTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/ReviewSQLiteOrderingTests.swift
@@ -1,0 +1,691 @@
+import Foundation
+import XCTest
+@testable import Flashcards
+
+final class ReviewSQLiteOrderingTests: XCTestCase {
+    private var databaseURL: URL?
+    private var database: LocalDatabase?
+
+    override func tearDownWithError() throws {
+        if let database {
+            try database.close()
+        }
+        if let databaseURL {
+            try? FileManager.default.removeItem(at: databaseURL)
+        }
+        self.database = nil
+        self.databaseURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testSQLiteReviewQueueAndTimelineUseRecentDuePriorityBuckets() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "old-due",
+            dueAt: "2026-03-09T07:59:59.999Z",
+            createdAt: "2026-03-09T08:30:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "recent-now",
+            dueAt: "2026-03-09T09:00:00.000Z",
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "recent-cutoff",
+            dueAt: "2026-03-09T08:00:00.000Z",
+            createdAt: "2026-03-09T07:30:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "new-card",
+            dueAt: nil,
+            createdAt: "2026-03-09T09:30:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "future-one-millisecond",
+            dueAt: "2026-03-09T09:00:00.001Z",
+            createdAt: "2026-03-09T10:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "malformed-due",
+            dueAt: "1000",
+            createdAt: "2026-03-09T11:00:00.000Z"
+        )
+
+        let limitedHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 3
+        )
+        let fullHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(limitedHead.seedReviewQueue.map(\.cardId), ["recent-cutoff", "recent-now", "old-due"])
+        XCTAssertTrue(limitedHead.hasMoreCards)
+        XCTAssertEqual(fullHead.seedReviewQueue.map(\.cardId), ["recent-cutoff", "recent-now", "old-due", "new-card"])
+        XCTAssertFalse(fullHead.hasMoreCards)
+        XCTAssertEqual(
+            timelinePage.cards.map(\.cardId),
+            ["recent-cutoff", "recent-now", "old-due", "new-card", "future-one-millisecond", "malformed-due"]
+        )
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueAndTimelineTreatVariableFractionDueAtAsParseable() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "recent-one-digit-fraction",
+            dueAt: "2026-03-09T08:30:00.1Z",
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "old-six-digit-fraction",
+            dueAt: "2026-03-09T07:30:00.123456Z",
+            createdAt: "2026-03-09T07:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "future-one-digit-fraction",
+            dueAt: "2026-03-09T09:00:00.1Z",
+            createdAt: "2026-03-09T09:30:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "malformed-due",
+            dueAt: "1000",
+            createdAt: "2026-03-09T10:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["recent-one-digit-fraction", "old-six-digit-fraction"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(
+            timelinePage.cards.map(\.cardId),
+            [
+                "recent-one-digit-fraction",
+                "old-six-digit-fraction",
+                "future-one-digit-fraction",
+                "malformed-due"
+            ]
+        )
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueAndTimelineMatchSwiftTruncatedFractionSemantics() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.123Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "canonical-now-older",
+            dueAt: "2026-03-09T09:00:00.123Z",
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "truncated-now-newer",
+            dueAt: "2026-03-09T09:00:00.123999Z",
+            createdAt: "2026-03-09T08:30:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "future-one-millisecond",
+            dueAt: "2026-03-09T09:00:00.124Z",
+            createdAt: "2026-03-09T09:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["truncated-now-newer", "canonical-now-older"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(
+            timelinePage.cards.map(\.cardId),
+            ["truncated-now-newer", "canonical-now-older", "future-one-millisecond"]
+        )
+        XCTAssertEqual(
+            timelinePage.cards.map(\.cardId),
+            sortCardsForReviewTimeline(cards: timelinePage.cards, now: now).map(\.cardId)
+        )
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewTimelineOrdersMalformedDueAtByCreatedAtThenCardId() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "malformed-newer-a",
+            dueAt: "3000",
+            createdAt: "2026-03-09T11:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "malformed-newer-z",
+            dueAt: "2000",
+            createdAt: "2026-03-09T11:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "malformed-older",
+            dueAt: "1000",
+            createdAt: "2026-03-09T10:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), [])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(
+            timelinePage.cards.map(\.cardId),
+            ["malformed-newer-a", "malformed-newer-z", "malformed-older"]
+        )
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueRejectsShapeValidInvalidTimestampComponents() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "recent-valid",
+            dueAt: "2026-03-09T08:59:00.000Z",
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "invalid-month",
+            dueAt: "2026-13-09T08:59:00.000Z",
+            createdAt: "2026-03-09T11:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "invalid-minute",
+            dueAt: "2026-03-09T08:99:00.000Z",
+            createdAt: "2026-03-09T10:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "invalid-second",
+            dueAt: "2026-03-09T08:59:60.000Z",
+            createdAt: "2026-03-09T09:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "invalid-calendar-day",
+            dueAt: "2026-02-31T08:59:00.000Z",
+            createdAt: "2026-03-09T12:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "invalid-non-leap-day",
+            dueAt: "2026-02-29T08:59:00.000Z",
+            createdAt: "2026-03-09T11:30:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["recent-valid"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(
+            timelinePage.cards.map(\.cardId),
+            [
+                "recent-valid",
+                "invalid-calendar-day",
+                "invalid-non-leap-day",
+                "invalid-month",
+                "invalid-minute",
+                "invalid-second"
+            ]
+        )
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueAcceptsValidLeapDayDueAt() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2024-02-29T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "valid-leap-day",
+            dueAt: "2024-02-29T08:59:00.000Z",
+            createdAt: "2024-02-29T08:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "invalid-calendar-day",
+            dueAt: "2024-02-30T08:59:00.000Z",
+            createdAt: "2024-02-29T09:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["valid-leap-day"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(timelinePage.cards.map(\.cardId), ["valid-leap-day", "invalid-calendar-day"])
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueAndTimelineOrderEquivalentDueTimesByCreatedAtDescending() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "same-due-older",
+            dueAt: "2026-03-09T08:30:00.000Z",
+            createdAt: "2026-03-09T07:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "same-due-newer",
+            dueAt: "2026-03-09T08:30:00Z",
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let timelinePage = try database.loadReviewTimelinePage(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10,
+            offset: 0
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["same-due-newer", "same-due-older"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(timelinePage.cards.map(\.cardId), ["same-due-newer", "same-due-older"])
+        XCTAssertFalse(timelinePage.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueIncludesOldDueNonCanonicalBeforeLimitedCanonicalRows() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "non-canonical-old-earliest",
+            dueAt: "2026-03-09T06:00:00Z",
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "canonical-old-first",
+            dueAt: "2026-03-09T06:30:00.000Z",
+            createdAt: "2026-03-09T08:30:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "canonical-old-second",
+            dueAt: "2026-03-09T07:00:00.000Z",
+            createdAt: "2026-03-09T08:45:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "canonical-old-third",
+            dueAt: "2026-03-09T07:30:00.000Z",
+            createdAt: "2026-03-09T09:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 2
+        )
+
+        XCTAssertEqual(
+            reviewHead.seedReviewQueue.map(\.cardId),
+            ["non-canonical-old-earliest", "canonical-old-first"]
+        )
+        XCTAssertTrue(reviewHead.hasMoreCards)
+    }
+
+    func testSQLiteReviewQueueOrdersLimitedNonCanonicalOldDueByNormalizedTimestampTies() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "fraction-a-newer",
+            dueAt: "2026-03-09T07:30:00.1Z",
+            createdAt: "2026-03-09T07:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "fraction-b-newer",
+            dueAt: "2026-03-09T07:30:00.1000Z",
+            createdAt: "2026-03-09T07:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "fraction-c-older",
+            dueAt: "2026-03-09T07:30:00.10000Z",
+            createdAt: "2026-03-09T06:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "fraction-d-oldest",
+            dueAt: "2026-03-09T07:30:00.100000Z",
+            createdAt: "2026-03-09T05:00:00.000Z"
+        )
+
+        let queueRows = try database.cardStore.loadReviewQueueRows(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 1,
+            excludedCardIds: []
+        )
+
+        XCTAssertEqual(queueRows.map(\.cardId), ["fraction-a-newer", "fraction-b-newer"])
+    }
+
+    func testSQLiteReviewCountsUseActiveQueueDueEligibility() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-03-09T09:00:00.000Z"))
+
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "recent-due",
+            dueAt: "2026-03-09T08:30:00.000Z",
+            createdAt: "2026-03-09T08:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "old-due",
+            dueAt: "2026-03-09T07:30:00Z",
+            createdAt: "2026-03-09T07:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "new-card",
+            dueAt: nil,
+            createdAt: "2026-03-09T10:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "future-due",
+            dueAt: "2026-03-09T09:00:00.001Z",
+            createdAt: "2026-03-09T11:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "malformed-due",
+            dueAt: "1000",
+            createdAt: "2026-03-09T12:00:00.000Z"
+        )
+        try self.insertCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: "invalid-calendar-day",
+            dueAt: "2026-02-31T08:59:00.000Z",
+            createdAt: "2026-03-09T13:00:00.000Z"
+        )
+
+        let reviewHead = try database.loadReviewHead(
+            workspaceId: workspace.workspaceId,
+            resolvedReviewFilter: .allCards,
+            reviewQueryDefinition: .allCards,
+            now: now,
+            limit: 10
+        )
+        let reviewCounts = try database.loadReviewCounts(
+            workspaceId: workspace.workspaceId,
+            reviewQueryDefinition: .allCards,
+            now: now
+        )
+
+        XCTAssertEqual(reviewHead.seedReviewQueue.map(\.cardId), ["recent-due", "old-due", "new-card"])
+        XCTAssertFalse(reviewHead.hasMoreCards)
+        XCTAssertEqual(reviewCounts, ReviewCounts(dueCount: 3, totalCount: 6))
+    }
+
+    func testSQLiteActiveDueBucketOrderUsesDueAtIndexOrder() throws {
+        XCTAssertFalse(cardStoreActiveDueBucketOrderSQL.lowercased().contains("julianday"))
+
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let planDetails = try database.core.query(
+            sql: """
+            EXPLAIN QUERY PLAN
+            SELECT
+            \(cardStoreSelectColumnsSQL)
+            FROM cards
+            WHERE workspace_id = ?
+                AND deleted_at IS NULL
+                AND \(cardStoreCanonicalDueAtSQL)
+                AND due_at < ?
+            ORDER BY \(cardStoreActiveDueBucketOrderSQL)
+            LIMIT ?
+            """,
+            values: [
+                .text(workspace.workspaceId),
+                .text("2026-03-09T08:00:00.000Z"),
+                .integer(11)
+            ]
+        ) { statement in
+            DatabaseCore.columnText(statement: statement, index: 3)
+        }
+        let queryPlan = planDetails.joined(separator: "\n")
+
+        XCTAssertTrue(queryPlan.contains("idx_cards_workspace_due_created_active"), queryPlan)
+        XCTAssertFalse(queryPlan.contains("USE TEMP B-TREE"), queryPlan)
+    }
+
+    private func makeDatabase() throws -> LocalDatabase {
+        let databaseURL = try self.makeDatabaseURL()
+        let database = try LocalDatabase(databaseURL: databaseURL)
+        self.databaseURL = databaseURL
+        self.database = database
+        return database
+    }
+
+    private func makeDatabaseURL() throws -> URL {
+        let databaseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString.lowercased(), isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: databaseDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        return databaseDirectory.appendingPathComponent("flashcards.sqlite", isDirectory: false)
+    }
+
+    private func insertCard(
+        database: LocalDatabase,
+        workspaceId: String,
+        cardId: String,
+        dueAt: String?,
+        createdAt: String
+    ) throws {
+        try database.core.execute(
+            sql: """
+            INSERT INTO cards (
+                card_id,
+                workspace_id,
+                front_text,
+                back_text,
+                tags_json,
+                effort_level,
+                due_at,
+                created_at,
+                reps,
+                lapses,
+                fsrs_card_state,
+                fsrs_step_index,
+                fsrs_stability,
+                fsrs_difficulty,
+                fsrs_last_reviewed_at,
+                fsrs_scheduled_days,
+                client_updated_at,
+                last_modified_by_replica_id,
+                last_operation_id,
+                updated_at,
+                deleted_at
+            )
+            VALUES (?, ?, ?, ?, ?, 'fast', ?, ?, 0, 0, 'new', NULL, NULL, NULL, NULL, NULL, ?, 'test-replica', ?, ?, NULL)
+            """,
+            values: [
+                .text(cardId),
+                .text(workspaceId),
+                .text("Front \(cardId)"),
+                .text("Back \(cardId)"),
+                .text("[]"),
+                dueAt.map(SQLiteValue.text) ?? .null,
+                .text(createdAt),
+                .text(createdAt),
+                .text("operation-\(cardId)"),
+                .text(createdAt)
+            ]
+        )
+    }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run src/localDb/reviews.test.ts src/localDb/cards.test.ts src/screens/review/ReviewScreen.test.tsx src/appData/progress/progressSource.test.tsx src/appData/progress/progressInvalidation.test.tsx",
+    "test": "vitest run src/appData/domain.test.ts src/localDb/reviews.test.ts src/localDb/cards.test.ts src/screens/review/ReviewScreen.test.tsx src/appData/progress/progressSource.test.tsx src/appData/progress/progressInvalidation.test.tsx",
     "test:e2e": "FLASHCARDS_E2E_TARGET=prod playwright test",
     "test:e2e:local": "node ./scripts/check-local-e2e-stack.mjs && FLASHCARDS_E2E_TARGET=local playwright test",
     "test:e2e:prod": "FLASHCARDS_E2E_TARGET=prod playwright test"

--- a/apps/web/src/appData/domain.test.ts
+++ b/apps/web/src/appData/domain.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { Card } from "../types";
+import { compareCardsForReviewOrder, recentDuePriorityWindow } from "./domain";
+
+function makeReviewOrderCard(cardId: string, dueAt: string | null, createdAt: string): Card {
+  return {
+    cardId,
+    frontText: cardId,
+    backText: "Back",
+    tags: [],
+    effortLevel: "fast",
+    dueAt,
+    createdAt,
+    reps: 0,
+    lapses: 0,
+    fsrsCardState: "new",
+    fsrsStepIndex: null,
+    fsrsStability: null,
+    fsrsDifficulty: null,
+    fsrsLastReviewedAt: null,
+    fsrsScheduledDays: null,
+    clientUpdatedAt: createdAt,
+    lastModifiedByReplicaId: "device-1",
+    lastOperationId: `operation-${cardId}`,
+    updatedAt: createdAt,
+    deletedAt: null,
+  };
+}
+
+function sortCardsForReviewOrder(cards: ReadonlyArray<Card>, nowTimestamp: number): ReadonlyArray<Card> {
+  return [...cards].sort((leftCard, rightCard) => compareCardsForReviewOrder(leftCard, rightCard, nowTimestamp));
+}
+
+describe("review order domain", () => {
+  it("uses an exact one-hour recent due priority window", () => {
+    expect(recentDuePriorityWindow).toBe(60 * 60 * 1000);
+  });
+
+  it("orders recent due, old due, null, future, and malformed buckets", () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const cards = [
+      makeReviewOrderCard("future-tomorrow", "2026-03-11T12:00:00.000Z", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("recent-1155", "2026-03-10T11:55:00.000Z", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("new-null", null, "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("malformed", "not-a-date", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("old-yesterday", "2026-03-09T12:00:00.000Z", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("recent-1115", "2026-03-10T11:15:00.000Z", "2026-03-10T09:00:00.000Z"),
+    ];
+
+    expect(sortCardsForReviewOrder(cards, nowTimestamp).map((card) => card.cardId)).toEqual([
+      "recent-1115",
+      "recent-1155",
+      "old-yesterday",
+      "new-null",
+      "future-tomorrow",
+      "malformed",
+    ]);
+  });
+
+  it("keeps recent boundary inclusive and future boundary exclusive", () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const cards = [
+      makeReviewOrderCard("future-one-ms", "2026-03-10T12:00:00.001Z", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("old-one-ms", "2026-03-10T10:59:59.999Z", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("due-now", "2026-03-10T12:00:00.000Z", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("recent-cutoff", "2026-03-10T11:00:00.000Z", "2026-03-10T09:00:00.000Z"),
+      makeReviewOrderCard("new-null", null, "2026-03-10T09:00:00.000Z"),
+    ];
+
+    expect(sortCardsForReviewOrder(cards, nowTimestamp).map((card) => card.cardId)).toEqual([
+      "recent-cutoff",
+      "due-now",
+      "old-one-ms",
+      "new-null",
+      "future-one-ms",
+    ]);
+  });
+
+  it("keeps due bucket tie-breakers by dueAt, newer createdAt, then cardId", () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const cards = [
+      makeReviewOrderCard("recent-b", "2026-03-10T11:30:00.000Z", "2026-03-10T09:30:00.000Z"),
+      makeReviewOrderCard("recent-a", "2026-03-10T11:30:00.000Z", "2026-03-10T09:30:00.000Z"),
+      makeReviewOrderCard("recent-newer", "2026-03-10T11:30:00.000Z", "2026-03-10T09:45:00.000Z"),
+      makeReviewOrderCard("old-b", "2026-03-09T11:30:00.000Z", "2026-03-10T09:30:00.000Z"),
+      makeReviewOrderCard("old-a", "2026-03-09T11:30:00.000Z", "2026-03-10T09:30:00.000Z"),
+      makeReviewOrderCard("old-newer", "2026-03-09T11:30:00.000Z", "2026-03-10T09:45:00.000Z"),
+    ];
+
+    expect(sortCardsForReviewOrder(cards, nowTimestamp).map((card) => card.cardId)).toEqual([
+      "recent-newer",
+      "recent-a",
+      "recent-b",
+      "old-newer",
+      "old-a",
+      "old-b",
+    ]);
+  });
+});

--- a/apps/web/src/appData/domain.ts
+++ b/apps/web/src/appData/domain.ts
@@ -51,6 +51,18 @@ export const ALL_CARDS_REVIEW_FILTER: ReviewFilter = {
   kind: "allCards",
 };
 
+export const recentDuePriorityWindow: number = 60 * 60 * 1000;
+
+type ReviewOrderBucket = "recentDue" | "oldDue" | "newNull" | "future" | "malformed";
+
+const reviewOrderBucketRanks: Readonly<Record<ReviewOrderBucket, number>> = {
+  recentDue: 0,
+  oldDue: 1,
+  newNull: 2,
+  future: 3,
+  malformed: 4,
+};
+
 export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -306,16 +318,18 @@ function getReviewOrderCreatedTimestamp(card: Card): number {
 
 /**
  * Keep review queue ordering aligned with:
- * - apps/ios/Flashcards/Flashcards/ReviewQuerySupport.swift::compareCardsForReviewOrder
+ * - apps/ios/Flashcards/Flashcards/Review/ReviewQuerySupport.swift::compareCardsForReviewOrder
  * - apps/ios/Flashcards/Flashcards/Database/CardStore+ReadSQL.swift review queue ORDER BY
  * - apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ReviewSupport.kt::sortCardsForReviewQueue
- * Ordering contract: timed due cards first, then null due cards, then future cards.
+ * Ordering contract: recent due cards in the inclusive 1-hour window first, then old due,
+ * then null-due/new cards, then future cards, then malformed dueAt cards.
+ * Active queues include only recent due, old due, and null-due/new cards.
  * Within each bucket, earlier dueAt comes first, then newer createdAt, then cardId ascending.
  * If this changes, mirror the same change across all three clients in the same change.
  */
 export function compareCardsForReviewOrder(leftCard: Card, rightCard: Card, nowTimestamp: number): number {
-  const leftOrderRank = getReviewOrderRank(leftCard, nowTimestamp);
-  const rightOrderRank = getReviewOrderRank(rightCard, nowTimestamp);
+  const leftOrderRank = reviewOrderBucketRanks[getReviewOrderBucket(leftCard, nowTimestamp)];
+  const rightOrderRank = reviewOrderBucketRanks[getReviewOrderBucket(rightCard, nowTimestamp)];
 
   if (leftOrderRank !== rightOrderRank) {
     return leftOrderRank - rightOrderRank;
@@ -336,17 +350,21 @@ export function compareCardsForReviewOrder(leftCard: Card, rightCard: Card, nowT
   return leftCard.cardId.localeCompare(rightCard.cardId);
 }
 
-function getReviewOrderRank(card: Card, nowTimestamp: number): number {
+function getReviewOrderBucket(card: Card, nowTimestamp: number): ReviewOrderBucket {
   if (card.dueAt === null) {
-    return 1;
+    return "newNull";
   }
 
   const dueAtTimestamp = new Date(card.dueAt).getTime();
   if (Number.isNaN(dueAtTimestamp)) {
-    return 2;
+    return "malformed";
   }
 
-  return dueAtTimestamp <= nowTimestamp ? 0 : 2;
+  if (dueAtTimestamp > nowTimestamp) {
+    return "future";
+  }
+
+  return dueAtTimestamp >= nowTimestamp - recentDuePriorityWindow ? "recentDue" : "oldDue";
 }
 
 export function deriveReviewTimeline(cards: ReadonlyArray<Card>): ReadonlyArray<Card> {

--- a/apps/web/src/localDb/cards.ts
+++ b/apps/web/src/localDb/cards.ts
@@ -28,6 +28,7 @@ type CardCursorIndexName =
 type IndexedCardCursorOptions = Readonly<{
   indexName: CardCursorIndexName;
   direction: IDBCursorDirection;
+  keyRange: IDBKeyRange | null;
 }>;
 
 function toStoredCard(workspaceId: string, card: Card): StoredCard {
@@ -85,7 +86,27 @@ function openIndexedCursor(
   store: IDBObjectStore,
   options: IndexedCardCursorOptions,
 ): IDBRequest<IDBCursorWithValue | null> {
-  return store.index(options.indexName).openCursor(null, options.direction);
+  return store.index(options.indexName).openCursor(options.keyRange, options.direction);
+}
+
+function makeWorkspaceIndexRange(workspaceId: string): IDBKeyRange {
+  return IDBKeyRange.bound([workspaceId], [workspaceId, []]);
+}
+
+function makeWorkspaceDueAtBeforeRange(workspaceId: string, dueAtExclusive: string): IDBKeyRange {
+  return IDBKeyRange.bound([workspaceId], [workspaceId, dueAtExclusive], false, true);
+}
+
+function makeWorkspaceDueAtBetweenInclusiveRange(
+  workspaceId: string,
+  lowerDueAtInclusive: string,
+  upperDueAtInclusive: string,
+): IDBKeyRange {
+  return IDBKeyRange.bound([workspaceId, lowerDueAtInclusive], [workspaceId, upperDueAtInclusive, []]);
+}
+
+function makeWorkspaceDueAtAfterRange(workspaceId: string, dueAtExclusive: string): IDBKeyRange {
+  return IDBKeyRange.bound([workspaceId, dueAtExclusive, []], [workspaceId, []]);
 }
 
 async function iterateCardsByIndex(
@@ -170,6 +191,7 @@ export async function iterateCardsByCreatedAtDesc(
     {
       indexName: "workspaceId_createdAt_cardId",
       direction: "prev",
+      keyRange: makeWorkspaceIndexRange(workspaceId),
     },
     (card) => {
       if (shouldStop) {
@@ -231,6 +253,7 @@ export async function iterateCardsByUpdatedAtDesc(
     {
       indexName: "workspaceId_updatedAt_cardId",
       direction: "prev",
+      keyRange: makeWorkspaceIndexRange(workspaceId),
     },
     (card) => {
       if (shouldStop) {
@@ -274,6 +297,62 @@ export async function iterateCardsByDueAtAsc(
     {
       indexName: "workspaceId_dueAt_cardId",
       direction: "next",
+      keyRange: makeWorkspaceIndexRange(workspaceId),
+    },
+    onCard,
+  );
+}
+
+export async function iterateCardsByDueAtAscBefore(
+  database: IDBDatabase,
+  workspaceId: string,
+  dueAtExclusive: string,
+  onCard: (card: Card) => boolean | void,
+): Promise<void> {
+  await iterateCardsByIndex(
+    database,
+    workspaceId,
+    {
+      indexName: "workspaceId_dueAt_cardId",
+      direction: "next",
+      keyRange: makeWorkspaceDueAtBeforeRange(workspaceId, dueAtExclusive),
+    },
+    onCard,
+  );
+}
+
+export async function iterateCardsByDueAtAscBetweenInclusive(
+  database: IDBDatabase,
+  workspaceId: string,
+  lowerDueAtInclusive: string,
+  upperDueAtInclusive: string,
+  onCard: (card: Card) => boolean | void,
+): Promise<void> {
+  await iterateCardsByIndex(
+    database,
+    workspaceId,
+    {
+      indexName: "workspaceId_dueAt_cardId",
+      direction: "next",
+      keyRange: makeWorkspaceDueAtBetweenInclusiveRange(workspaceId, lowerDueAtInclusive, upperDueAtInclusive),
+    },
+    onCard,
+  );
+}
+
+export async function iterateCardsByDueAtAscAfter(
+  database: IDBDatabase,
+  workspaceId: string,
+  dueAtExclusive: string,
+  onCard: (card: Card) => boolean | void,
+): Promise<void> {
+  await iterateCardsByIndex(
+    database,
+    workspaceId,
+    {
+      indexName: "workspaceId_dueAt_cardId",
+      direction: "next",
+      keyRange: makeWorkspaceDueAtAfterRange(workspaceId, dueAtExclusive),
     },
     onCard,
   );
@@ -309,6 +388,7 @@ async function iterateCardsByEffortAndCreatedAtDesc(
     {
       indexName: "workspaceId_effort_createdAt_cardId",
       direction: "prev",
+      keyRange: makeWorkspaceIndexRange(workspaceId),
     },
     (card) => {
       if (card.effortLevel !== effortLevel) {
@@ -375,6 +455,7 @@ async function iterateCardsByEffortAndUpdatedAtDesc(
     {
       indexName: "workspaceId_effort_updatedAt_cardId",
       direction: "prev",
+      keyRange: makeWorkspaceIndexRange(workspaceId),
     },
     (card) => {
       if (card.effortLevel !== effortLevel) {

--- a/apps/web/src/localDb/reviews.test.ts
+++ b/apps/web/src/localDb/reviews.test.ts
@@ -124,6 +124,515 @@ describe("localDb reviews", () => {
     }
   });
 
+  it("orders active review queue by recent due, old due, then null and leaves future or malformed cards for timeline", async () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const originalNow = Date.now;
+    Date.now = () => nowTimestamp;
+
+    try {
+      await replaceCards(workspaceId, [
+        makeCard({
+          cardId: "future-tomorrow",
+          frontText: "Future tomorrow",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-11T12:00:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "recent-1155",
+          frontText: "Recent 11:55",
+          backText: "back",
+          tags: ["code"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:55:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "new-null",
+          frontText: "New null",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "malformed",
+          frontText: "Malformed",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "not-a-date",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "old-yesterday",
+          frontText: "Old yesterday",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-09T12:00:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "recent-1115",
+          frontText: "Recent 11:15",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:15:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+      ]);
+
+      const queueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 10);
+      const timelinePage = await loadReviewTimelinePage(workspaceId, { kind: "allCards" }, 10, 0);
+      const grammarQueueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "tag", tag: "grammar" }, 10);
+
+      expect(queueSnapshot.cards.map((card) => card.cardId)).toEqual([
+        "recent-1115",
+        "recent-1155",
+        "old-yesterday",
+        "new-null",
+      ]);
+      expect(queueSnapshot.reviewCounts).toEqual({
+        dueCount: 4,
+        totalCount: 6,
+      });
+      expect(timelinePage.cards.map((card) => card.cardId)).toEqual([
+        "recent-1115",
+        "recent-1155",
+        "old-yesterday",
+        "new-null",
+        "future-tomorrow",
+        "malformed",
+      ]);
+      expect(grammarQueueSnapshot.cards.map((card) => card.cardId)).toEqual([
+        "recent-1115",
+        "old-yesterday",
+        "new-null",
+      ]);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("keeps recent due boundaries inclusive and excludes now plus one millisecond from the active queue", async () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const originalNow = Date.now;
+    Date.now = () => nowTimestamp;
+
+    try {
+      await replaceCards(workspaceId, [
+        makeCard({
+          cardId: "future-one-ms",
+          frontText: "Future one ms",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.001Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "malformed-in-range",
+          frontText: "Malformed in range",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:30:broken",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "old-one-ms",
+          frontText: "Old one ms",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T10:59:59.999Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "due-now",
+          frontText: "Due now",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "new-null",
+          frontText: "New null",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "recent-cutoff",
+          frontText: "Recent cutoff",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:00:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+      ]);
+
+      const queueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 10);
+      const timelinePage = await loadReviewTimelinePage(workspaceId, { kind: "allCards" }, 10, 0);
+
+      expect(queueSnapshot.cards.map((card) => card.cardId)).toEqual([
+        "recent-cutoff",
+        "due-now",
+        "old-one-ms",
+        "new-null",
+      ]);
+      expect(timelinePage.cards.map((card) => card.cardId)).toEqual([
+        "recent-cutoff",
+        "due-now",
+        "old-one-ms",
+        "new-null",
+        "future-one-ms",
+        "malformed-in-range",
+      ]);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("includes non-canonical whole-second dueAt at the inclusive now boundary", async () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const originalNow = Date.now;
+    Date.now = () => nowTimestamp;
+
+    try {
+      await replaceCards(workspaceId, [
+        makeCard({
+          cardId: "due-now-short-z",
+          frontText: "Due now short Z",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "future-one-ms",
+          frontText: "Future one ms",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.001Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "malformed",
+          frontText: "Malformed",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "not-a-date",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "new-null",
+          frontText: "New null",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+      ]);
+
+      const queueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 10);
+      const timelinePage = await loadReviewTimelinePage(workspaceId, { kind: "allCards" }, 10, 0);
+      const queueCardIds = queueSnapshot.cards.map((card) => card.cardId);
+
+      expect(queueCardIds).toEqual([
+        "due-now-short-z",
+        "new-null",
+      ]);
+      expect(new Set(queueCardIds).size).toBe(queueCardIds.length);
+      expect(timelinePage.cards.map((card) => card.cardId)).toEqual([
+        "due-now-short-z",
+        "new-null",
+        "future-one-ms",
+        "malformed",
+      ]);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("includes short fractional dueAt variants at the inclusive now boundary without duplicates", async () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.100Z");
+    const originalNow = Date.now;
+    Date.now = () => nowTimestamp;
+
+    try {
+      await replaceCards(workspaceId, [
+        makeCard({
+          cardId: "old-cutoff-second",
+          frontText: "Old cutoff second",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:00:00Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "recent-cutoff-short-fraction",
+          frontText: "Recent cutoff short fraction",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:00:00.1Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "due-now-canonical",
+          frontText: "Due now canonical",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.100Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "due-now-short-fraction",
+          frontText: "Due now short fraction",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.1Z",
+          createdAt: "2026-03-10T09:03:00.000Z",
+        }),
+        makeCard({
+          cardId: "due-now-two-digit-fraction",
+          frontText: "Due now two digit fraction",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.10Z",
+          createdAt: "2026-03-10T09:02:00.000Z",
+        }),
+        makeCard({
+          cardId: "future-one-ms",
+          frontText: "Future one ms",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.101Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "malformed",
+          frontText: "Malformed",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T12:00:00.broken",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "new-null",
+          frontText: "New null",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+      ]);
+
+      const queueSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 10);
+      const timelinePage = await loadReviewTimelinePage(workspaceId, { kind: "allCards" }, 10, 0);
+      const queueCardIds = queueSnapshot.cards.map((card) => card.cardId);
+
+      expect(queueCardIds).toEqual([
+        "recent-cutoff-short-fraction",
+        "due-now-short-fraction",
+        "due-now-two-digit-fraction",
+        "due-now-canonical",
+        "old-cutoff-second",
+        "new-null",
+      ]);
+      expect(new Set(queueCardIds).size).toBe(queueCardIds.length);
+      expect(timelinePage.cards.map((card) => card.cardId)).toEqual([
+        "recent-cutoff-short-fraction",
+        "due-now-short-fraction",
+        "due-now-two-digit-fraction",
+        "due-now-canonical",
+        "old-cutoff-second",
+        "new-null",
+        "future-one-ms",
+        "malformed",
+      ]);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("continues active review chunks across recent due, old due, and null buckets when the cursor card is excluded", async () => {
+    const nowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const originalNow = Date.now;
+    Date.now = () => nowTimestamp;
+
+    try {
+      await replaceCards(workspaceId, [
+        makeCard({
+          cardId: "recent-1115",
+          frontText: "Recent 11:15",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:15:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "recent-1155",
+          frontText: "Recent 11:55",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:55:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "old-yesterday",
+          frontText: "Old yesterday",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-09T12:00:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "new-null",
+          frontText: "New null",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "future-tomorrow",
+          frontText: "Future tomorrow",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-11T12:00:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+      ]);
+
+      const initialSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 2);
+      const chunk = await loadReviewQueueChunk(
+        workspaceId,
+        { kind: "allCards" },
+        initialSnapshot.nextCursor,
+        2,
+        new Set(["recent-1155"]),
+      );
+
+      expect(initialSnapshot.cards.map((card) => card.cardId)).toEqual([
+        "recent-1115",
+        "recent-1155",
+      ]);
+      expect(chunk.cards.map((card) => card.cardId)).toEqual([
+        "old-yesterday",
+        "new-null",
+      ]);
+      expect(chunk.nextCursor).toBeNull();
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("continues active review chunks from the original queue window when the recent boundary moves", async () => {
+    const initialNowTimestamp = Date.parse("2026-03-10T12:00:00.000Z");
+    const laterNowTimestamp = Date.parse("2026-03-10T12:20:00.000Z");
+    const originalNow = Date.now;
+    Date.now = () => initialNowTimestamp;
+
+    try {
+      await replaceCards(workspaceId, [
+        makeCard({
+          cardId: "recent-1105",
+          frontText: "Recent 11:05",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:05:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "recent-1110",
+          frontText: "Recent 11:10",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:10:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "recent-1115",
+          frontText: "Recent 11:15",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T11:15:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "old-1000",
+          frontText: "Old 10:00",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: "2026-03-10T10:00:00.000Z",
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+        makeCard({
+          cardId: "new-null",
+          frontText: "New null",
+          backText: "back",
+          tags: ["grammar"],
+          effortLevel: "fast",
+          dueAt: null,
+          createdAt: "2026-03-10T09:00:00.000Z",
+        }),
+      ]);
+
+      const initialSnapshot = await loadReviewQueueSnapshot(workspaceId, { kind: "allCards" }, 2);
+      Date.now = () => laterNowTimestamp;
+      const chunk = await loadReviewQueueChunk(
+        workspaceId,
+        { kind: "allCards" },
+        initialSnapshot.nextCursor,
+        2,
+        new Set(initialSnapshot.cards.map((card) => card.cardId)),
+      );
+
+      expect(initialSnapshot.cards.map((card) => card.cardId)).toEqual([
+        "recent-1105",
+        "recent-1110",
+      ]);
+      expect(chunk.cards.map((card) => card.cardId)).toEqual([
+        "recent-1115",
+        "old-1000",
+      ]);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
   it("keeps timed due ahead of null due ordering with stable cardId tie-breaks", async () => {
     const nowTimestamp = Date.parse("2025-01-08T00:00:00.000Z");
     const originalNow = Date.now;

--- a/apps/web/src/localDb/reviews.ts
+++ b/apps/web/src/localDb/reviews.ts
@@ -12,9 +12,16 @@ import {
   compareCardsForReviewOrder,
   isCardDue,
   matchesDeckFilterDefinition,
+  recentDuePriorityWindow,
 } from "../appData/domain";
 import { loadAllowedCardIdsForTags } from "./cardTags";
-import { iterateCardsByCreatedAtDesc, iterateCardsByDueAtAsc } from "./cards";
+import {
+  iterateCardsByCreatedAtDesc,
+  iterateCardsByDueAtAsc,
+  iterateCardsByDueAtAscAfter,
+  iterateCardsByDueAtAscBefore,
+  iterateCardsByDueAtAscBetweenInclusive,
+} from "./cards";
 import {
   closeDatabaseAfter,
   closeDatabaseAfterWrite,
@@ -35,15 +42,23 @@ import {
 } from "./progress";
 import { decodeCursor, encodeCursor } from "./queryShared";
 
-type ReviewCandidateAccumulator = Readonly<{
-  matchingCards: ReadonlyArray<Card>;
-  dueCards: ReadonlyArray<Card>;
-}>;
-
 type ReviewFilterResolution = Readonly<{
   resolvedReviewFilter: ReviewFilter;
   deck: Deck | null;
   allowedTagCardIds: ReadonlySet<string> | null;
+}>;
+
+type ReviewCardCursorIterator = (
+  database: IDBDatabase,
+  workspaceId: string,
+  onCard: (card: Card) => boolean | void,
+) => Promise<void>;
+
+type DueAtBucketPredicate = (dueAtTimestamp: number, nowTimestamp: number) => boolean;
+
+type ReviewQueueCursorState = Readonly<{
+  cardId: string;
+  asOfTimestamp: number;
 }>;
 
 async function resolveReviewFilterFromIndexedDb(
@@ -123,65 +138,46 @@ function matchesResolvedReviewFilter(
   return filterResolution.allowedTagCardIds?.has(card.cardId) ?? false;
 }
 
-function createEmptyReviewCandidateAccumulator(): ReviewCandidateAccumulator {
-  return {
-    matchingCards: [],
-    dueCards: [],
-  };
+function toIsoTimestamp(timestamp: number): string {
+  return new Date(timestamp).toISOString();
 }
 
-function appendReviewCandidate(
-  accumulator: ReviewCandidateAccumulator,
-  card: Card,
-  nowTimestamp: number,
-): ReviewCandidateAccumulator {
-  return {
-    matchingCards: [...accumulator.matchingCards, card],
-    dueCards: isCardDue(card, nowTimestamp)
-      ? [...accumulator.dueCards, card]
-      : accumulator.dueCards,
-  };
+function toIsoSecondPrefix(timestamp: number): string {
+  return toIsoTimestamp(timestamp).slice(0, 19);
 }
 
-async function collectReviewCandidates(
-  database: IDBDatabase,
-  workspaceId: string,
-  reviewFilter: ReviewFilter,
-  nowTimestamp: number,
-): Promise<Readonly<{
-  filterResolution: ReviewFilterResolution;
-  accumulator: ReviewCandidateAccumulator;
-}>> {
-  const filterResolution = await resolveReviewFilterFromIndexedDb(database, workspaceId, reviewFilter);
-  let accumulator = createEmptyReviewCandidateAccumulator();
-  await iterateReviewCardsInCanonicalOrder(database, workspaceId, nowTimestamp, (card) => {
-    if (matchesResolvedReviewFilter(card, filterResolution) === false) {
-      return true;
-    }
-
-    accumulator = appendReviewCandidate(accumulator, card, nowTimestamp);
-    return true;
-  });
-
-  return {
-    filterResolution,
-    accumulator,
-  };
+function toIsoSecondUpperBound(timestamp: number): string {
+  // IndexedDB compares dueAt as text, so include non-canonical forms that parse inside the same UTC second.
+  return `${toIsoSecondPrefix(timestamp)}\uffff`;
 }
 
-async function iterateReviewCardsInCanonicalOrder(
+function makeDueAtSecondGroupKey(dueAt: string): string {
+  return dueAt.slice(0, 19);
+}
+
+function isRecentDueTimestamp(dueAtTimestamp: number, nowTimestamp: number): boolean {
+  return dueAtTimestamp >= nowTimestamp - recentDuePriorityWindow && dueAtTimestamp <= nowTimestamp;
+}
+
+function isOldDueTimestamp(dueAtTimestamp: number, nowTimestamp: number): boolean {
+  return dueAtTimestamp < nowTimestamp - recentDuePriorityWindow;
+}
+
+function isFutureDueTimestamp(dueAtTimestamp: number, nowTimestamp: number): boolean {
+  return dueAtTimestamp > nowTimestamp;
+}
+
+async function iterateTimedReviewCardsByDueAt(
   database: IDBDatabase,
   workspaceId: string,
   nowTimestamp: number,
+  cursorIterator: ReviewCardCursorIterator,
+  matchesBucket: DueAtBucketPredicate,
   onCard: (card: Card) => boolean | void,
-): Promise<void> {
+): Promise<boolean> {
   let shouldStop = false;
-  const futureCards: Array<Card> = [];
-  const invalidCards: Array<Card> = [];
-
-  let currentDueAt: string | null | undefined;
+  let currentDueAtSecondGroupKey: string | null | undefined;
   let currentDueGroup: Array<Card> = [];
-  let currentDueGroupKind: "timedDue" | "future" | "invalid" | null = null;
 
   function flushCurrentDueGroup(): boolean {
     const sortedGroup = [...currentDueGroup].sort(
@@ -189,24 +185,17 @@ async function iterateReviewCardsInCanonicalOrder(
     );
     currentDueGroup = [];
 
-    if (currentDueGroupKind === "timedDue") {
-      for (const card of sortedGroup) {
-        if (onCard(card) === false) {
-          shouldStop = true;
-          return false;
-        }
+    for (const card of sortedGroup) {
+      if (onCard(card) === false) {
+        shouldStop = true;
+        return false;
       }
-    } else if (currentDueGroupKind === "future") {
-      futureCards.push(...sortedGroup);
-    } else if (currentDueGroupKind === "invalid") {
-      invalidCards.push(...sortedGroup);
     }
 
-    currentDueGroupKind = null;
     return true;
   }
 
-  await iterateCardsByDueAtAsc(database, workspaceId, (card) => {
+  await cursorIterator(database, workspaceId, (card) => {
     if (shouldStop) {
       return false;
     }
@@ -216,22 +205,18 @@ async function iterateReviewCardsInCanonicalOrder(
     }
 
     const dueAtTimestamp = new Date(card.dueAt).getTime();
-    const isInvalidDueAt = Number.isNaN(dueAtTimestamp);
-    const isTimedDue = isInvalidDueAt === false && dueAtTimestamp <= nowTimestamp;
-    const nextGroupKind: "timedDue" | "future" | "invalid" = isTimedDue
-      ? "timedDue"
-      : isInvalidDueAt
-        ? "invalid"
-        : "future";
-
-    if (currentDueAt === undefined) {
-      currentDueAt = card.dueAt;
-      currentDueGroup = [card];
-      currentDueGroupKind = nextGroupKind;
+    if (Number.isNaN(dueAtTimestamp) || matchesBucket(dueAtTimestamp, nowTimestamp) === false) {
       return true;
     }
 
-    if (currentDueAt === card.dueAt) {
+    const dueAtSecondGroupKey = makeDueAtSecondGroupKey(card.dueAt);
+    if (currentDueAtSecondGroupKey === undefined) {
+      currentDueAtSecondGroupKey = dueAtSecondGroupKey;
+      currentDueGroup = [card];
+      return true;
+    }
+
+    if (currentDueAtSecondGroupKey === dueAtSecondGroupKey) {
       currentDueGroup = [...currentDueGroup, card];
       return true;
     }
@@ -240,26 +225,30 @@ async function iterateReviewCardsInCanonicalOrder(
       return false;
     }
 
-    currentDueAt = card.dueAt;
+    currentDueAtSecondGroupKey = dueAtSecondGroupKey;
     currentDueGroup = [card];
-    currentDueGroupKind = nextGroupKind;
     return true;
   });
 
   if (shouldStop) {
-    return;
+    return false;
   }
 
   if (currentDueGroup.length > 0) {
     if (flushCurrentDueGroup() === false) {
-      return;
+      return false;
     }
   }
 
-  if (shouldStop) {
-    return;
-  }
+  return true;
+}
 
+async function iterateNullDueReviewCards(
+  database: IDBDatabase,
+  workspaceId: string,
+  onCard: (card: Card) => boolean | void,
+): Promise<boolean> {
+  let shouldStop = false;
   let currentCreatedAt: string | null | undefined;
   let currentNullGroup: Array<Card> = [];
 
@@ -281,6 +270,7 @@ async function iterateReviewCardsInCanonicalOrder(
     if (shouldStop) {
       return false;
     }
+
     if (card.deletedAt !== null || card.dueAt !== null) {
       return true;
     }
@@ -309,68 +299,237 @@ async function iterateReviewCardsInCanonicalOrder(
     flushCurrentNullGroup();
   }
 
-  if (shouldStop) {
+  return shouldStop === false;
+}
+
+async function iterateMalformedDueAtReviewCards(
+  database: IDBDatabase,
+  workspaceId: string,
+  nowTimestamp: number,
+  onCard: (card: Card) => boolean | void,
+): Promise<boolean> {
+  const malformedCards: Array<Card> = [];
+
+  await iterateCardsByDueAtAsc(database, workspaceId, (card) => {
+    if (card.deletedAt !== null || card.dueAt === null) {
+      return true;
+    }
+
+    const dueAtTimestamp = new Date(card.dueAt).getTime();
+    if (Number.isNaN(dueAtTimestamp)) {
+      malformedCards.push(card);
+    }
+
+    return true;
+  });
+
+  const sortedMalformedCards = [...malformedCards].sort(
+    (leftCard, rightCard) => compareCardsForReviewOrder(leftCard, rightCard, nowTimestamp),
+  );
+  for (const card of sortedMalformedCards) {
+    if (onCard(card) === false) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+async function iterateActiveReviewCardsInCanonicalOrder(
+  database: IDBDatabase,
+  workspaceId: string,
+  nowTimestamp: number,
+  onCard: (card: Card) => boolean | void,
+): Promise<boolean> {
+  const recentDueCutoffTimestamp = nowTimestamp - recentDuePriorityWindow;
+  const recentDueCutoffLowerBound = toIsoSecondPrefix(recentDueCutoffTimestamp);
+  const recentDueCutoffUpperBound = toIsoSecondUpperBound(recentDueCutoffTimestamp);
+  const nowUpperBound = toIsoSecondUpperBound(nowTimestamp);
+
+  const didFinishRecentDueCards = await iterateTimedReviewCardsByDueAt(
+    database,
+    workspaceId,
+    nowTimestamp,
+    (cursorDatabase, cursorWorkspaceId, cursorOnCard) => iterateCardsByDueAtAscBetweenInclusive(
+      cursorDatabase,
+      cursorWorkspaceId,
+      recentDueCutoffLowerBound,
+      nowUpperBound,
+      cursorOnCard,
+    ),
+    isRecentDueTimestamp,
+    onCard,
+  );
+  if (didFinishRecentDueCards === false) {
+    return false;
+  }
+
+  const didFinishOldDueCards = await iterateTimedReviewCardsByDueAt(
+    database,
+    workspaceId,
+    nowTimestamp,
+    (cursorDatabase, cursorWorkspaceId, cursorOnCard) => iterateCardsByDueAtAscBefore(
+      cursorDatabase,
+      cursorWorkspaceId,
+      recentDueCutoffUpperBound,
+      cursorOnCard,
+    ),
+    isOldDueTimestamp,
+    onCard,
+  );
+  if (didFinishOldDueCards === false) {
+    return false;
+  }
+
+  return iterateNullDueReviewCards(database, workspaceId, onCard);
+}
+
+async function iterateReviewCardsInCanonicalOrder(
+  database: IDBDatabase,
+  workspaceId: string,
+  nowTimestamp: number,
+  onCard: (card: Card) => boolean | void,
+): Promise<void> {
+  const didFinishActiveCards = await iterateActiveReviewCardsInCanonicalOrder(database, workspaceId, nowTimestamp, onCard);
+  if (didFinishActiveCards === false) {
     return;
   }
 
-  for (const card of futureCards) {
-    if (onCard(card) === false) {
-      return;
-    }
+  const nowIso = toIsoTimestamp(nowTimestamp);
+  const didFinishFutureCards = await iterateTimedReviewCardsByDueAt(
+    database,
+    workspaceId,
+    nowTimestamp,
+    (cursorDatabase, cursorWorkspaceId, cursorOnCard) => iterateCardsByDueAtAscAfter(
+      cursorDatabase,
+      cursorWorkspaceId,
+      nowIso,
+      cursorOnCard,
+    ),
+    isFutureDueTimestamp,
+    onCard,
+  );
+  if (didFinishFutureCards === false) {
+    return;
   }
 
-  for (const card of invalidCards) {
-    if (onCard(card) === false) {
-      return;
-    }
-  }
+  await iterateMalformedDueAtReviewCards(database, workspaceId, nowTimestamp, onCard);
 }
 
-function makeReviewCursorCardIdPredicate(cursor: string | null): Readonly<{
-  matches: (cardId: string) => boolean;
-  isSet: boolean;
-}> {
-  if (cursor === null) {
-    return {
-      matches: () => false,
-      isSet: false,
+async function makeReviewCountsFromIndexedDb(
+  database: IDBDatabase,
+  workspaceId: string,
+  filterResolution: ReviewFilterResolution,
+  nowTimestamp: number,
+): Promise<ReviewCounts> {
+  let reviewCounts: ReviewCounts = {
+    dueCount: 0,
+    totalCount: 0,
+  };
+
+  await iterateCardsByCreatedAtDesc(database, workspaceId, (card) => {
+    if (card.deletedAt !== null || matchesResolvedReviewFilter(card, filterResolution) === false) {
+      return true;
+    }
+
+    reviewCounts = {
+      dueCount: reviewCounts.dueCount + (isCardDue(card, nowTimestamp) ? 1 : 0),
+      totalCount: reviewCounts.totalCount + 1,
     };
+    return true;
+  });
+
+  return reviewCounts;
+}
+
+async function loadActiveReviewQueuePage(
+  database: IDBDatabase,
+  workspaceId: string,
+  filterResolution: ReviewFilterResolution,
+  nowTimestamp: number,
+  cursorState: ReviewQueueCursorState | null,
+  limit: number,
+  excludedCardIds: ReadonlySet<string>,
+): Promise<Readonly<{ cards: ReadonlyArray<Card>; nextCursor: string | null }>> {
+  const cursorPredicate = makeReviewCursorCardIdPredicate(cursorState);
+  let hasReachedCursor = cursorPredicate.isSet === false;
+  let pageCards: Array<Card> = [];
+  let hasMoreCards = false;
+
+  await iterateActiveReviewCardsInCanonicalOrder(database, workspaceId, nowTimestamp, (card) => {
+    if (matchesResolvedReviewFilter(card, filterResolution) === false) {
+      return true;
+    }
+
+    if (hasReachedCursor === false) {
+      if (cursorPredicate.matches(card.cardId)) {
+        hasReachedCursor = true;
+      }
+      return true;
+    }
+
+    if (excludedCardIds.has(card.cardId)) {
+      return true;
+    }
+
+    if (pageCards.length < limit) {
+      pageCards = [...pageCards, card];
+      return true;
+    }
+
+    hasMoreCards = true;
+    return false;
+  });
+
+  return {
+    cards: pageCards,
+    nextCursor: hasMoreCards && pageCards.length > 0
+      ? encodeReviewQueueCursor(pageCards[pageCards.length - 1]?.cardId ?? "", nowTimestamp)
+      : null,
+  };
+}
+
+function encodeReviewQueueCursor(cardId: string, asOfTimestamp: number): string {
+  if (cardId === "") {
+    throw new Error("Review queue cursor cannot be built without a card id");
   }
 
+  return encodeCursor({ cardId, asOfTimestamp });
+}
+
+function decodeReviewQueueCursor(cursor: string): ReviewQueueCursorState {
   const parsedCursor = decodeCursor(cursor);
   const cardId = parsedCursor.cardId;
   if (typeof cardId !== "string" || cardId === "") {
     throw new Error("review cursor.cardId must be a non-empty string");
   }
 
+  const asOfTimestamp = parsedCursor.asOfTimestamp;
+  if (typeof asOfTimestamp !== "number" || Number.isFinite(asOfTimestamp) === false) {
+    throw new Error("review cursor.asOfTimestamp must be a finite number");
+  }
+
   return {
-    matches: (candidateCardId) => candidateCardId === cardId,
-    isSet: true,
+    cardId,
+    asOfTimestamp,
   };
 }
 
-function makeReviewCountsFromCards(cards: ReadonlyArray<Card>, nowTimestamp: number): ReviewCounts {
-  return cards.reduce<ReviewCounts>((result, card) => ({
-    dueCount: result.dueCount + (isCardDue(card, nowTimestamp) ? 1 : 0),
-    totalCount: result.totalCount + 1,
-  }), {
-    dueCount: 0,
-    totalCount: 0,
-  });
-}
-
-function buildReviewQueueCursor(cards: ReadonlyArray<Card>, pageCards: ReadonlyArray<Card>): string | null {
-  if (pageCards.length === 0) {
-    return null;
+function makeReviewCursorCardIdPredicate(cursorState: ReviewQueueCursorState | null): Readonly<{
+  matches: (cardId: string) => boolean;
+  isSet: boolean;
+}> {
+  if (cursorState === null) {
+    return {
+      matches: () => false,
+      isSet: false,
+    };
   }
 
-  const lastCard = pageCards[pageCards.length - 1];
-  const lastCardIndex = cards.findIndex((card) => card.cardId === lastCard.cardId);
-  if (lastCardIndex === -1 || lastCardIndex >= cards.length - 1) {
-    return null;
-  }
-
-  return encodeCursor({ cardId: lastCard.cardId });
+  return {
+    matches: (candidateCardId) => candidateCardId === cursorState.cardId,
+    isSet: true,
+  };
 }
 
 function deleteWorkspaceReviewEvents(
@@ -408,14 +567,25 @@ export async function loadReviewQueueSnapshot(
 ): Promise<ReviewQueueSnapshot> {
   return closeDatabaseAfter(async (database) => {
     const nowTimestamp = Date.now();
-    const { filterResolution, accumulator } = await collectReviewCandidates(database, workspaceId, reviewFilter, nowTimestamp);
-    const pageCards = accumulator.dueCards.slice(0, limit);
+    const filterResolution = await resolveReviewFilterFromIndexedDb(database, workspaceId, reviewFilter);
+    const [queuePage, reviewCounts] = await Promise.all([
+      loadActiveReviewQueuePage(
+        database,
+        workspaceId,
+        filterResolution,
+        nowTimestamp,
+        null,
+        limit,
+        new Set<string>(),
+      ),
+      makeReviewCountsFromIndexedDb(database, workspaceId, filterResolution, nowTimestamp),
+    ]);
 
     return {
       resolvedReviewFilter: filterResolution.resolvedReviewFilter,
-      cards: pageCards,
-      nextCursor: buildReviewQueueCursor(accumulator.dueCards, pageCards),
-      reviewCounts: makeReviewCountsFromCards(accumulator.matchingCards, nowTimestamp),
+      cards: queuePage.cards,
+      nextCursor: queuePage.nextCursor,
+      reviewCounts,
     };
   });
 }
@@ -428,46 +598,18 @@ export async function loadReviewQueueChunk(
   excludedCardIds: ReadonlySet<string>,
 ): Promise<Readonly<{ cards: ReadonlyArray<Card>; nextCursor: string | null }>> {
   return closeDatabaseAfter(async (database) => {
-    const nowTimestamp = Date.now();
+    const cursorState = cursor === null ? null : decodeReviewQueueCursor(cursor);
+    const nowTimestamp = cursorState === null ? Date.now() : cursorState.asOfTimestamp;
     const filterResolution = await resolveReviewFilterFromIndexedDb(database, workspaceId, reviewFilter);
-    const cursorPredicate = makeReviewCursorCardIdPredicate(cursor);
-    let hasReachedCursor = cursorPredicate.isSet === false;
-    let pageCards: Array<Card> = [];
-    let hasMoreCards = false;
-
-    await iterateReviewCardsInCanonicalOrder(database, workspaceId, nowTimestamp, (card) => {
-      if (excludedCardIds.has(card.cardId)) {
-        return true;
-      }
-      if (matchesResolvedReviewFilter(card, filterResolution) === false) {
-        return true;
-      }
-      if (isCardDue(card, nowTimestamp) === false) {
-        return true;
-      }
-
-      if (hasReachedCursor === false) {
-        if (cursorPredicate.matches(card.cardId)) {
-          hasReachedCursor = true;
-        }
-        return true;
-      }
-
-      if (pageCards.length < limit) {
-        pageCards = [...pageCards, card];
-        return true;
-      }
-
-      hasMoreCards = true;
-      return false;
-    });
-
-    return {
-      cards: pageCards,
-      nextCursor: hasMoreCards && pageCards.length > 0
-        ? encodeCursor({ cardId: pageCards[pageCards.length - 1]?.cardId ?? "" })
-        : null,
-    };
+    return loadActiveReviewQueuePage(
+      database,
+      workspaceId,
+      filterResolution,
+      nowTimestamp,
+      cursorState,
+      limit,
+      excludedCardIds,
+    );
   });
 }
 

--- a/apps/web/src/screens/review/ReviewScreen.test.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
+import type { Card } from "../../types";
 import {
   clickElementAsync,
   createCard,
@@ -329,47 +330,180 @@ describe("ReviewScreen", () => {
     expect(state.appData.submitReviewItem).toHaveBeenCalledTimes(8);
   });
 
-  it("keeps the presented card stable across a background queue reorder and advances to the new canonical head after review", async () => {
+  it("keeps an omitted presented card stable across a bounded refresh and advances to the canonical head after review", async () => {
     const state = getState();
     const currentCard = createCard({
       cardId: "card-current",
       frontText: "Current front",
       backText: "Current back",
-      dueAt: "2026-03-10T11:55:00.000Z",
+      dueAt: "2026-03-09T12:00:00.000Z",
     });
-    const newlyDueCard = createCard({
-      cardId: "card-newly-due",
-      frontText: "Newly due front",
-      backText: "Newly due back",
-      dueAt: "2026-03-10T11:50:00.000Z",
-      createdAt: "2026-03-10T11:59:00.000Z",
-      updatedAt: "2026-03-10T11:59:00.000Z",
+    const recentCards = Array.from({ length: 8 }, (_, index) => createCard({
+      cardId: `card-recent-${index + 1}`,
+      frontText: `Recent due ${index + 1} front`,
+      backText: `Recent due ${index + 1} back`,
+      dueAt: `2026-03-10T11:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      createdAt: `2026-03-10T10:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      updatedAt: `2026-03-10T10:${String(index + 1).padStart(2, "0")}:00.000Z`,
+    }));
+    const futureCard = createCard({
+      cardId: "card-future",
+      frontText: "Future front",
+      backText: "Future back",
+      dueAt: "2026-03-11T12:00:00.000Z",
+      createdAt: "2026-03-10T09:15:00.000Z",
+      updatedAt: "2026-03-10T09:15:00.000Z",
     });
-    state.cards = [currentCard, newlyDueCard];
+    state.cards = [currentCard, ...recentCards, futureCard];
     state.reviewQueue = [currentCard];
-    state.reviewTimeline = [currentCard, newlyDueCard];
+    state.reviewTimeline = [currentCard, ...recentCards, futureCard];
+    state.appData.getCardById.mockImplementation(async (cardId: string): Promise<Card> => {
+      if (cardId === currentCard.cardId) {
+        return currentCard;
+      }
+
+      throw new Error(`Unexpected card lookup: ${cardId}`);
+    });
     state.appData.submitReviewItem.mockImplementation(async (): Promise<Card> => currentCard);
 
     await renderReviewScreen();
 
     expect(getContainer().textContent).toContain("Current front");
-    expect(getContainer().textContent).not.toContain("Newly due frontCurrent front");
+    expect(getContainer().textContent).not.toContain("Recent due 1 frontCurrent front");
 
-    state.reviewQueue = [newlyDueCard, currentCard];
-    state.reviewTimeline = [newlyDueCard, currentCard];
+    state.reviewQueue = [...recentCards];
+    state.reviewTimeline = [...recentCards, futureCard];
     state.appData.localReadVersion = 1;
 
     await rerenderReviewScreen();
 
+    expect(state.appData.getCardById).toHaveBeenCalledWith("card-current");
     expect(getContainer().textContent).toContain("Current front");
     const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
-    expect(queueTitlesAfterRefresh).toEqual(["Current front", "Newly due front"]);
+    expect(queueTitlesAfterRefresh).toEqual([
+      "Current front",
+      ...recentCards.map((card) => card.frontText),
+      "Future front",
+    ]);
 
     await revealAnswer();
     await dispatchDocumentKeydown("3");
 
     expect(state.appData.submitReviewItem).toHaveBeenCalledWith("card-current", 2);
-    expect(getContainer().textContent).toContain("Newly due front");
+    expect(getContainer().textContent).toContain("Recent due 1 front");
     expect(getContainer().textContent).not.toContain("Current frontCurrent back");
+
+    state.reviewQueue = [currentCard, ...recentCards];
+    state.reviewTimeline = [currentCard, ...recentCards, futureCard];
+    state.appData.localReadVersion = 2;
+
+    await rerenderReviewScreen();
+
+    const queueTitlesAfterReappearance = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
+    expect(queueTitlesAfterReappearance).toEqual([
+      "Recent due 1 front",
+      "Current front",
+      ...recentCards.slice(1).map((card) => card.frontText),
+      "Future front",
+    ]);
+  });
+
+  it("does not preserve an omitted presented card after it stops matching the selected filter", async () => {
+    const state = getState();
+    state.appData.selectedReviewFilter = {
+      kind: "tag",
+      tag: "grammar",
+    };
+    const currentCard = createCard({
+      cardId: "card-current-filter",
+      frontText: "Current filter front",
+      backText: "Current filter back",
+      tags: ["grammar"],
+      dueAt: "2026-03-09T12:00:00.000Z",
+    });
+    const currentCardWithoutSelectedTag = {
+      ...currentCard,
+      tags: ["code"],
+    };
+    const canonicalCards = Array.from({ length: 8 }, (_, index) => createCard({
+      cardId: `card-filter-head-${index + 1}`,
+      frontText: `Filter head ${index + 1} front`,
+      backText: `Filter head ${index + 1} back`,
+      tags: ["grammar"],
+      dueAt: `2026-03-10T11:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      createdAt: `2026-03-10T10:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      updatedAt: `2026-03-10T10:${String(index + 1).padStart(2, "0")}:00.000Z`,
+    }));
+
+    state.cards = [currentCard, ...canonicalCards];
+    state.reviewQueue = [currentCard];
+    state.reviewTimeline = [currentCard, ...canonicalCards];
+    state.appData.getCardById.mockImplementation(async (cardId: string): Promise<Card> => {
+      if (cardId === currentCard.cardId) {
+        return currentCardWithoutSelectedTag;
+      }
+
+      throw new Error(`Unexpected card lookup: ${cardId}`);
+    });
+
+    await renderReviewScreen();
+
+    expect(getContainer().textContent).toContain("Current filter front");
+
+    state.cards = [currentCardWithoutSelectedTag, ...canonicalCards];
+    state.reviewQueue = [...canonicalCards];
+    state.reviewTimeline = [...canonicalCards];
+    state.appData.localReadVersion = 1;
+
+    await rerenderReviewScreen();
+
+    expect(state.appData.getCardById).toHaveBeenCalledWith("card-current-filter");
+    expect(getContainer().textContent).toContain("Filter head 1 front");
+    expect(getContainer().textContent).not.toContain("Current filter front");
+    const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
+    expect(queueTitlesAfterRefresh).toEqual(canonicalCards.map((card) => card.frontText));
+  });
+
+  it("does not preserve an omitted presented card after it is missing locally", async () => {
+    const state = getState();
+    const currentCard = createCard({
+      cardId: "card-current-missing",
+      frontText: "Current missing front",
+      backText: "Current missing back",
+      dueAt: "2026-03-09T12:00:00.000Z",
+    });
+    const canonicalCards = Array.from({ length: 8 }, (_, index) => createCard({
+      cardId: `card-missing-head-${index + 1}`,
+      frontText: `Missing head ${index + 1} front`,
+      backText: `Missing head ${index + 1} back`,
+      dueAt: `2026-03-10T11:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      createdAt: `2026-03-10T10:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      updatedAt: `2026-03-10T10:${String(index + 1).padStart(2, "0")}:00.000Z`,
+    }));
+
+    state.cards = [currentCard, ...canonicalCards];
+    state.reviewQueue = [currentCard];
+    state.reviewTimeline = [currentCard, ...canonicalCards];
+    state.appData.getCardById.mockImplementation(async (cardId: string): Promise<Card> => {
+      throw new Error(`Card not found: ${cardId}`);
+    });
+
+    await renderReviewScreen();
+
+    expect(getContainer().textContent).toContain("Current missing front");
+
+    state.cards = [...canonicalCards];
+    state.reviewQueue = [...canonicalCards];
+    state.reviewTimeline = [...canonicalCards];
+    state.appData.localReadVersion = 1;
+
+    await rerenderReviewScreen();
+
+    expect(state.appData.getCardById).toHaveBeenCalledWith("card-current-missing");
+    expect(getContainer().textContent).toContain("Missing head 1 front");
+    expect(getContainer().textContent).not.toContain("Current missing front");
+    expect(getContainer().textContent).not.toContain("Card not found: card-current-missing");
+    const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
+    expect(queueTitlesAfterRefresh).toEqual(canonicalCards.map((card) => card.frontText));
   });
 });

--- a/apps/web/src/screens/review/ReviewScreen.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.tsx
@@ -429,6 +429,7 @@ export function ReviewScreen(): ReactElement {
     workspaceSettings,
     localReadVersion,
     localCardCount,
+    getCardById,
     refreshLocalData,
     selectReviewFilter,
     submitReviewItem,
@@ -461,6 +462,7 @@ export function ReviewScreen(): ReactElement {
     tagSuggestions,
   } = useReviewScreenData({
     activeWorkspaceId: activeWorkspace?.workspaceId ?? null,
+    getCardById,
     localReadVersion,
     selectedReviewFilter,
     setErrorMessage,

--- a/apps/web/src/screens/review/useReviewScreenData.ts
+++ b/apps/web/src/screens/review/useReviewScreenData.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import { ALL_CARDS_REVIEW_FILTER, isReviewFilterEqual } from "../../appData/domain";
+import {
+  ALL_CARDS_REVIEW_FILTER,
+  isCardDue,
+  isReviewFilterEqual,
+  matchesDeckFilterDefinition,
+} from "../../appData/domain";
 import { useI18n } from "../../i18n";
 import { loadDecksListSnapshot } from "../../localDb/decks";
 import {
@@ -27,6 +32,7 @@ import { formatEffortLevelLabel } from "../shared/featureFormatting";
 
 type UseReviewScreenDataParams = Readonly<{
   activeWorkspaceId: string | null;
+  getCardById: (cardId: string) => Promise<Card>;
   localReadVersion: number;
   selectedReviewFilter: ReviewFilter;
   setErrorMessage: (message: string) => void;
@@ -88,20 +94,18 @@ function resolveReviewFilterTitle(
 
 function buildDisplayedReviewQueue(
   canonicalReviewQueue: ReadonlyArray<Card>,
-  presentedCardId: string | null,
+  presentedCard: Card | null,
 ): ReadonlyArray<Card> {
-  if (presentedCardId === null) {
+  if (presentedCard === null) {
     return canonicalReviewQueue;
   }
 
-  const presentedCard = canonicalReviewQueue.find((card) => card.cardId === presentedCardId);
-  if (presentedCard === undefined) {
-    return canonicalReviewQueue;
-  }
+  const canonicalPresentedCard = canonicalReviewQueue.find((card) => card.cardId === presentedCard.cardId);
+  const displayedPresentedCard = canonicalPresentedCard ?? presentedCard;
 
   return [
-    presentedCard,
-    ...canonicalReviewQueue.filter((card) => card.cardId !== presentedCardId),
+    displayedPresentedCard,
+    ...canonicalReviewQueue.filter((card) => card.cardId !== presentedCard.cardId),
   ];
 }
 
@@ -120,23 +124,95 @@ function buildDisplayedReviewTimeline(
   ];
 }
 
-function resolvePresentedCardId(
+function resolveCanonicalPresentedCard(
   canonicalReviewQueue: ReadonlyArray<Card>,
-  previousPresentedCardId: string | null,
-): string | null {
-  if (previousPresentedCardId !== null) {
-    const previousPresentedCard = canonicalReviewQueue.find((card) => card.cardId === previousPresentedCardId);
-    if (previousPresentedCard !== undefined) {
-      return previousPresentedCard.cardId;
+  previousPresentedCard: Card | null,
+): Card | null {
+  if (previousPresentedCard !== null) {
+    const canonicalPreviousPresentedCard = canonicalReviewQueue.find((card) => card.cardId === previousPresentedCard.cardId);
+    if (canonicalPreviousPresentedCard !== undefined) {
+      return canonicalPreviousPresentedCard;
     }
   }
 
-  return canonicalReviewQueue[0]?.cardId ?? null;
+  return canonicalReviewQueue[0] ?? null;
+}
+
+function matchesResolvedReviewFilterForPreservation(
+  card: Card,
+  resolvedReviewFilter: ReviewFilter,
+  deckSummaries: ReadonlyArray<DeckSummary>,
+): boolean {
+  if (resolvedReviewFilter.kind === "allCards") {
+    return true;
+  }
+
+  if (resolvedReviewFilter.kind === "deck") {
+    const deckSummary = deckSummaries.find((deck) => deck.deckId === resolvedReviewFilter.deckId);
+    return deckSummary === undefined ? false : matchesDeckFilterDefinition(deckSummary.filterDefinition, card);
+  }
+
+  if (resolvedReviewFilter.kind === "effort") {
+    return card.effortLevel === resolvedReviewFilter.effortLevel;
+  }
+
+  return card.tags.includes(resolvedReviewFilter.tag);
+}
+
+function isPreservablePresentedCard(
+  card: Card,
+  resolvedReviewFilter: ReviewFilter,
+  deckSummaries: ReadonlyArray<DeckSummary>,
+  nowTimestamp: number,
+): boolean {
+  return isCardDue(card, nowTimestamp) && matchesResolvedReviewFilterForPreservation(card, resolvedReviewFilter, deckSummaries);
+}
+
+function isMissingPresentedCardError(error: unknown, cardId: string): boolean {
+  return error instanceof Error && error.message === `Card not found: ${cardId}`;
+}
+
+async function loadPresentedCardForPreservation(
+  cardId: string,
+  getCardById: (cardId: string) => Promise<Card>,
+): Promise<Card | null> {
+  try {
+    return await getCardById(cardId);
+  } catch (error) {
+    if (isMissingPresentedCardError(error, cardId)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+async function resolvePresentedCard(
+  canonicalReviewQueue: ReadonlyArray<Card>,
+  previousPresentedCard: Card | null,
+  resolvedReviewFilter: ReviewFilter,
+  deckSummaries: ReadonlyArray<DeckSummary>,
+  getCardById: (cardId: string) => Promise<Card>,
+): Promise<Card | null> {
+  if (previousPresentedCard === null) {
+    return canonicalReviewQueue[0] ?? null;
+  }
+
+  const canonicalPresentedCard = canonicalReviewQueue.find((card) => card.cardId === previousPresentedCard.cardId);
+  if (canonicalPresentedCard !== undefined) {
+    return canonicalPresentedCard;
+  }
+
+  const loadedPresentedCard = await loadPresentedCardForPreservation(previousPresentedCard.cardId, getCardById);
+  return loadedPresentedCard !== null && isPreservablePresentedCard(loadedPresentedCard, resolvedReviewFilter, deckSummaries, Date.now())
+    ? loadedPresentedCard
+    : canonicalReviewQueue[0] ?? null;
 }
 
 export function useReviewScreenData(params: UseReviewScreenDataParams): UseReviewScreenDataResult {
   const {
     activeWorkspaceId,
+    getCardById,
     localReadVersion,
     selectedReviewFilter,
     setErrorMessage,
@@ -155,18 +231,18 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const [isReviewLoading, setIsReviewLoading] = useState<boolean>(true);
   const [reviewLoadErrorMessage, setReviewLoadErrorMessage] = useState<string>("");
   const [hasLoadedReviewData, setHasLoadedReviewData] = useState<boolean>(false);
-  const [presentedCardId, setPresentedCardId] = useState<string | null>(null);
+  const [presentedCard, setPresentedCard] = useState<Card | null>(null);
   const previousReviewFilterRef = useRef<ReviewFilter | null>(null);
-  const presentedCardIdRef = useRef<string | null>(null);
+  const presentedCardRef = useRef<Card | null>(null);
   const reviewLoadingSnapshot = activeWorkspaceId === null
     ? null
     : readReviewLoadingSnapshot(activeWorkspaceId, selectedReviewFilter);
   const isInitialReviewLoad = isReviewLoading && hasLoadedReviewData === false;
-  const activeReviewQueue = buildDisplayedReviewQueue(canonicalReviewQueue, presentedCardId);
+  const activeReviewQueue = buildDisplayedReviewQueue(canonicalReviewQueue, presentedCard);
 
   useEffect(() => {
-    presentedCardIdRef.current = presentedCardId;
-  }, [presentedCardId]);
+    presentedCardRef.current = presentedCard;
+  }, [presentedCard]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -208,15 +284,22 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           t("filters.allCards"),
           (effortLevel) => formatEffortLevelLabel(t, effortLevel),
         );
-        const nextPresentedCardId = shouldShowBlockingLoader
-          ? resolvePresentedCardId(reviewQueueSnapshot.cards, null)
-          : resolvePresentedCardId(reviewQueueSnapshot.cards, presentedCardIdRef.current);
-        const nextActiveReviewQueue = buildDisplayedReviewQueue(reviewQueueSnapshot.cards, nextPresentedCardId);
+        const nextPresentedCard = await resolvePresentedCard(
+          reviewQueueSnapshot.cards,
+          shouldShowBlockingLoader ? null : presentedCardRef.current,
+          nextResolvedReviewFilter,
+          decksSnapshot.deckSummaries,
+          getCardById,
+        );
+        if (isCancelled) {
+          return;
+        }
+        const nextActiveReviewQueue = buildDisplayedReviewQueue(reviewQueueSnapshot.cards, nextPresentedCard);
 
         setResolvedReviewFilter(nextResolvedReviewFilter);
         setSelectedReviewFilterTitle(nextSelectedReviewFilterTitle);
         setCanonicalReviewQueue(reviewQueueSnapshot.cards);
-        setPresentedCardId(nextPresentedCardId);
+        setPresentedCard(nextPresentedCard);
         setReviewCounts(reviewQueueSnapshot.reviewCounts);
         setReviewQueueCursor(reviewQueueSnapshot.nextCursor);
         setQueueCards(buildDisplayedReviewTimeline(reviewTimelinePage.cards, nextActiveReviewQueue));
@@ -254,7 +337,7 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     return () => {
       isCancelled = true;
     };
-  }, [activeWorkspaceId, localReadVersion, selectedReviewFilter]);
+  }, [activeWorkspaceId, getCardById, localReadVersion, selectedReviewFilter]);
 
   async function handleReview(card: Card, rating: 0 | 1 | 2 | 3): Promise<boolean> {
     setErrorMessage("");
@@ -262,11 +345,11 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     try {
       await submitReviewItem(card.cardId, rating);
       const nextCanonicalReviewQueue = canonicalReviewQueue.filter((queuedCard) => queuedCard.cardId !== card.cardId);
-      const nextPresentedCardId = resolvePresentedCardId(nextCanonicalReviewQueue, null);
-      const nextActiveReviewQueue = buildDisplayedReviewQueue(nextCanonicalReviewQueue, nextPresentedCardId);
+      const nextPresentedCard = resolveCanonicalPresentedCard(nextCanonicalReviewQueue, null);
+      const nextActiveReviewQueue = buildDisplayedReviewQueue(nextCanonicalReviewQueue, nextPresentedCard);
 
       setCanonicalReviewQueue(nextCanonicalReviewQueue);
-      setPresentedCardId(nextPresentedCardId);
+      setPresentedCard(nextPresentedCard);
       setQueueCards((currentCards) => buildDisplayedReviewTimeline(
         currentCards.filter((queuedCard) => queuedCard.cardId !== card.cardId),
         nextActiveReviewQueue,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,7 +226,7 @@ Implemented sync behavior:
   - recompute the card schedule
   - update the card snapshot
   - emit sync changes
-- Review visibility is compute-on-read with `due_at <= now()`.
+- Review eligibility is compute-on-read: due cards use `due_at <= now()`, new cards use `due_at IS NULL`, and future or malformed due values stay out of the active queue.
 - Backend, iOS, and Android maintain mirrored scheduling logic and state validation.
 - The web app computes review submissions locally too, but it does not keep a fourth standalone scheduler copy in `apps/web`.
 - Instead, the web review flow reuses the backend scheduler module directly from `apps/backend/src/schedule.ts` when it needs the next local `dueAt` and FSRS state.

--- a/docs/fsrs-scheduling-logic.md
+++ b/docs/fsrs-scheduling-logic.md
@@ -233,6 +233,31 @@ Behavior:
 
 Memory updates for `relearning` remain short-term FSRS updates even if the card is answered on a later UTC day than the scheduled step.
 
+## Review queue presentation
+
+Review queue ordering is a cross-client presentation policy.
+It chooses the next active card shown to the user; it does not change FSRS transitions, interval calculations, due counts, sync payloads, API contracts, database schema, remote config, workspace scheduler settings, or persisted scheduler state.
+
+At queue evaluation time `now`, `recentDuePriorityWindow` is exactly `1 hour`.
+Active queue entries are presented in this order:
+
+1. recent due cards, where `dueAt` is in the inclusive range `[now - 1 hour, now]`
+2. old due cards, where `dueAt < now - 1 hour`
+3. new cards, where `dueAt` is `null`
+
+The recent-due boundary is inclusive at both ends: `dueAt == now` and `dueAt == now - 1 hour` are recent due.
+Cards with `dueAt > now` and cards with malformed `dueAt` values are not active queue entries, though preview or timeline surfaces may show them where supported.
+
+Tie-breakers inside the recent due and old due buckets must remain stable:
+
+1. `dueAt ASC`
+2. `createdAt DESC`
+3. `cardId ASC`
+
+The card currently displayed to the user remains pinned until it is answered, even if the canonical queue order changes in the background.
+Cards that become due after `Again` or another short-step review can rise ahead of a large old-overdue tail on the next normal queue refresh or review action.
+There is no requirement to refresh an idle review screen solely because a card crosses into the recent-due window.
+
 ## FSRS math
 
 The implementation uses the official FSRS-6 default weights for:


### PR DESCRIPTION
## Summary
- prioritize recently due review cards ahead of old overdue cards across Web, iOS, and Android
- preserve displayed/current cards during bounded background refreshes while keeping canonical queue order stable
- align Web IndexedDB cursor/pinned-current handling and iOS SQLite due-count/date eligibility
- update scheduler/review docs and targeted client tests

## Tests
- iOS: targeted ReviewBackgroundReconcileTests + ReviewQueueRuntimeTests passed
- iOS: targeted ReviewSQLiteOrderingTests passed
- Android: targeted ReviewPinnedCurrentCardPresentationTest passed
- Web: vitest localDb/reviews.test.ts + ReviewScreen.test.tsx passed
- Web: tsc --noEmit passed
- git --no-pager diff --check passed