### PR TITLE
Harden Android progress refresh against uncaught coroutine exceptions

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app.di
 
 import android.content.Context
+import android.util.Log
 import com.flashcardsopensourceapp.app.AutoSyncController
 import com.flashcardsopensourceapp.app.navigation.AppPackageInfo
 import com.flashcardsopensourceapp.app.navigation.loadPackageInfo
@@ -53,6 +54,7 @@ import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvi
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -65,6 +67,8 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.time.ZoneId
+
+private const val appGraphLogTag: String = "AppGraph"
 
 sealed interface AppStartupState {
     data object Loading : AppStartupState
@@ -80,7 +84,13 @@ class AppGraph(
     context: Context
 ) {
     private val appJob = SupervisorJob()
-    private val appScope = CoroutineScope(appJob + Dispatchers.IO)
+    // Backstop for any uncaught exception escaping an appScope.launch site so the
+    // process never crashes on a missed try/catch. Coroutine machinery filters
+    // CancellationException out before it reaches this handler.
+    private val appScopeExceptionHandler = CoroutineExceptionHandler { _, error ->
+        Log.w(appGraphLogTag, "event=app_scope_uncaught_exception", error)
+    }
+    private val appScope = CoroutineScope(appJob + Dispatchers.IO + appScopeExceptionHandler)
     private val startupStateMutable = MutableStateFlow<AppStartupState>(AppStartupState.Loading)
     private var startupJob: Job? = null
     private var reviewHistoryAppliedObserverJob: Job? = null

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepository.kt
@@ -20,6 +20,7 @@ import com.flashcardsopensourceapp.data.local.model.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.model.SyncStatusSnapshot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -115,11 +116,16 @@ class LocalProgressRepository(
     private val localCacheRebuildCoordinator = ProgressLocalCacheRebuildCoordinator()
     private var reviewScheduleSyncRefreshTrackerState: ProgressReviewScheduleSyncRefreshTrackerState? = null
 
-    init {
-        appScope.launch {
-            observeProgressInputs().collect { inputs ->
-                handleProgressInputs(inputs = inputs)
-            }
+    // Captured handle for the input-observation flow so the lifecycle of this
+    // long-running collector is explicit rather than hidden inside an init block.
+    // Cancellation flows through appJob today; the handle is here so the collector
+    // is no longer anonymous and can be disposed independently in the future.
+    private val observeInputsJob: Job = launchAndLogFailure(
+        event = "progress_inputs_collect_failed",
+        fields = emptyList()
+    ) {
+        observeProgressInputs().collect { inputs ->
+            handleProgressInputs(inputs = inputs)
         }
     }
 
@@ -438,7 +444,10 @@ class LocalProgressRepository(
         reviewScheduleSyncRefreshTrackerState = reviewScheduleSyncRefreshTrackerResult.state
 
         if (currentSummaryStoreState.isLocalCacheReady.not() || currentSeriesStoreState.isLocalCacheReady.not()) {
-            appScope.launch {
+            launchAndLogFailure(
+                event = "progress_local_cache_ready_background_failed",
+                fields = listOf("timeZone" to currentSummaryStoreState.scopeKey.timeZone)
+            ) {
                 ensureLocalCacheReady(timeZone = currentSummaryStoreState.scopeKey.timeZone)
             }
         }
@@ -451,7 +460,12 @@ class LocalProgressRepository(
                 currentReviewHistoryFingerprint = currentSummaryStoreState.reviewHistoryFingerprint
             )
         ) {
-            appScope.launch {
+            launchAndLogFailure(
+                event = "progress_summary_background_refresh_failed",
+                fields = listOf(
+                    "scopeKey" to serializeProgressSummaryScopeKey(scopeKey = currentSummaryStoreState.scopeKey)
+                )
+            ) {
                 refreshSummaryFromStoreState(
                     storeState = currentSummaryStoreState,
                     refreshReason = ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
@@ -467,7 +481,12 @@ class LocalProgressRepository(
                 currentReviewHistoryFingerprint = currentSeriesStoreState.reviewHistoryFingerprint
             )
         ) {
-            appScope.launch {
+            launchAndLogFailure(
+                event = "progress_series_background_refresh_failed",
+                fields = listOf(
+                    "scopeKey" to serializeProgressSeriesScopeKey(scopeKey = currentSeriesStoreState.scopeKey)
+                )
+            ) {
                 refreshSeriesFromStoreState(
                     storeState = currentSeriesStoreState,
                     refreshReason = ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
@@ -483,7 +502,12 @@ class LocalProgressRepository(
                 currentReviewScheduleFingerprint = currentReviewScheduleStoreState.reviewScheduleFingerprint
             ) || reviewScheduleSyncRefreshTrackerResult.shouldRefresh
         ) {
-            appScope.launch {
+            launchAndLogFailure(
+                event = "progress_review_schedule_background_refresh_failed",
+                fields = listOf(
+                    "scopeKey" to serializeProgressReviewScheduleScopeKey(scopeKey = currentReviewScheduleStoreState.scopeKey)
+                )
+            ) {
                 refreshReviewScheduleFromStoreState(
                     storeState = currentReviewScheduleStoreState,
                     refreshReason = ProgressRefreshReason.SYNC_COMPLETED_WITH_REVIEW_HISTORY_CHANGE
@@ -519,10 +543,11 @@ class LocalProgressRepository(
                     initialStoreState = storeState,
                     syncMode = syncMode
                 )
-            } catch (error: CancellationException) {
-                summaryRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
-                throw error
-            } catch (error: Exception) {
+            } catch (error: Throwable) {
+                // Cleanup-and-rethrow: always release the coordinator before propagating,
+                // including for CancellationException (preserves structured concurrency)
+                // and Error (so OOM/StackOverflow does not leave the coordinator in
+                // inFlight forever).
                 summaryRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
                 throw error
             }
@@ -575,10 +600,7 @@ class LocalProgressRepository(
                     initialStoreState = storeState,
                     syncMode = syncMode
                 )
-            } catch (error: CancellationException) {
-                seriesRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
-                throw error
-            } catch (error: Exception) {
+            } catch (error: Throwable) {
                 seriesRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
                 throw error
             }
@@ -631,10 +653,7 @@ class LocalProgressRepository(
                     initialStoreState = storeState,
                     syncMode = syncMode
                 )
-            } catch (error: CancellationException) {
-                reviewScheduleRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
-                throw error
-            } catch (error: Exception) {
+            } catch (error: Throwable) {
                 reviewScheduleRefreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
                 throw error
             }
@@ -1112,6 +1131,31 @@ class LocalProgressRepository(
             today = clockSnapshot.today,
             zoneId = clockSnapshot.zoneId
         )
+    }
+
+    // Single entry point for every appScope.launch in this class. It re-throws
+    // CancellationException to keep structured concurrency intact, and swallows any
+    // other Exception after a structured warning. Errors (OOM/StackOverflow) are
+    // intentionally not caught here — they bubble up to the appScope's
+    // CoroutineExceptionHandler in AppGraph.
+    private fun launchAndLogFailure(
+        event: String,
+        fields: List<Pair<String, String?>>,
+        block: suspend () -> Unit
+    ): Job {
+        return appScope.launch {
+            try {
+                block()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                logProgressRepositoryWarning(
+                    event = event,
+                    fields = fields,
+                    error = error
+                )
+            }
+        }
     }
 }
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -14,6 +14,8 @@ import com.flashcardsopensourceapp.data.local.model.ProgressSeriesSnapshot
 import com.flashcardsopensourceapp.data.local.model.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
 import com.flashcardsopensourceapp.data.local.repository.progressHistoryDayCount
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -57,15 +59,44 @@ class ProgressViewModel(
     }
 
     fun refreshIfInvalidated() {
-        viewModelScope.launch { progressRepository.refreshSummaryIfInvalidated() }
-        viewModelScope.launch { progressRepository.refreshSeriesIfInvalidated() }
-        viewModelScope.launch { progressRepository.refreshReviewScheduleIfInvalidated() }
+        launchAndLogFailure(event = "progress_summary_refresh_if_invalidated_failed") {
+            progressRepository.refreshSummaryIfInvalidated()
+        }
+        launchAndLogFailure(event = "progress_series_refresh_if_invalidated_failed") {
+            progressRepository.refreshSeriesIfInvalidated()
+        }
+        launchAndLogFailure(event = "progress_review_schedule_refresh_if_invalidated_failed") {
+            progressRepository.refreshReviewScheduleIfInvalidated()
+        }
     }
 
     fun refreshManually() {
-        viewModelScope.launch { progressRepository.refreshSummaryManually() }
-        viewModelScope.launch { progressRepository.refreshSeriesManually() }
-        viewModelScope.launch { progressRepository.refreshReviewScheduleManually() }
+        launchAndLogFailure(event = "progress_summary_refresh_manually_failed") {
+            progressRepository.refreshSummaryManually()
+        }
+        launchAndLogFailure(event = "progress_series_refresh_manually_failed") {
+            progressRepository.refreshSeriesManually()
+        }
+        launchAndLogFailure(event = "progress_review_schedule_refresh_manually_failed") {
+            progressRepository.refreshReviewScheduleManually()
+        }
+    }
+
+    // viewModelScope has a SupervisorJob but no CoroutineExceptionHandler, so any
+    // uncaught throw from the suspend body would crash the process. This helper
+    // re-throws CancellationException to keep structured concurrency intact and
+    // logs anything else as a warning. Errors (OOM/StackOverflow) are not caught
+    // here on purpose — there is no scope-level handler downstream to recover them.
+    private fun launchAndLogFailure(event: String, block: suspend () -> Unit): Job {
+        return viewModelScope.launch {
+            try {
+                block()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                logProgressViewModelWarning(event = event, error = error)
+            }
+        }
     }
 }
 
@@ -349,6 +380,23 @@ private fun ProgressWeekContext.isStartOfWeek(
     date: LocalDate
 ): Boolean {
     return startOfWeek(date = date) == date
+}
+
+private fun logProgressViewModelWarning(
+    event: String,
+    error: Throwable
+) {
+    val message = buildProgressViewModelLogMessage(
+        event = event,
+        fields = emptyList()
+    )
+    val didLog = runCatching {
+        Log.w(progressViewModelLogTag, message, error)
+    }.isSuccess
+    if (didLog.not()) {
+        println("$progressViewModelLogTag W $message")
+        println(error.stackTraceToString())
+    }
 }
 
 private fun logProgressUiStateMappingFailure(


### PR DESCRIPTION
## Summary
- Install a `CoroutineExceptionHandler` on `appScope` so any uncaught throw from an `appScope.launch` site logs a warning instead of crashing the process. Required after [630b57f1](https://github.com/kirill-markin/flashcards-open-source-app/commit/630b57f1) made `ensureLocalCacheReady` and refresh coordinators propagate failures to waiters.
- Route every `appScope.launch` in `LocalProgressRepository` and every `viewModelScope.launch` in `ProgressViewModel` through a `launchAndLogFailure` helper that re-throws `CancellationException`, swallows other `Exception` after a structured warning, and lets `Error` reach the global handler.
- Capture the input-observation collector into a `private val observeInputsJob: Job` so the lifecycle handle is explicit instead of hidden in `init`.
- Collapse the three refresh-loop double catches (`CancellationException` + `Exception`) into a single `catch (Throwable)` cleanup-and-rethrow so OOM/StackOverflow can no longer leave a coordinator stuck in `inFlight`.

## Test plan
- [x] `./gradlew :data:local:compileDebugKotlin :feature:progress:compileDebugKotlin :app:compileDebugKotlin` — clean (only pre-existing warnings in `AiChatRuntime.kt`).
- [ ] Manual smoke on device/emulator: open Progress screen with airplane mode toggling and verify no crash plus expected `progress_*_failed` events in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)