### PR TITLE
Fix iOS outbox attempt_count double-bump and tighten sync types

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
@@ -302,7 +302,10 @@ struct CloudSyncRunner {
             acknowledgedReviewScheduleImpactingOperationCount: 0,
             cleanedUpOperationCount: deletionSummary.operationCount,
             cleanedUpReviewEventOperationCount: deletionSummary.operationCount,
-            cleanedUpReviewScheduleImpactingOperationCount: deletionSummary.reviewScheduleImpactingOperationCount
+            // Review-event outbox rows are always enqueued non-impacting (see
+            // OutboxStore.enqueueReviewEventAppendOperation), so cleanup never
+            // touches the schedule-impacting counter.
+            cleanedUpReviewScheduleImpactingOperationCount: 0
         )
     }
 
@@ -625,8 +628,11 @@ struct CloudSyncRunner {
                 )
             }
 
+            // Only the network call goes through the transport-failure catch so we don't
+            // double-bump attempt_count when handling per-operation rejections below.
+            let pushResponse: SyncPushResponse
             do {
-                let pushResponse: SyncPushResponse = try await self.transport.request(
+                pushResponse = try await self.transport.request(
                     apiBaseUrl: linkedSession.apiBaseUrl,
                     authorizationHeader: linkedSession.authorization.headerValue,
                     path: "\(syncBasePath)/push",
@@ -640,53 +646,53 @@ struct CloudSyncRunner {
                         }
                     )
                 )
-
-                let acknowledgedOperationIds = pushResponse.operations.compactMap { result -> String? in
-                    switch result.status {
-                    case "applied", "ignored", "duplicate":
-                        return result.operationId
-                    case "rejected":
-                        return nil
-                    default:
-                        return nil
-                    }
-                }
-                let rejectedResults = pushResponse.operations.filter { result in
-                    result.status == "rejected"
-                }
-
-                if acknowledgedOperationIds.isEmpty == false {
-                    let acknowledgedOperationIdSet = Set(acknowledgedOperationIds)
-                    let acknowledgedReviewEventCount = outboxEntries.filter { entry in
-                        acknowledgedOperationIdSet.contains(entry.operationId)
-                            && entry.operation.entityType == .reviewEvent
-                    }.count
-                    let acknowledgedReviewScheduleImpactingCount = outboxEntries.filter { entry in
-                        acknowledgedOperationIdSet.contains(entry.operationId) && entry.reviewScheduleImpact
-                    }.count
-                    try self.database.deleteOutboxEntries(operationIds: acknowledgedOperationIds)
-                    acknowledgedOperationCount += acknowledgedOperationIds.count
-                    acknowledgedReviewEventOperationCount += acknowledgedReviewEventCount
-                    acknowledgedReviewScheduleImpactingOperationCount += acknowledgedReviewScheduleImpactingCount
-                }
-
-                if rejectedResults.isEmpty == false {
-                    let rejectionMessage = rejectedResults.map { result in
-                        let errorMessage = result.error ?? "Unknown rejection"
-                        return "\(result.operationId): \(errorMessage)"
-                    }.joined(separator: "; ")
-                    try self.database.markOutboxEntriesFailed(
-                        operationIds: rejectedResults.map(\.operationId),
-                        message: rejectionMessage
-                    )
-                    throw LocalStoreError.validation("Cloud sync rejected one or more operations: \(rejectionMessage)")
-                }
             } catch {
                 try self.database.markOutboxEntriesFailed(
                     operationIds: outboxEntries.map(\.operationId),
                     message: error.localizedDescription
                 )
                 throw error
+            }
+
+            let acknowledgedOperationIds = pushResponse.operations.compactMap { result -> String? in
+                switch result.status {
+                case "applied", "ignored", "duplicate":
+                    return result.operationId
+                case "rejected":
+                    return nil
+                default:
+                    return nil
+                }
+            }
+            let rejectedResults = pushResponse.operations.filter { result in
+                result.status == "rejected"
+            }
+
+            if acknowledgedOperationIds.isEmpty == false {
+                let acknowledgedOperationIdSet = Set(acknowledgedOperationIds)
+                let acknowledgedReviewEventCount = outboxEntries.filter { entry in
+                    acknowledgedOperationIdSet.contains(entry.operationId)
+                        && entry.operation.entityType == .reviewEvent
+                }.count
+                let acknowledgedReviewScheduleImpactingCount = outboxEntries.filter { entry in
+                    acknowledgedOperationIdSet.contains(entry.operationId) && entry.reviewScheduleImpact
+                }.count
+                try self.database.deleteOutboxEntries(operationIds: acknowledgedOperationIds)
+                acknowledgedOperationCount += acknowledgedOperationIds.count
+                acknowledgedReviewEventOperationCount += acknowledgedReviewEventCount
+                acknowledgedReviewScheduleImpactingOperationCount += acknowledgedReviewScheduleImpactingCount
+            }
+
+            if rejectedResults.isEmpty == false {
+                let rejectionMessage = rejectedResults.map { result in
+                    let errorMessage = result.error ?? "Unknown rejection"
+                    return "\(result.operationId): \(errorMessage)"
+                }.joined(separator: "; ")
+                try self.database.markOutboxEntriesFailed(
+                    operationIds: rejectedResults.map(\.operationId),
+                    message: rejectionMessage
+                )
+                throw LocalStoreError.validation("Cloud sync rejected one or more operations: \(rejectionMessage)")
             }
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
@@ -121,6 +121,9 @@ extension LocalDatabase {
         now: String
     ) throws -> Card {
         let operationId = UUID().uuidString.lowercased()
+        // For new cards (cardId == nil), saveCard uses `now` for cards.created_at and the
+        // outbox row is enqueued with clientUpdatedAt == `now` — keep the same string for
+        // both writes so OutboxStore's create-marker invariant holds.
         let persistedCard = try self.cardStore.saveCard(
             workspaceId: workspaceId,
             input: input,

--- a/apps/ios/Flashcards/Flashcards/Database/OutboxStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/OutboxStore.swift
@@ -47,7 +47,6 @@ private struct ReviewEventOutboxPayload: Codable {
 private struct ReviewEventOutboxCandidate {
     let operationId: String
     let payloadJson: String
-    let reviewScheduleImpact: Bool
 }
 
 private struct PendingReviewScheduleCardTotalDeltaEntry {
@@ -64,7 +63,6 @@ private struct PendingReviewScheduleCardTotalChange {
 
 struct DeletedOutboxEntriesSummary: Hashable {
     let operationCount: Int
-    let reviewScheduleImpactingOperationCount: Int
 }
 
 private struct SyncStateRow {
@@ -148,7 +146,7 @@ struct OutboxStore {
     ) throws -> DeletedOutboxEntriesSummary {
         let candidates = try self.core.query(
             sql: """
-            SELECT operation_id, payload_json, review_schedule_impact
+            SELECT operation_id, payload_json
             FROM outbox
             WHERE workspace_id = ? AND entity_type = 'review_event'
             """,
@@ -156,8 +154,7 @@ struct OutboxStore {
         ) { statement in
             ReviewEventOutboxCandidate(
                 operationId: DatabaseCore.columnText(statement: statement, index: 0),
-                payloadJson: DatabaseCore.columnText(statement: statement, index: 1),
-                reviewScheduleImpact: DatabaseCore.columnInt64(statement: statement, index: 2) != 0
+                payloadJson: DatabaseCore.columnText(statement: statement, index: 1)
             )
         }
 
@@ -171,10 +168,7 @@ struct OutboxStore {
 
         let staleOperationIds = staleCandidates.map(\.operationId)
         try self.deleteOutboxEntries(operationIds: staleOperationIds)
-        return DeletedOutboxEntriesSummary(
-            operationCount: staleOperationIds.count,
-            reviewScheduleImpactingOperationCount: staleCandidates.filter(\.reviewScheduleImpact).count
-        )
+        return DeletedOutboxEntriesSummary(operationCount: staleOperationIds.count)
     }
 
     func hasPendingCardOperation(
@@ -440,6 +434,12 @@ struct OutboxStore {
         }
     }
 
+    // Initial-create invariant: when this enqueues the very first upsert for a card,
+    // `clientUpdatedAt` MUST equal `card.createdAt` (same instant string, produced by a
+    // single `nowIsoTimestamp()` reused at the call site). All later upserts for the
+    // same cardId (edits, tombstones, review-applied schedule writes) MUST pass a
+    // `clientUpdatedAt` strictly later than `cards.created_at`. The create-detection in
+    // parsePendingReviewScheduleCardTotalChange relies on that string equality.
     func enqueueCardUpsertOperation(
         workspaceId: String,
         installationId: String,
@@ -719,6 +719,7 @@ struct OutboxStore {
         }
 
         let createdAt = try self.loadCardCreatedAt(workspaceId: workspaceId, cardId: entry.entityId)
+        // Initial-create marker: see enqueueCardUpsertOperation contract.
         return PendingReviewScheduleCardTotalChange(
             hasLocalCreate: createdAt == entry.clientUpdatedAt,
             finalIsDeleted: payload.deletedAt != nil


### PR DESCRIPTION
## Summary

Three iOS sync-correctness fixes:

- **`pushOutboxBatches` double-bump** — narrowed the catch in `CloudSyncRunner.pushOutboxBatches` so the per-operation rejection branch and the transport-failure catch can no longer both touch the same row. Rejected ops now bump `attempt_count` exactly once with the rejection-specific message; transport failures still mark the whole batch failed; post-push DB errors propagate without falsely flipping acknowledged ops to "failed".
- **Always-zero count removed** — `reviewScheduleImpactingOperationCount` is gone from `DeletedOutboxEntriesSummary`. Review-event outbox rows are always enqueued non-impacting (`enqueueReviewEventAppendOperation`), so the field could only ever be `0`. The single consumer now passes `0` inline with a comment pointing at the producer-side invariant. Type system enforces what was previously a convention.
- **Create-marker invariant documented** — `parsePendingReviewScheduleCardTotalChange` detects "this outbox row is the original create" via string equality `cards.created_at == outbox.client_updated_at`. The contract is now documented at `enqueueCardUpsertOperation` (definition), at the equality check (consumer), and at `persistCardMutation` (call site that establishes the invariant by reusing the same `now` string for both writes).

## Test plan

- [ ] Manual: link a workspace, force a server-side rejection (e.g. tampered op), confirm `attempt_count` increments by 1 (not 2) and `last_error` carries the rejection message rather than `error.localizedDescription`.
- [ ] iOS smoke flows continue to pass on the happy push path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)