### PR TITLE
Make web replaceCards atomic and run api.test.ts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run src/appData/domain.test.ts src/localDb/reviews.test.ts src/localDb/reviewSchedule.test.ts src/localDb/cards.test.ts src/screens/review/ReviewScreen.test.tsx src/appData/progress/progressSource.test.tsx src/appData/progress/progressInvalidation.test.tsx",
+    "test": "vitest run src/appData/domain.test.ts src/localDb/reviews.test.ts src/localDb/reviewSchedule.test.ts src/localDb/cards.test.ts src/screens/review/ReviewScreen.test.tsx src/appData/progress/progressSource.test.tsx src/appData/progress/progressInvalidation.test.tsx src/api.test.ts",
     "test:e2e": "FLASHCARDS_E2E_TARGET=prod playwright test",
     "test:e2e:local": "node ./scripts/check-local-e2e-stack.mjs && FLASHCARDS_E2E_TARGET=local playwright test",
     "test:e2e:prod": "FLASHCARDS_E2E_TARGET=prod playwright test"

--- a/apps/web/src/localDb/cards.ts
+++ b/apps/web/src/localDb/cards.ts
@@ -118,7 +118,8 @@ function openIndexedCursor(
   return store.index(options.indexName).openCursor(options.keyRange, options.direction);
 }
 
-function makeWorkspaceIndexRange(workspaceId: string): IDBKeyRange {
+/** Compound-key range matching every key prefixed by `workspaceId`: lower `[workspaceId]` is shorter than any real key, and upper `[workspaceId, []]` exploits IDB's type ordering (Array > String/Number) to sort above every primitive second component. */
+function makeWorkspaceKeyRange(workspaceId: string): IDBKeyRange {
   return IDBKeyRange.bound([workspaceId], [workspaceId, []]);
 }
 
@@ -222,7 +223,7 @@ async function iterateCardsByCreatedAtDescMapped<CardValue extends Card>(
     {
       indexName: "workspaceId_createdAt_cardId",
       direction: "prev",
-      keyRange: makeWorkspaceIndexRange(workspaceId),
+      keyRange: makeWorkspaceKeyRange(workspaceId),
     },
     mapRecord,
     (card) => {
@@ -301,7 +302,7 @@ export async function iterateCardsByUpdatedAtDesc(
     {
       indexName: "workspaceId_updatedAt_cardId",
       direction: "prev",
-      keyRange: makeWorkspaceIndexRange(workspaceId),
+      keyRange: makeWorkspaceKeyRange(workspaceId),
     },
     toCard,
     (card) => {
@@ -346,7 +347,7 @@ export async function iterateCardsByDueAtAsc(
     {
       indexName: "workspaceId_dueAt_cardId",
       direction: "next",
-      keyRange: makeWorkspaceIndexRange(workspaceId),
+      keyRange: makeWorkspaceKeyRange(workspaceId),
     },
     toCard,
     onCard,
@@ -445,7 +446,7 @@ async function iterateCardsByEffortAndCreatedAtDesc(
     {
       indexName: "workspaceId_effort_createdAt_cardId",
       direction: "prev",
-      keyRange: makeWorkspaceIndexRange(workspaceId),
+      keyRange: makeWorkspaceKeyRange(workspaceId),
     },
     toCard,
     (card) => {
@@ -513,7 +514,7 @@ async function iterateCardsByEffortAndUpdatedAtDesc(
     {
       indexName: "workspaceId_effort_updatedAt_cardId",
       direction: "prev",
-      keyRange: makeWorkspaceIndexRange(workspaceId),
+      keyRange: makeWorkspaceKeyRange(workspaceId),
     },
     toCard,
     (card) => {
@@ -731,23 +732,6 @@ function insertCardIntoSortedWindow(
   }
 
   return nextWindow;
-}
-
-function deleteWorkspaceScopedRecords(
-  store: IDBObjectStore,
-  workspaceId: string,
-): IDBRequest<IDBValidKey[]> {
-  const request = store.getAllKeys();
-  request.onsuccess = () => {
-    for (const key of request.result) {
-      if (!Array.isArray(key) || key[0] !== workspaceId) {
-        continue;
-      }
-
-      store.delete(key);
-    }
-  };
-  return request;
 }
 
 export async function loadActiveCardCountWithDatabase(database: IDBDatabase, workspaceId: string): Promise<number> {
@@ -977,29 +961,17 @@ export async function replaceCards(workspaceId: string, cards: ReadonlyArray<Car
     await runReadwrite(database, ["cards", "cardTags"], (transaction) => {
       const cardsStore = transaction.objectStore("cards");
       const cardTagsStore = transaction.objectStore("cardTags");
-      const deleteCardsRequest = cardsStore.getAllKeys();
-      deleteCardsRequest.onsuccess = () => {
-        for (const key of deleteCardsRequest.result) {
-          if (!Array.isArray(key) || key[0] !== workspaceId) {
-            continue;
-          }
+      const workspaceKeyRange = makeWorkspaceKeyRange(workspaceId);
 
-          cardsStore.delete(key);
-        }
+      const deleteCardsRequest = cardsStore.delete(workspaceKeyRange);
+      cardTagsStore.delete(workspaceKeyRange);
 
-        deleteWorkspaceScopedRecords(cardTagsStore, workspaceId);
-      };
-      return deleteCardsRequest;
-    });
-
-    await runReadwrite(database, ["cards", "cardTags"], (transaction) => {
-      const store = transaction.objectStore("cards");
-      const cardTagsStore = transaction.objectStore("cardTags");
       for (const card of cards) {
-        store.put(toStoredCard(workspaceId, card));
+        cardsStore.put(toStoredCard(workspaceId, card));
         putCardTagRecords(cardTagsStore, workspaceId, card);
       }
-      return null;
+
+      return deleteCardsRequest;
     });
   });
 }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -134,6 +134,7 @@ export type ProgressSeries = Readonly<{
   dailyReviews: ReadonlyArray<DailyReviewPoint>;
 }>;
 
+/** Canonical bucket order for the progress chart and the runtime validation set for incoming bucket keys. Reordering or removing entries is a breaking change for the UI. */
 export const progressReviewScheduleBucketKeys = [
   "new",
   "today",


### PR DESCRIPTION
## Summary
- `apps/web/src/localDb/cards.ts:replaceCards` now runs in a single readwrite transaction with one `IDBObjectStore.delete(IDBKeyRange)` per store and FIFO-ordered puts. Concurrent readers (e.g. the review-schedule hook) no longer observe an empty-workspace window between the delete and the rewrite.
- Renames `makeWorkspaceIndexRange` → `makeWorkspaceKeyRange` (its body is valid for primary keys too) and documents the `[workspaceId, []]` upper-bound trick once on the helper. The dead `deleteWorkspaceScopedRecords` helper is removed.
- `apps/web/package.json` test script now includes `src/api.test.ts`, picking up the negative-path parser tests for the progress endpoints.
- One-line JSDoc on `progressReviewScheduleBucketKeys` flagging it as the canonical bucket order and runtime validation set.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npm test` — 8 files, 135/135 passing (now including `src/api.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)