### PR TITLE
Inject TimeProvider into Android sync outbox and clean up touched code

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -50,7 +50,7 @@ import com.flashcardsopensourceapp.data.local.repository.LocalSyncRepository
 import com.flashcardsopensourceapp.data.local.repository.LocalWorkspaceRepository
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
 import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
-import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
+import com.flashcardsopensourceapp.data.local.repository.SystemTimeProvider
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import kotlinx.coroutines.CancellationException
@@ -112,7 +112,7 @@ class AppGraph(
     private val aiCoroutineDispatchers = AiCoroutineDispatchers(io = Dispatchers.IO)
     private val localProgressCacheStore = LocalProgressCacheStore(
         database = database,
-        timeProvider = SystemProgressTimeProvider
+        timeProvider = SystemTimeProvider
     )
     private val aiChatLiveRemoteService = AiChatLiveRemoteService(dispatchers = aiCoroutineDispatchers)
     private val aiChatRemoteService = AiChatRemoteService(
@@ -123,7 +123,8 @@ class AppGraph(
         database = database,
         preferencesStore = cloudPreferencesStore,
         reviewPreferencesStore = reviewPreferencesStore,
-        localProgressCacheStore = localProgressCacheStore
+        localProgressCacheStore = localProgressCacheStore,
+        timeProvider = SystemTimeProvider
     )
     private val strictRemindersScheduler = AndroidStrictRemindersScheduler(context = context)
     private val cloudOperationCoordinator = CloudOperationCoordinator()
@@ -218,7 +219,7 @@ class AppGraph(
         cloudAccountRepository = cloudAccountRepository,
         syncRepository = syncRepository,
         localProgressCacheStore = localProgressCacheStore,
-        timeProvider = SystemProgressTimeProvider
+        timeProvider = SystemTimeProvider
     )
     val progressContextRefreshController = ProgressContextRefreshController(
         appScope = appScope,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/AppDatabaseTest.kt
@@ -35,7 +35,7 @@ import com.flashcardsopensourceapp.data.local.repository.LocalReviewRepository
 import com.flashcardsopensourceapp.data.local.repository.LocalWorkspaceRepository
 import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
-import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
+import com.flashcardsopensourceapp.data.local.repository.SystemTimeProvider
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.data.local.review.SharedPreferencesReviewPreferencesStore
 import kotlinx.coroutines.flow.Flow
@@ -80,8 +80,9 @@ class AppDatabaseTest {
             reviewPreferencesStore = SharedPreferencesReviewPreferencesStore(context = context),
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
-                timeProvider = SystemProgressTimeProvider
-            )
+                timeProvider = SystemTimeProvider
+            ),
+            timeProvider = SystemTimeProvider
         )
         syncRepository = FakeSyncRepository()
     }
@@ -1501,7 +1502,7 @@ class AppDatabaseTest {
             syncLocalStore = syncLocalStore,
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
-                timeProvider = SystemProgressTimeProvider
+                timeProvider = SystemTimeProvider
             )
         )
     }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStoreContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStoreContractTest.kt
@@ -23,7 +23,7 @@ import com.flashcardsopensourceapp.data.local.model.SyncOperationPayload
 import com.flashcardsopensourceapp.data.local.model.encodeSchedulerStepListJson
 import com.flashcardsopensourceapp.data.local.model.makeDefaultWorkspaceSchedulerSettings
 import com.flashcardsopensourceapp.data.local.repository.LocalProgressCacheStore
-import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
+import com.flashcardsopensourceapp.data.local.repository.SystemTimeProvider
 import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
 import com.flashcardsopensourceapp.data.local.review.SharedPreferencesReviewPreferencesStore
 import kotlinx.coroutines.CoroutineStart
@@ -71,8 +71,9 @@ class SyncLocalStoreContractTest {
             reviewPreferencesStore = reviewPreferencesStore,
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
-                timeProvider = SystemProgressTimeProvider
-            )
+                timeProvider = SystemTimeProvider
+            ),
+            timeProvider = SystemTimeProvider
         )
     }
 

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestEnvironment.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestEnvironment.kt
@@ -30,7 +30,7 @@ import com.flashcardsopensourceapp.data.local.repository.CloudOperationCoordinat
 import com.flashcardsopensourceapp.data.local.repository.LocalCloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.LocalProgressCacheStore
 import com.flashcardsopensourceapp.data.local.repository.LocalSyncRepository
-import com.flashcardsopensourceapp.data.local.repository.SystemProgressTimeProvider
+import com.flashcardsopensourceapp.data.local.repository.SystemTimeProvider
 import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
 import com.flashcardsopensourceapp.data.local.review.SharedPreferencesReviewPreferencesStore
 import kotlinx.coroutines.Dispatchers
@@ -135,8 +135,9 @@ internal class CloudIdentityTestEnvironment private constructor(
             reviewPreferencesStore = reviewPreferencesStore,
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
-                timeProvider = SystemProgressTimeProvider
-            )
+                timeProvider = SystemTimeProvider
+            ),
+            timeProvider = SystemTimeProvider
         )
         val repository = LocalCloudAccountRepository(
             database = database,
@@ -178,8 +179,9 @@ internal class CloudIdentityTestEnvironment private constructor(
             reviewPreferencesStore = reviewPreferencesStore,
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
-                timeProvider = SystemProgressTimeProvider
-            )
+                timeProvider = SystemTimeProvider
+            ),
+            timeProvider = SystemTimeProvider
         )
         val coordinator = CloudGuestSessionCoordinator(
             database = database,
@@ -323,8 +325,9 @@ internal class CloudIdentityTestEnvironment private constructor(
             reviewPreferencesStore = reviewPreferencesStore,
             localProgressCacheStore = LocalProgressCacheStore(
                 database = database,
-                timeProvider = SystemProgressTimeProvider
-            )
+                timeProvider = SystemTimeProvider
+            ),
+            timeProvider = SystemTimeProvider
         )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncLocalStore.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.data.local.model.PersistedOutboxEntry
 import com.flashcardsopensourceapp.data.local.model.ReviewEventSyncPayload
 import com.flashcardsopensourceapp.data.local.model.SyncEntityType
 import com.flashcardsopensourceapp.data.local.repository.LocalProgressCacheStore
+import com.flashcardsopensourceapp.data.local.repository.TimeProvider
 import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
 import kotlinx.coroutines.flow.Flow
 import org.json.JSONArray
@@ -26,12 +27,14 @@ class SyncLocalStore(
     database: AppDatabase,
     preferencesStore: CloudPreferencesStore,
     reviewPreferencesStore: ReviewPreferencesStore,
-    localProgressCacheStore: LocalProgressCacheStore
+    localProgressCacheStore: LocalProgressCacheStore,
+    timeProvider: TimeProvider
 ) {
     private val reviewHistoryChangePublisher = ReviewHistoryChangePublisher()
     private val outboxLocalStore = SyncOutboxLocalStore(
         database = database,
-        preferencesStore = preferencesStore
+        preferencesStore = preferencesStore,
+        timeProvider = timeProvider
     )
     private val syncStateLocalStore = SyncStateLocalStore(database = database)
     private val hotStateLocalStore = SyncHotStateLocalStore(database = database)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncOutboxLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/SyncOutboxLocalStore.kt
@@ -12,13 +12,15 @@ import com.flashcardsopensourceapp.data.local.model.SyncAction
 import com.flashcardsopensourceapp.data.local.model.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.SyncOperationPayload
 import com.flashcardsopensourceapp.data.local.model.formatIsoTimestamp
+import com.flashcardsopensourceapp.data.local.repository.TimeProvider
 import java.util.UUID
 
 private const val outboxBatchLimit: Int = 200
 
 internal class SyncOutboxLocalStore(
     private val database: AppDatabase,
-    private val preferencesStore: CloudPreferencesStore
+    private val preferencesStore: CloudPreferencesStore,
+    private val timeProvider: TimeProvider
 ) {
     suspend fun enqueueCardUpsert(card: CardEntity, tags: List<String>, affectsReviewSchedule: Boolean) {
         insertOutboxEntry(
@@ -137,7 +139,7 @@ internal class SyncOutboxLocalStore(
                     operationType = action.toRemoteValue(),
                     payloadJson = payloadJson,
                     clientUpdatedAtIso = clientUpdatedAtIso,
-                    createdAtMillis = System.currentTimeMillis(),
+                    createdAtMillis = timeProvider.currentTimeMillis(),
                     affectsReviewSchedule = affectsReviewSchedule,
                     attemptCount = 0,
                     lastError = null

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/AppDatabase.kt
@@ -717,6 +717,9 @@ val migration15To16: Migration = object : Migration(15, 16) {
         )
         db.execSQL(
             """
+            -- Conservative backfill: legacy card/upsert outbox rows pre-date the
+            -- affectsReviewSchedule column, so mark them as schedule-affecting to
+            -- avoid skipping FSRS/queue invalidations on first sync after upgrade.
             UPDATE outbox_entries
             SET affectsReviewSchedule = 1
             WHERE entityType = 'card' AND operationType = 'upsert'

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressCacheStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressCacheStore.kt
@@ -11,7 +11,7 @@ import java.time.ZoneId
 
 class LocalProgressCacheStore(
     private val database: AppDatabase,
-    private val timeProvider: ProgressTimeProvider
+    private val timeProvider: TimeProvider
 ) {
     suspend fun recordReviewInTransaction(
         reviewLog: ReviewLogEntity,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalProgressRepository.kt
@@ -101,7 +101,7 @@ class LocalProgressRepository(
     private val cloudAccountRepository: CloudAccountRepository,
     private val syncRepository: SyncRepository,
     private val localProgressCacheStore: LocalProgressCacheStore,
-    private val timeProvider: ProgressTimeProvider
+    private val timeProvider: TimeProvider
 ) : ProgressRepository {
     private val summarySnapshotMutable = MutableStateFlow<ProgressSummarySnapshot?>(null)
     private val seriesSnapshotMutable = MutableStateFlow<ProgressSeriesSnapshot?>(null)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressClockSnapshot.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/ProgressClockSnapshot.kt
@@ -4,21 +4,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 
-interface ProgressTimeProvider {
-    fun currentZoneId(): ZoneId
-    fun currentTimeMillis(): Long
-}
-
-object SystemProgressTimeProvider : ProgressTimeProvider {
-    override fun currentZoneId(): ZoneId {
-        return ZoneId.systemDefault()
-    }
-
-    override fun currentTimeMillis(): Long {
-        return System.currentTimeMillis()
-    }
-}
-
 internal data class ProgressClockSnapshot(
     val zoneId: ZoneId,
     val currentTimeMillis: Long,
@@ -26,7 +11,7 @@ internal data class ProgressClockSnapshot(
 )
 
 internal fun createProgressClockSnapshot(
-    timeProvider: ProgressTimeProvider
+    timeProvider: TimeProvider
 ): ProgressClockSnapshot {
     val zoneId = timeProvider.currentZoneId()
     val currentTimeMillis = timeProvider.currentTimeMillis()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/TimeProvider.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/TimeProvider.kt
@@ -1,0 +1,18 @@
+package com.flashcardsopensourceapp.data.local.repository
+
+import java.time.ZoneId
+
+interface TimeProvider {
+    fun currentZoneId(): ZoneId
+    fun currentTimeMillis(): Long
+}
+
+object SystemTimeProvider : TimeProvider {
+    override fun currentZoneId(): ZoneId {
+        return ZoneId.systemDefault()
+    }
+
+    override fun currentTimeMillis(): Long {
+        return System.currentTimeMillis()
+    }
+}

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -13,7 +13,6 @@
     <string name="progress_streak_summary_reviewed_today">Reviewed today</string>
     <string name="progress_streak_summary_not_reviewed_today">Not reviewed today</string>
     <string name="progress_reviews_title">Reviews</string>
-    <string name="progress_reviews_subtitle">Last 20 weeks</string>
     <string name="progress_reviews_previous_week">Previous week</string>
     <string name="progress_reviews_next_week">Next week</string>
     <string name="progress_reviews_empty_week">No reviews yet in this week.</string>


### PR DESCRIPTION
## Summary
- Rename `ProgressTimeProvider`/`SystemProgressTimeProvider` to the generic `TimeProvider`/`SystemTimeProvider`; the abstraction is now used by both Progress and Sync, so the Progress-prefix was misleading. Progress-specific snapshot helpers split into their own `ProgressClockSnapshot.kt`.
- Inject `TimeProvider` into `SyncOutboxLocalStore` so outbox `createdAtMillis` no longer reaches into `System.currentTimeMillis()` directly. Wired through `SyncLocalStore` to all 4 call sites (production + 3 androidTest).
- Add an explanatory SQL comment to the `15→16` migration documenting why legacy card/upsert outbox rows are conservatively backfilled to `affectsReviewSchedule = 1`.
- Remove unused `progress_reviews_subtitle` string resource.

## Test plan
- [x] `./gradlew :data:local:assembleDebug :app:assembleDebug :data:local:assembleDebugAndroidTest :app:assembleDebugAndroidTest` (BUILD SUCCESSFUL, 234 tasks)
- [ ] CI Android Release pipeline on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)