### PR TITLE
Speed up web review-schedule sync and dedupe outbox predicates

### DIFF
--- a/apps/web/src/appData/progress/progressScope.ts
+++ b/apps/web/src/appData/progress/progressScope.ts
@@ -115,3 +115,31 @@ export function resolveProgressRefreshKey(
 
   return buildProgressRefreshKey(scopeKey, progressServerInvalidationVersion, manualRefreshVersion);
 }
+
+export function buildProgressReviewScheduleRefreshKey(
+  scopeKey: ProgressScopeKey,
+  progressServerInvalidationVersion: number,
+  progressScheduleLocalVersion: number,
+  manualRefreshVersion: number,
+): string {
+  return `${scopeKey}::${progressServerInvalidationVersion}::${progressScheduleLocalVersion}::${manualRefreshVersion}`;
+}
+
+export function resolveProgressReviewScheduleRefreshKey(
+  scopeKey: ProgressScopeKey | null,
+  canLoadServerBase: boolean,
+  progressServerInvalidationVersion: number,
+  progressScheduleLocalVersion: number,
+  manualRefreshVersion: number,
+): string | null {
+  if (scopeKey === null || canLoadServerBase === false) {
+    return null;
+  }
+
+  return buildProgressReviewScheduleRefreshKey(
+    scopeKey,
+    progressServerInvalidationVersion,
+    progressScheduleLocalVersion,
+    manualRefreshVersion,
+  );
+}

--- a/apps/web/src/appData/progress/useProgressSource.ts
+++ b/apps/web/src/appData/progress/useProgressSource.ts
@@ -41,9 +41,11 @@ import {
 } from "./progressReducer";
 import {
   buildProgressRefreshKey,
+  buildProgressReviewScheduleRefreshKey,
   canLoadProgressServerBase,
   collectAccessibleWorkspaceIds,
   resolveProgressRefreshKey,
+  resolveProgressReviewScheduleRefreshKey,
   resolveProgressReviewScheduleScopeKey,
   resolveProgressSeriesScopeKey,
   resolveProgressSummaryScopeKey,
@@ -89,34 +91,6 @@ type ProgressReviewScheduleRefreshRequest = Readonly<{
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function buildProgressReviewScheduleRefreshKey(
-  scopeKey: ProgressScopeKey,
-  progressServerInvalidationVersion: number,
-  progressScheduleLocalVersion: number,
-  manualRefreshVersion: number,
-): string {
-  return `${scopeKey}::${progressServerInvalidationVersion}::${progressScheduleLocalVersion}::${manualRefreshVersion}`;
-}
-
-function resolveProgressReviewScheduleRefreshKey(
-  scopeKey: ProgressScopeKey | null,
-  canLoadServerBase: boolean,
-  progressServerInvalidationVersion: number,
-  progressScheduleLocalVersion: number,
-  manualRefreshVersion: number,
-): string | null {
-  if (scopeKey === null || canLoadServerBase === false) {
-    return null;
-  }
-
-  return buildProgressReviewScheduleRefreshKey(
-    scopeKey,
-    progressServerInvalidationVersion,
-    progressScheduleLocalVersion,
-    manualRefreshVersion,
-  );
 }
 
 export function useProgressSource(params: UseProgressSourceParams): UseProgressSourceResult {

--- a/apps/web/src/appData/useSyncEngine.ts
+++ b/apps/web/src/appData/useSyncEngine.ts
@@ -15,6 +15,7 @@ import {
 import { webAppVersion } from "../clientIdentity";
 import {
   loadCardById,
+  loadCardsByIds,
   putCard,
 } from "../localDb/cards";
 import {
@@ -26,6 +27,7 @@ import {
 } from "../localDb/decks";
 import {
   deleteOutboxRecord,
+  isScheduleRelevantCardOutboxRecord,
   listOutboxRecords,
   putOutboxRecord,
   type PersistedOutboxRecord,
@@ -172,14 +174,6 @@ function isProgressReviewEventOperation(
   return record.operation.entityType === "review_event" && record.operation.action === "append";
 }
 
-function isProgressReviewScheduleCardOperation(
-  record: PersistedOutboxRecord,
-): boolean {
-  return record.operation.entityType === "card"
-    && record.operation.action === "upsert"
-    && (record.affectsReviewSchedule ?? true);
-}
-
 function isAcknowledgedPushStatus(status: SyncPushResult["operations"][number]["status"]): boolean {
   return status === "applied" || status === "ignored" || status === "duplicate";
 }
@@ -188,18 +182,20 @@ async function doHotSyncEntriesAffectReviewSchedule(
   workspaceId: string,
   entries: ReadonlyArray<SyncBootstrapEntry>,
 ): Promise<boolean> {
-  for (const entry of entries) {
-    if (entry.entityType !== "card") {
-      continue;
-    }
-
-    const existingCard = await loadCardById(workspaceId, entry.payload.cardId);
-    if (doesCardMutationAffectReviewSchedule(existingCard, entry.payload)) {
-      return true;
-    }
+  const cardEntries = entries.filter((entry) => entry.entityType === "card");
+  if (cardEntries.length === 0) {
+    return false;
   }
 
-  return false;
+  const existingCards = await loadCardsByIds(
+    workspaceId,
+    cardEntries.map((entry) => entry.payload.cardId),
+  );
+
+  return cardEntries.some((entry) => doesCardMutationAffectReviewSchedule(
+    existingCards.get(entry.payload.cardId) ?? null,
+    entry.payload,
+  ));
 }
 
 function requireSeedTimestamp(label: string, value: string): number {
@@ -412,7 +408,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           const batchIncludesProgressReviewEvents = batch.some(isProgressReviewEventOperation);
           const reviewScheduleOperationIds = new Set(
             batch
-              .filter(isProgressReviewScheduleCardOperation)
+              .filter(isScheduleRelevantCardOutboxRecord)
               .map((record) => record.operationId),
           );
           try {

--- a/apps/web/src/localDb/cards.ts
+++ b/apps/web/src/localDb/cards.ts
@@ -949,6 +949,60 @@ export async function loadCardById(workspaceId: string, cardId: string): Promise
   return toCard(card);
 }
 
+export async function loadCardsByIds(
+  workspaceId: string,
+  cardIds: ReadonlyArray<string>,
+): Promise<ReadonlyMap<string, Card>> {
+  if (cardIds.length === 0) {
+    return new Map();
+  }
+
+  const uniqueCardIds = [...new Set(cardIds)];
+
+  return closeDatabaseAfter((database) => new Promise<ReadonlyMap<string, Card>>((resolve, reject) => {
+    const transaction = database.transaction(["cards"], "readonly");
+    const cardsStore = transaction.objectStore("cards");
+    const cardsByCardId = new Map<string, Card>();
+    let firstRequestError: Error | null = null;
+
+    function rememberRequestError(error: Error): void {
+      if (firstRequestError === null) {
+        firstRequestError = error;
+      }
+    }
+
+    transaction.onerror = () => {
+      reject(firstRequestError ?? describeIndexedDbError("IndexedDB cards batch read failed", transaction.error));
+    };
+
+    transaction.onabort = () => {
+      reject(firstRequestError ?? describeIndexedDbError("IndexedDB cards batch read aborted", transaction.error));
+    };
+
+    transaction.oncomplete = () => {
+      resolve(cardsByCardId);
+    };
+
+    for (const cardId of uniqueCardIds) {
+      const request = cardsStore.get([workspaceId, cardId]);
+      request.onerror = () => {
+        rememberRequestError(describeIndexedDbError(
+          `IndexedDB cards batch get failed: workspaceId=${workspaceId}, cardId=${cardId}`,
+          request.error,
+        ));
+      };
+      request.onsuccess = () => {
+        const record = request.result as StoredCard | undefined;
+        if (record === undefined || record.deletedAt !== null) {
+          return;
+        }
+
+        cardsByCardId.set(cardId, toCard(record));
+      };
+    }
+  }));
+}
+
 export async function loadCardsMatchingDeck(
   workspaceId: string,
   filterDefinition: Readonly<{

--- a/apps/web/src/localDb/outbox.ts
+++ b/apps/web/src/localDb/outbox.ts
@@ -17,6 +17,23 @@ export type PersistedOutboxRecord = Readonly<{
   operation: SyncPushOperation;
 }>;
 
+type CardUpsertOutboxOperation = Extract<
+  SyncPushOperation,
+  Readonly<{ entityType: "card"; action: "upsert" }>
+>;
+
+export type ScheduleRelevantCardOutboxRecord = PersistedOutboxRecord & Readonly<{
+  operation: CardUpsertOutboxOperation;
+}>;
+
+export function isScheduleRelevantCardOutboxRecord(
+  record: PersistedOutboxRecord,
+): record is ScheduleRelevantCardOutboxRecord {
+  return record.operation.entityType === "card"
+    && record.operation.action === "upsert"
+    && (record.affectsReviewSchedule ?? true);
+}
+
 export async function putOutboxRecord(record: PersistedOutboxRecord): Promise<void> {
   await closeDatabaseAfterWrite(async (database) => {
     await runReadwrite(database, ["outbox"], (transaction) => transaction.objectStore("outbox").put(record));

--- a/apps/web/src/localDb/reviewSchedule.ts
+++ b/apps/web/src/localDb/reviewSchedule.ts
@@ -15,7 +15,12 @@ import {
   describeIndexedDbError,
   type StoredCard,
 } from "./core";
-import { listOutboxRecordsForWorkspaces, type PersistedOutboxRecord } from "./outbox";
+import {
+  isScheduleRelevantCardOutboxRecord,
+  listOutboxRecordsForWorkspaces,
+  type PersistedOutboxRecord,
+  type ScheduleRelevantCardOutboxRecord,
+} from "./outbox";
 import { hasHydratedHotState } from "./workspace";
 
 type LocalDateParts = Readonly<{
@@ -45,21 +50,14 @@ type ReviewScheduleBoundaryMillis = Readonly<{
   startOfDay721Millis: number;
 }>;
 
-type PendingReviewScheduleCardOperation = Extract<
-  PersistedOutboxRecord["operation"],
-  Readonly<{ entityType: "card"; action: "upsert" }>
->;
-
-type PendingReviewScheduleCardOutboxRecord = PersistedOutboxRecord & Readonly<{
-  operation: PendingReviewScheduleCardOperation;
-}>;
-
-type PendingReviewScheduleCardTotalChange = Readonly<{
+type ScheduleRelevantCardTotalChange = Readonly<{
   hasLocalCreate: boolean;
   finalIsDeleted: boolean;
 }>;
 
 const localDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+// Module-scoped cache: Intl.DateTimeFormat allocation is hot during per-card
+// bucket assignment, so reuse a formatter per timeZone across calls.
 const dateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
 
 function parseIntegerPart(value: string): number {
@@ -247,26 +245,9 @@ function isValidTimedDueAtBucketMillis(dueAtBucketMillis: number): boolean {
     && isMalformedDueAtBucketMillis(dueAtBucketMillis) === false;
 }
 
-function isPendingReviewScheduleCardChange(outboxRecord: PersistedOutboxRecord): boolean {
-  const operation = outboxRecord.operation;
-  if (operation.entityType !== "card" || operation.action !== "upsert") {
-    return false;
-  }
-
-  return outboxRecord.affectsReviewSchedule ?? true;
-}
-
-function isPendingReviewScheduleCardOutboxRecord(
-  outboxRecord: PersistedOutboxRecord,
-): outboxRecord is PendingReviewScheduleCardOutboxRecord {
-  return outboxRecord.operation.entityType === "card"
-    && outboxRecord.operation.action === "upsert"
-    && (outboxRecord.affectsReviewSchedule ?? true);
-}
-
-function comparePendingReviewScheduleCardOutboxRecords(
-  left: PendingReviewScheduleCardOutboxRecord,
-  right: PendingReviewScheduleCardOutboxRecord,
+function compareScheduleRelevantCardOutboxRecords(
+  left: ScheduleRelevantCardOutboxRecord,
+  right: ScheduleRelevantCardOutboxRecord,
 ): number {
   if (left.operation.clientUpdatedAt < right.operation.clientUpdatedAt) {
     return -1;
@@ -279,9 +260,9 @@ function comparePendingReviewScheduleCardOutboxRecords(
   return left.operationId.localeCompare(right.operationId);
 }
 
-function parsePendingReviewScheduleCardTotalChange(
-  outboxRecord: PendingReviewScheduleCardOutboxRecord,
-): PendingReviewScheduleCardTotalChange {
+function parseScheduleRelevantCardTotalChange(
+  outboxRecord: ScheduleRelevantCardOutboxRecord,
+): ScheduleRelevantCardTotalChange {
   const operation = outboxRecord.operation;
 
   if (operation.payload.cardId !== operation.entityId) {
@@ -299,13 +280,13 @@ function parsePendingReviewScheduleCardTotalChange(
 function calculatePendingReviewScheduleCardTotalDelta(
   outboxRecords: ReadonlyArray<PersistedOutboxRecord>,
 ): number {
-  const changesByCardId = new Map<string, PendingReviewScheduleCardTotalChange>();
+  const changesByCardId = new Map<string, ScheduleRelevantCardTotalChange>();
   const cardOutboxRecords = outboxRecords
-    .filter(isPendingReviewScheduleCardOutboxRecord)
-    .sort(comparePendingReviewScheduleCardOutboxRecords);
+    .filter(isScheduleRelevantCardOutboxRecord)
+    .sort(compareScheduleRelevantCardOutboxRecords);
 
   for (const outboxRecord of cardOutboxRecords) {
-    const parsedChange = parsePendingReviewScheduleCardTotalChange(outboxRecord);
+    const parsedChange = parseScheduleRelevantCardTotalChange(outboxRecord);
     const existingChange = changesByCardId.get(outboxRecord.operation.entityId);
     changesByCardId.set(outboxRecord.operation.entityId, {
       hasLocalCreate: existingChange?.hasLocalCreate === true || parsedChange.hasLocalCreate,
@@ -425,6 +406,19 @@ function makeEmptyBucketCounts(): Map<ProgressReviewScheduleBucketKey, number> {
   }
 
   return counts;
+}
+
+function makeZeroBucketRecord(): Record<ProgressReviewScheduleBucketKey, number> {
+  return {
+    new: 0,
+    today: 0,
+    days1To7: 0,
+    days8To30: 0,
+    days31To90: 0,
+    days91To360: 0,
+    years1To2: 0,
+    later: 0,
+  };
 }
 
 function readBucketCount(
@@ -572,17 +566,6 @@ function readReviewScheduleSnapshot(
   });
 }
 
-function addBucketCounts(
-  left: ReadonlyArray<ProgressReviewScheduleBucket>,
-  right: ReadonlyArray<ProgressReviewScheduleBucket>,
-): ReadonlyArray<ProgressReviewScheduleBucket> {
-  return progressReviewScheduleBucketKeys.map((bucketKey): ProgressReviewScheduleBucket => ({
-    key: bucketKey,
-    count: (left.find((bucket) => bucket.key === bucketKey)?.count ?? 0)
-      + (right.find((bucket) => bucket.key === bucketKey)?.count ?? 0),
-  }));
-}
-
 function sumBucketCounts(buckets: ReadonlyArray<ProgressReviewScheduleBucket>): number {
   return buckets.reduce((totalCards, bucket) => totalCards + bucket.count, 0);
 }
@@ -590,18 +573,18 @@ function sumBucketCounts(buckets: ReadonlyArray<ProgressReviewScheduleBucket>): 
 function mergeWorkspaceBucketCounts(
   bucketCountsByWorkspace: ReviewScheduleBucketCountsByWorkspace,
 ): ReadonlyArray<ProgressReviewScheduleBucket> {
-  let mergedBuckets: ReadonlyArray<ProgressReviewScheduleBucket> = progressReviewScheduleBucketKeys
-    .map((bucketKey): ProgressReviewScheduleBucket => ({ key: bucketKey, count: 0 }));
+  const totals = makeZeroBucketRecord();
 
   for (const [workspaceId, workspaceCounts] of bucketCountsByWorkspace) {
-    const workspaceBuckets = progressReviewScheduleBucketKeys.map((bucketKey): ProgressReviewScheduleBucket => ({
-      key: bucketKey,
-      count: readBucketCount(workspaceCounts, bucketKey, workspaceId),
-    }));
-    mergedBuckets = addBucketCounts(mergedBuckets, workspaceBuckets);
+    for (const bucketKey of progressReviewScheduleBucketKeys) {
+      totals[bucketKey] += readBucketCount(workspaceCounts, bucketKey, workspaceId);
+    }
   }
 
-  return mergedBuckets;
+  return progressReviewScheduleBucketKeys.map((bucketKey): ProgressReviewScheduleBucket => ({
+    key: bucketKey,
+    count: totals[bucketKey],
+  }));
 }
 
 export async function loadLocalProgressReviewSchedule(
@@ -643,7 +626,7 @@ export async function hasPendingProgressReviewScheduleCardChanges(
   }
 
   const outboxRecords = await listOutboxRecordsForWorkspaces(workspaceIds);
-  return outboxRecords.some(isPendingReviewScheduleCardChange);
+  return outboxRecords.some(isScheduleRelevantCardOutboxRecord);
 }
 
 export async function calculatePendingProgressReviewScheduleCardTotalDelta(


### PR DESCRIPTION
## Summary

- Drop the O(B²) bucket-merge in `mergeWorkspaceBucketCounts` (single-pass `Record<key, number>` accumulator, no `Array.find`).
- Collapse the per-card readonly IDB transaction loop in `doHotSyncEntriesAffectReviewSchedule` into one batched `loadCardsByIds` transaction (~200x fewer db opens per 200-entry sync page).
- Dedupe three near-identical `card upsert + affectsReviewSchedule ?? true` predicates into a single shared `isScheduleRelevantCardOutboxRecord` (+ `ScheduleRelevantCardOutboxRecord` type) in `localDb/outbox.ts`.
- Co-locate `buildProgressReviewScheduleRefreshKey` / `resolveProgressReviewScheduleRefreshKey` next to their siblings in `progressScope.ts`.
- Add per-request `onerror` to `loadCardsByIds` for `(workspaceId, cardId)` debug context, mirroring the existing `readReviewScheduleSnapshot` pattern.

No behavioral change. No new tests.

## Test plan

- [x] `cd apps/web && pnpm tsc -b --noEmit` — clean
- [x] `cd apps/web && npm test` — 100/100 across 7 files (incl. `reviewSchedule.test.ts`, `domain.test.ts`, `progressSource.test.tsx`)
- [ ] Manual smoke: sign in to a workspace with ~50+ cards, watch DevTools → Performance during bootstrap. Confirm one readonly IDB tx for the existing-card lookup instead of one per card entry, and that the Progress screen's review-schedule bucket counts match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)