### PR TITLE
Persist iOS outbox is_initial_create and clean up sync invariants

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/CloudDiagnosticsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/CloudDiagnosticsSupport.swift
@@ -33,6 +33,7 @@ func logCloudFlowPhase(
     migrationKind: String? = nil,
     remoteWorkspaceIsEmpty: Bool? = nil,
     operationsCount: Int? = nil,
+    reviewScheduleImpactingOperationCount: Int? = nil,
     changesCount: Int? = nil,
     errorMessage: String? = nil
 ) {
@@ -51,6 +52,7 @@ func logCloudFlowPhase(
         migrationKind=\(migrationKind ?? "-", privacy: .public) \
         remoteWorkspaceIsEmpty=\(remoteWorkspaceIsEmpty.map(String.init) ?? "-", privacy: .public) \
         operations=\(operationsCount.map(String.init) ?? "-", privacy: .public) \
+        reviewScheduleImpactingOperations=\(reviewScheduleImpactingOperationCount.map(String.init) ?? "-", privacy: .public) \
         changes=\(changesCount.map(String.init) ?? "-", privacy: .public) \
         error=\(errorMessage ?? "-", privacy: .public)
         """

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
@@ -289,7 +289,13 @@ struct CloudSyncRunner {
             outcome: "self_heal",
             workspaceId: workspaceId,
             installationId: installationId,
-            operationsCount: deletionSummary.operationCount
+            operationsCount: deletionSummary.operationCount,
+            // review_event outbox rows are always non-impacting (see
+            // OutboxStore.enqueueReviewEventAppendOperation), so this cleanup
+            // can never touch the schedule-impacting counter. The literal 0
+            // makes that invariant visible in the structured log instead of
+            // implicit by omission.
+            reviewScheduleImpactingOperationCount: 0
         )
 
         return CloudSyncResult(

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
@@ -122,6 +122,11 @@ extension LocalDatabase {
     ) throws -> Card {
         let operationId = UUID().uuidString.lowercased()
         let isInitialCreate = cardId == nil
+        // Fresh creates install the card into the review queue; text/tag edits
+        // via this path don't touch FSRS fields, so the schedule is unaffected.
+        // Both intents happen to coincide here but are computed independently
+        // so a future change to either side stays surgical.
+        let reviewScheduleImpact = cardId == nil
         let persistedCard = try self.cardStore.saveCard(
             workspaceId: workspaceId,
             input: input,
@@ -137,7 +142,7 @@ extension LocalDatabase {
             clientUpdatedAt: now,
             card: persistedCard,
             isInitialCreate: isInitialCreate,
-            reviewScheduleImpact: isInitialCreate
+            reviewScheduleImpact: reviewScheduleImpact
         )
         return persistedCard
     }

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
@@ -123,9 +123,8 @@ extension LocalDatabase {
         let operationId = UUID().uuidString.lowercased()
         let isInitialCreate = cardId == nil
         // Fresh creates install the card into the review queue; text/tag edits
-        // via this path don't touch FSRS fields, so the schedule is unaffected.
-        // Both intents happen to coincide here but are computed independently
-        // so a future change to either side stays surgical.
+        // don't touch FSRS fields. Kept as two separate locals — both happen to
+        // derive from `cardId == nil` today but encode independent intents.
         let reviewScheduleImpact = cardId == nil
         let persistedCard = try self.cardStore.saveCard(
             workspaceId: workspaceId,

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+CardMutations.swift
@@ -121,9 +121,7 @@ extension LocalDatabase {
         now: String
     ) throws -> Card {
         let operationId = UUID().uuidString.lowercased()
-        // For new cards (cardId == nil), saveCard uses `now` for cards.created_at and the
-        // outbox row is enqueued with clientUpdatedAt == `now` — keep the same string for
-        // both writes so OutboxStore's create-marker invariant holds.
+        let isInitialCreate = cardId == nil
         let persistedCard = try self.cardStore.saveCard(
             workspaceId: workspaceId,
             input: input,
@@ -138,7 +136,8 @@ extension LocalDatabase {
             operationId: operationId,
             clientUpdatedAt: now,
             card: persistedCard,
-            reviewScheduleImpact: cardId == nil
+            isInitialCreate: isInitialCreate,
+            reviewScheduleImpact: isInitialCreate
         )
         return persistedCard
     }
@@ -163,6 +162,7 @@ extension LocalDatabase {
             operationId: operationId,
             clientUpdatedAt: now,
             card: deletedCard,
+            isInitialCreate: false,
             reviewScheduleImpact: true
         )
         return deletedCard

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase+Review.swift
@@ -57,6 +57,7 @@ extension LocalDatabase {
                 operationId: cardOperationId,
                 clientUpdatedAt: reviewSubmission.reviewedAtClient,
                 card: updatedCard,
+                isInitialCreate: false,
                 reviewScheduleImpact: true
             )
             return updatedCard

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabaseMigrator.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabaseMigrator.swift
@@ -56,6 +56,9 @@ struct LocalDatabaseMigrator {
             case 13:
                 try self.migrateSchemaVersion13To14()
                 schemaVersion = 14
+            case 14:
+                try self.migrateSchemaVersion14To15()
+                schemaVersion = 15
             default:
                 throw LocalStoreError.database("Unsupported local schema version: \(schemaVersion)")
             }
@@ -445,6 +448,14 @@ struct LocalDatabaseMigrator {
             return
         }
 
+        // `NOT NULL DEFAULT 1` is "safe-on": every legacy outbox row gets marked
+        // as schedule-impacting by default, then the backfill below explicitly
+        // downgrades the three known-non-impacting entity types. The remaining
+        // entity_type — `card` — is the only one that can carry schedule writes,
+        // and pre-existing card rows are conservatively treated as impacting until
+        // reconciled by the next push. The CHECK constraint is the load-bearing
+        // typecheck preventing accidental NULL/non-binary values from ever being
+        // mis-counted by the impacting-counter family in CloudSyncResult.
         try self.core.execute(
             sql: """
             ALTER TABLE outbox
@@ -455,12 +466,62 @@ struct LocalDatabaseMigrator {
         try self.backfillLegacyOutboxReviewScheduleImpact()
     }
 
+    // Downgrades the three entity types that are never schedule-impacting by
+    // construction: `deck` and `workspace_scheduler_settings` carry no card
+    // schedule state, and `review_event` rows record only the rating/timestamp
+    // pair (the schedule write that follows a review is enqueued separately on
+    // the matching `card` upsert with reviewScheduleImpact: true).
     private func backfillLegacyOutboxReviewScheduleImpact() throws {
         try self.core.execute(
             sql: """
             UPDATE outbox
             SET review_schedule_impact = 0
             WHERE entity_type IN ('deck', 'workspace_scheduler_settings', 'review_event')
+            """,
+            values: []
+        )
+    }
+
+    // Adds the `is_initial_create` outbox column so pending card-total deltas can
+    // read create-vs-update intent directly off the row instead of inferring it
+    // from a timestamp coincidence (cards.created_at == client_updated_at). The
+    // legacy heuristic was correct but fragile: any change that decoupled the two
+    // writes would silently drift the unsynced-cards counter. Persisting the bit
+    // makes the data self-describing.
+    private func migrateSchemaVersion14To15() throws {
+        if try self.core.columnExists(tableName: "outbox", columnName: "is_initial_create") {
+            try self.backfillLegacyOutboxIsInitialCreate()
+            return
+        }
+
+        try self.core.execute(
+            sql: """
+            ALTER TABLE outbox
+            ADD COLUMN is_initial_create INTEGER NOT NULL DEFAULT 0 CHECK (is_initial_create IN (0, 1))
+            """,
+            values: []
+        )
+        try self.backfillLegacyOutboxIsInitialCreate()
+    }
+
+    // Replays the legacy detection heuristic exactly once at migration time:
+    // a pending card upsert whose client_updated_at matches the card's created_at
+    // is the first local create. This mirrors the previous in-memory check in
+    // OutboxStore.parsePendingReviewScheduleCardTotalChange so pre-existing
+    // outbox rows continue to count correctly after the schema change.
+    private func backfillLegacyOutboxIsInitialCreate() throws {
+        try self.core.execute(
+            sql: """
+            UPDATE outbox
+            SET is_initial_create = 1
+            WHERE entity_type = 'card'
+                AND operation_type = 'upsert'
+                AND EXISTS (
+                    SELECT 1 FROM cards
+                    WHERE cards.workspace_id = outbox.workspace_id
+                        AND cards.card_id = outbox.entity_id
+                        AND cards.created_at = outbox.client_updated_at
+                )
             """,
             values: []
         )

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabaseSchema.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabaseSchema.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum LocalDatabaseSchema {
-    static let currentVersion: Int = 14
+    static let currentVersion: Int = 15
 
     static var baseMigrationSQL: String {
         let defaultEnableFuzzValue: Int = defaultSchedulerSettingsConfig.enableFuzz ? 1 : 0
@@ -100,6 +100,7 @@ enum LocalDatabaseSchema {
             created_at TEXT NOT NULL, -- when the pending operation entered the local outbox
             attempt_count INTEGER NOT NULL DEFAULT 0, -- retry counter for sync diagnostics and exponential backoff decisions
             review_schedule_impact INTEGER NOT NULL DEFAULT 1 CHECK (review_schedule_impact IN (0, 1)), -- whether this pending operation must force the local review schedule overlay
+            is_initial_create INTEGER NOT NULL DEFAULT 0 CHECK (is_initial_create IN (0, 1)), -- whether this is the very first local upsert for the entity, used by pending card-total deltas to count creates that have not yet been acknowledged
             last_error TEXT -- most recent sync failure message for debugging and user-facing diagnostics
         );
 

--- a/apps/ios/Flashcards/Flashcards/Database/OutboxStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/OutboxStore.swift
@@ -52,7 +52,7 @@ private struct ReviewEventOutboxCandidate {
 private struct PendingReviewScheduleCardTotalDeltaEntry {
     let operationId: String
     let entityId: String
-    let clientUpdatedAt: String
+    let isInitialCreate: Bool
     let payloadJson: String
 }
 
@@ -210,7 +210,7 @@ struct OutboxStore {
     ) throws -> Int {
         let entries = try self.core.query(
             sql: """
-            SELECT operation_id, entity_id, client_updated_at, payload_json
+            SELECT operation_id, entity_id, is_initial_create, payload_json
             FROM outbox
             WHERE workspace_id = ?
                 AND installation_id = ?
@@ -227,17 +227,14 @@ struct OutboxStore {
             PendingReviewScheduleCardTotalDeltaEntry(
                 operationId: DatabaseCore.columnText(statement: statement, index: 0),
                 entityId: DatabaseCore.columnText(statement: statement, index: 1),
-                clientUpdatedAt: DatabaseCore.columnText(statement: statement, index: 2),
+                isInitialCreate: DatabaseCore.columnInt64(statement: statement, index: 2) != 0,
                 payloadJson: DatabaseCore.columnText(statement: statement, index: 3)
             )
         }
 
         var changesByCardId: [String: PendingReviewScheduleCardTotalChange] = [:]
         for entry in entries {
-            let parsedChange = try self.parsePendingReviewScheduleCardTotalChange(
-                workspaceId: workspaceId,
-                entry: entry
-            )
+            let parsedChange = try self.parsePendingReviewScheduleCardTotalChange(entry: entry)
             let existingChange = changesByCardId[entry.entityId]
             changesByCardId[entry.entityId] = PendingReviewScheduleCardTotalChange(
                 hasLocalCreate: existingChange?.hasLocalCreate == true || parsedChange.hasLocalCreate,
@@ -434,18 +431,20 @@ struct OutboxStore {
         }
     }
 
-    // Initial-create invariant: when this enqueues the very first upsert for a card,
-    // `clientUpdatedAt` MUST equal `card.createdAt` (same instant string, produced by a
-    // single `nowIsoTimestamp()` reused at the call site). All later upserts for the
-    // same cardId (edits, tombstones, review-applied schedule writes) MUST pass a
-    // `clientUpdatedAt` strictly later than `cards.created_at`. The create-detection in
-    // parsePendingReviewScheduleCardTotalChange relies on that string equality.
+    // `isInitialCreate` is the explicit "this is the very first local upsert for
+    // this card" bit consumed by loadPendingReviewScheduleCardTotalDelta. Callers
+    // pass true exactly once per card (the create path) and false for every later
+    // upsert (edits, tombstones, review-applied schedule writes). The bit is
+    // persisted on the outbox row (see is_initial_create column, schema v15) so
+    // pending card-total deltas read intent directly instead of inferring it from
+    // a timestamp coincidence.
     func enqueueCardUpsertOperation(
         workspaceId: String,
         installationId: String,
         operationId: String,
         clientUpdatedAt: String,
         card: Card,
+        isInitialCreate: Bool,
         reviewScheduleImpact: Bool
     ) throws {
         let payloadJson = try self.core.encodeJsonString(
@@ -476,6 +475,7 @@ struct OutboxStore {
             operationType: "upsert",
             payloadJson: payloadJson,
             clientUpdatedAt: clientUpdatedAt,
+            isInitialCreate: isInitialCreate,
             reviewScheduleImpact: reviewScheduleImpact
         )
     }
@@ -505,6 +505,7 @@ struct OutboxStore {
             operationType: "upsert",
             payloadJson: payloadJson,
             clientUpdatedAt: clientUpdatedAt,
+            isInitialCreate: false,
             reviewScheduleImpact: false
         )
     }
@@ -535,10 +536,21 @@ struct OutboxStore {
             operationType: "upsert",
             payloadJson: payloadJson,
             clientUpdatedAt: clientUpdatedAt,
+            isInitialCreate: false,
             reviewScheduleImpact: false
         )
     }
 
+    // review_event outbox rows are structurally non-impacting: the row records
+    // only the rating/timestamp pair for the review history stream. The card
+    // schedule write that follows a review is enqueued separately on the matching
+    // `card` upsert with reviewScheduleImpact: true (see LocalDatabase+Review.swift).
+    // Pending-card-total deltas (loadPendingReviewScheduleCardTotalDelta) and the
+    // post-acknowledge counters
+    // (CloudSyncResult.acknowledgedReviewScheduleImpactingOperationCount,
+    // cleanedUpReviewScheduleImpactingOperationCount) must never include
+    // review_event rows. The v13→v14 backfill enforces this for legacy rows; new
+    // rows enforce it via the literal `false` passed below.
     func enqueueReviewEventAppendOperation(
         workspaceId: String,
         installationId: String,
@@ -565,6 +577,7 @@ struct OutboxStore {
             operationType: "append",
             payloadJson: payloadJson,
             clientUpdatedAt: clientUpdatedAt,
+            isInitialCreate: false,
             reviewScheduleImpact: false
         )
     }
@@ -578,6 +591,7 @@ struct OutboxStore {
         operationType: String,
         payloadJson: String,
         clientUpdatedAt: String,
+        isInitialCreate: Bool,
         reviewScheduleImpact: Bool
     ) throws {
         try self.core.execute(
@@ -594,9 +608,10 @@ struct OutboxStore {
                 created_at,
                 attempt_count,
                 review_schedule_impact,
+                is_initial_create,
                 last_error
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, NULL)
             """,
             values: [
                 .text(operationId),
@@ -608,7 +623,8 @@ struct OutboxStore {
                 .text(payloadJson),
                 .text(clientUpdatedAt),
                 .text(nowIsoTimestamp()),
-                .integer(reviewScheduleImpact ? 1 : 0)
+                .integer(reviewScheduleImpact ? 1 : 0),
+                .integer(isInitialCreate ? 1 : 0)
             ]
         )
     }
@@ -705,7 +721,6 @@ struct OutboxStore {
     }
 
     private func parsePendingReviewScheduleCardTotalChange(
-        workspaceId: String,
         entry: PendingReviewScheduleCardTotalDeltaEntry
     ) throws -> PendingReviewScheduleCardTotalChange {
         let payload = try self.core.decoder.decode(
@@ -718,10 +733,8 @@ struct OutboxStore {
             )
         }
 
-        let createdAt = try self.loadCardCreatedAt(workspaceId: workspaceId, cardId: entry.entityId)
-        // Initial-create marker: see enqueueCardUpsertOperation contract.
         return PendingReviewScheduleCardTotalChange(
-            hasLocalCreate: createdAt == entry.clientUpdatedAt,
+            hasLocalCreate: entry.isInitialCreate,
             finalIsDeleted: payload.deletedAt != nil
         )
     }

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
@@ -386,12 +386,13 @@ final class LocalDatabaseLifecycleTests: XCTestCase {
             )
         )
         // The fresh-create card upsert (cards.created_at == client_updated_at)
-        // is backfilled to is_initial_create = 1.
+        // is backfilled to is_initial_create = 1. MIN catches a regression where
+        // the WHERE clause unexpectedly matches multiple rows of mixed values.
         XCTAssertEqual(
             1,
             try migratedDatabase.core.scalarInt(
                 sql: """
-                SELECT is_initial_create
+                SELECT MIN(is_initial_create)
                 FROM outbox
                 WHERE workspace_id = ?
                     AND entity_id = ?
@@ -407,7 +408,7 @@ final class LocalDatabaseLifecycleTests: XCTestCase {
             0,
             try migratedDatabase.core.scalarInt(
                 sql: """
-                SELECT is_initial_create
+                SELECT COALESCE(SUM(is_initial_create), 0)
                 FROM outbox
                 WHERE workspace_id = ?
                     AND entity_id = ?

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
@@ -333,6 +333,106 @@ final class LocalDatabaseLifecycleTests: XCTestCase {
         )
     }
 
+    func testSchemaVersion14MigrationBackfillsExistingOutboxIsInitialCreate() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let card = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.createDeck(
+            workspaceId: workspace.workspaceId,
+            input: DeckEditorInput(
+                name: "Deck",
+                filterDefinition: buildDeckFilterDefinition(effortLevels: [.medium], tags: [])
+            )
+        )
+        try database.updateWorkspaceSchedulerSettings(
+            workspaceId: workspace.workspaceId,
+            desiredRetention: 0.9,
+            learningStepsMinutes: [1, 10],
+            relearningStepsMinutes: [10],
+            maximumIntervalDays: 365,
+            enableFuzz: true
+        )
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: card.cardId,
+                rating: .good,
+                reviewedAtClient: "2026-04-18T12:00:00.000Z"
+            )
+        )
+        try database.close()
+        self.database = nil
+
+        try self.prepareSchemaVersion14Database(databaseURL: try XCTUnwrap(self.databaseURL))
+
+        let migratedDatabase = try LocalDatabase(databaseURL: try XCTUnwrap(self.databaseURL))
+        self.database = migratedDatabase
+
+        XCTAssertEqual(LocalDatabaseSchema.currentVersion, try self.loadSchemaVersion(database: migratedDatabase))
+        XCTAssertTrue(
+            try self.hasColumn(
+                database: migratedDatabase,
+                tableName: "outbox",
+                columnName: "is_initial_create"
+            )
+        )
+        // The fresh-create card upsert (cards.created_at == client_updated_at)
+        // is backfilled to is_initial_create = 1.
+        XCTAssertEqual(
+            1,
+            try migratedDatabase.core.scalarInt(
+                sql: """
+                SELECT is_initial_create
+                FROM outbox
+                WHERE workspace_id = ?
+                    AND entity_id = ?
+                    AND entity_type = 'card'
+                    AND operation_type = 'upsert'
+                    AND client_updated_at != '2026-04-18T12:00:00.000Z'
+                """,
+                values: [.text(workspace.workspaceId), .text(card.cardId)]
+            )
+        )
+        // The review-driven card upsert (different client_updated_at) stays at 0.
+        XCTAssertEqual(
+            0,
+            try migratedDatabase.core.scalarInt(
+                sql: """
+                SELECT is_initial_create
+                FROM outbox
+                WHERE workspace_id = ?
+                    AND entity_id = ?
+                    AND entity_type = 'card'
+                    AND operation_type = 'upsert'
+                    AND client_updated_at = '2026-04-18T12:00:00.000Z'
+                """,
+                values: [.text(workspace.workspaceId), .text(card.cardId)]
+            )
+        )
+        // Non-card entity types are never initial creates.
+        XCTAssertEqual(
+            0,
+            try migratedDatabase.core.scalarInt(
+                sql: """
+                SELECT COALESCE(SUM(is_initial_create), 0)
+                FROM outbox
+                WHERE workspace_id = ?
+                    AND entity_type IN ('deck', 'workspace_scheduler_settings', 'review_event')
+                """,
+                values: [.text(workspace.workspaceId)]
+            )
+        )
+    }
+
     private func makeDatabase() throws -> LocalDatabase {
         let databaseURL = try self.makeDatabaseURL()
         let database = try LocalDatabase(databaseURL: databaseURL)
@@ -660,6 +760,84 @@ final class LocalDatabaseLifecycleTests: XCTestCase {
         guard execResult == SQLITE_OK else {
             let message = String(cString: sqlite3_errmsg(connection))
             throw LocalStoreError.database("Failed to prepare schema v13 fixture: \(message)")
+        }
+    }
+
+    private func prepareSchemaVersion14Database(databaseURL: URL) throws {
+        var connection: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            databaseURL.path,
+            &connection,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        )
+        guard openResult == SQLITE_OK, let connection else {
+            throw LocalStoreError.database("Failed to open schema v14 test database")
+        }
+        defer {
+            sqlite3_close_v2(connection)
+        }
+
+        // Recreate the outbox table with the v14 column set (review_schedule_impact
+        // present, is_initial_create absent) so the v14→v15 migration runs against
+        // an authentic pre-migration shape.
+        let downgradeSQL = """
+        PRAGMA legacy_alter_table = ON;
+        DROP INDEX IF EXISTS idx_outbox_workspace_created_at;
+        ALTER TABLE outbox RENAME TO outbox_v15;
+        CREATE TABLE outbox (
+            operation_id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+            installation_id TEXT NOT NULL,
+            entity_type TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            operation_type TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            client_updated_at TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            review_schedule_impact INTEGER NOT NULL DEFAULT 1 CHECK (review_schedule_impact IN (0, 1)),
+            last_error TEXT
+        );
+        INSERT INTO outbox (
+            operation_id,
+            workspace_id,
+            installation_id,
+            entity_type,
+            entity_id,
+            operation_type,
+            payload_json,
+            client_updated_at,
+            created_at,
+            attempt_count,
+            review_schedule_impact,
+            last_error
+        )
+        SELECT
+            operation_id,
+            workspace_id,
+            installation_id,
+            entity_type,
+            entity_id,
+            operation_type,
+            payload_json,
+            client_updated_at,
+            created_at,
+            attempt_count,
+            review_schedule_impact,
+            last_error
+        FROM outbox_v15;
+        DROP TABLE outbox_v15;
+        CREATE INDEX IF NOT EXISTS idx_outbox_workspace_created_at
+            ON outbox(workspace_id, created_at ASC);
+        PRAGMA legacy_alter_table = OFF;
+        PRAGMA user_version = 14;
+        """
+
+        let execResult = sqlite3_exec(connection, downgradeSQL, nil, nil, nil)
+        guard execResult == SQLITE_OK else {
+            let message = String(cString: sqlite3_errmsg(connection))
+            throw LocalStoreError.database("Failed to prepare schema v14 fixture: \(message)")
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace the fragile string-equality detector for "first local create of this card" (`cards.created_at == client_updated_at`) with a persisted `is_initial_create` column on `outbox` (schema v15). The bit is now written explicitly by every enqueue path and read directly when computing pending-card-total deltas.
- The v14→v15 backfill replays the old heuristic exactly once at upgrade time, so post-migration counts are bit-identical to the previous in-memory check.
- Surface the review-schedule-impacting subset of cleaned-up operations as its own structured field (`reviewScheduleImpactingOperations=`) in the cloud-flow log, emitted from the stale-review-event self-heal path.
- Document two existing invariants in code: `review_event` outbox rows are structurally non-impacting, and v13→v14 picks `DEFAULT 1` as the deliberate "safe-on" choice for the migration backfill.

## Why

The previous detector worked by coincidence — `cards.created_at` and the outbox row's `client_updated_at` happen to share the same string for new-card creates because the call site reuses one `nowIsoTimestamp()`. Any change that decoupled those two writes (e.g. re-issuing `nowIsoTimestamp()` between `cardStore.saveCard` and `outboxStore.enqueueCardUpsertOperation`) would silently drift the unsynced-cards counter without breaking anything else. Persisting the bit makes the data self-describing and removes the implicit ordering contract.

## Test plan

- [x] iOS Debug build green on iPhone 17e (iOS 26.4) simulator
- [x] `LocalDatabaseLifecycleTests` (7 tests) — exercises the migration chain through v15 including the v13→v14 backfill test, which now runs v13→v14→v15 cleanly
- [x] `ProgressSyncCompletionTests` (8), `ReviewSelectionSyncRecoveryTests` (4), `LinkedSyncBootstrapAndRetryTests` (7) — all pass
- [ ] Manual smoke (optional): drive a sync on the simulator with `Console.app` filtered to subsystem `com.flashcardsopensourceapp.Flashcards`, category `cloud`; trigger any cleanup phase and confirm the new `reviewScheduleImpactingOperations=…` field appears in the log line.

## Notes for reviewer

- No backend or Android changes — pure iOS local-DB schema bump and observability work. Backend wire format is unchanged.
- The v14→v15 ALTER TABLE is idempotent (`columnExists` guard) and the backfill is a single UPDATE; both run inside the existing migration transaction.
- The `is_initial_create` column DEFAULT is `0` (safe-off): for non-card entity types the value is always 0, and for card rows the value is always passed explicitly by the new `isInitialCreate` parameter on `enqueueCardUpsertOperation`. Legacy rows are surgically promoted to `1` by the backfill where the old heuristic would have matched.
- The pre-existing `AIChatStoreRunToolCallTracking{Bootstrap,PostSync}Tests` (8 cases) fail on this branch but also fail on `main` with no changes — flaky/broken before this work; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)