### PR TITLE
Guard iOS chat cancel cleanup and fix Xcode Cloud test regressions

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
@@ -168,6 +168,13 @@ extension AIChatStore {
                     sessionId: sessionId,
                     runId: stopRunId
                 )
+                // The cancel-cleanup branches below mutate state for the run we
+                // were stopping. If composerPhase moved off .stopping (e.g. a
+                // new run started or transitionToIdle already ran) the
+                // response is stale and must not clobber the new state.
+                guard self.composerPhase == .stopping else {
+                    return
+                }
                 if stopResponse.stopped == false {
                     self.transitionToIdle()
                     self.startLinkedBootstrap(forceReloadState: true, resumeAttemptDiagnostics: nil)

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
@@ -68,4 +68,106 @@ final class AIChatStoreRunStopTests: XCTestCase {
         XCTAssertEqual(store.composerPhase, .running)
         XCTAssertEqual(store.activeRunId, "run-2")
     }
+
+    /// Locks in the invariant that a stale stopRun response cannot clobber a
+    /// run that started after the cancel was issued. The cancel-cleanup
+    /// branches in `cancelStreaming` mutate `transitionToIdle` and active
+    /// streaming markers; without the `composerPhase == .stopping` guard, an
+    /// in-flight stop for run-A would wipe run-B's state when its response
+    /// arrives.
+    ///
+    /// The race is forced deterministically by suspending the cancel Task at
+    /// `stopRun` via a gate, transitioning to run-B from the test, then
+    /// releasing the gate. After release, the cancel Task's body and its
+    /// `defer`-scheduled persist are awaited explicitly so assertions run
+    /// against the steady state — not a transient pre-clobber moment.
+    func testStopRunResponseIsIgnoredWhenNewRunStartedDuringCancel() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        // Drain the constructor's defensive cancelStreaming pipeline before
+        // the test sets up its own race, otherwise its incidental stopRun
+        // call counts toward stopRunRequests and confuses the gate timing.
+        await store.waitForPendingStatePersistence()
+
+        let runA = AIChatStoreTestSupport.makeActiveRun()
+        let runBSession = AIChatActiveRunSession(
+            sessionId: "session-1",
+            conversationScopeId: "session-1",
+            runId: "run-2",
+            liveStream: runA.live.stream,
+            liveCursor: "cursor-2",
+            streamEpoch: nil
+        )
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.transitionToStreaming(
+            activeRun: AIChatActiveRunSession(
+                sessionId: "session-1",
+                conversationScopeId: "session-1",
+                runId: runA.runId,
+                liveStream: runA.live.stream,
+                liveCursor: runA.live.cursor,
+                streamEpoch: nil
+            )
+        )
+        store.persistStateSynchronously(state: store.currentPersistedState())
+
+        let initialStopRunCount = context.chatService.stopRunRequests.count
+        let stopRunGate = AIChatStoreTestSupport.AsyncGate()
+        context.chatService.stopRunGate = stopRunGate
+        // Default fake response is `stopped: true, stillRunning: false`,
+        // which would trigger the cancel-cleanup branch and clobber run-B
+        // without the new guard.
+
+        store.cancelStreaming()
+
+        // Wait until the test's cancel Task has reached the (blocked) stopRun
+        // call, so we know the cancel pipeline is in-flight before we race a
+        // new run against it.
+        let didReachStopRun = await AIChatStoreTestSupport.waitForCondition(
+            description: "stopRun observed by fake",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.chatService.stopRunRequests.count == initialStopRunCount + 1
+            }
+        )
+        XCTAssertTrue(didReachStopRun)
+        XCTAssertEqual(store.composerPhase, .stopping)
+
+        // A new run starts before the cancel response lands.
+        store.transitionToStreaming(activeRun: runBSession)
+        XCTAssertEqual(store.composerPhase, .running)
+        XCTAssertEqual(store.activeRunId, "run-2")
+
+        await stopRunGate.release()
+
+        // Yield MainActor so the just-resumed cancel Task continuation gets
+        // a chance to run before the test resumes. In practice MainActor
+        // processes the gate-released continuation ahead of the test's
+        // re-enqueued continuation, so one yield is sufficient; Swift's
+        // concurrency model doesn't formally guarantee this ordering, so if
+        // a future runtime change makes this flaky, raise the yield count
+        // or replace with an explicit settle-counter signal from the fake.
+        //
+        // The cancel Task body is synchronous after stopRun returns and its
+        // `defer` always schedules a persist via schedulePersistCurrentState,
+        // so once the body has run, waitForPendingStatePersistence is the
+        // deterministic drain step.
+        await Task.yield()
+        await store.waitForPendingStatePersistence()
+
+        XCTAssertEqual(
+            store.activeRunId,
+            "run-2",
+            "stale stop-A cleanup must not clobber the freshly-streaming run-B"
+        )
+        XCTAssertEqual(store.composerPhase, .running)
+        XCTAssertEqual(context.chatService.stopRunRequests.last?.runId, "run-1")
+    }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
@@ -217,6 +217,7 @@ enum AIChatStoreTestSupport {
         var startRunRequests: [AIChatStartRunRequestBody]
         var createNewSessionRequests: [AIChatNewSessionRequestBody]
         var stopRunRequests: [(sessionId: String, runId: String?)]
+        var stopRunGate: AsyncGate?
         var loadBootstrapHandler: ((String?) throws -> AIChatBootstrapResponse)?
         var startRunHandler: ((AIChatStartRunRequestBody) throws -> AIChatStartRunResponse)?
         var createNewSessionHandler: ((AIChatNewSessionRequestBody) throws -> AIChatNewSessionResponse)?
@@ -234,6 +235,7 @@ enum AIChatStoreTestSupport {
             self.startRunRequests = []
             self.createNewSessionRequests = []
             self.stopRunRequests = []
+            self.stopRunGate = nil
             self.loadBootstrapHandler = nil
             self.startRunHandler = nil
             self.createNewSessionHandler = nil
@@ -317,12 +319,16 @@ enum AIChatStoreTestSupport {
             _ = session
             self.events.append("stopRun:\(sessionId):\(runId ?? "nil")")
             self.stopRunRequests.append((sessionId: sessionId, runId: runId))
+            if let stopRunGate = self.stopRunGate {
+                await stopRunGate.wait()
+                self.stopRunGate = nil
+            }
             if let stopRunHandler {
                 return try stopRunHandler(sessionId, runId)
             }
             return AIChatStopRunResponse(
                 sessionId: sessionId,
-                stopped: false,
+                stopped: true,
                 stillRunning: false
             )
         }
@@ -663,6 +669,16 @@ enum AIChatStoreTestSupport {
         }
     }
 
+    /// One-shot suspension primitive used by the test fakes to inject races at
+    /// known async boundaries (loadBootstrap, runLinkedSync, stopRun).
+    ///
+    /// Usage convention across the fakes: the property holding the gate is
+    /// read with `if let gate = self.gateField`, awaited via `gate.wait()`,
+    /// and then that property is cleared to nil so that subsequent calls to
+    /// the same fake method pass through unblocked. The nil-out is
+    /// intentional — tests typically only need to gate the first call. If a
+    /// future test needs to gate every call, omit the nil-out at the call
+    /// site rather than changing this type.
     actor AsyncGate {
         private var continuation: CheckedContinuation<Void, Never>?
         private var isReleased: Bool

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalStoreTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalStoreTests.swift
@@ -257,6 +257,7 @@ final class ProgressLocalStoreTests: ProgressStoreTestCase {
         XCTAssertEqual(1, try self.pendingCardReviewScheduleImpactSum(database: database, workspaceId: workspace.workspaceId))
     }
 
+    @discardableResult
     private func addReviewScheduleCardAtBoundary(
         database: LocalDatabase,
         workspaceId: String,

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressRefreshMergeTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressRefreshMergeTests.swift
@@ -450,6 +450,18 @@ final class ProgressRefreshMergeTests: ProgressStoreTestCase {
             ]
         )
 
+        // Two caches need to be invalidated to force a fresh local-fallback
+        // evaluation:
+        //   1. handleReviewScheduleLocalCardStateDidChange bumps the local
+        //      revision so the local-fallback cache key (keyed on
+        //      progressReviewScheduleLocalRevision) misses. Direct SQL
+        //      bypasses saveCard, which is the production path that fires
+        //      this hook; we mirror it explicitly here.
+        //   2. invalidateProgressReviewSchedule drops the server-base cache
+        //      and persisted server snapshot for this scope, ensuring the
+        //      next prepare falls back to the local computation we want to
+        //      surface as an error.
+        context.store.handleReviewScheduleLocalCardStateDidChange(now: now)
         context.store.invalidateProgressReviewSchedule(scopeKey: scheduleScopeKey)
         XCTAssertNoThrow(try context.store.prepareProgressSnapshot(now: now))
 


### PR DESCRIPTION
## Summary

- **Production fix:** add a `composerPhase == .stopping` guard before the post-`stopRun` cleanup in `AIChatStore.cancelStreaming` so a stale stop-A response can't clobber a freshly-streaming run-B.
- **Test target sweep:** fix the 11 test failures + 10 unused-result warnings from Xcode Cloud build 327 (4 unique test methods plus the 10 warnings on `addReviewScheduleCardAtBoundary`).
- **Test infra:** add `stopRunGate` to the AI chat fake (mirrors `loadBootstrapGate`/`runLinkedSyncGate`), document the consumed-once usage convention on `AsyncGate`, and add an explicit regression test (`testStopRunResponseIsIgnoredWhenNewRunStartedDuringCancel`) that fails when the production guard is removed.

## Test plan

- [x] `xcodebuild ... -only-testing:'Flashcards Open Source App Tests'` — 292/292 pass on iPhone 17e (iOS 26.4).
- [x] New regression test verified to fail when the production guard is removed (`activeRunId == nil` instead of `"run-2"`, `composerPhase == .idle` instead of `.running`).
- [x] New test stable across 5 consecutive runs (~50–360 ms, no flakiness observed).
- [x] Watch the next Xcode Cloud `Test - iOS` action on `main` for 0 warnings + 0 test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)