### PR TITLE
Unify Progress donut palette and link selection across all clients

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -6,6 +6,8 @@ import android.icu.util.TimeZone
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -48,6 +50,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
@@ -55,11 +58,18 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
@@ -74,7 +84,9 @@ import java.text.NumberFormat
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.Locale
+import kotlin.math.atan2
 import kotlin.math.min
+import kotlin.math.sqrt
 
 private val progressSectionShape = RoundedCornerShape(28.dp)
 private const val reviewChartVisibleGridLines: Int = 4
@@ -735,12 +747,17 @@ private fun ReviewScheduleSectionCard(
             maximumFractionDigits = 0
         }
     }
-    val bucketColors = createReviewScheduleBucketColors()
+    val bucketColors = reviewScheduleBucketColors
+    val selectedRowBackground = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.20f)
+    var selectedBucketKey by rememberSaveable { mutableStateOf<ProgressReviewScheduleBucketKey?>(null) }
 
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .testTag(progressReviewScheduleSectionTag),
+            .testTag(progressReviewScheduleSectionTag)
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = { selectedBucketKey = null })
+            },
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer
         ),
@@ -761,6 +778,17 @@ private fun ReviewScheduleSectionCard(
                 ReviewScheduleDonutChart(
                     uiState = uiState,
                     bucketColors = bucketColors,
+                    selectedBucketKey = selectedBucketKey,
+                    accentColor = MaterialTheme.colorScheme.primary,
+                    onTapSegment = { tappedKey ->
+                        selectedBucketKey = if (tappedKey == null) {
+                            null
+                        } else if (selectedBucketKey == tappedKey) {
+                            null
+                        } else {
+                            tappedKey
+                        }
+                    },
                     modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
             } else {
@@ -777,7 +805,17 @@ private fun ReviewScheduleSectionCard(
                         bucket = bucket,
                         color = bucketColors.getValue(bucket.key),
                         countLabel = countFormatter.format(bucket.count.toLong()),
-                        percentageLabel = percentFormatter.format(bucket.percentage.toDouble())
+                        percentageLabel = percentFormatter.format(bucket.percentage.toDouble()),
+                        isSelected = selectedBucketKey == bucket.key,
+                        isAnySelected = selectedBucketKey != null,
+                        selectedBackground = selectedRowBackground,
+                        onClick = {
+                            selectedBucketKey = if (selectedBucketKey == bucket.key) {
+                                null
+                            } else {
+                                bucket.key
+                            }
+                        }
                     )
                 }
             }
@@ -789,21 +827,47 @@ private fun ReviewScheduleSectionCard(
 private fun ReviewScheduleDonutChart(
     uiState: ProgressReviewScheduleSectionUiState,
     bucketColors: Map<ProgressReviewScheduleBucketKey, Color>,
+    selectedBucketKey: ProgressReviewScheduleBucketKey?,
+    accentColor: Color,
+    onTapSegment: (ProgressReviewScheduleBucketKey?) -> Unit,
     modifier: Modifier
 ) {
-    val chartDescription = stringResource(id = R.string.progress_review_schedule_chart_content_description)
+    val baseChartDescription = stringResource(id = R.string.progress_review_schedule_chart_content_description)
+    val selectedBucketLabel = selectedBucketKey?.let { reviewScheduleBucketLabel(bucketKey = it) }
+    val chartDescription = if (selectedBucketLabel != null) {
+        "$baseChartDescription, $selectedBucketLabel"
+    } else {
+        baseChartDescription
+    }
     val emptyTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest
     val strokeWidth = 28.dp
+    val ringStrokeWidth = 2.dp
+    val ringGap = 3.dp
+    val strokeWidthPx = with(LocalDensity.current) { strokeWidth.toPx() }
+    val currentOnTapSegment by rememberUpdatedState(onTapSegment)
+    val currentBuckets by rememberUpdatedState(uiState.buckets)
 
     Canvas(
         modifier = modifier
             .size(184.dp)
             .testTag(progressReviewScheduleDonutChartTag)
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val tappedKey = bucketKeyAtOffset(
+                        offset = offset,
+                        canvasWidth = size.width.toFloat(),
+                        canvasHeight = size.height.toFloat(),
+                        strokeWidthPx = strokeWidthPx,
+                        buckets = currentBuckets
+                    )
+                    currentOnTapSegment(tappedKey)
+                }
+            }
             .semantics {
                 contentDescription = chartDescription
+                liveRegion = LiveRegionMode.Polite
             }
     ) {
-        val strokeWidthPx = strokeWidth.toPx()
         val diameter = min(size.width, size.height) - strokeWidthPx
         val topLeft = Offset(
             x = (size.width - diameter) / 2f,
@@ -823,13 +887,18 @@ private fun ReviewScheduleDonutChart(
             )
         )
 
-        var startAngle = -90f
-        uiState.buckets.filter { bucket ->
+        val nonEmptyBuckets = uiState.buckets.filter { bucket ->
             bucket.count > 0
-        }.forEach { bucket ->
+        }
+        var startAngle = -90f
+        var selectedSegmentStart: Float? = null
+        var selectedSegmentSweep: Float? = null
+        nonEmptyBuckets.forEach { bucket ->
             val sweepAngle = 360f * bucket.percentage
+            val isDimmed = selectedBucketKey != null && selectedBucketKey != bucket.key
+            val baseColor = bucketColors.getValue(bucket.key)
             drawArc(
-                color = bucketColors.getValue(bucket.key),
+                color = if (isDimmed) baseColor.copy(alpha = 0.35f) else baseColor,
                 startAngle = startAngle,
                 sweepAngle = sweepAngle,
                 useCenter = false,
@@ -840,7 +909,36 @@ private fun ReviewScheduleDonutChart(
                     cap = StrokeCap.Butt
                 )
             )
+            if (selectedBucketKey == bucket.key) {
+                selectedSegmentStart = startAngle
+                selectedSegmentSweep = sweepAngle
+            }
             startAngle += sweepAngle
+        }
+
+        val ringStartAngle = selectedSegmentStart
+        val ringSweepAngle = selectedSegmentSweep
+        if (ringStartAngle != null && ringSweepAngle != null) {
+            val ringStrokePx = ringStrokeWidth.toPx()
+            val ringGapPx = ringGap.toPx()
+            val ringDiameter = diameter + strokeWidthPx + ringGapPx * 2 + ringStrokePx
+            val ringTopLeft = Offset(
+                x = (size.width - ringDiameter) / 2f,
+                y = (size.height - ringDiameter) / 2f
+            )
+            val ringSize = Size(width = ringDiameter, height = ringDiameter)
+            drawArc(
+                color = accentColor,
+                startAngle = ringStartAngle,
+                sweepAngle = ringSweepAngle,
+                useCenter = false,
+                topLeft = ringTopLeft,
+                size = ringSize,
+                style = Stroke(
+                    width = ringStrokePx,
+                    cap = StrokeCap.Round
+                )
+            )
         }
     }
 }
@@ -850,14 +948,31 @@ private fun ReviewScheduleLegendRow(
     bucket: ProgressReviewScheduleBucketUiState,
     color: Color,
     countLabel: String,
-    percentageLabel: String
+    percentageLabel: String,
+    isSelected: Boolean,
+    isAnySelected: Boolean,
+    selectedBackground: Color,
+    onClick: () -> Unit
 ) {
+    val rowAlpha = if (isAnySelected && isSelected.not()) 0.35f else 1f
+    val backgroundColor = if (isSelected) selectedBackground else Color.Transparent
+    val isInteractive = bucket.count > 0
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .semantics(mergeDescendants = true) {}
+            .clip(RoundedCornerShape(8.dp))
+            .background(backgroundColor)
+            .clickable(enabled = isInteractive, onClick = onClick)
+            .alpha(rowAlpha)
+            .padding(horizontal = 8.dp, vertical = 6.dp)
+            .semantics(mergeDescendants = true) {
+                if (isInteractive) {
+                    role = Role.Button
+                    selected = isSelected
+                }
+            }
     ) {
         Box(
             modifier = Modifier
@@ -884,21 +999,53 @@ private fun ReviewScheduleLegendRow(
     }
 }
 
-@Composable
-private fun createReviewScheduleBucketColors(): Map<ProgressReviewScheduleBucketKey, Color> {
-    val colorScheme = MaterialTheme.colorScheme
-    val colors = listOf(
-        colorScheme.primary,
-        colorScheme.tertiary,
-        colorScheme.secondary,
-        colorScheme.error,
-        colorScheme.primaryContainer,
-        colorScheme.tertiaryContainer,
-        colorScheme.secondaryContainer,
-        colorScheme.outline
-    )
+// Canonical palette — see docs/progress-pie-palette.md.
+// Keep the hex values in sync with the iOS and Web clients.
+private val reviewScheduleBucketColors: Map<ProgressReviewScheduleBucketKey, Color> = mapOf(
+    ProgressReviewScheduleBucketKey.NEW to Color(0xFFE69F00),
+    ProgressReviewScheduleBucketKey.TODAY to Color(0xFFD7263D),
+    ProgressReviewScheduleBucketKey.DAYS_1_TO_7 to Color(0xFFF2A65A),
+    ProgressReviewScheduleBucketKey.DAYS_8_TO_30 to Color(0xFF2BB673),
+    ProgressReviewScheduleBucketKey.DAYS_31_TO_90 to Color(0xFF1FB5C1),
+    ProgressReviewScheduleBucketKey.DAYS_91_TO_360 to Color(0xFF3F7CC8),
+    ProgressReviewScheduleBucketKey.YEARS_1_TO_2 to Color(0xFF8E5BD9),
+    ProgressReviewScheduleBucketKey.LATER to Color(0xFF7A8088),
+)
 
-    return ProgressReviewScheduleBucketKey.orderedEntries.zip(colors).toMap()
+// Pure helper: maps a tap on the donut canvas to the bucket whose wedge it lands on,
+// or null when the tap falls outside the ring (donut hole or canvas corners).
+private fun bucketKeyAtOffset(
+    offset: Offset,
+    canvasWidth: Float,
+    canvasHeight: Float,
+    strokeWidthPx: Float,
+    buckets: List<ProgressReviewScheduleBucketUiState>
+): ProgressReviewScheduleBucketKey? {
+    val centerX = canvasWidth / 2f
+    val centerY = canvasHeight / 2f
+    val dx = offset.x - centerX
+    val dy = offset.y - centerY
+    val distance = sqrt(dx * dx + dy * dy)
+    val centralRadius = (min(canvasWidth, canvasHeight) - strokeWidthPx) / 2f
+    val halfBand = strokeWidthPx / 2f
+    if (distance < centralRadius - halfBand || distance > centralRadius + halfBand) {
+        return null
+    }
+    val nonEmpty = buckets.filter { it.count > 0 }
+    if (nonEmpty.isEmpty()) {
+        return null
+    }
+    val rawDegrees = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble())).toFloat()
+    val angleFromTop = ((rawDegrees + 90f) % 360f + 360f) % 360f
+    var startAngle = 0f
+    nonEmpty.forEach { bucket ->
+        val sweepAngle = 360f * bucket.percentage
+        if (angleFromTop >= startAngle && angleFromTop < startAngle + sweepAngle) {
+            return bucket.key
+        }
+        startAngle += sweepAngle
+    }
+    return nonEmpty.last().key
 }
 
 @Composable

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -557,6 +557,9 @@ private struct ProgressReviewsSection: View {
 private struct ProgressReviewScheduleSection: View {
     let snapshot: ReviewScheduleSnapshot
 
+    @State private var selectedBucketKey: ReviewScheduleBucketKey?
+    @State private var selectedAngle: Int?
+
     private var buckets: [ReviewScheduleBucket] {
         self.snapshot.schedule.buckets
     }
@@ -585,9 +588,11 @@ private struct ProgressReviewScheduleSection: View {
                         SectorMark(
                             angle: .value("Cards", bucket.count),
                             innerRadius: .ratio(0.62),
+                            outerRadius: .ratio(self.outerRadiusRatio(for: bucket.key)),
                             angularInset: 1.4
                         )
                         .foregroundStyle(progressReviewScheduleBucketColor(key: bucket.key))
+                        .opacity(self.segmentOpacity(for: bucket.key))
                         .accessibilityLabel(progressReviewScheduleBucketTitle(key: bucket.key))
                         .accessibilityValue(
                             progressReviewScheduleBucketAccessibilityValue(
@@ -598,16 +603,23 @@ private struct ProgressReviewScheduleSection: View {
                     }
                 }
                 .chartLegend(.hidden)
+                .chartAngleSelection(value: self.$selectedAngle)
                 .frame(height: progressReviewScheduleChartHeight)
                 .accessibilityElement(children: .contain)
                 .accessibilityLabel(progressReviewScheduleChartAccessibilityLabel())
-                .accessibilityValue(progressReviewScheduleAccessibilitySummary(snapshot: self.snapshot))
+                .accessibilityValue(self.chartAccessibilityValue)
+                .onChange(of: self.selectedAngle) { _, newValue in
+                    self.handleChartAngleSelection(newValue)
+                }
 
                 VStack(alignment: .leading, spacing: 10) {
                     ForEach(self.buckets) { bucket in
                         ProgressReviewScheduleLegendRow(
                             bucket: bucket,
-                            totalCards: self.snapshot.schedule.totalCards
+                            totalCards: self.snapshot.schedule.totalCards,
+                            isSelected: self.selectedBucketKey == bucket.key,
+                            isAnySelected: self.selectedBucketKey != nil,
+                            onTap: { self.toggleSelection(for: bucket.key) }
                         )
                     }
                 }
@@ -625,12 +637,97 @@ private struct ProgressReviewScheduleSection: View {
             }
         }
         .padding(.vertical, 4)
+        .background(
+            // Background tap layer — only fires when no foreground view (chart, legend row)
+            // claims the tap, so it doesn't compete with the Charts framework's selection gesture.
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    self.selectedBucketKey = nil
+                }
+        )
     }
+
+    private var chartAccessibilityValue: String {
+        let summary = progressReviewScheduleAccessibilitySummary(snapshot: self.snapshot)
+        guard let selected = self.selectedBucketKey else {
+            return summary
+        }
+        let selectedTitle = progressReviewScheduleBucketTitle(key: selected)
+        return "\(selectedTitle), \(summary)"
+    }
+
+    private func isDimmed(_ key: ReviewScheduleBucketKey) -> Bool {
+        guard let selected = self.selectedBucketKey else {
+            return false
+        }
+        return selected != key
+    }
+
+    private func segmentOpacity(for key: ReviewScheduleBucketKey) -> Double {
+        self.isDimmed(key) ? 0.35 : 1.0
+    }
+
+    private func outerRadiusRatio(for key: ReviewScheduleBucketKey) -> Double {
+        self.isDimmed(key) ? 0.94 : 1.0
+    }
+
+    private func toggleSelection(for key: ReviewScheduleBucketKey) {
+        if self.selectedBucketKey == key {
+            self.selectedBucketKey = nil
+        } else {
+            self.selectedBucketKey = key
+        }
+    }
+
+    private func handleChartAngleSelection(_ angleValue: Int?) {
+        guard let angleValue else {
+            return
+        }
+        let totalCards = self.snapshot.schedule.totalCards
+        guard totalCards > 0 else {
+            return
+        }
+        let tappedKey = bucketKeyForChartAngle(
+            angleValue: angleValue,
+            buckets: self.nonEmptyBuckets
+        )
+        guard let tappedKey else {
+            return
+        }
+        self.toggleSelection(for: tappedKey)
+        // Reset so a tap on the same segment fires another onChange (toggle-off).
+        self.selectedAngle = nil
+    }
+}
+
+// Boundary policy: an exact tap on a wedge boundary maps to the earlier wedge.
+// Pure mapping from a Swift Charts angle-selection value (running cards count)
+// to the bucket whose wedge it falls inside.
+private func bucketKeyForChartAngle(
+    angleValue: Int,
+    buckets: [ReviewScheduleBucket]
+) -> ReviewScheduleBucketKey? {
+    guard buckets.isEmpty == false else {
+        return nil
+    }
+    var runningTotal: Int = 0
+    for bucket in buckets {
+        runningTotal += bucket.count
+        if angleValue <= runningTotal {
+            return bucket.key
+        }
+    }
+    assertionFailure("bucketKeyForChartAngle: angleValue \(angleValue) exceeded running total \(runningTotal); Charts may have changed its angle-binding clamping behavior")
+    return buckets.last?.key
 }
 
 private struct ProgressReviewScheduleLegendRow: View {
     let bucket: ReviewScheduleBucket
     let totalCards: Int
+    let isSelected: Bool
+    let isAnySelected: Bool
+    let onTap: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
@@ -652,7 +749,22 @@ private struct ProgressReviewScheduleLegendRow: View {
                 .font(.subheadline.monospacedDigit())
                 .foregroundStyle(.secondary)
         }
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(self.isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+                .padding(.horizontal, -8)
+                .padding(.vertical, -4)
+        )
+        .opacity(self.isAnySelected && self.isSelected == false ? 0.35 : 1.0)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard self.bucket.count > 0 else {
+                return
+            }
+            self.onTap()
+        }
         .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(self.bucket.count > 0 ? .isButton : [])
         .accessibilityLabel(progressReviewScheduleBucketTitle(key: self.bucket.key))
         .accessibilityValue(
             progressReviewScheduleBucketAccessibilityValue(
@@ -893,24 +1005,26 @@ private func progressReviewScheduleBucketTitle(key: ReviewScheduleBucketKey) -> 
     }
 }
 
+// Canonical palette — see docs/progress-pie-palette.md.
+// Keep the hex values in sync with the Android and Web clients.
 private func progressReviewScheduleBucketColor(key: ReviewScheduleBucketKey) -> Color {
     switch key {
     case .new:
-        return .accentColor
+        return Color(red: 0xE6 / 255, green: 0x9F / 255, blue: 0x00 / 255)
     case .today:
-        return .red
+        return Color(red: 0xD7 / 255, green: 0x26 / 255, blue: 0x3D / 255)
     case .days1To7:
-        return .blue
+        return Color(red: 0xF2 / 255, green: 0xA6 / 255, blue: 0x5A / 255)
     case .days8To30:
-        return .green
+        return Color(red: 0x2B / 255, green: 0xB6 / 255, blue: 0x73 / 255)
     case .days31To90:
-        return .mint
+        return Color(red: 0x1F / 255, green: 0xB5 / 255, blue: 0xC1 / 255)
     case .days91To360:
-        return .purple
+        return Color(red: 0x3F / 255, green: 0x7C / 255, blue: 0xC8 / 255)
     case .years1To2:
-        return .pink
+        return Color(red: 0x8E / 255, green: 0x5B / 255, blue: 0xD9 / 255)
     case .later:
-        return .gray
+        return Color(red: 0x7A / 255, green: 0x80 / 255, blue: 0x88 / 255)
     }
 }
 

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -62,17 +62,27 @@ type ReviewScheduleBucketView = Readonly<{
   percentageLabel: string;
   color: string;
 }>;
+type ReviewScheduleDonutSegment = Readonly<{
+  key: ProgressReviewScheduleBucketKey;
+  color: string;
+  pathD: string;
+}>;
 
+// Canonical palette — see docs/progress-pie-palette.md.
+// Keep the hex values in sync with the iOS and Android clients.
 const reviewScheduleBucketColors: Readonly<Record<ProgressReviewScheduleBucketKey, string>> = {
-  new: "#7dd3fc",
-  today: "#f97316",
-  days1To7: "#22c55e",
-  days8To30: "#14b8a6",
-  days31To90: "#a78bfa",
-  days91To360: "#f59e0b",
-  years1To2: "#f43f5e",
-  later: "#94a3b8",
+  new: "#E69F00",
+  today: "#D7263D",
+  days1To7: "#F2A65A",
+  days8To30: "#2BB673",
+  days31To90: "#1FB5C1",
+  days91To360: "#3F7CC8",
+  years1To2: "#8E5BD9",
+  later: "#7A8088",
 };
+
+const reviewScheduleDonutOuterRadius = 100;
+const reviewScheduleDonutInnerRadius = 62;
 
 const futureStreakDayStyle: Readonly<CSSProperties> = {
   borderStyle: "dashed",
@@ -357,23 +367,58 @@ function buildReviewScheduleBucketViews(
   }));
 }
 
-function buildReviewScheduleDonutBackground(bucketViews: ReadonlyArray<ReviewScheduleBucketView>): string {
+function polarToCartesian(angleDegrees: number, radius: number): { x: number; y: number } {
+  const angleRadians = ((angleDegrees - 90) * Math.PI) / 180;
+  return {
+    x: radius * Math.cos(angleRadians),
+    y: radius * Math.sin(angleRadians),
+  };
+}
+
+function buildAnnulusSegmentPath(startAngle: number, endAngle: number): string {
+  const sweep = endAngle - startAngle;
+  // Use `>=` (not `===`) to absorb floating-point drift in `(count / total) * 360`.
+  if (sweep >= 360) {
+    // Single full ring: split into two semicircle annulus arcs so the path is non-degenerate.
+    const half = startAngle + 180;
+    return [
+      buildAnnulusSegmentPath(startAngle, half),
+      buildAnnulusSegmentPath(half, startAngle + 360),
+    ].join(" ");
+  }
+  const outerStart = polarToCartesian(startAngle, reviewScheduleDonutOuterRadius);
+  const outerEnd = polarToCartesian(endAngle, reviewScheduleDonutOuterRadius);
+  const innerStart = polarToCartesian(endAngle, reviewScheduleDonutInnerRadius);
+  const innerEnd = polarToCartesian(startAngle, reviewScheduleDonutInnerRadius);
+  const largeArcFlag = sweep > 180 ? 1 : 0;
+  return [
+    `M ${outerStart.x} ${outerStart.y}`,
+    `A ${reviewScheduleDonutOuterRadius} ${reviewScheduleDonutOuterRadius} 0 ${largeArcFlag} 1 ${outerEnd.x} ${outerEnd.y}`,
+    `L ${innerStart.x} ${innerStart.y}`,
+    `A ${reviewScheduleDonutInnerRadius} ${reviewScheduleDonutInnerRadius} 0 ${largeArcFlag} 0 ${innerEnd.x} ${innerEnd.y}`,
+    "Z",
+  ].join(" ");
+}
+
+function buildReviewScheduleDonutSegments(
+  bucketViews: ReadonlyArray<ReviewScheduleBucketView>,
+): ReadonlyArray<ReviewScheduleDonutSegment> {
   const totalCount = bucketViews.reduce((totalCards, bucket) => totalCards + bucket.count, 0);
   if (totalCount <= 0) {
-    return "conic-gradient(rgba(255, 255, 255, 0.12) 0% 100%)";
+    return [];
   }
-
-  let currentOffset = 0;
-  const segments = bucketViews
-    .filter((bucket) => bucket.count > 0)
-    .map((bucket): string => {
-      const startOffset = currentOffset;
-      const endOffset = currentOffset + ((bucket.count / totalCount) * 100);
-      currentOffset = endOffset;
-      return `${bucket.color} ${startOffset}% ${endOffset}%`;
-    });
-
-  return `conic-gradient(${segments.join(", ")})`;
+  const nonEmpty = bucketViews.filter((bucket) => bucket.count > 0);
+  let currentAngle = 0;
+  return nonEmpty.map((bucket): ReviewScheduleDonutSegment => {
+    const startAngle = currentAngle;
+    const endAngle = currentAngle + (bucket.count / totalCount) * 360;
+    currentAngle = endAngle;
+    return {
+      key: bucket.key,
+      color: bucket.color,
+      pathD: buildAnnulusSegmentPath(startAngle, endAngle),
+    };
+  });
 }
 
 export function ProgressScreen(): ReactElement {
@@ -404,6 +449,7 @@ export function ProgressScreen(): ReactElement {
   });
   const { locale, matchedBrowserLanguageTag, direction, t, formatDate, formatNumber } = useI18n();
   const [selectedPageStartLocalDate, setSelectedPageStartLocalDate] = useState<string | null>(null);
+  const [selectedReviewScheduleBucket, setSelectedReviewScheduleBucket] = useState<ProgressReviewScheduleBucketKey | null>(null);
   const progressSummary = progressSourceState.summary.renderedSnapshot;
   const progress = progressSourceState.series.renderedSnapshot;
   const reviewSchedule = progressSourceState.reviewSchedule.renderedSnapshot;
@@ -420,6 +466,10 @@ export function ProgressScreen(): ReactElement {
   useEffect(() => {
     setSelectedPageStartLocalDate(null);
   }, [progressSourceState.series.renderedSnapshot]);
+
+  useEffect(() => {
+    setSelectedReviewScheduleBucket(null);
+  }, [progressSourceState.reviewSchedule.renderedSnapshot]);
 
   const dailyReviews = progress === null ? [] : sortDailyReviews(progress.dailyReviews);
   const today = progress === null ? "" : progress.to;
@@ -448,10 +498,20 @@ export function ProgressScreen(): ReactElement {
   });
   const previousWeekArrow = resolveChartNavigationArrow(direction, "previous");
   const nextWeekArrow = resolveChartNavigationArrow(direction, "next");
+  // The bucket views and donut segments are derived from the snapshot on every render.
+  // The work is cheap (8 buckets, short string concats and arc math); a useMemo here
+  // would be a no-op because t/formatNumber from useI18n are rebuilt per render.
   const reviewScheduleBucketViews = reviewSchedule === null
     ? []
     : buildReviewScheduleBucketViews(reviewSchedule, t, formatNumber);
-  const reviewScheduleDonutBackground = buildReviewScheduleDonutBackground(reviewScheduleBucketViews);
+  const reviewScheduleDonutSegments = buildReviewScheduleDonutSegments(reviewScheduleBucketViews);
+  const reviewScheduleHasSelection = selectedReviewScheduleBucket !== null;
+  const handleSelectReviewScheduleBucket = (bucketKey: ProgressReviewScheduleBucketKey): void => {
+    setSelectedReviewScheduleBucket((previous) => (previous === bucketKey ? null : bucketKey));
+  };
+  const handleClearReviewScheduleSelection = (): void => {
+    setSelectedReviewScheduleBucket(null);
+  };
 
   return (
     <main className="container">
@@ -658,7 +718,11 @@ export function ProgressScreen(): ReactElement {
             </section>
 
             {reviewSchedule !== null ? (
-              <section className="content-card progress-section" data-testid="progress-review-schedule-card">
+              <section
+                className="content-card progress-section"
+                data-testid="progress-review-schedule-card"
+                onClick={handleClearReviewScheduleSelection}
+              >
                 <div className="progress-section-head">
                   <div className="progress-chart-heading">
                     <h2 className="progress-section-title">{t("progressScreen.reviewSchedule.title")}</h2>
@@ -671,36 +735,81 @@ export function ProgressScreen(): ReactElement {
                 </div>
 
                 <div className="progress-review-schedule">
-                  <div
-                    className="progress-review-schedule-donut"
-                    style={{ background: reviewScheduleDonutBackground }}
-                    aria-hidden="true"
-                  >
-                    <span className="progress-review-schedule-donut-hole" />
-                  </div>
+                  {reviewScheduleDonutSegments.length > 0 ? (
+                    <svg
+                      className="progress-review-schedule-donut"
+                      viewBox="-110 -110 220 220"
+                      role="img"
+                      aria-label={t("progressScreen.reviewSchedule.title")}
+                    >
+                      {reviewScheduleDonutSegments.map((segment) => {
+                        const isSelected = selectedReviewScheduleBucket === segment.key;
+                        const segmentClassName = !reviewScheduleHasSelection
+                          ? "progress-donut-segment"
+                          : isSelected
+                            ? "progress-donut-segment is-selected"
+                            : "progress-donut-segment is-dimmed";
+                        return (
+                          <path
+                            key={segment.key}
+                            d={segment.pathD}
+                            fill={segment.color}
+                            className={segmentClassName}
+                            data-testid={`progress-review-schedule-segment-${segment.key}`}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handleSelectReviewScheduleBucket(segment.key);
+                            }}
+                          />
+                        );
+                      })}
+                    </svg>
+                  ) : (
+                    <div className="progress-review-schedule-donut progress-review-schedule-donut-empty" aria-hidden="true" />
+                  )}
 
                   <ul
                     className="progress-review-schedule-list"
                     aria-label={t("progressScreen.reviewSchedule.legendLabel")}
                   >
-                    {reviewScheduleBucketViews.map((bucket) => (
-                      <li
-                        key={bucket.key}
-                        className="progress-review-schedule-row"
-                        data-testid={`progress-review-schedule-bucket-${bucket.key}`}
-                      >
-                        <span
-                          className="progress-review-schedule-swatch"
-                          style={{ backgroundColor: bucket.color }}
-                          aria-hidden="true"
-                        />
-                        <span className="progress-review-schedule-label">{bucket.label}</span>
-                        <span className="progress-review-schedule-values">
-                          <span className="progress-review-schedule-count">{formatNumber(bucket.count)}</span>
-                          <span className="progress-review-schedule-percent">{bucket.percentageLabel}</span>
-                        </span>
-                      </li>
-                    ))}
+                    {reviewScheduleBucketViews.map((bucket) => {
+                      const isSelected = selectedReviewScheduleBucket === bucket.key;
+                      const isInteractive = bucket.count > 0;
+                      const rowClassName = !reviewScheduleHasSelection
+                        ? "progress-review-schedule-row"
+                        : isSelected
+                          ? "progress-review-schedule-row is-selected"
+                          : "progress-review-schedule-row is-dimmed";
+                      return (
+                        <li
+                          key={bucket.key}
+                          className={rowClassName}
+                          data-testid={`progress-review-schedule-bucket-${bucket.key}`}
+                        >
+                          <button
+                            type="button"
+                            className="progress-review-schedule-row-button"
+                            disabled={!isInteractive}
+                            aria-pressed={isInteractive ? isSelected : undefined}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handleSelectReviewScheduleBucket(bucket.key);
+                            }}
+                          >
+                            <span
+                              className="progress-review-schedule-swatch"
+                              style={{ backgroundColor: bucket.color }}
+                              aria-hidden="true"
+                            />
+                            <span className="progress-review-schedule-label">{bucket.label}</span>
+                            <span className="progress-review-schedule-values">
+                              <span className="progress-review-schedule-count">{formatNumber(bucket.count)}</span>
+                              <span className="progress-review-schedule-percent">{bucket.percentageLabel}</span>
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
                   </ul>
                 </div>
               </section>

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -345,24 +345,39 @@
 }
 
 .progress-review-schedule-donut {
-  position: relative;
   width: min(100%, 220px);
   aspect-ratio: 1;
   justify-self: center;
-  border-radius: 50%;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    0 18px 36px rgba(0, 0, 0, 0.18);
+  display: block;
 }
 
-.progress-review-schedule-donut-hole {
-  position: absolute;
-  inset: 28%;
+svg.progress-review-schedule-donut {
+  overflow: visible;
+  filter: drop-shadow(0 18px 36px rgba(0, 0, 0, 0.18));
+}
+
+.progress-review-schedule-donut-empty {
   border-radius: 50%;
-  background: var(--panel);
+  background: rgba(255, 255, 255, 0.08);
   box-shadow:
-    inset 0 0 0 1px var(--panel-border),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 0 0 1px var(--panel-border);
+}
+
+.progress-donut-segment {
+  cursor: pointer;
+  transition: opacity 120ms ease, transform 120ms ease;
+  transform-origin: center;
+}
+
+.progress-donut-segment.is-dimmed {
+  opacity: 0.35;
+}
+
+.progress-donut-segment.is-selected {
+  stroke: var(--accent);
+  stroke-width: 2;
+  transform: scale(1.03);
 }
 
 .progress-review-schedule-list {
@@ -374,17 +389,45 @@
 }
 
 .progress-review-schedule-row {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  transition: background-color 120ms ease, opacity 120ms ease;
+}
+
+.progress-review-schedule-row:last-child {
+  border-bottom: 0;
+}
+
+.progress-review-schedule-row.is-dimmed {
+  opacity: 0.35;
+}
+
+.progress-review-schedule-row.is-selected {
+  background: var(--accent-soft);
+  border-bottom-color: transparent;
+}
+
+.progress-review-schedule-row-button {
+  all: unset;
   display: grid;
   grid-template-columns: 12px minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
   min-height: 38px;
-  padding: 8px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 8px;
+  width: 100%;
+  box-sizing: border-box;
+  cursor: pointer;
+  border-radius: 8px;
 }
 
-.progress-review-schedule-row:last-child {
-  border-bottom: 0;
+.progress-review-schedule-row-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.progress-review-schedule-row-button:disabled {
+  cursor: default;
 }
 
 .progress-review-schedule-swatch {
@@ -456,9 +499,5 @@
 
   .progress-review-schedule-donut {
     max-width: 180px;
-  }
-
-  .progress-review-schedule-row {
-    grid-template-columns: 12px minmax(0, 1fr) auto;
   }
 }

--- a/docs/progress-pie-palette.md
+++ b/docs/progress-pie-palette.md
@@ -1,0 +1,58 @@
+# Progress donut chart palette
+
+Canonical color palette for the **Review schedule** donut chart on the Progress tab. The same hex values are duplicated in each client because each platform consumes color in a different native form (`SwiftUI.Color`, Compose `Color`, CSS hex).
+
+**Whenever a hex value here changes, update all three client files in the same commit.** No exceptions — visual parity across iOS / Android / Web is the point of this palette.
+
+## Palette
+
+Ordered by `ReviewScheduleBucketKey.stableOrder`:
+
+| # | Bucket key      | Hex       | Note                                  |
+|---|-----------------|-----------|---------------------------------------|
+| 1 | `new`           | `#E69F00` | Honey amber — warm, kindred to brand  |
+| 2 | `today`         | `#D7263D` | Crimson — urgent, distinct from brand |
+| 3 | `days1To7`      | `#F2A65A` | Peach — near-term warm                |
+| 4 | `days8To30`     | `#2BB673` | Emerald                               |
+| 5 | `days31To90`    | `#1FB5C1` | Cyan-teal                             |
+| 6 | `days91To360`   | `#3F7CC8` | Steel blue                            |
+| 7 | `years1To2`     | `#8E5BD9` | Violet                                |
+| 8 | `later`         | `#7A8088` | Slate graphite — neutral / archived   |
+
+Properties: 8 hues spaced ~30–45° apart on the wheel, mid saturation, mid lightness — readable on dark and light backgrounds. Brand orange (`#C44B2D`) is intentionally **not** in the palette so wedges don't blend into surrounding accents (titles, buttons). The accent color returns only as the *selection emphasis ring*.
+
+## Selection emphasis
+
+The functional contract is identical across clients — single-select, second tap on the same bucket clears it, click outside the chart clears it, and non-selected segments and legend rows dim to opacity 0.35. The wedge emphasis itself is per-platform native, because each client's CLAUDE.md rule is to stay maximally native to its platform (iOS-native on iOS, Material 3 on Android) rather than force a single visual treatment everywhere.
+
+Shared invariants when one bucket is selected:
+- Non-selected segments and legend rows render at **opacity 0.35**.
+- The selected legend row gets a soft accent background: `Color.accentColor.opacity(0.12)` on iOS, `MaterialTheme.colorScheme.primaryContainer` at 20% alpha on Android, `var(--accent-soft)` on Web.
+
+Per-platform selected-wedge emphasis:
+
+| Client  | Selected wedge treatment                                                                                       |
+|---------|----------------------------------------------------------------------------------------------------------------|
+| iOS     | `outerRadius` pop-out — selected wedge `.ratio(1.0)`, others `.ratio(0.94)`. Swift Charts' `SectorMark` exposes no stroke modifier, so the pop-out is the native idiom. |
+| Android | 2 dp accent stroke drawn just outside the selected wedge in `MaterialTheme.colorScheme.primary`.               |
+| Web     | 2 px accent stroke on the selected `<path>` (`var(--accent)`) plus `transform: scale(1.03)` for a subtle pop.  |
+
+## Accessibility
+
+Every client must announce the selected bucket to its native assistive tech (VoiceOver / TalkBack / web screen readers) when selection changes, and every client must mark interactive legend rows as buttons only when they are actually tappable (zero-count rows are not announced as buttons). The per-platform mechanisms differ because each client uses its native a11y API, but the user-observable contract is identical.
+
+| Client  | Selected-bucket announce                                                                                       | Legend-row role                                                                                  |
+|---------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| iOS     | Dynamic `chartAccessibilityValue` prepended to the chart's `.accessibilityValue`; SwiftUI re-emits the value-changed notification so VoiceOver re-announces while focused. | `.accessibilityAddTraits(.isButton)` only when `bucket.count > 0`.                               |
+| Android | Dynamic `contentDescription` plus `liveRegion = LiveRegionMode.Polite` on the chart, so TalkBack proactively announces the change even if focus is on a legend row. | `role = Role.Button` and `selected = isSelected` set only when `isInteractive` (`count > 0`).    |
+| Web     | Announced via `aria-pressed` toggling on the focused legend `<button>`, since the legend is the keyboard-focused element when toggling. | Native `<button>` element with `disabled` attribute when `count === 0`, which removes it from the Tab order. |
+
+Whenever any client's a11y mechanism changes (e.g., a new screen reader API replaces an old one), update the table here in the same change so this doc stays the source of truth.
+
+## Source-of-truth files
+
+| Client  | File                                                                                                              | Symbol                                  |
+|---------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| iOS     | `apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift`                                                    | `progressReviewScheduleBucketColor(key:)` |
+| Android | `apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt`       | `reviewScheduleBucketColors`            |
+| Web     | `apps/web/src/screens/progress/ProgressScreen.tsx`                                                                | `reviewScheduleBucketColors`            |


### PR DESCRIPTION
## Summary

- Pick a single 8-color palette ([`docs/progress-pie-palette.md`](docs/progress-pie-palette.md)) and use the same hex values on iOS, Android, and Web so the chart looks identical across clients. Fixes the Android-side bug where the chart was rendering three near-identical orange wedges (the prior code pulled colors from `MaterialTheme.colorScheme` primary/secondary/tertiary slots, all of which map to the brand orange).
- Add native single-select highlighting that links the chart and the legend: tap a wedge or a legend row to highlight the matching pair, dim the others to opacity 0.35, and tap outside (or tap the same target again) to clear. Selection emphasis stays platform-native — iOS uses SwiftUI Charts' `outerRadius` pop-out, Android draws a 2 dp accent ring, Web adds a 2 px accent stroke + `scale(1.03)` on the SVG path.
- Each client announces the selected bucket to screen readers: iOS via a dynamic chart `accessibilityValue`, Android via a dynamic `contentDescription` + `LiveRegionMode.Polite`, Web via `aria-pressed` on the focused legend `<button>`. Legend rows declare the button role only when their bucket is interactive (`count > 0`).
- Web swaps the old `conic-gradient()` div for an inline `<svg>` with hand-built annulus paths — makes per-segment hit-testing trivial and avoids adding a charting dependency.

## Test plan

- [x] Web: `npm run build` succeeds, all 135 vitest tests pass.
- [x] Android: `:feature:progress:compileDebugKotlin --rerun-tasks` BUILD SUCCESSFUL.
- [x] iOS: `swiftc -parse` against the iOS 26 simulator SDK is clean.
- [ ] iOS simulator smoke: open the Progress tab on a workspace with cards in multiple buckets, tap segments and legend rows, confirm highlight + dim + outside-tap clear.
- [ ] Android emulator smoke: same flow on a Pixel API 36 emulator. Verify wedges show 8 distinct colors (no three-orange-wedges regression). Rotate the device — selection persists via `rememberSaveable`.
- [ ] Web `npm run dev` smoke: inspect the donut DOM (should be `<svg>` not a `conic-gradient` div), tab through legend buttons with the keyboard, hit Enter to toggle selection.
- [ ] Cross-client visual parity: take a screenshot of the same workspace's donut on all three clients side-by-side; wedge colors and ordering should be identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)