### PR TITLE
Restore tiny iOS Progress donut slices

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -588,8 +588,7 @@ private struct ProgressReviewScheduleSection: View {
                         SectorMark(
                             angle: .value("Cards", bucket.count),
                             innerRadius: .ratio(0.62),
-                            outerRadius: .ratio(self.outerRadiusRatio(for: bucket.key)),
-                            angularInset: 1.4
+                            outerRadius: .ratio(self.outerRadiusRatio(for: bucket.key))
                         )
                         .foregroundStyle(progressReviewScheduleBucketColor(key: bucket.key))
                         .opacity(self.segmentOpacity(for: bucket.key))


### PR DESCRIPTION
## Summary
- The iOS Review-schedule donut used `SectorMark(angularInset: 1.4)`, which subtracts 1.4° from each side of every slice. Any bucket smaller than the combined 2.8° gap (e.g. 1-7d, 8-30d, 31-90d, 91-360d at typical decks) collapsed to zero width, leaving a visible empty slot at the top of the chart while the legend still listed the buckets correctly.
- Removed the `angularInset` parameter so SwiftUI Charts uses its default (0). Tiny sub-degree slices now render as thin colored arcs, matching the contiguous-arc behavior of the web SVG donut in `apps/web/src/screens/progress/ProgressScreen.tsx`.

## Test plan
- [ ] Build iOS app and open Progress tab on a workspace with a deck dominated by `New` plus several small buckets (~2k cards). Confirm the donut top no longer shows an empty gap and the small buckets appear as thin slices in their palette colors.
- [ ] Tap each thin slice and confirm chart-angle selection still highlights the correct legend row.
- [ ] Confirm the two-bucket case (only New + Today) still looks correct — slices remain distinguishable by color.
- [ ] Compare side-by-side against the web Progress screen on the same workspace; slice composition should match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)