### PR TITLE
Switch admin panel to UTC and add UTC notice in hero

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -22,7 +22,6 @@ type AppState =
       status: "ready";
       config: AdminAppConfig;
       session: AdminSession;
-      timezone: string;
       defaultRange: ReviewEventsByDateRange;
       report: ReviewEventsByDateReport;
       isReportLoading: boolean;
@@ -30,14 +29,6 @@ type AppState =
     }>;
 
 const calendarDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/u;
-
-function resolveBrowserTimezone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-  } catch {
-    return "UTC";
-  }
-}
 
 function parseCalendarDate(date: string, fieldName: string): Date {
   const match = calendarDatePattern.exec(date);
@@ -171,9 +162,8 @@ export default function App(): JSX.Element {
       try {
         config = getAdminAppConfig();
         const session = await fetchAdminSession(config);
-        const timezone = resolveBrowserTimezone();
-        const defaultRange = await loadReviewEventsByDateDefaultRange(config, timezone);
-        const report = await loadReviewEventsByDateReport(config, timezone, defaultRange.from, defaultRange.to);
+        const defaultRange = await loadReviewEventsByDateDefaultRange(config);
+        const report = await loadReviewEventsByDateReport(config, defaultRange.from, defaultRange.to);
 
         if (cancelled) {
           return;
@@ -183,7 +173,6 @@ export default function App(): JSX.Element {
           status: "ready",
           config,
           session,
-          timezone,
           defaultRange,
           report,
           isReportLoading: false,
@@ -236,7 +225,6 @@ export default function App(): JSX.Element {
     try {
       const report = await loadReviewEventsByDateReport(
         readyState.config,
-        readyState.timezone,
         range.from,
         range.to,
       );

--- a/apps/admin/src/adminApi.ts
+++ b/apps/admin/src/adminApi.ts
@@ -70,7 +70,6 @@ export type ReviewEventsByDateRow = Readonly<{
 
 export type ReviewEventsByDateReport = Readonly<{
   generatedAtUtc: string;
-  timezone: string;
   from: string;
   to: string;
   totalReviewEvents: number;

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
@@ -110,12 +110,13 @@ function formatCompactDateLabel(date: string): string {
   }).format(parseCalendarDate(date));
 }
 
-function formatGeneratedAt(value: string, timezone: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
+function formatGeneratedAt(value: string): string {
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(value));
+  return `${formatted} UTC`;
 }
 
 function escapeHtml(value: string): string {
@@ -734,11 +735,12 @@ export function ReviewEventsByDateDashboard(
           <h1>Review Events By Date</h1>
         </div>
         <p className="subhead">
-          Daily unique reviewers and stacked review-event volume by calendar date. The first two charts show overall user activity and per-user event volume. The two platform charts below compare active users and review events across <strong>web</strong>, <strong>android</strong>, and <strong>ios</strong>. Dates are grouped in the <strong>{props.report.timezone}</strong> timezone.
+          Daily unique reviewers and stacked review-event volume by calendar date. The first two charts show overall user activity and per-user event volume. The two platform charts below compare active users and review events across <strong>web</strong>, <strong>android</strong>, and <strong>ios</strong>. Dates are grouped in <strong>UTC</strong>.
         </p>
         <div className="hero-meta">
           <span className="hero-badge">Signed in as {props.adminEmail}</span>
           <span className="hero-badge">Range {formatDateRangeLabel(props.report.from)} to {formatDateRangeLabel(props.report.to)}</span>
+          <span className="hero-badge">All dates and times in UTC</span>
         </div>
       </section>
 
@@ -812,7 +814,7 @@ export function ReviewEventsByDateDashboard(
           <div className="chart-meta">
             <span>Stacked review events by user</span>
             <div className="chart-meta-right">
-              <span>Generated {formatGeneratedAt(props.report.generatedAtUtc, props.report.timezone)}</span>
+              <span>Generated {formatGeneratedAt(props.report.generatedAtUtc)}</span>
             </div>
           </div>
           <div className="chart-scroll">

--- a/apps/admin/src/reports/reviewEventsByDate/query.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/query.ts
@@ -217,7 +217,6 @@ function buildPlatformReviewEventTotals(
 function buildReviewEventsByDateReport(
   resultSet: AdminQueryResultSet,
   executedAtUtc: string,
-  timezone: string,
   from: string,
   to: string,
 ): ReviewEventsByDateReport {
@@ -255,7 +254,6 @@ function buildReviewEventsByDateReport(
 
   return {
     generatedAtUtc: executedAtUtc,
-    timezone,
     from,
     to,
     totalReviewEvents,
@@ -267,29 +265,24 @@ function buildReviewEventsByDateReport(
   };
 }
 
-export function buildReviewEventsByDateDefaultRangeSql(timezone: string): string {
-  const escapedTimezone = escapeSqlStringLiteral(timezone);
-
+export function buildReviewEventsByDateDefaultRangeSql(): string {
   return [
     "SELECT",
     "  COALESCE(",
-    `    to_char(MIN(timezone(${escapedTimezone}, review_events.reviewed_at_server)::date), 'YYYY-MM-DD'),`,
-    `    to_char(timezone(${escapedTimezone}, now())::date, 'YYYY-MM-DD')`,
+    "    to_char(MIN((review_events.reviewed_at_server AT TIME ZONE 'UTC')::date), 'YYYY-MM-DD'),",
+    "    to_char((now() AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD')",
     "  ) AS from_date,",
-    `  to_char(timezone(${escapedTimezone}, now())::date, 'YYYY-MM-DD') AS to_date`,
+    "  to_char((now() AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD') AS to_date",
     "FROM content.review_events AS review_events",
   ].join("\n");
 }
 
-export function buildReviewEventsByDateSql(timezone: string, from: string, to: string): string {
+export function buildReviewEventsByDateSql(from: string, to: string): string {
   assertValidDateRange({ from, to }, "report");
 
   return [
     "SELECT",
-    "  to_char(timezone(",
-    `    ${escapeSqlStringLiteral(timezone)},`,
-    "    review_events.reviewed_at_server",
-    "  )::date, 'YYYY-MM-DD') AS review_date,",
+    "  to_char((review_events.reviewed_at_server AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD') AS review_date,",
     "  workspace_replicas.user_id,",
     "  COALESCE(NULLIF(btrim(user_settings.email), ''), '(no email)') AS email,",
     "  workspace_replicas.platform,",
@@ -300,15 +293,15 @@ export function buildReviewEventsByDateSql(timezone: string, from: string, to: s
     "LEFT JOIN org.user_settings AS user_settings",
     "  ON user_settings.user_id = workspace_replicas.user_id",
     "WHERE review_events.reviewed_at_server >= (",
-    `  ${escapeSqlStringLiteral(from)}::date::timestamp AT TIME ZONE ${escapeSqlStringLiteral(timezone)}`,
+    `  ${escapeSqlStringLiteral(from)}::date::timestamp AT TIME ZONE 'UTC'`,
     ")",
     "  AND review_events.reviewed_at_server < (",
-    `    (${escapeSqlStringLiteral(to)}::date + INTERVAL '1 day')::timestamp AT TIME ZONE ${escapeSqlStringLiteral(timezone)}`,
+    `    (${escapeSqlStringLiteral(to)}::date + INTERVAL '1 day')::timestamp AT TIME ZONE 'UTC'`,
     "  )",
     "  AND workspace_replicas.actor_kind = 'client_installation'",
     "  AND workspace_replicas.platform IN ('web', 'android', 'ios')",
     "GROUP BY",
-    `  timezone(${escapeSqlStringLiteral(timezone)}, review_events.reviewed_at_server)::date,`,
+    "  (review_events.reviewed_at_server AT TIME ZONE 'UTC')::date,",
     "  workspace_replicas.user_id,",
     "  COALESCE(NULLIF(btrim(user_settings.email), ''), '(no email)'),",
     "  workspace_replicas.platform",
@@ -322,9 +315,8 @@ export function buildReviewEventsByDateSql(timezone: string, from: string, to: s
 
 export async function loadReviewEventsByDateDefaultRange(
   config: AdminAppConfig,
-  timezone: string,
 ): Promise<ReviewEventsByDateRange> {
-  const response = await runAdminQuery(config, buildReviewEventsByDateDefaultRangeSql(timezone));
+  const response = await runAdminQuery(config, buildReviewEventsByDateDefaultRangeSql());
   if (response.resultSets.length !== 1) {
     throw new Error("Review events default range query must return exactly one result set.");
   }
@@ -352,11 +344,10 @@ export async function loadReviewEventsByDateDefaultRange(
 
 export async function loadReviewEventsByDateReport(
   config: AdminAppConfig,
-  timezone: string,
   from: string,
   to: string,
 ): Promise<ReviewEventsByDateReport> {
-  const response = await runAdminQuery(config, buildReviewEventsByDateSql(timezone, from, to));
+  const response = await runAdminQuery(config, buildReviewEventsByDateSql(from, to));
   if (response.resultSets.length !== 1) {
     throw new Error("Review events report must return exactly one result set.");
   }
@@ -366,5 +357,5 @@ export async function loadReviewEventsByDateReport(
     throw new Error("Review events report result set is missing.");
   }
 
-  return buildReviewEventsByDateReport(resultSet, response.executedAtUtc, timezone, from, to);
+  return buildReviewEventsByDateReport(resultSet, response.executedAtUtc, from, to);
 }


### PR DESCRIPTION
## Summary

- Admin per-day numbers (unique users, per-platform review events, peaks) diverged from the public global-metrics snapshot at `https://api.flashcards-open-source-app.com/v1/global/snapshot` because the admin bucketed by the browser's timezone (e.g. `Europe/Madrid`) while the snapshot already buckets by UTC. For "May 3" that's a ~2-hour shift in the 24-hour window, so the same calendar date covers different events in each source.
- Switch admin SQL to hardcoded `AT TIME ZONE 'UTC'` to mirror [apps/backend/src/globalMetrics/reporting.ts](apps/backend/src/globalMetrics/reporting.ts). Drop browser-timezone resolution, the `timezone` parameter on the SQL builders/loaders, and the `timezone` field on `ReviewEventsByDateReport` and `AppState`.
- Surface the change in the UI: subhead now reads "Dates are grouped in **UTC**", a new `All dates and times in UTC` hero badge sits next to the existing meta badges, and the Generated timestamp ends with " UTC".

## Test plan

- [ ] After deploy, open `admin.flashcards-open-source-app.com` and confirm the new subhead, the new hero badge, and that the Generated timestamp under the stacked review-events chart explicitly shows UTC.
- [ ] Pick any past day from `https://api.flashcards-open-source-app.com/v1/global/snapshot`, set the admin date range to that single UTC day, and verify Total Review Events, the per-platform totals, and the daily-unique-users value match the snapshot's `days[date]` exactly. (These were the numbers that disagreed before this change.)
- [ ] Repeat the cross-check for at least one earlier day to rule out off-by-one drift on the date-range bounds.
- [ ] Confirm the default range loaded on first paint runs from the earliest UTC day with activity through today-UTC and the report renders without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)