### PR TITLE
Render Progress reviews chart as a full 7-day week

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -533,7 +533,6 @@ private fun ReviewsSectionCard(
     val chartGridLineColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f)
     val previousWeekLabel = stringResource(id = R.string.progress_reviews_previous_week)
     val nextWeekLabel = stringResource(id = R.string.progress_reviews_next_week)
-    val emptyWeekLabel = stringResource(id = R.string.progress_reviews_empty_week)
 
     LaunchedEffect(pageStartDateKeys) {
         if (selectedPageStartDateKey == null) {
@@ -640,89 +639,81 @@ private fun ReviewsSectionCard(
             }
 
             visiblePage?.let { page ->
-                if (page.hasReviewActivity) {
-                    Row(
-                        verticalAlignment = Alignment.Top,
-                        modifier = Modifier.fillMaxWidth()
+                Row(
+                    verticalAlignment = Alignment.Top,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    ReviewsYAxis(
+                        upperBound = page.upperBound,
+                        modifier = Modifier
+                            .padding(top = 6.dp)
+                            .width(reviewChartAxisWidth)
+                    )
+
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    Column(
+                        modifier = Modifier.weight(1f)
                     ) {
-                        ReviewsYAxis(
-                            upperBound = page.upperBound,
+                        Box(
                             modifier = Modifier
-                                .padding(top = 6.dp)
-                                .width(reviewChartAxisWidth)
-                        )
+                                .fillMaxWidth()
+                                .height(reviewChartHeight)
+                                .testTag(progressReviewsActivityChartTag)
+                                .clip(RoundedCornerShape(22.dp))
+                                .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                                .drawBehind {
+                                    val lineStep = size.height / reviewChartVisibleGridLines.toFloat()
 
-                        Spacer(modifier = Modifier.width(12.dp))
-
-                        Column(
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(reviewChartHeight)
-                                    .testTag(progressReviewsActivityChartTag)
-                                    .clip(RoundedCornerShape(22.dp))
-                                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                                    .drawBehind {
-                                        val lineStep = size.height / reviewChartVisibleGridLines.toFloat()
-
-                                        repeat(reviewChartVisibleGridLines) { index ->
-                                            val y = lineStep * index
-                                            drawLine(
-                                                color = chartGridLineColor,
-                                                start = androidx.compose.ui.geometry.Offset(0f, y),
-                                                end = androidx.compose.ui.geometry.Offset(size.width, y),
-                                                strokeWidth = 1.dp.toPx()
-                                            )
-                                        }
-                                    }
-                                    .padding(
-                                        horizontal = reviewChartHorizontalPadding,
-                                        vertical = reviewChartVerticalPadding
-                                    )
-                            ) {
-                                Row(
-                                    horizontalArrangement = Arrangement.spacedBy(reviewChartColumnSpacing),
-                                    verticalAlignment = Alignment.Bottom,
-                                    modifier = Modifier.fillMaxSize()
-                                ) {
-                                    page.days.forEach { day ->
-                                        ReviewBarColumn(
-                                            day = day,
-                                            upperBound = page.upperBound,
-                                            modifier = Modifier
-                                                .weight(1f)
-                                                .fillMaxHeight()
+                                    repeat(reviewChartVisibleGridLines) { index ->
+                                        val y = lineStep * index
+                                        drawLine(
+                                            color = chartGridLineColor,
+                                            start = androidx.compose.ui.geometry.Offset(0f, y),
+                                            end = androidx.compose.ui.geometry.Offset(size.width, y),
+                                            strokeWidth = 1.dp.toPx()
                                         )
                                     }
                                 }
-                            }
-
-                            Spacer(modifier = Modifier.height(8.dp))
-
+                                .padding(
+                                    horizontal = reviewChartHorizontalPadding,
+                                    vertical = reviewChartVerticalPadding
+                                )
+                        ) {
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(reviewChartColumnSpacing),
-                                verticalAlignment = Alignment.Top,
-                                modifier = Modifier.fillMaxWidth()
+                                verticalAlignment = Alignment.Bottom,
+                                modifier = Modifier.fillMaxSize()
                             ) {
                                 page.days.forEach { day ->
-                                    ReviewChartLabel(
+                                    ReviewBarColumn(
                                         day = day,
+                                        upperBound = page.upperBound,
                                         modifier = Modifier
                                             .weight(1f)
-                                            .height(reviewChartLabelHeight)
+                                            .fillMaxHeight()
                                     )
                                 }
                             }
                         }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(reviewChartColumnSpacing),
+                            verticalAlignment = Alignment.Top,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            page.days.forEach { day ->
+                                ReviewChartLabel(
+                                    day = day,
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .height(reviewChartLabelHeight)
+                                )
+                            }
+                        }
                     }
-                } else {
-                    Text(
-                        text = emptyWeekLabel,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
                 }
             }
         }

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
@@ -16,7 +16,6 @@ data class ProgressReviewPageUiState(
     val endDate: LocalDate,
     val startDateKey: String,
     val days: List<ProgressHistoryDayUiState>,
-    val hasReviewActivity: Boolean,
     val upperBound: Int
 )
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -259,10 +259,13 @@ private fun List<ParsedProgressPoint>.toReviewPages(
 
     for (day in reviewDays) {
         val weekStart = weekContext.startOfWeek(date = day.date)
-        if (currentWeekStart != null && currentWeekStart != weekStart) {
+        val activeWeekStart = currentWeekStart
+        if (activeWeekStart != null && activeWeekStart != weekStart) {
             pages.add(
                 createReviewPage(
-                    days = currentPageDays
+                    weekStart = activeWeekStart,
+                    days = currentPageDays,
+                    today = today
                 )
             )
             currentPageDays = mutableListOf(day)
@@ -274,10 +277,13 @@ private fun List<ParsedProgressPoint>.toReviewPages(
         currentWeekStart = weekStart
     }
 
-    if (currentPageDays.isNotEmpty()) {
+    val finalWeekStart = currentWeekStart
+    if (finalWeekStart != null && currentPageDays.isNotEmpty()) {
         pages.add(
             createReviewPage(
-                days = currentPageDays
+                weekStart = finalWeekStart,
+                days = currentPageDays,
+                today = today
             )
         )
     }
@@ -286,20 +292,44 @@ private fun List<ParsedProgressPoint>.toReviewPages(
 }
 
 private fun createReviewPage(
-    days: List<ProgressHistoryDayUiState>
+    weekStart: LocalDate,
+    days: List<ProgressHistoryDayUiState>,
+    today: LocalDate
 ): ProgressReviewPageUiState {
-    val startDate = days.first().date
-    val endDate = days.last().date
-    val maximumReviewCount = days.maxOfOrNull { day -> day.reviewCount } ?: 0
+    val paddedDays = padReviewPageDaysToFullWeek(
+        weekStart = weekStart,
+        days = days,
+        today = today
+    )
+    val startDate = paddedDays.first().date
+    val endDate = paddedDays.last().date
+    val maximumReviewCount = paddedDays.maxOfOrNull { day -> day.reviewCount } ?: 0
 
     return ProgressReviewPageUiState(
         startDate = startDate,
         endDate = endDate,
         startDateKey = startDate.toString(),
-        days = days,
-        hasReviewActivity = days.any { day -> day.reviewCount > 0 },
+        days = paddedDays,
         upperBound = calculateReviewChartUpperBound(maximumReviewCount = maximumReviewCount)
     )
+}
+
+private fun padReviewPageDaysToFullWeek(
+    weekStart: LocalDate,
+    days: List<ProgressHistoryDayUiState>,
+    today: LocalDate
+): List<ProgressHistoryDayUiState> {
+    val existingByDate = days.associateBy { day -> day.date }
+
+    return (0 until daysPerWeek).map { dayIndex ->
+        val date = weekStart.plusDays(dayIndex.toLong())
+        existingByDate[date] ?: ProgressHistoryDayUiState(
+            date = date,
+            dayOfMonthLabel = date.dayOfMonth.toString(),
+            reviewCount = 0,
+            isToday = date == today
+        )
+    }
 }
 
 private fun calculateReviewChartUpperBound(

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
     <string name="progress_reviews_title">Reviews</string>
     <string name="progress_reviews_previous_week">Previous week</string>
     <string name="progress_reviews_next_week">Next week</string>
-    <string name="progress_reviews_empty_week">No reviews yet in this week.</string>
     <string name="progress_review_schedule_title">Review schedule</string>
     <string name="progress_review_schedule_empty">No active cards yet.</string>
     <string name="progress_review_schedule_chart_content_description">Review schedule chart</string>

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -363,9 +363,11 @@ private struct ProgressReviewsSection: View {
     }
 
     private var chartPages: [ProgressReviewChartPage] {
-        makeProgressReviewChartPages(
+        let today = self.chartDays.first(where: { day in day.isToday })?.date
+        return makeProgressReviewChartPages(
             chartDays: self.chartDays,
-            calendar: self.chartCalendar
+            calendar: self.chartCalendar,
+            today: today
         )
     }
 
@@ -467,68 +469,64 @@ private struct ProgressReviewsSection: View {
             }
 
             if let visiblePage = self.visiblePage {
-                if visiblePage.hasReviewActivity {
-                    Chart {
-                        ForEach(visiblePage.days) { day in
-                            BarMark(
+                Chart {
+                    ForEach(visiblePage.days) { day in
+                        if day.isToday && day.reviewCount == 0 {
+                            RectangleMark(
                                 x: .value("Day", day.localDate),
-                                y: .value("Reviews", day.reviewCount)
+                                yStart: .value("Floor", 0),
+                                yEnd: .value("Ceiling", self.visiblePageUpperBound)
                             )
-                            .foregroundStyle(progressChartBarStyle(day: day))
+                            .foregroundStyle(Color.accentColor.opacity(0.12))
+                            .cornerRadius(8)
                         }
+                        BarMark(
+                            x: .value("Day", day.localDate),
+                            y: .value("Reviews", day.reviewCount)
+                        )
+                        .foregroundStyle(progressChartBarStyle(day: day))
                     }
-                    .chartYScale(domain: 0 ... self.visiblePageUpperBound)
-                    .chartXAxis {
-                        AxisMarks(values: visiblePage.xAxisValues) { value in
-                            AxisTick()
-                                .foregroundStyle(Color(uiColor: .separator).opacity(0.35))
-                            AxisValueLabel {
-                                if let localDate = value.as(String.self), let day = visiblePage.day(localDate: localDate) {
-                                    VStack(spacing: 2) {
-                                        Text(
-                                            progressWeekdayLabel(
-                                                date: day.date,
-                                                calendar: self.chartCalendar
-                                            )
+                }
+                .chartYScale(domain: 0 ... self.visiblePageUpperBound)
+                .chartXAxis {
+                    AxisMarks(values: visiblePage.xAxisValues) { value in
+                        AxisTick()
+                            .foregroundStyle(Color(uiColor: .separator).opacity(0.35))
+                        AxisValueLabel {
+                            if let localDate = value.as(String.self), let day = visiblePage.day(localDate: localDate) {
+                                VStack(spacing: 2) {
+                                    Text(
+                                        progressWeekdayLabel(
+                                            date: day.date,
+                                            calendar: self.chartCalendar
                                         )
-                                        Text(
-                                            progressReviewChartDayLabel(
-                                                date: day.date,
-                                                calendar: self.chartCalendar
-                                            )
+                                    )
+                                    Text(
+                                        progressReviewChartDayLabel(
+                                            date: day.date,
+                                            calendar: self.chartCalendar
                                         )
-                                    }
+                                    )
                                 }
                             }
                         }
                     }
-                    .chartYAxis {
-                        AxisMarks(position: .leading) { value in
-                            AxisGridLine()
-                                .foregroundStyle(Color(uiColor: .separator).opacity(0.18))
-                            AxisTick()
-                                .foregroundStyle(Color(uiColor: .separator).opacity(0.35))
-                            AxisValueLabel()
-                        }
-                    }
-                    .chartPlotStyle { plotArea in
-                        plotArea
-                            .background(Color(uiColor: .secondarySystemGroupedBackground).opacity(0.45))
-                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                    }
-                    .frame(height: progressChartHeight)
-                } else {
-                    Text(
-                        String(
-                            localized: "progress.screen.reviews.empty",
-                            defaultValue: "No reviews yet in this week.",
-                            table: progressStringsTableName,
-                            comment: "Progress reviews section empty caption"
-                        )
-                    )
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
                 }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        AxisGridLine()
+                            .foregroundStyle(Color(uiColor: .separator).opacity(0.18))
+                        AxisTick()
+                            .foregroundStyle(Color(uiColor: .separator).opacity(0.35))
+                        AxisValueLabel()
+                    }
+                }
+                .chartPlotStyle { plotArea in
+                    plotArea
+                        .background(Color(uiColor: .secondarySystemGroupedBackground).opacity(0.45))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+                .frame(height: progressChartHeight)
             }
         }
         .padding(.vertical, 4)
@@ -800,12 +798,6 @@ private struct ProgressReviewChartPage: Identifiable {
         self.startLocalDate
     }
 
-    var hasReviewActivity: Bool {
-        self.days.contains(where: { day in
-            day.reviewCount > 0
-        })
-    }
-
     var xAxisValues: [String] {
         self.days.map(\.localDate)
     }
@@ -824,7 +816,8 @@ private struct ProgressReviewChartSelectionResetToken: Equatable {
 
 private func makeProgressReviewChartPages(
     chartDays: [ProgressChartDay],
-    calendar: Calendar
+    calendar: Calendar,
+    today: Date?
 ) -> [ProgressReviewChartPage] {
     guard chartDays.isEmpty == false else {
         return []
@@ -841,7 +834,16 @@ private func makeProgressReviewChartPages(
 
         let weekStart = calendar.startOfDay(for: weekInterval.start)
         if let activeWeekStart = currentWeekStart, activeWeekStart != weekStart {
-            pages.append(ProgressReviewChartPage(days: currentPageDays))
+            pages.append(
+                ProgressReviewChartPage(
+                    days: padReviewChartPageToFullWeek(
+                        currentPageDays: currentPageDays,
+                        weekStart: activeWeekStart,
+                        calendar: calendar,
+                        today: today
+                    )
+                )
+            )
             currentPageDays = [day]
             currentWeekStart = weekStart
             continue
@@ -851,11 +853,58 @@ private func makeProgressReviewChartPages(
         currentWeekStart = weekStart
     }
 
-    if currentPageDays.isEmpty == false {
-        pages.append(ProgressReviewChartPage(days: currentPageDays))
+    if let weekStart = currentWeekStart, currentPageDays.isEmpty == false {
+        pages.append(
+            ProgressReviewChartPage(
+                days: padReviewChartPageToFullWeek(
+                    currentPageDays: currentPageDays,
+                    weekStart: weekStart,
+                    calendar: calendar,
+                    today: today
+                )
+            )
+        )
     }
 
     return pages
+}
+
+private func padReviewChartPageToFullWeek(
+    currentPageDays: [ProgressChartDay],
+    weekStart: Date,
+    calendar: Calendar,
+    today: Date?
+) -> [ProgressChartDay] {
+    let existingByLocalDate = Dictionary(uniqueKeysWithValues: currentPageDays.map { day in
+        (day.localDate, day)
+    })
+
+    return (0 ..< progressDaysPerWeek).map { offset in
+        guard let rawDate = calendar.date(byAdding: .day, value: offset, to: weekStart) else {
+            preconditionFailure("Failed to advance week start by \(offset) days")
+        }
+
+        let date = calendar.startOfDay(for: rawDate)
+        let localDate = progressLocalDateString(date: date, calendar: calendar)
+
+        if let existing = existingByLocalDate[localDate] {
+            return existing
+        }
+
+        let isToday: Bool
+        if let today {
+            isToday = calendar.isDate(date, inSameDayAs: today)
+        } else {
+            isToday = false
+        }
+
+        return ProgressChartDay(
+            date: date,
+            localDate: localDate,
+            reviewCount: 0,
+            isToday: isToday
+        )
+    }
 }
 
 private func progressReviewChartPageDateRange(
@@ -929,15 +978,7 @@ private func progressReviewChartDayLabel(date: Date, calendar: Calendar) -> Stri
 }
 
 private func progressChartBarStyle(day: ProgressChartDay) -> AnyShapeStyle {
-    if day.reviewCount > 0 && day.isToday {
-        return AnyShapeStyle(Color.accentColor)
-    }
-
     if day.reviewCount > 0 {
-        return AnyShapeStyle(Color.accentColor)
-    }
-
-    if day.isToday {
         return AnyShapeStyle(Color.accentColor)
     }
 

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressTypes.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-private let progressDaysPerWeek: Int = 7
+let progressDaysPerWeek: Int = 7
 private let progressStreakWeekCount: Int = 5
 let reviewProgressBadgeOverflowThreshold: Int = 99
 
@@ -779,7 +779,7 @@ private func progressDate(localDate: String, calendar: Calendar) throws -> Date 
     return date
 }
 
-private func progressLocalDateString(date: Date, calendar: Calendar) -> String {
+func progressLocalDateString(date: Date, calendar: Calendar) -> String {
     let components = calendar.dateComponents([.year, .month, .day], from: date)
 
     guard let year = components.year, let month = components.month, let day = components.day else {

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -3659,65 +3659,6 @@
         }
       }
     },
-    "progress.screen.reviews.empty" : {
-      "comment" : "Progress reviews section empty caption",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "لا توجد مراجعات بعد في هذا الأسبوع."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "In dieser Woche gibt es noch keine Wiederholungen."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No reviews yet in this week."
-          }
-        },
-        "es-ES" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todavía no hay repasos en esta semana."
-          }
-        },
-        "es-MX" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todavía no hay repasos en esta semana."
-          }
-        },
-        "hi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "इस सप्ताह अभी तक कोई रिव्यू नहीं है।"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "この週にはまだ復習がありません。"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "На этой неделе пока нет повторений."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "本周还没有复习。"
-          }
-        }
-      }
-    },
     "progress.screen.reviews.next_week" : {
       "comment" : "Accessibility label for the next reviews week button",
       "localizations" : {

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -129,7 +129,6 @@ const arCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "الأسبوع السابق",
     nextWeek: "الأسبوع التالي",
-    emptyWeek: "لا توجد مراجعات بعد في هذا الأسبوع.",
     reviewSchedule: {
       title: "جدول المراجعة",
       totalCards: "إجمالي البطاقات: {{count}}",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -129,7 +129,6 @@ const deCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Vorherige Woche",
     nextWeek: "Nächste Woche",
-    emptyWeek: "In dieser Woche gibt es noch keine Wiederholungen.",
     reviewSchedule: {
       title: "Wiederholungsplan",
       totalCards: "Karten gesamt: {{count}}",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -127,7 +127,6 @@ const enCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Previous week",
     nextWeek: "Next week",
-    emptyWeek: "No reviews yet in this week.",
     reviewSchedule: {
       title: "Review schedule",
       totalCards: "Total cards: {{count}}",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -129,7 +129,6 @@ const esEsCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Semana anterior",
     nextWeek: "Semana siguiente",
-    emptyWeek: "Todavía no hay repasos en esta semana.",
     reviewSchedule: {
       title: "Calendario de repasos",
       totalCards: "Tarjetas totales: {{count}}",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -129,7 +129,6 @@ const esMxCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Semana anterior",
     nextWeek: "Semana siguiente",
-    emptyWeek: "Todavía no hay repasos en esta semana.",
     reviewSchedule: {
       title: "Calendario de repasos",
       totalCards: "Tarjetas totales: {{count}}",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -129,7 +129,6 @@ const hiCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "पिछला सप्ताह",
     nextWeek: "अगला सप्ताह",
-    emptyWeek: "इस सप्ताह अभी तक कोई रिव्यू नहीं है।",
     reviewSchedule: {
       title: "रिव्यू शेड्यूल",
       totalCards: "कुल कार्ड: {{count}}",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -129,7 +129,6 @@ export const jaCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "前の週",
     nextWeek: "次の週",
-    emptyWeek: "この週にはまだ復習がありません。",
     reviewSchedule: {
       title: "復習スケジュール",
       totalCards: "合計カード数: {{count}}",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -129,7 +129,6 @@ export const ruCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Предыдущая неделя",
     nextWeek: "Следующая неделя",
-    emptyWeek: "На этой неделе пока нет повторений.",
     reviewSchedule: {
       title: "Расписание повторений",
       totalCards: "Всего карточек: {{count}}",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -129,7 +129,6 @@ export const zhHansCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "上一周",
     nextWeek: "下一周",
-    emptyWeek: "本周还没有复习。",
     reviewSchedule: {
       title: "复习计划",
       totalCards: "卡片总数：{{count}}",

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -387,7 +387,7 @@ describe("ProgressScreen", () => {
       throw new Error("Progress chart range was not found");
     }
 
-    expect(chartRange.textContent).toBe(createNativeWeekRangeLabel("en", "2026-04-19", "2026-04-21"));
+    expect(chartRange.textContent).toBe(createNativeWeekRangeLabel("en", "2026-04-19", "2026-04-25"));
   });
 
   it("renders the review schedule donut and ordered bucket list", async () => {
@@ -453,7 +453,7 @@ describe("ProgressScreen", () => {
     expect(nextWeekButton.textContent).toBe("<");
   });
 
-  it("shows an empty state instead of a fake y-axis for inactive weeks", async () => {
+  it("renders a full seven-column chart even when the week has no review activity", async () => {
     useProgressSourceMock.mockReturnValue({
       progressSourceState: {
         summary: {
@@ -568,7 +568,9 @@ describe("ProgressScreen", () => {
       previousWeekButton.click();
     });
 
-    expect(container.textContent).toContain("No reviews yet in this week.");
-    expect(container.querySelector("[data-testid='progress-chart-y-label-max']")).toBeNull();
+    expect(container.textContent).not.toContain("No reviews yet in this week.");
+    expect(container.querySelector("[data-testid='progress-chart-y-label-max']")).not.toBeNull();
+    const inactiveWeekBars = container.querySelectorAll("[data-testid^='progress-chart-bar-']");
+    expect(inactiveWeekBars).toHaveLength(7);
   });
 });

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -53,7 +53,6 @@ type ChartPage = Readonly<{
   endDate: string;
   startLocalDate: string;
   upperBound: number;
-  hasReviewActivity: boolean;
 }>;
 type ReviewScheduleBucketView = Readonly<{
   key: ProgressReviewScheduleBucketKey;
@@ -228,8 +227,25 @@ function buildChartPage(
     endDate: dailyReviews[dailyReviews.length - 1]?.date ?? "",
     startLocalDate: dailyReviews[0]?.date ?? "",
     upperBound,
-    hasReviewActivity: dailyReviews.some((day) => day.reviewCount > 0),
   };
+}
+
+function padPageDaysToFullWeek(
+  pageDays: ReadonlyArray<DailyReview>,
+  weekStart: string,
+): ReadonlyArray<DailyReview> {
+  const reviewCounts = createDailyReviewCountMap(pageDays);
+  const fullWeek: Array<DailyReview> = [];
+
+  for (let dayOffset = 0; dayOffset < streakWeekLength; dayOffset += 1) {
+    const date = shiftLocalDate(weekStart, dayOffset);
+    fullWeek.push({
+      date,
+      reviewCount: reviewCounts.get(date) ?? 0,
+    });
+  }
+
+  return fullWeek;
 }
 
 function buildChartPages(
@@ -250,7 +266,7 @@ function buildChartPages(
     const weekStart = getStartOfWeek(day.date, weekContext);
 
     if (currentWeekStart !== null && currentWeekStart !== weekStart) {
-      chartPages.push(buildChartPage(currentPageDays, today, formatDate));
+      chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
       currentPageDays = [day];
       currentWeekStart = weekStart;
       continue;
@@ -260,8 +276,8 @@ function buildChartPages(
     currentWeekStart = weekStart;
   }
 
-  if (currentPageDays.length > 0) {
-    chartPages.push(buildChartPage(currentPageDays, today, formatDate));
+  if (currentPageDays.length > 0 && currentWeekStart !== null) {
+    chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
   }
 
   return chartPages;
@@ -644,9 +660,7 @@ export function ProgressScreen(): ReactElement {
                 ) : null}
               </div>
 
-              {visiblePage !== null && visiblePage.hasReviewActivity === false ? (
-                <p className="progress-chart-empty">{t("progressScreen.emptyWeek")}</p>
-              ) : (
+              {visiblePage !== null && (
                 <div className="progress-chart-shell">
                   <div className="progress-chart-y-axis" aria-hidden="true">
                     {chartGuideLabels.map((label, index) => (
@@ -667,11 +681,8 @@ export function ProgressScreen(): ReactElement {
                       ))}
                     </div>
 
-                    <div
-                      className="progress-chart-columns"
-                      style={visiblePage === null ? undefined : { gridTemplateColumns: `repeat(${visiblePage.days.length}, minmax(0, 1fr))` }}
-                    >
-                      {(visiblePage?.days ?? []).map((day) => {
+                    <div className="progress-chart-columns">
+                      {visiblePage.days.map((day) => {
                         const columnClassName = [
                           "progress-chart-column",
                           day.isToday && day.reviewCount === 0 ? "progress-chart-column-today" : "",

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -245,6 +245,7 @@
 .progress-chart-columns {
   position: relative;
   display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 10px;
   align-items: end;
   min-height: 248px;
@@ -328,13 +329,6 @@
 .progress-chart-column-today .progress-chart-weekday {
   color: var(--accent);
   font-weight: 700;
-}
-
-.progress-chart-empty {
-  margin: 0;
-  color: var(--text-tertiary);
-  font-size: 13px;
-  line-height: 1.3;
 }
 
 .progress-review-schedule {


### PR DESCRIPTION
## Summary

- Pads each weekly Progress chart page to exactly 7 columns across web, iOS, and Android. Days without reviews render as zero-bar slots instead of collapsing the chart width.
- Removes the "No reviews yet in this week." caption and its localization keys from all three clients.
- Adds a today-empty column highlight on iOS (RectangleMark) to match the existing column-tint UX on web and Android. Also unifies the iOS days-per-week constant and trims dead branches in progressChartBarStyle.

## Test plan

- [x] Web: tsc -b clean; vitest 7/8 (the 1 failure on the donut/schedule test pre-exists on main).
- [x] Android: ./gradlew :feature:progress:compileDebugKotlin :feature:progress:testDebugUnitTest — BUILD SUCCESSFUL with no new warnings.
- [ ] iOS: spot-check on a simulator that the all-zero current week renders the seven-column chart with the today column tinted (no Swift toolchain in the build environment that produced this PR).
- [ ] Manual: navigate Progress on each client; confirm partial-current-week shows the missing days as empty columns and that no "no reviews this week" caption appears anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)