### PR TITLE
Exclude @example.com users from reviewer-activity aggregations

### DIFF
--- a/apps/admin/src/reports/reviewEventsByDate/query.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/query.ts
@@ -277,6 +277,14 @@ export function buildReviewEventsByDateDefaultRangeSql(): string {
   ].join("\n");
 }
 
+// Per-user breakdown for the admin "Review events by date" report (chart + table).
+// The user-identity filters here (the `actor_kind` / `platform` allowlist and the
+// `@example.com` email exclusion) are the same rules encoded in
+// `clientInstallationActivityWhereSqlFragments` and `exampleComEmailExclusionSqlFragments`
+// in `apps/backend/src/globalMetrics/reporting.ts`, which back the public
+// `/v1/global/snapshot` endpoint and the scheduled snapshot Lambda. This admin query
+// lives in a separate package, so the rules are intentionally restated here. If any
+// rule changes, update both files.
 export function buildReviewEventsByDateSql(from: string, to: string): string {
   assertValidDateRange({ from, to }, "report");
 
@@ -300,6 +308,10 @@ export function buildReviewEventsByDateSql(from: string, to: string): string {
     "  )",
     "  AND workspace_replicas.actor_kind = 'client_installation'",
     "  AND workspace_replicas.platform IN ('web', 'android', 'ios')",
+    "  AND (",
+    "    user_settings.email IS NULL",
+    "    OR LOWER(btrim(user_settings.email)) NOT LIKE '%@example.com'",
+    "  )",
     "GROUP BY",
     "  (review_events.reviewed_at_server AT TIME ZONE 'UTC')::date,",
     "  workspace_replicas.user_id,",

--- a/apps/backend/src/globalMetrics/reporting.ts
+++ b/apps/backend/src/globalMetrics/reporting.ts
@@ -9,6 +9,40 @@ import {
   type GlobalMetricsSnapshotTotalsRow,
 } from "./snapshot";
 
+// The three SQL builders below back the public anonymized endpoint
+// (`apps/backend/src/routes/globalSnapshot.ts`) and the scheduled snapshot Lambda
+// (`apps/backend/src/lambda-global-metrics-snapshot.ts`).
+//
+// The two fragment constants below are the canonical encoding of the user-identity
+// filters shared by those three queries. The same rules are restated in the admin
+// per-user query at `apps/admin/src/reports/reviewEventsByDate/query.ts`
+// (`buildReviewEventsByDateSql`), which lives in a separate package. If any rule
+// changes, update both files.
+
+// WHERE-fragment that restricts review activity to real client-app installations on
+// supported user-facing platforms (excludes system actors and the 'system' platform).
+const clientInstallationActivityWhereSqlFragments = [
+  "  AND workspace_replicas.actor_kind = 'client_installation'",
+  "  AND workspace_replicas.platform IN ('web', 'android', 'ios')",
+] as const;
+
+// SQL fragments that exclude users whose known email ends with `@example.com`.
+// `joinFragments` and `whereFragments` MUST be spread together into the same query:
+// the WHERE fragment references `user_settings.email`, which is only in scope after
+// the JOIN fragment brings `org.user_settings` in.
+const exampleComEmailExclusionSqlFragments = {
+  joinFragments: [
+    "LEFT JOIN org.user_settings AS user_settings",
+    "  ON user_settings.user_id = workspace_replicas.user_id",
+  ],
+  whereFragments: [
+    "  AND (",
+    "    user_settings.email IS NULL",
+    "    OR LOWER(btrim(user_settings.email)) NOT LIKE '%@example.com'",
+    "  )",
+  ],
+} as const;
+
 type GlobalMetricsSnapshotHistoricalStartDateRow = Readonly<{
   historical_start_date: string | null;
 }>;
@@ -20,9 +54,10 @@ function buildGlobalMetricsSnapshotHistoricalStartDateSql(): string {
     "FROM content.review_events AS review_events",
     "INNER JOIN sync.workspace_replicas AS workspace_replicas",
     "  ON workspace_replicas.replica_id = review_events.replica_id",
+    ...exampleComEmailExclusionSqlFragments.joinFragments,
     "WHERE review_events.reviewed_at_server < $1::timestamptz",
-    "  AND workspace_replicas.actor_kind = 'client_installation'",
-    "  AND workspace_replicas.platform IN ('web', 'android', 'ios')",
+    ...clientInstallationActivityWhereSqlFragments,
+    ...exampleComEmailExclusionSqlFragments.whereFragments,
   ].join(" ");
 }
 
@@ -37,9 +72,10 @@ function buildGlobalMetricsSnapshotTotalsSql(): string {
     "FROM content.review_events AS review_events",
     "INNER JOIN sync.workspace_replicas AS workspace_replicas",
     "  ON workspace_replicas.replica_id = review_events.replica_id",
+    ...exampleComEmailExclusionSqlFragments.joinFragments,
     "WHERE review_events.reviewed_at_server < $1::timestamptz",
-    "  AND workspace_replicas.actor_kind = 'client_installation'",
-    "  AND workspace_replicas.platform IN ('web', 'android', 'ios')",
+    ...clientInstallationActivityWhereSqlFragments,
+    ...exampleComEmailExclusionSqlFragments.whereFragments,
   ].join(" ");
 }
 
@@ -55,10 +91,11 @@ function buildGlobalMetricsSnapshotDaysSql(): string {
     "FROM content.review_events AS review_events",
     "INNER JOIN sync.workspace_replicas AS workspace_replicas",
     "  ON workspace_replicas.replica_id = review_events.replica_id",
+    ...exampleComEmailExclusionSqlFragments.joinFragments,
     "WHERE review_events.reviewed_at_server >= $1::timestamptz",
     "  AND review_events.reviewed_at_server < $2::timestamptz",
-    "  AND workspace_replicas.actor_kind = 'client_installation'",
-    "  AND workspace_replicas.platform IN ('web', 'android', 'ios')",
+    ...clientInstallationActivityWhereSqlFragments,
+    ...exampleComEmailExclusionSqlFragments.whereFragments,
     "GROUP BY (review_events.reviewed_at_server AT TIME ZONE 'UTC')::date",
     "ORDER BY review_date ASC",
   ].join(" ");


### PR DESCRIPTION
## Summary
- Excludes users whose known email ends with `@example.com` from the admin "Daily unique users with at least 1 review event" chart and the table beneath it.
- Same exclusion applied to the public anonymized `GET /v1/global/snapshot` endpoint and the scheduled snapshot Lambda (shared SQL).
- Encodes the rule as two canonical fragments in `apps/backend/src/globalMetrics/reporting.ts` (`clientInstallationActivityWhereSqlFragments`, `exampleComEmailExclusionSqlFragments`); admin per-user query in a separate package restates the rule with a cross-reference comment.
- Filter is NULL-safe, case-insensitive, and trim-tolerant: `email IS NULL OR LOWER(btrim(email)) NOT LIKE '%@example.com'`.

Backward-compatible: snapshot JSON shape unchanged; only the values (counts) shift down by the excluded users.

## Test plan
- [x] `tsc --noEmit` (backend) and `tsc -b` (admin) clean.
- [x] All 13 tests in `apps/backend/src/globalMetrics/*` and `apps/backend/src/routes/globalSnapshot.test.ts` pass.
- [ ] After merge: open admin "Review events by date" report, confirm rows with `*@example.com` no longer appear and "Daily unique users" count drops accordingly.
- [ ] After next snapshot Lambda run: compare `s3://.../v1/global-snapshot.json` `uniqueReviewingUsers` against admin numbers — should match.
- [ ] `GET https://api.flashcards-open-source-app.com/v1/global/snapshot` totals/days consistent with admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)