### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -8,7 +8,7 @@
       "name": "flashcards-auth",
       "version": "1.2.2",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1041.0",
+        "@aws-sdk/client-secrets-manager": "^3.1042.0",
         "@hono/node-server": "^2.0.1",
         "aws-jwt-verify": "^5.1.1",
         "hono": "^4.12.16",
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1041.0.tgz",
-      "integrity": "sha512-dr4AbZ5hIDyecKHWyYy0LhK3h6q/jd6QWem46wyHulJ6IBRPENlpB7iXo7KKFWkgKSweCEqjHVB5W+3WB4JiYw==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1042.0.tgz",
+      "integrity": "sha512-doHP17OwqhcuW3e7fKkFfF4rDFM0hY8IVIwqwvBQRLk6IsZXzpl/YRhQWuIiy9O7BSZgzKKE+XytdElsTd9PWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1041.0",
+    "@aws-sdk/client-secrets-manager": "^3.1042.0",
     "@hono/node-server": "^2.0.1",
     "aws-jwt-verify": "^5.1.1",
     "hono": "^4.12.16",

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -8,20 +8,20 @@
       "name": "flashcards-open-source-app-backend",
       "version": "1.2.2",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.1041.0",
-        "@aws-sdk/client-lambda": "^3.1041.0",
-        "@aws-sdk/client-s3": "^3.1041.0",
-        "@aws-sdk/client-secrets-manager": "^3.1041.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.1042.0",
+        "@aws-sdk/client-lambda": "^3.1042.0",
+        "@aws-sdk/client-s3": "^3.1042.0",
+        "@aws-sdk/client-secrets-manager": "^3.1042.0",
         "@hono/node-server": "^2.0.1",
-        "@langfuse/openai": "^5.2.0",
-        "@langfuse/otel": "^5.2.0",
-        "@langfuse/tracing": "^5.2.0",
+        "@langfuse/openai": "^5.3.0",
+        "@langfuse/otel": "^5.3.0",
+        "@langfuse/tracing": "^5.3.0",
         "@opentelemetry/sdk-node": "^0.216.0",
         "aws-jwt-verify": "^5.1.1",
         "hono": "^4.12.16",
-        "openai": "^6.35.0",
+        "openai": "^6.36.0",
         "pg": "^8.20.0",
-        "zod": "^4.4.2"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.161",
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1041.0.tgz",
-      "integrity": "sha512-rv8Ogf84/N6TSYeAp3IdU6naYU+z+jZ1XedvD/cS8yrgmb4OyU/fBJjQJcJTfjFIL+OYdne2kVfUd8+OrnFsbg==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1042.0.tgz",
+      "integrity": "sha512-etXFv1GDbK4p9hEHG99F5/gap/V9UDcuH5zpKlUkC0yRXzdfDCgUe8qiIQRKPv/ef6/zRAm1zsqR4EUhAI0IvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1041.0.tgz",
-      "integrity": "sha512-J8zz0t+HPLwJblG4PdVlAJ93DxtMkYHHfD+lpTvmzQ6LBBfexbC+d31l8DcmUrbV2dK8dCreldjYlXSe/X6sQA==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1042.0.tgz",
+      "integrity": "sha512-g2NJMMGjQ18LvPapz75s8UzRaxJ2P5bF2Y025/eyVuBtzdCuW6XYoJxP29Tp39BzYgFb+HEtwATyZss/V6KdZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
-      "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
+      "integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1041.0.tgz",
-      "integrity": "sha512-dr4AbZ5hIDyecKHWyYy0LhK3h6q/jd6QWem46wyHulJ6IBRPENlpB7iXo7KKFWkgKSweCEqjHVB5W+3WB4JiYw==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1042.0.tgz",
+      "integrity": "sha512-doHP17OwqhcuW3e7fKkFfF4rDFM0hY8IVIwqwvBQRLk6IsZXzpl/YRhQWuIiy9O7BSZgzKKE+XytdElsTd9PWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1539,31 +1539,31 @@
       }
     },
     "node_modules/@langfuse/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-zUD0vdrFN/LsufBfR6oPWCT4KIb4zeH8sZtF1YjKVTrPjR+WPWJJb9TI20PFByHo4XFJoLUXdTJNfMWtUx0iEg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.3.0.tgz",
+      "integrity": "sha512-9JnDpSMBxsy6Mw5YTc0vERpAYJG5jJKxLtgv1mgA4yrNGWOtqV6ShkSSb/mWE7CeyKFnIFM0lRJpqblrMaRfQA==",
       "license": "MIT",
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@langfuse/openai": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@langfuse/openai/-/openai-5.2.0.tgz",
-      "integrity": "sha512-rRcgqlarJ8GVn/kZUBF/9DunMo5CY1NXlqn72UvhV1rcuWLnYQyqAm7u1xd2+6pG2ezVliCp25sfsMYGTY6FwA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/openai/-/openai-5.3.0.tgz",
+      "integrity": "sha512-5I6ZiiSZ0a8jRhEZMY0Q/yK6LqYYSoMiuJl6momOBwMZW7s3wVEopActhQLfBBesPXDEaFm6wnqf9f6b4ohPJg==",
       "license": "MIT",
       "dependencies": {
-        "@langfuse/core": "^5.2.0",
-        "@langfuse/tracing": "^5.2.0"
+        "@langfuse/core": "^5.3.0",
+        "@langfuse/tracing": "^5.3.0"
       }
     },
     "node_modules/@langfuse/otel": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.2.0.tgz",
-      "integrity": "sha512-U2ArG13tjY7Ybl5K8QE91Igpg2HXoBHXQNqmnw9JNZYatSV/ABgLS6SlUGQS/i4qbdQT+9k6lK3GUf99D+6B4w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/otel/-/otel-5.3.0.tgz",
+      "integrity": "sha512-CJUz3oCD0RMbe+1cPxnuLD/JhsUnLt02DhLP6ZXzhFoi07rHsf8T5oUyCwLRNRH4x2tl87u3aTiOcBJqSK6/fQ==",
       "license": "MIT",
       "dependencies": {
-        "@langfuse/core": "^5.2.0"
+        "@langfuse/core": "^5.3.0"
       },
       "engines": {
         "node": ">=20"
@@ -1576,12 +1576,12 @@
       }
     },
     "node_modules/@langfuse/tracing": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.2.0.tgz",
-      "integrity": "sha512-lMNkcwujfsEAHFiw9uJSTGd+90BwdeR1BVP3c/bANujkIfZ/nWhkTSO9IlRU5Gs4dMLAFqaPGEMVZaIgEPLquw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.3.0.tgz",
+      "integrity": "sha512-Fz6da1O+OqrwG69nF1UAjdaZrYUfR+h+DyVjXJLTNhTrOCqx/jTiIVAP5A32rB07+l4ESgzfO4K222A6cdPW1w==",
       "license": "MIT",
       "dependencies": {
-        "@langfuse/core": "^5.2.0"
+        "@langfuse/core": "^5.3.0"
       },
       "engines": {
         "node": ">=20"
@@ -3230,9 +3230,9 @@
       "license": "MIT"
     },
     "node_modules/openai": {
-      "version": "6.35.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
-      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "version": "6.36.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.36.0.tgz",
+      "integrity": "sha512-Has2YbIusMq9wQEierFsgf9c783dy1y9arX459LmphNacEkkM5yxi2RIyXP0LmkOroQyW19iTwALHL8Yf26UKA==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -3620,9 +3620,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
-      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,20 +10,20 @@
     "test": "npm run bundle --prefix ../../api && node scripts/run-tests.mjs"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.1041.0",
-    "@aws-sdk/client-lambda": "^3.1041.0",
-    "@aws-sdk/client-s3": "^3.1041.0",
-    "@aws-sdk/client-secrets-manager": "^3.1041.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1042.0",
+    "@aws-sdk/client-lambda": "^3.1042.0",
+    "@aws-sdk/client-s3": "^3.1042.0",
+    "@aws-sdk/client-secrets-manager": "^3.1042.0",
     "@hono/node-server": "^2.0.1",
-    "@langfuse/openai": "^5.2.0",
-    "@langfuse/otel": "^5.2.0",
-    "@langfuse/tracing": "^5.2.0",
+    "@langfuse/openai": "^5.3.0",
+    "@langfuse/otel": "^5.3.0",
+    "@langfuse/tracing": "^5.3.0",
     "@opentelemetry/sdk-node": "^0.216.0",
     "aws-jwt-verify": "^5.1.1",
     "hono": "^4.12.16",
-    "openai": "^6.35.0",
+    "openai": "^6.36.0",
     "pg": "^8.20.0",
-    "zod": "^4.4.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.161",

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.2.2",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.0",
-        "@aws-sdk/client-cloudwatch": "^3.1041.0",
-        "@aws-sdk/client-s3": "^3.1041.0",
+        "@aws-sdk/client-cloudwatch": "^3.1042.0",
+        "@aws-sdk/client-s3": "^3.1042.0",
         "aws-cdk-lib": "^2.252.0",
         "constructs": "^10.6.0"
       },
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1041.0.tgz",
-      "integrity": "sha512-xbV1kuJRmmBg4j/ldbJDJjeRwhflR1zwGGOYDwlZa8R7UH8+HkmZJA99Cc+JZpqXotlwC46438VPrHA56b6DCQ==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1042.0.tgz",
+      "integrity": "sha512-rGvviVCfiOkS6ACwcJJsMDEc8zI7Q5kD/jUc33Vo/qdTMoSVJzpHlTJCMwtotOkkhEYVeoNsYn7U8PmNrY+UhQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1041.0.tgz",
-      "integrity": "sha512-sQV14bIqslnBHuSlLMD+fc3pH+ajop6vnrFlJ4wM4JDqcYwVik4O+9srnZUrkesFw5y+CN0GfOQ06CAgtC4mjQ==",
+      "version": "3.1042.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
+      "integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "^5.0.0",
-    "@aws-sdk/client-cloudwatch": "^3.1041.0",
-    "@aws-sdk/client-s3": "^3.1041.0",
+    "@aws-sdk/client-cloudwatch": "^3.1042.0",
+    "@aws-sdk/client-s3": "^3.1042.0",
     "aws-cdk-lib": "^2.252.0",
     "constructs": "^10.6.0"
   },


### PR DESCRIPTION
## Summary

Updates the latest dependency drift found in the scheduled audit:

- Bumps AWS SDK clients from 3.1041.0 to 3.1042.0 in auth, backend, and infra.
- Bumps backend Langfuse packages from 5.2.0 to 5.3.0.
- Bumps backend `openai` from 6.35.0 to 6.36.0.
- Bumps backend `zod` from 4.4.2 to 4.4.3.

## Validation

Ran under Node 24.15.0:

- `npm ci --prefix api`
- `npm ci --prefix apps/auth`
- `npm ci --prefix apps/backend`
- `npm ci --prefix infra/aws`
- `npm run build --prefix apps/auth`
- `npm run test --prefix apps/auth`
- `npm run lint --prefix apps/backend`
- `npm run build --prefix apps/backend`
- `npm run test --prefix apps/backend`
- `npm run build --prefix infra/aws`
- `npm run test --prefix infra/aws`

Known audit leftovers remain unchanged: latest-stable `@redocly/cli` transitive advisories in `api`, and latest-stable `@aws-crypto/client-node` transitive `uuid` advisory in `infra/aws`.