### PR TITLE
Add app icon badge when no review today on iOS and Android

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/NotificationTapSmokeTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/NotificationTapSmokeTestSupport.kt
@@ -74,7 +74,8 @@ internal fun LiveSmokeContext.postReviewReminderNotification(
     val notificationId = showReviewReminderNotification(
         context = context,
         frontText = frontText,
-        requestId = requestId
+        requestId = requestId,
+        showAppIconBadge = true
     )
     waitForNotificationCondition(
         timeoutMillis = externalUiTimeoutMillis,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsWorkspaceNavGraph.kt
@@ -108,6 +108,9 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
                             trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
                             nowMillis = System.currentTimeMillis()
                         )
+                    },
+                    onAppIconBadgeDisabled = {
+                        appGraph.reviewNotificationsManager.clearDeliveredReviewReminderNotifications()
                     }
                 )
             )
@@ -121,6 +124,7 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
                 onUpdateInactivityWindowStart = reviewNotificationsViewModel::updateInactivityWindowStart,
                 onUpdateInactivityWindowEnd = reviewNotificationsViewModel::updateInactivityWindowEnd,
                 onUpdateIdleMinutes = reviewNotificationsViewModel::updateIdleMinutes,
+                onUpdateShowAppIconBadge = reviewNotificationsViewModel::updateShowAppIconBadge,
                 onUpdateStrictRemindersEnabled = reviewNotificationsViewModel::updateStrictRemindersEnabled,
                 onMarkSystemPermissionRequested = reviewNotificationsViewModel::markSystemPermissionRequested,
                 onPermissionGranted = {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/AppNotificationTap.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/AppNotificationTap.kt
@@ -35,7 +35,7 @@ data class AppNotificationTapFallback(
     val details: String?
 )
 
-private const val appNotificationLogTag: String = "FlashcardsAppNotification"
+internal const val appNotificationLogTag: String = "FlashcardsAppNotification"
 
 fun logAppNotificationTapFallback(fallback: AppNotificationTapFallback) {
     val message = buildAppNotificationTapLogMessage(fallback = fallback)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationWorker.kt
@@ -1,8 +1,14 @@
 package com.flashcardsopensourceapp.app.notifications
 
 import android.content.Context
+import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.flashcardsopensourceapp.app.FlashcardsApplication
+import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
+import com.flashcardsopensourceapp.data.local.notifications.SharedPreferencesReviewNotificationsStore
+import java.time.Instant
+import java.time.ZoneId
 
 class ReviewNotificationWorker(
     appContext: Context,
@@ -17,12 +23,55 @@ class ReviewNotificationWorker(
             ?: return Result.failure()
         val requestId = inputData.getString(reviewNotificationRequestIdDataKey)
             ?: return Result.failure()
+        val workspaceId = inputData.getString(reviewNotificationWorkspaceIdDataKey)
+            ?: return Result.failure()
+
+        // Read live so a toggle-off after schedule time wins immediately, even if a
+        // worker is already mid-flight. Combined with the today-review check below,
+        // this is the single source of truth for the badge decision.
+        val store = resolveReviewNotificationsStore()
+        val liveShowAppIconBadge = store.loadSettings(workspaceId = workspaceId).showAppIconBadge
+        val showAppIconBadge = liveShowAppIconBadge && hasReviewedTodayLocally().not()
 
         showReviewReminderNotification(
             context = applicationContext,
             frontText = frontText,
-            requestId = requestId
+            requestId = requestId,
+            showAppIconBadge = showAppIconBadge
         )
         return Result.success()
+    }
+
+    private fun resolveReviewNotificationsStore(): ReviewNotificationsStore {
+        val appGraphStore = (applicationContext as? FlashcardsApplication)
+            ?.appGraphOrNull
+            ?.reviewNotificationsStore
+        if (appGraphStore != null) {
+            return appGraphStore
+        }
+        // Cold-start fallback: the worker can fire before Application.onCreate has published the graph.
+        return SharedPreferencesReviewNotificationsStore(context = applicationContext)
+    }
+
+    private suspend fun hasReviewedTodayLocally(): Boolean {
+        val app = applicationContext as? FlashcardsApplication ?: return false
+        val database = app.appGraphOrNull?.database ?: return false
+        val zoneId = ZoneId.systemDefault()
+        val nowMillis = System.currentTimeMillis()
+        val today = Instant.ofEpochMilli(nowMillis).atZone(zoneId).toLocalDate()
+        val startMillis = today.atStartOfDay(zoneId).toInstant().toEpochMilli()
+        val endMillis = today.plusDays(1).atStartOfDay(zoneId).toInstant().toEpochMilli()
+        return runCatching {
+            database.reviewLogDao().hasReviewLogsBetween(
+                startMillis = startMillis,
+                endMillis = endMillis
+            )
+        }.onFailure { error ->
+            Log.e(
+                appNotificationLogTag,
+                "hasReviewedTodayLocally: review log lookup failed; defaulting to false",
+                error
+            )
+        }.getOrElse { false }
     }
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicLong
 const val reviewNotificationChannelId: String = "review-reminders"
 const val reviewNotificationFrontTextDataKey: String = "frontText"
 const val reviewNotificationRequestIdDataKey: String = "requestId"
+const val reviewNotificationWorkspaceIdDataKey: String = "workspaceId"
 const val reviewNotificationWorkTag: String = "review-notification"
 
 class ReviewNotificationsManager(
@@ -245,8 +246,11 @@ class ReviewNotificationsManager(
      * Review reminders are identified by the dedicated review channel and the
      * `review-notification::` tag namespace. Legacy reminders without a tag are
      * also removed as long as they are still posted on the review channel.
+     *
+     * Public so callers can drop the launcher icon badge synchronously, e.g. when
+     * the user disables the "Show app icon badge" toggle.
      */
-    private fun clearDeliveredReviewReminderNotifications() {
+    fun clearDeliveredReviewReminderNotifications() {
         val notificationManager = context.getSystemService(NotificationManager::class.java)
         val deliveredNotifications = notificationManager.activeNotifications.filter { notification ->
             isReviewReminderNotification(notification = notification)
@@ -280,11 +284,15 @@ class ReviewNotificationsManager(
         return tag.startsWith(reviewReminderNotificationTagPrefix)
     }
 
-    private fun enqueuePayload(payload: ScheduledReviewNotificationPayload, nowMillis: Long) {
+    private fun enqueuePayload(
+        payload: ScheduledReviewNotificationPayload,
+        nowMillis: Long
+    ) {
         val delayMillis = maxOf(1L, payload.scheduledAtMillis - nowMillis)
         val inputData = Data.Builder()
             .putString(reviewNotificationFrontTextDataKey, payload.frontText)
             .putString(reviewNotificationRequestIdDataKey, payload.requestId)
+            .putString(reviewNotificationWorkspaceIdDataKey, payload.workspaceId)
             .build()
         val request = OneTimeWorkRequestBuilder<ReviewNotificationWorker>()
             .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewReminderNotificationContent.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewReminderNotificationContent.kt
@@ -35,7 +35,8 @@ data class ReviewReminderNotificationContent(
 fun buildReviewReminderNotificationContent(
     context: Context,
     frontText: String,
-    requestId: String
+    requestId: String,
+    showAppIconBadge: Boolean
 ): ReviewReminderNotificationContent {
     ensureReviewNotificationChannel(context = context)
     val pendingIntent = createReviewReminderPendingIntent(
@@ -48,7 +49,7 @@ fun buildReviewReminderNotificationContent(
         text = frontText,
         locale = locale
     )
-    val notification = NotificationCompat.Builder(context, reviewNotificationChannelId)
+    val builder = NotificationCompat.Builder(context, reviewNotificationChannelId)
         .setSmallIcon(android.R.drawable.ic_dialog_info)
         .setContentTitle(appName)
         .setContentText(bidiSafeFrontText)
@@ -56,7 +57,13 @@ fun buildReviewReminderNotificationContent(
         .setContentIntent(pendingIntent)
         .setAutoCancel(true)
         .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-        .build()
+    if (showAppIconBadge) {
+        // Launcher support varies by OEM (Pixel/Samsung honor this; some do not).
+        // Best-effort red dot or "1" on the app icon while the user has not reviewed today.
+        builder.setNumber(1)
+        builder.setBadgeIconType(NotificationCompat.BADGE_ICON_SMALL)
+    }
+    val notification = builder.build()
 
     return ReviewReminderNotificationContent(
         notificationTag = reviewReminderNotificationTag(requestId = requestId),
@@ -71,7 +78,8 @@ fun buildReviewReminderNotificationContent(
 fun showReviewReminderNotification(
     context: Context,
     frontText: String,
-    requestId: String
+    requestId: String,
+    showAppIconBadge: Boolean
 ): Int {
     if (hasNotificationPermission(context = context).not()) {
         throw SecurityException("POST_NOTIFICATIONS is not granted for package '${context.packageName}'.")
@@ -80,7 +88,8 @@ fun showReviewReminderNotification(
     val notificationContent = buildReviewReminderNotificationContent(
         context = context,
         frontText = frontText,
-        requestId = requestId
+        requestId = requestId,
+        showAppIconBadge = showAppIconBadge
     )
     notifyReviewReminder(
         context = context,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsReconcileTrigger.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsReconcileTrigger.kt
@@ -3,7 +3,10 @@ package com.flashcardsopensourceapp.data.local.notifications
 /**
  * Identifies why review reminders are being reconciled.
  *
- * Only [APP_ACTIVE] clears already-delivered reminders from the notification shade.
+ * [APP_ACTIVE] clears already-delivered reminders because the user has returned
+ * to the app and the previous reminders have served their purpose. [REVIEW_RECORDED]
+ * also clears them because the moment a card is reviewed, any "review reminder"
+ * notification (and the launcher icon badge it carries) is no longer relevant.
  * The remaining triggers only reconcile pending work and scheduled payloads.
  */
 enum class ReviewNotificationsReconcileTrigger(
@@ -13,7 +16,7 @@ enum class ReviewNotificationsReconcileTrigger(
     APP_BACKGROUND(shouldClearDeliveredReviewNotifications = false),
     SETTINGS_CHANGED(shouldClearDeliveredReviewNotifications = false),
     PERMISSION_CHANGED(shouldClearDeliveredReviewNotifications = false),
-    REVIEW_RECORDED(shouldClearDeliveredReviewNotifications = false),
+    REVIEW_RECORDED(shouldClearDeliveredReviewNotifications = true),
     FILTER_CHANGED(shouldClearDeliveredReviewNotifications = false),
     WORKSPACE_CHANGED(shouldClearDeliveredReviewNotifications = false)
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
@@ -60,7 +60,8 @@ data class ReviewNotificationsSettings(
     val isEnabled: Boolean,
     val selectedMode: ReviewNotificationMode,
     val daily: DailyReviewNotificationsSettings,
-    val inactivity: InactivityReviewNotificationsSettings
+    val inactivity: InactivityReviewNotificationsSettings,
+    val showAppIconBadge: Boolean
 )
 
 data class NotificationPermissionPromptState(
@@ -105,7 +106,8 @@ fun defaultReviewNotificationsSettings(): ReviewNotificationsSettings {
             windowEndHour = defaultInactivityReminderWindowEndHour,
             windowEndMinute = defaultInactivityReminderWindowEndMinute,
             idleMinutes = 120
-        )
+        ),
+        showAppIconBadge = true
     )
 }
 
@@ -702,6 +704,7 @@ private fun encodeSettings(settings: ReviewNotificationsSettings): String {
                 put("idleMinutes", settings.inactivity.idleMinutes)
             }
         )
+        put("showAppIconBadge", settings.showAppIconBadge)
     }.toString()
 }
 
@@ -733,7 +736,10 @@ private fun decodeSettings(rawValue: String): ReviewNotificationsSettings {
             windowEndHour = inactivityPayload.getInt("windowEndHour"),
             windowEndMinute = inactivityPayload.getInt("windowEndMinute"),
             idleMinutes = inactivityPayload.getInt("idleMinutes")
-        )
+        ),
+        // Missing key in stored payloads written before this field existed defaults to ON,
+        // so users get the badge automatically on upgrade.
+        showAppIconBadge = payload.optBoolean("showAppIconBadge", true)
     )
 }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
@@ -46,6 +46,7 @@ fun ReviewNotificationsRoute(
     onUpdateInactivityWindowStart: (Int, Int) -> Unit,
     onUpdateInactivityWindowEnd: (Int, Int) -> Unit,
     onUpdateIdleMinutes: (Int) -> Unit,
+    onUpdateShowAppIconBadge: (Boolean) -> Unit,
     onUpdateStrictRemindersEnabled: (Boolean) -> Unit,
     onMarkSystemPermissionRequested: () -> Unit,
     onPermissionGranted: () -> Unit,
@@ -163,6 +164,25 @@ fun ReviewNotificationsRoute(
                             Switch(
                                 checked = uiState.settings.isEnabled,
                                 onCheckedChange = onUpdateEnabled
+                            )
+                        }
+                    )
+                }
+            }
+
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    ListItem(
+                        headlineContent = {
+                            Text(stringResource(R.string.settings_notifications_show_app_icon_badge_title))
+                        },
+                        supportingContent = {
+                            Text(stringResource(R.string.settings_notifications_show_app_icon_badge_body))
+                        },
+                        trailingContent = {
+                            Switch(
+                                checked = uiState.settings.showAppIconBadge,
+                                onCheckedChange = onUpdateShowAppIconBadge
                             )
                         }
                     )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsViewModel.kt
@@ -24,7 +24,8 @@ class ReviewNotificationsViewModel(
     private val reviewNotificationsStore: ReviewNotificationsStore,
     private val strictRemindersStore: StrictRemindersStore,
     private val onReviewSettingsChanged: () -> Unit,
-    private val onStrictRemindersSettingsChanged: () -> Unit
+    private val onStrictRemindersSettingsChanged: () -> Unit,
+    private val onAppIconBadgeDisabled: () -> Unit
 ) : ViewModel() {
     private val refreshVersion = MutableStateFlow(value = 0)
 
@@ -103,6 +104,17 @@ class ReviewNotificationsViewModel(
         }
     }
 
+    fun updateShowAppIconBadge(value: Boolean) {
+        updateSettings { settings ->
+            settings.copy(showAppIconBadge = value)
+        }
+        // When the toggle is turned off, drop any badge currently shown so the
+        // user gets immediate feedback rather than waiting for a future event.
+        if (value.not()) {
+            onAppIconBadgeDisabled()
+        }
+    }
+
     fun updateStrictRemindersEnabled(isEnabled: Boolean) {
         val nextSettings = StrictRemindersSettings(isEnabled = isEnabled)
         strictRemindersStore.saveStrictRemindersSettings(settings = nextSettings)
@@ -136,7 +148,8 @@ fun createReviewNotificationsViewModelFactory(
     reviewNotificationsStore: ReviewNotificationsStore,
     strictRemindersStore: StrictRemindersStore,
     onReviewSettingsChanged: () -> Unit,
-    onStrictRemindersSettingsChanged: () -> Unit
+    onStrictRemindersSettingsChanged: () -> Unit,
+    onAppIconBadgeDisabled: () -> Unit
 ): ViewModelProvider.Factory {
     return viewModelFactory {
         initializer {
@@ -145,7 +158,8 @@ fun createReviewNotificationsViewModelFactory(
                 reviewNotificationsStore = reviewNotificationsStore,
                 strictRemindersStore = strictRemindersStore,
                 onReviewSettingsChanged = onReviewSettingsChanged,
-                onStrictRemindersSettingsChanged = onStrictRemindersSettingsChanged
+                onStrictRemindersSettingsChanged = onStrictRemindersSettingsChanged,
+                onAppIconBadgeDisabled = onAppIconBadgeDisabled
             )
         }
     }

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -193,6 +193,8 @@
     <string name="settings_notifications_strict_reminders_device_note">Applies to this device only.</string>
     <string name="settings_notifications_reminders_title">Workspace review reminders</string>
     <string name="settings_notifications_reminders_body">Send study cards from the current workspace review filter on this device.</string>
+    <string name="settings_notifications_show_app_icon_badge_title">Show app icon badge</string>
+    <string name="settings_notifications_show_app_icon_badge_body">When a review reminder fires and you haven\'t reviewed any card yet today, a red 1 appears on the app icon. The badge clears as soon as you review a card or open the app.</string>
     <string name="settings_notifications_mode_daily">Daily</string>
     <string name="settings_notifications_mode_inactivity">Inactivity</string>
     <string name="settings_notifications_daily_title">Daily reminder</string>

--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -227,6 +227,7 @@ struct FlashcardsApp: App {
                         )
                         store.reconcileReviewNotifications(trigger: .appActive, now: now)
                         store.reconcileStrictReminders(trigger: .appActive, now: now)
+                        store.clearAppIconBadge()
                     } else if nextPhase == .background || nextPhase == .inactive {
                         store.reconcileReviewNotifications(trigger: .appBackground, now: Date())
                         store.reconcileStrictReminders(trigger: .appBackground, now: Date())
@@ -305,6 +306,7 @@ struct FlashcardsApp: App {
             }
             self.store.reconcileReviewNotifications(trigger: .appActive, now: now)
             self.store.reconcileStrictReminders(trigger: .appActive, now: now)
+            self.store.clearAppIconBadge()
 
             if let launchScenario = self.uiTestLaunchScenario {
                 self.store.uiTestLaunchPreparationStatus = .ready(launchScenario: launchScenario)

--- a/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/FlashcardsStore+ReviewNotifications.swift
@@ -23,7 +23,8 @@ extension FlashcardsStore {
                 isEnabled: isEnabled,
                 selectedMode: self.reviewNotificationsSettings.selectedMode,
                 daily: self.reviewNotificationsSettings.daily,
-                inactivity: self.reviewNotificationsSettings.inactivity
+                inactivity: self.reviewNotificationsSettings.inactivity,
+                showAppIconBadge: self.reviewNotificationsSettings.showAppIconBadge
             )
         )
     }
@@ -34,7 +35,8 @@ extension FlashcardsStore {
                 isEnabled: self.reviewNotificationsSettings.isEnabled,
                 selectedMode: selectedMode,
                 daily: self.reviewNotificationsSettings.daily,
-                inactivity: self.reviewNotificationsSettings.inactivity
+                inactivity: self.reviewNotificationsSettings.inactivity,
+                showAppIconBadge: self.reviewNotificationsSettings.showAppIconBadge
             )
         )
     }
@@ -45,7 +47,8 @@ extension FlashcardsStore {
                 isEnabled: self.reviewNotificationsSettings.isEnabled,
                 selectedMode: self.reviewNotificationsSettings.selectedMode,
                 daily: DailyReviewNotificationsSettings(hour: hour, minute: minute),
-                inactivity: self.reviewNotificationsSettings.inactivity
+                inactivity: self.reviewNotificationsSettings.inactivity,
+                showAppIconBadge: self.reviewNotificationsSettings.showAppIconBadge
             )
         )
     }
@@ -68,9 +71,34 @@ extension FlashcardsStore {
                     windowEndHour: windowEndHour,
                     windowEndMinute: windowEndMinute,
                     idleMinutes: idleMinutes
-                )
+                ),
+                showAppIconBadge: self.reviewNotificationsSettings.showAppIconBadge
             )
         )
+    }
+
+    func updateReviewNotificationsAppIconBadgeEnabled(isEnabled: Bool) {
+        self.updateReviewNotificationsSettings(
+            settings: ReviewNotificationsSettings(
+                isEnabled: self.reviewNotificationsSettings.isEnabled,
+                selectedMode: self.reviewNotificationsSettings.selectedMode,
+                daily: self.reviewNotificationsSettings.daily,
+                inactivity: self.reviewNotificationsSettings.inactivity,
+                showAppIconBadge: isEnabled
+            )
+        )
+        // When the toggle is turned off, drop any badge currently shown on the icon
+        // so the user gets immediate feedback rather than waiting for the next reminder.
+        if isEnabled == false {
+            self.clearAppIconBadge()
+        }
+    }
+
+    /// Clears the app icon badge. Safe to call from any path; resets to zero unconditionally.
+    func clearAppIconBadge() {
+        Task { @MainActor in
+            try? await UNUserNotificationCenter.current().setBadgeCount(0)
+        }
     }
 
     func dismissReviewNotificationPrePrompt(markDismissed: Bool) {
@@ -166,6 +194,8 @@ extension FlashcardsStore {
         self.userDefaults.set(nextCount, forKey: reviewNotificationSuccessfulReviewCountUserDefaultsKey)
         self.userDefaults.set(now.timeIntervalSince1970, forKey: reviewNotificationLastActiveAtUserDefaultsKey)
         self.reconcileReviewNotifications(trigger: .reviewRecorded, now: now)
+        // Reconcile clears the badge asynchronously via .reviewRecorded; this gives instant feedback before that Task runs.
+        self.clearAppIconBadge()
         self.recordSuccessfulStrictReminderReview(reviewedAt: reviewedAt, now: now)
         let reviewCount = self.loadReviewNotificationPromptReviewCount(persistedReviewCount: nextCount)
         Task { @MainActor in
@@ -294,9 +324,9 @@ extension FlashcardsStore {
             lastActiveAt: lastActiveAt
         )
 
-        let payloads: [ScheduledReviewNotificationPayload]
+        let loadResult: ScheduledReviewNotificationLoadResult
         do {
-            payloads = try await loadScheduledReviewNotificationPayloads(snapshot: snapshot)
+            loadResult = try await loadScheduledReviewNotificationPayloads(snapshot: snapshot)
         } catch {
             logFlashcardsError(
                 domain: "ios_notifications",
@@ -316,6 +346,14 @@ extension FlashcardsStore {
             return
         }
 
+        let payloads = loadResult.payloads
+        // Once the user has reviewed today, every reminder that fires later TODAY must
+        // not raise the icon badge. Future-day reminders still attach the badge because
+        // we do not yet know whether the user will review on those days. The reschedule
+        // path runs on every review submission so this stays current.
+        let badgeCalendar = Calendar.autoupdatingCurrent
+        let hasReviewedToday = loadResult.hasReviewedToday
+
         for payload in payloads {
             guard self.reviewNotificationsRescheduleGeneration == generation else {
                 return
@@ -328,6 +366,13 @@ extension FlashcardsStore {
             content.body = payload.notificationBodyText
             content.sound = .default
             content.userInfo = buildAppNotificationUserInfo(notificationType: .reviewReminder)
+            let scheduledAt = Date(timeIntervalSince1970: TimeInterval(payload.scheduledAtMillis) / 1000)
+            let isScheduledForToday = badgeCalendar.isDate(scheduledAt, inSameDayAs: now)
+            let attachBadge = self.reviewNotificationsSettings.showAppIconBadge
+                && !(isScheduledForToday && hasReviewedToday)
+            if attachBadge {
+                content.badge = NSNumber(value: 1)
+            }
 
             let interval = max(1, TimeInterval(payload.scheduledAtMillis) / 1000 - now.timeIntervalSince1970)
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewNotificationsAppDelegate.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewNotificationsAppDelegate.swift
@@ -29,6 +29,13 @@ final class ReviewNotificationsAppDelegate: NSObject, UIApplicationDelegate, UNU
             return
         }
 
+        // Clear the app icon badge as soon as the user taps the notification — even
+        // before the app finishes foregrounding — so the icon stops nagging the
+        // user the moment they react to it.
+        Task { @MainActor in
+            try? await UNUserNotificationCenter.current().setBadgeCount(0)
+        }
+
         let appState = Self.currentApplicationStateString()
         if request == .openStrictReminder
             && isCurrentStrictReminderNotification(userInfo: userInfo, userDefaults: .standard) == false {

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewNotificationsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewNotificationsSupport.swift
@@ -59,13 +59,15 @@ enum ReviewNotificationsReconcileTrigger: Hashable, Sendable {
     case filterChanged
     case workspaceChanged
 
-    /// Only `appActive` clears delivered reminders because the user has already returned
-    /// to the app and the old reminders have served their purpose.
+    /// `appActive` clears delivered reminders because the user has returned to the
+    /// app and the old reminders have served their purpose. `reviewRecorded` also
+    /// clears them because the moment a card is reviewed, any "review reminder"
+    /// notification (and the icon badge it carries) is no longer relevant.
     var shouldClearDeliveredReviewNotifications: Bool {
         switch self {
-        case .appActive:
+        case .appActive, .reviewRecorded:
             return true
-        case .appBackground, .settingsChanged, .permissionChanged, .reviewRecorded, .filterChanged, .workspaceChanged:
+        case .appBackground, .settingsChanged, .permissionChanged, .filterChanged, .workspaceChanged:
             return false
         }
     }
@@ -84,11 +86,41 @@ struct InactivityReviewNotificationsSettings: Codable, Hashable, Sendable {
     let idleMinutes: Int
 }
 
-struct ReviewNotificationsSettings: Codable, Hashable, Sendable {
+struct ReviewNotificationsSettings: Hashable, Sendable {
     let isEnabled: Bool
     let selectedMode: ReviewNotificationMode
     let daily: DailyReviewNotificationsSettings
     let inactivity: InactivityReviewNotificationsSettings
+    let showAppIconBadge: Bool
+}
+
+extension ReviewNotificationsSettings: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case isEnabled
+        case selectedMode
+        case daily
+        case inactivity
+        case showAppIconBadge
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        self.selectedMode = try container.decode(ReviewNotificationMode.self, forKey: .selectedMode)
+        self.daily = try container.decode(DailyReviewNotificationsSettings.self, forKey: .daily)
+        self.inactivity = try container.decode(InactivityReviewNotificationsSettings.self, forKey: .inactivity)
+        // Missing key defaults to ON so existing users get the badge automatically.
+        self.showAppIconBadge = try container.decodeIfPresent(Bool.self, forKey: .showAppIconBadge) ?? true
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.isEnabled, forKey: .isEnabled)
+        try container.encode(self.selectedMode, forKey: .selectedMode)
+        try container.encode(self.daily, forKey: .daily)
+        try container.encode(self.inactivity, forKey: .inactivity)
+        try container.encode(self.showAppIconBadge, forKey: .showAppIconBadge)
+    }
 }
 
 struct NotificationPermissionPromptState: Codable, Hashable, Sendable {
@@ -261,6 +293,11 @@ struct ReviewNotificationSchedulingSnapshot: Sendable {
     let lastActiveAt: Date?
 }
 
+struct ScheduledReviewNotificationLoadResult: Sendable {
+    let payloads: [ScheduledReviewNotificationPayload]
+    let hasReviewedToday: Bool
+}
+
 enum ReviewNotificationPermissionStatus: Hashable, Sendable {
     case allowed
     case notRequested
@@ -323,7 +360,8 @@ func makeDefaultReviewNotificationsSettings() -> ReviewNotificationsSettings {
             windowEndHour: defaultInactivityReminderWindowEndHour,
             windowEndMinute: defaultInactivityReminderWindowEndMinute,
             idleMinutes: 120
-        )
+        ),
+        showAppIconBadge: true
     )
 }
 
@@ -653,9 +691,9 @@ private func buildRepeatedReviewNotificationPayloads(
 
 func loadScheduledReviewNotificationPayloads(
     snapshot: ReviewNotificationSchedulingSnapshot
-) async throws -> [ScheduledReviewNotificationPayload] {
+) async throws -> ScheduledReviewNotificationLoadResult {
     guard let databaseURL = snapshot.databaseURL else {
-        return []
+        return ScheduledReviewNotificationLoadResult(payloads: [], hasReviewedToday: false)
     }
 
     return try await Task.detached(priority: .utility) {
@@ -682,7 +720,7 @@ func loadScheduledReviewNotificationPayloads(
             )
         case .inactivity:
             guard let lastActiveAt = snapshot.lastActiveAt else {
-                return []
+                return ScheduledReviewNotificationLoadResult(payloads: [], hasReviewedToday: false)
             }
             scheduledDates = buildInactivityReviewNotificationDates(
                 lastActiveAt: lastActiveAt,
@@ -692,23 +730,42 @@ func loadScheduledReviewNotificationPayloads(
             )
         }
 
+        // Compute `hasReviewedToday` on the same connection so the rescheduler
+        // does not need to reopen the database. On the (improbable) failure
+        // path of `Calendar.date(byAdding: .day, value: 1, to:)` we default to
+        // `false` so the badge still attaches per the user's setting; the user
+        // retains control and can clear it by opening the app or reviewing.
+        let startOfToday = calendar.startOfDay(for: snapshot.now)
+        let hasReviewedToday: Bool
+        if let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday) {
+            hasReviewedToday = (try? database.hasAppWideReviewEvent(start: startOfToday, end: startOfTomorrow)) ?? false
+        } else {
+            hasReviewedToday = false
+        }
+
         let limitedScheduledDates = Array(scheduledDates.prefix(reviewNotificationPendingRequestsLimit))
+        let payloads: [ScheduledReviewNotificationPayload]
         if let currentCard {
-            return buildRepeatedReviewNotificationPayloads(
+            payloads = buildRepeatedReviewNotificationPayloads(
                 workspaceId: snapshot.workspaceId,
                 currentCard: currentCard,
                 scheduledDates: limitedScheduledDates,
                 calendar: calendar,
                 mode: mode
             )
+        } else {
+            payloads = buildFallbackReviewNotificationPayloads(
+                workspaceId: snapshot.workspaceId,
+                reviewFilter: makePersistedReviewFilter(reviewFilter: snapshot.reviewFilter),
+                scheduledDates: limitedScheduledDates,
+                calendar: calendar,
+                mode: mode
+            )
         }
 
-        return buildFallbackReviewNotificationPayloads(
-            workspaceId: snapshot.workspaceId,
-            reviewFilter: makePersistedReviewFilter(reviewFilter: snapshot.reviewFilter),
-            scheduledDates: limitedScheduledDates,
-            calendar: calendar,
-            mode: mode
+        return ScheduledReviewNotificationLoadResult(
+            payloads: payloads,
+            hasReviewedToday: hasReviewedToday
         )
     }.value
 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/ReviewNotificationsSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/ReviewNotificationsSettingsView.swift
@@ -71,6 +71,26 @@ struct ReviewNotificationsSettingsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+
+                Toggle(
+                    aiSettingsLocalized("settings.notifications.appIconBadge.toggle", "Show app icon badge"),
+                    isOn: Binding(
+                        get: {
+                            store.reviewNotificationsSettings.showAppIconBadge
+                        },
+                        set: { isEnabled in
+                            store.updateReviewNotificationsAppIconBadgeEnabled(isEnabled: isEnabled)
+                        }
+                    )
+                )
+
+                Text(
+                    aiSettingsLocalized(
+                        "settings.notifications.appIconBadge.description",
+                        "When a review reminder fires and you haven't reviewed any card yet today, a red 1 appears on the app icon. The badge clears as soon as you review a card or open the app."
+                    )
+                )
+                    .foregroundStyle(.secondary)
             }
 
             Section(aiSettingsLocalized("settings.notifications.section.strictReminders", "Strict reminders")) {

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "تذكيرات مراجعة مساحة العمل";
 "settings.notifications.reviewReminders.description" = "تستخدم هذه التذكيرات مساحة العمل الحالية فقط وتبقى على هذا الجهاز.";
 "settings.notifications.enableWorkspaceReminders" = "تفعيل تذكيرات مساحة العمل";
+"settings.notifications.appIconBadge.toggle" = "إظهار شارة أيقونة التطبيق";
+"settings.notifications.appIconBadge.description" = "عندما يصدر تذكير بالمراجعة ولم تراجع أي بطاقة بعد اليوم، يظهر رقم 1 أحمر على أيقونة التطبيق. تختفي الشارة بمجرد مراجعة بطاقة أو فتح التطبيق.";
 "settings.notifications.section.strictReminders" = "تذكيرات صارمة";
 "settings.notifications.enableStrictReminders" = "تفعيل التذكيرات الصارمة";
 "settings.notifications.strictReminders.description" = "إذا لم تراجع في أي مكان داخل التطبيق خلال يوم محلي، فسيذكرك Flashcards قبل نهاية ذلك اليوم بـ 4 و3 و2 ساعة.";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "Arbeitsbereichsbezogene Wiederholungserinnerungen";
 "settings.notifications.reviewReminders.description" = "Diese Erinnerungen verwenden nur den aktuellen Arbeitsbereich und bleiben auf diesem Gerät.";
 "settings.notifications.enableWorkspaceReminders" = "Arbeitsbereichserinnerungen aktivieren";
+"settings.notifications.appIconBadge.toggle" = "App-Symbol-Badge anzeigen";
+"settings.notifications.appIconBadge.description" = "Wenn eine Wiederholungserinnerung ausgelöst wird und du heute noch keine Karte wiederholt hast, erscheint eine rote 1 auf dem App-Symbol. Das Badge verschwindet, sobald du eine Karte wiederholst oder die App öffnest.";
 "settings.notifications.section.strictReminders" = "Strikte Erinnerungen";
 "settings.notifications.enableStrictReminders" = "Strikte Erinnerungen aktivieren";
 "settings.notifications.strictReminders.description" = "Wenn du an einem lokalen Tag nirgendwo in der App wiederholt hast, erinnert dich Flashcards 4, 3 und 2 Stunden vor Tagesende.";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "Recordatorios de repaso del espacio de trabajo";
 "settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual y se quedan en este dispositivo.";
 "settings.notifications.enableWorkspaceReminders" = "Activar recordatorios del espacio de trabajo";
+"settings.notifications.appIconBadge.toggle" = "Mostrar la insignia en el icono de la app";
+"settings.notifications.appIconBadge.description" = "Cuando se dispara un recordatorio de repaso y aún no has repasado ninguna tarjeta hoy, aparece un 1 rojo en el icono de la app. La insignia desaparece en cuanto repasas una tarjeta o abres la app.";
 "settings.notifications.section.strictReminders" = "Recordatorios estrictos";
 "settings.notifications.enableStrictReminders" = "Activar recordatorios estrictos";
 "settings.notifications.strictReminders.description" = "Si no has repasado en ninguna parte de la app durante un dia local, Flashcards te recuerda 4, 3 y 2 horas antes de que termine ese dia.";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "Recordatorios de repaso del espacio de trabajo";
 "settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual y se quedan en este dispositivo.";
 "settings.notifications.enableWorkspaceReminders" = "Activar recordatorios del espacio de trabajo";
+"settings.notifications.appIconBadge.toggle" = "Mostrar la insignia en el ícono de la app";
+"settings.notifications.appIconBadge.description" = "Cuando se dispara un recordatorio de repaso y aún no has repasado ninguna tarjeta hoy, aparece un 1 rojo en el ícono de la app. La insignia desaparece en cuanto repasas una tarjeta o abres la app.";
 "settings.notifications.section.strictReminders" = "Recordatorios estrictos";
 "settings.notifications.enableStrictReminders" = "Activar recordatorios estrictos";
 "settings.notifications.strictReminders.description" = "Si no has repasado en ninguna parte de la app durante un dia local, Flashcards te recuerda 4, 3 y 2 horas antes de que termine ese dia.";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "वर्कस्पेस रिव्यू रिमाइंडर";
 "settings.notifications.reviewReminders.description" = "ये रिमाइंडर केवल मौजूदा वर्कस्पेस का उपयोग करते हैं और इसी डिवाइस पर रहते हैं।";
 "settings.notifications.enableWorkspaceReminders" = "वर्कस्पेस रिमाइंडर चालू करें";
+"settings.notifications.appIconBadge.toggle" = "ऐप आइकन बैज दिखाएं";
+"settings.notifications.appIconBadge.description" = "जब रिव्यू रिमाइंडर ट्रिगर होता है और आपने आज तक किसी कार्ड का रिव्यू नहीं किया है, तो ऐप आइकन पर लाल 1 दिखाई देता है। जैसे ही आप किसी कार्ड का रिव्यू करते हैं या ऐप खोलते हैं, बैज हट जाता है।";
 "settings.notifications.section.strictReminders" = "स्ट्रिक्ट रिमाइंडर";
 "settings.notifications.enableStrictReminders" = "स्ट्रिक्ट रिमाइंडर चालू करें";
 "settings.notifications.strictReminders.description" = "अगर आपने किसी स्थानीय दिन ऐप में कहीं भी रिव्यू नहीं किया है, तो Flashcards उस दिन के खत्म होने से 4, 3 और 2 घंटे पहले याद दिलाता है।";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "ワークスペースの復習リマインダー";
 "settings.notifications.reviewReminders.description" = "これらのリマインダーは現在のワークスペースだけを使い、このデバイスに保存されます。";
 "settings.notifications.enableWorkspaceReminders" = "ワークスペースのリマインダーを有効にする";
+"settings.notifications.appIconBadge.toggle" = "アプリアイコンにバッジを表示";
+"settings.notifications.appIconBadge.description" = "復習リマインダーが届き、まだ今日カードを復習していない場合、アプリアイコンに赤い 1 が表示されます。カードを復習するかアプリを開くとバッジは消えます。";
 "settings.notifications.section.strictReminders" = "ストリクトリマインダー";
 "settings.notifications.enableStrictReminders" = "ストリクトリマインダーを有効にする";
 "settings.notifications.strictReminders.description" = "ローカル日のあいだにアプリ内のどこでも復習していない場合、Flashcards はその日が終わる 4 時間前、3 時間前、2 時間前に通知します。";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "Напоминания о повторении для рабочего пространства";
 "settings.notifications.reviewReminders.description" = "Эти напоминания используют только текущее рабочее пространство и остаются на этом устройстве.";
 "settings.notifications.enableWorkspaceReminders" = "Включить напоминания рабочего пространства";
+"settings.notifications.appIconBadge.toggle" = "Показывать значок на иконке приложения";
+"settings.notifications.appIconBadge.description" = "Когда срабатывает напоминание о повторении, а вы ещё не повторили ни одной карточки сегодня, на иконке приложения появляется красная единица. Значок исчезает, как только вы повторите карточку или откроете приложение.";
 "settings.notifications.section.strictReminders" = "Строгие напоминания";
 "settings.notifications.enableStrictReminders" = "Включить строгие напоминания";
 "settings.notifications.strictReminders.description" = "Если в течение локального дня вы нигде в приложении не повторяли, Flashcards напомнит за 4, 3 и 2 часа до конца этого дня.";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -400,6 +400,8 @@
 "settings.notifications.section.reviewReminders" = "工作区复习提醒";
 "settings.notifications.reviewReminders.description" = "这些提醒只使用当前工作区，并且仅保留在此设备上。";
 "settings.notifications.enableWorkspaceReminders" = "启用工作区提醒";
+"settings.notifications.appIconBadge.toggle" = "在应用图标上显示徽章";
+"settings.notifications.appIconBadge.description" = "当复习提醒触发且您今天还未复习任何卡片时,应用图标上会出现红色的 1。一旦您复习一张卡片或打开应用,徽章就会消失。";
 "settings.notifications.section.strictReminders" = "严格提醒";
 "settings.notifications.enableStrictReminders" = "启用严格提醒";
 "settings.notifications.strictReminders.description" = "如果你在某个本地日没有在应用中的任何地方复习，Flashcards 会在当天结束前 4、3、2 小时提醒你。";

--- a/apps/ios/Flashcards/FlashcardsTests/Review/ReviewNotificationsSupportTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/ReviewNotificationsSupportTests.swift
@@ -56,7 +56,8 @@ final class ReviewNotificationsSupportTests: XCTestCase {
                 windowEndHour: 19,
                 windowEndMinute: 0,
                 idleMinutes: 60
-            )
+            ),
+            showAppIconBadge: true
         )
 
         let persistedData = try JSONEncoder().encode(disabledSettings)


### PR DESCRIPTION
## Summary

- iOS and Android: while the user has not reviewed any flashcard today, the launcher app icon shows a system-native red "1" badge. The badge rides on the existing review-reminder local notifications (`content.badge` on iOS, `setNumber(1) + BADGE_ICON_SMALL` on Android) — no new scheduler, no APNs/FCM, no server changes.
- New per-workspace toggle "Show app icon badge" lives next to the existing reminder mode toggles in Settings → Notifications, default ON. Codec migration uses `decodeIfPresent ?? true` (iOS) and `optBoolean(..., true)` (Android) so existing users get the badge automatically on upgrade.
- Reliable clearing across every path: app foreground (`scenePhase` / `ON_RESUME`), notification tap, review submission, and toggle-off. iOS gates badge attachment at schedule time using a single consolidated DB query (`ScheduledReviewNotificationLoadResult`); Android moves the decision to the worker at fire time, reading the live preference plus a defensive today-review DAO check.
- `REVIEW_RECORDED` reconcile triggers on both platforms now drop delivered review reminders so stale reminders don't outlive their purpose.

## Test plan

- [ ] iOS: Settings → Notifications shows new "Show app icon badge" toggle, ON by default. Set daily reminder ~90s in the future, background app, verify red `1` on Springboard icon.
- [ ] iOS: Tap the notification → app opens to Review → badge clears.
- [ ] iOS: Foreground via icon (not via tap) → badge clears.
- [ ] iOS: Submit any review → badge clears immediately.
- [ ] iOS: In inactivity mode, verify subsequent same-day reminders fire WITHOUT badge after a review.
- [ ] iOS: Toggle the switch OFF → currently-shown badge clears immediately; next reminder fires without badge.
- [ ] Android: Same scenarios on Pixel/Samsung emulator (badge appearance varies by OEM launcher).
- [ ] Android: Verify Play Console translation queue gets `settings_notifications_show_app_icon_badge_title` and `settings_notifications_show_app_icon_badge_body` before the next Android release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)