### PR TITLE
[codex] Stabilize iOS AI live stream keepalive test

### DIFF
--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatLiveStreamClientTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatLiveStreamClientTests.swift
@@ -421,13 +421,14 @@ final class AIChatLiveStreamClientTests: XCTestCase {
     }
 
     func testLiveStreamKeepsConnectionAliveAcrossKeepaliveComments() async throws {
+        let inactivityTimeoutSeconds: TimeInterval = 1.5
         let client = AIChatLiveStreamClient(
             urlSession: self.makeURLSession(),
             decoder: makeFlashcardsRemoteJSONDecoder(),
             configuration: AIChatLiveStreamConfiguration(
                 requestTimeoutSeconds: 600,
                 resourceTimeoutSeconds: 600,
-                inactivityTimeoutSeconds: 0.15
+                inactivityTimeoutSeconds: inactivityTimeoutSeconds
             )
         )
         AIChatLiveStreamTestURLProtocol.loadingHandler = { liveProtocol, request in
@@ -439,13 +440,21 @@ final class AIChatLiveStreamClientTests: XCTestCase {
             )!
             liveProtocol.emit(response: response)
             liveProtocol.scheduleLoading {
-                try? await Task.sleep(for: .milliseconds(50))
+                // The terminal event arrives after the first inactivity deadline,
+                // so this verifies that keepalive comments reset the timer.
+                try? await Task.sleep(for: .milliseconds(250))
                 guard Task.isCancelled == false else {
                     return
                 }
                 liveProtocol.emit(data: Data(": keepalive\n\n".utf8))
 
-                try? await Task.sleep(for: .milliseconds(50))
+                try? await Task.sleep(for: .milliseconds(800))
+                guard Task.isCancelled == false else {
+                    return
+                }
+                liveProtocol.emit(data: Data(": keepalive\n\n".utf8))
+
+                try? await Task.sleep(for: .milliseconds(800))
                 guard Task.isCancelled == false else {
                     return
                 }


### PR DESCRIPTION
## Summary

Stabilizes the iOS AI live stream keepalive XCTest that failed in Xcode Cloud with `staleStream(idleTimeoutSeconds: 0.15)`.

## Root Cause

The test used a 150 ms inactivity timeout and scheduled fake SSE keepalive/terminal data with very small real-time sleeps. On Xcode Cloud, one simulator destination could delay the scheduled keepalive long enough for the inactivity timeout to fire first.

## Changes

- Keeps production live stream behavior unchanged.
- Widens only the test-only inactivity timeout to 1.5 seconds.
- Sends keepalive comments before the terminal event.
- Leaves the terminal event after the first inactivity deadline, so the test still proves keepalive comments reset the timer.

## Validation

- `xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'platform=iOS Simulator,id=E722C4FC-DE0A-46FE-9B3F-FF0B3899C690' -only-testing:'Flashcards Open Source App Tests/AIChatLiveStreamClientTests/testLiveStreamKeepsConnectionAliveAcrossKeepaliveComments' test`
- Same targeted test with `-test-iterations 3`
- Review: 3 independent subagent review passes found no P0-P4 issues.