### PR TITLE
[codex] Update dependency and toolchain drift

### DIFF
--- a/apps/android/ci/Dockerfile
+++ b/apps/android/ci/Dockerfile
@@ -1,7 +1,7 @@
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:566.0.0-stable
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:567.0.0-stable
 
 ARG ANDROID_CMDLINE_TOOLS_VERSION=14742923
-ARG ANDROID_BUILD_TOOLS_VERSION=36.0.0
+ARG ANDROID_BUILD_TOOLS_VERSION=37.0.0
 ARG ANDROID_PLATFORM_VERSION=36
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.0"
+agp = "9.2.1"
 kotlin = "2.3.21"
 ksp = "2.3.7"
 coreKtx = "1.18.0"

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -8,10 +8,10 @@
       "name": "flashcards-auth",
       "version": "1.3.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1042.0",
+        "@aws-sdk/client-secrets-manager": "^3.1043.0",
         "@hono/node-server": "^2.0.1",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.16",
+        "hono": "^4.12.17",
         "pg": "^8.20.0"
       },
       "devDependencies": {
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1042.0.tgz",
-      "integrity": "sha512-doHP17OwqhcuW3e7fKkFfF4rDFM0hY8IVIwqwvBQRLk6IsZXzpl/YRhQWuIiy9O7BSZgzKKE+XytdElsTd9PWQ==",
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1043.0.tgz",
+      "integrity": "sha512-xjxE4CSid16j9yBFuykNinW7z+RwqJGxqCDD+hh99jL6YRmVa6FZOkv96gur5jHfrolbb0e19aS3ztD7UWmcLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1864,9 +1864,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.17",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
+      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -10,10 +10,10 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1042.0",
+    "@aws-sdk/client-secrets-manager": "^3.1043.0",
     "@hono/node-server": "^2.0.1",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.16",
+    "hono": "^4.12.17",
     "pg": "^8.20.0"
   },
   "devDependencies": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -8,17 +8,17 @@
       "name": "flashcards-open-source-app-backend",
       "version": "1.3.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.1042.0",
-        "@aws-sdk/client-lambda": "^3.1042.0",
-        "@aws-sdk/client-s3": "^3.1042.0",
-        "@aws-sdk/client-secrets-manager": "^3.1042.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.1043.0",
+        "@aws-sdk/client-lambda": "^3.1043.0",
+        "@aws-sdk/client-s3": "^3.1043.0",
+        "@aws-sdk/client-secrets-manager": "^3.1043.0",
         "@hono/node-server": "^2.0.1",
         "@langfuse/openai": "^5.3.0",
         "@langfuse/otel": "^5.3.0",
         "@langfuse/tracing": "^5.3.0",
         "@opentelemetry/sdk-node": "^0.216.0",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.16",
+        "hono": "^4.12.17",
         "openai": "^6.36.0",
         "pg": "^8.20.0",
         "zod": "^4.4.3"
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1042.0.tgz",
-      "integrity": "sha512-etXFv1GDbK4p9hEHG99F5/gap/V9UDcuH5zpKlUkC0yRXzdfDCgUe8qiIQRKPv/ef6/zRAm1zsqR4EUhAI0IvQ==",
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1043.0.tgz",
+      "integrity": "sha512-k9NoDN3nC6F7CHxhyHuh4JyFKQd1pcN4gvcf7PbZrbq2N+uPu1VVDZ9X8k4XbFbz1kAgh4XZjrgMJThooq4fqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1042.0.tgz",
-      "integrity": "sha512-g2NJMMGjQ18LvPapz75s8UzRaxJ2P5bF2Y025/eyVuBtzdCuW6XYoJxP29Tp39BzYgFb+HEtwATyZss/V6KdZg==",
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1043.0.tgz",
+      "integrity": "sha512-4q7hRDe+NHGRTZQmY07FPAMY65HevqHlzQG3SiBEoQfv6vvRVQQAHHOKU4nBzWFU2sICMFsfnqfFhRDIjMiafg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
-      "integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1043.0.tgz",
+      "integrity": "sha512-QrDh9PACpmijOgbVnvQIvoWFZcMEBoGw0qiQRfGvsUEcB1JPCS2U5R0irB4XQSmsBlQUNlNeXVfpx3JI++NqrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1042.0.tgz",
-      "integrity": "sha512-doHP17OwqhcuW3e7fKkFfF4rDFM0hY8IVIwqwvBQRLk6IsZXzpl/YRhQWuIiy9O7BSZgzKKE+XytdElsTd9PWQ==",
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1043.0.tgz",
+      "integrity": "sha512-xjxE4CSid16j9yBFuykNinW7z+RwqJGxqCDD+hh99jL6YRmVa6FZOkv96gur5jHfrolbb0e19aS3ztD7UWmcLQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -3173,9 +3173,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.17",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.17.tgz",
+      "integrity": "sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,17 +10,17 @@
     "test": "npm run bundle --prefix ../../api && node scripts/run-tests.mjs"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.1042.0",
-    "@aws-sdk/client-lambda": "^3.1042.0",
-    "@aws-sdk/client-s3": "^3.1042.0",
-    "@aws-sdk/client-secrets-manager": "^3.1042.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1043.0",
+    "@aws-sdk/client-lambda": "^3.1043.0",
+    "@aws-sdk/client-s3": "^3.1043.0",
+    "@aws-sdk/client-secrets-manager": "^3.1043.0",
     "@hono/node-server": "^2.0.1",
     "@langfuse/openai": "^5.3.0",
     "@langfuse/otel": "^5.3.0",
     "@langfuse/tracing": "^5.3.0",
     "@opentelemetry/sdk-node": "^0.216.0",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.16",
+    "hono": "^4.12.17",
     "openai": "^6.36.0",
     "pg": "^8.20.0",
     "zod": "^4.4.3"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -12,7 +12,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.14.2"
+        "react-router-dom": "^7.15.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -2495,9 +2495,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -2517,12 +2517,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.2"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.14.2"
+    "react-router-dom": "^7.15.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/infra/aws/lib/database.ts
+++ b/infra/aws/lib/database.ts
@@ -16,6 +16,11 @@ export interface DatabaseResult {
   reportingDbSecret: cdk.aws_secretsmanager.Secret;
 }
 
+const postgresEngineVersion = rds.PostgresEngineVersion.of("18.3", "18", {
+  s3Export: true,
+  s3Import: true,
+});
+
 export function database(scope: Construct, props: DatabaseProps): DatabaseResult {
   const dbCredentials = rds.Credentials.fromGeneratedSecret("flashcards_owner", {
     secretName: "flashcards-open-source-app/db-credentials",
@@ -24,7 +29,7 @@ export function database(scope: Construct, props: DatabaseProps): DatabaseResult
 
   const parameterGroup = new rds.ParameterGroup(scope, "DbParams", {
     engine: rds.DatabaseInstanceEngine.postgres({
-      version: rds.PostgresEngineVersion.VER_18,
+      version: postgresEngineVersion,
     }),
     parameters: {
       "log_connections": "all",
@@ -35,7 +40,7 @@ export function database(scope: Construct, props: DatabaseProps): DatabaseResult
 
   const db = new rds.DatabaseInstance(scope, "Db", {
     engine: rds.DatabaseInstanceEngine.postgres({
-      version: rds.PostgresEngineVersion.VER_18,
+      version: postgresEngineVersion,
     }),
     instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MICRO),
     vpc: props.vpc,

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.0",
-        "@aws-sdk/client-cloudwatch": "^3.1042.0",
-        "@aws-sdk/client-s3": "^3.1042.0",
+        "@aws-sdk/client-cloudwatch": "^3.1043.0",
+        "@aws-sdk/client-s3": "^3.1043.0",
         "aws-cdk-lib": "^2.252.0",
         "constructs": "^10.6.0"
       },
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1042.0.tgz",
-      "integrity": "sha512-rGvviVCfiOkS6ACwcJJsMDEc8zI7Q5kD/jUc33Vo/qdTMoSVJzpHlTJCMwtotOkkhEYVeoNsYn7U8PmNrY+UhQ==",
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1043.0.tgz",
+      "integrity": "sha512-s/TjLAnkULfZY8Iob7Jtzf4HIvfCxG+Y1WD9nlUoq2WTM3tc3BVl0bcM0lIUQaxYybw3mrpNIAduvOa5Y5v+ng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -658,9 +658,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1042.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1042.0.tgz",
-      "integrity": "sha512-z3Ibstr7ckDT10dz/nkk4+93LitrrO49Oq563/JoFHt30ZNodPBCfSxysKcelLyi/lNVF1MZrhZZfikUAG3iNQ==",
+      "version": "3.1043.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1043.0.tgz",
+      "integrity": "sha512-QrDh9PACpmijOgbVnvQIvoWFZcMEBoGw0qiQRfGvsUEcB1JPCS2U5R0irB4XQSmsBlQUNlNeXVfpx3JI++NqrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "^5.0.0",
-    "@aws-sdk/client-cloudwatch": "^3.1042.0",
-    "@aws-sdk/client-s3": "^3.1042.0",
+    "@aws-sdk/client-cloudwatch": "^3.1043.0",
+    "@aws-sdk/client-s3": "^3.1043.0",
     "aws-cdk-lib": "^2.252.0",
     "constructs": "^10.6.0"
   },


### PR DESCRIPTION
## Summary

- Update direct npm drift in auth, backend, web, and AWS infra packages.
- Update Android build tooling pins for AGP, Google Cloud CLI, and Android SDK build tools.
- Pin the CDK RDS PostgreSQL engine declaration explicitly to PostgreSQL 18.3.

## Validation

- `npx -y node@24.15.0 "$(command -v npm)" ci --prefix api`
- `npx -y node@24.15.0 "$(command -v npm)" ci --prefix apps/auth`
- `npx -y node@24.15.0 "$(command -v npm)" ci --prefix apps/backend`
- `npx -y node@24.15.0 "$(command -v npm)" ci --prefix apps/web`
- `npx -y node@24.15.0 "$(command -v npm)" ci --prefix infra/aws`
- `npx -y node@24.15.0 "$(command -v npm)" run build --prefix apps/auth`
- `npx -y node@24.15.0 "$(command -v npm)" run test --prefix apps/auth`
- `npx -y node@24.15.0 "$(command -v npm)" run lint --prefix apps/backend`
- `npx -y node@24.15.0 "$(command -v npm)" run build --prefix apps/backend`
- `npx -y node@24.15.0 "$(command -v npm)" run test --prefix apps/backend`
- `npx -y node@24.15.0 "$(command -v npm)" run build --prefix apps/web`
- `npx -y node@24.15.0 "$(command -v npm)" run test --prefix apps/web`
- `npx -y node@24.15.0 "$(command -v npm)" run build --prefix infra/aws`
- `npx -y node@24.15.0 "$(command -v npm)" run test --prefix infra/aws`
- `docker manifest inspect gcr.io/google.com/cloudsdktool/google-cloud-cli:567.0.0-stable`
- `bash scripts/run-android-ci.sh`