### PR TITLE
[codex] Use repo-local iOS DerivedData path

### DIFF
--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -80,6 +80,7 @@ Only test the app against the final supported iOS target.
 - Prefer background CLI runs with `simctl` and `xcodebuild` instead of opening heavy Xcode UI flows
 - Do not open a visible Simulator window for test runs unless the user explicitly asks for a visible simulator at that time
 - Prefer `xcodebuild ... test` so each run validates the current sources and build settings on the selected simulator
+- Pass `-derivedDataPath "tmp/ios-derived-data"` for local CLI builds and tests so repeated runs reuse repo-local build artifacts instead of creating new global DerivedData directories
 - If a test fails, inspect the generated `.xcresult` bundle and read the relevant screenshots, attachments, and logs before changing code
 - If no suitable local runtime is already installed, stop and ask the user how to proceed instead of downloading extra simulator runtimes
 
@@ -101,8 +102,8 @@ Preferred command pattern:
 ```bash
 xcrun simctl list devices available
 xcrun simctl bootstatus <device-uuid> -b
-xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'platform=iOS Simulator,id=<device-uuid>' test
-xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'platform=iOS Simulator,id=<device-uuid>' -only-testing:'Flashcards Open Source App UI Tests/LiveSmokeSettingsTests/testLiveSmokeLocalNavigationFlow' test
+xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'platform=iOS Simulator,id=<device-uuid>' test
+xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'platform=iOS Simulator,id=<device-uuid>' -only-testing:'Flashcards Open Source App UI Tests/LiveSmokeSettingsTests/testLiveSmokeLocalNavigationFlow' test
 ```
 
 ## Native Test Stack

--- a/docs/ios-local-setup.md
+++ b/docs/ios-local-setup.md
@@ -118,6 +118,7 @@ xcodebuild \
   -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" \
   -scheme "Flashcards Open Source App" \
   -configuration Release \
+  -derivedDataPath "tmp/ios-derived-data" \
   -destination "generic/platform=iOS" \
   -archivePath "tmp/ios-archives/Flashcards-Review.xcarchive" \
   -allowProvisioningUpdates \
@@ -147,6 +148,7 @@ If iOS tests are requested, run them only on one specific iPhone simulator runti
 Prefer an already booted local iPhone simulator on the final supported iOS runtime. Reuse that exact device instead of booting a different one when possible.
 Prefer the background CLI flow over opening heavy Xcode UI: `xcrun simctl bootstatus`, then `xcodebuild test`.
 Do not open a visible iOS Simulator window for test runs unless the user explicitly asks for a visible simulator at that time.
+Pass `-derivedDataPath "tmp/ios-derived-data"` for local CLI builds and tests so repeated runs reuse repo-local build artifacts instead of creating new global DerivedData directories.
 If an iOS test fails, inspect the generated `.xcresult` bundle and read the relevant screenshots, attachments, and logs before changing code.
 If a suitable simulator is already warmed, keep using it and avoid rebuilding unnecessarily.
 If no suitable local iPhone simulator runtime is already available, do not trigger extra runtime downloads or installations. Stop and ask the user how to proceed.
@@ -156,6 +158,6 @@ Preferred local CLI examples:
 ```bash
 xcrun simctl list devices available
 xcrun simctl bootstatus <device-uuid> -b
-xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'platform=iOS Simulator,id=<device-uuid>' test
-xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -destination 'platform=iOS Simulator,id=<device-uuid>' -only-testing:'Flashcards Open Source App UI Tests/LiveSmokeSettingsTests/testLiveSmokeLocalNavigationFlow' test
+xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'platform=iOS Simulator,id=<device-uuid>' test
+xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'platform=iOS Simulator,id=<device-uuid>' -only-testing:'Flashcards Open Source App UI Tests/LiveSmokeSettingsTests/testLiveSmokeLocalNavigationFlow' test
 ```

--- a/docs/ios-localization.md
+++ b/docs/ios-localization.md
@@ -273,6 +273,7 @@ Preferred build check:
 ```bash
 xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" \
   -scheme "Flashcards Open Source App" \
+  -derivedDataPath "tmp/ios-derived-data" \
   -destination 'generic/platform=iOS Simulator' \
   CODE_SIGNING_ALLOWED=NO \
   build

--- a/scripts/capture-ios-marketing-screenshot.sh
+++ b/scripts/capture-ios-marketing-screenshot.sh
@@ -152,6 +152,7 @@ localization_code="$(resolve_requested_locale "$requested_locale")"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 project_path="$repo_root/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj"
 scheme_name="Flashcards Open Source App"
+derived_data_path="$repo_root/tmp/ios-derived-data"
 runtime_configuration_path="/tmp/flashcards-open-source-app-ios-marketing-screenshot-config.json"
 screenshot_run_marker_path=""
 
@@ -201,6 +202,7 @@ run_ios_marketing_xcodebuild_test() {
     xcodebuild \
       -project "$project_path" \
       -scheme "$scheme_name" \
+      -derivedDataPath "$derived_data_path" \
       -destination "platform=iOS Simulator,id=$simulator_id" \
       "-only-testing:Flashcards Open Source App UI Tests/$selected_test_identifier" \
       test


### PR DESCRIPTION
## Summary
- Document `tmp/ios-derived-data` as the preferred local DerivedData path for iOS CLI builds and tests.
- Update the iOS marketing screenshot capture script to pass the repo-local DerivedData path to `xcodebuild`.

## Validation
- `bash -n scripts/capture-ios-marketing-screenshot.sh`

## Impact
Keeps repeated local iOS CLI runs from creating additional global DerivedData directories while preserving the existing Xcode build and test flow.