### PR TITLE
[codex] Fix AI chat dictation draft editing

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AiRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AiRouteTest.kt
@@ -600,8 +600,9 @@ private fun makeAiUiState(
     showOpenAccountStatusForConversationError: Boolean = false,
     focusComposerRequestVersion: Long = 0L
 ): AiUiState {
-    val canUseDraft = isConversationReady &&
-        isConversationLoading.not() &&
+    val canUseDraftText = isConversationReady &&
+        isConversationLoading.not()
+    val canUseDraft = canUseDraftText &&
         isComposerBusy.not() &&
         isStreaming.not()
     return AiUiState(
@@ -622,6 +623,7 @@ private fun makeAiUiState(
         isComposerBusy = isComposerBusy,
         isStreaming = isStreaming,
         canStopStreaming = canStopStreaming,
+        canEditDraftText = canUseDraftText,
         canEditDraft = canUseDraft,
         canManageDraftAttachments = canUseDraft,
         canAddDraftAttachment = canUseDraft,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiUiState.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiUiState.kt
@@ -27,6 +27,7 @@ data class AiUiState(
     val isComposerBusy: Boolean,
     val isStreaming: Boolean,
     val canStopStreaming: Boolean,
+    val canEditDraftText: Boolean,
     val canEditDraft: Boolean,
     val canManageDraftAttachments: Boolean,
     val canAddDraftAttachment: Boolean,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
@@ -119,7 +119,7 @@ internal class AiChatRuntime(
     }
 
     fun updateDraftMessage(draftMessage: String) {
-        if (canEditAiDraft(state = runtimeStateMutable.value).not()) {
+        if (canEditAiDraftText(state = runtimeStateMutable.value).not()) {
             return
         }
         runtimeStateMutable.update { state ->

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiDraftState.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiDraftState.kt
@@ -91,14 +91,30 @@ internal data class AiDraftState(
 
 internal typealias AiChatRuntimeState = AiDraftState
 
-internal fun canEditAiDraft(state: AiChatRuntimeState): Boolean {
+/**
+ * Text editing intentionally stays available during dictation so the IME and cursor remain active.
+ */
+internal fun canEditAiDraftText(state: AiChatRuntimeState): Boolean {
     if (state.conversationBootstrapState != AiConversationBootstrapState.READY) {
+        return false
+    }
+    if (
+        state.dictationState != AiChatDictationState.IDLE &&
+        state.composerPhase == AiComposerPhase.STOPPING
+    ) {
+        return true
+    }
+    return canPrepareAiDraftInComposerPhase(composerPhase = state.composerPhase)
+}
+
+internal fun canEditAiDraft(state: AiChatRuntimeState): Boolean {
+    if (canEditAiDraftText(state = state).not()) {
         return false
     }
     if (state.dictationState != AiChatDictationState.IDLE) {
         return false
     }
-    return canPrepareAiDraftInComposerPhase(composerPhase = state.composerPhase)
+    return true
 }
 
 internal fun canManageAiDraftAttachments(state: AiChatRuntimeState): Boolean {

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapper.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapper.kt
@@ -72,6 +72,7 @@ internal fun mapToAiUiState(
     val canEditConversation = isComposerBusy.not()
         && isConversationReady
         && runtimeState.dictationState == AiChatDictationState.IDLE
+    val canEditDraftText = canEditAiDraftText(state = runtimeState)
     val canEditDraft = canEditAiDraft(state = runtimeState)
     val canManageDraftAttachments = canManageAiDraftAttachments(state = runtimeState)
     val composerSuggestions = if (
@@ -106,6 +107,7 @@ internal fun mapToAiUiState(
         isComposerBusy = isComposerBusy,
         isStreaming = isStreaming,
         canStopStreaming = hasActiveRun && runtimeState.composerPhase != AiComposerPhase.STOPPING,
+        canEditDraftText = canEditDraftText,
         canEditDraft = canEditDraft,
         canManageDraftAttachments = canManageDraftAttachments,
         canAddDraftAttachment = canManageDraftAttachments && chatConfig.features.attachmentsEnabled,
@@ -148,6 +150,7 @@ internal fun makeInitialAiUiState(hasConsent: Boolean, textProvider: AiTextProvi
         isComposerBusy = false,
         isStreaming = false,
         canStopStreaming = false,
+        canEditDraftText = false,
         canEditDraft = false,
         canManageDraftAttachments = false,
         canAddDraftAttachment = false,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiComposerContent.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiComposerContent.kt
@@ -216,7 +216,7 @@ internal fun AiComposer(
                 },
                 minLines = 1,
                 maxLines = aiComposerMaximumLineCount,
-                enabled = uiState.canEditDraft,
+                enabled = uiState.canEditDraftText,
                 trailingIcon = {
                     FilledIconButton(
                         onClick = if (uiState.canStopStreaming) {

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeConversationResetAndSendTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeConversationResetAndSendTest.kt
@@ -176,6 +176,53 @@ class AiChatRuntimeConversationResetAndSendTest {
     }
 
     @Test
+    fun draftMessageCanChangeWhileDictationIsActive() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        repository.transcribeAudioGates += CompletableDeferred<Unit>()
+        repository.transcribeAudioResponse = AiChatTranscriptionResult(
+            text = "late transcript",
+            sessionId = "session-1"
+        )
+        val runtime = makeRuntime(scope = this, repository = repository)
+
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
+        runtime.startDictationPermissionRequest()
+        runtime.updateDraftMessage(draftMessage = "Typed while requesting permission")
+
+        assertEquals(AiChatDictationState.REQUESTING_PERMISSION, runtime.state.value.dictationState)
+        assertEquals("Typed while requesting permission", runtime.state.value.draftMessage)
+
+        runtime.startDictationRecording()
+        runtime.updateDraftMessage(draftMessage = "Typed while recording")
+
+        assertEquals(AiChatDictationState.RECORDING, runtime.state.value.dictationState)
+        assertEquals("Typed while recording", runtime.state.value.draftMessage)
+
+        runtime.transcribeRecordedAudio(
+            fileName = "clip.m4a",
+            mediaType = "audio/m4a",
+            audioBytes = byteArrayOf(1, 2, 3)
+        )
+        runCurrent()
+        runtime.updateDraftMessage(draftMessage = "Typed while transcribing")
+
+        assertEquals(AiChatDictationState.TRANSCRIBING, runtime.state.value.dictationState)
+        assertEquals("Typed while transcribing", runtime.state.value.draftMessage)
+
+        runtime.cancelDictation()
+        runCurrent()
+    }
+
+    @Test
     fun cancelDictationDuringTranscribingPreventsTranscriptAppend() = runTest {
         val repository = FakeAiChatRepository()
         repository.nextEnsureSessionId = "dictation-session-1"

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapperTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapperTest.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
+import com.flashcardsopensourceapp.data.local.model.AiChatDictationState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.defaultAiChatServerConfig
 import com.flashcardsopensourceapp.data.local.model.makeDefaultAiChatPersistedState
@@ -26,6 +27,7 @@ class AiUiStateMapperTest {
         assertTrue(uiState.isStreaming)
         assertTrue(uiState.isComposerBusy)
         assertTrue(uiState.isCardHandoffReady)
+        assertTrue(uiState.canEditDraftText)
         assertTrue(uiState.canEditDraft)
         assertTrue(uiState.canManageDraftAttachments)
         assertTrue(uiState.canAddDraftAttachment)
@@ -58,6 +60,7 @@ class AiUiStateMapperTest {
             val uiState = mapRuntimeState(runtimeState = runtimeState)
 
             assertFalse(uiState.isCardHandoffReady)
+            assertFalse(uiState.canEditDraftText)
             assertFalse(uiState.canEditDraft)
             assertFalse(uiState.canManageDraftAttachments)
             assertFalse(uiState.canAddDraftAttachment)
@@ -83,10 +86,56 @@ class AiUiStateMapperTest {
 
         val uiState = mapRuntimeState(runtimeState = runtimeState)
 
+        assertTrue(uiState.canEditDraftText)
         assertTrue(uiState.canEditDraft)
         assertTrue(uiState.canManageDraftAttachments)
         assertFalse(uiState.canAddDraftAttachment)
         assertFalse(uiState.canToggleDictation)
+    }
+
+    @Test
+    fun activeDictationKeepsTextEditableButLocksDraftActions() {
+        val activeStates: List<AiChatDictationState> = listOf(
+            AiChatDictationState.REQUESTING_PERMISSION,
+            AiChatDictationState.RECORDING,
+            AiChatDictationState.TRANSCRIBING
+        )
+        val editableComposerPhases: List<AiComposerPhase> = listOf(
+            AiComposerPhase.IDLE,
+            AiComposerPhase.STOPPING
+        )
+
+        activeStates.forEach { dictationState ->
+            editableComposerPhases.forEach { composerPhase ->
+                val runtimeState = makeAiDraftState(
+                    workspaceId = defaultTestWorkspaceId,
+                    persistedState = makeDefaultAiChatPersistedState()
+                ).copy(
+                    activeRun = if (composerPhase == AiComposerPhase.STOPPING) {
+                        makeActiveRun(runId = "run-1", cursor = "0")
+                    } else {
+                        null
+                    },
+                    composerPhase = composerPhase,
+                    dictationState = dictationState,
+                    draftMessage = "Typed while recording"
+                )
+
+                val uiState = mapRuntimeState(runtimeState = runtimeState)
+
+                assertTrue(uiState.canEditDraftText)
+                assertFalse(uiState.canEditDraft)
+                assertFalse(uiState.canManageDraftAttachments)
+                assertFalse(uiState.canAddDraftAttachment)
+                if (dictationState == AiChatDictationState.RECORDING) {
+                    assertTrue(uiState.canToggleDictation)
+                } else {
+                    assertFalse(uiState.canToggleDictation)
+                }
+                assertFalse(uiState.canSend)
+                assertFalse(uiState.canStartNewChat)
+            }
+        }
     }
 
     private fun mapRuntimeState(runtimeState: AiChatRuntimeState): AiUiState {

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatComposerAccessoryView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatComposerAccessoryView.swift
@@ -258,6 +258,6 @@ extension AIChatView {
     }
 
     var composerTextFieldDisabled: Bool {
-        self.chatStore.canEditDraft == false
+        self.chatStore.canEditDraftText == false
     }
 }

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+Surface.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension AIChatStore {
     func clearHistory() {
-        guard self.isChatInteractive else {
+        guard self.canStartNewChat else {
             return
         }
 

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+UIState.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+UIState.swift
@@ -10,9 +10,19 @@ extension AIChatStore {
     }
 
     var canEditDraft: Bool {
-        self.isChatInteractive
+        self.canEditDraftText
             && self.dictationState == .idle
-            && aiChatComposerPhaseAllowsDraftPreparation(self.composerPhase)
+    }
+
+    /// Text editing intentionally stays available during dictation so the keyboard and cursor remain active.
+    var canEditDraftText: Bool {
+        guard self.isChatInteractive else {
+            return false
+        }
+        if aiChatDictationStateKeepsDraftTextEditable(self.dictationState) {
+            return true
+        }
+        return aiChatComposerPhaseAllowsDraftPreparation(self.composerPhase)
     }
 
     var canModifyDraftAttachments: Bool {
@@ -49,6 +59,19 @@ extension AIChatStore {
     var canStopResponse: Bool {
         self.isChatInteractive
             && (self.composerPhase == .startingRun || self.composerPhase == .running)
+    }
+
+    var canStartNewChat: Bool {
+        guard self.isChatInteractive else {
+            return false
+        }
+        guard self.dictationState == .idle else {
+            return false
+        }
+        return self.messages.isEmpty == false
+            || self.pendingAttachments.isEmpty == false
+            || self.trimmedInputText().isEmpty == false
+            || self.isStreaming
     }
 
     var isComposerBusy: Bool {
@@ -206,6 +229,15 @@ func aiChatComposerPhaseAllowsDraftPreparation(_ phase: AIChatComposerPhase) -> 
         return true
     case .preparingSend, .startingRun, .stopping:
         return false
+    }
+}
+
+func aiChatDictationStateKeepsDraftTextEditable(_ state: AIChatDictationState) -> Bool {
+    switch state {
+    case .idle:
+        return false
+    case .requestingPermission, .recording, .transcribing:
+        return true
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatView.swift
@@ -134,11 +134,7 @@ struct AIChatView: View {
     }
 
     var isNewChatDisabled: Bool {
-        self.chatStore.messages.isEmpty
-            && self.chatStore.pendingAttachments.isEmpty
-            && self.chatStore.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && self.chatStore.isStreaming == false
-            && self.chatStore.dictationState == .idle
+        self.chatStore.canStartNewChat == false
     }
 
     var isAlertPresentedBinding: Binding<Bool> {

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreComposerCapabilityTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreComposerCapabilityTests.swift
@@ -13,18 +13,23 @@ final class AIChatStoreComposerCapabilityTests: XCTestCase {
         let store = context.makeStore()
         store.acceptExternalProviderConsent()
 
+        XCTAssertTrue(store.canEditDraftText)
         XCTAssertTrue(store.canEditDraft)
         XCTAssertTrue(store.canAttachToDraft)
         XCTAssertTrue(store.canStartDictation)
         XCTAssertTrue(store.canUseDictation)
+        XCTAssertFalse(store.canStartNewChat)
 
         store.transitionToPreparingSend()
+        XCTAssertFalse(store.canEditDraftText)
         XCTAssertFalse(store.canEditDraft)
         XCTAssertFalse(store.canAttachToDraft)
         XCTAssertFalse(store.canStartDictation)
         XCTAssertFalse(store.canUseDictation)
+        XCTAssertFalse(store.canStartNewChat)
 
         store.transitionToStartingRun()
+        XCTAssertFalse(store.canEditDraftText)
         XCTAssertFalse(store.canEditDraft)
         XCTAssertFalse(store.canAttachToDraft)
         XCTAssertFalse(store.canStartDictation)
@@ -32,18 +37,22 @@ final class AIChatStoreComposerCapabilityTests: XCTestCase {
 
         store.inputText = "Prepare the next draft."
         store.transitionToStreaming(activeRun: makeAIChatCapabilityTestActiveRunSession())
+        XCTAssertTrue(store.canEditDraftText)
         XCTAssertTrue(store.canEditDraft)
         XCTAssertTrue(store.canAttachToDraft)
         XCTAssertTrue(store.canStartDictation)
         XCTAssertTrue(store.canUseDictation)
         XCTAssertFalse(store.canSendMessage)
         XCTAssertTrue(store.canStopResponse)
+        XCTAssertTrue(store.canStartNewChat)
 
         store.transitionToStopping(runId: "run-1")
+        XCTAssertFalse(store.canEditDraftText)
         XCTAssertFalse(store.canEditDraft)
         XCTAssertFalse(store.canAttachToDraft)
         XCTAssertFalse(store.canStartDictation)
         XCTAssertFalse(store.canUseDictation)
+        XCTAssertTrue(store.canStartNewChat)
     }
 
     func testDictationStartIsBlockedBeforeAcceptedRunButRecordingCanStillStop() throws {
@@ -63,13 +72,79 @@ final class AIChatStoreComposerCapabilityTests: XCTestCase {
 
         store.transitionToStreaming(activeRun: makeAIChatCapabilityTestActiveRunSession())
         store.dictationState = .recording
+        XCTAssertTrue(store.canEditDraftText)
         XCTAssertFalse(store.canEditDraft)
         XCTAssertFalse(store.canAttachToDraft)
         XCTAssertFalse(store.canStartDictation)
         XCTAssertTrue(store.canUseDictation)
 
         store.transitionToStopping(runId: "run-1")
+        XCTAssertTrue(store.canEditDraftText)
+        XCTAssertFalse(store.canEditDraft)
+        XCTAssertFalse(store.canAttachToDraft)
+        XCTAssertFalse(store.canStartDictation)
+        XCTAssertFalse(store.canStartNewChat)
         XCTAssertTrue(store.canUseDictation)
+    }
+
+    func testActiveDictationKeepsTextEditingOpenButLocksDraftActions() throws {
+        let activeStates: [AIChatDictationState] = [
+            .requestingPermission,
+            .recording,
+            .transcribing
+        ]
+
+        for dictationState in activeStates {
+            let context = AIChatStoreTestSupport.Context.make()
+            defer {
+                context.tearDown()
+            }
+
+            try context.configureGuestCloudSession()
+            let store = context.makeStore()
+            store.acceptExternalProviderConsent()
+            store.applyComposerSuggestions([
+                AIChatComposerSuggestion(
+                    id: "suggestion-1",
+                    text: "Summarize my cards",
+                    source: "test",
+                    assistantItemId: nil
+                )
+            ])
+            XCTAssertEqual(store.visibleComposerSuggestions.map(\.id), ["suggestion-1"])
+
+            store.dictationState = dictationState
+
+            XCTAssertTrue(store.canEditDraftText)
+            XCTAssertTrue(store.visibleComposerSuggestions.isEmpty)
+
+            let activeRun = makeAIChatCapabilityTestActiveRunSession()
+            store.transitionToStreaming(activeRun: activeRun)
+            store.inputText = "Draft should stay"
+            XCTAssertFalse(store.canEditDraft)
+            XCTAssertFalse(store.canModifyDraftAttachments)
+            XCTAssertFalse(store.canAttachToDraft)
+            XCTAssertFalse(store.canAttachCardToDraft)
+            XCTAssertFalse(store.canStartDictation)
+            XCTAssertEqual(store.canUseDictation, dictationState == .recording)
+            XCTAssertFalse(store.canSendMessage)
+            XCTAssertFalse(store.canStartNewChat)
+
+            store.transitionToStopping(runId: activeRun.runId)
+            XCTAssertTrue(store.canEditDraftText)
+            XCTAssertFalse(store.canEditDraft)
+            XCTAssertFalse(store.canModifyDraftAttachments)
+            XCTAssertFalse(store.canAttachToDraft)
+            XCTAssertFalse(store.canAttachCardToDraft)
+            XCTAssertFalse(store.canStartDictation)
+            XCTAssertEqual(store.canUseDictation, dictationState == .recording)
+            XCTAssertFalse(store.canSendMessage)
+            XCTAssertFalse(store.canStartNewChat)
+
+            store.clearHistory()
+            XCTAssertEqual(store.inputText, "Draft should stay")
+            XCTAssertEqual(store.dictationState, dictationState)
+        }
     }
 
     func testCardHandoffAppendsToDraftDuringRunningWithoutResettingActiveRun() throws {


### PR DESCRIPTION
## Summary

- Keeps AI chat composer text editing enabled while dictation is requesting permission, recording, or transcribing.
- Separates text-entry capability from stricter draft actions so send, attachments, suggestions, New Chat, and dictation start remain blocked during active dictation.
- Aligns iOS and Android behavior, including stopping a live response while dictation is active.

## Validation

- `git --no-pager diff --check`
- `git --no-pager diff --check origin/main...HEAD`
- `xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'platform=iOS Simulator,id=29406788-D88C-4ECF-ABDD-6407A1F95DE3' -only-testing:'Flashcards Open Source App Tests/AIChatStoreComposerCapabilityTests' test`
- Earlier focused Android runtime/mapper unit tests passed before the final iOS-only test assertion cleanup.