### PR TITLE
[codex] Add admin review events user filter

### DIFF
--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent, type JSX } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent, type JSX } from "react";
 import * as d3 from "d3";
 import {
   reviewEventPlatforms,
@@ -7,8 +7,12 @@ import {
   type ReviewEventsByDatePlatformReviewEventTotal,
   type ReviewEventsByDateReport,
   type ReviewEventsByDateUniqueUserCohort,
+  type ReviewEventsByDateUser,
 } from "../../adminApi";
-import type { ReviewEventsByDateRange } from "./query";
+import {
+  filterReviewEventsByDateReportByUsers,
+  type ReviewEventsByDateRange,
+} from "./query";
 
 type ChartTooltipState = Readonly<{
   visible: boolean;
@@ -39,6 +43,18 @@ type GroupedChartRectEntry = Readonly<{
   key: ReviewEventPlatform;
   date: string;
   value: number;
+}>;
+
+type ActiveUserFilter = Readonly<{
+  userId: string;
+  label: string;
+  secondaryLabel: string;
+  hasUserInReport: boolean;
+}>;
+
+type SearchableUserFilterOption = Readonly<{
+  user: ReviewEventsByDateUser;
+  searchableValue: string;
 }>;
 
 type ChartFrameParams = Readonly<{
@@ -81,6 +97,16 @@ const uniqueUserCohortColors: Readonly<Record<UniqueUserCohortKey, string>> = {
   returning: "var(--accent)",
   new: "#2e6f95",
 };
+const userColorPalette: ReadonlyArray<string> = [
+  ...d3.schemeTableau10,
+  ...d3.schemeSet2,
+  ...d3.schemeDark2,
+  "#e15759",
+  "#76b7b2",
+  "#f28e2b",
+  "#59a14f",
+];
+const visibleUserFilterOptionLimit = 50;
 
 function parseCalendarDate(date: string): Date {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
@@ -215,17 +241,19 @@ function getPeakGroupedValue(items: ReadonlyArray<MatrixChartEntry>): number {
 }
 
 function getUserColorScale(userIds: ReadonlyArray<string>): d3.ScaleOrdinal<string, string> {
-  const palette = [
-    ...d3.schemeTableau10,
-    ...d3.schemeSet2,
-    ...d3.schemeDark2,
-    "#e15759",
-    "#76b7b2",
-    "#f28e2b",
-    "#59a14f",
-  ].slice(0, userIds.length);
+  const colors = userIds.map((userId) => userColorPalette[getUserColorPaletteIndex(userId)]);
 
-  return d3.scaleOrdinal<string, string>(userIds, palette);
+  return d3.scaleOrdinal<string, string>(userIds, colors);
+}
+
+function getUserColorPaletteIndex(userId: string): number {
+  let hash = 0;
+
+  for (const character of userId) {
+    hash = ((hash << 5) - hash + character.charCodeAt(0)) | 0;
+  }
+
+  return Math.abs(hash) % userColorPalette.length;
 }
 
 function getPlatformColor(platform: string): string {
@@ -234,6 +262,34 @@ function getPlatformColor(platform: string): string {
   }
 
   return platformColors[platform as ReviewEventPlatform];
+}
+
+function getUserFilterLabel(user: ReviewEventsByDateUser): string {
+  return user.email === "(no email)" ? user.userId : user.email;
+}
+
+function getUserFilterSecondaryLabel(user: ReviewEventsByDateUser): string {
+  return user.email === "(no email)" ? user.email : user.userId;
+}
+
+function getNormalizedSearchValue(value: string): string {
+  return value.trim().toLocaleLowerCase("en-US");
+}
+
+function getUserFilterSearchableValue(user: ReviewEventsByDateUser): string {
+  return getNormalizedSearchValue([
+    getUserFilterLabel(user),
+    user.userId,
+    user.email,
+  ].join(" "));
+}
+
+function doesUserMatchSearch(option: SearchableUserFilterOption, normalizedSearchValue: string): boolean {
+  return normalizedSearchValue === "" || option.searchableValue.includes(normalizedSearchValue);
+}
+
+function getStableUserColorDomain(users: ReadonlyArray<ReviewEventsByDateUser>): ReadonlyArray<string> {
+  return users.map((user) => user.userId).sort((leftUserId, rightUserId) => leftUserId.localeCompare(rightUserId));
 }
 
 function createTickDates(dates: ReadonlyArray<string>): ReadonlyArray<string> {
@@ -374,6 +430,8 @@ export function ReviewEventsByDateDashboard(
     from: props.report.from,
     to: props.report.to,
   });
+  const [selectedUserIds, setSelectedUserIds] = useState<ReadonlyArray<string>>([]);
+  const [userFilterSearchValue, setUserFilterSearchValue] = useState<string>("");
 
   useEffect(() => {
     setDraftRange({
@@ -389,6 +447,42 @@ export function ReviewEventsByDateDashboard(
       from,
     }));
   }
+
+  function handleUserFilterSearchChange(event: ChangeEvent<HTMLInputElement>): void {
+    setUserFilterSearchValue(event.currentTarget.value);
+  }
+
+  function handleUserFilterChange(event: ChangeEvent<HTMLInputElement>): void {
+    const userId = event.currentTarget.value;
+    const isChecked = event.currentTarget.checked;
+    setSelectedUserIds((currentUserIds) => {
+      if (isChecked) {
+        if (currentUserIds.includes(userId)) {
+          return currentUserIds;
+        }
+
+        return [...currentUserIds, userId];
+      }
+
+      return currentUserIds.filter((currentUserId) => currentUserId !== userId);
+    });
+  }
+
+  function handleUserFilterRemove(userId: string): void {
+    setSelectedUserIds((currentUserIds) => currentUserIds.filter((currentUserId) => currentUserId !== userId));
+  }
+
+  function handleUserFilterClear(): void {
+    setSelectedUserIds([]);
+  }
+
+  const handleChartUserFilterApply = useCallback((userId: string): void => {
+    setSelectedUserIds([userId]);
+    setTooltipState((currentState) => ({
+      ...currentState,
+      visible: false,
+    }));
+  }, []);
 
   function handleToDateChange(event: ChangeEvent<HTMLInputElement>): void {
     const to = event.currentTarget.value;
@@ -408,52 +502,98 @@ export function ReviewEventsByDateDashboard(
     props.onDateRangeReset();
   }
 
+  const filteredReport = useMemo(
+    () => filterReviewEventsByDateReportByUsers(props.report, selectedUserIds),
+    [props.report, selectedUserIds],
+  );
+  const selectedUserIdSet = useMemo(
+    () => new Set(selectedUserIds),
+    [selectedUserIds],
+  );
+  const rawUserById = useMemo(
+    () => new Map(props.report.users.map((user) => [user.userId, user])),
+    [props.report.users],
+  );
+  const activeUserFilters = useMemo(
+    (): ReadonlyArray<ActiveUserFilter> => selectedUserIds.map((userId) => {
+      const user = rawUserById.get(userId);
+      return {
+        userId,
+        label: user === undefined ? userId : getUserFilterLabel(user),
+        secondaryLabel: user === undefined ? "No review events in range" : getUserFilterSecondaryLabel(user),
+        hasUserInReport: user !== undefined,
+      };
+    }),
+    [rawUserById, selectedUserIds],
+  );
+  const normalizedUserFilterSearchValue = useMemo(
+    () => getNormalizedSearchValue(userFilterSearchValue),
+    [userFilterSearchValue],
+  );
+  const searchableUserFilterOptions = useMemo(
+    (): ReadonlyArray<SearchableUserFilterOption> => props.report.users.map((user) => ({
+      user,
+      searchableValue: getUserFilterSearchableValue(user),
+    })),
+    [props.report.users],
+  );
+  const matchingUserFilterOptions = useMemo(
+    () => searchableUserFilterOptions
+      .filter((option) => doesUserMatchSearch(option, normalizedUserFilterSearchValue))
+      .map((option) => option.user),
+    [normalizedUserFilterSearchValue, searchableUserFilterOptions],
+  );
+  const visibleUserFilterOptions = useMemo(
+    () => matchingUserFilterOptions.slice(0, visibleUserFilterOptionLimit),
+    [matchingUserFilterOptions],
+  );
+  const hiddenUserFilterOptionCount = matchingUserFilterOptions.length - visibleUserFilterOptions.length;
   const dates = useMemo(
-    () => props.report.dateTotals.map((item) => item.date),
-    [props.report.dateTotals],
+    () => filteredReport.dateTotals.map((item) => item.date),
+    [filteredReport.dateTotals],
   );
   const tickDates = useMemo(
     () => createTickDates(dates),
     [dates],
   );
-  const userIds = useMemo(
-    () => props.report.users.map((user) => user.userId),
+  const allUserIds = useMemo(
+    () => getStableUserColorDomain(props.report.users),
     [props.report.users],
   );
+  const userIds = useMemo(
+    () => filteredReport.users.map((user) => user.userId),
+    [filteredReport.users],
+  );
   const userColorScale = useMemo(
-    () => getUserColorScale(userIds),
-    [userIds],
+    () => getUserColorScale(allUserIds),
+    [allUserIds],
   );
   const dailyUniqueUserCohortMatrix = useMemo(
-    () => buildDailyUniqueUserCohortMatrix(props.report.dailyUniqueUserCohorts),
-    [props.report.dailyUniqueUserCohorts],
+    () => buildDailyUniqueUserCohortMatrix(filteredReport.dailyUniqueUserCohorts),
+    [filteredReport.dailyUniqueUserCohorts],
   );
   const dailyUniqueUserTotals = useMemo<ReadonlyArray<DailyValueEntry>>(
-    () => props.report.dailyUniqueUserCohorts.map((item) => ({
+    () => filteredReport.dailyUniqueUserCohorts.map((item) => ({
       date: item.date,
       value: item.newReviewingUsers + item.returningReviewingUsers,
     })),
-    [props.report.dailyUniqueUserCohorts],
+    [filteredReport.dailyUniqueUserCohorts],
   );
   const userMatrix = useMemo(
-    () => buildUserMatrix(props.report),
-    [props.report],
+    () => buildUserMatrix(filteredReport),
+    [filteredReport],
   );
   const platformActiveUsersMatrix = useMemo(
-    () => buildPlatformMatrix(props.report.platformActiveUserTotals, (item) => item.activeUserCount, dates),
-    [dates, props.report.platformActiveUserTotals],
+    () => buildPlatformMatrix(filteredReport.platformActiveUserTotals, (item) => item.activeUserCount, dates),
+    [dates, filteredReport.platformActiveUserTotals],
   );
   const platformReviewEventsMatrix = useMemo(
-    () => buildPlatformMatrix(props.report.platformReviewEventTotals, (item) => item.reviewEventCount, dates),
-    [dates, props.report.platformReviewEventTotals],
+    () => buildPlatformMatrix(filteredReport.platformReviewEventTotals, (item) => item.reviewEventCount, dates),
+    [dates, filteredReport.platformReviewEventTotals],
   );
   const totalReviewEventsByDate = useMemo(
-    () => new Map(props.report.dateTotals.map((item) => [item.date, item.totalReviewEvents])),
-    [props.report.dateTotals],
-  );
-  const userById = useMemo(
-    () => new Map(props.report.users.map((user) => [user.userId, user])),
-    [props.report.users],
+    () => new Map(filteredReport.dateTotals.map((item) => [item.date, item.totalReviewEvents])),
+    [filteredReport.dateTotals],
   );
   const dailyUniqueUsersByDate = useMemo(
     () => new Map(dailyUniqueUserTotals.map((item) => [item.date, item.value])),
@@ -468,8 +608,8 @@ export function ReviewEventsByDateDashboard(
     [dailyUniqueUserTotals],
   );
   const peakDailyVolume = useMemo(
-    () => d3.max(props.report.dateTotals, (item) => item.totalReviewEvents) ?? 0,
-    [props.report.dateTotals],
+    () => d3.max(filteredReport.dateTotals, (item) => item.totalReviewEvents) ?? 0,
+    [filteredReport.dateTotals],
   );
   const peakDailyPlatformUsers = useMemo(
     () => getPeakGroupedValue(platformActiveUsersMatrix),
@@ -609,7 +749,7 @@ export function ReviewEventsByDateDashboard(
       .keys(userIds)
       .value((entry, key) => entry.valuesByKey[key] ?? 0)(userMatrix);
 
-    userReviewEventsGroup.selectAll(".series")
+    const userReviewEventBars = userReviewEventsGroup.selectAll(".series")
       .data(userSeries)
       .join("g")
       .attr("class", "series")
@@ -623,14 +763,14 @@ export function ReviewEventsByDateDashboard(
         value: entry.data.valuesByKey[segment.key] ?? 0,
       })).filter((entry) => entry.value > 0))
       .join("rect")
-      .attr("class", "bar-segment")
+      .attr("class", `bar-segment user-review-events${props.isReportLoading ? "" : " clickable"}`)
       .attr("x", (entry) => x(entry.date) ?? 0)
       .attr("y", (entry) => userReviewEventsY(entry.y1))
       .attr("width", x.bandwidth())
       .attr("height", (entry) => Math.max(0, userReviewEventsY(entry.y0) - userReviewEventsY(entry.y1)))
       .attr("rx", 2)
       .on("mousemove", (event, entry: StackedChartRectEntry) => {
-        const user = userById.get(entry.key);
+        const user = rawUserById.get(entry.key);
         if (user === undefined) {
           return;
         }
@@ -649,6 +789,15 @@ export function ReviewEventsByDateDashboard(
         );
       })
       .on("mouseleave", hideTooltip);
+
+    if (props.isReportLoading === false) {
+      userReviewEventBars
+        .on("click", (_event: MouseEvent, entry: StackedChartRectEntry) => {
+          handleChartUserFilterApply(entry.key);
+        });
+    } else {
+      userReviewEventBars.on("click", null);
+    }
 
     const platformUsersY = d3.scaleLinear()
       .domain([0, Math.max(1, peakDailyPlatformUsers)])
@@ -760,16 +909,18 @@ export function ReviewEventsByDateDashboard(
     tickDates,
     totalPlatformReviewEventsByDate,
     totalReviewEventsByDate,
-    userById,
+    handleChartUserFilterApply,
+    props.isReportLoading,
+    rawUserById,
     userColorScale,
     userIds,
     userMatrix,
   ]);
 
   const summaryCards = [
-    { label: "Total Review Events", value: props.report.totalReviewEvents.toLocaleString("en-US") },
-    { label: "Users With Review Events", value: props.report.users.length.toLocaleString("en-US") },
-    { label: "Days In Range", value: props.report.dateTotals.length.toLocaleString("en-US") },
+    { label: "Total Review Events", value: filteredReport.totalReviewEvents.toLocaleString("en-US") },
+    { label: "Users With Review Events", value: filteredReport.users.length.toLocaleString("en-US") },
+    { label: "Days In Range", value: filteredReport.dateTotals.length.toLocaleString("en-US") },
     { label: "Peak Daily Volume", value: peakDailyVolume.toLocaleString("en-US") },
     { label: "Peak Daily Unique Users", value: peakDailyUniqueUsers.toLocaleString("en-US") },
   ];
@@ -791,11 +942,11 @@ export function ReviewEventsByDateDashboard(
         </div>
       </section>
 
-      <section className="filter-panel" aria-labelledby="review-date-range-title">
+      <section className="filter-panel" aria-labelledby="review-filters-title">
         <div className="filter-panel-header">
           <div>
             <p className="eyebrow">Filters</p>
-            <h2 id="review-date-range-title">Date Range</h2>
+            <h2 id="review-filters-title">Filters</h2>
           </div>
           <span className={`filter-status${props.isReportLoading ? " active" : ""}`} aria-live="polite">
             {props.isReportLoading ? "Updating" : `Default ${props.defaultRange.from} to ${props.defaultRange.to}`}
@@ -833,6 +984,101 @@ export function ReviewEventsByDateDashboard(
             </button>
           </div>
         </form>
+        <div className="user-filter-section" aria-label="User filter">
+          <div className="user-filter-header">
+            <span>User</span>
+            <span>
+              {selectedUserIds.length === 0
+                ? "All users"
+                : `${selectedUserIds.length} selected`}
+            </span>
+          </div>
+          {props.report.users.length > 0 ? (
+            <>
+              <label className="user-filter-search">
+                <span>Search users</span>
+                <input
+                  type="search"
+                  value={userFilterSearchValue}
+                  placeholder="Email or user ID"
+                  disabled={props.isReportLoading}
+                  onChange={handleUserFilterSearchChange}
+                />
+              </label>
+              {visibleUserFilterOptions.length > 0 ? (
+                <div className="user-filter-options">
+                  {visibleUserFilterOptions.map((user) => (
+                    <label
+                      key={user.userId}
+                      className={`user-filter-option${selectedUserIdSet.has(user.userId) ? " selected" : ""}`}
+                    >
+                      <input
+                        type="checkbox"
+                        value={user.userId}
+                        checked={selectedUserIdSet.has(user.userId)}
+                        disabled={props.isReportLoading}
+                        onChange={handleUserFilterChange}
+                      />
+                      <span className="user-filter-swatch" style={{ backgroundColor: userColorScale(user.userId) }} />
+                      <span className="user-filter-option-text">
+                        <span className="user-filter-option-primary">{getUserFilterLabel(user)}</span>
+                        <span className="user-filter-option-secondary">
+                          {user.userId} - {user.totalReviewEvents.toLocaleString("en-US")} events
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              ) : (
+                <p className="user-filter-empty">No users match this search.</p>
+              )}
+              {hiddenUserFilterOptionCount > 0 ? (
+                <p className="user-filter-limit">
+                  Showing {visibleUserFilterOptions.length.toLocaleString("en-US")} of {matchingUserFilterOptions.length.toLocaleString("en-US")} matching users.
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="user-filter-empty">No users with review events in this range.</p>
+          )}
+          {activeUserFilters.length > 0 ? (
+            <div className="active-filter-chips" aria-label="Active user filters">
+              {activeUserFilters.map((filter) => (
+                <span key={filter.userId} className="active-filter-chip">
+                  <span
+                    className="active-filter-swatch"
+                    style={{
+                      backgroundColor: filter.hasUserInReport
+                        ? userColorScale(filter.userId)
+                        : "rgba(255, 255, 255, 0.36)",
+                    }}
+                  />
+                  <span className="active-filter-text">
+                    <span>{filter.label}</span>
+                    <span>{filter.secondaryLabel}</span>
+                  </span>
+                  <button
+                    className="active-filter-remove"
+                    type="button"
+                    disabled={props.isReportLoading}
+                    aria-label={`Remove user filter ${filter.label}`}
+                    onClick={() => handleUserFilterRemove(filter.userId)}
+                  >
+                    x
+                  </button>
+                </span>
+              ))}
+              <button
+                className="filter-button filter-button-compact"
+                type="button"
+                disabled={props.isReportLoading}
+                onClick={handleUserFilterClear}
+              >
+                Clear users
+              </button>
+            </div>
+          ) : null}
+        </div>
         {props.dateRangeError !== "" ? (
           <p className="filter-error" role="alert">{props.dateRangeError}</p>
         ) : null}

--- a/apps/admin/src/reports/reviewEventsByDate/query.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/query.ts
@@ -36,6 +36,16 @@ type ReviewEventsByDateDefaultRangeQueryRow = Readonly<{
   to_date: string;
 }>;
 
+type ReviewEventsByDateAggregateFields = Readonly<Pick<
+  ReviewEventsByDateReport,
+  | "totalReviewEvents"
+  | "users"
+  | "dateTotals"
+  | "dailyUniqueUserCohorts"
+  | "platformActiveUserTotals"
+  | "platformReviewEventTotals"
+>>;
+
 function parseCalendarDate(date: string): Date {
   const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(date);
   if (match === null) {
@@ -239,6 +249,20 @@ function buildDailyUniqueUserCohorts(
   }));
 }
 
+function buildReviewEventsByDateAggregateFields(
+  rows: ReadonlyArray<ReviewEventsByDateRow>,
+  dates: ReadonlyArray<string>,
+): ReviewEventsByDateAggregateFields {
+  return {
+    totalReviewEvents: rows.reduce((sum, row) => sum + row.reviewEventCount, 0),
+    users: buildReviewEventsByDateUsers(rows),
+    dateTotals: buildReviewEventsByDateTotals(rows, dates),
+    dailyUniqueUserCohorts: buildDailyUniqueUserCohorts(rows, dates),
+    platformActiveUserTotals: buildPlatformActiveUserTotals(rows, dates),
+    platformReviewEventTotals: buildPlatformReviewEventTotals(rows, dates),
+  };
+}
+
 function buildReviewEventsByDateReport(
   resultSet: AdminQueryResultSet,
   executedAtUtc: string,
@@ -272,24 +296,34 @@ function buildReviewEventsByDateReport(
     });
 
   const dates = buildRequestedDateRange(from, to);
-  const dateTotals = buildReviewEventsByDateTotals(rows, dates);
-  const dailyUniqueUserCohorts = buildDailyUniqueUserCohorts(rows, dates);
-  const platformActiveUserTotals = buildPlatformActiveUserTotals(rows, dates);
-  const platformReviewEventTotals = buildPlatformReviewEventTotals(rows, dates);
-  const users = buildReviewEventsByDateUsers(rows);
-  const totalReviewEvents = rows.reduce((sum, row) => sum + row.reviewEventCount, 0);
+  const aggregateFields = buildReviewEventsByDateAggregateFields(rows, dates);
 
   return {
     generatedAtUtc: executedAtUtc,
     from,
     to,
-    totalReviewEvents,
-    users,
-    dateTotals,
-    dailyUniqueUserCohorts,
-    platformActiveUserTotals,
-    platformReviewEventTotals,
+    ...aggregateFields,
     rows,
+  };
+}
+
+export function filterReviewEventsByDateReportByUsers(
+  report: ReviewEventsByDateReport,
+  selectedUserIds: ReadonlyArray<string>,
+): ReviewEventsByDateReport {
+  if (selectedUserIds.length === 0) {
+    return report;
+  }
+
+  const selectedUserIdSet = new Set(selectedUserIds);
+  const rows = report.rows.filter((row) => selectedUserIdSet.has(row.userId));
+  const dates = buildRequestedDateRange(report.from, report.to);
+  const aggregateFields = buildReviewEventsByDateAggregateFields(rows, dates);
+
+  return {
+    ...report,
+    rows,
+    ...aggregateFields,
   };
 }
 

--- a/apps/admin/src/styles.css
+++ b/apps/admin/src/styles.css
@@ -239,11 +239,224 @@ h2 {
   transform: translateY(-1px);
 }
 
+.filter-button-compact {
+  height: 34px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+
 .filter-error {
   margin: 0;
   color: #ffb6a6;
   font-size: 13px;
   font-weight: 700;
+}
+
+.user-filter-section {
+  display: grid;
+  gap: 10px;
+  padding-top: 2px;
+}
+
+.user-filter-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.user-filter-search {
+  display: grid;
+  gap: 7px;
+  max-width: 420px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.user-filter-search input {
+  width: 100%;
+  height: 40px;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: none;
+  padding: 0 12px;
+  outline: none;
+}
+
+.user-filter-search input:focus {
+  border-color: rgba(214, 90, 56, 0.78);
+  box-shadow: 0 0 0 3px rgba(196, 75, 45, 0.18);
+}
+
+.user-filter-search input:disabled {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.user-filter-search input::placeholder {
+  color: var(--muted-soft);
+}
+
+.user-filter-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
+  gap: 8px;
+  max-height: 224px;
+  overflow: auto;
+  padding: 2px 2px 4px;
+}
+
+.user-filter-option {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  min-height: 48px;
+  padding: 8px 10px;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.user-filter-option.selected {
+  border-color: rgba(214, 90, 56, 0.62);
+  background: rgba(196, 75, 45, 0.14);
+}
+
+.user-filter-option input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  flex: 0 0 auto;
+  accent-color: var(--accent);
+}
+
+.user-filter-option:has(input:disabled) {
+  cursor: wait;
+  opacity: 0.68;
+}
+
+.user-filter-swatch,
+.active-filter-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+.user-filter-option-text {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.user-filter-option-primary,
+.user-filter-option-secondary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-filter-option-primary {
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.user-filter-option-secondary {
+  color: var(--muted-soft);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.user-filter-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.user-filter-limit {
+  margin: 0;
+  color: var(--muted-soft);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.active-filter-chips {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.active-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 100%;
+  min-height: 34px;
+  padding: 5px 6px 5px 10px;
+  border: 1px solid rgba(214, 90, 56, 0.48);
+  border-radius: 999px;
+  background: rgba(196, 75, 45, 0.14);
+  color: var(--text);
+}
+
+.active-filter-text {
+  display: grid;
+  min-width: 0;
+  max-width: 360px;
+}
+
+.active-filter-text span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.active-filter-text span:first-child {
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.active-filter-text span:last-child {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.active-filter-remove {
+  display: inline-grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.active-filter-remove:disabled {
+  cursor: wait;
+  opacity: 0.62;
 }
 
 .metric-card,
@@ -363,6 +576,10 @@ h2 {
 
 .bar-segment:hover {
   opacity: 0.82;
+}
+
+.bar-segment.user-review-events.clickable {
+  cursor: pointer;
 }
 
 .tooltip {


### PR DESCRIPTION
## Summary
- add a client-side User filter to the admin review events dashboard
- rebuild dashboard aggregates from filtered rows while preserving active date buckets
- allow stacked user chart segment clicks to apply a single-user filter

## Validation
- npm --prefix apps/admin run build