### PR TITLE
[codex] Split review events dashboard

### DIFF
--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateCharts.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateCharts.tsx
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useRef, useState, type JSX } from "react";
+import { reviewEventPlatforms, type ReviewEventsByDateUser } from "../../adminApi";
+import {
+  getPlatformColor,
+  platformLabels,
+  uniqueUserCohortColors,
+  uniqueUserCohortKeys,
+  uniqueUserCohortLabels,
+  type ChartTooltipState,
+  type ReviewEventsByDateChartModel,
+} from "./chartModel";
+import {
+  renderDailyUniqueUsersChart,
+  renderPlatformActiveUsersChart,
+  renderPlatformReviewEventsChart,
+  renderUserReviewEventsChart,
+} from "./chartRenderers";
+import { formatGeneratedAt } from "./formatting";
+
+type ReviewEventsByDateChartsProps = Readonly<{
+  chartModel: ReviewEventsByDateChartModel;
+  generatedAtUtc: string;
+  isReportLoading: boolean;
+  userById: ReadonlyMap<string, ReviewEventsByDateUser>;
+  onUserFilterApply: (userId: string) => void;
+}>;
+
+function ChartTooltip(props: ChartTooltipState): JSX.Element {
+  return (
+    <div
+      className={`tooltip${props.visible ? " visible" : ""}`}
+      style={{ left: props.left, top: props.top }}
+      dangerouslySetInnerHTML={{ __html: props.html }}
+    />
+  );
+}
+
+function PlatformKey(): JSX.Element {
+  return (
+    <div className="platform-key" aria-label="Platform color key">
+      {reviewEventPlatforms.map((platform) => (
+        <span key={platform} className="platform-key-item">
+          <span className="platform-key-swatch" style={{ backgroundColor: getPlatformColor(platform) }} />
+          <span>{platformLabels[platform]}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function UniqueUserCohortKey(): JSX.Element {
+  return (
+    <div className="platform-key" aria-label="Unique users cohort color key">
+      {uniqueUserCohortKeys.map((cohort) => (
+        <span key={cohort} className="platform-key-item">
+          <span className="platform-key-swatch" style={{ backgroundColor: uniqueUserCohortColors[cohort] }} />
+          <span>{uniqueUserCohortLabels[cohort]}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): JSX.Element {
+  const uniqueUsersChartRef = useRef<SVGSVGElement | null>(null);
+  const userReviewEventsChartRef = useRef<SVGSVGElement | null>(null);
+  const platformUsersChartRef = useRef<SVGSVGElement | null>(null);
+  const platformReviewEventsChartRef = useRef<SVGSVGElement | null>(null);
+  const [tooltipState, setTooltipState] = useState<ChartTooltipState>({
+    visible: false,
+    html: "",
+    left: 0,
+    top: 0,
+  });
+
+  const handleUserFilterApply = useCallback((userId: string): void => {
+    props.onUserFilterApply(userId);
+    setTooltipState((currentState) => ({
+      ...currentState,
+      visible: false,
+    }));
+  }, [props.onUserFilterApply]);
+
+  useEffect(() => {
+    const uniqueUsersSvgElement = uniqueUsersChartRef.current;
+    const userReviewEventsSvgElement = userReviewEventsChartRef.current;
+    const platformUsersSvgElement = platformUsersChartRef.current;
+    const platformReviewEventsSvgElement = platformReviewEventsChartRef.current;
+    if (
+      uniqueUsersSvgElement === null
+      || userReviewEventsSvgElement === null
+      || platformUsersSvgElement === null
+      || platformReviewEventsSvgElement === null
+    ) {
+      return;
+    }
+
+    function showTooltip(html: string, clientX: number, clientY: number): void {
+      const padding = 18;
+      const nextLeft = Math.max(padding, Math.min(window.innerWidth - 340, clientX + 18));
+      const nextTop = Math.max(padding, Math.min(window.innerHeight - 220, clientY + 18));
+      setTooltipState({
+        visible: true,
+        html,
+        left: nextLeft,
+        top: nextTop,
+      });
+    }
+
+    function hideTooltip(): void {
+      setTooltipState((currentState) => ({
+        ...currentState,
+        visible: false,
+      }));
+    }
+
+    const tooltipHandlers = {
+      showTooltip,
+      hideTooltip,
+    };
+
+    renderDailyUniqueUsersChart({
+      svgElement: uniqueUsersSvgElement,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      dailyUniqueUserCohortMatrix: props.chartModel.dailyUniqueUserCohortMatrix,
+      dailyUniqueUsersByDate: props.chartModel.dailyUniqueUsersByDate,
+      totalReviewEventsByDate: props.chartModel.totalReviewEventsByDate,
+      peakDailyUniqueUsers: props.chartModel.peakDailyUniqueUsers,
+      tooltipHandlers,
+    });
+    renderUserReviewEventsChart({
+      svgElement: userReviewEventsSvgElement,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      userMatrix: props.chartModel.userMatrix,
+      userIds: props.chartModel.userIds,
+      userColorScale: props.chartModel.userColorScale,
+      userById: props.userById,
+      totalReviewEventsByDate: props.chartModel.totalReviewEventsByDate,
+      peakDailyVolume: props.chartModel.peakDailyVolume,
+      isReportLoading: props.isReportLoading,
+      onUserFilterApply: handleUserFilterApply,
+      tooltipHandlers,
+    });
+    renderPlatformActiveUsersChart({
+      svgElement: platformUsersSvgElement,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      platformActiveUsersMatrix: props.chartModel.platformActiveUsersMatrix,
+      dailyUniqueUsersByDate: props.chartModel.dailyUniqueUsersByDate,
+      peakDailyPlatformUsers: props.chartModel.peakDailyPlatformUsers,
+      tooltipHandlers,
+    });
+    renderPlatformReviewEventsChart({
+      svgElement: platformReviewEventsSvgElement,
+      dates: props.chartModel.dates,
+      tickDates: props.chartModel.tickDates,
+      platformReviewEventsMatrix: props.chartModel.platformReviewEventsMatrix,
+      totalPlatformReviewEventsByDate: props.chartModel.totalPlatformReviewEventsByDate,
+      peakDailyPlatformReviewEvents: props.chartModel.peakDailyPlatformReviewEvents,
+      tooltipHandlers,
+    });
+  }, [
+    props.chartModel,
+    props.isReportLoading,
+    props.userById,
+    handleUserFilterApply,
+  ]);
+
+  return (
+    <>
+      <section className="chart-column">
+        <div className="chart-shell">
+          <div className="chart-meta">
+            <span>Daily unique users with at least 1 review event &mdash; new vs returning</span>
+            <div className="chart-meta-right">
+              <UniqueUserCohortKey />
+            </div>
+          </div>
+          <div className="chart-scroll">
+            <svg ref={uniqueUsersChartRef} />
+          </div>
+        </div>
+
+        <div className="chart-shell">
+          <div className="chart-meta">
+            <span>Stacked review events by user</span>
+            <div className="chart-meta-right">
+              <span>Generated {formatGeneratedAt(props.generatedAtUtc)}</span>
+            </div>
+          </div>
+          <div className="chart-scroll">
+            <svg ref={userReviewEventsChartRef} />
+          </div>
+        </div>
+
+        <div className="chart-shell">
+          <div className="chart-meta">
+            <span>Daily active users by platform</span>
+            <div className="chart-meta-right">
+              <PlatformKey />
+            </div>
+          </div>
+          <div className="chart-scroll">
+            <svg ref={platformUsersChartRef} />
+          </div>
+        </div>
+
+        <div className="chart-shell">
+          <div className="chart-meta">
+            <span>Daily review events by platform</span>
+            <div className="chart-meta-right">
+              <PlatformKey />
+            </div>
+          </div>
+          <div className="chart-scroll">
+            <svg ref={platformReviewEventsChartRef} />
+          </div>
+        </div>
+      </section>
+
+      <ChartTooltip {...tooltipState} />
+    </>
+  );
+}

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
@@ -1,409 +1,24 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent, type JSX } from "react";
-import * as d3 from "d3";
+import { useCallback, useEffect, useMemo, useState, type JSX } from "react";
+import type { ReviewEventsByDateReport } from "../../adminApi";
+import { buildReviewEventsByDateChartModel } from "./chartModel";
+import { ReviewEventsByDateCharts } from "./ReviewEventsByDateCharts";
+import { ReviewEventsByDateFilters } from "./ReviewEventsByDateFilters";
 import {
-  reviewEventPlatforms,
-  type ReviewEventPlatform,
-  type ReviewEventsByDatePlatformActiveUserTotal,
-  type ReviewEventsByDatePlatformReviewEventTotal,
-  type ReviewEventsByDateReport,
-  type ReviewEventsByDateUniqueUserCohort,
-  type ReviewEventsByDateUser,
-} from "../../adminApi";
+  buildReviewEventsByDateSummaryCards,
+  ReviewEventsByDateSummary,
+} from "./ReviewEventsByDateSummary";
+import { formatDateRangeLabel } from "./formatting";
+import {
+  buildActiveUserFilters,
+  buildSearchableUserFilterOptions,
+  doesUserMatchSearch,
+  getNormalizedSearchValue,
+  visibleUserFilterOptionLimit,
+} from "./userFilters";
 import {
   filterReviewEventsByDateReportByUsers,
   type ReviewEventsByDateRange,
 } from "./query";
-
-type ChartTooltipState = Readonly<{
-  visible: boolean;
-  html: string;
-  left: number;
-  top: number;
-}>;
-
-type DailyValueEntry = Readonly<{
-  date: string;
-  value: number;
-}>;
-
-type MatrixChartEntry = Readonly<{
-  date: string;
-  valuesByKey: Readonly<Record<string, number>>;
-}>;
-
-type StackedChartRectEntry = Readonly<{
-  key: string;
-  date: string;
-  value: number;
-  y0: number;
-  y1: number;
-}>;
-
-type GroupedChartRectEntry = Readonly<{
-  key: ReviewEventPlatform;
-  date: string;
-  value: number;
-}>;
-
-type ActiveUserFilter = Readonly<{
-  userId: string;
-  label: string;
-  secondaryLabel: string;
-  hasUserInReport: boolean;
-}>;
-
-type SearchableUserFilterOption = Readonly<{
-  user: ReviewEventsByDateUser;
-  searchableValue: string;
-}>;
-
-type ChartFrameParams = Readonly<{
-  chartWidth: number;
-  chartHeight: number;
-  margin: Readonly<{
-    top: number;
-    right: number;
-    bottom: number;
-    left: number;
-  }>;
-  x: d3.ScaleBand<string>;
-  y: d3.ScaleLinear<number, number>;
-  tickDates: ReadonlyArray<string>;
-  yAxisLabel: string;
-}>;
-
-const chartMargin = { top: 28, right: 68, bottom: 88, left: 68 } as const;
-const chartWidth = 1320;
-const simpleChartHeight = 300;
-const stackedChartHeight = 620;
-const platformLabels: Readonly<Record<ReviewEventPlatform, string>> = {
-  web: "Web",
-  android: "Android",
-  ios: "iOS",
-};
-const platformColors: Readonly<Record<ReviewEventPlatform, string>> = {
-  web: "#4e79a7",
-  android: "#59a14f",
-  ios: "#f28e2b",
-};
-
-const uniqueUserCohortKeys = ["returning", "new"] as const;
-type UniqueUserCohortKey = (typeof uniqueUserCohortKeys)[number];
-const uniqueUserCohortLabels: Readonly<Record<UniqueUserCohortKey, string>> = {
-  returning: "Returning",
-  new: "New",
-};
-const uniqueUserCohortColors: Readonly<Record<UniqueUserCohortKey, string>> = {
-  returning: "var(--accent)",
-  new: "#2e6f95",
-};
-const userColorPalette: ReadonlyArray<string> = [
-  ...d3.schemeTableau10,
-  ...d3.schemeSet2,
-  ...d3.schemeDark2,
-  "#e15759",
-  "#76b7b2",
-  "#f28e2b",
-  "#59a14f",
-];
-const visibleUserFilterOptionLimit = 50;
-
-function parseCalendarDate(date: string): Date {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
-  if (match === null) {
-    throw new Error(`Invalid report date: ${date}`);
-  }
-
-  const year = Number(match[1]);
-  const monthIndex = Number(match[2]) - 1;
-  const day = Number(match[3]);
-  const parsedDate = new Date(Date.UTC(year, monthIndex, day));
-
-  if (
-    Number.isNaN(parsedDate.getTime())
-    || parsedDate.getUTCFullYear() !== year
-    || parsedDate.getUTCMonth() !== monthIndex
-    || parsedDate.getUTCDate() !== day
-  ) {
-    throw new Error(`Invalid report date: ${date}`);
-  }
-
-  return parsedDate;
-}
-
-function formatDateRangeLabel(date: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone: "UTC",
-    month: "short",
-    day: "2-digit",
-    year: "numeric",
-  }).format(parseCalendarDate(date));
-}
-
-function formatCompactDateLabel(date: string): string {
-  return new Intl.DateTimeFormat("en-US", {
-    timeZone: "UTC",
-    month: "short",
-    day: "2-digit",
-  }).format(parseCalendarDate(date));
-}
-
-function formatGeneratedAt(value: string): string {
-  const formatted = new Intl.DateTimeFormat("en-US", {
-    timeZone: "UTC",
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(value));
-  return `${formatted} UTC`;
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll("\"", "&quot;")
-    .replaceAll("'", "&#39;");
-}
-
-function buildDailyUniqueUserCohortMatrix(
-  cohorts: ReadonlyArray<ReviewEventsByDateUniqueUserCohort>,
-): ReadonlyArray<MatrixChartEntry> {
-  return cohorts.map((cohort) => ({
-    date: cohort.date,
-    valuesByKey: {
-      returning: cohort.returningReviewingUsers,
-      new: cohort.newReviewingUsers,
-    },
-  }));
-}
-
-function buildUserMatrix(report: ReviewEventsByDateReport): ReadonlyArray<MatrixChartEntry> {
-  const valuesByDate = new Map<string, Record<string, number>>();
-
-  for (const row of report.rows) {
-    const currentValues = valuesByDate.get(row.date) ?? {};
-    currentValues[row.userId] = (currentValues[row.userId] ?? 0) + row.reviewEventCount;
-    valuesByDate.set(row.date, currentValues);
-  }
-
-  return report.dateTotals.map((item) => ({
-    date: item.date,
-    valuesByKey: valuesByDate.get(item.date) ?? {},
-  }));
-}
-
-function buildPlatformMatrix<Item extends Readonly<{ date: string; platform: ReviewEventPlatform }>>(
-  items: ReadonlyArray<Item>,
-  getValue: (item: Item) => number,
-  dates: ReadonlyArray<string>,
-): ReadonlyArray<MatrixChartEntry> {
-  const valuesByDate = new Map<string, Record<string, number>>();
-
-  for (const item of items) {
-    const currentValues = valuesByDate.get(item.date) ?? {};
-    currentValues[item.platform] = getValue(item);
-    valuesByDate.set(item.date, currentValues);
-  }
-
-  return dates.map((date) => ({
-    date,
-    valuesByKey: valuesByDate.get(date) ?? {},
-  }));
-}
-
-function buildTotalsByDate(items: ReadonlyArray<DailyValueEntry | MatrixChartEntry>): ReadonlyMap<string, number> {
-  const totalsByDate = new Map<string, number>();
-
-  for (const item of items) {
-    if ("value" in item) {
-      totalsByDate.set(item.date, item.value);
-      continue;
-    }
-
-    const nextTotal = Object.values(item.valuesByKey).reduce((sum, value) => sum + value, 0);
-    totalsByDate.set(item.date, nextTotal);
-  }
-
-  return totalsByDate;
-}
-
-function getPeakDailyValue(items: ReadonlyArray<DailyValueEntry>): number {
-  return d3.max(items, (item) => item.value) ?? 0;
-}
-
-function getPeakStackedValue(items: ReadonlyArray<MatrixChartEntry>): number {
-  return d3.max(items, (item) => Object.values(item.valuesByKey).reduce((sum, value) => sum + value, 0)) ?? 0;
-}
-
-function getPeakGroupedValue(items: ReadonlyArray<MatrixChartEntry>): number {
-  return d3.max(items, (item) => d3.max(reviewEventPlatforms, (platform) => item.valuesByKey[platform] ?? 0) ?? 0) ?? 0;
-}
-
-function getUserColorScale(userIds: ReadonlyArray<string>): d3.ScaleOrdinal<string, string> {
-  const colors = userIds.map((userId) => userColorPalette[getUserColorPaletteIndex(userId)]);
-
-  return d3.scaleOrdinal<string, string>(userIds, colors);
-}
-
-function getUserColorPaletteIndex(userId: string): number {
-  let hash = 0;
-
-  for (const character of userId) {
-    hash = ((hash << 5) - hash + character.charCodeAt(0)) | 0;
-  }
-
-  return Math.abs(hash) % userColorPalette.length;
-}
-
-function getPlatformColor(platform: string): string {
-  if (reviewEventPlatforms.includes(platform as ReviewEventPlatform) === false) {
-    throw new Error(`Unsupported platform color key: ${platform}`);
-  }
-
-  return platformColors[platform as ReviewEventPlatform];
-}
-
-function getUserFilterLabel(user: ReviewEventsByDateUser): string {
-  return user.email === "(no email)" ? user.userId : user.email;
-}
-
-function getUserFilterSecondaryLabel(user: ReviewEventsByDateUser): string {
-  return user.email === "(no email)" ? user.email : user.userId;
-}
-
-function getNormalizedSearchValue(value: string): string {
-  return value.trim().toLocaleLowerCase("en-US");
-}
-
-function getUserFilterSearchableValue(user: ReviewEventsByDateUser): string {
-  return getNormalizedSearchValue([
-    getUserFilterLabel(user),
-    user.userId,
-    user.email,
-  ].join(" "));
-}
-
-function doesUserMatchSearch(option: SearchableUserFilterOption, normalizedSearchValue: string): boolean {
-  return normalizedSearchValue === "" || option.searchableValue.includes(normalizedSearchValue);
-}
-
-function getStableUserColorDomain(users: ReadonlyArray<ReviewEventsByDateUser>): ReadonlyArray<string> {
-  return users.map((user) => user.userId).sort((leftUserId, rightUserId) => leftUserId.localeCompare(rightUserId));
-}
-
-function createTickDates(dates: ReadonlyArray<string>): ReadonlyArray<string> {
-  return dates.filter(
-    (_date, index) => dates.length <= 22 || index % Math.ceil(dates.length / 16) === 0,
-  );
-}
-
-function renderChartFrame(
-  svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
-  params: ChartFrameParams,
-): d3.Selection<SVGGElement, unknown, null, undefined> {
-  const innerWidth = params.chartWidth - params.margin.left - params.margin.right;
-  const innerHeight = params.chartHeight - params.margin.top - params.margin.bottom;
-
-  svg.selectAll("*").remove();
-  svg.attr("viewBox", `0 0 ${params.chartWidth} ${params.chartHeight}`);
-
-  const group = svg.append("g").attr("transform", `translate(${params.margin.left},${params.margin.top})`);
-
-  group.append("g")
-    .attr("class", "grid")
-    .call(
-      d3.axisLeft(params.y)
-        .ticks(Math.min(8, Math.max(2, Math.round(params.y.domain()[1]) + 1)))
-        .tickSize(-innerWidth)
-        .tickFormat(() => ""),
-    )
-    .call((grid) => grid.select(".domain").remove());
-
-  group.append("g")
-    .attr("class", "axis")
-    .call(
-      d3.axisLeft(params.y)
-        .ticks(Math.min(8, Math.max(2, Math.round(params.y.domain()[1]) + 1)))
-        .tickFormat((value) => d3.format(",")(Number(value))),
-    );
-
-  group.append("g")
-    .attr("class", "axis")
-    .attr("transform", `translate(${innerWidth},0)`)
-    .call(
-      d3.axisRight(params.y)
-        .ticks(Math.min(8, Math.max(2, Math.round(params.y.domain()[1]) + 1)))
-        .tickFormat((value) => d3.format(",")(Number(value))),
-    );
-
-  group.append("g")
-    .attr("class", "axis")
-    .attr("transform", `translate(0,${innerHeight})`)
-    .call(
-      d3.axisBottom(params.x)
-        .tickValues(params.tickDates)
-        .tickFormat((value) => formatCompactDateLabel(value)),
-    )
-    .call((axis) => axis.selectAll("text")
-      .attr("transform", "rotate(-32)")
-      .style("text-anchor", "end")
-      .attr("dx", "-0.5em")
-      .attr("dy", "0.3em"));
-
-  group.append("text")
-    .attr("class", "axis-label")
-    .attr("x", -innerHeight / 2)
-    .attr("y", -48)
-    .attr("transform", "rotate(-90)")
-    .attr("text-anchor", "middle")
-    .text(params.yAxisLabel);
-
-  group.append("text")
-    .attr("class", "axis-label")
-    .attr("x", innerWidth / 2)
-    .attr("y", innerHeight + 74)
-    .attr("text-anchor", "middle")
-    .text("Review date");
-
-  return group;
-}
-
-function ChartTooltip(props: ChartTooltipState): JSX.Element {
-  return (
-    <div
-      className={`tooltip${props.visible ? " visible" : ""}`}
-      style={{ left: props.left, top: props.top }}
-      dangerouslySetInnerHTML={{ __html: props.html }}
-    />
-  );
-}
-
-function PlatformKey(): JSX.Element {
-  return (
-    <div className="platform-key" aria-label="Platform color key">
-      {reviewEventPlatforms.map((platform) => (
-        <span key={platform} className="platform-key-item">
-          <span className="platform-key-swatch" style={{ backgroundColor: platformColors[platform] }} />
-          <span>{platformLabels[platform]}</span>
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function UniqueUserCohortKey(): JSX.Element {
-  return (
-    <div className="platform-key" aria-label="Unique users cohort color key">
-      {uniqueUserCohortKeys.map((cohort) => (
-        <span key={cohort} className="platform-key-item">
-          <span className="platform-key-swatch" style={{ backgroundColor: uniqueUserCohortColors[cohort] }} />
-          <span>{uniqueUserCohortLabels[cohort]}</span>
-        </span>
-      ))}
-    </div>
-  );
-}
 
 export function ReviewEventsByDateDashboard(
   props: Readonly<{
@@ -416,16 +31,6 @@ export function ReviewEventsByDateDashboard(
     onDateRangeReset: () => void;
   }>,
 ): JSX.Element {
-  const uniqueUsersChartRef = useRef<SVGSVGElement | null>(null);
-  const userReviewEventsChartRef = useRef<SVGSVGElement | null>(null);
-  const platformUsersChartRef = useRef<SVGSVGElement | null>(null);
-  const platformReviewEventsChartRef = useRef<SVGSVGElement | null>(null);
-  const [tooltipState, setTooltipState] = useState<ChartTooltipState>({
-    visible: false,
-    html: "",
-    left: 0,
-    top: 0,
-  });
   const [draftRange, setDraftRange] = useState<ReviewEventsByDateRange>({
     from: props.report.from,
     to: props.report.to,
@@ -440,21 +45,30 @@ export function ReviewEventsByDateDashboard(
     });
   }, [props.report.from, props.report.to]);
 
-  function handleFromDateChange(event: ChangeEvent<HTMLInputElement>): void {
-    const from = event.currentTarget.value;
+  function handleFromDateChange(from: string): void {
     setDraftRange((currentRange) => ({
       ...currentRange,
       from,
     }));
   }
 
-  function handleUserFilterSearchChange(event: ChangeEvent<HTMLInputElement>): void {
-    setUserFilterSearchValue(event.currentTarget.value);
+  function handleToDateChange(to: string): void {
+    setDraftRange((currentRange) => ({
+      ...currentRange,
+      to,
+    }));
   }
 
-  function handleUserFilterChange(event: ChangeEvent<HTMLInputElement>): void {
-    const userId = event.currentTarget.value;
-    const isChecked = event.currentTarget.checked;
+  function handleDateRangeSubmit(): void {
+    props.onDateRangeApply(draftRange);
+  }
+
+  function handleDateRangeReset(): void {
+    setDraftRange(props.defaultRange);
+    props.onDateRangeReset();
+  }
+
+  function handleUserFilterChange(userId: string, isChecked: boolean): void {
     setSelectedUserIds((currentUserIds) => {
       if (isChecked) {
         if (currentUserIds.includes(userId)) {
@@ -478,29 +92,7 @@ export function ReviewEventsByDateDashboard(
 
   const handleChartUserFilterApply = useCallback((userId: string): void => {
     setSelectedUserIds([userId]);
-    setTooltipState((currentState) => ({
-      ...currentState,
-      visible: false,
-    }));
   }, []);
-
-  function handleToDateChange(event: ChangeEvent<HTMLInputElement>): void {
-    const to = event.currentTarget.value;
-    setDraftRange((currentRange) => ({
-      ...currentRange,
-      to,
-    }));
-  }
-
-  function handleDateRangeSubmit(event: FormEvent<HTMLFormElement>): void {
-    event.preventDefault();
-    props.onDateRangeApply(draftRange);
-  }
-
-  function handleDateRangeReset(): void {
-    setDraftRange(props.defaultRange);
-    props.onDateRangeReset();
-  }
 
   const filteredReport = useMemo(
     () => filterReviewEventsByDateReportByUsers(props.report, selectedUserIds),
@@ -510,31 +102,20 @@ export function ReviewEventsByDateDashboard(
     () => new Set(selectedUserIds),
     [selectedUserIds],
   );
-  const rawUserById = useMemo(
+  const userById = useMemo(
     () => new Map(props.report.users.map((user) => [user.userId, user])),
     [props.report.users],
   );
   const activeUserFilters = useMemo(
-    (): ReadonlyArray<ActiveUserFilter> => selectedUserIds.map((userId) => {
-      const user = rawUserById.get(userId);
-      return {
-        userId,
-        label: user === undefined ? userId : getUserFilterLabel(user),
-        secondaryLabel: user === undefined ? "No review events in range" : getUserFilterSecondaryLabel(user),
-        hasUserInReport: user !== undefined,
-      };
-    }),
-    [rawUserById, selectedUserIds],
+    () => buildActiveUserFilters(selectedUserIds, userById),
+    [selectedUserIds, userById],
   );
   const normalizedUserFilterSearchValue = useMemo(
     () => getNormalizedSearchValue(userFilterSearchValue),
     [userFilterSearchValue],
   );
   const searchableUserFilterOptions = useMemo(
-    (): ReadonlyArray<SearchableUserFilterOption> => props.report.users.map((user) => ({
-      user,
-      searchableValue: getUserFilterSearchableValue(user),
-    })),
+    () => buildSearchableUserFilterOptions(props.report.users),
     [props.report.users],
   );
   const matchingUserFilterOptions = useMemo(
@@ -548,382 +129,18 @@ export function ReviewEventsByDateDashboard(
     [matchingUserFilterOptions],
   );
   const hiddenUserFilterOptionCount = matchingUserFilterOptions.length - visibleUserFilterOptions.length;
-  const dates = useMemo(
-    () => filteredReport.dateTotals.map((item) => item.date),
-    [filteredReport.dateTotals],
+  const chartModel = useMemo(
+    () => buildReviewEventsByDateChartModel(filteredReport, props.report.users),
+    [filteredReport, props.report.users],
   );
-  const tickDates = useMemo(
-    () => createTickDates(dates),
-    [dates],
+  const summaryCards = useMemo(
+    () => buildReviewEventsByDateSummaryCards(
+      filteredReport,
+      chartModel.peakDailyVolume,
+      chartModel.peakDailyUniqueUsers,
+    ),
+    [chartModel.peakDailyUniqueUsers, chartModel.peakDailyVolume, filteredReport],
   );
-  const allUserIds = useMemo(
-    () => getStableUserColorDomain(props.report.users),
-    [props.report.users],
-  );
-  const userIds = useMemo(
-    () => filteredReport.users.map((user) => user.userId),
-    [filteredReport.users],
-  );
-  const userColorScale = useMemo(
-    () => getUserColorScale(allUserIds),
-    [allUserIds],
-  );
-  const dailyUniqueUserCohortMatrix = useMemo(
-    () => buildDailyUniqueUserCohortMatrix(filteredReport.dailyUniqueUserCohorts),
-    [filteredReport.dailyUniqueUserCohorts],
-  );
-  const dailyUniqueUserTotals = useMemo<ReadonlyArray<DailyValueEntry>>(
-    () => filteredReport.dailyUniqueUserCohorts.map((item) => ({
-      date: item.date,
-      value: item.newReviewingUsers + item.returningReviewingUsers,
-    })),
-    [filteredReport.dailyUniqueUserCohorts],
-  );
-  const userMatrix = useMemo(
-    () => buildUserMatrix(filteredReport),
-    [filteredReport],
-  );
-  const platformActiveUsersMatrix = useMemo(
-    () => buildPlatformMatrix(filteredReport.platformActiveUserTotals, (item) => item.activeUserCount, dates),
-    [dates, filteredReport.platformActiveUserTotals],
-  );
-  const platformReviewEventsMatrix = useMemo(
-    () => buildPlatformMatrix(filteredReport.platformReviewEventTotals, (item) => item.reviewEventCount, dates),
-    [dates, filteredReport.platformReviewEventTotals],
-  );
-  const totalReviewEventsByDate = useMemo(
-    () => new Map(filteredReport.dateTotals.map((item) => [item.date, item.totalReviewEvents])),
-    [filteredReport.dateTotals],
-  );
-  const dailyUniqueUsersByDate = useMemo(
-    () => new Map(dailyUniqueUserTotals.map((item) => [item.date, item.value])),
-    [dailyUniqueUserTotals],
-  );
-  const totalPlatformReviewEventsByDate = useMemo(
-    () => buildTotalsByDate(platformReviewEventsMatrix),
-    [platformReviewEventsMatrix],
-  );
-  const peakDailyUniqueUsers = useMemo(
-    () => getPeakDailyValue(dailyUniqueUserTotals),
-    [dailyUniqueUserTotals],
-  );
-  const peakDailyVolume = useMemo(
-    () => d3.max(filteredReport.dateTotals, (item) => item.totalReviewEvents) ?? 0,
-    [filteredReport.dateTotals],
-  );
-  const peakDailyPlatformUsers = useMemo(
-    () => getPeakGroupedValue(platformActiveUsersMatrix),
-    [platformActiveUsersMatrix],
-  );
-  const peakDailyPlatformReviewEvents = useMemo(
-    () => getPeakStackedValue(platformReviewEventsMatrix),
-    [platformReviewEventsMatrix],
-  );
-
-  useEffect(() => {
-    const uniqueUsersSvgElement = uniqueUsersChartRef.current;
-    const userReviewEventsSvgElement = userReviewEventsChartRef.current;
-    const platformUsersSvgElement = platformUsersChartRef.current;
-    const platformReviewEventsSvgElement = platformReviewEventsChartRef.current;
-    if (
-      uniqueUsersSvgElement === null
-      || userReviewEventsSvgElement === null
-      || platformUsersSvgElement === null
-      || platformReviewEventsSvgElement === null
-    ) {
-      return;
-    }
-
-    const uniqueUsersSvg = d3.select(uniqueUsersSvgElement);
-    const userReviewEventsSvg = d3.select(userReviewEventsSvgElement);
-    const platformUsersSvg = d3.select(platformUsersSvgElement);
-    const platformReviewEventsSvg = d3.select(platformReviewEventsSvgElement);
-    const innerWidth = chartWidth - chartMargin.left - chartMargin.right;
-    const simpleInnerHeight = simpleChartHeight - chartMargin.top - chartMargin.bottom;
-    const stackedInnerHeight = stackedChartHeight - chartMargin.top - chartMargin.bottom;
-    const x = d3.scaleBand<string>()
-      .domain(dates)
-      .range([0, innerWidth])
-      .paddingInner(0.08)
-      .paddingOuter(0.04);
-    const platformUsersX = d3.scaleBand<ReviewEventPlatform>()
-      .domain(reviewEventPlatforms)
-      .range([0, x.bandwidth()])
-      .paddingInner(0.16)
-      .paddingOuter(0.08);
-    const numberFormatter = d3.format(",");
-
-    function showTooltip(html: string, clientX: number, clientY: number): void {
-      const padding = 18;
-      const nextLeft = Math.max(padding, Math.min(window.innerWidth - 340, clientX + 18));
-      const nextTop = Math.max(padding, Math.min(window.innerHeight - 220, clientY + 18));
-      setTooltipState({
-        visible: true,
-        html,
-        left: nextLeft,
-        top: nextTop,
-      });
-    }
-
-    function hideTooltip(): void {
-      setTooltipState((currentState) => ({
-        ...currentState,
-        visible: false,
-      }));
-    }
-
-    const uniqueUsersY = d3.scaleLinear()
-      .domain([0, Math.max(1, peakDailyUniqueUsers)])
-      .nice()
-      .range([simpleInnerHeight, 0]);
-
-    const uniqueUsersGroup = renderChartFrame(uniqueUsersSvg, {
-      chartWidth,
-      chartHeight: simpleChartHeight,
-      margin: chartMargin,
-      x,
-      y: uniqueUsersY,
-      tickDates,
-      yAxisLabel: "Unique users",
-    });
-
-    const uniqueUsersSeries = d3.stack<MatrixChartEntry>()
-      .keys(uniqueUserCohortKeys)
-      .value((entry, key) => entry.valuesByKey[key] ?? 0)(dailyUniqueUserCohortMatrix);
-
-    uniqueUsersGroup.selectAll(".series")
-      .data(uniqueUsersSeries)
-      .join("g")
-      .attr("class", "series")
-      .attr("fill", (segment) => uniqueUserCohortColors[segment.key as UniqueUserCohortKey])
-      .selectAll("rect")
-      .data((segment) => segment.map((entry) => ({
-        key: segment.key,
-        date: entry.data.date,
-        y0: entry[0],
-        y1: entry[1],
-        value: entry.data.valuesByKey[segment.key] ?? 0,
-      })).filter((entry) => entry.value > 0))
-      .join("rect")
-      .attr("class", "bar-segment daily-unique-users")
-      .attr("x", (entry) => x(entry.date) ?? 0)
-      .attr("y", (entry) => uniqueUsersY(entry.y1))
-      .attr("width", x.bandwidth())
-      .attr("height", (entry) => Math.max(0, uniqueUsersY(entry.y0) - uniqueUsersY(entry.y1)))
-      .attr("rx", 3)
-      .attr("stroke", "rgba(255, 255, 255, 0.18)")
-      .attr("stroke-width", 1)
-      .on("mousemove", (event, entry: StackedChartRectEntry) => {
-        const cohortKey = entry.key as UniqueUserCohortKey;
-        const totalUniqueUsers = dailyUniqueUsersByDate.get(entry.date) ?? entry.value;
-        showTooltip(
-          [
-            `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
-            `<p class="tooltip-subtitle">${escapeHtml(uniqueUserCohortLabels[cohortKey])}</p>`,
-            `<div class="tooltip-metric"><span>Unique users in this cohort</span><strong>${numberFormatter(entry.value)}</strong></div>`,
-            `<div class="tooltip-metric"><span>Total unique users</span><strong>${numberFormatter(totalUniqueUsers)}</strong></div>`,
-            `<div class="tooltip-metric"><span>Total review events</span><strong>${numberFormatter(totalReviewEventsByDate.get(entry.date) ?? 0)}</strong></div>`,
-          ].join(""),
-          event.clientX,
-          event.clientY,
-        );
-      })
-      .on("mouseleave", hideTooltip);
-
-    const userReviewEventsY = d3.scaleLinear()
-      .domain([0, Math.max(1, peakDailyVolume)])
-      .nice()
-      .range([stackedInnerHeight, 0]);
-
-    const userReviewEventsGroup = renderChartFrame(userReviewEventsSvg, {
-      chartWidth,
-      chartHeight: stackedChartHeight,
-      margin: chartMargin,
-      x,
-      y: userReviewEventsY,
-      tickDates,
-      yAxisLabel: "Review events",
-    });
-
-    const userSeries = d3.stack<MatrixChartEntry>()
-      .keys(userIds)
-      .value((entry, key) => entry.valuesByKey[key] ?? 0)(userMatrix);
-
-    const userReviewEventBars = userReviewEventsGroup.selectAll(".series")
-      .data(userSeries)
-      .join("g")
-      .attr("class", "series")
-      .attr("fill", (segment) => userColorScale(segment.key))
-      .selectAll("rect")
-      .data((segment) => segment.map((entry) => ({
-        key: segment.key,
-        date: entry.data.date,
-        y0: entry[0],
-        y1: entry[1],
-        value: entry.data.valuesByKey[segment.key] ?? 0,
-      })).filter((entry) => entry.value > 0))
-      .join("rect")
-      .attr("class", `bar-segment user-review-events${props.isReportLoading ? "" : " clickable"}`)
-      .attr("x", (entry) => x(entry.date) ?? 0)
-      .attr("y", (entry) => userReviewEventsY(entry.y1))
-      .attr("width", x.bandwidth())
-      .attr("height", (entry) => Math.max(0, userReviewEventsY(entry.y0) - userReviewEventsY(entry.y1)))
-      .attr("rx", 2)
-      .on("mousemove", (event, entry: StackedChartRectEntry) => {
-        const user = rawUserById.get(entry.key);
-        if (user === undefined) {
-          return;
-        }
-
-        showTooltip(
-          [
-            `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
-            `<p class="tooltip-user-primary">${escapeHtml(user.email)}</p>`,
-            `<p class="tooltip-user-secondary">${escapeHtml(user.userId)}</p>`,
-            `<div class="tooltip-metric"><span>User review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
-            `<div class="tooltip-metric"><span>Total on this date</span><strong>${numberFormatter(totalReviewEventsByDate.get(entry.date) ?? entry.value)}</strong></div>`,
-            `<div class="tooltip-metric"><span>User total</span><strong>${numberFormatter(user.totalReviewEvents)}</strong></div>`,
-          ].join(""),
-          event.clientX,
-          event.clientY,
-        );
-      })
-      .on("mouseleave", hideTooltip);
-
-    if (props.isReportLoading === false) {
-      userReviewEventBars
-        .on("click", (_event: MouseEvent, entry: StackedChartRectEntry) => {
-          handleChartUserFilterApply(entry.key);
-        });
-    } else {
-      userReviewEventBars.on("click", null);
-    }
-
-    const platformUsersY = d3.scaleLinear()
-      .domain([0, Math.max(1, peakDailyPlatformUsers)])
-      .nice()
-      .range([stackedInnerHeight, 0]);
-
-    const platformUsersGroup = renderChartFrame(platformUsersSvg, {
-      chartWidth,
-      chartHeight: stackedChartHeight,
-      margin: chartMargin,
-      x,
-      y: platformUsersY,
-      tickDates,
-      yAxisLabel: "Active users",
-    });
-
-    const platformUserBars = platformActiveUsersMatrix.flatMap((entry) => reviewEventPlatforms.map((platform) => ({
-      key: platform,
-      date: entry.date,
-      value: entry.valuesByKey[platform] ?? 0,
-    })).filter((item) => item.value > 0));
-
-    platformUsersGroup.selectAll<SVGGElement, GroupedChartRectEntry>(".series")
-      .data(platformUserBars)
-      .join("rect")
-      .attr("class", "bar-segment")
-      .attr("fill", (entry) => getPlatformColor(entry.key))
-      .attr("x", (entry) => (x(entry.date) ?? 0) + (platformUsersX(entry.key) ?? 0))
-      .attr("y", (entry) => platformUsersY(entry.value))
-      .attr("width", platformUsersX.bandwidth())
-      .attr("height", (entry) => Math.max(0, stackedInnerHeight - platformUsersY(entry.value)))
-      .attr("rx", 2)
-      .on("mousemove", (event, entry: GroupedChartRectEntry) => {
-        showTooltip(
-          [
-            `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
-            `<p class="tooltip-subtitle">${escapeHtml(platformLabels[entry.key])}</p>`,
-            `<div class="tooltip-metric"><span>Active users on this platform</span><strong>${numberFormatter(entry.value)}</strong></div>`,
-            `<div class="tooltip-metric"><span>Total unique users on this date</span><strong>${numberFormatter(dailyUniqueUsersByDate.get(entry.date) ?? 0)}</strong></div>`,
-          ].join(""),
-          event.clientX,
-          event.clientY,
-        );
-      })
-      .on("mouseleave", hideTooltip);
-
-    const platformReviewEventsY = d3.scaleLinear()
-      .domain([0, Math.max(1, peakDailyPlatformReviewEvents)])
-      .nice()
-      .range([stackedInnerHeight, 0]);
-
-    const platformReviewEventsGroup = renderChartFrame(platformReviewEventsSvg, {
-      chartWidth,
-      chartHeight: stackedChartHeight,
-      margin: chartMargin,
-      x,
-      y: platformReviewEventsY,
-      tickDates,
-      yAxisLabel: "Review events",
-    });
-
-    const platformReviewEventsSeries = d3.stack<MatrixChartEntry>()
-      .keys(reviewEventPlatforms)
-      .value((entry, key) => entry.valuesByKey[key] ?? 0)(platformReviewEventsMatrix);
-
-    platformReviewEventsGroup.selectAll(".series")
-      .data(platformReviewEventsSeries)
-      .join("g")
-      .attr("class", "series")
-      .attr("fill", (segment) => getPlatformColor(segment.key))
-      .selectAll("rect")
-      .data((segment) => segment.map((entry) => ({
-        key: segment.key,
-        date: entry.data.date,
-        y0: entry[0],
-        y1: entry[1],
-        value: entry.data.valuesByKey[segment.key] ?? 0,
-      })).filter((entry) => entry.value > 0))
-      .join("rect")
-      .attr("class", "bar-segment")
-      .attr("x", (entry) => x(entry.date) ?? 0)
-      .attr("y", (entry) => platformReviewEventsY(entry.y1))
-      .attr("width", x.bandwidth())
-      .attr("height", (entry) => Math.max(0, platformReviewEventsY(entry.y0) - platformReviewEventsY(entry.y1)))
-      .attr("rx", 2)
-      .on("mousemove", (event, entry: StackedChartRectEntry) => {
-        showTooltip(
-          [
-            `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
-            `<p class="tooltip-subtitle">${escapeHtml(platformLabels[entry.key as ReviewEventPlatform])}</p>`,
-            `<div class="tooltip-metric"><span>Review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
-            `<div class="tooltip-metric"><span>All platforms on this date</span><strong>${numberFormatter(totalPlatformReviewEventsByDate.get(entry.date) ?? 0)}</strong></div>`,
-          ].join(""),
-          event.clientX,
-          event.clientY,
-        );
-      })
-      .on("mouseleave", hideTooltip);
-  }, [
-    dailyUniqueUserCohortMatrix,
-    dates,
-    peakDailyPlatformReviewEvents,
-    peakDailyPlatformUsers,
-    peakDailyUniqueUsers,
-    peakDailyVolume,
-    dailyUniqueUsersByDate,
-    platformActiveUsersMatrix,
-    platformReviewEventsMatrix,
-    tickDates,
-    totalPlatformReviewEventsByDate,
-    totalReviewEventsByDate,
-    handleChartUserFilterApply,
-    props.isReportLoading,
-    rawUserById,
-    userColorScale,
-    userIds,
-    userMatrix,
-  ]);
-
-  const summaryCards = [
-    { label: "Total Review Events", value: filteredReport.totalReviewEvents.toLocaleString("en-US") },
-    { label: "Users With Review Events", value: filteredReport.users.length.toLocaleString("en-US") },
-    { label: "Days In Range", value: filteredReport.dateTotals.length.toLocaleString("en-US") },
-    { label: "Peak Daily Volume", value: peakDailyVolume.toLocaleString("en-US") },
-    { label: "Peak Daily Unique Users", value: peakDailyUniqueUsers.toLocaleString("en-US") },
-  ];
 
   return (
     <main className="shell">
@@ -942,208 +159,39 @@ export function ReviewEventsByDateDashboard(
         </div>
       </section>
 
-      <section className="filter-panel" aria-labelledby="review-filters-title">
-        <div className="filter-panel-header">
-          <div>
-            <p className="eyebrow">Filters</p>
-            <h2 id="review-filters-title">Filters</h2>
-          </div>
-          <span className={`filter-status${props.isReportLoading ? " active" : ""}`} aria-live="polite">
-            {props.isReportLoading ? "Updating" : `Default ${props.defaultRange.from} to ${props.defaultRange.to}`}
-          </span>
-        </div>
-        <form className="date-filter-form" noValidate onSubmit={handleDateRangeSubmit}>
-          <label className="date-filter-field">
-            <span>From</span>
-            <input
-              type="date"
-              value={draftRange.from}
-              min={props.defaultRange.from}
-              max={props.defaultRange.to}
-              disabled={props.isReportLoading}
-              onChange={handleFromDateChange}
-            />
-          </label>
-          <label className="date-filter-field">
-            <span>To</span>
-            <input
-              type="date"
-              value={draftRange.to}
-              min={props.defaultRange.from}
-              max={props.defaultRange.to}
-              disabled={props.isReportLoading}
-              onChange={handleToDateChange}
-            />
-          </label>
-          <div className="date-filter-actions">
-            <button className="filter-button filter-button-primary" type="submit" disabled={props.isReportLoading}>
-              Apply
-            </button>
-            <button className="filter-button" type="button" disabled={props.isReportLoading} onClick={handleDateRangeReset}>
-              Reset
-            </button>
-          </div>
-        </form>
-        <div className="user-filter-section" aria-label="User filter">
-          <div className="user-filter-header">
-            <span>User</span>
-            <span>
-              {selectedUserIds.length === 0
-                ? "All users"
-                : `${selectedUserIds.length} selected`}
-            </span>
-          </div>
-          {props.report.users.length > 0 ? (
-            <>
-              <label className="user-filter-search">
-                <span>Search users</span>
-                <input
-                  type="search"
-                  value={userFilterSearchValue}
-                  placeholder="Email or user ID"
-                  disabled={props.isReportLoading}
-                  onChange={handleUserFilterSearchChange}
-                />
-              </label>
-              {visibleUserFilterOptions.length > 0 ? (
-                <div className="user-filter-options">
-                  {visibleUserFilterOptions.map((user) => (
-                    <label
-                      key={user.userId}
-                      className={`user-filter-option${selectedUserIdSet.has(user.userId) ? " selected" : ""}`}
-                    >
-                      <input
-                        type="checkbox"
-                        value={user.userId}
-                        checked={selectedUserIdSet.has(user.userId)}
-                        disabled={props.isReportLoading}
-                        onChange={handleUserFilterChange}
-                      />
-                      <span className="user-filter-swatch" style={{ backgroundColor: userColorScale(user.userId) }} />
-                      <span className="user-filter-option-text">
-                        <span className="user-filter-option-primary">{getUserFilterLabel(user)}</span>
-                        <span className="user-filter-option-secondary">
-                          {user.userId} - {user.totalReviewEvents.toLocaleString("en-US")} events
-                        </span>
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              ) : (
-                <p className="user-filter-empty">No users match this search.</p>
-              )}
-              {hiddenUserFilterOptionCount > 0 ? (
-                <p className="user-filter-limit">
-                  Showing {visibleUserFilterOptions.length.toLocaleString("en-US")} of {matchingUserFilterOptions.length.toLocaleString("en-US")} matching users.
-                </p>
-              ) : null}
-            </>
-          ) : (
-            <p className="user-filter-empty">No users with review events in this range.</p>
-          )}
-          {activeUserFilters.length > 0 ? (
-            <div className="active-filter-chips" aria-label="Active user filters">
-              {activeUserFilters.map((filter) => (
-                <span key={filter.userId} className="active-filter-chip">
-                  <span
-                    className="active-filter-swatch"
-                    style={{
-                      backgroundColor: filter.hasUserInReport
-                        ? userColorScale(filter.userId)
-                        : "rgba(255, 255, 255, 0.36)",
-                    }}
-                  />
-                  <span className="active-filter-text">
-                    <span>{filter.label}</span>
-                    <span>{filter.secondaryLabel}</span>
-                  </span>
-                  <button
-                    className="active-filter-remove"
-                    type="button"
-                    disabled={props.isReportLoading}
-                    aria-label={`Remove user filter ${filter.label}`}
-                    onClick={() => handleUserFilterRemove(filter.userId)}
-                  >
-                    x
-                  </button>
-                </span>
-              ))}
-              <button
-                className="filter-button filter-button-compact"
-                type="button"
-                disabled={props.isReportLoading}
-                onClick={handleUserFilterClear}
-              >
-                Clear users
-              </button>
-            </div>
-          ) : null}
-        </div>
-        {props.dateRangeError !== "" ? (
-          <p className="filter-error" role="alert">{props.dateRangeError}</p>
-        ) : null}
-      </section>
+      <ReviewEventsByDateFilters
+        defaultRange={props.defaultRange}
+        draftRange={draftRange}
+        isReportLoading={props.isReportLoading}
+        dateRangeError={props.dateRangeError}
+        reportUsers={props.report.users}
+        selectedUserIds={selectedUserIds}
+        selectedUserIdSet={selectedUserIdSet}
+        userFilterSearchValue={userFilterSearchValue}
+        visibleUserFilterOptions={visibleUserFilterOptions}
+        matchingUserFilterOptionCount={matchingUserFilterOptions.length}
+        hiddenUserFilterOptionCount={hiddenUserFilterOptionCount}
+        activeUserFilters={activeUserFilters}
+        userColorScale={chartModel.userColorScale}
+        onFromDateChange={handleFromDateChange}
+        onToDateChange={handleToDateChange}
+        onDateRangeSubmit={handleDateRangeSubmit}
+        onDateRangeReset={handleDateRangeReset}
+        onUserFilterSearchChange={setUserFilterSearchValue}
+        onUserFilterChange={handleUserFilterChange}
+        onUserFilterRemove={handleUserFilterRemove}
+        onUserFilterClear={handleUserFilterClear}
+      />
 
-      <section className="summary-grid">
-        {summaryCards.map((card) => (
-          <article key={card.label} className="metric-card">
-            <p className="metric-label">{card.label}</p>
-            <p className="metric-value">{card.value}</p>
-          </article>
-        ))}
-      </section>
+      <ReviewEventsByDateSummary cards={summaryCards} />
 
-      <section className="chart-column">
-        <div className="chart-shell">
-          <div className="chart-meta">
-            <span>Daily unique users with at least 1 review event &mdash; new vs returning</span>
-            <div className="chart-meta-right">
-              <UniqueUserCohortKey />
-            </div>
-          </div>
-          <div className="chart-scroll">
-            <svg ref={uniqueUsersChartRef} />
-          </div>
-        </div>
-
-        <div className="chart-shell">
-          <div className="chart-meta">
-            <span>Stacked review events by user</span>
-            <div className="chart-meta-right">
-              <span>Generated {formatGeneratedAt(props.report.generatedAtUtc)}</span>
-            </div>
-          </div>
-          <div className="chart-scroll">
-            <svg ref={userReviewEventsChartRef} />
-          </div>
-        </div>
-
-        <div className="chart-shell">
-          <div className="chart-meta">
-            <span>Daily active users by platform</span>
-            <div className="chart-meta-right">
-              <PlatformKey />
-            </div>
-          </div>
-          <div className="chart-scroll">
-            <svg ref={platformUsersChartRef} />
-          </div>
-        </div>
-
-        <div className="chart-shell">
-          <div className="chart-meta">
-            <span>Daily review events by platform</span>
-            <div className="chart-meta-right">
-              <PlatformKey />
-            </div>
-          </div>
-          <div className="chart-scroll">
-            <svg ref={platformReviewEventsChartRef} />
-          </div>
-        </div>
-      </section>
-
-      <ChartTooltip {...tooltipState} />
+      <ReviewEventsByDateCharts
+        chartModel={chartModel}
+        generatedAtUtc={props.report.generatedAtUtc}
+        isReportLoading={props.isReportLoading}
+        userById={userById}
+        onUserFilterApply={handleChartUserFilterApply}
+      />
     </main>
   );
 }

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateFilters.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateFilters.tsx
@@ -1,0 +1,184 @@
+import type { FormEvent, JSX } from "react";
+import type { ReviewEventsByDateUser } from "../../adminApi";
+import type { ReviewEventsByDateRange } from "./query";
+import { getUserFilterLabel, type ActiveUserFilter } from "./userFilters";
+
+type ReviewEventsByDateFiltersProps = Readonly<{
+  defaultRange: ReviewEventsByDateRange;
+  draftRange: ReviewEventsByDateRange;
+  isReportLoading: boolean;
+  dateRangeError: string;
+  reportUsers: ReadonlyArray<ReviewEventsByDateUser>;
+  selectedUserIds: ReadonlyArray<string>;
+  selectedUserIdSet: ReadonlySet<string>;
+  userFilterSearchValue: string;
+  visibleUserFilterOptions: ReadonlyArray<ReviewEventsByDateUser>;
+  matchingUserFilterOptionCount: number;
+  hiddenUserFilterOptionCount: number;
+  activeUserFilters: ReadonlyArray<ActiveUserFilter>;
+  userColorScale: (userId: string) => string;
+  onFromDateChange: (from: string) => void;
+  onToDateChange: (to: string) => void;
+  onDateRangeSubmit: () => void;
+  onDateRangeReset: () => void;
+  onUserFilterSearchChange: (searchValue: string) => void;
+  onUserFilterChange: (userId: string, isChecked: boolean) => void;
+  onUserFilterRemove: (userId: string) => void;
+  onUserFilterClear: () => void;
+}>;
+
+export function ReviewEventsByDateFilters(props: ReviewEventsByDateFiltersProps): JSX.Element {
+  function handleDateRangeSubmit(event: FormEvent<HTMLFormElement>): void {
+    event.preventDefault();
+    props.onDateRangeSubmit();
+  }
+
+  return (
+    <section className="filter-panel" aria-labelledby="review-filters-title">
+      <div className="filter-panel-header">
+        <div>
+          <p className="eyebrow">Filters</p>
+          <h2 id="review-filters-title">Filters</h2>
+        </div>
+        <span className={`filter-status${props.isReportLoading ? " active" : ""}`} aria-live="polite">
+          {props.isReportLoading ? "Updating" : `Default ${props.defaultRange.from} to ${props.defaultRange.to}`}
+        </span>
+      </div>
+      <form className="date-filter-form" noValidate onSubmit={handleDateRangeSubmit}>
+        <label className="date-filter-field">
+          <span>From</span>
+          <input
+            type="date"
+            value={props.draftRange.from}
+            min={props.defaultRange.from}
+            max={props.defaultRange.to}
+            disabled={props.isReportLoading}
+            onChange={(event) => props.onFromDateChange(event.currentTarget.value)}
+          />
+        </label>
+        <label className="date-filter-field">
+          <span>To</span>
+          <input
+            type="date"
+            value={props.draftRange.to}
+            min={props.defaultRange.from}
+            max={props.defaultRange.to}
+            disabled={props.isReportLoading}
+            onChange={(event) => props.onToDateChange(event.currentTarget.value)}
+          />
+        </label>
+        <div className="date-filter-actions">
+          <button className="filter-button filter-button-primary" type="submit" disabled={props.isReportLoading}>
+            Apply
+          </button>
+          <button
+            className="filter-button"
+            type="button"
+            disabled={props.isReportLoading}
+            onClick={props.onDateRangeReset}
+          >
+            Reset
+          </button>
+        </div>
+      </form>
+      <div className="user-filter-section" aria-label="User filter">
+        <div className="user-filter-header">
+          <span>User</span>
+          <span>
+            {props.selectedUserIds.length === 0
+              ? "All users"
+              : `${props.selectedUserIds.length} selected`}
+          </span>
+        </div>
+        {props.reportUsers.length > 0 ? (
+          <>
+            <label className="user-filter-search">
+              <span>Search users</span>
+              <input
+                type="search"
+                value={props.userFilterSearchValue}
+                placeholder="Email or user ID"
+                disabled={props.isReportLoading}
+                onChange={(event) => props.onUserFilterSearchChange(event.currentTarget.value)}
+              />
+            </label>
+            {props.visibleUserFilterOptions.length > 0 ? (
+              <div className="user-filter-options">
+                {props.visibleUserFilterOptions.map((user) => (
+                  <label
+                    key={user.userId}
+                    className={`user-filter-option${props.selectedUserIdSet.has(user.userId) ? " selected" : ""}`}
+                  >
+                    <input
+                      type="checkbox"
+                      value={user.userId}
+                      checked={props.selectedUserIdSet.has(user.userId)}
+                      disabled={props.isReportLoading}
+                      onChange={(event) => props.onUserFilterChange(user.userId, event.currentTarget.checked)}
+                    />
+                    <span className="user-filter-swatch" style={{ backgroundColor: props.userColorScale(user.userId) }} />
+                    <span className="user-filter-option-text">
+                      <span className="user-filter-option-primary">{getUserFilterLabel(user)}</span>
+                      <span className="user-filter-option-secondary">
+                        {user.userId} - {user.totalReviewEvents.toLocaleString("en-US")} events
+                      </span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className="user-filter-empty">No users match this search.</p>
+            )}
+            {props.hiddenUserFilterOptionCount > 0 ? (
+              <p className="user-filter-limit">
+                Showing {props.visibleUserFilterOptions.length.toLocaleString("en-US")} of {props.matchingUserFilterOptionCount.toLocaleString("en-US")} matching users.
+              </p>
+            ) : null}
+          </>
+        ) : (
+          <p className="user-filter-empty">No users with review events in this range.</p>
+        )}
+        {props.activeUserFilters.length > 0 ? (
+          <div className="active-filter-chips" aria-label="Active user filters">
+            {props.activeUserFilters.map((filter) => (
+              <span key={filter.userId} className="active-filter-chip">
+                <span
+                  className="active-filter-swatch"
+                  style={{
+                    backgroundColor: filter.hasUserInReport
+                      ? props.userColorScale(filter.userId)
+                      : "rgba(255, 255, 255, 0.36)",
+                  }}
+                />
+                <span className="active-filter-text">
+                  <span>{filter.label}</span>
+                  <span>{filter.secondaryLabel}</span>
+                </span>
+                <button
+                  className="active-filter-remove"
+                  type="button"
+                  disabled={props.isReportLoading}
+                  aria-label={`Remove user filter ${filter.label}`}
+                  onClick={() => props.onUserFilterRemove(filter.userId)}
+                >
+                  x
+                </button>
+              </span>
+            ))}
+            <button
+              className="filter-button filter-button-compact"
+              type="button"
+              disabled={props.isReportLoading}
+              onClick={props.onUserFilterClear}
+            >
+              Clear users
+            </button>
+          </div>
+        ) : null}
+      </div>
+      {props.dateRangeError !== "" ? (
+        <p className="filter-error" role="alert">{props.dateRangeError}</p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateSummary.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateSummary.tsx
@@ -1,0 +1,36 @@
+import type { JSX } from "react";
+import type { ReviewEventsByDateReport } from "../../adminApi";
+
+export type ReviewEventsByDateSummaryCard = Readonly<{
+  label: string;
+  value: string;
+}>;
+
+export function buildReviewEventsByDateSummaryCards(
+  filteredReport: ReviewEventsByDateReport,
+  peakDailyVolume: number,
+  peakDailyUniqueUsers: number,
+): ReadonlyArray<ReviewEventsByDateSummaryCard> {
+  return [
+    { label: "Total Review Events", value: filteredReport.totalReviewEvents.toLocaleString("en-US") },
+    { label: "Users With Review Events", value: filteredReport.users.length.toLocaleString("en-US") },
+    { label: "Days In Range", value: filteredReport.dateTotals.length.toLocaleString("en-US") },
+    { label: "Peak Daily Volume", value: peakDailyVolume.toLocaleString("en-US") },
+    { label: "Peak Daily Unique Users", value: peakDailyUniqueUsers.toLocaleString("en-US") },
+  ];
+}
+
+export function ReviewEventsByDateSummary(
+  props: Readonly<{ cards: ReadonlyArray<ReviewEventsByDateSummaryCard> }>,
+): JSX.Element {
+  return (
+    <section className="summary-grid">
+      {props.cards.map((card) => (
+        <article key={card.label} className="metric-card">
+          <p className="metric-label">{card.label}</p>
+          <p className="metric-value">{card.value}</p>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/apps/admin/src/reports/reviewEventsByDate/chartModel.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/chartModel.ts
@@ -1,0 +1,257 @@
+import * as d3 from "d3";
+import {
+  reviewEventPlatforms,
+  type ReviewEventPlatform,
+  type ReviewEventsByDateReport,
+  type ReviewEventsByDateUniqueUserCohort,
+  type ReviewEventsByDateUser,
+} from "../../adminApi";
+
+export type ChartTooltipState = Readonly<{
+  visible: boolean;
+  html: string;
+  left: number;
+  top: number;
+}>;
+
+export type DailyValueEntry = Readonly<{
+  date: string;
+  value: number;
+}>;
+
+export type MatrixChartEntry = Readonly<{
+  date: string;
+  valuesByKey: Readonly<Record<string, number>>;
+}>;
+
+export type StackedChartRectEntry = Readonly<{
+  key: string;
+  date: string;
+  value: number;
+  y0: number;
+  y1: number;
+}>;
+
+export type GroupedChartRectEntry = Readonly<{
+  key: ReviewEventPlatform;
+  date: string;
+  value: number;
+}>;
+
+export type ReviewEventsByDateChartModel = Readonly<{
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  userIds: ReadonlyArray<string>;
+  userColorScale: d3.ScaleOrdinal<string, string>;
+  dailyUniqueUserCohortMatrix: ReadonlyArray<MatrixChartEntry>;
+  userMatrix: ReadonlyArray<MatrixChartEntry>;
+  platformActiveUsersMatrix: ReadonlyArray<MatrixChartEntry>;
+  platformReviewEventsMatrix: ReadonlyArray<MatrixChartEntry>;
+  totalReviewEventsByDate: ReadonlyMap<string, number>;
+  dailyUniqueUsersByDate: ReadonlyMap<string, number>;
+  totalPlatformReviewEventsByDate: ReadonlyMap<string, number>;
+  peakDailyUniqueUsers: number;
+  peakDailyVolume: number;
+  peakDailyPlatformUsers: number;
+  peakDailyPlatformReviewEvents: number;
+}>;
+
+export const chartMargin = { top: 28, right: 68, bottom: 88, left: 68 } as const;
+export const chartWidth = 1320;
+export const simpleChartHeight = 300;
+export const stackedChartHeight = 620;
+
+export const platformLabels: Readonly<Record<ReviewEventPlatform, string>> = {
+  web: "Web",
+  android: "Android",
+  ios: "iOS",
+};
+
+const platformColors: Readonly<Record<ReviewEventPlatform, string>> = {
+  web: "#4e79a7",
+  android: "#59a14f",
+  ios: "#f28e2b",
+};
+
+export const uniqueUserCohortKeys = ["returning", "new"] as const;
+export type UniqueUserCohortKey = (typeof uniqueUserCohortKeys)[number];
+
+export const uniqueUserCohortLabels: Readonly<Record<UniqueUserCohortKey, string>> = {
+  returning: "Returning",
+  new: "New",
+};
+
+export const uniqueUserCohortColors: Readonly<Record<UniqueUserCohortKey, string>> = {
+  returning: "var(--accent)",
+  new: "#2e6f95",
+};
+
+const userColorPalette: ReadonlyArray<string> = [
+  ...d3.schemeTableau10,
+  ...d3.schemeSet2,
+  ...d3.schemeDark2,
+  "#e15759",
+  "#76b7b2",
+  "#f28e2b",
+  "#59a14f",
+];
+
+export function buildReviewEventsByDateChartModel(
+  report: ReviewEventsByDateReport,
+  stableUsers: ReadonlyArray<ReviewEventsByDateUser>,
+): ReviewEventsByDateChartModel {
+  const dates = report.dateTotals.map((item) => item.date);
+  const tickDates = createTickDates(dates);
+  const allUserIds = getStableUserColorDomain(stableUsers);
+  const userIds = report.users.map((user) => user.userId);
+  const userColorScale = getUserColorScale(allUserIds);
+  const dailyUniqueUserCohortMatrix = buildDailyUniqueUserCohortMatrix(report.dailyUniqueUserCohorts);
+  const dailyUniqueUserTotals = report.dailyUniqueUserCohorts.map((item) => ({
+    date: item.date,
+    value: item.newReviewingUsers + item.returningReviewingUsers,
+  }));
+  const userMatrix = buildUserMatrix(report);
+  const platformActiveUsersMatrix = buildPlatformMatrix(
+    report.platformActiveUserTotals,
+    (item) => item.activeUserCount,
+    dates,
+  );
+  const platformReviewEventsMatrix = buildPlatformMatrix(
+    report.platformReviewEventTotals,
+    (item) => item.reviewEventCount,
+    dates,
+  );
+  const totalReviewEventsByDate = new Map(report.dateTotals.map((item) => [item.date, item.totalReviewEvents]));
+  const dailyUniqueUsersByDate = new Map(dailyUniqueUserTotals.map((item) => [item.date, item.value]));
+  const totalPlatformReviewEventsByDate = buildTotalsByDate(platformReviewEventsMatrix);
+  const peakDailyUniqueUsers = getPeakDailyValue(dailyUniqueUserTotals);
+  const peakDailyVolume = d3.max(report.dateTotals, (item) => item.totalReviewEvents) ?? 0;
+  const peakDailyPlatformUsers = getPeakGroupedValue(platformActiveUsersMatrix);
+  const peakDailyPlatformReviewEvents = getPeakStackedValue(platformReviewEventsMatrix);
+
+  return {
+    dates,
+    tickDates,
+    userIds,
+    userColorScale,
+    dailyUniqueUserCohortMatrix,
+    userMatrix,
+    platformActiveUsersMatrix,
+    platformReviewEventsMatrix,
+    totalReviewEventsByDate,
+    dailyUniqueUsersByDate,
+    totalPlatformReviewEventsByDate,
+    peakDailyUniqueUsers,
+    peakDailyVolume,
+    peakDailyPlatformUsers,
+    peakDailyPlatformReviewEvents,
+  };
+}
+
+export function getPlatformColor(platform: string): string {
+  if (reviewEventPlatforms.includes(platform as ReviewEventPlatform) === false) {
+    throw new Error(`Unsupported platform color key: ${platform}`);
+  }
+
+  return platformColors[platform as ReviewEventPlatform];
+}
+
+function buildDailyUniqueUserCohortMatrix(
+  cohorts: ReadonlyArray<ReviewEventsByDateUniqueUserCohort>,
+): ReadonlyArray<MatrixChartEntry> {
+  return cohorts.map((cohort) => ({
+    date: cohort.date,
+    valuesByKey: {
+      returning: cohort.returningReviewingUsers,
+      new: cohort.newReviewingUsers,
+    },
+  }));
+}
+
+function buildUserMatrix(report: ReviewEventsByDateReport): ReadonlyArray<MatrixChartEntry> {
+  const valuesByDate = new Map<string, Record<string, number>>();
+
+  for (const row of report.rows) {
+    const currentValues = valuesByDate.get(row.date) ?? {};
+    currentValues[row.userId] = (currentValues[row.userId] ?? 0) + row.reviewEventCount;
+    valuesByDate.set(row.date, currentValues);
+  }
+
+  return report.dateTotals.map((item) => ({
+    date: item.date,
+    valuesByKey: valuesByDate.get(item.date) ?? {},
+  }));
+}
+
+function buildPlatformMatrix<Item extends Readonly<{ date: string; platform: ReviewEventPlatform }>>(
+  items: ReadonlyArray<Item>,
+  getValue: (item: Item) => number,
+  dates: ReadonlyArray<string>,
+): ReadonlyArray<MatrixChartEntry> {
+  const valuesByDate = new Map<string, Record<string, number>>();
+
+  for (const item of items) {
+    const currentValues = valuesByDate.get(item.date) ?? {};
+    currentValues[item.platform] = getValue(item);
+    valuesByDate.set(item.date, currentValues);
+  }
+
+  return dates.map((date) => ({
+    date,
+    valuesByKey: valuesByDate.get(date) ?? {},
+  }));
+}
+
+function buildTotalsByDate(items: ReadonlyArray<DailyValueEntry | MatrixChartEntry>): ReadonlyMap<string, number> {
+  const totalsByDate = new Map<string, number>();
+
+  for (const item of items) {
+    if ("value" in item) {
+      totalsByDate.set(item.date, item.value);
+      continue;
+    }
+
+    const nextTotal = Object.values(item.valuesByKey).reduce((sum, value) => sum + value, 0);
+    totalsByDate.set(item.date, nextTotal);
+  }
+
+  return totalsByDate;
+}
+
+function getPeakDailyValue(items: ReadonlyArray<DailyValueEntry>): number {
+  return d3.max(items, (item) => item.value) ?? 0;
+}
+
+function getPeakStackedValue(items: ReadonlyArray<MatrixChartEntry>): number {
+  return d3.max(items, (item) => Object.values(item.valuesByKey).reduce((sum, value) => sum + value, 0)) ?? 0;
+}
+
+function getPeakGroupedValue(items: ReadonlyArray<MatrixChartEntry>): number {
+  return d3.max(items, (item) => d3.max(reviewEventPlatforms, (platform) => item.valuesByKey[platform] ?? 0) ?? 0) ?? 0;
+}
+
+function getUserColorScale(userIds: ReadonlyArray<string>): d3.ScaleOrdinal<string, string> {
+  const colors = userIds.map((userId) => userColorPalette[getUserColorPaletteIndex(userId)]);
+
+  return d3.scaleOrdinal<string, string>(userIds, colors);
+}
+
+function getUserColorPaletteIndex(userId: string): number {
+  let hash = 0;
+
+  for (const character of userId) {
+    hash = ((hash << 5) - hash + character.charCodeAt(0)) | 0;
+  }
+
+  return Math.abs(hash) % userColorPalette.length;
+}
+
+function getStableUserColorDomain(users: ReadonlyArray<ReviewEventsByDateUser>): ReadonlyArray<string> {
+  return users.map((user) => user.userId).sort((leftUserId, rightUserId) => leftUserId.localeCompare(rightUserId));
+}
+
+function createTickDates(dates: ReadonlyArray<string>): ReadonlyArray<string> {
+  return dates.filter(
+    (_date, index) => dates.length <= 22 || index % Math.ceil(dates.length / 16) === 0,
+  );
+}

--- a/apps/admin/src/reports/reviewEventsByDate/chartRenderers.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/chartRenderers.ts
@@ -1,0 +1,402 @@
+import * as d3 from "d3";
+import {
+  reviewEventPlatforms,
+  type ReviewEventPlatform,
+  type ReviewEventsByDateUser,
+} from "../../adminApi";
+import {
+  chartMargin,
+  chartWidth,
+  getPlatformColor,
+  platformLabels,
+  simpleChartHeight,
+  stackedChartHeight,
+  uniqueUserCohortColors,
+  uniqueUserCohortKeys,
+  uniqueUserCohortLabels,
+  type GroupedChartRectEntry,
+  type MatrixChartEntry,
+  type StackedChartRectEntry,
+  type UniqueUserCohortKey,
+} from "./chartModel";
+import { escapeHtml, formatCompactDateLabel, formatDateRangeLabel } from "./formatting";
+
+type ChartFrameParams = Readonly<{
+  chartHeight: number;
+  x: d3.ScaleBand<string>;
+  y: d3.ScaleLinear<number, number>;
+  tickDates: ReadonlyArray<string>;
+  yAxisLabel: string;
+}>;
+
+type ChartTooltipHandlers = Readonly<{
+  showTooltip: (html: string, clientX: number, clientY: number) => void;
+  hideTooltip: () => void;
+}>;
+
+export type RenderDailyUniqueUsersChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  dailyUniqueUserCohortMatrix: ReadonlyArray<MatrixChartEntry>;
+  dailyUniqueUsersByDate: ReadonlyMap<string, number>;
+  totalReviewEventsByDate: ReadonlyMap<string, number>;
+  peakDailyUniqueUsers: number;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+export type RenderUserReviewEventsChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  userMatrix: ReadonlyArray<MatrixChartEntry>;
+  userIds: ReadonlyArray<string>;
+  userColorScale: d3.ScaleOrdinal<string, string>;
+  userById: ReadonlyMap<string, ReviewEventsByDateUser>;
+  totalReviewEventsByDate: ReadonlyMap<string, number>;
+  peakDailyVolume: number;
+  isReportLoading: boolean;
+  onUserFilterApply: (userId: string) => void;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+export type RenderPlatformActiveUsersChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  platformActiveUsersMatrix: ReadonlyArray<MatrixChartEntry>;
+  dailyUniqueUsersByDate: ReadonlyMap<string, number>;
+  peakDailyPlatformUsers: number;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+export type RenderPlatformReviewEventsChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  platformReviewEventsMatrix: ReadonlyArray<MatrixChartEntry>;
+  totalPlatformReviewEventsByDate: ReadonlyMap<string, number>;
+  peakDailyPlatformReviewEvents: number;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+const numberFormatter = d3.format(",");
+
+function getInnerWidth(): number {
+  return chartWidth - chartMargin.left - chartMargin.right;
+}
+
+function getInnerHeight(chartHeight: number): number {
+  return chartHeight - chartMargin.top - chartMargin.bottom;
+}
+
+function createDateScale(dates: ReadonlyArray<string>): d3.ScaleBand<string> {
+  return d3.scaleBand<string>()
+    .domain(dates)
+    .range([0, getInnerWidth()])
+    .paddingInner(0.08)
+    .paddingOuter(0.04);
+}
+
+function renderChartFrame(
+  svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
+  params: ChartFrameParams,
+): d3.Selection<SVGGElement, unknown, null, undefined> {
+  const innerWidth = getInnerWidth();
+  const innerHeight = getInnerHeight(params.chartHeight);
+
+  svg.selectAll("*").remove();
+  svg.attr("viewBox", `0 0 ${chartWidth} ${params.chartHeight}`);
+
+  const group = svg.append("g").attr("transform", `translate(${chartMargin.left},${chartMargin.top})`);
+
+  group.append("g")
+    .attr("class", "grid")
+    .call(
+      d3.axisLeft(params.y)
+        .ticks(Math.min(8, Math.max(2, Math.round(params.y.domain()[1]) + 1)))
+        .tickSize(-innerWidth)
+        .tickFormat(() => ""),
+    )
+    .call((grid) => grid.select(".domain").remove());
+
+  group.append("g")
+    .attr("class", "axis")
+    .call(
+      d3.axisLeft(params.y)
+        .ticks(Math.min(8, Math.max(2, Math.round(params.y.domain()[1]) + 1)))
+        .tickFormat((value) => numberFormatter(Number(value))),
+    );
+
+  group.append("g")
+    .attr("class", "axis")
+    .attr("transform", `translate(${innerWidth},0)`)
+    .call(
+      d3.axisRight(params.y)
+        .ticks(Math.min(8, Math.max(2, Math.round(params.y.domain()[1]) + 1)))
+        .tickFormat((value) => numberFormatter(Number(value))),
+    );
+
+  group.append("g")
+    .attr("class", "axis")
+    .attr("transform", `translate(0,${innerHeight})`)
+    .call(
+      d3.axisBottom(params.x)
+        .tickValues(params.tickDates)
+        .tickFormat((value) => formatCompactDateLabel(value)),
+    )
+    .call((axis) => axis.selectAll("text")
+      .attr("transform", "rotate(-32)")
+      .style("text-anchor", "end")
+      .attr("dx", "-0.5em")
+      .attr("dy", "0.3em"));
+
+  group.append("text")
+    .attr("class", "axis-label")
+    .attr("x", -innerHeight / 2)
+    .attr("y", -48)
+    .attr("transform", "rotate(-90)")
+    .attr("text-anchor", "middle")
+    .text(params.yAxisLabel);
+
+  group.append("text")
+    .attr("class", "axis-label")
+    .attr("x", innerWidth / 2)
+    .attr("y", innerHeight + 74)
+    .attr("text-anchor", "middle")
+    .text("Review date");
+
+  return group;
+}
+
+export function renderDailyUniqueUsersChart(params: RenderDailyUniqueUsersChartParams): void {
+  const svg = d3.select(params.svgElement);
+  const x = createDateScale(params.dates);
+  const innerHeight = getInnerHeight(simpleChartHeight);
+  const y = d3.scaleLinear()
+    .domain([0, Math.max(1, params.peakDailyUniqueUsers)])
+    .nice()
+    .range([innerHeight, 0]);
+  const group = renderChartFrame(svg, {
+    chartHeight: simpleChartHeight,
+    x,
+    y,
+    tickDates: params.tickDates,
+    yAxisLabel: "Unique users",
+  });
+  const series = d3.stack<MatrixChartEntry>()
+    .keys(uniqueUserCohortKeys)
+    .value((entry, key) => entry.valuesByKey[key] ?? 0)(params.dailyUniqueUserCohortMatrix);
+
+  group.selectAll(".series")
+    .data(series)
+    .join("g")
+    .attr("class", "series")
+    .attr("fill", (segment) => uniqueUserCohortColors[segment.key as UniqueUserCohortKey])
+    .selectAll("rect")
+    .data((segment) => segment.map((entry) => ({
+      key: segment.key,
+      date: entry.data.date,
+      y0: entry[0],
+      y1: entry[1],
+      value: entry.data.valuesByKey[segment.key] ?? 0,
+    })).filter((entry) => entry.value > 0))
+    .join("rect")
+    .attr("class", "bar-segment daily-unique-users")
+    .attr("x", (entry) => x(entry.date) ?? 0)
+    .attr("y", (entry) => y(entry.y1))
+    .attr("width", x.bandwidth())
+    .attr("height", (entry) => Math.max(0, y(entry.y0) - y(entry.y1)))
+    .attr("rx", 3)
+    .attr("stroke", "rgba(255, 255, 255, 0.18)")
+    .attr("stroke-width", 1)
+    .on("mousemove", (event, entry: StackedChartRectEntry) => {
+      const cohortKey = entry.key as UniqueUserCohortKey;
+      const totalUniqueUsers = params.dailyUniqueUsersByDate.get(entry.date) ?? entry.value;
+      params.tooltipHandlers.showTooltip(
+        [
+          `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
+          `<p class="tooltip-subtitle">${escapeHtml(uniqueUserCohortLabels[cohortKey])}</p>`,
+          `<div class="tooltip-metric"><span>Unique users in this cohort</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+          `<div class="tooltip-metric"><span>Total unique users</span><strong>${numberFormatter(totalUniqueUsers)}</strong></div>`,
+          `<div class="tooltip-metric"><span>Total review events</span><strong>${numberFormatter(params.totalReviewEventsByDate.get(entry.date) ?? 0)}</strong></div>`,
+        ].join(""),
+        event.clientX,
+        event.clientY,
+      );
+    })
+    .on("mouseleave", params.tooltipHandlers.hideTooltip);
+}
+
+export function renderUserReviewEventsChart(params: RenderUserReviewEventsChartParams): void {
+  const svg = d3.select(params.svgElement);
+  const x = createDateScale(params.dates);
+  const innerHeight = getInnerHeight(stackedChartHeight);
+  const y = d3.scaleLinear()
+    .domain([0, Math.max(1, params.peakDailyVolume)])
+    .nice()
+    .range([innerHeight, 0]);
+  const group = renderChartFrame(svg, {
+    chartHeight: stackedChartHeight,
+    x,
+    y,
+    tickDates: params.tickDates,
+    yAxisLabel: "Review events",
+  });
+  const series = d3.stack<MatrixChartEntry>()
+    .keys(params.userIds)
+    .value((entry, key) => entry.valuesByKey[key] ?? 0)(params.userMatrix);
+  const bars = group.selectAll(".series")
+    .data(series)
+    .join("g")
+    .attr("class", "series")
+    .attr("fill", (segment) => params.userColorScale(segment.key))
+    .selectAll("rect")
+    .data((segment) => segment.map((entry) => ({
+      key: segment.key,
+      date: entry.data.date,
+      y0: entry[0],
+      y1: entry[1],
+      value: entry.data.valuesByKey[segment.key] ?? 0,
+    })).filter((entry) => entry.value > 0))
+    .join("rect")
+    .attr("class", `bar-segment user-review-events${params.isReportLoading ? "" : " clickable"}`)
+    .attr("x", (entry) => x(entry.date) ?? 0)
+    .attr("y", (entry) => y(entry.y1))
+    .attr("width", x.bandwidth())
+    .attr("height", (entry) => Math.max(0, y(entry.y0) - y(entry.y1)))
+    .attr("rx", 2)
+    .on("mousemove", (event, entry: StackedChartRectEntry) => {
+      const user = params.userById.get(entry.key);
+      if (user === undefined) {
+        return;
+      }
+
+      params.tooltipHandlers.showTooltip(
+        [
+          `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
+          `<p class="tooltip-user-primary">${escapeHtml(user.email)}</p>`,
+          `<p class="tooltip-user-secondary">${escapeHtml(user.userId)}</p>`,
+          `<div class="tooltip-metric"><span>User review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+          `<div class="tooltip-metric"><span>Total on this date</span><strong>${numberFormatter(params.totalReviewEventsByDate.get(entry.date) ?? entry.value)}</strong></div>`,
+          `<div class="tooltip-metric"><span>User total</span><strong>${numberFormatter(user.totalReviewEvents)}</strong></div>`,
+        ].join(""),
+        event.clientX,
+        event.clientY,
+      );
+    })
+    .on("mouseleave", params.tooltipHandlers.hideTooltip);
+
+  if (params.isReportLoading === false) {
+    bars.on("click", (_event: MouseEvent, entry: StackedChartRectEntry) => {
+      params.onUserFilterApply(entry.key);
+    });
+  } else {
+    bars.on("click", null);
+  }
+}
+
+export function renderPlatformActiveUsersChart(params: RenderPlatformActiveUsersChartParams): void {
+  const svg = d3.select(params.svgElement);
+  const x = createDateScale(params.dates);
+  const innerHeight = getInnerHeight(stackedChartHeight);
+  const platformUsersX = d3.scaleBand<ReviewEventPlatform>()
+    .domain(reviewEventPlatforms)
+    .range([0, x.bandwidth()])
+    .paddingInner(0.16)
+    .paddingOuter(0.08);
+  const y = d3.scaleLinear()
+    .domain([0, Math.max(1, params.peakDailyPlatformUsers)])
+    .nice()
+    .range([innerHeight, 0]);
+  const group = renderChartFrame(svg, {
+    chartHeight: stackedChartHeight,
+    x,
+    y,
+    tickDates: params.tickDates,
+    yAxisLabel: "Active users",
+  });
+  const bars = params.platformActiveUsersMatrix.flatMap((entry) => reviewEventPlatforms.map((platform) => ({
+    key: platform,
+    date: entry.date,
+    value: entry.valuesByKey[platform] ?? 0,
+  })).filter((item) => item.value > 0));
+
+  group.selectAll<SVGGElement, GroupedChartRectEntry>(".series")
+    .data(bars)
+    .join("rect")
+    .attr("class", "bar-segment")
+    .attr("fill", (entry) => getPlatformColor(entry.key))
+    .attr("x", (entry) => (x(entry.date) ?? 0) + (platformUsersX(entry.key) ?? 0))
+    .attr("y", (entry) => y(entry.value))
+    .attr("width", platformUsersX.bandwidth())
+    .attr("height", (entry) => Math.max(0, innerHeight - y(entry.value)))
+    .attr("rx", 2)
+    .on("mousemove", (event, entry: GroupedChartRectEntry) => {
+      params.tooltipHandlers.showTooltip(
+        [
+          `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
+          `<p class="tooltip-subtitle">${escapeHtml(platformLabels[entry.key])}</p>`,
+          `<div class="tooltip-metric"><span>Active users on this platform</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+          `<div class="tooltip-metric"><span>Total unique users on this date</span><strong>${numberFormatter(params.dailyUniqueUsersByDate.get(entry.date) ?? 0)}</strong></div>`,
+        ].join(""),
+        event.clientX,
+        event.clientY,
+      );
+    })
+    .on("mouseleave", params.tooltipHandlers.hideTooltip);
+}
+
+export function renderPlatformReviewEventsChart(params: RenderPlatformReviewEventsChartParams): void {
+  const svg = d3.select(params.svgElement);
+  const x = createDateScale(params.dates);
+  const innerHeight = getInnerHeight(stackedChartHeight);
+  const y = d3.scaleLinear()
+    .domain([0, Math.max(1, params.peakDailyPlatformReviewEvents)])
+    .nice()
+    .range([innerHeight, 0]);
+  const group = renderChartFrame(svg, {
+    chartHeight: stackedChartHeight,
+    x,
+    y,
+    tickDates: params.tickDates,
+    yAxisLabel: "Review events",
+  });
+  const series = d3.stack<MatrixChartEntry>()
+    .keys(reviewEventPlatforms)
+    .value((entry, key) => entry.valuesByKey[key] ?? 0)(params.platformReviewEventsMatrix);
+
+  group.selectAll(".series")
+    .data(series)
+    .join("g")
+    .attr("class", "series")
+    .attr("fill", (segment) => getPlatformColor(segment.key))
+    .selectAll("rect")
+    .data((segment) => segment.map((entry) => ({
+      key: segment.key,
+      date: entry.data.date,
+      y0: entry[0],
+      y1: entry[1],
+      value: entry.data.valuesByKey[segment.key] ?? 0,
+    })).filter((entry) => entry.value > 0))
+    .join("rect")
+    .attr("class", "bar-segment")
+    .attr("x", (entry) => x(entry.date) ?? 0)
+    .attr("y", (entry) => y(entry.y1))
+    .attr("width", x.bandwidth())
+    .attr("height", (entry) => Math.max(0, y(entry.y0) - y(entry.y1)))
+    .attr("rx", 2)
+    .on("mousemove", (event, entry: StackedChartRectEntry) => {
+      params.tooltipHandlers.showTooltip(
+        [
+          `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
+          `<p class="tooltip-subtitle">${escapeHtml(platformLabels[entry.key as ReviewEventPlatform])}</p>`,
+          `<div class="tooltip-metric"><span>Review events</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+          `<div class="tooltip-metric"><span>All platforms on this date</span><strong>${numberFormatter(params.totalPlatformReviewEventsByDate.get(entry.date) ?? 0)}</strong></div>`,
+        ].join(""),
+        event.clientX,
+        event.clientY,
+      );
+    })
+    .on("mouseleave", params.tooltipHandlers.hideTooltip);
+}

--- a/apps/admin/src/reports/reviewEventsByDate/formatting.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/formatting.ts
@@ -1,0 +1,57 @@
+function parseCalendarDate(date: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(date);
+  if (match === null) {
+    throw new Error(`Invalid report date: ${date}`);
+  }
+
+  const year = Number.parseInt(match[1], 10);
+  const monthIndex = Number.parseInt(match[2], 10) - 1;
+  const day = Number.parseInt(match[3], 10);
+  const parsedDate = new Date(Date.UTC(year, monthIndex, day));
+
+  if (
+    Number.isNaN(parsedDate.getTime())
+    || parsedDate.getUTCFullYear() !== year
+    || parsedDate.getUTCMonth() !== monthIndex
+    || parsedDate.getUTCDate() !== day
+  ) {
+    throw new Error(`Invalid report date: ${date}`);
+  }
+
+  return parsedDate;
+}
+
+export function formatDateRangeLabel(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+  }).format(parseCalendarDate(date));
+}
+
+export function formatCompactDateLabel(date: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    month: "short",
+    day: "2-digit",
+  }).format(parseCalendarDate(date));
+}
+
+export function formatGeneratedAt(value: string): string {
+  const formatted = new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+  return `${formatted} UTC`;
+}
+
+export function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+}

--- a/apps/admin/src/reports/reviewEventsByDate/userFilters.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/userFilters.ts
@@ -1,0 +1,66 @@
+import type { ReviewEventsByDateUser } from "../../adminApi";
+
+export type ActiveUserFilter = Readonly<{
+  userId: string;
+  label: string;
+  secondaryLabel: string;
+  hasUserInReport: boolean;
+}>;
+
+export type SearchableUserFilterOption = Readonly<{
+  user: ReviewEventsByDateUser;
+  searchableValue: string;
+}>;
+
+export const visibleUserFilterOptionLimit = 50;
+
+export function getUserFilterLabel(user: ReviewEventsByDateUser): string {
+  return user.email === "(no email)" ? user.userId : user.email;
+}
+
+export function getUserFilterSecondaryLabel(user: ReviewEventsByDateUser): string {
+  return user.email === "(no email)" ? user.email : user.userId;
+}
+
+export function getNormalizedSearchValue(value: string): string {
+  return value.trim().toLocaleLowerCase("en-US");
+}
+
+export function getUserFilterSearchableValue(user: ReviewEventsByDateUser): string {
+  return getNormalizedSearchValue([
+    getUserFilterLabel(user),
+    user.userId,
+    user.email,
+  ].join(" "));
+}
+
+export function doesUserMatchSearch(
+  option: SearchableUserFilterOption,
+  normalizedSearchValue: string,
+): boolean {
+  return normalizedSearchValue === "" || option.searchableValue.includes(normalizedSearchValue);
+}
+
+export function buildActiveUserFilters(
+  selectedUserIds: ReadonlyArray<string>,
+  userById: ReadonlyMap<string, ReviewEventsByDateUser>,
+): ReadonlyArray<ActiveUserFilter> {
+  return selectedUserIds.map((userId) => {
+    const user = userById.get(userId);
+    return {
+      userId,
+      label: user === undefined ? userId : getUserFilterLabel(user),
+      secondaryLabel: user === undefined ? "No review events in range" : getUserFilterSecondaryLabel(user),
+      hasUserInReport: user !== undefined,
+    };
+  });
+}
+
+export function buildSearchableUserFilterOptions(
+  users: ReadonlyArray<ReviewEventsByDateUser>,
+): ReadonlyArray<SearchableUserFilterOption> {
+  return users.map((user) => ({
+    user,
+    searchableValue: getUserFilterSearchableValue(user),
+  }));
+}


### PR DESCRIPTION
## Summary
- split the admin review-events-by-date dashboard into focused report-local modules
- preserve the existing dashboard entrypoint, props, styles, filters, D3 rendering behavior, legends, and tooltips

## Validation
- cd apps/admin && npm run build
- code review with three focused subagents returned green light