### PR TITLE
Prevent AI chat send from refocusing composer

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AiRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AiRouteTest.kt
@@ -3,12 +3,19 @@ package com.flashcardsopensourceapp.app
 import android.content.ClipboardManager
 import androidx.activity.ComponentActivity
 import androidx.compose.material3.Text
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -43,6 +50,7 @@ import com.flashcardsopensourceapp.feature.ai.aiConversationSurfaceTag
 import com.flashcardsopensourceapp.feature.ai.aiUserMessageBubbleTag
 import com.flashcardsopensourceapp.feature.ai.formatAiConsentWorkspaceDisclosureText
 import com.flashcardsopensourceapp.feature.ai.R as AiFeatureR
+import java.util.concurrent.atomic.AtomicBoolean
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -307,6 +315,71 @@ class AiRouteTest : FirebaseAppInstrumentationTimeoutTest() {
 
         composeRule.onNodeWithContentDescription(sendLabel).assertIsDisplayed()
         composeRule.onNodeWithTag(aiComposerSendButtonTag).assertIsEnabled()
+    }
+
+    @Test
+    fun sendClearsComposerFocusBeforeDispatchingMessage() {
+        var didSend = false
+        val didRequestForcedFocusClear = AtomicBoolean(false)
+        var didRequestForcedFocusClearAtDispatch: Boolean? = null
+        composeRule.setContent {
+            val delegateFocusManager = LocalFocusManager.current
+            val recordingFocusManager = remember(delegateFocusManager) {
+                RecordingFocusManager(
+                    delegateFocusManager = delegateFocusManager,
+                    didRequestForcedClearFocus = didRequestForcedFocusClear
+                )
+            }
+            CompositionLocalProvider(LocalFocusManager provides recordingFocusManager) {
+                FlashcardsTheme {
+                    AiRoute(
+                        uiState = makeAiUiState(
+                            draftMessage = "hello",
+                            canSend = true
+                        ),
+                        onAcceptConsent = {},
+                        onDraftMessageChange = {},
+                        onApplyComposerSuggestion = {},
+                        onSendMessage = {
+                            didRequestForcedFocusClearAtDispatch = didRequestForcedFocusClear.get()
+                            didSend = true
+                        },
+                        onCancelStreaming = {},
+                        onNewChat = {},
+                        onOpenAccountStatus = {},
+                        onDismissErrorMessage = {},
+                        onDismissAlert = {},
+                        onAddPendingAttachment = {},
+                        onRemovePendingAttachment = {},
+                        onStartDictationPermissionRequest = {},
+                        onStartDictationRecording = {},
+                        onTranscribeRecordedAudio = { _, _, _ -> },
+                        onCancelDictation = {},
+                        onScreenVisible = {},
+                        onScreenHidden = {},
+                        onWarmUpSessionIfNeeded = {},
+                        onRetryConversationLoad = {},
+                        onShowAlert = {},
+                        onShowErrorMessage = {}
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag(aiComposerMessageFieldTag).performClick()
+        composeRule.onNodeWithTag(aiComposerMessageFieldTag).assertIsFocused()
+        assertTrue(
+            "Expected no forced focus clear before tapping send.",
+            didRequestForcedFocusClear.get().not()
+        )
+
+        composeRule.onNodeWithTag(aiComposerSendButtonTag).performClick()
+        assertTrue(
+            "Expected the AI composer focus to request forced clear before send dispatch.",
+            didRequestForcedFocusClearAtDispatch == true
+        )
+        composeRule.onNodeWithTag(aiComposerMessageFieldTag).assertIsNotFocused()
+        assertTrue(didSend)
     }
 
     @Test
@@ -636,4 +709,20 @@ private fun makeAiUiState(
         activeAlert = null,
         errorMessage = ""
     )
+}
+
+private class RecordingFocusManager(
+    private val delegateFocusManager: FocusManager,
+    private val didRequestForcedClearFocus: AtomicBoolean
+) : FocusManager {
+    override fun clearFocus(force: Boolean) {
+        delegateFocusManager.clearFocus(force = force)
+        if (force) {
+            didRequestForcedClearFocus.set(true)
+        }
+    }
+
+    override fun moveFocus(focusDirection: FocusDirection): Boolean {
+        return delegateFocusManager.moveFocus(focusDirection = focusDirection)
+    }
 }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
@@ -404,7 +404,10 @@ internal fun AiRouteContent(
                         uiState = uiState,
                         onDraftMessageChange = onDraftMessageChange,
                         onApplyComposerSuggestion = onApplyComposerSuggestion,
-                        onSendMessage = onSendMessage,
+                        onSendMessage = {
+                            dismissComposerFocus()
+                            onSendMessage()
+                        },
                         onCancelStreaming = onCancelStreaming,
                         onRemovePendingAttachment = onRemovePendingAttachment,
                         onOpenAttachmentMenu = {

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatComposerAccessoryView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatComposerAccessoryView.swift
@@ -133,14 +133,15 @@ extension AIChatView {
                     .disabled(self.composerTextFieldDisabled)
                     .autocorrectionDisabled(true)
                     .focused(self.$isComposerFocused)
-                    .onTapGesture {
-                        self.isComposerFocused = true
-                    }
                     .lineLimit(1...aiChatComposerMaximumLineCount)
                     .padding(.leading, 12)
                     .padding(.top, self.chatStore.dictationState == .idle ? 12 : aiChatComposerDictationTextFieldTopPadding)
                     .padding(.trailing, aiChatComposerSendButtonReservedTrailingPadding)
                     .padding(.bottom, 12)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        self.isComposerFocused = true
+                    }
                     .accessibilityIdentifier(UITestIdentifier.aiComposerTextField)
 
                     Button {
@@ -171,12 +172,6 @@ extension AIChatView {
                             .padding(.trailing, aiChatComposerSendButtonReservedTrailingPadding)
                     }
                 }
-                .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                .simultaneousGesture(
-                    TapGesture().onEnded {
-                        self.isComposerFocused = true
-                    }
-                )
 
                 HStack {
                     self.composerModelControl

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatView.swift
@@ -534,7 +534,7 @@ struct AIChatView: View {
             return
         }
         self.chatStore.sendMessage()
-        self.isComposerFocused = true
+        self.dismissComposerFocus()
     }
 
     func dismissComposerFocus() {


### PR DESCRIPTION
## Summary
- clear AI chat composer focus after send on iOS and Android
- remove the iOS container-wide tap refocus path that affected Send taps
- add Android instrumentation coverage for focus clearing before send dispatch

## Validation
- git --no-pager diff --check
- xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'generic/platform=iOS Simulator' build
- ./gradlew :app:compileDebugAndroidTestKotlin