### PR TITLE
[codex] Fix Android AI provisioning retry

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatBootstrapCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatBootstrapCoordinator.kt
@@ -869,13 +869,17 @@ private fun isLikelyTransientBootstrapIoException(error: IOException): Boolean {
     if (error is SSLException) {
         return isTransportLikeSslException(error = error)
     }
-    return false
+    return hasTransientTransportMessage(error = error)
 }
 
 private fun isTransportLikeSslException(error: SSLException): Boolean {
     if (hasTransientTransportCause(error = error)) {
         return true
     }
+    return hasTransientTransportMessage(error = error)
+}
+
+private fun hasTransientTransportMessage(error: Throwable): Boolean {
     val message = error.message?.lowercase() ?: return false
     val transportMessageFragments: List<String> = listOf(
         "connection reset",


### PR DESCRIPTION
## Summary
- retry plain transport-shaped `IOException` messages during AI chat bootstrap/session provisioning
- keep send and dictation able to preempt pending fresh-session provisioning retries

## Root cause
Plain `IOException("connection reset")` was not classified as transient, so fresh-session provisioning moved the new local chat to `FAILED` before user actions could retry through the explicit provisioning path.

## Validation
- `./gradlew :feature:ai:testDebugUnitTest --tests 'com.flashcardsopensourceapp.feature.ai.runtime.AiChatRuntimeConversationResetAndSendTest.dictationPreemptsRetryingFreshSessionProvisioningAndSkipsTranscriptionWhenOneShotFails' --tests 'com.flashcardsopensourceapp.feature.ai.runtime.AiChatRuntimeConversationResetAndSendTest.sendMessagePreemptsRetryingFreshSessionProvisioningAfterClearConversation'`
- `./gradlew :feature:ai:testDebugUnitTest --tests 'com.flashcardsopensourceapp.feature.ai.runtime.AiChatRuntimeBootstrapProvisioningTest'`
- `./gradlew :feature:ai:testDebugUnitTest`