### PR TITLE
[codex] Fix stale CSRF recovery

### DIFF
--- a/apps/admin/src/adminApi.ts
+++ b/apps/admin/src/adminApi.ts
@@ -104,8 +104,12 @@ type AdminSessionState = Readonly<{
   csrfToken: string | null;
 }>;
 
+const staleSessionCsrfTokenErrorCode = "SESSION_CSRF_TOKEN_INVALID";
+const staleSessionCsrfTokenErrorMessage = "Invalid X-CSRF-Token header";
+
 let adminSessionState: AdminSessionState | undefined;
 let adminSessionRecoveryPromise: Promise<AdminSession> | undefined;
+let adminSessionCsrfRecoveryPromise: Promise<void> | undefined;
 
 async function parseApiError(response: Response): Promise<never> {
   let message = `Request failed with status ${response.status}`;
@@ -125,6 +129,37 @@ async function parseApiError(response: Response): Promise<never> {
   }
 
   throw new AdminApiError(response.status, message, code);
+}
+
+function isRecoverableAdminCsrfPayload(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value === staleSessionCsrfTokenErrorMessage;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  return objectValue.code === staleSessionCsrfTokenErrorCode
+    || objectValue.error === staleSessionCsrfTokenErrorMessage;
+}
+
+async function readAdminJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text === "") {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+async function isRecoverableAdminCsrfResponse(response: Response): Promise<boolean> {
+  if (response.status !== 403) {
+    return false;
+  }
+
+  return isRecoverableAdminCsrfPayload(await readAdminJsonResponse(response.clone()));
 }
 
 function resetAdminSessionState(): void {
@@ -253,6 +288,23 @@ async function recoverAdminSession(config: AdminAppConfig): Promise<AdminSession
   return adminSessionRecoveryPromise;
 }
 
+async function recoverAdminSessionCsrf(config: AdminAppConfig): Promise<void> {
+  const activeRecoveryPromise = adminSessionCsrfRecoveryPromise;
+  if (activeRecoveryPromise !== undefined) {
+    return activeRecoveryPromise;
+  }
+
+  const recoveryPromise = (async (): Promise<void> => {
+    await fetchAdminSession(config);
+  })();
+
+  adminSessionCsrfRecoveryPromise = recoveryPromise.finally(() => {
+    adminSessionCsrfRecoveryPromise = undefined;
+  });
+
+  return adminSessionCsrfRecoveryPromise;
+}
+
 async function ensureAdminSessionLoaded(config: AdminAppConfig): Promise<void> {
   if (adminSessionState !== undefined) {
     return;
@@ -290,9 +342,24 @@ export async function runAdminQuery(
 
   let response = await performAdminFetch(config, "/admin/reports/query", requestInit);
 
-  if (response.status === 401) {
-    await recoverAdminSession(config);
-    response = await performAdminFetch(config, "/admin/reports/query", requestInit);
+  let didRecoverSession: boolean = false;
+  let didRecoverSessionCsrf: boolean = false;
+  while (true) {
+    if (response.status === 401 && didRecoverSession === false) {
+      didRecoverSession = true;
+      await recoverAdminSession(config);
+      response = await performAdminFetch(config, "/admin/reports/query", requestInit);
+      continue;
+    }
+
+    if (didRecoverSessionCsrf === false && await isRecoverableAdminCsrfResponse(response)) {
+      didRecoverSessionCsrf = true;
+      await recoverAdminSessionCsrf(config);
+      response = await performAdminFetch(config, "/admin/reports/query", requestInit);
+      continue;
+    }
+
+    break;
   }
 
   if (!response.ok) {

--- a/apps/backend/src/requestSecurity.ts
+++ b/apps/backend/src/requestSecurity.ts
@@ -157,6 +157,6 @@ export async function enforceSessionCsrfProtection(
 
   const expectedToken = await getSessionCsrfToken(sessionToken);
   if (!isMatchingToken(expectedToken, csrfToken)) {
-    throw new HttpError(403, "Invalid X-CSRF-Token header");
+    throw new HttpError(403, "Invalid X-CSRF-Token header", "SESSION_CSRF_TOKEN_INVALID");
   }
 }

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -778,6 +778,84 @@ describe("AI chat transport", () => {
     expect(new Headers(chatRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-1");
   });
 
+  it("reloads the session CSRF token and retries once after a stale CSRF rejection", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-1",
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: "Invalid X-CSRF-Token header",
+        code: "SESSION_CSRF_TOKEN_INVALID",
+      }), {
+        status: 403,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }))
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-2",
+      }))
+      .mockResolvedValueOnce(createNewChatSessionResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createNewChatSession("session-1", "workspace-1", "en");
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8080/v1/chat/new");
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("http://localhost:8080/v1/chat/new");
+
+    const staleRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
+    const retriedRequestInit = fetchMock.mock.calls[3]?.[1] as RequestInit | undefined;
+    expect(new Headers(staleRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-1");
+    expect(new Headers(retriedRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-2");
+  });
+
+  it("uses normal auth recovery when the retry after stale CSRF returns unauthorized", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-1",
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: "Invalid X-CSRF-Token header",
+        code: "SESSION_CSRF_TOKEN_INVALID",
+      }), {
+        status: 403,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }))
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-2",
+      }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockResolvedValueOnce(createSessionResponse({
+        csrfToken: "csrf-token-3",
+      }))
+      .mockResolvedValueOnce(createNewChatSessionResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await createNewChatSession("session-1", "workspace-1", "en");
+
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8080/v1/chat/new");
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("http://localhost:8080/v1/chat/new");
+    expect(fetchMock.mock.calls[4]?.[0]).toBe("http://localhost:8081/api/refresh-session");
+    expect(fetchMock.mock.calls[5]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[6]?.[0]).toBe("http://localhost:8080/v1/chat/new");
+
+    const firstRequestInit = fetchMock.mock.calls[1]?.[1] as RequestInit | undefined;
+    const csrfRetriedRequestInit = fetchMock.mock.calls[3]?.[1] as RequestInit | undefined;
+    const authRetriedRequestInit = fetchMock.mock.calls[6]?.[1] as RequestInit | undefined;
+    expect(new Headers(firstRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-1");
+    expect(new Headers(csrfRetriedRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-2");
+    expect(new Headers(authRetriedRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-3");
+  });
+
   it("deduplicates session transport bootstrap for parallel unsafe requests", async () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(createSessionResponse())

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -116,10 +116,13 @@ type ChatResumeRequestDiagnostics = Readonly<{
 export type AuthUiLocale = Locale;
 
 const collectionPageLimit = 100;
+const staleSessionCsrfTokenErrorCode = "SESSION_CSRF_TOKEN_INVALID";
+const staleSessionCsrfTokenErrorMessage = "Invalid X-CSRF-Token header";
 
 let sessionCsrfToken: string | null = null;
 let sessionCsrfState: SessionCsrfState = "unknown";
 let sessionRecoveryPromise: Promise<void> | null = null;
+let sessionCsrfRecoveryPromise: Promise<void> | null = null;
 let sessionTransportReadyPromise: Promise<void> | null = null;
 let redirectInFlight = false;
 let authRedirectPreparationPromise: Promise<void> | null = null;
@@ -171,6 +174,7 @@ export function resetApiClientStateForTests(): void {
   sessionCsrfToken = null;
   sessionCsrfState = "unknown";
   sessionRecoveryPromise = null;
+  sessionCsrfRecoveryPromise = null;
   sessionTransportReadyPromise = null;
   redirectInFlight = false;
   authRedirectPreparationPromise = null;
@@ -313,6 +317,16 @@ function getJsonErrorCode(value: unknown): string | null {
   return typeof objectValue.code === "string" && objectValue.code !== "" ? objectValue.code : null;
 }
 
+function isRecoverableSessionCsrfPayload(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value === staleSessionCsrfTokenErrorMessage;
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  return objectValue.code === staleSessionCsrfTokenErrorCode
+    || objectValue.error === staleSessionCsrfTokenErrorMessage;
+}
+
 async function readJsonResponse(response: Response): Promise<unknown> {
   const text = await response.text();
   if (text === "") {
@@ -335,6 +349,14 @@ async function parseJsonPayload(response: Response): Promise<unknown> {
   }
 
   return payload;
+}
+
+async function isRecoverableSessionCsrfResponse(response: Response): Promise<boolean> {
+  if (response.status !== 403) {
+    return false;
+  }
+
+  return isRecoverableSessionCsrfPayload(await readJsonResponse(response.clone()));
 }
 
 /**
@@ -415,6 +437,27 @@ async function recoverSession(prepareForAuthRedirect: PrepareForAuthRedirect | n
   return sessionRecoveryPromise;
 }
 
+/**
+ * Reloads the current session-bound CSRF token after another same-site app has
+ * rotated the shared session cookie.
+ */
+async function recoverSessionCsrf(): Promise<void> {
+  const activeRecovery = sessionCsrfRecoveryPromise;
+  if (activeRecovery !== null) {
+    return activeRecovery;
+  }
+
+  const recoveryTask = (async (): Promise<void> => {
+    await loadSessionInfoWithRecovery();
+  })();
+
+  sessionCsrfRecoveryPromise = recoveryTask.finally(() => {
+    sessionCsrfRecoveryPromise = null;
+  });
+
+  return sessionCsrfRecoveryPromise;
+}
+
 async function ensureSessionTransportReadyForUnsafeRequest(): Promise<void> {
   if (sessionCsrfState !== "unknown") {
     return;
@@ -446,8 +489,8 @@ async function ensureSessionTransportReadyForUnsafeRequest(): Promise<void> {
 
 /**
  * Wraps raw API fetches with a single silent refresh attempt. Every request is
- * retried at most once, and the retry only runs after `/me` has reloaded the
- * current session transport and CSRF token.
+ * allowed one auth recovery and one stale-CSRF recovery, with each retry only
+ * running after `/me` has reloaded the current session transport and CSRF token.
  */
 async function requestResponse(
   pathname: string,
@@ -458,18 +501,38 @@ async function requestResponse(
     await ensureSessionTransportReadyForUnsafeRequest();
   }
 
-  const response = await performFetch(pathname, init);
-  if (response.status !== 401 || options.authRecoveryMode === "skip") {
+  let response: Response = await performFetch(pathname, init);
+  if (options.authRecoveryMode === "skip") {
     return response;
   }
 
-  await recoverSession(options.prepareForAuthRedirect);
-  const retriedResponse = await performFetch(pathname, init);
-  if (retriedResponse.status === 401) {
-    await redirectToLogin(options.prepareForAuthRedirect);
-  }
+  let didRecoverSession: boolean = false;
+  let didRecoverSessionCsrf: boolean = false;
+  while (true) {
+    if (response.status === 401) {
+      if (didRecoverSession) {
+        await redirectToLogin(options.prepareForAuthRedirect);
+      }
 
-  return retriedResponse;
+      didRecoverSession = true;
+      await recoverSession(options.prepareForAuthRedirect);
+      response = await performFetch(pathname, init);
+      continue;
+    }
+
+    if (
+      didRecoverSessionCsrf === false
+      && isUnsafeMethod(getMethod(init))
+      && await isRecoverableSessionCsrfResponse(response)
+    ) {
+      didRecoverSessionCsrf = true;
+      await recoverSessionCsrf();
+      response = await performFetch(pathname, init);
+      continue;
+    }
+
+    return response;
+  }
 }
 
 async function requestJson(


### PR DESCRIPTION
## Summary
- Add a stable backend error code for invalid session CSRF tokens while preserving the existing 403 response message.
- Recover stale CSRF tokens once in the web API client by reloading `/me`, updating the cached token, and retrying the original unsafe request.
- Apply the same one-shot stale-CSRF recovery around admin report queries via `/admin/session`.
- Add focused web transport coverage for stale CSRF recovery and the auth-recovery interaction after a CSRF retry.

## Root Cause
The web and admin clients could keep using a cached CSRF token after another shared-cookie surface rotated the session cookie. The backend correctly rejected the unsafe request, but the client treated the recoverable stale-token race as a user-visible error.

## Validation
- `npm --prefix apps/web run test`
- `npm --prefix apps/web run build`
- `npm --prefix apps/admin run build`
- `npm --prefix apps/backend run lint`
- `git --no-pager diff --check`