### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@v6.1.0
 
       - name: Install Android SDK packages
         env:
@@ -85,7 +85,7 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@v6.1.0
 
       - name: Install Android SDK packages
         env:
@@ -106,7 +106,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Run data:local instrumentation suite on emulator
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@v2.37.0
         with:
           api-level: 36
           target: google_apis

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -479,7 +479,7 @@ jobs:
           distribution: temurin
           java-version: '17'
 
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@v6.1.0
 
       - uses: google-github-actions/auth@v3
         id: auth
@@ -559,7 +559,7 @@ jobs:
           path: apps/android/app/build/outputs/bundle/release/app-release.aab
 
       - name: Upload bundle to Google Play production track as draft release
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@v1.1.5
         with:
           serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
           packageName: ${{ vars.ANDROID_PLAY_PACKAGE_NAME }}

--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -286,7 +286,7 @@ jobs:
             infra/aws/package-lock.json
 
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@v6.1.1
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -11,13 +11,13 @@
         "@aws-sdk/client-secrets-manager": "^3.1048.0",
         "@hono/node-server": "^2.0.2",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.18",
+        "hono": "^4.12.19",
         "pg": "^8.20.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.1",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -1096,9 +1096,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1275,9 +1275,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
-      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -13,13 +13,13 @@
     "@aws-sdk/client-secrets-manager": "^3.1048.0",
     "@hono/node-server": "^2.0.2",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.18",
+    "hono": "^4.12.19",
     "pg": "^8.20.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
-    "tsx": "^4.22.0",
+    "tsx": "^4.22.1",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -18,7 +18,7 @@
         "@langfuse/tracing": "^5.3.0",
         "@opentelemetry/sdk-node": "^0.218.0",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.18",
+        "hono": "^4.12.19",
         "openai": "^6.38.0",
         "pg": "^8.20.0",
         "zod": "^4.4.3"
@@ -27,7 +27,7 @@
         "@types/aws-lambda": "^8.10.161",
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
-        "tsx": "^4.22.0",
+        "tsx": "^4.22.1",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -2188,9 +2188,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.19",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
+      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2508,9 +2508,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
-      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
+      "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,7 @@
     "@langfuse/tracing": "^5.3.0",
     "@opentelemetry/sdk-node": "^0.218.0",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.18",
+    "hono": "^4.12.19",
     "openai": "^6.38.0",
     "pg": "^8.20.0",
     "zod": "^4.4.3"
@@ -29,7 +29,7 @@
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
-    "tsx": "^4.22.0",
+    "tsx": "^4.22.1",
     "typescript": "^6.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Update auth/backend Hono and tsx pins to the latest stable patch releases.
- Pin drifted GitHub Actions refs to the latest stable patch tags.

## Validation

- npm ci --prefix api
- npm ci --prefix apps/auth
- npm ci --prefix apps/backend
- npm run build --prefix apps/auth
- npm run test --prefix apps/auth
- npm run lint --prefix apps/backend
- npm run build --prefix apps/backend
- npm run test --prefix apps/backend
- npm audit --json in all six Node projects
- workflow YAML parse
- git diff --check

Heavy Android/iOS tests were not run locally per repository guidance.