### PR TITLE
[codex] Document iOS simulator run permission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ When proposing a test plan, treat "real testing" as one of these two options onl
 For iOS local testing details, see [docs/ios-local-setup.md](docs/ios-local-setup.md).
 For Android local testing details, see [docs/android-ci-cd.md](docs/android-ci-cd.md).
 Running `./gradlew` is resource-heavy in this repository. Do not run `./gradlew` locally unless the user explicitly allows it for the current task. When allowed, choose the narrowest Gradle task that validates the change, and avoid broad Gradle runs without a clear reason.
+Running iOS simulator-backed tests or local smoke flows is resource-heavy in this repository. Do not run iOS simulator `xcodebuild test`, XCUITest, screenshot-generation, or local smoke flows unless the user explicitly allows that simulator-backed run for the current task. When allowed, choose the narrowest iOS simulator run that validates the change, and avoid broad iOS test runs without a clear reason.
 For the optional private analytical DB access path, granted reporting permissions, and operator setup flow, see [docs/analytics-db-access.md](docs/analytics-db-access.md).
 
 ## Release Gates and Monitoring

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -73,9 +73,10 @@ Only test the app against the final supported iOS target.
 - Do not try to cover the iOS app exhaustively with tests
 - Do not add isolated unit tests by default
 - Prefer native integration, parity, or UI tests when they validate a real module boundary or user flow
+- Do not run iOS simulator-backed tests, UI tests, screenshot-generation, or local smoke flows unless the user explicitly allows that simulator-backed run for the current task
 - Do not spend time validating older iOS versions
 - Do not add compatibility code for older iOS versions unless explicitly requested
-- If tests are requested, use one locally available iPhone simulator runtime only
+- If an iOS simulator-backed run is explicitly allowed, use one locally available iPhone simulator runtime only
 - Prefer an already booted local iPhone simulator on the final supported runtime
 - Prefer background CLI runs with `simctl` and `xcodebuild` instead of opening heavy Xcode UI flows
 - Do not open a visible Simulator window for test runs unless the user explicitly asks for a visible simulator at that time
@@ -88,7 +89,7 @@ The most trusted iOS checks are the simulator-backed native smoke flows because 
 
 ## Local Test Workflow
 
-For local iOS test runs, prefer this sequence:
+When the user has explicitly allowed a local iOS simulator-backed test run for the current task, prefer this sequence:
 
 1. Reuse an already booted iPhone simulator when available.
 2. Wait for that simulator with `xcrun simctl bootstatus <device-uuid> -b`.

--- a/apps/ios/docs/marketing-screenshots.md
+++ b/apps/ios/docs/marketing-screenshots.md
@@ -11,6 +11,7 @@ The generator is a small manual pipeline built from:
 - deterministic localized fixture data used by both the UI tests and app-side UI-test seeding
 
 It writes into the directories used for committed App Store marketing PNG assets and derived marketing compositions, but it is not part of CI or release-gate validation.
+Because this generator drives local iOS simulator-backed XCUITest flows, do not run screenshot-generation scripts unless the user explicitly allows that simulator-backed run for the current task.
 The generator configuration now targets five-shot outputs. Existing repository media can still contain the previous four-shot assets until the screenshot flows and derived-material builder are run and the generated PNGs are reviewed.
 
 ## What is included

--- a/docs/ios-local-setup.md
+++ b/docs/ios-local-setup.md
@@ -142,9 +142,11 @@ distribution.
 ## Local Testing Rules
 
 The iOS Xcode project is file-synchronized, so new Swift files can be added without manual `project.pbxproj` edits.
-Run iOS tests locally when they help validate the requested change or when the user asks for them.
+Running iOS simulator-backed tests and local smoke flows is resource-heavy in this repository.
+Do not run iOS simulator `xcodebuild test`, XCUITest, screenshot-generation, or local smoke flows unless the user explicitly allows that simulator-backed run for the current task.
+When allowed, choose the narrowest iOS simulator run that validates the change, and avoid broad iOS test runs without a clear reason.
 iOS full test runs can take a bit more than 2 minutes locally, and that is normal.
-If iOS tests are requested, run them only on one specific iPhone simulator runtime that is already downloaded locally.
+If an iOS simulator-backed run is explicitly allowed, run it only on one specific iPhone simulator runtime that is already downloaded locally.
 Prefer an already booted local iPhone simulator on the final supported iOS runtime. Reuse that exact device instead of booting a different one when possible.
 Prefer the background CLI flow over opening heavy Xcode UI: `xcrun simctl bootstatus`, then `xcodebuild test`.
 Do not open a visible iOS Simulator window for test runs unless the user explicitly asks for a visible simulator at that time.


### PR DESCRIPTION
## Summary

- Add a root AGENTS.md rule requiring explicit user permission before local iOS simulator-backed test, smoke, XCUITest, or screenshot-generation runs.
- Align the iOS app README and local setup docs with the new gate.
- Add the same guard to the iOS marketing screenshot runbook because it drives local simulator-backed XCUITest flows.

## Why

The repo already requires explicit approval before local Gradle runs because they are resource-heavy. iOS simulator-backed runs have the same practical cost, so the documentation now makes that permission gate explicit.

## Validation

- Documentation-only change; no local Gradle, Xcode, simulator, smoke, or screenshot-generation commands were run.