### PR TITLE
[codex] Fix auth route test narrowing

### DIFF
--- a/apps/auth/src/agentAuthRoutes.test.ts
+++ b/apps/auth/src/agentAuthRoutes.test.ts
@@ -407,6 +407,7 @@ test("agent verify-code rejects non-placeholder demo account codes", async () =>
 
   assert.equal(response.status, 400);
   assert.equal(payload.ok, false);
+  assert.ok(payload.error);
   assert.equal(payload.error.code, "OTP_CODE_INVALID");
   assert.match(payload.instructions, /00000000/);
   assert.equal(signInWithPasswordCalled, false);


### PR DESCRIPTION
## Summary
- narrow the agent error envelope in the demo placeholder test before reading error.code
- fixes the auth TypeScript build failure from the AWS/Web release workflow

## Validation
- npm --prefix apps/auth run build
- node --test --import tsx src/agentAuthRoutes.test.ts
- git diff --check