### PR TITLE
[codex] Add backend Sentry observability

### DIFF
--- a/.github/workflows/aws-web-release.yml
+++ b/.github/workflows/aws-web-release.yml
@@ -254,6 +254,10 @@ jobs:
           CDK_CONTEXT_REGION: ${{ vars.AWS_REGION }}
           CDK_CONTEXT_RESEND_API_KEY_SECRET_ARN: ${{ vars.CDK_RESEND_API_KEY_SECRET_ARN }}
           CDK_CONTEXT_RESEND_SENDER_EMAIL: ${{ vars.CDK_RESEND_SENDER_EMAIL }}
+          CDK_CONTEXT_SENTRY_DSN_SECRET_ARN: ${{ vars.CDK_SENTRY_DSN_SECRET_ARN }}
+          CDK_CONTEXT_SENTRY_ENVIRONMENT: ${{ vars.CDK_SENTRY_ENVIRONMENT }}
+          CDK_CONTEXT_SENTRY_RELEASE: ${{ github.sha }}
+          CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.CDK_SENTRY_TRACES_SAMPLE_RATE }}
           CDK_CONTEXT_WEB_CERTIFICATE_ARN_US_EAST_1: ${{ vars.CDK_WEB_CERTIFICATE_ARN_US_EAST_1 }}
         run: |
           python3 ../../scripts/write-ci-cdk-context.py \
@@ -330,6 +334,15 @@ jobs:
           CDK_CONTEXT_REGION: ${{ vars.AWS_REGION }}
           CDK_CONTEXT_RESEND_API_KEY_SECRET_ARN: ${{ vars.CDK_RESEND_API_KEY_SECRET_ARN }}
           CDK_CONTEXT_RESEND_SENDER_EMAIL: ${{ vars.CDK_RESEND_SENDER_EMAIL }}
+          CDK_CONTEXT_SENTRY_DSN_SECRET_ARN: ${{ vars.CDK_SENTRY_DSN_SECRET_ARN }}
+          CDK_CONTEXT_SENTRY_ENVIRONMENT: ${{ vars.CDK_SENTRY_ENVIRONMENT }}
+          CDK_CONTEXT_SENTRY_RELEASE: ${{ github.sha }}
+          CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE: ${{ vars.CDK_SENTRY_TRACES_SAMPLE_RATE }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_BACKEND_PROJECT }}
+          SENTRY_RELEASE: ${{ github.sha }}
+          SENTRY_UPLOAD_BACKEND_SOURCEMAPS: true
           CDK_CONTEXT_WEB_CERTIFICATE_ARN_US_EAST_1: ${{ vars.CDK_WEB_CERTIFICATE_ARN_US_EAST_1 }}
         run: |
           python3 ../../scripts/write-ci-cdk-context.py \

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,16 @@ pnpm-debug.log*
 apps/web/playwright-report/
 apps/web/test-results/
 
+# Python cache files
+__pycache__/
+*.py[cod]
+*$py.class
+.mypy_cache/
+.pytest_cache/
+.pyre/
+.pytype/
+.ruff_cache/
+
 # macOS
 .DS_Store
 

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -16,7 +16,8 @@
         "@langfuse/openai": "^5.3.0",
         "@langfuse/otel": "^5.3.0",
         "@langfuse/tracing": "^5.3.0",
-        "@opentelemetry/sdk-node": "^0.218.0",
+        "@opentelemetry/sdk-trace-base": "^2.7.1",
+        "@sentry/aws-serverless": "^10.52.0",
         "aws-jwt-verify": "^5.1.1",
         "hono": "^4.12.19",
         "openai": "^6.38.0",
@@ -24,6 +25,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@sentry/cli": "^3.4.2",
         "@types/aws-lambda": "^8.10.161",
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
@@ -1150,35 +1152,70 @@
         "node": ">=18"
       }
     },
-    "node_modules/@grpc/grpc-js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
-      "license": "Apache-2.0",
+    "node_modules/@fastify/otel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+      "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "@grpc/proto-loader": "^0.8.0",
-        "@js-sdsl/ordered-map": "^4.4.2"
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "minimatch": "^10.2.4"
       },
-      "engines": {
-        "node": ">=12.10.0"
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
       }
     },
-    "node_modules/@grpc/proto-loader": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
-      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash.camelcase": "^4.3.0",
-        "long": "^5.0.0",
-        "protobufjs": "^7.5.5",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+        "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.212.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.212.0",
+        "import-in-the-middle": "^2.0.6",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1191,16 +1228,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@js-sdsl/ordered-map": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
-      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@langfuse/core": {
@@ -1281,39 +1308,12 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.218.0.tgz",
       "integrity": "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/configuration": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.218.0.tgz",
-      "integrity": "sha512-W8wIz7H2R1pufR5jfjb3gU2XkMpm2x/7b1RJcsuzvd70Il/rWWE+g5/Od7hQKrxRTSrTrOWlru101PWXz5I1EQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "yaml": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      }
-    },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.7.1.tgz",
-      "integrity": "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/core": {
@@ -1331,171 +1331,12 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.218.0.tgz",
-      "integrity": "sha512-hoxrNH1l/Xy6F9WTJ5IK+6j1r9nQFlPOmrnTlhYHTySdunfXLmUCPv3bQtKYntxag9h3wLYBZQ2HI6FOx+BT2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/sdk-logs": "0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.218.0.tgz",
-      "integrity": "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/sdk-logs": "0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.218.0.tgz",
-      "integrity": "sha512-1/noQNsp9gXD75HPzgjBrcF1+XTtry7pFAUfxVEJgg7mPv2AawKQuYkhMmJ8qjxz4Ubc3Y8bwvfxevXsKTq4cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.218.0",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.218.0.tgz",
-      "integrity": "sha512-YapQ9vNMX0NSZF6LK5pWAFfjpJleV2O9uYWfYGeb/5F1Kb9rPGK8tZDMJFa/sOksgdFuflDvYuA0B4qjDB4fjQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-metrics": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.218.0.tgz",
-      "integrity": "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-metrics": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.218.0.tgz",
-      "integrity": "sha512-ubLddKjWULhla9YZRCj/rTBeppjJYE4e9w0icx5mTu3eFhWjQzbV75NYjXuIlEG+NJsBl6d+sTFw5Qu+oej4oQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-metrics": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.218.0.tgz",
-      "integrity": "sha512-RT5oEyu1kddZJ1vt7/BUo5wV+P7hpNAESsR3dUd3+8deHuX7gWNoCOZn+SfDT+hJHlIJ5h/AxiCLXIrutswDJg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-metrics": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.218.0.tgz",
-      "integrity": "sha512-3fXxVQEj9TNAFaCi79JeFKfeLd0sDtInaR3gaZDVlzNSPHtz8PZuCV34JKWjD4XXzT20IdMe8IpX6mRVNDA4Tw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
       "version": "0.218.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.218.0.tgz",
       "integrity": "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/otlp-exporter-base": "0.218.0",
@@ -1510,17 +1351,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz",
-      "integrity": "sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==",
+    "node_modules/@opentelemetry/instrumentation-amqplib": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+      "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/otlp-transformer": "0.218.0",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1529,31 +1368,872 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.7.1.tgz",
-      "integrity": "sha512-mfsD9bKAxcKrh5+y08TPodvClBO0CznBE3p79YAGnO81WI4LrdsGA65T53e4iTSbCalW4WaUpkbeJcbpyIUHfg==",
+    "node_modules/@opentelemetry/instrumentation-amqplib/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1",
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-sdk": {
+      "version": "0.69.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.69.0.tgz",
+      "integrity": "sha512-JfSp3anFL5Lx/ysQSa4MnKxvSsXSnYpgQ831Y+yNs5wJZcJC4tB+YpnKH+bU5oFdKEF59FpI6Gn5Wg2vjVpR2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-sdk/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-aws-sdk/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+      "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/connect": "3.4.38"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-connect/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader": {
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+      "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-dataloader/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+      "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fs/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+      "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-generic-pool/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+      "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+      "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-hapi/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+      "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/instrumentation": "0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.218.0.tgz",
-      "integrity": "sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==",
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+      "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-kafkajs/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+      "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa": {
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+      "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.36.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-koa/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
+      "version": "0.58.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+      "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-lru-memoizer/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+      "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+      "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongoose/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+      "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+      "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@opentelemetry/sql-common": "^0.41.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql2/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+      "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.2",
+        "@types/pg": "8.15.6",
+        "@types/pg-pool": "2.0.7"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+      "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
@@ -1569,26 +2249,9 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.218.0.tgz",
       "integrity": "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-transformer": "0.218.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.218.0.tgz",
-      "integrity": "sha512-H/lCGJ536N98VpYJOaWTQOkv4Dx6TnmStK6Rqfu1W7KkFbPAx04hjdYEMZF/YbnHzPUSIK4kM6OE2GKGBTpV9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
         "@opentelemetry/otlp-transformer": "0.218.0"
       },
       "engines": {
@@ -1603,6 +2266,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.218.0.tgz",
       "integrity": "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
@@ -1616,36 +2280,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-b3": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.7.1.tgz",
-      "integrity": "sha512-RJid6E2CKyeGfKBzXKF21ejabGMHypFkPAh3qZ+NvI+SGjuIye79t3PmiqcDgtRzdKH6ynXzbfslQ8DfpRUg2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.7.1.tgz",
-      "integrity": "sha512-KMjVBHzP4N60bOzxja76M1F1hZZ43lGPga5ix+mkv9+kk1nx9SbkxSvJsMbuVUxdPQmsPTqGShmhN8ulrMOg6Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/resources": {
@@ -1669,6 +2303,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.218.0.tgz",
       "integrity": "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/core": "2.7.1",
@@ -1687,6 +2322,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.7.1.tgz",
       "integrity": "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1"
@@ -1696,45 +2332,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.218.0.tgz",
-      "integrity": "sha512-tPMjHrLV5gsfNdYqoRHjeGbCAZBXXD9c1Qo/2ut7VwnUABDNh76xNxrT0SEhkIIJuCN45bbN1vZnYL1gY0IkOg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.218.0",
-        "@opentelemetry/configuration": "0.218.0",
-        "@opentelemetry/context-async-hooks": "2.7.1",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.218.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.218.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.218.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.218.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.218.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.218.0",
-        "@opentelemetry/exporter-prometheus": "0.218.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.218.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.218.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.218.0",
-        "@opentelemetry/exporter-zipkin": "2.7.1",
-        "@opentelemetry/instrumentation": "0.218.0",
-        "@opentelemetry/otlp-exporter-base": "0.218.0",
-        "@opentelemetry/propagator-b3": "2.7.1",
-        "@opentelemetry/propagator-jaeger": "2.7.1",
-        "@opentelemetry/resources": "2.7.1",
-        "@opentelemetry/sdk-logs": "0.218.0",
-        "@opentelemetry/sdk-metrics": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1",
-        "@opentelemetry/sdk-trace-node": "2.7.1",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -1754,23 +2351,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.7.1.tgz",
-      "integrity": "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.7.1",
-        "@opentelemetry/core": "2.7.1",
-        "@opentelemetry/sdk-trace-base": "2.7.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
@@ -1780,69 +2360,432 @@
         "node": ">=14"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "license": "BSD-3-Clause",
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
       }
     },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
+    "node_modules/@prisma/instrumentation": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+      "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.207.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.8"
+      }
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "license": "BSD-3-Clause"
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
+    "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
     },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
+    "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
     },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
+    "node_modules/@sentry/aws-serverless": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.53.1.tgz",
+      "integrity": "sha512-FVShx75vQVN2IjwF1mrV4J/i/l7G+Bp/XajKMB2dcWH0+HBwpOmIVO5jIrz0Ptta6Di/X5bCnTV3ncGl7QFqjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-aws-sdk": "0.69.0",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry/core": "10.53.1",
+        "@sentry/node": "10.53.1",
+        "@sentry/node-core": "10.53.1",
+        "@types/aws-lambda": "^8.10.62"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/aws-serverless/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@sentry/aws-serverless/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.4.2.tgz",
+      "integrity": "sha512-8HOEe8y4ZtSxBhABSq4fzGgWc1PAR15ptfhrBwxTaqgXAN6CUsPCC/uvdO4gtgo8zKFkD0E5n34YY09tEXJGRg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "3.4.2",
+        "@sentry/cli-linux-arm": "3.4.2",
+        "@sentry/cli-linux-arm64": "3.4.2",
+        "@sentry/cli-linux-i686": "3.4.2",
+        "@sentry/cli-linux-x64": "3.4.2",
+        "@sentry/cli-win32-arm64": "3.4.2",
+        "@sentry/cli-win32-i686": "3.4.2",
+        "@sentry/cli-win32-x64": "3.4.2"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.4.2.tgz",
+      "integrity": "sha512-MMCkBxj8l5IolwJyf7mv5v/rKOdZS8YCVmXUzv+H75j28j2lvLfsScWh0YaRkzv6+ATYkG1Z5g2J1alv91OuYQ==",
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.4.2.tgz",
+      "integrity": "sha512-oLnskL/TD/SkcqZ8xSPSSZfSSTEswiyx/hqtENmzR8aKIEiyZlDD8sH2h5CCevVDTGO2WDbOWZQCKFlWtIWP1Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.4.2.tgz",
+      "integrity": "sha512-xsA7DjZkFBBu5WLINimWv50h+jSxS5+F+6DxMYcgXkYZ4pbEWToG+IcBaZGsqXKNIYIUyd7hQvqCH/LFNAqShA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.4.2.tgz",
+      "integrity": "sha512-AD8l7GGwGIixALSYeIBWsAqLQgi90df4Z3XIGPOqkJWSg5xh40Qk0r1zHXUwayGabtY8YgDlcAUS1CQ+1Tqu9Q==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.4.2.tgz",
+      "integrity": "sha512-H73CL6EIdYi75iEUpGF26ojIZk+vTvAKc3Yj4uXRup2kmOikM9uliRlZRgmVsDExApgCDuzFrLzdKFYbJJ03aA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.4.2.tgz",
+      "integrity": "sha512-fjBS2to5oJpfWmK5l14fZgoRfTOAZIFqa4Ej+urOLU3NH4etehDRHgGMcxPPLjoVkkAC6M/auf1+rQc1tt0olg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.4.2.tgz",
+      "integrity": "sha512-20jpyvG8g7QUSa+zBFXEPhvMf5EB4YILCZb1xhGwEZsfwUPN02qRoCwpY018/jKimxEJRGpCHhxC9ybUceQaNg==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.4.2.tgz",
+      "integrity": "sha512-FfFQzBkTvyU7AafzaOxhAFlmXKMe+9aXKNjnvA4VRHeBExdS71ZHKcPn44rZppoDLHWCrR2nm35WZG4so+jmSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+      "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.53.1.tgz",
+      "integrity": "sha512-rxHVil0tJAmz+keFcZCj1LaUdgdkK66E/l0gqh2p1209PNCGoD3lnClFr6vusy1aF3zF8O9JPtuMEJzXOKhs+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/otel": "0.18.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/instrumentation-amqplib": "0.61.0",
+        "@opentelemetry/instrumentation-connect": "0.57.0",
+        "@opentelemetry/instrumentation-dataloader": "0.31.0",
+        "@opentelemetry/instrumentation-fs": "0.33.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+        "@opentelemetry/instrumentation-graphql": "0.62.0",
+        "@opentelemetry/instrumentation-hapi": "0.60.0",
+        "@opentelemetry/instrumentation-http": "0.214.0",
+        "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+        "@opentelemetry/instrumentation-knex": "0.58.0",
+        "@opentelemetry/instrumentation-koa": "0.62.0",
+        "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+        "@opentelemetry/instrumentation-mongodb": "0.67.0",
+        "@opentelemetry/instrumentation-mongoose": "0.60.0",
+        "@opentelemetry/instrumentation-mysql": "0.60.0",
+        "@opentelemetry/instrumentation-mysql2": "0.60.0",
+        "@opentelemetry/instrumentation-pg": "0.66.0",
+        "@opentelemetry/instrumentation-tedious": "0.33.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@prisma/instrumentation": "7.6.0",
+        "@sentry/core": "10.53.1",
+        "@sentry/node-core": "10.53.1",
+        "@sentry/opentelemetry": "10.53.1",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.53.1.tgz",
+      "integrity": "sha512-iH7SMcM/7jPbN+t7+7ussQOiIqI4BMOGt4VYWlV71/z7k0pY+YPaSvlfVkNXfISiDzFAKv0ecCY3BmsLMu1xDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1",
+        "@sentry/opentelemetry": "10.53.1",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.53.1.tgz",
+      "integrity": "sha512-Zok6UXla0mFOjd1YnVb1TZtQNOry9v93fXUqx8jmDaygwWM2BwvP8rBQabLz0/OZXo8+35oge+Vmw+QY5aesnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
     },
     "node_modules/@smithy/core": {
       "version": "3.24.3",
@@ -1930,8 +2873,25 @@
       "version": "8.10.161",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
       "integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.12.4",
@@ -1946,12 +2906,29 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
+      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
+      }
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/acorn": {
@@ -1975,30 +2952,6 @@
         "acorn": "^8"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/aws-jwt-verify": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-5.1.1.tgz",
@@ -2008,48 +2961,37 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
-      "license": "MIT"
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2068,12 +3010,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -2117,15 +3053,6 @@
         "@esbuild/win32-x64": "0.28.0"
       }
     },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
@@ -2163,6 +3090,12 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2176,15 +3109,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/hono": {
@@ -2211,26 +3135,27 @@
         "node": ">=18"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
       "engines": {
-        "node": ">=8"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT"
-    },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -2408,38 +3333,22 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=0.4.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
@@ -2461,32 +3370,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strnum": {
@@ -2540,27 +3423,36 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">= 8"
       }
     },
     "node_modules/xml-naming": {
@@ -2585,57 +3477,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -18,7 +18,8 @@
     "@langfuse/openai": "^5.3.0",
     "@langfuse/otel": "^5.3.0",
     "@langfuse/tracing": "^5.3.0",
-    "@opentelemetry/sdk-node": "^0.218.0",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@sentry/aws-serverless": "^10.52.0",
     "aws-jwt-verify": "^5.1.1",
     "hono": "^4.12.19",
     "openai": "^6.38.0",
@@ -26,6 +27,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@sentry/cli": "^3.4.2",
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -22,6 +22,13 @@ import {
 import { getGuestAiWeightedMonthlyTokenCap } from "./guestAiQuotaConfig";
 import { logRequestError } from "./server/logging";
 import { getAllowedOrigins } from "./server/requestContext";
+import {
+  captureBackendException,
+  continueBackendTrace,
+  createBackendObservationScope,
+  normalizeCaughtError,
+} from "./observability/sentry";
+import { hasReportedBackendException } from "./observability/reporting";
 
 export type AppEnv = {
   Variables: {
@@ -136,6 +143,22 @@ function createAgentConnectionManagementInstructions(code: string | null, status
   return "Refresh the settings screen and try again.";
 }
 
+function shouldCaptureRequestFailureException(error: unknown): boolean {
+  if (error instanceof AuthError) {
+    return false;
+  }
+
+  if (error instanceof HttpError) {
+    if (error.code === "CHAT_LIVE_RESUME_CONTRACT_VIOLATION") {
+      return false;
+    }
+
+    return error.statusCode >= 500;
+  }
+
+  return true;
+}
+
 function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono<AppEnv> {
   const app = new Hono<AppEnv>({ strict: false }).basePath(basePath);
   app.use("*", async (context, next) => {
@@ -144,15 +167,26 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
     context.header("X-Request-Id", requestId);
     await next();
   });
+  app.use("*", async (context, next) => {
+    const sentryTrace = context.req.header("sentry-trace") || null;
+    const baggage = context.req.header("baggage") || null;
+    const traceCarrier = sentryTrace === null && baggage === null
+      ? null
+      : { sentryTrace, baggage };
+    await continueBackendTrace(traceCarrier, async () => {
+      await next();
+    });
+  });
   app.use(globalSnapshotPath, cors({
     origin: "*",
     allowMethods: ["GET", "OPTIONS"],
+    allowHeaders: ["authorization", "sentry-trace", "baggage"],
     exposeHeaders: ["retry-after"],
   }));
   app.use("*", cors({
     origin: allowedOrigins,
     allowMethods: ["GET", "POST", "PATCH", "PUT", "OPTIONS"],
-    allowHeaders: ["content-type", "authorization", "x-csrf-token"],
+    allowHeaders: ["content-type", "authorization", "x-csrf-token", "sentry-trace", "baggage"],
     exposeHeaders: [
       "cache-control",
       "content-encoding",
@@ -170,6 +204,38 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
   app.onError((error, context) => {
     const requestId = context.get("requestId");
     logRequestError(requestId, context.req.path, context.req.method, error);
+    const normalizedError = normalizeCaughtError(error);
+    if (
+      hasReportedBackendException(normalizedError) === false
+      && shouldCaptureRequestFailureException(error)
+    ) {
+      captureBackendException({
+        action: "request_failed",
+        error: normalizedError,
+        scope: createBackendObservationScope(
+          "backend-api",
+          requestId,
+          context.req.path,
+          context.req.method,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ),
+        details: {
+          statusCode: error instanceof HttpError ? error.statusCode : 500,
+          code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : String(error),
+          validationIssues: error instanceof HttpError
+            ? (error.details?.validationIssues ?? []).map((issue) => ({
+              path: issue.path,
+              code: issue.code,
+            }))
+            : [],
+        },
+      });
+    }
     const apiKeyRequest = usesApiKeyAuthorizationHeader(context.req.raw);
     const agentConnectionManagementRequest = isAgentConnectionManagementPath(context.req.path);
 

--- a/apps/backend/src/chat/live.ts
+++ b/apps/backend/src/chat/live.ts
@@ -11,7 +11,16 @@ import {
   type ChatLiveEventPayload,
 } from "./contract";
 import type { ChatComposerSuggestion } from "./composerSuggestions";
-import { getErrorLogContext, logCloudRouteEvent } from "../server/logging";
+import { getErrorLogContext } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  captureBackendWarning,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendObservationScope,
+  type ChatLiveLifecycleDetails,
+} from "../observability/sentry";
 import {
   getChatRunSnapshot,
   getRecoveredChatSessionSnapshot,
@@ -46,6 +55,10 @@ type ChatLiveStreamDependencies = Readonly<{
   waitForNextPollInterval: typeof waitForNextPollInterval;
 }>;
 
+export type ChatLiveStreamResult = Readonly<{
+  capturedSentryEvent: boolean;
+}>;
+
 type AssistantMessageDonePayload = Extract<ChatLiveEventPayload, Readonly<{ type: "assistant_message_done" }>>;
 type ComposerSuggestionsUpdatedPayload = Extract<ChatLiveEventPayload, Readonly<{ type: "composer_suggestions_updated" }>>;
 type AssistantReasoningDonePayload = Extract<ChatLiveEventPayload, Readonly<{ type: "assistant_reasoning_done" }>>;
@@ -64,6 +77,7 @@ type BacklogReplayState = Readonly<{
   previousAssistantContent: ReadonlyArray<ContentPart>;
   shouldStop: boolean;
   terminationReason: string | null;
+  capturedSentryEvent: boolean;
 }>;
 
 const defaultChatLiveStreamDependencies: ChatLiveStreamDependencies = {
@@ -74,24 +88,120 @@ const defaultChatLiveStreamDependencies: ChatLiveStreamDependencies = {
   waitForNextPollInterval,
 };
 
-function logLiveLifecycleEvent(
-  action: string,
+type ChatLiveLifecycleAction =
+  | "chat_live_backlog_failed"
+  | "chat_live_write_failed"
+  | "chat_live_client_disconnected"
+  | "chat_live_stream_closed";
+
+type ChatLiveLifecycleErrorDetails = Readonly<{
+  errorClass: string;
+  errorMessage: string;
+  errorStack: string | null;
+  sourceFile: string | null;
+  sourceLine: number | null;
+  sourceColumn: number | null;
+}>;
+
+type ChatLiveLifecyclePayload = Readonly<{
+  connectionDurationMs: number | null;
+  terminationReason: string | null;
+  closeReason: string | null;
+  errorDetails: ChatLiveLifecycleErrorDetails | null;
+}>;
+
+function getChatLiveLifecycleErrorDetails(error: unknown): ChatLiveLifecycleErrorDetails {
+  const errorContext = getErrorLogContext(error);
+
+  return {
+    errorClass: errorContext.errorClass,
+    errorMessage: errorContext.errorMessage,
+    errorStack: errorContext.errorStack,
+    sourceFile: errorContext.sourceFile,
+    sourceLine: errorContext.sourceLine,
+    sourceColumn: errorContext.sourceColumn,
+  };
+}
+
+function buildChatLiveLifecycleDetails(
   params: LiveStreamParams,
-  payload: Record<string, unknown>,
-  isError: boolean,
-): void {
-  logCloudRouteEvent(action, {
-    requestId: params.requestId ?? null,
-    sessionId: params.sessionId,
-    runId: params.runId,
-    userId: params.userId,
-    workspaceId: params.workspaceId,
+  payload: ChatLiveLifecyclePayload,
+): ChatLiveLifecycleDetails {
+  if (payload.errorDetails === null) {
+    return {
+      afterCursor: params.afterCursor ?? null,
+      resumeAttemptId: params.resumeAttemptId ?? null,
+      clientPlatform: params.clientPlatform ?? null,
+      clientVersion: params.clientVersion ?? null,
+      connectionDurationMs: payload.connectionDurationMs,
+      terminationReason: payload.terminationReason,
+      closeReason: payload.closeReason,
+      errorClass: null,
+      errorMessage: null,
+      errorStack: null,
+      sourceFile: null,
+      sourceLine: null,
+      sourceColumn: null,
+    };
+  }
+
+  return {
     afterCursor: params.afterCursor ?? null,
     resumeAttemptId: params.resumeAttemptId ?? null,
     clientPlatform: params.clientPlatform ?? null,
     clientVersion: params.clientVersion ?? null,
-    ...payload,
-  }, isError);
+    connectionDurationMs: payload.connectionDurationMs,
+    terminationReason: payload.terminationReason,
+    closeReason: payload.closeReason,
+    errorClass: payload.errorDetails.errorClass,
+    errorMessage: payload.errorDetails.errorMessage,
+    errorStack: payload.errorDetails.errorStack,
+    sourceFile: payload.errorDetails.sourceFile,
+    sourceLine: payload.errorDetails.sourceLine,
+    sourceColumn: payload.errorDetails.sourceColumn,
+  };
+}
+
+function createChatLiveObservationScope(
+  params: LiveStreamParams,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "chat-live",
+    params.requestId ?? null,
+    null,
+    "GET",
+    params.userId,
+    params.workspaceId,
+    null,
+    params.runId,
+    params.sessionId,
+  );
+}
+
+function logLiveLifecycleEvent(
+  action: ChatLiveLifecycleAction,
+  params: LiveStreamParams,
+  payload: ChatLiveLifecyclePayload,
+): boolean {
+  const scope = createChatLiveObservationScope(params);
+  const details = buildChatLiveLifecycleDetails(params, payload);
+
+  if (action === "chat_live_backlog_failed" || action === "chat_live_write_failed") {
+    captureBackendWarning({
+      action,
+      message: `${action} warning`,
+      scope,
+      details,
+    });
+    return true;
+  }
+
+  addBackendBreadcrumb({
+    action,
+    scope,
+    details,
+  });
+  return false;
 }
 
 function cursorOrNull(lastEmittedCursor: number): string | null {
@@ -322,6 +432,7 @@ async function replayBacklogEvents(
       previousAssistantContent,
       shouldStop: false,
       terminationReason: null,
+      capturedSentryEvent: false,
     };
   }
 
@@ -346,6 +457,7 @@ async function replayBacklogEvents(
         previousAssistantContent,
         shouldStop: true,
         terminationReason: "backlog_reset_required",
+        capturedSentryEvent: false,
       };
     }
 
@@ -373,6 +485,7 @@ async function replayBacklogEvents(
           previousAssistantContent: nextPreviousContent,
           shouldStop: true,
           terminationReason: "client_disconnect",
+          capturedSentryEvent: false,
         };
       }
     }
@@ -383,11 +496,15 @@ async function replayBacklogEvents(
       previousAssistantContent: nextPreviousContent,
       shouldStop: false,
       terminationReason: null,
+      capturedSentryEvent: false,
     };
   } catch (error) {
-    logLiveLifecycleEvent("chat_live_backlog_failed", params, {
-      ...getErrorLogContext(error),
-    }, true);
+    const capturedSentryEvent = logLiveLifecycleEvent("chat_live_backlog_failed", params, {
+      connectionDurationMs: null,
+      terminationReason: null,
+      closeReason: null,
+      errorDetails: getChatLiveLifecycleErrorDetails(error),
+    });
     emitTerminal(buildResetRequiredPayload(lastDeliveredCursor, assistantItemId));
     return {
       lastObservedCursor,
@@ -395,6 +512,7 @@ async function replayBacklogEvents(
       previousAssistantContent,
       shouldStop: true,
       terminationReason: "backlog_reset_required",
+      capturedSentryEvent,
     };
   }
 }
@@ -405,7 +523,7 @@ async function replayBacklogEvents(
 export async function runLiveStream(
   stream: Writable,
   params: LiveStreamParams,
-): Promise<void> {
+): Promise<ChatLiveStreamResult> {
   return runLiveStreamWithDependencies(stream, params, defaultChatLiveStreamDependencies);
 }
 
@@ -413,7 +531,7 @@ export async function runLiveStreamWithDependencies(
   stream: Writable,
   params: LiveStreamParams,
   dependencies: ChatLiveStreamDependencies,
-): Promise<void> {
+): Promise<ChatLiveStreamResult> {
   const connectionState = createLiveConnectionState(stream);
   const serialize = createChatLiveEventSerializer({
     sessionId: params.sessionId,
@@ -429,6 +547,11 @@ export async function runLiveStreamWithDependencies(
   let hasEmittedComposerSuggestions = false;
   let terminationReason = "completed";
   let terminalEventEmitted = false;
+  let capturedSentryEvent = false;
+
+  const buildLiveStreamResult = (): ChatLiveStreamResult => ({
+    capturedSentryEvent,
+  });
 
   const emit = (data: string): boolean => {
     if (isStreamWritable(stream, connectionState) === false) {
@@ -439,11 +562,12 @@ export async function runLiveStreamWithDependencies(
       stream.write(data);
       return true;
     } catch (error) {
-      logLiveLifecycleEvent("chat_live_write_failed", params, {
+      capturedSentryEvent = logLiveLifecycleEvent("chat_live_write_failed", params, {
         connectionDurationMs: Date.now() - connectionStart,
+        terminationReason: null,
         closeReason: "write_error",
-        ...getErrorLogContext(error),
-      }, true);
+        errorDetails: getChatLiveLifecycleErrorDetails(error),
+      }) || capturedSentryEvent;
       return false;
     }
   };
@@ -472,7 +596,7 @@ export async function runLiveStreamWithDependencies(
     if (initialRun === null || initialRun.sessionId !== params.sessionId) {
       emitTerminal(buildResetRequiredPayload(lastDeliveredCursor));
       terminationReason = "missing_run";
-      return;
+      return buildLiveStreamResult();
     }
 
     const backlogState = await replayBacklogEvents(
@@ -488,9 +612,10 @@ export async function runLiveStreamWithDependencies(
     lastObservedCursor = backlogState.lastObservedCursor;
     lastDeliveredCursor = backlogState.lastDeliveredCursor;
     previousAssistantContent = backlogState.previousAssistantContent;
+    capturedSentryEvent = capturedSentryEvent || backlogState.capturedSentryEvent;
     if (backlogState.shouldStop) {
       terminationReason = backlogState.terminationReason ?? terminationReason;
-      return;
+      return buildLiveStreamResult();
     }
 
     while (isStreamWritable(stream, connectionState)) {
@@ -678,10 +803,18 @@ export async function runLiveStreamWithDependencies(
     }
   } catch (error) {
     terminationReason = "poll_error";
-    logLiveLifecycleEvent("chat_live_poll_failed", params, {
-      connectionDurationMs: Date.now() - connectionStart,
-      ...getErrorLogContext(error),
-    }, true);
+    captureBackendException({
+      action: "chat_live_poll_failed",
+      error: normalizeCaughtError(error),
+      scope: createChatLiveObservationScope(params),
+      details: buildChatLiveLifecycleDetails(params, {
+        connectionDurationMs: Date.now() - connectionStart,
+        terminationReason: "poll_error",
+        closeReason: null,
+        errorDetails: getChatLiveLifecycleErrorDetails(error),
+      }),
+    });
+    capturedSentryEvent = true;
     emitTerminal({
       type: "run_terminal",
       cursor: cursorOrNull(lastDeliveredCursor),
@@ -703,17 +836,19 @@ export async function runLiveStreamWithDependencies(
     if (terminationReason === "client_disconnect") {
       logLiveLifecycleEvent("chat_live_client_disconnected", params, {
         connectionDurationMs,
+        terminationReason: null,
         closeReason,
-        ...(closeError === null ? {} : getErrorLogContext(closeError)),
-      }, true);
-      return;
+        errorDetails: closeError === null ? null : getChatLiveLifecycleErrorDetails(closeError),
+      });
+    } else {
+      logLiveLifecycleEvent("chat_live_stream_closed", params, {
+        connectionDurationMs,
+        terminationReason,
+        closeReason,
+        errorDetails: closeError === null ? null : getChatLiveLifecycleErrorDetails(closeError),
+      });
     }
-
-    logLiveLifecycleEvent("chat_live_stream_closed", params, {
-      connectionDurationMs,
-      terminationReason,
-      closeReason,
-      ...(closeError === null ? {} : getErrorLogContext(closeError)),
-    }, terminationReason === "poll_error" || terminationReason === "max_duration_reset_required");
   }
+
+  return buildLiveStreamResult();
 }

--- a/apps/backend/src/chat/liveAuth.ts
+++ b/apps/backend/src/chat/liveAuth.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { HttpError } from "../errors";
+import type { BackendTraceCarrier } from "../observability/sentry";
 import { getBackendChatLiveAuthSecret } from "../secrets";
 
 const CHAT_LIVE_AUTH_TOKEN_VERSION = 1;
@@ -12,6 +13,7 @@ type ChatLiveAuthPayload = Readonly<{
   sessionId: string;
   runId: string;
   expiresAt: number;
+  traceContext?: BackendTraceCarrier | null;
 }>;
 
 export type ChatLiveStreamEnvelope = Readonly<{
@@ -25,6 +27,7 @@ type VerifiedChatLiveAuth = Readonly<{
   workspaceId: string;
   sessionId: string;
   runId: string;
+  traceContext?: BackendTraceCarrier | null;
 }>;
 
 function getChatLiveUrl(): string {
@@ -55,6 +58,24 @@ function signPayload(encodedPayload: string, secret: string): string {
     .digest("base64url");
 }
 
+function decodeTraceContext(value: BackendTraceCarrier | null | undefined): BackendTraceCarrier | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (
+    typeof value.sentryTrace !== "string" && value.sentryTrace !== null
+    || typeof value.baggage !== "string" && value.baggage !== null
+  ) {
+    throw new Error("Chat live trace context is invalid");
+  }
+
+  return {
+    sentryTrace: value.sentryTrace,
+    baggage: value.baggage,
+  };
+}
+
 function decodePayload(encodedPayload: string): ChatLiveAuthPayload {
   try {
     const decoded = Buffer.from(encodedPayload, "base64url").toString("utf8");
@@ -82,6 +103,7 @@ function decodePayload(encodedPayload: string): ChatLiveAuthPayload {
       sessionId: parsed.sessionId,
       runId: parsed.runId,
       expiresAt: parsed.expiresAt,
+      traceContext: decodeTraceContext(parsed.traceContext),
     };
   } catch {
     throw new HttpError(401, "Chat live auth token is invalid", "CHAT_LIVE_AUTH_INVALID");
@@ -101,6 +123,7 @@ export async function createChatLiveStreamEnvelope(
   workspaceId: string,
   sessionId: string,
   runId: string,
+  traceContext: BackendTraceCarrier | null,
 ): Promise<ChatLiveStreamEnvelope> {
   const expiresAt = Date.now() + CHAT_LIVE_AUTH_TTL_MS;
   const payload: ChatLiveAuthPayload = {
@@ -110,6 +133,7 @@ export async function createChatLiveStreamEnvelope(
     sessionId,
     runId,
     expiresAt,
+    traceContext,
   };
   const secret = await getBackendChatLiveAuthSecret(getBackendChatLiveAuthSecretArn());
   const encodedPayload = encodePayload(payload);
@@ -171,5 +195,6 @@ export async function verifyChatLiveAuthorizationHeader(
     workspaceId: payload.workspaceId,
     sessionId: payload.sessionId,
     runId: payload.runId,
+    traceContext: payload.traceContext ?? null,
   };
 }

--- a/apps/backend/src/chat/liveRequest.ts
+++ b/apps/backend/src/chat/liveRequest.ts
@@ -5,6 +5,7 @@ import {
   parseOptionalWorkspaceIdParam,
   resolveAccessibleChatWorkspaceId,
 } from "../server/requestContext";
+import type { BackendTraceCarrier } from "../observability/sentry";
 import { assertChatLiveRunAccess } from "./liveAccess";
 import {
   CHAT_LIVE_AFTER_CURSOR_INVALID_CODE,
@@ -20,6 +21,7 @@ export type LiveStreamParams = Readonly<{
   afterCursor: number | undefined;
   userId: string;
   workspaceId: string;
+  traceContext?: BackendTraceCarrier | null;
   requestId?: string;
   resumeAttemptId?: string;
   clientPlatform?: string;
@@ -107,6 +109,7 @@ export async function handleLiveRequest(
       afterCursor,
       userId: verifiedLiveAuth.userId,
       workspaceId: verifiedLiveAuth.workspaceId,
+      traceContext: verifiedLiveAuth.traceContext ?? null,
       resumeAttemptId: readOptionalHeader(headers, "X-Chat-Resume-Attempt-Id"),
       clientPlatform: readOptionalHeader(headers, "X-Client-Platform"),
       clientVersion: readOptionalHeader(headers, "X-Client-Version"),
@@ -156,6 +159,7 @@ export async function handleLiveRequest(
     afterCursor,
     userId: authResult.userId,
     workspaceId,
+    traceContext: null,
     resumeAttemptId: readOptionalHeader(headers, "X-Chat-Resume-Attempt-Id"),
     clientPlatform: readOptionalHeader(headers, "X-Client-Platform"),
     clientVersion: readOptionalHeader(headers, "X-Client-Version"),

--- a/apps/backend/src/chat/openai/toolCalls.ts
+++ b/apps/backend/src/chat/openai/toolCalls.ts
@@ -20,6 +20,9 @@ export type ToolCallOutputRawItem = Readonly<{
   callId?: string;
   id?: string;
   name?: string;
+  status?: string;
+  input?: string;
+  output?: string;
 }>;
 
 export type ToolCallPosition = Readonly<{
@@ -61,6 +64,106 @@ type ToolCallUpdate = Readonly<{
 }>;
 
 const TERMINAL_TOOL_PROVIDER_STATUSES = new Set(["completed", "failed", "incomplete"]);
+
+type ToolCallInvariantMetadata = Readonly<{
+  itemType: string;
+  responseIndex: number | null;
+  outputIndex: number | null;
+  sequenceNumber: number | null;
+  providerStatus: string | null;
+  hasId: boolean;
+  hasCallId: boolean;
+  hasName: boolean;
+  hasArguments: boolean;
+  argumentsLength: number | null;
+  hasInput: boolean;
+  inputLength: number | null;
+  hasOutput: boolean;
+  outputLength: number | null;
+}>;
+
+type ToolCallInvariantContext = Readonly<{
+  responseIndex: number | null;
+  outputIndex: number | null;
+  sequenceNumber: number | null;
+  output: unknown;
+}>;
+
+function getStringLength(value: unknown): number | null {
+  return typeof value === "string" ? value.length : null;
+}
+
+function createToolCallInvariantContext(
+  responseIndex: number | null,
+  outputIndex: number | null,
+  sequenceNumber: number | null,
+  output: unknown,
+): ToolCallInvariantContext {
+  return {
+    responseIndex,
+    outputIndex,
+    sequenceNumber,
+    output,
+  };
+}
+
+function createToolCallInvariantContextFromPosition(position: ToolCallPosition): ToolCallInvariantContext {
+  return createToolCallInvariantContext(
+    position.responseIndex,
+    position.outputIndex,
+    position.sequenceNumber,
+    undefined,
+  );
+}
+
+function createToolCallInvariantContextFromSnapshot(
+  snapshot: ToolCallEvent | null,
+  output: unknown,
+): ToolCallInvariantContext {
+  return createToolCallInvariantContext(
+    snapshot?.responseIndex ?? null,
+    snapshot?.outputIndex ?? null,
+    snapshot?.sequenceNumber ?? null,
+    output,
+  );
+}
+
+function buildToolCallInvariantMetadata(
+  rawItem: FunctionToolCallRawItem | ToolCallOutputRawItem,
+  context: ToolCallInvariantContext,
+): ToolCallInvariantMetadata {
+  const argumentsValue = "arguments" in rawItem ? rawItem.arguments : undefined;
+  const inputValue = "input" in rawItem ? rawItem.input : undefined;
+  const rawOutputValue = "output" in rawItem ? rawItem.output : undefined;
+  const outputValue = context.output !== undefined && context.output !== null
+    ? context.output
+    : rawOutputValue;
+
+  return {
+    itemType: rawItem.type,
+    responseIndex: context.responseIndex,
+    outputIndex: context.outputIndex,
+    sequenceNumber: context.sequenceNumber,
+    providerStatus: typeof rawItem.status === "string" ? rawItem.status : null,
+    hasId: typeof rawItem.id === "string",
+    hasCallId: typeof rawItem.callId === "string",
+    hasName: typeof rawItem.name === "string",
+    hasArguments: argumentsValue !== undefined && argumentsValue !== null,
+    argumentsLength: getStringLength(argumentsValue),
+    hasInput: inputValue !== undefined && inputValue !== null,
+    inputLength: getStringLength(inputValue),
+    hasOutput: outputValue !== undefined && outputValue !== null,
+    outputLength: getStringLength(outputValue),
+  };
+}
+
+function buildToolCallInvariantErrorMessage(
+  reason: string,
+  rawItem: FunctionToolCallRawItem | ToolCallOutputRawItem,
+  context: ToolCallInvariantContext,
+): string {
+  return `${reason}: ${JSON.stringify(buildToolCallInvariantMetadata(rawItem, context))}`;
+}
 
 function stringifyToolValue(value: unknown): string | null {
   if (value === undefined || value === null) {
@@ -110,7 +213,10 @@ function createToolCallEvent(
 /**
  * Returns the stable tool-call identifier required to merge provider updates across events.
  */
-export function getRequiredToolCallId(rawItem: FunctionToolCallRawItem | ToolCallOutputRawItem): string {
+function getRequiredToolCallId(
+  rawItem: FunctionToolCallRawItem | ToolCallOutputRawItem,
+  context: ToolCallInvariantContext,
+): string {
   if ("callId" in rawItem && typeof rawItem.callId === "string" && rawItem.callId.length > 0) {
     return rawItem.callId;
   }
@@ -119,12 +225,17 @@ export function getRequiredToolCallId(rawItem: FunctionToolCallRawItem | ToolCal
     return rawItem.id;
   }
 
-  throw new Error(`OpenAI tool call is missing a stable identifier: ${JSON.stringify(rawItem)}`);
+  throw new Error(buildToolCallInvariantErrorMessage(
+    "OpenAI tool call is missing a stable identifier",
+    rawItem,
+    context,
+  ));
 }
 
 function getRequiredToolItemId(
   rawItem: FunctionToolCallRawItem | ToolCallOutputRawItem,
   previousSnapshot: ToolCallEvent | null,
+  context: ToolCallInvariantContext,
 ): string {
   if (typeof rawItem.id === "string" && rawItem.id.length > 0) {
     return rawItem.id;
@@ -134,18 +245,27 @@ function getRequiredToolItemId(
     return previousSnapshot.itemId;
   }
 
-  throw new Error(`OpenAI tool call is missing an output item id: ${JSON.stringify(rawItem)}`);
+  throw new Error(buildToolCallInvariantErrorMessage(
+    "OpenAI tool call is missing an output item id",
+    rawItem,
+    context,
+  ));
 }
 
 function getRequiredToolOutputIndex(
   previousSnapshot: ToolCallEvent | null,
   rawItem: ToolCallOutputRawItem,
+  context: ToolCallInvariantContext,
 ): number {
   if (previousSnapshot !== null) {
     return previousSnapshot.outputIndex;
   }
 
-  throw new Error(`OpenAI tool call output arrived before a tracked output item existed: ${JSON.stringify(rawItem)}`);
+  throw new Error(buildToolCallInvariantErrorMessage(
+    "OpenAI tool call output arrived before a tracked output item existed",
+    rawItem,
+    context,
+  ));
 }
 
 function buildFunctionToolCallEvent(
@@ -153,9 +273,10 @@ function buildFunctionToolCallEvent(
   position: ToolCallPosition,
 ): ToolCallEvent {
   const providerStatus = typeof rawItem.status === "string" ? rawItem.status : null;
+  const invariantContext = createToolCallInvariantContextFromPosition(position);
 
   return createToolCallEvent(
-    getRequiredToolCallId(rawItem),
+    getRequiredToolCallId(rawItem, invariantContext),
     position.itemId,
     rawItem.name,
     isTerminalToolProviderStatus(providerStatus) ? "completed" : "started",
@@ -175,17 +296,18 @@ function buildToolOutputEvent(
   rawOutput: unknown,
   refreshRoute: boolean,
 ): ToolCallEvent {
-  const id = getRequiredToolCallId(rawItem);
+  const invariantContext = createToolCallInvariantContextFromSnapshot(previousSnapshot, rawOutput);
+  const id = getRequiredToolCallId(rawItem, invariantContext);
   const output = stringifyToolValue(rawOutput);
   const name = previousSnapshot?.name ?? (typeof rawItem.name === "string" ? rawItem.name : "tool");
 
   return createToolCallEvent(
     id,
-    getRequiredToolItemId(rawItem, previousSnapshot),
+    getRequiredToolItemId(rawItem, previousSnapshot, invariantContext),
     name,
     "completed",
     previousSnapshot?.responseIndex ?? 0,
-    getRequiredToolOutputIndex(previousSnapshot, rawItem),
+    getRequiredToolOutputIndex(previousSnapshot, rawItem, invariantContext),
     previousSnapshot?.sequenceNumber ?? null,
     "completed",
     previousSnapshot?.input ?? null,
@@ -363,7 +485,10 @@ export function applyToolCallOutput(
   nowMs: number,
   refreshRoute: boolean,
 ): ToolCallUpdate {
-  const toolCallId = getRequiredToolCallId(rawItem);
+  const toolCallId = getRequiredToolCallId(
+    rawItem,
+    createToolCallInvariantContext(null, null, null, output),
+  );
   const previousState = toolStates.get(toolCallId) ?? findToolStateByItemId(
     toolStates,
     rawItem.id ?? "",

--- a/apps/backend/src/chat/openai/toolExecutor.ts
+++ b/apps/backend/src/chat/openai/toolExecutor.ts
@@ -5,10 +5,65 @@ import {
   type ExecutedChatToolCall,
 } from "./tools";
 
-function sanitizeToolOutputForTelemetry(output: string): string {
-  return output.length <= 4_000
-    ? output
-    : `${output.slice(0, 4_000)}...`;
+type ToolTelemetryMetadata = Readonly<{
+  toolName: string;
+  toolCallId: string;
+  argumentLength: number;
+  hasArguments: boolean;
+  durationMs: number | null;
+  outputLength: number | null;
+  ok: boolean | null;
+  errorClass: string | null;
+  errorMessage: string | null;
+}>;
+
+function getToolArgumentLength(argumentsJson: string): number {
+  return argumentsJson.length;
+}
+
+function hasToolArguments(argumentsJson: string): boolean {
+  return argumentsJson.trim().length > 0 && argumentsJson.trim() !== "{}";
+}
+
+function getErrorClass(error: unknown): string {
+  return error instanceof Error ? error.name : "NonErrorThrow";
+}
+
+function getSafeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim() !== "") {
+    return "tool execution failed";
+  }
+
+  if (error instanceof Error) {
+    return "tool execution failed without message";
+  }
+
+  return "tool execution failed with non-error throw";
+}
+
+function buildToolTelemetryMetadata(
+  params: Readonly<{
+    toolName: string;
+    toolCallId: string;
+    argumentsJson: string;
+    durationMs: number | null;
+    outputLength: number | null;
+    ok: boolean | null;
+    errorClass: string | null;
+    errorMessage: string | null;
+  }>,
+): ToolTelemetryMetadata {
+  return {
+    toolName: params.toolName,
+    toolCallId: params.toolCallId,
+    argumentLength: getToolArgumentLength(params.argumentsJson),
+    hasArguments: hasToolArguments(params.argumentsJson),
+    durationMs: params.durationMs,
+    outputLength: params.outputLength,
+    ok: params.ok,
+    errorClass: params.errorClass,
+    errorMessage: params.errorMessage,
+  };
 }
 
 /**
@@ -26,12 +81,19 @@ export async function runOneToolCall(
     params.item.name,
     {
       input: {
-        arguments: params.item.arguments,
+        argumentLength: getToolArgumentLength(params.item.arguments),
+        hasArguments: hasToolArguments(params.item.arguments),
       },
-      metadata: {
+      metadata: buildToolTelemetryMetadata({
         toolName: params.item.name,
         toolCallId: params.item.call_id,
-      },
+        argumentsJson: params.item.arguments,
+        durationMs: null,
+        outputLength: null,
+        ok: null,
+        errorClass: null,
+        errorMessage: null,
+      }),
     },
     {
       asType: "tool",
@@ -52,26 +114,37 @@ export async function runOneToolCall(
 
     toolObservation?.updateOtelSpanAttributes({
       output: {
-        output: sanitizeToolOutputForTelemetry(result.output),
+        ok: true,
+        outputLength: result.output.length,
       },
-      metadata: {
+      metadata: buildToolTelemetryMetadata({
         toolName: params.item.name,
         toolCallId: params.item.call_id,
-        durationMs: String(Date.now() - startedAt),
-      },
+        argumentsJson: params.item.arguments,
+        durationMs: Date.now() - startedAt,
+        outputLength: result.output.length,
+        ok: true,
+        errorClass: null,
+        errorMessage: null,
+      }),
     });
     toolObservation?.end();
     return result;
   } catch (error) {
     toolObservation?.updateOtelSpanAttributes({
       output: {
-        error: error instanceof Error ? error.message : String(error),
+        ok: false,
       },
-      metadata: {
+      metadata: buildToolTelemetryMetadata({
         toolName: params.item.name,
         toolCallId: params.item.call_id,
-        durationMs: String(Date.now() - startedAt),
-      },
+        argumentsJson: params.item.arguments,
+        durationMs: Date.now() - startedAt,
+        outputLength: null,
+        ok: false,
+        errorClass: getErrorClass(error),
+        errorMessage: getSafeErrorMessage(error),
+      }),
     });
     toolObservation?.end();
     throw error;

--- a/apps/backend/src/chat/runtime.ts
+++ b/apps/backend/src/chat/runtime.ts
@@ -38,7 +38,16 @@ import {
   updateAssistantMessageItem,
   updateAssistantMessageItemAndInvalidateMainContent,
 } from "./store";
-import { logChatWorkerLifecycleEvent, type ChatWorkerLogContext } from "./workerLogging";
+import {
+  captureChatWorkerTerminalStateException,
+  logChatWorkerLifecycleEvent,
+  type ChatWorkerLogContext,
+} from "./workerLogging";
+import {
+  normalizeCaughtError,
+  startBackendSpan,
+  type ChatWorkerLifecycleDetails,
+} from "../observability/sentry";
 import type {
   ChatStreamEvent,
   ContentPart,
@@ -57,6 +66,12 @@ const INCOMPLETE_TOOL_CALL_PROVIDER_STATUS = "incomplete";
  */
 const CHAT_WORKER_PRE_TIMEOUT_BUFFER_MS = 180_000;
 const DEADLINE_REACHED_MESSAGE = "This response took too long, so I stopped the run before the server timeout. Please try again or split the request into smaller steps.";
+const GENERIC_RUNTIME_ERROR_MESSAGE = "The AI response failed before it could finish. Please try again.";
+const PROVIDER_ERROR_MESSAGE = "The AI provider could not complete the response. Please try again.";
+const PROVIDER_AUTH_ERROR_MESSAGE = "The AI provider could not authenticate the request. Please try again later.";
+const PROVIDER_RATE_LIMITED_ERROR_MESSAGE = "The AI provider is rate limited right now. Please try again in a few minutes.";
+const PROVIDER_UNAVAILABLE_ERROR_MESSAGE = "The AI provider is temporarily unavailable. Please try again soon.";
+const PROVIDER_ABORT_ERROR_MESSAGE = "The AI request was interrupted. Please try again.";
 
 type ChatRunDiagnostics = Readonly<{
   requestId: string;
@@ -92,6 +107,16 @@ type ChatWorkerAbortReason =
   | "deadline_reached";
 
 type ChatWorkerExecutionPhase = "idle" | "model" | "tool";
+
+type SafeProviderErrorDetails = Pick<
+  ChatWorkerLifecycleDetails,
+  | "providerErrorClass"
+  | "providerErrorMessage"
+  | "providerErrorStatus"
+  | "providerErrorCode"
+  | "providerErrorCategory"
+  | "providerRequestId"
+>;
 
 export type ChatWorkerRunResult = Readonly<{
   outcome: "completed" | "cancelled" | "ownership_lost" | "failed" | "interrupted";
@@ -150,6 +175,112 @@ function toIsoStringOrNull(value: Date | null): string | null {
   return value === null ? null : value.toISOString();
 }
 
+function readErrorRecordStringField(error: unknown, fieldName: string): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const value = (error as Readonly<Record<string, unknown>>)[fieldName];
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue === "" ? null : trimmedValue;
+}
+
+function classifyProviderErrorCategory(error: unknown, providerStatus: number | null): string | null {
+  if (error instanceof OpenAI.APIUserAbortError || (error instanceof Error && error.name === "AbortError")) {
+    return "provider_abort";
+  }
+
+  if (error instanceof Error && error.name === "ChatProviderTerminalEventError") {
+    return "provider_error";
+  }
+
+  if (providerStatus === 401 || providerStatus === 403) {
+    return "provider_auth";
+  }
+
+  if (providerStatus === 402 || providerStatus === 429) {
+    return "provider_rate_limited";
+  }
+
+  if (providerStatus !== null && providerStatus >= 500) {
+    return "provider_unavailable";
+  }
+
+  if (providerStatus !== null || error instanceof OpenAI.APIError) {
+    return "provider_error";
+  }
+
+  return error === null ? null : "runtime_error";
+}
+
+function createSafeProviderErrorDetails(error: unknown | null): SafeProviderErrorDetails {
+  if (error === null) {
+    return {
+      providerErrorClass: null,
+      providerErrorMessage: null,
+      providerErrorStatus: null,
+      providerErrorCode: null,
+      providerErrorCategory: null,
+      providerRequestId: null,
+    };
+  }
+
+  const errorContext = getErrorLogContext(error);
+  const providerMetadata = getAIProviderFailureMetadata(error);
+
+  return {
+    providerErrorClass: errorContext.errorClass,
+    providerErrorMessage: null,
+    providerErrorStatus: providerMetadata.upstreamStatus,
+    providerErrorCode: readErrorRecordStringField(error, "code"),
+    providerErrorCategory: classifyProviderErrorCategory(error, providerMetadata.upstreamStatus),
+    providerRequestId: providerMetadata.upstreamRequestId,
+  };
+}
+
+function createPublicTerminalErrorMessage(error: unknown): string {
+  const providerMetadata = getAIProviderFailureMetadata(error);
+  const category = classifyProviderErrorCategory(error, providerMetadata.upstreamStatus);
+
+  if (category === "provider_auth") {
+    return PROVIDER_AUTH_ERROR_MESSAGE;
+  }
+
+  if (category === "provider_rate_limited") {
+    return PROVIDER_RATE_LIMITED_ERROR_MESSAGE;
+  }
+
+  if (category === "provider_unavailable") {
+    return PROVIDER_UNAVAILABLE_ERROR_MESSAGE;
+  }
+
+  if (category === "provider_abort") {
+    return PROVIDER_ABORT_ERROR_MESSAGE;
+  }
+
+  if (category === "provider_error") {
+    return PROVIDER_ERROR_MESSAGE;
+  }
+
+  return GENERIC_RUNTIME_ERROR_MESSAGE;
+}
+
+function isHandledProviderFailure(error: unknown): boolean {
+  const providerMetadata = getAIProviderFailureMetadata(error);
+  const category = classifyProviderErrorCategory(error, providerMetadata.upstreamStatus);
+  return category !== null && category !== "runtime_error";
+}
+
+function createProviderTerminalEventError(): Error {
+  const error = new Error("Chat provider emitted a terminal error event");
+  error.name = "ChatProviderTerminalEventError";
+  return error;
+}
+
 function logAbortRequested(
   context: ChatWorkerLogContext,
   reason: ChatWorkerAbortReason,
@@ -165,12 +296,11 @@ function logAbortRequested(
     ownershipLost,
     runStatus: null,
     sessionState: null,
-    providerErrorClass: null,
-    providerErrorMessage: null,
-    providerRequestId: null,
+    ...createSafeProviderErrorDetails(null),
     heartbeatAt: toIsoStringOrNull(heartbeatAt),
     startedAt: null,
     finishedAt: null,
+    outcome: null,
   }, false);
 }
 
@@ -186,12 +316,11 @@ function logProviderCallStarted(
     ownershipLost: false,
     runStatus: null,
     sessionState: null,
-    providerErrorClass: null,
-    providerErrorMessage: null,
-    providerRequestId: null,
+    ...createSafeProviderErrorDetails(null),
     heartbeatAt: null,
     startedAt: startedAt.toISOString(),
     finishedAt: null,
+    outcome: null,
   }, false);
 }
 
@@ -203,8 +332,6 @@ function logProviderCallAborted(
   ownershipLost: boolean,
   signalAborted: boolean,
 ): void {
-  const errorContext = getErrorLogContext(error);
-  const providerMetadata = getAIProviderFailureMetadata(error);
   logChatWorkerLifecycleEvent("chat_worker_provider_call_aborted", context, {
     abortReason,
     signalAborted,
@@ -212,12 +339,11 @@ function logProviderCallAborted(
     ownershipLost,
     runStatus: null,
     sessionState: null,
-    providerErrorClass: errorContext.errorClass,
-    providerErrorMessage: errorContext.errorMessage,
-    providerRequestId: providerMetadata.upstreamRequestId,
+    ...createSafeProviderErrorDetails(error),
     heartbeatAt: null,
     startedAt: null,
     finishedAt: null,
+    outcome: null,
   }, false);
 }
 
@@ -233,22 +359,35 @@ function logTerminalStatePersisted(
   startedAt: Date,
   finishedAt: Date,
 ): void {
-  const errorContext = error === null ? null : getErrorLogContext(error);
-  const providerMetadata = error === null ? null : getAIProviderFailureMetadata(error);
-
-  logChatWorkerLifecycleEvent("chat_worker_terminal_state_persisted", context, {
+  const payload = {
     abortReason,
     signalAborted,
     cancellationRequested,
     ownershipLost,
     runStatus,
     sessionState,
-    providerErrorClass: errorContext?.errorClass ?? null,
-    providerErrorMessage: errorContext?.errorMessage ?? null,
-    providerRequestId: providerMetadata?.upstreamRequestId ?? null,
+    ...createSafeProviderErrorDetails(error),
+    heartbeatAt: null,
     startedAt: startedAt.toISOString(),
     finishedAt: finishedAt.toISOString(),
-  }, runStatus === "failed");
+    outcome: null,
+  };
+
+  if (runStatus === "failed" && error !== null && !isHandledProviderFailure(error)) {
+    captureChatWorkerTerminalStateException(
+      context,
+      payload,
+      normalizeCaughtError(error),
+    );
+    return;
+  }
+
+  logChatWorkerLifecycleEvent(
+    "chat_worker_terminal_state_persisted",
+    context,
+    payload,
+    runStatus === "failed",
+  );
 }
 
 /**
@@ -400,7 +539,6 @@ async function generateTerminalComposerSuggestions(
       params.uiLocale,
     );
   } catch (error) {
-    const errorContext = getErrorLogContext(error);
     logChatWorkerLifecycleEvent("chat_worker_composer_suggestions_failed", logContext, {
       abortReason: null,
       signalAborted: false,
@@ -408,11 +546,11 @@ async function generateTerminalComposerSuggestions(
       ownershipLost: false,
       runStatus: null,
       sessionState: null,
-      providerErrorClass: errorContext.errorClass,
-      providerErrorMessage: errorContext.errorMessage,
-      providerRequestId: null,
+      ...createSafeProviderErrorDetails(error),
+      heartbeatAt: null,
       startedAt: null,
       finishedAt: null,
+      outcome: null,
     }, true);
     return emptyChatComposerSuggestions();
   }
@@ -489,7 +627,6 @@ export async function runPersistedChatSessionWithDeps(
   const persistFailed = async (
     error: unknown,
   ): Promise<ChatWorkerRunResult> => {
-    const message = error instanceof Error ? error.message : String(error);
     assistantContent = finalizeAssistantToolCalls(assistantContent);
     const finishedAt = new Date();
     await dependencies.persistAssistantTerminalError(params.userId, params.workspaceId, {
@@ -497,7 +634,7 @@ export async function runPersistedChatSessionWithDeps(
       sessionId: params.sessionId,
       assistantItemId: params.assistantItemId,
       assistantContent,
-      errorMessage: message,
+      errorMessage: createPublicTerminalErrorMessage(error),
       sessionState: "idle",
     });
     isFinalized = true;
@@ -764,21 +901,24 @@ export async function runPersistedChatSessionWithDeps(
         }
 
         logProviderCallStarted(logContext, new Date(), abortController.signal.aborted);
-        const completion: OpenAILoopCompletion = await dependencies.startOpenAILoop({
-          requestId: params.requestId,
-          userId: params.userId,
-          workspaceId: params.workspaceId,
-          sessionId: params.sessionId,
-          timezone: params.timezone,
-          localMessages: params.localMessages,
-          turnInput: params.turnInput,
-          rootObservation,
-          signal: abortController.signal,
-          onExecutionPhaseChanged: (phase): void => {
-            executionPhase = phase;
-          },
-          shouldStopBeforeNextStep: (): boolean => abortReason === "deadline_reached",
-        }, async (event): Promise<void> => {
+        const completion: OpenAILoopCompletion = await startBackendSpan(
+          "chat.worker.openai_loop",
+          "ai.openai",
+          async () => dependencies.startOpenAILoop({
+            requestId: params.requestId,
+            userId: params.userId,
+            workspaceId: params.workspaceId,
+            sessionId: params.sessionId,
+            timezone: params.timezone,
+            localMessages: params.localMessages,
+            turnInput: params.turnInput,
+            rootObservation,
+            signal: abortController.signal,
+            onExecutionPhaseChanged: (phase): void => {
+              executionPhase = phase;
+            },
+            shouldStopBeforeNextStep: (): boolean => abortReason === "deadline_reached",
+          }, async (event): Promise<void> => {
           const shouldIgnoreEvent = stopRequestedByUser
             || ownershipLost
             || (
@@ -822,9 +962,10 @@ export async function runPersistedChatSessionWithDeps(
               assistantContent,
             );
           } else if (event.type === "error") {
-            runtimeResult = await persistFailed(new Error(event.message));
+            runtimeResult = await persistFailed(createProviderTerminalEventError());
           }
-        });
+          }),
+        );
 
         if (runtimeResult !== null) {
           return;

--- a/apps/backend/src/chat/tests/chat-live-errors.test.ts
+++ b/apps/backend/src/chat/tests/chat-live-errors.test.ts
@@ -117,6 +117,7 @@ test("handleLiveRequest prefers an explicit workspaceId for non-Live auth fallba
     resumeAttemptId: "resume-1",
     clientPlatform: "web",
     clientVersion: "web-test",
+    traceContext: null,
   });
 });
 

--- a/apps/backend/src/chat/tests/chat-live-resume.test.ts
+++ b/apps/backend/src/chat/tests/chat-live-resume.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { PassThrough } from "node:stream";
-import { runLiveStreamWithDependencies } from "../live";
+import {
+  runLiveStreamWithDependencies,
+  type ChatLiveStreamResult,
+} from "../live";
 import type { ChatComposerSuggestion } from "../composerSuggestions";
 import type { ChatRunSnapshot } from "../runs";
 import type { PersistedChatMessageItem } from "../store";
@@ -108,6 +111,32 @@ async function collectStreamOutput(
   }
 
   return output;
+}
+
+async function collectStreamResult(
+  execute: (stream: PassThrough) => Promise<ChatLiveStreamResult>,
+): Promise<Readonly<{
+  output: string;
+  result: ChatLiveStreamResult;
+}>> {
+  const stream = new PassThrough();
+  stream.setEncoding("utf8");
+  let output = "";
+  stream.on("data", (chunk: string) => {
+    output += chunk;
+  });
+
+  const result = await execute(stream);
+  if (stream.readableEnded === false) {
+    await new Promise<void>((resolve) => {
+      stream.on("end", () => resolve());
+    });
+  }
+
+  return {
+    output,
+    result,
+  };
 }
 
 function parseLiveEvents(output: string): ReadonlyArray<unknown> {
@@ -776,6 +805,51 @@ test("recovered session read emits reset_required immediately when the attached 
       streamEpoch: "run-1",
       outcome: "reset_required",
       assistantItemId: "assistant-8",
+    },
+  ]);
+});
+
+test("poll failures mark the stream result for Sentry flush and keep the terminal SSE contract", async () => {
+  const { output, result } = await collectStreamResult(async (stream) =>
+    runLiveStreamWithDependencies(stream, {
+      sessionId: "session-1",
+      runId: "run-1",
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      afterCursor: undefined,
+      requestId: "request-poll-error-1",
+    }, {
+      getChatRunSnapshot: async () => createRunSnapshot({
+        status: "running",
+        assistantItemId: "assistant-9",
+        lastErrorMessage: null,
+      }),
+      getRecoveredChatSessionSnapshot: async () => {
+        throw new Error("session poll failed");
+      },
+      listChatMessagesAfterCursor: async () => [],
+      listChatMessagesLatest: async () => ({
+        messages: [],
+        oldestCursor: null,
+        newestCursor: null,
+        hasOlder: false,
+      }),
+      waitForNextPollInterval: async () => true,
+    }));
+
+  assert.equal(result.capturedSentryEvent, true);
+  assert.deepEqual(parseLiveEvents(output), [
+    {
+      type: "run_terminal",
+      sessionId: "session-1",
+      conversationScopeId: "session-1",
+      runId: "run-1",
+      cursor: null,
+      sequenceNumber: 1,
+      streamEpoch: "run-1",
+      outcome: "error",
+      message: "Failed to poll session state",
+      isError: true,
     },
   ]);
 });

--- a/apps/backend/src/chat/tests/chat-route-contract.test.ts
+++ b/apps/backend/src/chat/tests/chat-route-contract.test.ts
@@ -4,10 +4,16 @@ import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { HttpError } from "../../errors";
 import { createChatRoutes } from "../../routes/chat";
+import type { AppEnv } from "../../app";
 import type { RequestContext } from "../../server/requestContext";
 import type { ChatSessionSnapshot, PersistedChatMessageItem } from "../store";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
+
+type ConsoleMethod = "log" | "warn" | "error";
+type StructuredLogRecord = Readonly<Record<string, unknown> & {
+  consoleMethod: ConsoleMethod;
+}>;
 
 function createRequestContext(): RequestContext {
   return {
@@ -23,7 +29,7 @@ function createRequestContext(): RequestContext {
 }
 
 function createRoutesWithHttpErrorJson() {
-  const app = new Hono();
+  const app = new Hono<AppEnv>();
   app.onError((error, context) => {
     const httpError = toHttpErrorLike(error);
     if (httpError !== null) {
@@ -94,6 +100,51 @@ function createAssistantItem(
   };
 }
 
+async function withCapturedLogs(
+  execute: () => Promise<void>,
+): Promise<ReadonlyArray<StructuredLogRecord>> {
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const records: Array<StructuredLogRecord> = [];
+
+  const captureMessage = (message: unknown, consoleMethod: ConsoleMethod): void => {
+    if (typeof message === "string") {
+      records.push({
+        ...(JSON.parse(message) as Record<string, unknown>),
+        consoleMethod,
+      });
+    }
+  };
+
+  console.log = (...args: unknown[]): void => {
+    captureMessage(args[0], "log");
+  };
+  console.warn = (...args: unknown[]): void => {
+    captureMessage(args[0], "warn");
+  };
+  console.error = (...args: unknown[]): void => {
+    captureMessage(args[0], "error");
+  };
+
+  try {
+    await execute();
+  } finally {
+    console.log = originalLog;
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+
+  return records;
+}
+
+function findLog(
+  records: ReadonlyArray<StructuredLogRecord>,
+  action: string,
+): StructuredLogRecord | undefined {
+  return records.find((record) => record.action === action);
+}
+
 test("GET /chat fails with a stable contract code when running snapshot has no in-progress assistant item", async () => {
   const routes = createChatRoutes({
     allowedOrigins: [],
@@ -128,6 +179,38 @@ test("GET /chat fails with a stable contract code when running snapshot has no i
   });
 });
 
+test("GET /chat resume contract warnings include the Hono request id", async () => {
+  const routes = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    getRecoveredChatSessionSnapshotFn: async () => createRunningSnapshot(),
+    listChatMessagesLatestFn: async () => ({
+      messages: [createAssistantItem("completed")],
+      oldestCursor: "6",
+      newestCursor: "6",
+      hasOlder: false,
+    }),
+  });
+  const app = createRoutesWithHttpErrorJson();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-route-1");
+    await next();
+  });
+  app.route("/", routes);
+
+  const logs = await withCapturedLogs(async () => {
+    const response = await app.request(`http://localhost/chat?sessionId=${SESSION_ONE}`);
+    assert.equal(response.status, 500);
+  });
+
+  const warningLog = findLog(logs, "chat_resume_contract_violation");
+  assert.equal(warningLog?.consoleMethod, "warn");
+  assert.equal(warningLog?.requestId, "request-route-1");
+});
+
 test("GET /chat fails with a stable contract code when a running snapshot cannot create a live stream", async () => {
   const routes = createChatRoutes({
     allowedOrigins: [],
@@ -156,6 +239,74 @@ test("GET /chat fails with a stable contract code when a running snapshot cannot
     requestId: null,
     code: "CHAT_LIVE_RESUME_CONTRACT_VIOLATION",
   });
+});
+
+test("POST /chat captures unexpected live envelope failures before returning the stable contract code", async () => {
+  let interruptCount = 0;
+  const routes = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    prepareChatRunFn: async () => ({
+      sessionId: SESSION_ONE,
+      runId: "run-1",
+      clientRequestId: "client-request-1",
+      runState: "running",
+      deduplicated: false,
+      shouldInvokeWorker: false,
+    }),
+    getRecoveredChatSessionSnapshotFn: async () => createRunningSnapshot(),
+    resolveLiveCursorFn: async () => "5",
+    listChatMessagesLatestFn: async () => ({
+      messages: [createAssistantItem("in_progress")],
+      oldestCursor: "6",
+      newestCursor: "6",
+      hasOlder: false,
+    }),
+    createChatLiveStreamEnvelopeFn: async () => {
+      throw new Error("live signer exploded");
+    },
+    interruptPreparedChatRunFn: async () => {
+      interruptCount += 1;
+    },
+  });
+  const app = createRoutesWithHttpErrorJson();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-route-2");
+    await next();
+  });
+  app.route("/", routes);
+
+  const logs = await withCapturedLogs(async () => {
+    const response = await app.request("http://localhost/chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        sessionId: SESSION_ONE,
+        clientRequestId: "client-request-1",
+        content: [{ type: "text", text: "hello" }],
+        timezone: "Europe/Madrid",
+      }),
+    });
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(await response.json(), {
+      error: "Chat live resume contract violation",
+      requestId: null,
+      code: "CHAT_LIVE_RESUME_CONTRACT_VIOLATION",
+    });
+  });
+
+  const exceptionLog = findLog(logs, "request_failed");
+  assert.equal(interruptCount, 1);
+  assert.equal(exceptionLog?.consoleMethod, "error");
+  assert.equal(exceptionLog?.requestId, "request-route-2");
+  assert.equal(exceptionLog?.runId, "run-1");
+  assert.equal(exceptionLog?.errorMessage, "live signer exploded");
 });
 
 test("POST /chat fails with a stable contract code when a running response cannot create a live stream", async () => {

--- a/apps/backend/src/chat/tests/chat-runtime.test.ts
+++ b/apps/backend/src/chat/tests/chat-runtime.test.ts
@@ -5,7 +5,10 @@ import type { ChatRuntimeDependencies, StartPersistedChatRunParams } from "../ru
 import { runPersistedChatSessionWithDeps } from "../runtime";
 import type { OpenAILoopCompletion, OpenAILoopEventSink, StartOpenAILoopParams } from "../openai/loop";
 
-type StructuredLogRecord = Readonly<Record<string, unknown>>;
+type ConsoleMethod = "log" | "warn" | "error";
+type StructuredLogRecord = Readonly<Record<string, unknown> & {
+  consoleMethod: ConsoleMethod;
+}>;
 
 type DependencyOverrides = Partial<ChatRuntimeDependencies>;
 
@@ -32,6 +35,20 @@ function createAbortError(): Error {
   const error = new Error("Request was aborted.");
   error.name = "AbortError";
   return error;
+}
+
+function createProviderApiError(rawMessage: string): Error & Readonly<{
+  status: number;
+  code: string;
+  requestID: string;
+}> {
+  const error = new Error(rawMessage);
+  error.name = "RateLimitError";
+  return Object.assign(error, {
+    status: 429,
+    code: "rate_limit_exceeded",
+    requestID: "req_provider_123",
+  });
 }
 
 function createParams(): StartPersistedChatRunParams {
@@ -100,26 +117,34 @@ async function withCapturedLogs(
   execute: () => Promise<void>,
 ): Promise<ReadonlyArray<StructuredLogRecord>> {
   const originalLog = console.log;
+  const originalWarn = console.warn;
   const originalError = console.error;
   const records: Array<StructuredLogRecord> = [];
 
-  console.log = (...args: unknown[]): void => {
-    const message = args[0];
+  const captureMessage = (message: unknown, consoleMethod: ConsoleMethod): void => {
     if (typeof message === "string") {
-      records.push(JSON.parse(message) as StructuredLogRecord);
+      records.push({
+        ...(JSON.parse(message) as Record<string, unknown>),
+        consoleMethod,
+      });
     }
   };
+
+  console.log = (...args: unknown[]): void => {
+    captureMessage(args[0], "log");
+  };
   console.error = (...args: unknown[]): void => {
-    const message = args[0];
-    if (typeof message === "string") {
-      records.push(JSON.parse(message) as StructuredLogRecord);
-    }
+    captureMessage(args[0], "error");
+  };
+  console.warn = (...args: unknown[]): void => {
+    captureMessage(args[0], "warn");
   };
 
   try {
     await execute();
   } finally {
     console.log = originalLog;
+    console.warn = originalWarn;
     console.error = originalError;
   }
 
@@ -204,6 +229,16 @@ function findLog(
   action: string,
 ): StructuredLogRecord | undefined {
   return records.find((record) => record.action === action);
+}
+
+function requireTerminalPersistParams(
+  params: PersistAssistantTerminalErrorParams | null,
+): PersistAssistantTerminalErrorParams {
+  if (params === null) {
+    throw new Error("Expected terminal persist params");
+  }
+
+  return params;
 }
 
 test("runPersistedChatSessionWithDeps finalizes a cancelled run when the user stops during the provider call", async () => {
@@ -841,6 +876,8 @@ test("runPersistedChatSessionWithDeps interrupts gracefully on the soft deadline
 
 test("runPersistedChatSessionWithDeps persists a failed run for real provider errors", async () => {
   let terminalPersistCount = 0;
+  let terminalPersistParams: PersistAssistantTerminalErrorParams | null = null;
+  const rawProviderMessage = "provider leaked raw prompt: user asked about private study notes";
 
   const logs = await withCapturedLogs(async () => {
     const result = await runPersistedChatSessionWithDeps(
@@ -858,10 +895,11 @@ test("runPersistedChatSessionWithDeps persists a failed run for real provider er
             contentIndex: 0,
             sequenceNumber: 1,
           });
-          throw new Error("provider exploded");
+          throw createProviderApiError(rawProviderMessage);
         },
-        persistAssistantTerminalError: async () => {
+        persistAssistantTerminalError: async (_userId, _workspaceId, params) => {
           terminalPersistCount += 1;
+          terminalPersistParams = params;
         },
       }),
     );
@@ -875,8 +913,110 @@ test("runPersistedChatSessionWithDeps persists a failed run for real provider er
   });
 
   assert.equal(terminalPersistCount, 1);
+  assert.equal(
+    requireTerminalPersistParams(terminalPersistParams).errorMessage,
+    "The AI provider is rate limited right now. Please try again in a few minutes.",
+  );
   assert.equal(findLog(logs, "chat_worker_provider_call_aborted"), undefined);
-  assert.equal(findLog(logs, "chat_worker_terminal_state_persisted")?.runStatus, "failed");
+  const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
+  assert.equal(terminalLog?.consoleMethod, "warn");
+  assert.equal(terminalLog?.runStatus, "failed");
+  assert.equal(terminalLog?.providerErrorClass, "RateLimitError");
+  assert.equal(terminalLog?.providerErrorMessage, null);
+  assert.equal(terminalLog?.providerErrorStatus, 429);
+  assert.equal(terminalLog?.providerErrorCode, "rate_limit_exceeded");
+  assert.equal(terminalLog?.providerErrorCategory, "provider_rate_limited");
+  assert.equal(terminalLog?.providerRequestId, "req_provider_123");
+  assert.equal(terminalLog?.lambdaRequestId, "lambda-request-1");
+  assert.equal(terminalLog?.errorClass, undefined);
+  assert.equal(terminalLog?.errorMessage, undefined);
+  assert.equal(JSON.stringify(terminalLog).includes(rawProviderMessage), false);
+});
+
+test("runPersistedChatSessionWithDeps captures unexpected runtime failures as backend exceptions", async () => {
+  const runtimeError = new Error("assistant content reducer exploded");
+  let terminalPersistParams: PersistAssistantTerminalErrorParams | null = null;
+
+  const logs = await withCapturedLogs(async () => {
+    const result = await runPersistedChatSessionWithDeps(
+      createParams(),
+      createDependencies({
+        startOpenAILoop: async (): Promise<OpenAILoopCompletion> => {
+          throw runtimeError;
+        },
+        persistAssistantTerminalError: async (_userId, _workspaceId, params) => {
+          terminalPersistParams = params;
+        },
+      }),
+    );
+
+    assert.deepEqual(result, {
+      outcome: "failed",
+      abortReason: null,
+      runStatus: "failed",
+      sessionState: "idle",
+    });
+  });
+
+  assert.equal(
+    requireTerminalPersistParams(terminalPersistParams).errorMessage,
+    "The AI response failed before it could finish. Please try again.",
+  );
+  const terminalLogs = logs.filter((record) => record.action === "chat_worker_terminal_state_persisted");
+  assert.equal(terminalLogs.length, 1);
+  const terminalLog = terminalLogs[0];
+  assert.equal(terminalLog?.consoleMethod, "error");
+  assert.equal(terminalLog?.runStatus, "failed");
+  assert.equal(terminalLog?.providerErrorCategory, "runtime_error");
+  assert.equal(terminalLog?.errorClass, "Error");
+  assert.equal(terminalLog?.errorMessage, "assistant content reducer exploded");
+  assert.equal(terminalLog?.lambdaRequestId, "lambda-request-1");
+});
+
+test("runPersistedChatSessionWithDeps does not log raw provider terminal event messages", async () => {
+  const rawProviderMessage = "provider terminal event included private prompt text";
+  let terminalPersistParams: PersistAssistantTerminalErrorParams | null = null;
+
+  const logs = await withCapturedLogs(async () => {
+    const result = await runPersistedChatSessionWithDeps(
+      createParams(),
+      createDependencies({
+        startOpenAILoop: async (
+          _params: StartOpenAILoopParams,
+          onEvent: OpenAILoopEventSink,
+        ): Promise<OpenAILoopCompletion> => {
+          await onEvent({
+            type: "error",
+            message: rawProviderMessage,
+          });
+          return createCompletedLoopCompletion();
+        },
+        persistAssistantTerminalError: async (_userId, _workspaceId, params) => {
+          terminalPersistParams = params;
+        },
+      }),
+    );
+
+    assert.deepEqual(result, {
+      outcome: "failed",
+      abortReason: null,
+      runStatus: "failed",
+      sessionState: "idle",
+    });
+  });
+
+  assert.equal(
+    requireTerminalPersistParams(terminalPersistParams).errorMessage,
+    "The AI provider could not complete the response. Please try again.",
+  );
+  const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
+  assert.equal(terminalLog?.consoleMethod, "warn");
+  assert.equal(terminalLog?.providerErrorClass, "ChatProviderTerminalEventError");
+  assert.equal(terminalLog?.providerErrorMessage, null);
+  assert.equal(terminalLog?.providerErrorCategory, "provider_error");
+  assert.equal(terminalLog?.errorClass, undefined);
+  assert.equal(terminalLog?.errorMessage, undefined);
+  assert.equal(JSON.stringify(terminalLog).includes(rawProviderMessage), false);
 });
 
 test("runPersistedChatSessionWithDeps exits without failing when the claimed run disappears before completion persistence", async () => {

--- a/apps/backend/src/chat/tests/chat-start-routes.test.ts
+++ b/apps/backend/src/chat/tests/chat-start-routes.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Hono } from "hono";
 import { HttpError } from "../../errors";
+import type { AppEnv } from "../../app";
+import type { BackendTraceCarrier } from "../../observability/sentry";
 import { createChatRoutes } from "../../routes/chat";
 import { ChatSessionConflictError } from "../store";
 import {
@@ -123,6 +126,118 @@ test("POST /chat can return an active run before the current turn appears in mes
     },
     deduplicated: true,
   });
+});
+
+
+test("POST /chat dispatches worker without a route-supplied trace carrier", async () => {
+  let workerInvocation: Readonly<{
+    runId: string;
+    userId: string;
+    workspaceId: string;
+    routeRequestId?: string | null;
+    chatRequestId?: string | null;
+    sessionId?: string | null;
+  }> | null = null;
+  let workerInvocationIncludesTraceContext = true;
+  let liveTraceContext: BackendTraceCarrier | null | undefined = undefined;
+  const routes = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    prepareChatRunFn: async (
+      _userId,
+      _workspaceId,
+      requestedSessionId,
+      content,
+      clientRequestId,
+      timezone,
+      uiLocale,
+    ) => {
+      assert.equal(requestedSessionId, SESSION_ONE);
+      assert.equal(content.length, 1);
+      assert.equal(clientRequestId, "client-request-dispatch");
+      assert.equal(timezone, "Europe/Madrid");
+      assert.equal(uiLocale, null);
+      return {
+        sessionId: SESSION_ONE,
+        runId: "run-dispatch",
+        clientRequestId,
+        runState: "running",
+        deduplicated: false,
+        shouldInvokeWorker: true,
+      };
+    },
+    invokeChatWorkerFn: async (payload) => {
+      workerInvocation = payload;
+      workerInvocationIncludesTraceContext = "traceContext" in payload;
+    },
+    getRecoveredChatSessionSnapshotFn: async () => createRunningSnapshot([]),
+    resolveLiveCursorFn: async () => null,
+    listChatMessagesLatestFn: async () => ({
+      messages: [{
+        sessionId: SESSION_ONE,
+        itemId: "assistant-item-dispatch",
+        itemOrder: 1,
+        role: "assistant",
+        content: [{ type: "text", text: "thinking" }],
+        state: "in_progress",
+        isError: false,
+        isStopped: false,
+        timestamp: 1,
+        updatedAt: 1,
+      }],
+      oldestCursor: "1",
+      newestCursor: "1",
+      hasOlder: false,
+    }),
+    createChatLiveStreamEnvelopeFn: async (
+      _userId,
+      _workspaceId,
+      _sessionId,
+      _runId,
+      traceContext,
+    ) => {
+      liveTraceContext = traceContext;
+      return {
+        url: "https://chat-live.example.com",
+        authorization: "Live test-token",
+        expiresAt: 1_000,
+      };
+    },
+  });
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "route-request-dispatch");
+    await next();
+  });
+  app.route("/", routes);
+
+  const response = await app.request("http://localhost/chat", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      sessionId: SESSION_ONE,
+      clientRequestId: "client-request-dispatch",
+      content: [{ type: "text", text: "hello" }],
+      timezone: "Europe/Madrid",
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(workerInvocation, {
+    runId: "run-dispatch",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    routeRequestId: "route-request-dispatch",
+    chatRequestId: "client-request-dispatch",
+    sessionId: SESSION_ONE,
+  });
+  assert.equal(workerInvocationIncludesTraceContext, false);
+  assert.notEqual(liveTraceContext, undefined);
 });
 
 
@@ -281,4 +396,3 @@ test("POST /chat maps active-run conflicts to a stable machine-readable code", a
     code: "CHAT_ACTIVE_RUN_IN_PROGRESS",
   });
 });
-

--- a/apps/backend/src/chat/tests/chat-worker-event.test.ts
+++ b/apps/backend/src/chat/tests/chat-worker-event.test.ts
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { InvokeCommand } from "@aws-sdk/client-lambda";
+import type {
+  BackendExceptionEvent,
+  BackendObservationScope,
+  BackendTraceCarrier,
+  ChatWorkerDispatchFailureDetails,
+} from "../../observability/sentry";
+import type { ChatWorkerEvent } from "../worker";
+import {
+  invokeChatWorkerOrPersistFailureWithDependencies,
+  invokeChatWorkerWithDependencies,
+  type ChatWorkerInvocation,
+} from "../workerInvoke";
+
+type ChatWorkerDispatchFailureEvent = Readonly<{
+  action: "chat_worker_dispatch_failed";
+  error: Error;
+  scope: BackendObservationScope;
+  details: ChatWorkerDispatchFailureDetails;
+}>;
+
+function requireDispatchFailureEvent(
+  event: BackendExceptionEvent | undefined,
+): ChatWorkerDispatchFailureEvent {
+  if (event === undefined || event.action !== "chat_worker_dispatch_failed") {
+    throw new Error("Expected chat_worker_dispatch_failed event");
+  }
+
+  return event;
+}
+
+test("ChatWorkerEvent includes and preserves Sentry trace carrier fields", () => {
+  const event: ChatWorkerEvent = {
+    runId: "run-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    traceContext: {
+      sentryTrace: "0123456789abcdef0123456789abcdef-0123456789abcdef-1",
+      baggage: "sentry-release=abc123,sentry-environment=production",
+    },
+  };
+
+  assert.deepEqual(JSON.parse(JSON.stringify(event)), {
+    runId: "run-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    traceContext: {
+      sentryTrace: "0123456789abcdef0123456789abcdef-0123456789abcdef-1",
+      baggage: "sentry-release=abc123,sentry-environment=production",
+    },
+  });
+});
+
+test("invokeChatWorkerWithDependencies copies trace context into the Lambda event payload", async () => {
+  const traceContext: BackendTraceCarrier = {
+    sentryTrace: "fedcba9876543210fedcba9876543210-fedcba9876543210-1",
+    baggage: "sentry-release=def456,sentry-environment=preview",
+  };
+  const sentCommands: Array<InvokeCommand> = [];
+
+  await invokeChatWorkerWithDependencies({
+    runId: "run-2",
+    userId: "user-2",
+    workspaceId: "workspace-2",
+  }, {
+    getTraceCarrier: () => traceContext,
+    getFunctionName: () => "chat-worker-test",
+    sendCommand: async (command: InvokeCommand): Promise<void> => {
+      sentCommands.push(command);
+    },
+  });
+
+  assert.equal(sentCommands.length, 1);
+  const command = sentCommands.at(0);
+  assert.ok(command !== undefined);
+  assert.equal(command.input.FunctionName, "chat-worker-test");
+  assert.equal(command.input.InvocationType, "Event");
+
+  const payload = command.input.Payload;
+  assert.ok(payload instanceof Uint8Array);
+  const event = JSON.parse(new TextDecoder().decode(payload)) as ChatWorkerInvocation;
+  assert.deepEqual(event, {
+    runId: "run-2",
+    userId: "user-2",
+    workspaceId: "workspace-2",
+    routeRequestId: null,
+    chatRequestId: null,
+    sessionId: null,
+    traceContext,
+  });
+});
+
+test("invokeChatWorkerOrPersistFailureWithDependencies captures dispatch failure before marking the run failed", async () => {
+  const dispatchError = new Error("Lambda invoke rejected");
+  const markError = new Error("database update rejected");
+  const capturedEvents: Array<BackendExceptionEvent> = [];
+  let markCallCount = 0;
+  let persistedErrorMessage: string | null = null;
+
+  await assert.rejects(
+    async () => invokeChatWorkerOrPersistFailureWithDependencies({
+      runId: "run-3",
+      userId: "user-3",
+      workspaceId: "workspace-3",
+      routeRequestId: "route-request-3",
+      chatRequestId: "client-request-3",
+      sessionId: "session-3",
+    }, {
+      invokeWorker: async (): Promise<void> => {
+        throw dispatchError;
+      },
+      markDispatchFailed: async (
+        _userId: string,
+        _workspaceId: string,
+        _runId: string,
+        errorMessage: string,
+      ): Promise<void> => {
+        markCallCount += 1;
+        persistedErrorMessage = errorMessage;
+        throw markError;
+      },
+      captureException: (event: BackendExceptionEvent): void => {
+        capturedEvents.push(event);
+      },
+    }),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof Error);
+      assert.equal(error.name, "ChatWorkerDispatchPersistenceFailureError");
+      assert.equal(
+        error.message,
+        "Chat worker dispatch failed before failed-state persistence failed: Lambda invoke rejected",
+      );
+      assert.equal(error.cause, markError);
+      return true;
+    },
+  );
+
+  assert.equal(markCallCount, 1);
+  assert.equal(persistedErrorMessage, "Chat worker dispatch failed: Lambda invoke rejected");
+  const capturedEvent = requireDispatchFailureEvent(capturedEvents.at(0));
+  assert.equal(capturedEvents.length, 1);
+  assert.equal(capturedEvent.error, dispatchError);
+  assert.equal(capturedEvent.details.message, "Lambda invoke rejected");
+  assert.equal(capturedEvent.scope.requestId, "route-request-3");
+  assert.equal(capturedEvent.scope.userId, "user-3");
+  assert.equal(capturedEvent.scope.workspaceId, "workspace-3");
+  assert.equal(capturedEvent.scope.chatRequestId, "client-request-3");
+  assert.equal(capturedEvent.scope.runId, "run-3");
+  assert.equal(capturedEvent.scope.sessionId, "session-3");
+});

--- a/apps/backend/src/chat/worker.ts
+++ b/apps/backend/src/chat/worker.ts
@@ -5,11 +5,16 @@
 import { claimChatRun } from "./runs";
 import { runPersistedChatSession, type ChatWorkerRunResult } from "./runtime";
 import { logChatWorkerLifecycleEvent } from "./workerLogging";
+import type { BackendTraceCarrier } from "../observability/sentry";
 
 export type ChatWorkerEvent = Readonly<{
   runId: string;
   userId: string;
   workspaceId: string;
+  routeRequestId?: string | null;
+  chatRequestId?: string | null;
+  sessionId?: string | null;
+  traceContext?: BackendTraceCarrier | null;
 }>;
 
 type ChatWorkerExecutionContext = Readonly<{
@@ -28,9 +33,9 @@ export async function handleChatWorkerEvent(
   if (claimedRun === null) {
     logChatWorkerLifecycleEvent("chat_worker_skip", {
       lambdaRequestId: executionContext.lambdaRequestId,
-      chatRequestId: null,
+      chatRequestId: event.chatRequestId ?? null,
       runId: event.runId,
-      sessionId: null,
+      sessionId: event.sessionId ?? null,
       userId: event.userId,
       workspaceId: event.workspaceId,
     }, {
@@ -46,6 +51,7 @@ export async function handleChatWorkerEvent(
       heartbeatAt: null,
       startedAt: null,
       finishedAt: null,
+      outcome: null,
     }, false);
     return;
   }
@@ -72,6 +78,7 @@ export async function handleChatWorkerEvent(
     heartbeatAt: null,
     startedAt: null,
     finishedAt: null,
+    outcome: null,
   }, false);
 
   const result: ChatWorkerRunResult = await runPersistedChatSession({

--- a/apps/backend/src/chat/workerInvoke.ts
+++ b/apps/backend/src/chat/workerInvoke.ts
@@ -3,12 +3,50 @@
  * The route layer persists the run first, then this module triggers the worker so the run survives client disconnects.
  */
 import { InvokeCommand, LambdaClient } from "@aws-sdk/client-lambda";
+import {
+  captureBackendException,
+  createBackendObservationScope,
+  getBackendTraceCarrier,
+  normalizeCaughtError,
+  type BackendExceptionEvent,
+  type BackendTraceCarrier,
+} from "../observability/sentry";
 import { markQueuedChatRunDispatchFailed } from "./runs";
+
+export type ChatWorkerDispatch = Readonly<{
+  runId: string;
+  userId: string;
+  workspaceId: string;
+  routeRequestId?: string | null;
+  chatRequestId?: string | null;
+  sessionId?: string | null;
+}>;
 
 export type ChatWorkerInvocation = Readonly<{
   runId: string;
   userId: string;
   workspaceId: string;
+  routeRequestId?: string | null;
+  chatRequestId?: string | null;
+  sessionId?: string | null;
+  traceContext: BackendTraceCarrier | null;
+}>;
+
+type ChatWorkerInvocationDependencies = Readonly<{
+  getTraceCarrier: () => BackendTraceCarrier | null;
+  getFunctionName: () => string;
+  sendCommand: (command: InvokeCommand) => Promise<void>;
+}>;
+
+type ChatWorkerDispatchFailureDependencies = Readonly<{
+  invokeWorker: (payload: ChatWorkerDispatch) => Promise<void>;
+  markDispatchFailed: (
+    userId: string,
+    workspaceId: string,
+    runId: string,
+    errorMessage: string,
+  ) => Promise<void>;
+  captureException: (event: BackendExceptionEvent) => void;
 }>;
 
 let lambdaClient: LambdaClient | null = null;
@@ -36,37 +74,131 @@ function getChatWorkerFunctionName(): string {
   return functionName;
 }
 
+function createChatWorkerInvocation(
+  payload: ChatWorkerDispatch,
+  traceContext: BackendTraceCarrier | null,
+): ChatWorkerInvocation {
+  return {
+    runId: payload.runId,
+    userId: payload.userId,
+    workspaceId: payload.workspaceId,
+    routeRequestId: payload.routeRequestId ?? null,
+    chatRequestId: payload.chatRequestId ?? null,
+    sessionId: payload.sessionId ?? null,
+    traceContext: traceContext === null
+      ? null
+      : {
+        sentryTrace: traceContext.sentryTrace,
+        baggage: traceContext.baggage,
+      },
+  };
+}
+
+function createChatWorkerInvokeCommand(
+  functionName: string,
+  invocation: ChatWorkerInvocation,
+): InvokeCommand {
+  return new InvokeCommand({
+    FunctionName: functionName,
+    InvocationType: "Event",
+    Payload: new TextEncoder().encode(JSON.stringify(invocation)),
+  });
+}
+
+export async function invokeChatWorkerWithDependencies(
+  payload: ChatWorkerDispatch,
+  dependencies: ChatWorkerInvocationDependencies,
+): Promise<void> {
+  const invocation = createChatWorkerInvocation(payload, dependencies.getTraceCarrier());
+  const command = createChatWorkerInvokeCommand(dependencies.getFunctionName(), invocation);
+  await dependencies.sendCommand(command);
+}
+
 /**
  * Dispatches a persisted chat run to the asynchronous worker without waiting for completion.
  */
 export async function invokeChatWorker(
-  payload: ChatWorkerInvocation,
+  payload: ChatWorkerDispatch,
 ): Promise<void> {
-  const command = new InvokeCommand({
-    FunctionName: getChatWorkerFunctionName(),
-    InvocationType: "Event",
-    Payload: new TextEncoder().encode(JSON.stringify(payload)),
+  await invokeChatWorkerWithDependencies(payload, {
+    getTraceCarrier: getBackendTraceCarrier,
+    getFunctionName: getChatWorkerFunctionName,
+    sendCommand: async (command: InvokeCommand): Promise<void> => {
+      await getLambdaClient().send(command);
+    },
   });
+}
 
-  await getLambdaClient().send(command);
+function createChatWorkerDispatchFailedEvent(
+  payload: ChatWorkerDispatch,
+  error: Error,
+  message: string,
+): BackendExceptionEvent {
+  return {
+    action: "chat_worker_dispatch_failed",
+    error,
+    scope: createBackendObservationScope(
+      "backend-api",
+      payload.routeRequestId ?? null,
+      null,
+      null,
+      payload.userId,
+      payload.workspaceId,
+      payload.chatRequestId ?? null,
+      payload.runId,
+      payload.sessionId ?? null,
+    ),
+    details: {
+      message,
+    },
+  };
+}
+
+function createDispatchPersistenceFailureError(
+  dispatchError: Error,
+  markError: Error,
+): Error {
+  const error = new Error(
+    `Chat worker dispatch failed before failed-state persistence failed: ${dispatchError.message}`,
+    { cause: markError },
+  );
+  error.name = "ChatWorkerDispatchPersistenceFailureError";
+  return error;
+}
+
+export async function invokeChatWorkerOrPersistFailureWithDependencies(
+  payload: ChatWorkerDispatch,
+  dependencies: ChatWorkerDispatchFailureDependencies,
+): Promise<void> {
+  try {
+    await dependencies.invokeWorker(payload);
+  } catch (error) {
+    const dispatchError = normalizeCaughtError(error);
+    const message = dispatchError.message;
+    dependencies.captureException(createChatWorkerDispatchFailedEvent(payload, dispatchError, message));
+    try {
+      await dependencies.markDispatchFailed(
+        payload.userId,
+        payload.workspaceId,
+        payload.runId,
+        `Chat worker dispatch failed: ${message}`,
+      );
+    } catch (markError) {
+      throw createDispatchPersistenceFailureError(dispatchError, normalizeCaughtError(markError));
+    }
+    throw dispatchError;
+  }
 }
 
 /**
  * Dispatches a persisted chat run and marks it as failed if worker invocation itself fails.
  */
 export async function invokeChatWorkerOrPersistFailure(
-  payload: ChatWorkerInvocation,
+  payload: ChatWorkerDispatch,
 ): Promise<void> {
-  try {
-    await invokeChatWorker(payload);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    await markQueuedChatRunDispatchFailed(
-      payload.userId,
-      payload.workspaceId,
-      payload.runId,
-      `Chat worker dispatch failed: ${message}`,
-    );
-    throw error;
-  }
+  await invokeChatWorkerOrPersistFailureWithDependencies(payload, {
+    invokeWorker: invokeChatWorker,
+    markDispatchFailed: markQueuedChatRunDispatchFailed,
+    captureException: captureBackendException,
+  });
 }

--- a/apps/backend/src/chat/workerLogging.ts
+++ b/apps/backend/src/chat/workerLogging.ts
@@ -1,4 +1,11 @@
-import { logCloudRouteEvent } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  captureBackendWarning,
+  createBackendObservationScope,
+  type BackendObservationScope,
+  type ChatWorkerLifecycleDetails,
+} from "../observability/sentry";
 
 export type ChatWorkerLogContext = Readonly<{
   lambdaRequestId: string | null;
@@ -9,23 +16,80 @@ export type ChatWorkerLogContext = Readonly<{
   workspaceId: string;
 }>;
 
+export type ChatWorkerLifecycleAction =
+  | "chat_worker_skip"
+  | "chat_worker_claimed"
+  | "chat_worker_finish"
+  | "chat_worker_abort_requested"
+  | "chat_worker_provider_call_started"
+  | "chat_worker_provider_call_aborted"
+  | "chat_worker_terminal_state_persisted"
+  | "chat_worker_composer_suggestions_failed";
+
+type ChatWorkerLifecyclePayload = Omit<ChatWorkerLifecycleDetails, "lambdaRequestId">;
+
+function createChatWorkerScope(context: ChatWorkerLogContext): BackendObservationScope {
+  return createBackendObservationScope(
+    "chat-worker",
+    context.lambdaRequestId,
+    null,
+    null,
+    context.userId,
+    context.workspaceId,
+    context.chatRequestId,
+    context.runId,
+    context.sessionId,
+  );
+}
+
+function createChatWorkerLifecycleDetails(
+  context: ChatWorkerLogContext,
+  payload: ChatWorkerLifecyclePayload,
+): ChatWorkerLifecycleDetails {
+  return {
+    lambdaRequestId: context.lambdaRequestId,
+    ...payload,
+  };
+}
+
 /**
  * Emits one structured chat-worker lifecycle event with the shared
  * correlation fields required for CloudWatch investigations.
  */
 export function logChatWorkerLifecycleEvent(
-  action: string,
+  action: ChatWorkerLifecycleAction,
   context: ChatWorkerLogContext,
-  payload: Record<string, unknown>,
+  payload: ChatWorkerLifecyclePayload,
   isError: boolean,
 ): void {
-  logCloudRouteEvent(action, {
-    lambdaRequestId: context.lambdaRequestId,
-    chatRequestId: context.chatRequestId,
-    runId: context.runId,
-    sessionId: context.sessionId,
-    userId: context.userId,
-    workspaceId: context.workspaceId,
-    ...payload,
-  }, isError);
+  const scope = createChatWorkerScope(context);
+  const details = createChatWorkerLifecycleDetails(context, payload);
+  if (isError && (action === "chat_worker_terminal_state_persisted" || action === "chat_worker_composer_suggestions_failed")) {
+    captureBackendWarning({
+      action,
+      message: `${action} warning`,
+      scope,
+      details,
+    });
+    return;
+  }
+
+  addBackendBreadcrumb({
+    action,
+    scope,
+    details,
+  });
+}
+
+export function captureChatWorkerTerminalStateException(
+  context: ChatWorkerLogContext,
+  payload: ChatWorkerLifecyclePayload,
+  error: Error,
+): void {
+  captureBackendException({
+    action: "chat_worker_terminal_state_persisted",
+    error,
+    scope: createChatWorkerScope(context),
+    details: createChatWorkerLifecycleDetails(context, payload),
+  });
 }

--- a/apps/backend/src/lambda-chat-live.ts
+++ b/apps/backend/src/lambda-chat-live.ts
@@ -5,17 +5,28 @@
  */
 import { randomUUID } from "node:crypto";
 import type { Writable } from "node:stream";
-import type { APIGatewayProxyEventV2 } from "aws-lambda";
-import { runLiveStream } from "./chat/live";
-import { createChatLiveErrorResponse } from "./chat/liveErrors";
-import { handleLiveRequest } from "./chat/liveRequest";
-import { getErrorLogContext, logCloudRouteEvent } from "./server/logging";
-import { initializeLangfuseTelemetry } from "./telemetry/langfuse";
+import type { APIGatewayProxyEventV2, StreamifyHandler } from "aws-lambda";
+import type { LiveStreamParams } from "./chat/liveRequest";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  type ChatLiveBootstrapFailureDetails,
+  continueBackendTrace,
+  createBackendObservationScope,
+  flushBackendSentry,
+  type BackendTraceCarrier,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  startBackendSpan,
+  wrapBackendStreamHandler,
+} from "./observability/sentry";
 
-initializeLangfuseTelemetry();
+initializeBackendSentry("chat-live");
 
 declare const awslambda: {
-  streamifyResponse: (handler: (event: APIGatewayProxyEventV2, responseStream: Writable) => Promise<void>) => unknown;
+  streamifyResponse: (
+    handler: StreamifyHandler<APIGatewayProxyEventV2, void>,
+  ) => StreamifyHandler<APIGatewayProxyEventV2, void>;
   HttpResponseStream: {
     from: (stream: Writable, metadata: Record<string, unknown>) => Writable;
   };
@@ -49,103 +60,406 @@ function getLiveAuthorizationScheme(authorizationHeader: string | undefined): st
   return "unknown";
 }
 
-export const handler = awslambda.streamifyResponse(
-  async (event: APIGatewayProxyEventV2, responseStream: Writable) => {
-    const requestId = getLiveRequestId(event);
-    const url = new URL(event.rawPath + "?" + (event.rawQueryString ?? ""), "http://localhost");
-    const authorizationHeader = event.headers?.authorization;
-    const origin = event.headers?.origin ?? null;
-    const method = event.requestContext.http.method;
+function hasLiveTraceCarrierValue(traceCarrier: BackendTraceCarrier | null | undefined): traceCarrier is BackendTraceCarrier {
+  return traceCarrier !== null
+    && traceCarrier !== undefined
+    && (traceCarrier.sentryTrace !== null || traceCarrier.baggage !== null);
+}
 
-    let params;
+function isPresentHeaderValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
 
-    try {
-      params = await handleLiveRequest(url, authorizationHeader, event.headers ?? {});
-    } catch (error) {
-      const errorResponse = createChatLiveErrorResponse(error, requestId);
-      logCloudRouteEvent("chat_live_request_error", {
-        requestId,
-        path: event.rawPath,
-        method,
-        rawQueryString: event.rawQueryString,
-        sessionId: url.searchParams.get("sessionId"),
-        runId: url.searchParams.get("runId"),
-        afterCursor: url.searchParams.get("afterCursor"),
-        origin,
-        authScheme: getLiveAuthorizationScheme(authorizationHeader),
-        resumeAttemptId: event.headers?.["x-chat-resume-attempt-id"] ?? null,
-        clientPlatform: event.headers?.["x-client-platform"] ?? null,
-        clientVersion: event.headers?.["x-client-version"] ?? null,
-        statusCode: errorResponse.statusCode,
-        code: errorResponse.body.code,
-        ...getErrorLogContext(error),
-      }, true);
-      const metadata = {
-        statusCode: errorResponse.statusCode,
-        headers: { "Content-Type": "application/json", "X-Request-Id": requestId },
-      };
-      const stream = awslambda.HttpResponseStream.from(responseStream, metadata);
-      stream.write(JSON.stringify(errorResponse.body));
-      stream.end();
-      return;
+function compareHeaderNames(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function readApiGatewayHeader(headers: APIGatewayProxyEventV2["headers"] | undefined, name: string): string | null {
+  if (headers === undefined) {
+    return null;
+  }
+
+  const exactValue = headers[name];
+  if (isPresentHeaderValue(exactValue)) {
+    return exactValue;
+  }
+
+  const normalizedName = name.toLowerCase();
+  const matchingNames = Object.keys(headers)
+    .filter((headerName) => headerName.toLowerCase() === normalizedName)
+    .sort(compareHeaderNames);
+
+  for (const headerName of matchingNames) {
+    const value = headers[headerName];
+    if (isPresentHeaderValue(value)) {
+      return value;
     }
+  }
 
+  return null;
+}
+
+function getRequestTraceCarrier(headers: APIGatewayProxyEventV2["headers"] | undefined): BackendTraceCarrier | null {
+  const sentryTrace = readApiGatewayHeader(headers, "sentry-trace");
+  const baggage = readApiGatewayHeader(headers, "baggage");
+  if (sentryTrace === null && baggage === null) {
+    return null;
+  }
+
+  return {
+    sentryTrace,
+    baggage,
+  };
+}
+
+function resolveLiveTraceCarrier(
+  tokenTraceCarrier: BackendTraceCarrier | null | undefined,
+  headers: APIGatewayProxyEventV2["headers"] | undefined,
+): BackendTraceCarrier | null {
+  if (hasLiveTraceCarrierValue(tokenTraceCarrier)) {
+    return tokenTraceCarrier;
+  }
+
+  return getRequestTraceCarrier(headers);
+}
+
+type LiveRequestSafeQueryDetails = Readonly<{
+  sessionId: string | null;
+  runId: string | null;
+  afterCursor: string | null;
+  hasToken: boolean;
+  hasWorkspaceId: boolean;
+}>;
+
+type ChatLiveRuntime = Readonly<{
+  runLiveStream: typeof import("./chat/live").runLiveStream;
+  createChatLiveErrorResponse: typeof import("./chat/liveErrors").createChatLiveErrorResponse;
+  handleLiveRequest: typeof import("./chat/liveRequest").handleLiveRequest;
+  flushLangfuseTelemetry: typeof import("./telemetry/langfuse").flushLangfuseTelemetry;
+}>;
+
+type ChatLiveBootstrapErrorBody = Readonly<{
+  error: string;
+  requestId: string;
+  code: "INTERNAL_ERROR";
+}>;
+
+let chatLiveRuntimePromise: Promise<ChatLiveRuntime> | null = null;
+
+async function createChatLiveRuntime(): Promise<ChatLiveRuntime> {
+  const [
+    { flushLangfuseTelemetry, initializeLangfuseTelemetry },
+    { runLiveStream },
+    { createChatLiveErrorResponse },
+    { handleLiveRequest },
+  ] = await Promise.all([
+    import("./telemetry/langfuse"),
+    import("./chat/live"),
+    import("./chat/liveErrors"),
+    import("./chat/liveRequest"),
+  ]);
+  initializeLangfuseTelemetry();
+  return {
+    runLiveStream,
+    createChatLiveErrorResponse,
+    handleLiveRequest,
+    flushLangfuseTelemetry,
+  };
+}
+
+function getChatLiveRuntime(): Promise<ChatLiveRuntime> {
+  if (chatLiveRuntimePromise === null) {
+    chatLiveRuntimePromise = createChatLiveRuntime();
+  }
+
+  return chatLiveRuntimePromise;
+}
+
+function createLiveRequestUrl(event: APIGatewayProxyEventV2): URL {
+  const querySuffix = event.rawQueryString === "" ? "" : `?${event.rawQueryString}`;
+  return new URL(`${event.rawPath}${querySuffix}`, "http://localhost");
+}
+
+function getLiveRequestSafeQueryDetails(url: URL): LiveRequestSafeQueryDetails {
+  return {
+    sessionId: url.searchParams.get("sessionId"),
+    runId: url.searchParams.get("runId"),
+    afterCursor: url.searchParams.get("afterCursor"),
+    hasToken: url.searchParams.has("token"),
+    hasWorkspaceId: url.searchParams.has("workspaceId"),
+  };
+}
+
+function createChatLiveBootstrapFailureDetails(
+  event: APIGatewayProxyEventV2,
+  error: Error,
+): ChatLiveBootstrapFailureDetails {
+  const requestId = getLiveRequestId(event);
+  const url = createLiveRequestUrl(event);
+  const safeQueryDetails = getLiveRequestSafeQueryDetails(url);
+  const authorizationHeader = readApiGatewayHeader(event.headers, "authorization") ?? undefined;
+
+  return {
+    statusCode: 500,
+    path: event.rawPath,
+    ...safeQueryDetails,
+    origin: readApiGatewayHeader(event.headers, "origin"),
+    authScheme: getLiveAuthorizationScheme(authorizationHeader),
+    resumeAttemptId: readApiGatewayHeader(event.headers, "x-chat-resume-attempt-id"),
+    clientPlatform: readApiGatewayHeader(event.headers, "x-client-platform"),
+    clientVersion: readApiGatewayHeader(event.headers, "x-client-version"),
+    code: "INTERNAL_ERROR",
+    message: error.message,
+  };
+}
+
+function createChatLiveBootstrapErrorBody(requestId: string): ChatLiveBootstrapErrorBody {
+  return {
+    error: "Request failed. Try again.",
+    requestId,
+    code: "INTERNAL_ERROR",
+  };
+}
+
+function writeChatLiveBootstrapErrorResponse(responseStream: Writable, requestId: string): void {
+  if (responseStream.destroyed || responseStream.writableEnded) {
+    return;
+  }
+
+  const metadata = {
+    statusCode: 500,
+    headers: { "Content-Type": "application/json", "X-Request-Id": requestId },
+  };
+  const stream = awslambda.HttpResponseStream.from(responseStream, metadata);
+  stream.write(JSON.stringify(createChatLiveBootstrapErrorBody(requestId)));
+  stream.end();
+}
+
+async function liveStreamHandler(
+  event: APIGatewayProxyEventV2,
+  responseStream: Writable,
+  runtime: ChatLiveRuntime,
+): Promise<void> {
+  const {
+    runLiveStream,
+    createChatLiveErrorResponse,
+    handleLiveRequest,
+    flushLangfuseTelemetry,
+  } = runtime;
+  const requestId = getLiveRequestId(event);
+  const url = createLiveRequestUrl(event);
+  const safeQueryDetails = getLiveRequestSafeQueryDetails(url);
+  const authorizationHeader = readApiGatewayHeader(event.headers, "authorization") ?? undefined;
+  const origin = readApiGatewayHeader(event.headers, "origin");
+  const resumeAttemptId = readApiGatewayHeader(event.headers, "x-chat-resume-attempt-id");
+  const clientPlatform = readApiGatewayHeader(event.headers, "x-client-platform");
+  const clientVersion = readApiGatewayHeader(event.headers, "x-client-version");
+  const method = event.requestContext.http.method;
+
+  let params: LiveStreamParams;
+
+  try {
+    params = await handleLiveRequest(url, authorizationHeader, event.headers ?? {});
+  } catch (error) {
+    const errorResponse = createChatLiveErrorResponse(error, requestId);
+    const scope = createBackendObservationScope(
+      "chat-live",
+      requestId,
+      event.rawPath,
+      method,
+      null,
+      null,
+      null,
+      url.searchParams.get("runId"),
+      url.searchParams.get("sessionId"),
+    );
+    const details = {
+      statusCode: errorResponse.statusCode,
+      path: event.rawPath,
+      ...safeQueryDetails,
+      origin,
+      authScheme: getLiveAuthorizationScheme(authorizationHeader),
+      resumeAttemptId,
+      clientPlatform,
+      clientVersion,
+      code: errorResponse.body.code,
+      message: error instanceof Error ? error.message : String(error),
+    };
+    if (errorResponse.statusCode >= 500) {
+      captureBackendException({
+        action: "chat_live_request_error",
+        error: normalizeCaughtError(error),
+        scope,
+        details,
+      });
+    } else {
+      addBackendBreadcrumb({
+        action: "chat_live_request_error",
+        scope,
+        details,
+      });
+    }
     const metadata = {
-      statusCode: 200,
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache, no-store",
-        "Connection": "keep-alive",
-        "X-Request-Id": requestId,
-      },
+      statusCode: errorResponse.statusCode,
+      headers: { "Content-Type": "application/json", "X-Request-Id": requestId },
     };
     const stream = awslambda.HttpResponseStream.from(responseStream, metadata);
+    stream.write(JSON.stringify(errorResponse.body));
+    stream.end();
+    if (errorResponse.statusCode >= 500) {
+      await Promise.all([
+        flushLangfuseTelemetry(),
+        flushBackendSentry(2000),
+      ]);
+    } else {
+      await flushLangfuseTelemetry();
+    }
+    return;
+  }
 
-    logCloudRouteEvent("chat_live_attach_start", {
+  const metadata = {
+    statusCode: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-store",
+      "Connection": "keep-alive",
+      "X-Request-Id": requestId,
+    },
+  };
+  const stream = awslambda.HttpResponseStream.from(responseStream, metadata);
+
+  addBackendBreadcrumb({
+    action: "chat_live_attach_start",
+    scope: createBackendObservationScope(
+      "chat-live",
       requestId,
-      path: event.rawPath,
+      event.rawPath,
       method,
-      rawQueryString: event.rawQueryString,
+      params.userId,
+      params.workspaceId,
+      null,
+      params.runId,
+      params.sessionId,
+    ),
+    details: {
+      statusCode: 200,
+      path: event.rawPath,
       sessionId: params.sessionId,
       runId: params.runId,
       afterCursor: params.afterCursor ?? null,
-      userId: params.userId,
-      workspaceId: params.workspaceId,
+      hasToken: safeQueryDetails.hasToken,
+      hasWorkspaceId: safeQueryDetails.hasWorkspaceId,
       origin,
       authScheme: getLiveAuthorizationScheme(authorizationHeader),
       resumeAttemptId: params.resumeAttemptId ?? null,
       clientPlatform: params.clientPlatform ?? null,
       clientVersion: params.clientVersion ?? null,
-      statusCode: 200,
-    }, false);
+    },
+  });
 
-    try {
-      await runLiveStream(stream, {
+  try {
+    const traceCarrier = resolveLiveTraceCarrier(params.traceContext ?? null, event.headers);
+    await continueBackendTrace(traceCarrier, async () => startBackendSpan(
+      "chat.live.stream",
+      "http.server.sse",
+      async () => runLiveStream(stream, {
         ...params,
         requestId,
-      });
-    } catch (error) {
-      logCloudRouteEvent("chat_live_stream_crashed", {
+      }),
+    ));
+    await Promise.all([
+      flushLangfuseTelemetry(),
+      flushBackendSentry(2000),
+    ]);
+  } catch (error) {
+    captureBackendException({
+      action: "chat_live_stream_crashed",
+      error: normalizeCaughtError(error),
+      scope: createBackendObservationScope(
+        "chat-live",
         requestId,
-        path: event.rawPath,
+        event.rawPath,
         method,
-        rawQueryString: event.rawQueryString,
+        params.userId,
+        params.workspaceId,
+        null,
+        params.runId,
+        params.sessionId,
+      ),
+      details: {
+        statusCode: 500,
+        path: event.rawPath,
         sessionId: params.sessionId,
         runId: params.runId,
         afterCursor: params.afterCursor ?? null,
-        userId: params.userId,
-        workspaceId: params.workspaceId,
+        hasToken: safeQueryDetails.hasToken,
+        hasWorkspaceId: safeQueryDetails.hasWorkspaceId,
         origin,
         authScheme: getLiveAuthorizationScheme(authorizationHeader),
         resumeAttemptId: params.resumeAttemptId ?? null,
         clientPlatform: params.clientPlatform ?? null,
         clientVersion: params.clientVersion ?? null,
-        statusCode: 500,
-        ...getErrorLogContext(error),
-      }, true);
-      if (stream.destroyed === false && stream.writableEnded === false) {
-        stream.end();
+      },
+    });
+    await Promise.all([
+      flushLangfuseTelemetry(),
+      flushBackendSentry(2000),
+    ]);
+    if (stream.destroyed === false && stream.writableEnded === false) {
+      stream.end();
+    }
+  }
+}
+
+const chatLiveStreamHandler: StreamifyHandler<APIGatewayProxyEventV2, void> = async (
+  event: APIGatewayProxyEventV2,
+  responseStream: awslambda.HttpResponseStream,
+): Promise<void> => {
+  let flushLangfuseTelemetry: (() => Promise<void>) | null = null;
+  try {
+    const runtime = await getChatLiveRuntime();
+    flushLangfuseTelemetry = runtime.flushLangfuseTelemetry;
+    await liveStreamHandler(event, responseStream, runtime);
+  } catch (error) {
+    const normalizedError = normalizeCaughtError(error);
+    const requestId = getLiveRequestId(event);
+    captureBackendException({
+      action: "chat_live_bootstrap_failed",
+      error: normalizedError,
+      scope: createBackendObservationScope(
+        "chat-live",
+        requestId,
+        event.rawPath,
+        event.requestContext.http.method,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: createChatLiveBootstrapFailureDetails(event, normalizedError),
+    });
+    try {
+      writeChatLiveBootstrapErrorResponse(responseStream, requestId);
+    } finally {
+      if (flushLangfuseTelemetry === null) {
+        await flushBackendSentry(2000);
+      } else {
+        await Promise.all([
+          flushLangfuseTelemetry(),
+          flushBackendSentry(2000),
+        ]);
       }
     }
-  },
-);
+  }
+};
+
+export const handler = wrapBackendStreamHandler(awslambda.streamifyResponse(chatLiveStreamHandler));

--- a/apps/backend/src/lambda-chat-worker.ts
+++ b/apps/backend/src/lambda-chat-worker.ts
@@ -1,12 +1,116 @@
 import type { Handler } from "aws-lambda";
-import { handleChatWorkerEvent, type ChatWorkerEvent } from "./chat/worker";
-import { initializeLangfuseTelemetry } from "./telemetry/langfuse";
+import type { ChatWorkerEvent } from "./chat/worker";
+import {
+  captureBackendException,
+  continueBackendTrace,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  startBackendSpan,
+  type ChatWorkerFailureDetails,
+  wrapBackendHandler,
+} from "./observability/sentry";
 
-initializeLangfuseTelemetry();
+initializeBackendSentry("chat-worker");
 
-export const handler: Handler<ChatWorkerEvent, void> = async (event, context) => {
-  await handleChatWorkerEvent(event, {
-    lambdaRequestId: context.awsRequestId ?? null,
-    getRemainingTimeInMillis: (): number => context.getRemainingTimeInMillis(),
-  });
+type HttpErrorClass = typeof import("./errors").HttpError;
+type ChatWorkerRuntime = Readonly<{
+  handleChatWorkerEvent: typeof import("./chat/worker").handleChatWorkerEvent;
+  flushLangfuseTelemetry: typeof import("./telemetry/langfuse").flushLangfuseTelemetry;
+  HttpError: HttpErrorClass;
+}>;
+
+let chatWorkerRuntimePromise: Promise<ChatWorkerRuntime> | null = null;
+
+async function createChatWorkerRuntime(): Promise<ChatWorkerRuntime> {
+  const [
+    { flushLangfuseTelemetry, initializeLangfuseTelemetry },
+    { handleChatWorkerEvent },
+    { HttpError },
+  ] = await Promise.all([
+    import("./telemetry/langfuse"),
+    import("./chat/worker"),
+    import("./errors"),
+  ]);
+  initializeLangfuseTelemetry();
+  return {
+    handleChatWorkerEvent,
+    flushLangfuseTelemetry,
+    HttpError,
+  };
+}
+
+function getChatWorkerRuntime(): Promise<ChatWorkerRuntime> {
+  if (chatWorkerRuntimePromise === null) {
+    chatWorkerRuntimePromise = createChatWorkerRuntime();
+  }
+
+  return chatWorkerRuntimePromise;
+}
+
+function createChatWorkerFailureDetails(
+  event: ChatWorkerEvent,
+  lambdaRequestId: string | null,
+  error: Error,
+  HttpError: HttpErrorClass | null,
+): ChatWorkerFailureDetails {
+  const isHttpError = HttpError !== null && error instanceof HttpError;
+  return {
+    lambdaRequestId,
+    routeRequestId: event.routeRequestId ?? null,
+    chatRequestId: event.chatRequestId ?? null,
+    runId: event.runId,
+    sessionId: event.sessionId ?? null,
+    userId: event.userId,
+    workspaceId: event.workspaceId,
+    statusCode: isHttpError ? error.statusCode : null,
+    code: isHttpError ? error.code : null,
+    message: error.message,
+  };
+}
+
+const chatWorkerHandler: Handler<ChatWorkerEvent, void> = async (event, context) => {
+  const lambdaRequestId = context.awsRequestId ?? null;
+  let runtimeHttpError: HttpErrorClass | null = null;
+  let runtime: ChatWorkerRuntime | null = null;
+  try {
+    const initializedRuntime = await getChatWorkerRuntime();
+    runtime = initializedRuntime;
+    runtimeHttpError = initializedRuntime.HttpError;
+    await continueBackendTrace(event.traceContext ?? null, async () => startBackendSpan(
+      "chat.worker.run",
+      "queue.process",
+      async () => {
+        await initializedRuntime.handleChatWorkerEvent(event, {
+          lambdaRequestId,
+          getRemainingTimeInMillis: (): number => context.getRemainingTimeInMillis(),
+        });
+      },
+    ));
+  } catch (error) {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendException({
+      action: "chat_worker_failed",
+      error: normalizedError,
+      scope: createBackendObservationScope(
+        "chat-worker",
+        lambdaRequestId,
+        null,
+        null,
+        event.userId,
+        event.workspaceId,
+        event.chatRequestId ?? null,
+        event.runId,
+        event.sessionId ?? null,
+      ),
+      details: createChatWorkerFailureDetails(event, lambdaRequestId, normalizedError, runtimeHttpError),
+    });
+    throw error;
+  } finally {
+    if (runtime !== null) {
+      await runtime.flushLangfuseTelemetry();
+    }
+  }
 };
+
+export const handler = wrapBackendHandler(chatWorkerHandler);

--- a/apps/backend/src/lambda-global-metrics-snapshot.ts
+++ b/apps/backend/src/lambda-global-metrics-snapshot.ts
@@ -1,43 +1,133 @@
 import type { Handler } from "aws-lambda";
-import { generateAndWriteGlobalMetricsSnapshot } from "./globalMetrics/generation";
-import { initializeLangfuseTelemetry } from "./telemetry/langfuse";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  type GlobalMetricsSnapshotFailureDetails,
+  wrapBackendHandler,
+} from "./observability/sentry";
 
-initializeLangfuseTelemetry();
+initializeBackendSentry("global-metrics-snapshot");
 
-export const handler: Handler<
-  unknown,
-  Readonly<{
-    ok: true;
-    bucketName: string;
-    objectKey: string;
-    generatedAtUtc: string;
-    asOfUtc: string;
-    from: string;
-    to: string;
-  }>
-> = async () => {
-  const result = await generateAndWriteGlobalMetricsSnapshot();
+type GlobalMetricsSnapshotResponse = Readonly<{
+  ok: true;
+  bucketName: string;
+  objectKey: string;
+  generatedAtUtc: string;
+  asOfUtc: string;
+  from: string;
+  to: string;
+}>;
 
-  console.log(JSON.stringify({
-    domain: "backend",
-    action: "global_metrics_snapshot_generated",
-    bucketName: result.bucketName,
-    objectKey: result.objectKey,
-    generatedAtUtc: result.snapshot.generatedAtUtc,
-    asOfUtc: result.snapshot.asOfUtc,
-    from: result.snapshot.from,
-    to: result.snapshot.to,
-    uniqueReviewingUsers: result.snapshot.totals.uniqueReviewingUsers,
-    reviewEvents: result.snapshot.totals.reviewEvents.total,
-  }));
+type GlobalMetricsSnapshotRuntime = Readonly<{
+  generateAndWriteGlobalMetricsSnapshot: typeof import("./globalMetrics/generation").generateAndWriteGlobalMetricsSnapshot;
+}>;
 
+let globalMetricsSnapshotRuntimePromise: Promise<GlobalMetricsSnapshotRuntime> | null = null;
+
+async function createGlobalMetricsSnapshotRuntime(): Promise<GlobalMetricsSnapshotRuntime> {
+  const [
+    { initializeLangfuseTelemetry },
+    { generateAndWriteGlobalMetricsSnapshot },
+  ] = await Promise.all([
+    import("./telemetry/langfuse"),
+    import("./globalMetrics/generation"),
+  ]);
+  initializeLangfuseTelemetry();
   return {
-    ok: true,
-    bucketName: result.bucketName,
-    objectKey: result.objectKey,
-    generatedAtUtc: result.snapshot.generatedAtUtc,
-    asOfUtc: result.snapshot.asOfUtc,
-    from: result.snapshot.from,
-    to: result.snapshot.to,
+    generateAndWriteGlobalMetricsSnapshot,
   };
+}
+
+function getGlobalMetricsSnapshotRuntime(): Promise<GlobalMetricsSnapshotRuntime> {
+  if (globalMetricsSnapshotRuntimePromise === null) {
+    globalMetricsSnapshotRuntimePromise = createGlobalMetricsSnapshotRuntime();
+  }
+
+  return globalMetricsSnapshotRuntimePromise;
+}
+
+function readOptionalTrimmedEnv(env: NodeJS.ProcessEnv, name: string): string | null {
+  const value = env[name];
+  if (value === undefined || value.trim() === "") {
+    return null;
+  }
+
+  return value.trim();
+}
+
+function createGlobalMetricsSnapshotFailureDetails(error: Error): GlobalMetricsSnapshotFailureDetails {
+  return {
+    bucketName: readOptionalTrimmedEnv(process.env, "GLOBAL_METRICS_S3_BUCKET_NAME"),
+    objectKey: readOptionalTrimmedEnv(process.env, "GLOBAL_METRICS_S3_OBJECT_KEY"),
+    message: error.message,
+  };
+}
+
+const globalMetricsSnapshotHandler: Handler<
+  unknown,
+  GlobalMetricsSnapshotResponse
+> = async (_event, context) => {
+  try {
+    const runtime = await getGlobalMetricsSnapshotRuntime();
+    const result = await runtime.generateAndWriteGlobalMetricsSnapshot();
+
+    addBackendBreadcrumb({
+      action: "global_metrics_snapshot_generated",
+      scope: createBackendObservationScope(
+        "global-metrics-snapshot",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: {
+        bucketName: result.bucketName,
+        objectKey: result.objectKey,
+        generatedAtUtc: result.snapshot.generatedAtUtc,
+        asOfUtc: result.snapshot.asOfUtc,
+        from: result.snapshot.from,
+        to: result.snapshot.to,
+        uniqueReviewingUsers: result.snapshot.totals.uniqueReviewingUsers,
+        reviewEvents: result.snapshot.totals.reviewEvents.total,
+      },
+    });
+
+    return {
+      ok: true,
+      bucketName: result.bucketName,
+      objectKey: result.objectKey,
+      generatedAtUtc: result.snapshot.generatedAtUtc,
+      asOfUtc: result.snapshot.asOfUtc,
+      from: result.snapshot.from,
+      to: result.snapshot.to,
+    };
+  } catch (error) {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendException({
+      action: "global_metrics_snapshot_failed",
+      error: normalizedError,
+      scope: createBackendObservationScope(
+        "global-metrics-snapshot",
+        context.awsRequestId ?? null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: createGlobalMetricsSnapshotFailureDetails(normalizedError),
+    });
+    throw error;
+  }
 };
+
+export const handler = wrapBackendHandler(globalMetricsSnapshotHandler);

--- a/apps/backend/src/lambda.ts
+++ b/apps/backend/src/lambda.ts
@@ -1,9 +1,125 @@
-import { handle } from "hono/aws-lambda";
-import { createApp } from "./app";
-import { initializeLangfuseTelemetry } from "./telemetry/langfuse";
+import type { Context } from "aws-lambda";
+import type { APIGatewayProxyResult, LambdaEvent } from "hono/aws-lambda";
+import {
+  captureBackendException,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  wrapBackendHandler,
+} from "./observability/sentry";
 
-initializeLangfuseTelemetry();
-const app = createApp("");
+initializeBackendSentry("backend-api");
+
+type BackendApiHandler = (
+  event: LambdaEvent,
+  context: Context,
+) => Promise<APIGatewayProxyResult>;
+
+type BackendApiRuntime = Readonly<{
+  handleRequest: BackendApiHandler;
+  flushLangfuseTelemetry: typeof import("./telemetry/langfuse").flushLangfuseTelemetry;
+}>;
+
+type BackendApiRequestContext = Readonly<{
+  requestId: string | null;
+  route: string | null;
+  method: string | null;
+}>;
+
+let backendApiRuntimePromise: Promise<BackendApiRuntime> | null = null;
+
+async function createBackendApiRuntime(): Promise<BackendApiRuntime> {
+  const [
+    { flushLangfuseTelemetry, initializeLangfuseTelemetry },
+    { handle },
+    { createApp },
+  ] = await Promise.all([
+    import("./telemetry/langfuse"),
+    import("hono/aws-lambda"),
+    import("./app"),
+  ]);
+  initializeLangfuseTelemetry();
+  const app = createApp("");
+  return {
+    handleRequest: handle(app),
+    flushLangfuseTelemetry,
+  };
+}
+
+function getBackendApiRuntime(): Promise<BackendApiRuntime> {
+  if (backendApiRuntimePromise === null) {
+    backendApiRuntimePromise = createBackendApiRuntime();
+  }
+
+  return backendApiRuntimePromise;
+}
+
+function getBackendApiRequestContext(event: LambdaEvent, context: Context): BackendApiRequestContext {
+  const lambdaRequestId = context.awsRequestId ?? null;
+  if ("rawPath" in event) {
+    return {
+      requestId: event.requestContext.requestId ?? lambdaRequestId,
+      route: event.rawPath,
+      method: event.requestContext.http.method,
+    };
+  }
+
+  if ("httpMethod" in event) {
+    const requestId = "requestId" in event.requestContext
+      ? event.requestContext.requestId
+      : lambdaRequestId;
+    return {
+      requestId,
+      route: event.path,
+      method: event.httpMethod,
+    };
+  }
+
+  return {
+    requestId: lambdaRequestId,
+    route: event.path,
+    method: event.method,
+  };
+}
+
+const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => {
+  let runtime: BackendApiRuntime | null = null;
+  try {
+    runtime = await getBackendApiRuntime();
+    return await runtime.handleRequest(event, context);
+  } catch (error) {
+    if (runtime === null) {
+      const normalizedError = normalizeCaughtError(error);
+      const requestContext = getBackendApiRequestContext(event, context);
+      captureBackendException({
+        action: "request_failed",
+        error: normalizedError,
+        scope: createBackendObservationScope(
+          "backend-api",
+          requestContext.requestId,
+          requestContext.route,
+          requestContext.method,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ),
+        details: {
+          statusCode: 500,
+          code: "INTERNAL_ERROR",
+          message: normalizedError.message,
+          validationIssues: [],
+        },
+      });
+    }
+    throw error;
+  } finally {
+    if (runtime !== null) {
+      await runtime.flushLangfuseTelemetry();
+    }
+  }
+};
 
 /**
  * Keeps the default buffered Lambda proxy behavior for the main backend
@@ -14,4 +130,4 @@ const app = createApp("");
  * benefit and would make API Gateway treat every route as a streaming
  * integration.
  */
-export const handler = handle(app);
+export const handler = wrapBackendHandler(backendApiBootstrapHandler);

--- a/apps/backend/src/migrate-lambda.ts
+++ b/apps/backend/src/migrate-lambda.ts
@@ -1,7 +1,80 @@
 import type { Handler } from "aws-lambda";
-import { runMigrations } from "./migrationRunner";
+import {
+  captureBackendException,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  type MigrationFailureDetails,
+  wrapBackendHandler,
+} from "./observability/sentry";
 
-export const handler: Handler = async () => {
-  const result = await runMigrations();
-  return result;
+initializeBackendSentry("migration");
+
+type MigrationRuntime = Readonly<{
+  runMigrations: typeof import("./migrationRunner").runMigrations;
+}>;
+
+type MigrationLambdaRuntimeRoleResult = Readonly<{
+  roleName: string;
+  configured: boolean;
+}>;
+
+type MigrationLambdaResult = Readonly<{
+  appliedMigrations: ReadonlyArray<string>;
+  appliedViews: ReadonlyArray<string>;
+  configuredRuntimeRoles: ReadonlyArray<MigrationLambdaRuntimeRoleResult>;
+}>;
+
+let migrationRuntimePromise: Promise<MigrationRuntime> | null = null;
+
+async function createMigrationRuntime(): Promise<MigrationRuntime> {
+  const { runMigrations } = await import("./migrationRunner");
+  return {
+    runMigrations,
+  };
+}
+
+function getMigrationRuntime(): Promise<MigrationRuntime> {
+  if (migrationRuntimePromise === null) {
+    migrationRuntimePromise = createMigrationRuntime();
+  }
+
+  return migrationRuntimePromise;
+}
+
+function createMigrationFailureDetails(error: Error): MigrationFailureDetails {
+  return {
+    migrationSurface: "lambda",
+    operation: "run_migrations",
+    message: error.message,
+  };
+}
+
+const migrationHandler: Handler<unknown, MigrationLambdaResult> = async (_event, context) => {
+  try {
+    const runtime = await getMigrationRuntime();
+    const result = await runtime.runMigrations();
+    return result;
+  } catch (error) {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendException({
+      action: "migration_failed",
+      error: normalizedError,
+      scope: createBackendObservationScope(
+        "migration",
+        context.awsRequestId ?? null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: createMigrationFailureDetails(normalizedError),
+    });
+    throw error;
+  }
 };
+
+export const handler = wrapBackendHandler(migrationHandler);

--- a/apps/backend/src/observability/reporting.ts
+++ b/apps/backend/src/observability/reporting.ts
@@ -1,0 +1,41 @@
+import { HttpError } from "../errors";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  hasCapturedBackendException,
+  type BackendBreadcrumbEvent,
+  type BackendExceptionEvent,
+} from "./sentry";
+
+const reportedBackendExceptionWrappers = new WeakSet<Error>();
+
+function isExpectedHttpError(error: unknown): boolean {
+  return error instanceof HttpError && error.statusCode < 500;
+}
+
+export function markBackendExceptionWrapperAsReported(error: Error): Error {
+  reportedBackendExceptionWrappers.add(error);
+  return error;
+}
+
+export function hasReportedBackendException(error: Error): boolean {
+  return hasCapturedBackendException(error) || reportedBackendExceptionWrappers.has(error);
+}
+
+export function reportBackendExceptionOrBreadcrumb(
+  error: unknown,
+  exceptionEvent: BackendExceptionEvent,
+  breadcrumbEvent: BackendBreadcrumbEvent,
+): void {
+  if (isExpectedHttpError(error)) {
+    addBackendBreadcrumb(breadcrumbEvent);
+    return;
+  }
+
+  if (hasReportedBackendException(exceptionEvent.error)) {
+    addBackendBreadcrumb(breadcrumbEvent);
+    return;
+  }
+
+  captureBackendException(exceptionEvent);
+}

--- a/apps/backend/src/observability/sanitizer.ts
+++ b/apps/backend/src/observability/sanitizer.ts
@@ -1,0 +1,377 @@
+type SanitizedObject = Readonly<{
+  [key: string]: SanitizedTelemetryValue;
+}>;
+
+export type SanitizedTelemetryValue =
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | ReadonlyArray<SanitizedTelemetryValue>
+  | SanitizedObject;
+
+const redactedSecretValue = "<redacted-secret>";
+const redactedContentValue = "<redacted-content>";
+const redactedBase64Value = "<redacted-base64>";
+
+const secretKeyFragments: ReadonlyArray<string> = [
+  "authorization",
+  "cookie",
+  "csrf",
+  "otp",
+  "password",
+  "secret",
+  "token",
+  "apikey",
+];
+
+const operationalTokenMetricKeyNames: ReadonlySet<string> = new Set([
+  "completiontokens",
+  "inputtokens",
+  "outputtokens",
+  "prompttokens",
+  "tokencount",
+  "totaltokens",
+]);
+
+const contentKeyNames: ReadonlyArray<string> = [
+  "args",
+  "arguments",
+  "fronttext",
+  "backtext",
+  "completion",
+  "completions",
+  "content",
+  "contextline",
+  "functionarguments",
+  "functionargs",
+  "genaicompletion",
+  "genaicompletions",
+  "genaiinputmessages",
+  "genaioutputmessages",
+  "genaiprompt",
+  "genaiprompts",
+  "headers",
+  "httpquery",
+  "httprequestheaders",
+  "httpresponseheaders",
+  "turninput",
+  "localmessages",
+  "message",
+  "messagecontent",
+  "modelinput",
+  "modeloutput",
+  "input",
+  "inputmessages",
+  "output",
+  "outputmessages",
+  "postcontext",
+  "precontext",
+  "prompt",
+  "prompts",
+  "query",
+  "querystring",
+  "requestquerystring",
+  "requestbody",
+  "requestheaders",
+  "responsebody",
+  "responseheaders",
+  "rawbody",
+  "rawresponsebody",
+  "search",
+  "searchparams",
+  "toolarguments",
+  "toolargs",
+  "urlquery",
+  "urlsearchparams",
+  "vars",
+  "body",
+  "filedata",
+  "imageurl",
+];
+
+const contentKeyFragments: ReadonlyArray<string> = [
+  "functionarguments",
+  "functionargs",
+  "genaicompletion",
+  "genaiprompt",
+  "httpbody",
+  "httpquery",
+  "httpheader",
+  "httprequestbody",
+  "httprequestheader",
+  "httpresponsebody",
+  "httpresponseheader",
+  "inputmessages",
+  "messagecontent",
+  "outputmessages",
+  "rawbody",
+  "rawresponsebody",
+  "requestbody",
+  "requestquerystring",
+  "requestheader",
+  "responsebody",
+  "responseheader",
+  "searchparams",
+  "toolarguments",
+  "toolargs",
+  "urlquery",
+  "urlsearchparams",
+];
+
+const exceptionTextKeyNames: ReadonlySet<string> = new Set([
+  "errormessage",
+  "errorstack",
+  "errorvalue",
+  "exceptionmessage",
+  "exceptionvalue",
+  "rawstack",
+  "stack",
+]);
+
+const rawQuerySensitiveKeyNames: ReadonlySet<string> = new Set([
+  "email",
+  "input",
+  "message",
+  "prompt",
+  "q",
+  "query",
+  "search",
+  "user",
+  "userid",
+]);
+
+const rawQuerySensitiveKeyFragments: ReadonlyArray<string> = [
+  "message",
+  "prompt",
+  "query",
+  "search",
+  "user",
+];
+
+const maskPatterns: ReadonlyArray<Readonly<{
+  pattern: RegExp;
+  replacement: string;
+}>> = [
+  {
+    pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+    replacement: "<masked-email>",
+  },
+  {
+    pattern: /(?<![-\w])\+\d{10,15}(?![-\w])/g,
+    replacement: "<masked-phone>",
+  },
+  {
+    pattern: /(?<![-\w])(?:\+\d{1,3}[\s.-]?)?(?:\(\d{3}\)|\d{3})[\s.-]\d{3}[\s.-]\d{4}(?![-\w])/g,
+    replacement: "<masked-phone>",
+  },
+  {
+    pattern: /(?<![-\w])1?[2-9]\d{2}[2-9]\d{6}(?![-\w])/g,
+    replacement: "<masked-phone>",
+  },
+  {
+    pattern: /\b(?:sk|pk|rk)[_-][A-Za-z0-9_-]{16,}\b/g,
+    replacement: "<masked-api-key>",
+  },
+  {
+    pattern: /\bdata:[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+(?:;[A-Za-z0-9!#$&^_.+-]+=[A-Za-z0-9!#$&^_.+-]+)*;base64,[A-Za-z0-9+/=_-]+/gi,
+    replacement: redactedBase64Value,
+  },
+  {
+    pattern: /(?<![-\w])\d{12,19}(?![-\w])/g,
+    replacement: "<masked-number>",
+  },
+];
+
+function normalizeTelemetryKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function shouldRedactSecretKey(key: string): boolean {
+  const normalizedKey = normalizeTelemetryKey(key);
+  return secretKeyFragments.some((fragment) => normalizedKey.includes(fragment));
+}
+
+function isOperationalTokenMetricKey(key: string): boolean {
+  return operationalTokenMetricKeyNames.has(normalizeTelemetryKey(key));
+}
+
+function shouldRedactSecretEntry(key: string, value: unknown): boolean {
+  if (typeof value === "number" && isOperationalTokenMetricKey(key)) {
+    return false;
+  }
+
+  return shouldRedactSecretKey(key) && typeof value !== "boolean";
+}
+
+function shouldRedactContentKey(key: string): boolean {
+  const normalizedKey = normalizeTelemetryKey(key);
+  return contentKeyNames.includes(normalizedKey)
+    || contentKeyFragments.some((fragment) => normalizedKey.includes(fragment));
+}
+
+function shouldRedactExceptionTextKey(key: string, value: unknown): boolean {
+  return typeof value === "string" && exceptionTextKeyNames.has(normalizeTelemetryKey(key));
+}
+
+function isTextContentPart(value: unknown): value is Readonly<{
+  type: string;
+  text: string;
+}> {
+  return typeof value === "object"
+    && value !== null
+    && "type" in value
+    && "text" in value
+    && (value as Readonly<{ type: unknown }>).type === "text"
+    && typeof (value as Readonly<{ text: unknown }>).text === "string";
+}
+
+function isSentryExceptionValue(value: unknown): value is Readonly<{
+  type?: unknown;
+  value?: unknown;
+  stacktrace?: unknown;
+}> {
+  return typeof value === "object"
+    && value !== null
+    && ("value" in value || "type" in value)
+    && ("stacktrace" in value || "mechanism" in value);
+}
+
+function isSensitiveRawQueryKey(key: string): boolean {
+  const normalizedKey = normalizeTelemetryKey(key);
+  return rawQuerySensitiveKeyNames.has(normalizedKey)
+    || rawQuerySensitiveKeyFragments.some((fragment) => normalizedKey.includes(fragment))
+    || (
+      secretKeyFragments.some((fragment) => normalizedKey.includes(fragment))
+      && operationalTokenMetricKeyNames.has(normalizedKey) === false
+    );
+}
+
+function isSensitiveRawQueryString(value: string): boolean {
+  const trimmedValue = value.trim().replace(/^\?/, "");
+  if (
+    trimmedValue === ""
+    || trimmedValue.includes("=") === false
+    || /^[A-Za-z0-9._~%!$&'()*+,;=:@/?-]+$/.test(trimmedValue) === false
+  ) {
+    return false;
+  }
+
+  return trimmedValue
+    .split(/[&;]/)
+    .some((part) => isSensitiveRawQueryKey(part.split("=", 1)[0] ?? ""));
+}
+
+function isSerializedJsonContainerString(value: string): boolean {
+  const trimmedValue = value.trim();
+  return (trimmedValue.startsWith("{") && trimmedValue.endsWith("}"))
+    || (trimmedValue.startsWith("[") && trimmedValue.endsWith("]"));
+}
+
+function sanitizeSerializedJsonContainerString(value: string): string | null {
+  if (isSerializedJsonContainerString(value) === false) {
+    return null;
+  }
+
+  try {
+    const parsedValue: unknown = JSON.parse(value);
+    if (
+      (typeof parsedValue !== "object" || parsedValue === null)
+      && Array.isArray(parsedValue) === false
+    ) {
+      return null;
+    }
+
+    return JSON.stringify(sanitizeBackendTelemetryValue(parsedValue));
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function sanitizeString(value: string): string {
+  const serializedJsonValue = sanitizeSerializedJsonContainerString(value);
+  if (serializedJsonValue !== null) {
+    return serializedJsonValue;
+  }
+
+  const valueWithoutUrlQueries = value
+    .replace(/\b(https?:\/\/[^\s?#"'<>]+)\?(?!<redacted-query>)[^\s"'<>)]*/gi, "$1?<redacted-query>")
+    .replace(/(?<![A-Za-z0-9])((?:\/[A-Za-z0-9._~!$&'()*+,;=:@%-]+)+)\?(?!<redacted-query>)[^\s"'<>)]*/g, "$1?<redacted-query>");
+
+  if (isSensitiveRawQueryString(valueWithoutUrlQueries)) {
+    return redactedContentValue;
+  }
+
+  return maskPatterns.reduce(
+    (currentValue, rule) => currentValue.replace(rule.pattern, rule.replacement),
+    valueWithoutUrlQueries,
+  );
+}
+
+function sanitizeTelemetryEntry(
+  key: string,
+  value: unknown,
+): SanitizedTelemetryValue {
+  const normalizedKey = normalizeTelemetryKey(key);
+  if (normalizedKey === "base64data") {
+    return redactedBase64Value;
+  }
+
+  if (shouldRedactSecretEntry(key, value)) {
+    return redactedSecretValue;
+  }
+
+  if (shouldRedactExceptionTextKey(key, value)) {
+    return redactedContentValue;
+  }
+
+  if (shouldRedactContentKey(key)) {
+    return redactedContentValue;
+  }
+
+  return sanitizeBackendTelemetryValue(value);
+}
+
+function sanitizeTelemetryObject(
+  value: Readonly<Record<string, unknown>>,
+): SanitizedObject {
+  const redactTextContentPart = isTextContentPart(value);
+  const redactSentryExceptionValue = isSentryExceptionValue(value);
+  return Object.fromEntries(
+    Object.entries(value).map(([key, childValue]) => {
+      const normalizedKey = normalizeTelemetryKey(key);
+      return [
+        key,
+        (redactTextContentPart && normalizedKey === "text")
+          || (redactSentryExceptionValue && normalizedKey === "value" && typeof childValue === "string")
+          ? redactedContentValue
+          : sanitizeTelemetryEntry(key, childValue),
+      ];
+    }),
+  );
+}
+
+export function sanitizeBackendTelemetryValue(value: unknown): SanitizedTelemetryValue {
+  if (typeof value === "string") {
+    return sanitizeString(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeBackendTelemetryValue(item));
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return sanitizeTelemetryObject(value as Readonly<Record<string, unknown>>);
+  }
+
+  return undefined;
+}

--- a/apps/backend/src/observability/sentry.test.ts
+++ b/apps/backend/src/observability/sentry.test.ts
@@ -1,0 +1,1246 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as Sentry from "@sentry/aws-serverless";
+import {
+  addBackendBreadcrumb,
+  type ChatWorkerLifecycleDetails,
+  captureBackendException,
+  captureBackendWarning,
+  createBackendObservationScope,
+  getBackendSentryConfig,
+  initializeBackendSentryWithDeps,
+  isBackendSentryInitializedForOpenTelemetry,
+  normalizeCaughtError,
+  resetBackendSentryForTests,
+} from "./sentry";
+import { hasReportedBackendException, reportBackendExceptionOrBreadcrumb } from "./reporting";
+import { sanitizeBackendTelemetryValue } from "./sanitizer";
+
+type ConsoleMethod = "log" | "warn" | "error";
+type MutableSentryModule = typeof Sentry & {
+  captureMessage: (
+    message: Parameters<typeof Sentry.captureMessage>[0],
+    captureContext: Parameters<typeof Sentry.captureMessage>[1],
+  ) => ReturnType<typeof Sentry.captureMessage>;
+  captureException: (
+    exception: Parameters<typeof Sentry.captureException>[0],
+  ) => ReturnType<typeof Sentry.captureException>;
+  openAIIntegration: typeof Sentry.openAIIntegration;
+};
+
+const sentryModule = require("@sentry/aws-serverless") as MutableSentryModule;
+type CapturedSentryInitOptions = NonNullable<Parameters<typeof Sentry.init>[0]>;
+
+function requireCapturedSentryInitOptions(
+  options: CapturedSentryInitOptions | null,
+): CapturedSentryInitOptions {
+  if (options === null) {
+    throw new Error("Expected backend Sentry init options to be captured.");
+  }
+
+  return options;
+}
+
+function requireBeforeSend(
+  beforeSend: CapturedSentryInitOptions["beforeSend"],
+): NonNullable<CapturedSentryInitOptions["beforeSend"]> {
+  if (beforeSend === undefined) {
+    throw new Error("Expected backend Sentry beforeSend to be configured.");
+  }
+
+  return beforeSend;
+}
+
+function requireBeforeSendSpan(
+  beforeSendSpan: CapturedSentryInitOptions["beforeSendSpan"],
+): NonNullable<CapturedSentryInitOptions["beforeSendSpan"]> {
+  if (beforeSendSpan === undefined) {
+    throw new Error("Expected backend Sentry beforeSendSpan to be configured.");
+  }
+
+  return beforeSendSpan;
+}
+
+function requireBeforeSendTransaction(
+  beforeSendTransaction: CapturedSentryInitOptions["beforeSendTransaction"],
+): NonNullable<CapturedSentryInitOptions["beforeSendTransaction"]> {
+  if (beforeSendTransaction === undefined) {
+    throw new Error("Expected backend Sentry beforeSendTransaction to be configured.");
+  }
+
+  return beforeSendTransaction;
+}
+
+function requireSynchronousSentryHookResult<Result>(
+  result: Result | PromiseLike<Result>,
+): Result {
+  if (
+    typeof result === "object"
+    && result !== null
+    && "then" in result
+    && typeof (result as Readonly<{ then?: unknown }>).then === "function"
+  ) {
+    throw new Error("Expected backend Sentry hook result to be synchronous in tests.");
+  }
+
+  return result as Result;
+}
+
+function withCapturedConsole(
+  method: ConsoleMethod,
+  fn: () => void,
+): ReadonlyArray<string> {
+  const originalMethod = console[method];
+  const messages: Array<string> = [];
+  console[method] = (message?: unknown): void => {
+    messages.push(typeof message === "string" ? message : String(message));
+  };
+
+  try {
+    fn();
+    return messages;
+  } finally {
+    console[method] = originalMethod;
+  }
+}
+
+test("backend Sentry config is disabled outside Lambda without a DSN", () => {
+  resetBackendSentryForTests();
+  assert.deepEqual(getBackendSentryConfig({}), { enabled: false });
+});
+
+test("backend Sentry config requires a DSN in Lambda", () => {
+  assert.throws(
+    () => getBackendSentryConfig({ AWS_LAMBDA_FUNCTION_NAME: "BackendHandler" }),
+    /SENTRY_DSN is required/,
+  );
+});
+
+test("backend Sentry config validates enabled settings", () => {
+  assert.throws(
+    () => getBackendSentryConfig({ SENTRY_DSN: "https://example.invalid/1" }),
+    /SENTRY_ENVIRONMENT is required/,
+  );
+  assert.throws(
+    () => getBackendSentryConfig({
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "2",
+    }),
+    /SENTRY_TRACES_SAMPLE_RATE/,
+  );
+
+  assert.deepEqual(
+    getBackendSentryConfig({
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0.1",
+    }),
+    {
+      enabled: true,
+      dsn: "https://example.invalid/1",
+      environment: "production",
+      release: "abc123",
+      tracesSampleRate: 0.1,
+    },
+  );
+});
+
+test("backend Sentry init preserves safe integrations only", () => {
+  resetBackendSentryForTests();
+  const originalOpenAIIntegration = sentryModule.openAIIntegration;
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+  let capturedOpenAIOptions: Parameters<typeof Sentry.openAIIntegration>[0] | null = null;
+
+  sentryModule.openAIIntegration = (options) => {
+    capturedOpenAIOptions = options ?? null;
+    return originalOpenAIIntegration(options);
+  };
+
+  try {
+    initializeBackendSentryWithDeps(
+      "backend-api",
+      {
+        SENTRY_DSN: "https://example.invalid/1",
+        SENTRY_ENVIRONMENT: "production",
+        SENTRY_RELEASE: "abc123",
+        SENTRY_TRACES_SAMPLE_RATE: "0.1",
+      },
+      {
+        init: (options) => {
+          capturedInitOptions = options;
+        },
+      },
+    );
+
+    const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+    assert.equal(typeof initOptions.integrations, "function");
+    if (typeof initOptions.integrations !== "function") {
+      throw new Error("Expected backend Sentry integrations to be configured by factory.");
+    }
+
+    const configuredIntegrations = initOptions.integrations([
+      Sentry.postgresIntegration(),
+      originalOpenAIIntegration(),
+      Sentry.httpIntegration(),
+      Sentry.nativeNodeFetchIntegration(),
+      Sentry.honoIntegration(),
+    ]);
+    const integrationNames = configuredIntegrations.map((integration: { name: string }) => integration.name);
+    assert.deepEqual(integrationNames, ["Http", "NodeFetch", "Hono", "OpenAI"]);
+    assert.deepEqual(capturedOpenAIOptions, {
+      recordInputs: false,
+      recordOutputs: false,
+    });
+  } finally {
+    sentryModule.openAIIntegration = originalOpenAIIntegration;
+  }
+});
+
+test("backend Sentry init does not register Langfuse span processors on Sentry OpenTelemetry provider", () => {
+  resetBackendSentryForTests();
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+
+  initializeBackendSentryWithDeps(
+    "chat-live",
+    {
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0.1",
+    },
+    {
+      init: (options) => {
+        capturedInitOptions = options;
+      },
+    },
+  );
+
+  const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+  assert.equal(initOptions.openTelemetrySpanProcessors, undefined);
+  assert.equal(isBackendSentryInitializedForOpenTelemetry(), true);
+});
+
+test("backend Sentry OpenTelemetry state is false until enabled init succeeds", () => {
+  resetBackendSentryForTests();
+  initializeBackendSentryWithDeps(
+    "backend-api",
+    {},
+    {
+      init: () => {
+        throw new Error("Sentry init should not run when disabled.");
+      },
+    },
+  );
+  assert.equal(isBackendSentryInitializedForOpenTelemetry(), false);
+
+  resetBackendSentryForTests();
+  assert.throws(
+    () => initializeBackendSentryWithDeps(
+      "backend-api",
+      {
+        SENTRY_DSN: "https://example.invalid/1",
+        SENTRY_ENVIRONMENT: "production",
+        SENTRY_RELEASE: "abc123",
+        SENTRY_TRACES_SAMPLE_RATE: "0.1",
+      },
+      {
+        init: () => {
+          throw new Error("init failed");
+        },
+      },
+    ),
+    /init failed/,
+  );
+  assert.equal(isBackendSentryInitializedForOpenTelemetry(), false);
+});
+
+test("backend Sentry beforeSend drops automatic recaptures of manually captured errors", () => {
+  resetBackendSentryForTests();
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+
+  initializeBackendSentryWithDeps(
+    "chat-worker",
+    {
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0.1",
+    },
+    {
+      init: (options) => {
+        capturedInitOptions = options;
+      },
+    },
+  );
+
+  const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+  const beforeSend = requireBeforeSend(initOptions.beforeSend);
+
+  const error = new Error("worker failed");
+  withCapturedConsole("error", () => {
+    captureBackendException({
+      action: "chat_worker_failed",
+      error,
+      scope: createBackendObservationScope(
+        "chat-worker",
+        "lambda-request-1",
+        null,
+        null,
+        "user-1",
+        "workspace-1",
+        null,
+        "run-1",
+        null,
+      ),
+      details: {
+        lambdaRequestId: "lambda-request-1",
+        routeRequestId: null,
+        chatRequestId: null,
+        runId: "run-1",
+        sessionId: null,
+        userId: "user-1",
+        workspaceId: "workspace-1",
+        statusCode: null,
+        code: null,
+        message: "worker failed",
+      },
+    });
+  });
+
+  const manualEvent: Parameters<NonNullable<CapturedSentryInitOptions["beforeSend"]>>[0] = {
+    type: undefined,
+    tags: {
+      "backend.manual_capture": "true",
+    },
+  };
+  const automaticEvent: Parameters<NonNullable<CapturedSentryInitOptions["beforeSend"]>>[0] = {
+    type: undefined,
+  };
+
+  assert.notEqual(beforeSend(manualEvent, { originalException: error }), null);
+  assert.equal(beforeSend(automaticEvent, { originalException: error }), null);
+});
+
+test("backend Sentry beforeSend redacts exception text and request query strings", () => {
+  resetBackendSentryForTests();
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+
+  initializeBackendSentryWithDeps(
+    "backend-api",
+    {
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0",
+    },
+    {
+      init: (options) => {
+        capturedInitOptions = options;
+      },
+    },
+  );
+
+  const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+  const beforeSend = requireBeforeSend(initOptions.beforeSend);
+  const sanitized = requireSynchronousSentryHookResult(beforeSend({
+    type: undefined,
+    message: "provider returned private user text user@example.com",
+    exception: {
+      values: [
+        {
+          type: "ProviderError",
+          value: "provider returned private user text user@example.com",
+          stacktrace: {
+            frames: [
+              {
+                context_line: "const prompt = 'private user text';",
+                filename: "/var/task/src/chat/runtime.ts",
+                function: "runProviderCall",
+                lineno: 42,
+                colno: 7,
+                vars: {
+                  prompt: "private user text",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    request: {
+      query_string: "token=secret&search=private",
+    },
+    contexts: {
+      rawRequest: {
+        queryString: "query=private",
+        querystring: "userText=private",
+      },
+    },
+  }, {}));
+
+  assert.notEqual(sanitized, null);
+  if (sanitized === null) {
+    throw new Error("Expected backend Sentry beforeSend to keep the event.");
+  }
+  assert.equal(sanitized?.message, "<redacted-content>");
+  assert.equal(sanitized?.exception?.values?.[0]?.type, "ProviderError");
+  assert.equal(sanitized?.exception?.values?.[0]?.value, "<redacted-content>");
+  assert.deepEqual(sanitized?.exception?.values?.[0]?.stacktrace?.frames?.[0], {
+    context_line: "<redacted-content>",
+    filename: "/var/task/src/chat/runtime.ts",
+    function: "runProviderCall",
+    lineno: 42,
+    colno: 7,
+    vars: "<redacted-content>",
+  });
+  assert.equal(sanitized?.request?.query_string, "<redacted-content>");
+  assert.equal(sanitized?.contexts?.rawRequest?.queryString, "<redacted-content>");
+  assert.equal(sanitized?.contexts?.rawRequest?.querystring, "<redacted-content>");
+});
+
+test("backend Sentry beforeSend preserves typed warning action title only", () => {
+  resetBackendSentryForTests();
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+
+  initializeBackendSentryWithDeps(
+    "backend-api",
+    {
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0",
+    },
+    {
+      init: (options) => {
+        capturedInitOptions = options;
+      },
+    },
+  );
+
+  const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+  const beforeSend = requireBeforeSend(initOptions.beforeSend);
+  const sanitized = requireSynchronousSentryHookResult(beforeSend({
+    type: undefined,
+    level: "warning",
+    message: "global_snapshot_error",
+    tags: {
+      "backend.manual_warning_capture": "true",
+      "backend.action": "global_snapshot_error",
+    },
+    contexts: {
+      backend: {
+        action: "global_snapshot_error",
+        message: "Snapshot unavailable for user@example.com",
+      },
+      rawRequest: {
+        queryString: "token=secret&search=private",
+      },
+    },
+    extra: {
+      details: {
+        message: "S3 object missing for user@example.com",
+      },
+    },
+  }, {}));
+
+  assert.notEqual(sanitized, null);
+  if (sanitized === null) {
+    throw new Error("Expected backend Sentry beforeSend to keep the event.");
+  }
+  assert.equal(sanitized.message, "global_snapshot_error");
+  assert.equal(sanitized.tags?.["backend.action"], "global_snapshot_error");
+  assert.equal(sanitized.contexts?.backend?.message, "<redacted-content>");
+  assert.equal(sanitized.contexts?.rawRequest?.queryString, "<redacted-content>");
+  assert.deepEqual(sanitized.extra, {
+    details: {
+      message: "<redacted-content>",
+    },
+  });
+});
+
+test("normalizeCaughtError preserves Error and converts non-Error throws", () => {
+  const error = new TypeError("bad input");
+  assert.equal(normalizeCaughtError(error), error);
+
+  const normalized = normalizeCaughtError("string failure");
+  assert.equal(normalized.name, "NonErrorThrow");
+  assert.equal(normalized.message, "string failure");
+});
+
+test("backend sanitizer redacts secrets and user content", () => {
+  const sanitized = sanitizeBackendTelemetryValue({
+    authorization: "Bearer token-value",
+    cookie: "session=secret",
+    csrfToken: "csrf-secret",
+    apiKey: "sk_12345678901234567890",
+    hasToken: true,
+    base64Data: "aGVsbG8=",
+    base64_data: "aGVsbG8=",
+    frontText: "question text",
+    front_text: "question text",
+    backText: "answer text",
+    back_text: "answer text",
+    turnInput: [{ type: "text", text: "private prompt" }],
+    localMessages: [{ role: "user", content: "private message" }],
+    local_messages: [{ role: "user", content: "private message" }],
+    model_input: [{ role: "user", content: "private input" }],
+    model_output: "private output",
+    prompt: "private prompt",
+    message: "private provider text",
+    completion: "private completion",
+    "gen_ai.prompt": "private gen ai prompt",
+    "gen_ai.completion": "private gen ai completion",
+    tool_arguments: "{\"frontText\":\"private question\"}",
+    arguments: "{\"backText\":\"private answer\"}",
+    headers: { authorization: "Bearer token-value" },
+    query: "token=secret&search=private",
+    query_string: "token=secret&search=private",
+    queryString: "search=private",
+    querystring: "userText=private",
+    request: {
+      query_string: "token=secret&query=private",
+    },
+    input_tokens: 11,
+    output_tokens: 12,
+    prompt_tokens: 13,
+    completion_tokens: 14,
+    total_tokens: 25,
+    rawResponseBody: "model output",
+    raw_response_body: "model output",
+    requestUrl: "https://api.example.invalid/v1/cards?token=secret&query=private",
+    directApiKey: "OpenAI key sk-proj-123456789012345678901234 and legacy key sk-12345678901234567890",
+    providerMessage: "OpenAI key sk-proj-123456789012345678901234 and legacy key sk-12345678901234567890",
+    sessionId: "11111111-1111-4111-8111-111111111111",
+    requestId: "request-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  });
+
+  assert.deepEqual(sanitized, {
+    authorization: "<redacted-secret>",
+    cookie: "<redacted-secret>",
+    csrfToken: "<redacted-secret>",
+    apiKey: "<redacted-secret>",
+    hasToken: true,
+    base64Data: "<redacted-base64>",
+    base64_data: "<redacted-base64>",
+    frontText: "<redacted-content>",
+    front_text: "<redacted-content>",
+    backText: "<redacted-content>",
+    back_text: "<redacted-content>",
+    turnInput: "<redacted-content>",
+    localMessages: "<redacted-content>",
+    local_messages: "<redacted-content>",
+    model_input: "<redacted-content>",
+    model_output: "<redacted-content>",
+    prompt: "<redacted-content>",
+    message: "<redacted-content>",
+    completion: "<redacted-content>",
+    "gen_ai.prompt": "<redacted-content>",
+    "gen_ai.completion": "<redacted-content>",
+    tool_arguments: "<redacted-content>",
+    arguments: "<redacted-content>",
+    headers: "<redacted-content>",
+    query: "<redacted-content>",
+    query_string: "<redacted-content>",
+    queryString: "<redacted-content>",
+    querystring: "<redacted-content>",
+    request: {
+      query_string: "<redacted-content>",
+    },
+    input_tokens: 11,
+    output_tokens: 12,
+    prompt_tokens: 13,
+    completion_tokens: 14,
+    total_tokens: 25,
+    rawResponseBody: "<redacted-content>",
+    raw_response_body: "<redacted-content>",
+    requestUrl: "https://api.example.invalid/v1/cards?<redacted-query>",
+    directApiKey: "<redacted-secret>",
+    providerMessage: "OpenAI key <masked-api-key> and legacy key <masked-api-key>",
+    sessionId: "11111111-1111-4111-8111-111111111111",
+    requestId: "request-1",
+    userId: "user-1",
+    workspaceId: "workspace-1",
+  });
+});
+
+test("backend Sentry beforeSendSpan sanitizes span payloads", () => {
+  resetBackendSentryForTests();
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+
+  initializeBackendSentryWithDeps(
+    "chat-worker",
+    {
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0",
+    },
+    {
+      init: (options) => {
+        capturedInitOptions = options;
+      },
+    },
+  );
+
+  const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+  const beforeSendSpan = requireBeforeSendSpan(initOptions.beforeSendSpan);
+  const beforeSendTransaction = requireBeforeSendTransaction(initOptions.beforeSendTransaction);
+  const sanitized = beforeSendSpan({
+    data: {
+      authorization: "Bearer token-value",
+      query: "token=secret&search=private",
+      "gen_ai.prompt": "private prompt",
+      "gen_ai.completion": "private completion",
+      "gen_ai.prompt.0.content": "private prompt part",
+      tool_arguments: "{\"frontText\":\"private question\"}",
+      "http.request.header.x-user": "private header",
+      "http.response.body": "private response body",
+      output: "private output",
+      hasArguments: true,
+      outputLength: 42,
+    },
+    description: "POST /v1/cards?token=secret&query=private",
+    op: "http.client",
+    parent_span_id: "2222222222222222",
+    span_id: "1111111111111111",
+    start_timestamp: 1,
+    status: "ok",
+    timestamp: 2,
+    trace_id: "11111111111111111111111111111111",
+  });
+
+  assert.equal(sanitized.description, "POST /v1/cards?<redacted-query>");
+  assert.deepEqual(sanitized.data, {
+    authorization: "<redacted-secret>",
+    query: "<redacted-content>",
+    "gen_ai.prompt": "<redacted-content>",
+    "gen_ai.completion": "<redacted-content>",
+    "gen_ai.prompt.0.content": "<redacted-content>",
+    tool_arguments: "<redacted-content>",
+    "http.request.header.x-user": "<redacted-content>",
+    "http.response.body": "<redacted-content>",
+    output: "<redacted-content>",
+    hasArguments: true,
+    outputLength: 42,
+  });
+
+  const sanitizedTransaction = requireSynchronousSentryHookResult(beforeSendTransaction({
+    type: "transaction",
+    transaction: "GET /v1/cards?token=secret",
+    spans: [
+      {
+        data: {
+          input: "private input",
+          hasArguments: true,
+        },
+        description: "GET /v1/cards?token=secret",
+        op: "http.server",
+        parent_span_id: "1111111111111111",
+        span_id: "2222222222222222",
+        start_timestamp: 1,
+        status: "ok",
+        timestamp: 2,
+        trace_id: "11111111111111111111111111111111",
+      },
+    ],
+  }, {}));
+
+  assert.notEqual(sanitizedTransaction, null);
+  if (sanitizedTransaction === null) {
+    throw new Error("Expected backend Sentry beforeSendTransaction to keep the event.");
+  }
+  assert.equal(sanitizedTransaction.transaction, "GET /v1/cards?<redacted-query>");
+  assert.deepEqual(sanitizedTransaction.spans?.[0]?.data, {
+    input: "<redacted-content>",
+    hasArguments: true,
+  });
+});
+
+test("backend sanitizer redacts direct text content part arrays", () => {
+  assert.deepEqual(
+    sanitizeBackendTelemetryValue([{ type: "text", text: "private prompt" }]),
+    [{ type: "text", text: "<redacted-content>" }],
+  );
+});
+
+test("backend sanitizer redacts serialized JSON container strings", () => {
+  assert.equal(
+    sanitizeBackendTelemetryValue(JSON.stringify({
+      image_url: "data:image/png;base64,AAAA",
+      file_data: "raw file bytes",
+      input: "private input",
+      output: "private output",
+      prompt: "private prompt",
+      message: "private provider message",
+      nested: {
+        content: "private content",
+        url: "data:image/png;base64,BBBB",
+      },
+      safeText: "contact user@example.com",
+    })),
+    JSON.stringify({
+      image_url: "<redacted-content>",
+      file_data: "<redacted-content>",
+      input: "<redacted-content>",
+      output: "<redacted-content>",
+      prompt: "<redacted-content>",
+      message: "<redacted-content>",
+      nested: {
+        content: "<redacted-content>",
+        url: "<redacted-base64>",
+      },
+      safeText: "contact <masked-email>",
+    }),
+  );
+
+  assert.equal(
+    sanitizeBackendTelemetryValue(JSON.stringify([
+      { type: "text", text: "private prompt" },
+      { base64Data: "aGVsbG8=", message: "private provider message" },
+    ])),
+    JSON.stringify([
+      { type: "text", text: "<redacted-content>" },
+      { base64Data: "<redacted-base64>", message: "<redacted-content>" },
+    ]),
+  );
+
+  assert.equal(
+    sanitizeBackendTelemetryValue("not json {\"prompt\":\"private\"}"),
+    "not json {\"prompt\":\"private\"}",
+  );
+});
+
+test("backend sanitizer masks phone numbers without masking dates and operational IDs", () => {
+  const sanitized = sanitizeBackendTelemetryValue(
+    "Call +14155552671, 4155552671, or (415) 555-2671 on 2026-05-17 for request 11111111-1111-4111-8111-111111111111.",
+  );
+
+  assert.equal(
+    sanitized,
+    "Call <masked-phone>, <masked-phone>, or <masked-phone> on 2026-05-17 for request 11111111-1111-4111-8111-111111111111.",
+  );
+});
+
+test("backend sanitizer redacts raw sensitive query strings", () => {
+  assert.equal(
+    sanitizeBackendTelemetryValue("token=secret&search=private"),
+    "<redacted-content>",
+  );
+  assert.equal(
+    sanitizeBackendTelemetryValue("userText=private"),
+    "<redacted-content>",
+  );
+  assert.equal(
+    sanitizeBackendTelemetryValue("input_tokens=12&output_tokens=10"),
+    "input_tokens=12&output_tokens=10",
+  );
+});
+
+test("backend sanitizer preserves unsupported values as undefined", () => {
+  const sanitized = sanitizeBackendTelemetryValue({
+    type: undefined,
+    nested: {
+      skipped: Symbol("unsupported"),
+      callback: (): void => {},
+    },
+    array: [undefined, 1n],
+  });
+
+  assert.deepEqual(sanitized, {
+    type: undefined,
+    nested: {
+      skipped: undefined,
+      callback: undefined,
+    },
+    array: [undefined, undefined],
+  });
+});
+
+test("backend sanitizer preserves operational token booleans", () => {
+  assert.deepEqual(
+    sanitizeBackendTelemetryValue({
+      hasToken: false,
+      input_tokens: 11,
+      output_tokens: 12,
+      prompt_tokens: 13,
+      completion_tokens: 14,
+      total_tokens: 25,
+      token: "real-token-value",
+      nested: {
+        hasRefreshToken: true,
+        tokenCount: 7,
+        authorization: "Bearer real-token-value",
+      },
+    }),
+    {
+      hasToken: false,
+      input_tokens: 11,
+      output_tokens: 12,
+      prompt_tokens: 13,
+      completion_tokens: 14,
+      total_tokens: 25,
+      token: "<redacted-secret>",
+      nested: {
+        hasRefreshToken: true,
+        tokenCount: 7,
+        authorization: "<redacted-secret>",
+      },
+    },
+  );
+});
+
+test("backend breadcrumb serialization keeps CloudWatch JSON shape", () => {
+  const details: ChatWorkerLifecycleDetails & Readonly<{
+    front_text: string;
+    nested: Readonly<{
+      raw_response_body: string;
+      safeCount: number;
+    }>;
+  }> = {
+    lambdaRequestId: "lambda-request-1",
+    abortReason: null,
+    signalAborted: false,
+    cancellationRequested: false,
+    ownershipLost: false,
+    runStatus: null,
+    sessionState: null,
+    providerErrorClass: null,
+    providerErrorMessage: null,
+    providerErrorStatus: null,
+    providerErrorCode: null,
+    providerErrorCategory: null,
+    providerRequestId: null,
+    heartbeatAt: null,
+    startedAt: null,
+    finishedAt: null,
+    outcome: null,
+    front_text: "private question",
+    nested: {
+      raw_response_body: "private response",
+      safeCount: 2,
+    },
+  };
+
+  const messages = withCapturedConsole("log", () => {
+    addBackendBreadcrumb({
+      action: "chat_worker_skip",
+      scope: createBackendObservationScope(
+        "chat-worker",
+        "lambda-request-1",
+        null,
+        null,
+        "user-1",
+        "workspace-1",
+        "chat-request-1",
+        "run-1",
+        null,
+      ),
+      details,
+    });
+  });
+
+  assert.equal(messages.length, 1);
+  assert.deepEqual(JSON.parse(messages[0] ?? ""), {
+    domain: "backend",
+    action: "chat_worker_skip",
+    service: "chat-worker",
+    requestId: "lambda-request-1",
+    route: null,
+    method: null,
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    chatRequestId: "chat-request-1",
+    runId: "run-1",
+    sessionId: null,
+    lambdaRequestId: "lambda-request-1",
+    abortReason: null,
+    signalAborted: false,
+    cancellationRequested: false,
+    ownershipLost: false,
+    runStatus: null,
+    sessionState: null,
+    providerErrorClass: null,
+    providerErrorMessage: null,
+    providerErrorStatus: null,
+    providerErrorCode: null,
+    providerErrorCategory: null,
+    providerRequestId: null,
+    heartbeatAt: null,
+    startedAt: null,
+    finishedAt: null,
+    outcome: null,
+    front_text: "<redacted-content>",
+    nested: {
+      raw_response_body: "<redacted-content>",
+      safeCount: 2,
+    },
+  });
+});
+
+test("backend warning and exception serialization include typed details", () => {
+  const warningMessages = withCapturedConsole("warn", () => {
+    captureBackendWarning({
+      action: "global_snapshot_error",
+      message: "Snapshot unavailable.",
+      scope: createBackendObservationScope(
+        "backend-api",
+        "request-1",
+        "/global/snapshot",
+        "GET",
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: {
+        statusCode: 503,
+        code: "GLOBAL_METRICS_SNAPSHOT_UNAVAILABLE",
+        storageErrorMessage: "S3 object missing for user@example.com",
+      },
+    });
+  });
+
+  const error = new Error("invoke failed for user@example.com");
+  error.stack = "Error: invoke failed for user@example.com\n    at dispatch (/var/task/src/chat/worker.ts:12:34)";
+  const exceptionMessages = withCapturedConsole("error", () => {
+    captureBackendException({
+      action: "chat_worker_dispatch_failed",
+      error,
+      scope: createBackendObservationScope(
+        "backend-api",
+        null,
+        null,
+        null,
+        "user-1",
+        "workspace-1",
+        null,
+        "run-1",
+        null,
+      ),
+      details: {
+        message: "invoke failed for user@example.com",
+      },
+    });
+  });
+
+  assert.equal(JSON.parse(warningMessages[0] ?? "").statusCode, 503);
+  assert.equal(
+    JSON.parse(warningMessages[0] ?? "").storageErrorMessage,
+    "S3 object missing for <masked-email>",
+  );
+  const exceptionRecord = JSON.parse(exceptionMessages[0] ?? "");
+  assert.equal(exceptionRecord.action, "chat_worker_dispatch_failed");
+  assert.equal(exceptionRecord.errorClass, "Error");
+  assert.equal(exceptionRecord.errorMessage, "invoke failed for <masked-email>");
+  assert.equal(
+    exceptionRecord.errorStack,
+    "Error: invoke failed for <masked-email>\n    at dispatch (/var/task/src/chat/worker.ts:12:34)",
+  );
+  assert.equal(exceptionRecord.sourceFile, "/var/task/src/chat/worker.ts");
+  assert.equal(exceptionRecord.sourceLine, 12);
+  assert.equal(exceptionRecord.sourceColumn, 34);
+  assert.equal(exceptionRecord.message, "<redacted-content>");
+});
+
+test("backend warnings create Sentry warning issues", () => {
+  const originalCaptureMessage = sentryModule.captureMessage;
+  let captureMessageCount = 0;
+  let capturedMessage: Parameters<typeof Sentry.captureMessage>[0] | null = null;
+  sentryModule.captureMessage = (message) => {
+    captureMessageCount += 1;
+    capturedMessage = message;
+    return "event-id";
+  };
+
+  try {
+    withCapturedConsole("warn", () => {
+      captureBackendWarning({
+        action: "global_snapshot_error",
+        message: "Snapshot unavailable for user@example.com.",
+        scope: createBackendObservationScope(
+          "backend-api",
+          "request-1",
+          "/global/snapshot",
+          "GET",
+          null,
+          null,
+          null,
+          null,
+          null,
+        ),
+        details: {
+          statusCode: 503,
+          code: "GLOBAL_METRICS_SNAPSHOT_UNAVAILABLE",
+          storageErrorMessage: "S3 object missing",
+        },
+      });
+    });
+
+    assert.equal(captureMessageCount, 1);
+    assert.equal(capturedMessage, "global_snapshot_error");
+  } finally {
+    sentryModule.captureMessage = originalCaptureMessage;
+  }
+});
+
+test("backend reporting does not recapture already captured exceptions", () => {
+  const originalCaptureException = sentryModule.captureException;
+  let captureExceptionCount = 0;
+  sentryModule.captureException = () => {
+    captureExceptionCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const error = new Error("dispatch failed");
+    const scope = createBackendObservationScope(
+      "backend-api",
+      "request-1",
+      "/chat/worker",
+      "POST",
+      "user-1",
+      "workspace-1",
+      null,
+      "run-1",
+      null,
+    );
+    const event = {
+      action: "workspace_create_error",
+      error,
+      scope,
+      details: {
+        statusCode: 500,
+        code: "WORKSPACE_CREATE_FAILED",
+        message: "dispatch failed",
+        validationIssues: [],
+      },
+    } as const;
+
+    withCapturedConsole("error", () => {
+      captureBackendException(event);
+    });
+    const breadcrumbMessages = withCapturedConsole("log", () => {
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        event,
+        {
+          action: "workspace_create_error",
+          scope,
+          details: {
+            statusCode: 500,
+            code: "WORKSPACE_CREATE_FAILED",
+            message: "dispatch failed",
+            validationIssues: [],
+          },
+        },
+      );
+    });
+
+    assert.equal(captureExceptionCount, 1);
+    assert.equal(JSON.parse(breadcrumbMessages[0] ?? "").action, "workspace_create_error");
+  } finally {
+    sentryModule.captureException = originalCaptureException;
+  }
+});
+
+test("backend reporting recognizes repeated normalized non-Error throws", () => {
+  const originalCaptureException = sentryModule.captureException;
+  let captureExceptionCount = 0;
+  sentryModule.captureException = () => {
+    captureExceptionCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const thrownError = "non-error route failure";
+    const scope = createBackendObservationScope(
+      "backend-api",
+      "request-2",
+      "/sync/push",
+      "POST",
+      "user-2",
+      "workspace-2",
+      null,
+      null,
+      null,
+    );
+    const routeEvent = {
+      action: "workspace_create_error",
+      error: normalizeCaughtError(thrownError),
+      scope,
+      details: {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+        message: thrownError,
+        validationIssues: [],
+      },
+    } as const;
+    const appEvent = {
+      action: "request_failed",
+      error: normalizeCaughtError(thrownError),
+      scope,
+      details: {
+        statusCode: 500,
+        code: "INTERNAL_ERROR",
+        message: thrownError,
+        validationIssues: [],
+      },
+    } as const;
+
+    withCapturedConsole("error", () => {
+      reportBackendExceptionOrBreadcrumb(
+        thrownError,
+        routeEvent,
+        {
+          action: "workspace_create_error",
+          scope,
+          details: {
+            statusCode: 500,
+            code: "INTERNAL_ERROR",
+            message: thrownError,
+            validationIssues: [],
+          },
+        },
+      );
+    });
+    const appDetectedPreviousReport = hasReportedBackendException(appEvent.error);
+    if (appDetectedPreviousReport === false) {
+      withCapturedConsole("error", () => {
+        captureBackendException(appEvent);
+      });
+    }
+
+    assert.equal(appDetectedPreviousReport, true);
+    assert.equal(captureExceptionCount, 1);
+  } finally {
+    sentryModule.captureException = originalCaptureException;
+  }
+});
+
+test("backend runtime exception serialization includes chat worker failure context", () => {
+  const exceptionMessages = withCapturedConsole("error", () => {
+    captureBackendException({
+      action: "chat_worker_failed",
+      error: new Error("worker failed"),
+      scope: createBackendObservationScope(
+        "chat-worker",
+        "lambda-request-1",
+        null,
+        null,
+        "user-1",
+        "workspace-1",
+        "chat-request-1",
+        "run-1",
+        "session-1",
+      ),
+      details: {
+        lambdaRequestId: "lambda-request-1",
+        routeRequestId: "route-request-1",
+        chatRequestId: "chat-request-1",
+        runId: "run-1",
+        sessionId: "session-1",
+        userId: "user-1",
+        workspaceId: "workspace-1",
+        statusCode: null,
+        code: null,
+        message: "worker failed",
+      },
+    });
+  });
+
+  const exceptionRecord = JSON.parse(exceptionMessages[0] ?? "");
+  assert.equal(exceptionRecord.action, "chat_worker_failed");
+  assert.equal(exceptionRecord.service, "chat-worker");
+  assert.equal(exceptionRecord.requestId, "lambda-request-1");
+  assert.equal(exceptionRecord.lambdaRequestId, "lambda-request-1");
+  assert.equal(exceptionRecord.routeRequestId, "route-request-1");
+  assert.equal(exceptionRecord.chatRequestId, "chat-request-1");
+  assert.equal(exceptionRecord.userId, "user-1");
+  assert.equal(exceptionRecord.workspaceId, "workspace-1");
+  assert.equal(exceptionRecord.runId, "run-1");
+  assert.equal(exceptionRecord.sessionId, "session-1");
+  assert.equal(exceptionRecord.statusCode, null);
+  assert.equal(exceptionRecord.code, null);
+  assert.equal(exceptionRecord.message, "<redacted-content>");
+  assert.equal(exceptionRecord.errorClass, "Error");
+  assert.equal(exceptionRecord.errorMessage, "worker failed");
+  assert.equal("error" in exceptionRecord, false);
+});
+
+test("backend runtime exception serialization includes global metrics failure context", () => {
+  const exceptionMessages = withCapturedConsole("error", () => {
+    captureBackendException({
+      action: "global_metrics_snapshot_failed",
+      error: new Error("snapshot failed"),
+      scope: createBackendObservationScope(
+        "global-metrics-snapshot",
+        "lambda-request-2",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: {
+        bucketName: "metrics-bucket",
+        objectKey: "v1/global-snapshot.json",
+        message: "snapshot failed",
+      },
+    });
+  });
+
+  const exceptionRecord = JSON.parse(exceptionMessages[0] ?? "");
+  assert.equal(exceptionRecord.action, "global_metrics_snapshot_failed");
+  assert.equal(exceptionRecord.service, "global-metrics-snapshot");
+  assert.equal(exceptionRecord.requestId, "lambda-request-2");
+  assert.equal(exceptionRecord.bucketName, "metrics-bucket");
+  assert.equal(exceptionRecord.objectKey, "v1/global-snapshot.json");
+  assert.equal(exceptionRecord.message, "<redacted-content>");
+  assert.equal(exceptionRecord.errorClass, "Error");
+  assert.equal(exceptionRecord.errorMessage, "snapshot failed");
+  assert.equal("error" in exceptionRecord, false);
+});
+
+test("backend runtime exception serialization includes migration failure context", () => {
+  const exceptionMessages = withCapturedConsole("error", () => {
+    captureBackendException({
+      action: "migration_failed",
+      error: new Error("migration failed"),
+      scope: createBackendObservationScope(
+        "migration",
+        "lambda-request-3",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details: {
+        migrationSurface: "lambda",
+        operation: "run_migrations",
+        message: "migration failed",
+      },
+    });
+  });
+
+  const exceptionRecord = JSON.parse(exceptionMessages[0] ?? "");
+  assert.equal(exceptionRecord.action, "migration_failed");
+  assert.equal(exceptionRecord.service, "migration");
+  assert.equal(exceptionRecord.requestId, "lambda-request-3");
+  assert.equal(exceptionRecord.migrationSurface, "lambda");
+  assert.equal(exceptionRecord.operation, "run_migrations");
+  assert.equal(exceptionRecord.message, "<redacted-content>");
+  assert.equal(exceptionRecord.errorClass, "Error");
+  assert.equal(exceptionRecord.errorMessage, "migration failed");
+  assert.equal("error" in exceptionRecord, false);
+});

--- a/apps/backend/src/observability/sentry.ts
+++ b/apps/backend/src/observability/sentry.ts
@@ -1,0 +1,1164 @@
+import type { Handler, StreamifyHandler } from "aws-lambda";
+import * as Sentry from "@sentry/aws-serverless";
+import {
+  sanitizeBackendTelemetryValue,
+  type SanitizedTelemetryValue,
+} from "./sanitizer";
+
+export type BackendService =
+  | "backend-api"
+  | "chat-worker"
+  | "chat-live"
+  | "global-metrics-snapshot"
+  | "migration";
+
+export type BackendObservationScope = Readonly<{
+  service: BackendService;
+  requestId: string | null;
+  route: string | null;
+  method: string | null;
+  userId: string | null;
+  workspaceId: string | null;
+  chatRequestId: string | null;
+  runId: string | null;
+  sessionId: string | null;
+}>;
+
+export type BackendTraceCarrier = Readonly<{
+  sentryTrace: string | null;
+  baggage: string | null;
+}>;
+
+export type BackendValidationIssueDetail = Readonly<{
+  path: string;
+  code: string;
+}>;
+
+export type BackendErrorLogDetails = Readonly<{
+  errorClass: string;
+  errorMessage: string;
+  errorStack: string | null;
+  sourceFile: string | null;
+  sourceLine: number | null;
+  sourceColumn: number | null;
+}>;
+
+export type BackendFailureDetails = Readonly<{
+  statusCode: number;
+  code: string | null;
+  message: string | null;
+  validationIssues: ReadonlyArray<BackendValidationIssueDetail>;
+}>;
+
+export type BackendDatabaseDetails = Readonly<{
+  sqlState: string | null;
+  constraint: string | null;
+  table: string | null;
+  detail: string | null;
+}>;
+
+export type BackendSyncConflictDetails = Readonly<{
+  syncConflictPhase: string | null;
+  syncConflictEntityType: "card" | "deck" | "review_event" | null;
+  syncConflictEntityId: string | null;
+  conflictingWorkspaceId: string | null;
+  constraint: string | null;
+  sqlState: string | null;
+  table: string | null;
+  entryIndex: number | null;
+  reviewEventIndex: number | null;
+  syncConflictRecoverable: boolean | null;
+}>;
+
+export type EmptyDetails = Readonly<{
+  ok: true;
+}>;
+
+export type AdminQueryDetails = Readonly<{
+  adminEmail: string;
+  statementCount: number;
+  durationMs: number;
+  success: boolean;
+  sqlFingerprint: string;
+}>;
+
+export type SyncPushDetails = Readonly<{
+  statusCode: number;
+  installationId: string;
+  platform: string;
+  appVersion: string | null;
+  operationsCount: number;
+  entityTypes: ReadonlyArray<string>;
+}>;
+
+export type SyncPullDetails = Readonly<{
+  statusCode: number;
+  installationId: string | null;
+  platform: string | null;
+  appVersion: string | null;
+  afterHotChangeId: number | null;
+  nextHotChangeId: number | null;
+  changesCount: number | null;
+}>;
+
+export type SyncBootstrapDetails = Readonly<{
+  statusCode: number;
+  installationId: string;
+  platform: string;
+  appVersion: string | null;
+  mode: string;
+}>;
+
+export type SyncReviewHistoryPullDetails = Readonly<{
+  statusCode: number;
+  installationId: string | null;
+  platform: string | null;
+  appVersion: string | null;
+  afterReviewSequenceId: number | null;
+  nextReviewSequenceId: number | null;
+  reviewEventsCount: number | null;
+}>;
+
+export type SyncReviewHistoryImportDetails = Readonly<{
+  statusCode: number;
+  installationId: string;
+  platform: string;
+  appVersion: string | null;
+  reviewEventsCount: number;
+  importedCount: number | null;
+  duplicateCount: number | null;
+}>;
+
+export type ProgressSummaryDetails = Readonly<{
+  statusCode: number;
+  authTransport: string;
+  timeZone: string | null;
+  currentStreakDays: number | null;
+  hasReviewedToday: boolean | null;
+  lastReviewedOn: string | null;
+  activeReviewDays: number | null;
+  generatedAt: string | null;
+}>;
+
+export type ProgressReviewScheduleDetails = Readonly<{
+  statusCode: number;
+  authTransport: string;
+  timeZone: string | null;
+  bucketCount: number | null;
+  totalCards: number | null;
+  generatedAt: string | null;
+}>;
+
+export type ProgressSeriesDetails = Readonly<{
+  statusCode: number;
+  authTransport: string;
+  timeZone: string | null;
+  from: string | null;
+  to: string | null;
+  returnedDayCount: number | null;
+  hasNonZeroReviewDays: boolean | null;
+  generatedAt: string | null;
+}>;
+
+export type AccountDeleteDetails = Readonly<{
+  statusCode: number;
+  transport: string;
+}>;
+
+export type WorkspaceTagsListDetails = Readonly<{
+  statusCode: number;
+  tagsCount: number | null;
+  totalCards: number | null;
+}>;
+
+export type CardsQueryDetails = Readonly<{
+  statusCode: number;
+  limit: number;
+  sortsCount: number;
+  hasSearch: boolean;
+  hasFilter: boolean;
+  resultsCount: number | null;
+  totalCount: number | null;
+  hasMore: boolean | null;
+}>;
+
+export type GuestUpgradeCompleteDetails = Readonly<{
+  statusCode: number;
+  selectionType: string;
+  guestWorkspaceSyncedAndOutboxDrained: boolean;
+  requiresGuestWorkspaceSyncedAndOutboxDrained: boolean;
+  supportsDroppedEntities: boolean;
+  targetSubjectUserId: string;
+  guestSessionId: string | null;
+  targetUserId: string | null;
+  targetWorkspaceId: string | null;
+  completionKind: string | null;
+}>;
+
+export type WorkspacesListDetails = Readonly<{
+  statusCode: number;
+  selectedWorkspaceId: string | null;
+  workspacesCount: number | null;
+  limit: number | null;
+  hasNextCursor: boolean | null;
+}>;
+
+export type WorkspaceIdDetails = Readonly<{
+  statusCode: number;
+}>;
+
+export type WorkspaceDeletePreviewDetails = Readonly<{
+  statusCode: number;
+  cardsCount: number | null;
+}>;
+
+export type WorkspaceDeleteDetails = Readonly<{
+  statusCode: number;
+  deletedCardsCount: number | null;
+  nextWorkspaceId: string | null;
+}>;
+
+export type WorkspaceResetProgressPreviewDetails = Readonly<{
+  statusCode: number;
+  cardsCount: number | null;
+}>;
+
+export type WorkspaceResetProgressDetails = Readonly<{
+  statusCode: number;
+  cardsResetCount: number | null;
+}>;
+
+export type WorkspaceTransactionDetails = Readonly<{
+  userId: string;
+  workspaceId: string;
+  stage: string | null;
+  code: string | null;
+  cardsResetCount: number | null;
+  memberCount: number | null;
+  selectedWorkspaceIdBeforeDelete: string | null;
+  selectedWorkspaceIdAfterPreparation: string | null;
+  deletedCardsCount: number | null;
+}> & BackendDatabaseDetails;
+
+export type ChatLiveRequestDetails = Readonly<{
+  statusCode: number;
+  path: string;
+  sessionId: string | null;
+  runId: string | null;
+  afterCursor: string | null;
+  hasToken: boolean;
+  hasWorkspaceId: boolean;
+  origin: string | null;
+  authScheme: string;
+  resumeAttemptId: string | null;
+  clientPlatform: string | null;
+  clientVersion: string | null;
+  code: string | null;
+  message: string | null;
+}>;
+
+export type ChatLiveAttachDetails = Readonly<{
+  statusCode: number;
+  path: string;
+  sessionId: string;
+  runId: string;
+  afterCursor: number | null;
+  hasToken: boolean;
+  hasWorkspaceId: boolean;
+  origin: string | null;
+  authScheme: string;
+  resumeAttemptId: string | null;
+  clientPlatform: string | null;
+  clientVersion: string | null;
+}>;
+
+export type ChatLiveStreamCrashDetails = Readonly<{
+  statusCode: number;
+  path: string;
+  sessionId: string;
+  runId: string;
+  afterCursor: number | null;
+  hasToken: boolean;
+  hasWorkspaceId: boolean;
+  origin: string | null;
+  authScheme: string;
+  resumeAttemptId: string | null;
+  clientPlatform: string | null;
+  clientVersion: string | null;
+}>;
+
+export type ChatLiveBootstrapFailureDetails = Readonly<{
+  statusCode: number;
+  path: string;
+  sessionId: string | null;
+  runId: string | null;
+  afterCursor: string | null;
+  hasToken: boolean;
+  hasWorkspaceId: boolean;
+  origin: string | null;
+  authScheme: string;
+  resumeAttemptId: string | null;
+  clientPlatform: string | null;
+  clientVersion: string | null;
+  code: string;
+  message: string;
+}>;
+
+export type ChatLiveLifecycleDetails = Readonly<{
+  afterCursor: number | null;
+  resumeAttemptId: string | null;
+  clientPlatform: string | null;
+  clientVersion: string | null;
+  connectionDurationMs: number | null;
+  terminationReason: string | null;
+  closeReason: string | null;
+  errorClass: string | null;
+  errorMessage: string | null;
+  errorStack: string | null;
+  sourceFile: string | null;
+  sourceLine: number | null;
+  sourceColumn: number | null;
+}>;
+
+export type ChatWorkerLifecycleDetails = Readonly<{
+  lambdaRequestId: string | null;
+  abortReason: string | null;
+  signalAborted: boolean;
+  cancellationRequested: boolean;
+  ownershipLost: boolean;
+  runStatus: string | null;
+  sessionState: string | null;
+  providerErrorClass: string | null;
+  providerErrorMessage: null;
+  providerErrorStatus?: number | null;
+  providerErrorCode?: string | null;
+  providerErrorCategory?: string | null;
+  providerRequestId: string | null;
+  heartbeatAt: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  outcome: string | null;
+}>;
+
+export type ChatWorkerDispatchFailureDetails = Readonly<{
+  message: string;
+}>;
+
+export type ChatWorkerFailureDetails = Readonly<{
+  lambdaRequestId: string | null;
+  routeRequestId: string | null;
+  chatRequestId: string | null;
+  runId: string;
+  sessionId: string | null;
+  userId: string;
+  workspaceId: string;
+  statusCode: number | null;
+  code: string | null;
+  message: string;
+}>;
+
+export type GlobalMetricsSnapshotGeneratedDetails = Readonly<{
+  bucketName: string;
+  objectKey: string;
+  generatedAtUtc: string;
+  asOfUtc: string;
+  from: string;
+  to: string;
+  uniqueReviewingUsers: number;
+  reviewEvents: number;
+}>;
+
+export type GlobalMetricsSnapshotFailureDetails = Readonly<{
+  bucketName: string | null;
+  objectKey: string | null;
+  message: string;
+}>;
+
+export type MigrationFailureDetails = Readonly<{
+  migrationSurface: "lambda";
+  operation: "run_migrations";
+  message: string;
+}>;
+
+type EventByAction<Action extends string, Details> = Readonly<{
+  action: Action;
+  scope: BackendObservationScope;
+  details: Details;
+}>;
+
+type FailureDetailsFor<Details> = Details & BackendFailureDetails;
+type SyncConflictFailureDetailsFor<Details> = FailureDetailsFor<Details> & BackendSyncConflictDetails;
+
+export type BackendBreadcrumbEvent =
+  | EventByAction<"admin_query", AdminQueryDetails>
+  | EventByAction<"global_metrics_snapshot_generated", GlobalMetricsSnapshotGeneratedDetails>
+  | EventByAction<"sync_push", SyncPushDetails>
+  | EventByAction<"sync_push_error", SyncConflictFailureDetailsFor<SyncPushDetails>>
+  | EventByAction<"sync_pull", SyncPullDetails>
+  | EventByAction<"sync_pull_error", FailureDetailsFor<SyncPullDetails>>
+  | EventByAction<"sync_bootstrap", SyncBootstrapDetails>
+  | EventByAction<"sync_bootstrap_error", SyncConflictFailureDetailsFor<SyncBootstrapDetails>>
+  | EventByAction<"sync_review_history_pull", SyncReviewHistoryPullDetails>
+  | EventByAction<"sync_review_history_pull_error", FailureDetailsFor<SyncReviewHistoryPullDetails>>
+  | EventByAction<"sync_review_history_import", SyncReviewHistoryImportDetails>
+  | EventByAction<"sync_review_history_import_error", SyncConflictFailureDetailsFor<SyncReviewHistoryImportDetails>>
+  | EventByAction<"me_progress_summary", ProgressSummaryDetails>
+  | EventByAction<"me_progress_summary_error", FailureDetailsFor<ProgressSummaryDetails>>
+  | EventByAction<"me_progress_review_schedule", ProgressReviewScheduleDetails>
+  | EventByAction<"me_progress_review_schedule_error", FailureDetailsFor<ProgressReviewScheduleDetails>>
+  | EventByAction<"me_progress_series", ProgressSeriesDetails>
+  | EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>>
+  | EventByAction<"account_delete", AccountDeleteDetails>
+  | EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>>
+  | EventByAction<"workspace_tags_list", WorkspaceTagsListDetails>
+  | EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>>
+  | EventByAction<"cards_query", CardsQueryDetails>
+  | EventByAction<"cards_query_error", FailureDetailsFor<CardsQueryDetails>>
+  | EventByAction<"guest_upgrade_complete", GuestUpgradeCompleteDetails>
+  | EventByAction<"guest_upgrade_complete_error", FailureDetailsFor<GuestUpgradeCompleteDetails>>
+  | EventByAction<"workspaces_list", WorkspacesListDetails>
+  | EventByAction<"workspaces_list_error", FailureDetailsFor<WorkspacesListDetails>>
+  | EventByAction<"workspace_create", WorkspaceIdDetails>
+  | EventByAction<"workspace_create_error", FailureDetailsFor<WorkspaceIdDetails>>
+  | EventByAction<"workspace_select", WorkspaceIdDetails>
+  | EventByAction<"workspace_select_error", FailureDetailsFor<WorkspaceIdDetails>>
+  | EventByAction<"workspace_rename", WorkspaceIdDetails>
+  | EventByAction<"workspace_rename_error", FailureDetailsFor<WorkspaceIdDetails>>
+  | EventByAction<"workspace_delete_preview", WorkspaceDeletePreviewDetails>
+  | EventByAction<"workspace_delete_preview_error", FailureDetailsFor<WorkspaceDeletePreviewDetails>>
+  | EventByAction<"workspace_delete", WorkspaceDeleteDetails>
+  | EventByAction<"workspace_delete_error", FailureDetailsFor<WorkspaceDeleteDetails>>
+  | EventByAction<"workspace_reset_progress_preview", WorkspaceResetProgressPreviewDetails>
+  | EventByAction<"workspace_reset_progress_preview_error", FailureDetailsFor<WorkspaceResetProgressPreviewDetails>>
+  | EventByAction<"workspace_reset_progress", WorkspaceResetProgressDetails>
+  | EventByAction<"workspace_reset_progress_error", FailureDetailsFor<WorkspaceResetProgressDetails>>
+  | EventByAction<"workspace_create_transaction_error", WorkspaceTransactionDetails>
+  | EventByAction<"workspace_delete_preview_transaction_error", WorkspaceTransactionDetails>
+  | EventByAction<"workspace_reset_progress_preview_transaction_error", WorkspaceTransactionDetails>
+  | EventByAction<"workspace_reset_progress_transaction_error", WorkspaceTransactionDetails>
+  | EventByAction<"workspace_delete_transaction_error", WorkspaceTransactionDetails>
+  | EventByAction<"chat_live_attach_start", ChatLiveAttachDetails>
+  | EventByAction<"chat_live_request_error", ChatLiveRequestDetails>
+  | EventByAction<"chat_live_client_disconnected", ChatLiveLifecycleDetails>
+  | EventByAction<"chat_live_stream_closed", ChatLiveLifecycleDetails>
+  | EventByAction<"chat_worker_skip", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_worker_claimed", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_worker_finish", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_worker_abort_requested", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_worker_provider_call_started", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_worker_provider_call_aborted", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_worker_terminal_state_persisted", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_worker_composer_suggestions_failed", ChatWorkerLifecycleDetails>;
+
+export type BackendWarningEvent =
+  | (EventByAction<"global_snapshot_error", Readonly<{
+    statusCode: number;
+    code: string | null;
+    storageErrorMessage: string;
+  }>> & Readonly<{ message: string }>)
+  | (EventByAction<"chat_live_backlog_failed", ChatLiveLifecycleDetails> & Readonly<{ message: string }>)
+  | (EventByAction<"chat_live_write_failed", ChatLiveLifecycleDetails> & Readonly<{ message: string }>)
+  | (EventByAction<"chat_worker_terminal_state_persisted", ChatWorkerLifecycleDetails> & Readonly<{ message: string }>)
+  | (EventByAction<"chat_worker_composer_suggestions_failed", ChatWorkerLifecycleDetails> & Readonly<{ message: string }>)
+  | (EventByAction<"chat_resume_contract_violation", Readonly<{
+    path: string;
+    method: string;
+    resumeAttemptId: string | null;
+    clientPlatform: string | null;
+    clientVersion: string | null;
+    violationReason: string;
+    resolvedLiveCursor: string | null;
+    snapshotRunState: string | null;
+    latestAssistantItemId: string | null;
+    latestAssistantItemOrder: number | null;
+    latestAssistantState: string | null;
+    inProgressAssistantItemId: string | null;
+    inProgressAssistantItemOrder: number | null;
+    terminationReason: string | null;
+  }>> & Readonly<{ message: string }>);
+
+export type BackendExceptionEvent =
+  | (EventByAction<"request_failed", BackendFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"sync_push_error", SyncConflictFailureDetailsFor<SyncPushDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"sync_pull_error", FailureDetailsFor<SyncPullDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"sync_bootstrap_error", SyncConflictFailureDetailsFor<SyncBootstrapDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"sync_review_history_pull_error", FailureDetailsFor<SyncReviewHistoryPullDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"sync_review_history_import_error", SyncConflictFailureDetailsFor<SyncReviewHistoryImportDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"me_progress_summary_error", FailureDetailsFor<ProgressSummaryDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"me_progress_review_schedule_error", FailureDetailsFor<ProgressReviewScheduleDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"cards_query_error", FailureDetailsFor<CardsQueryDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"guest_upgrade_complete_error", FailureDetailsFor<GuestUpgradeCompleteDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspaces_list_error", FailureDetailsFor<WorkspacesListDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_create_error", FailureDetailsFor<WorkspaceIdDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_select_error", FailureDetailsFor<WorkspaceIdDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_rename_error", FailureDetailsFor<WorkspaceIdDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_delete_preview_error", FailureDetailsFor<WorkspaceDeletePreviewDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_delete_error", FailureDetailsFor<WorkspaceDeleteDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_reset_progress_preview_error", FailureDetailsFor<WorkspaceResetProgressPreviewDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_reset_progress_error", FailureDetailsFor<WorkspaceResetProgressDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_create_transaction_error", WorkspaceTransactionDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_delete_preview_transaction_error", WorkspaceTransactionDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_reset_progress_preview_transaction_error", WorkspaceTransactionDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_reset_progress_transaction_error", WorkspaceTransactionDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"workspace_delete_transaction_error", WorkspaceTransactionDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"chat_worker_dispatch_failed", ChatWorkerDispatchFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"chat_worker_failed", ChatWorkerFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"global_metrics_snapshot_failed", GlobalMetricsSnapshotFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"migration_failed", MigrationFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"chat_live_bootstrap_failed", ChatLiveBootstrapFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"chat_live_request_error", ChatLiveRequestDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"chat_live_stream_crashed", ChatLiveStreamCrashDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"chat_live_poll_failed", ChatLiveLifecycleDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"chat_worker_terminal_state_persisted", ChatWorkerLifecycleDetails> & Readonly<{ error: Error }>);
+
+type BackendLogEvent = BackendBreadcrumbEvent | BackendWarningEvent | BackendExceptionEvent;
+
+type InitializeBackendSentryDependencies = Readonly<{
+  init: (options: BackendSentryInitOptions) => void;
+}>;
+
+type BackendSentryInitOptions = NonNullable<Parameters<typeof Sentry.init>[0]>;
+type BackendSentryEvent = Parameters<NonNullable<BackendSentryInitOptions["beforeSend"]>>[0];
+type BackendSentryEventHint = Parameters<NonNullable<BackendSentryInitOptions["beforeSend"]>>[1];
+type BackendSentrySpan = Parameters<NonNullable<BackendSentryInitOptions["beforeSendSpan"]>>[0];
+type BackendSentryTransactionEvent = Parameters<NonNullable<BackendSentryInitOptions["beforeSendTransaction"]>>[0];
+type BackendSentryIntegration = ReturnType<typeof Sentry.honoIntegration>;
+type BackendSentryIntegrationFactory = (
+  defaultIntegrations: Array<BackendSentryIntegration>,
+) => Array<BackendSentryIntegration>;
+type BackendSentryContextData = Parameters<Sentry.Scope["setContext"]>[1];
+type BackendSentryBreadcrumbData = NonNullable<Parameters<typeof Sentry.addBreadcrumb>[0]["data"]>;
+
+type BackendSentryConfig =
+  | Readonly<{ enabled: false }>
+  | Readonly<{
+    enabled: true;
+    dsn: string;
+    environment: string;
+    release: string;
+    tracesSampleRate: number;
+  }>;
+
+const initializedServices = new Set<BackendService>();
+const capturedExceptionSet = new WeakSet<Error>();
+const normalizedNonErrorObjectMap = new WeakMap<object, Error>();
+const normalizedNonErrorPrimitiveMap = new Map<NonErrorPrimitive, Error>();
+const manualBackendCaptureTagName = "backend.manual_capture";
+const manualBackendWarningCaptureTagName = "backend.manual_warning_capture";
+const backendActionTagName = "backend.action";
+const manualBackendCaptureTagValue = "true";
+const disabledDefaultIntegrationNames = new Set<string>(["Postgres", "OpenAI"]);
+const redactedExceptionTextValue = "<redacted-content>";
+const exceptionTextFieldNames: ReadonlySet<string> = new Set([
+  "errormessage",
+  "errorstack",
+  "errorvalue",
+  "exceptionmessage",
+  "exceptionvalue",
+  "message",
+  "providererrormessage",
+  "rawstack",
+  "stack",
+  "value",
+]);
+const cloudWatchActionableExceptionTextFieldNames: ReadonlySet<string> = new Set([
+  "errormessage",
+  "errorstack",
+]);
+let backendSentryInitializedForOpenTelemetry = false;
+
+type NonErrorPrimitive = string | number | boolean | bigint | symbol | null | undefined;
+
+function isAwsLambdaRuntime(env: NodeJS.ProcessEnv): boolean {
+  return (env.AWS_EXECUTION_ENV ?? "").startsWith("AWS_Lambda_")
+    || (env.AWS_LAMBDA_FUNCTION_NAME ?? "") !== "";
+}
+
+function readRequiredSentryValue(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${name} is required when backend Sentry is enabled`);
+  }
+
+  return value.trim();
+}
+
+function parseTraceSampleRate(rawValue: string): number {
+  const tracesSampleRate = Number.parseFloat(rawValue);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("SENTRY_TRACES_SAMPLE_RATE must be a number between 0 and 1");
+  }
+
+  return tracesSampleRate;
+}
+
+export function getBackendSentryConfig(env: NodeJS.ProcessEnv): BackendSentryConfig {
+  const dsn = env.SENTRY_DSN;
+  if (dsn === undefined || dsn.trim() === "") {
+    if (isAwsLambdaRuntime(env)) {
+      throw new Error("SENTRY_DSN is required in AWS Lambda backend runtimes");
+    }
+
+    return { enabled: false };
+  }
+
+  return {
+    enabled: true,
+    dsn: dsn.trim(),
+    environment: readRequiredSentryValue(env, "SENTRY_ENVIRONMENT"),
+    release: readRequiredSentryValue(env, "SENTRY_RELEASE"),
+    tracesSampleRate: parseTraceSampleRate(readRequiredSentryValue(env, "SENTRY_TRACES_SAMPLE_RATE")),
+  };
+}
+
+function isManuallyCapturedSentryEvent(event: BackendSentryEvent): boolean {
+  return event.tags?.[manualBackendCaptureTagName] === manualBackendCaptureTagValue;
+}
+
+function getManualBackendWarningMessage(event: BackendSentryEvent): string | null {
+  if (event.tags?.[manualBackendWarningCaptureTagName] !== manualBackendCaptureTagValue) {
+    return null;
+  }
+
+  if (typeof event.message !== "string") {
+    return null;
+  }
+
+  return event.tags?.[backendActionTagName] === event.message ? event.message : null;
+}
+
+function shouldDropPreviouslyCapturedBackendException(
+  event: BackendSentryEvent,
+  hint: BackendSentryEventHint,
+): boolean {
+  if (isManuallyCapturedSentryEvent(event)) {
+    return false;
+  }
+
+  const originalException = hint.originalException;
+  return originalException instanceof Error && capturedExceptionSet.has(originalException);
+}
+
+function sanitizeSentryEvent(event: BackendSentryEvent, hint: BackendSentryEventHint): BackendSentryEvent | null {
+  if (shouldDropPreviouslyCapturedBackendException(event, hint)) {
+    return null;
+  }
+
+  const manualBackendWarningMessage = getManualBackendWarningMessage(event);
+  const sanitizedEvent = sanitizeBackendTelemetryValue(redactExceptionTextFields(event)) as unknown as typeof event;
+  if (manualBackendWarningMessage === null) {
+    return sanitizedEvent;
+  }
+
+  return {
+    ...sanitizedEvent,
+    message: manualBackendWarningMessage,
+  };
+}
+
+function sanitizeSentrySpan(span: BackendSentrySpan): BackendSentrySpan {
+  return sanitizeBackendTelemetryValue(redactExceptionTextFields(span)) as unknown as typeof span;
+}
+
+function sanitizeSentryTransactionEvent(event: BackendSentryTransactionEvent): BackendSentryTransactionEvent {
+  return sanitizeBackendTelemetryValue(redactExceptionTextFields(event)) as unknown as typeof event;
+}
+
+function hasSentryIntegrationNamed(
+  integrations: ReadonlyArray<BackendSentryIntegration>,
+  integrationName: string,
+): boolean {
+  return integrations.some((integration) => integration.name === integrationName);
+}
+
+function appendSentryIntegrationIfMissing(
+  integrations: ReadonlyArray<BackendSentryIntegration>,
+  integrationName: string,
+  integration: BackendSentryIntegration,
+): ReadonlyArray<BackendSentryIntegration> {
+  if (hasSentryIntegrationNamed(integrations, integrationName)) {
+    return integrations;
+  }
+
+  return [...integrations, integration];
+}
+
+function createConfiguredOpenAIIntegration(): BackendSentryIntegration {
+  return Sentry.openAIIntegration({
+    recordInputs: false,
+    recordOutputs: false,
+  });
+}
+
+function createConfiguredSentryIntegrations(
+  defaultIntegrations: ReadonlyArray<BackendSentryIntegration>,
+): Array<BackendSentryIntegration> {
+  const filteredIntegrations = defaultIntegrations.filter(
+    (integration) => disabledDefaultIntegrationNames.has(integration.name) === false,
+  );
+  const integrationsWithHono = appendSentryIntegrationIfMissing(
+    filteredIntegrations,
+    "Hono",
+    Sentry.honoIntegration(),
+  );
+  const integrationsWithHttp = appendSentryIntegrationIfMissing(
+    integrationsWithHono,
+    "Http",
+    Sentry.httpIntegration(),
+  );
+  const integrationsWithFetch = appendSentryIntegrationIfMissing(
+    integrationsWithHttp,
+    "NodeFetch",
+    Sentry.nativeNodeFetchIntegration(),
+  );
+
+  return [
+    ...integrationsWithFetch,
+    createConfiguredOpenAIIntegration(),
+  ];
+}
+
+function createSentryIntegrations(): BackendSentryIntegrationFactory {
+  return (defaultIntegrations) => createConfiguredSentryIntegrations(defaultIntegrations);
+}
+
+export function initializeBackendSentryWithDeps(
+  service: BackendService,
+  env: NodeJS.ProcessEnv,
+  dependencies: InitializeBackendSentryDependencies,
+): void {
+  if (initializedServices.has(service)) {
+    return;
+  }
+
+  const config = getBackendSentryConfig(env);
+  if (!config.enabled) {
+    initializedServices.add(service);
+    return;
+  }
+
+  dependencies.init({
+    dsn: config.dsn,
+    environment: config.environment,
+    release: config.release,
+    tracesSampleRate: config.tracesSampleRate,
+    sendDefaultPii: false,
+    beforeSend: (event, hint) => sanitizeSentryEvent(event, hint),
+    beforeSendSpan: (span) => sanitizeSentrySpan(span),
+    beforeSendTransaction: (event) => sanitizeSentryTransactionEvent(event),
+    integrations: createSentryIntegrations(),
+  });
+  backendSentryInitializedForOpenTelemetry = true;
+  initializedServices.add(service);
+}
+
+export function initializeBackendSentry(service: BackendService): void {
+  initializeBackendSentryWithDeps(service, process.env, {
+    init: Sentry.init,
+  });
+}
+
+export function resetBackendSentryForTests(): void {
+  initializedServices.clear();
+  backendSentryInitializedForOpenTelemetry = false;
+}
+
+export function isBackendSentryInitializedForOpenTelemetry(): boolean {
+  return backendSentryInitializedForOpenTelemetry;
+}
+
+export function normalizeCaughtError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  if ((typeof error === "object" && error !== null) || typeof error === "function") {
+    const cachedError = normalizedNonErrorObjectMap.get(error as object);
+    if (cachedError !== undefined) {
+      return cachedError;
+    }
+
+    const normalizedError = createNonErrorThrowWrapper(error);
+    normalizedNonErrorObjectMap.set(error as object, normalizedError);
+    return normalizedError;
+  }
+
+  const primitiveError = error as NonErrorPrimitive;
+  const cachedError = normalizedNonErrorPrimitiveMap.get(primitiveError);
+  if (cachedError !== undefined) {
+    return cachedError;
+  }
+
+  const normalizedError = createNonErrorThrowWrapper(error);
+  normalizedNonErrorPrimitiveMap.set(primitiveError, normalizedError);
+  return normalizedError;
+}
+
+function createNonErrorThrowWrapper(error: unknown): Error {
+  const normalizedError = new Error(String(error));
+  normalizedError.name = "NonErrorThrow";
+  return normalizedError;
+}
+
+export function hasCapturedBackendException(error: Error): boolean {
+  return capturedExceptionSet.has(error);
+}
+
+function normalizeTelemetryKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function shouldRedactExceptionTextField(key: string, value: unknown): boolean {
+  return typeof value === "string" && exceptionTextFieldNames.has(normalizeTelemetryKey(key));
+}
+
+function redactExceptionTextFields(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactExceptionTextFields(item));
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Readonly<Record<string, unknown>>).map(([key, childValue]) => [
+      key,
+      shouldRedactExceptionTextField(key, childValue)
+        ? redactedExceptionTextValue
+        : redactExceptionTextFields(childValue),
+    ]),
+  );
+}
+
+function shouldRedactCloudWatchExceptionDetailTextField(key: string, value: unknown): boolean {
+  const normalizedKey = normalizeTelemetryKey(key);
+  return typeof value === "string"
+    && exceptionTextFieldNames.has(normalizedKey)
+    && cloudWatchActionableExceptionTextFieldNames.has(normalizedKey) === false;
+}
+
+function redactCloudWatchExceptionDetailTextFields(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactCloudWatchExceptionDetailTextFields(item));
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Readonly<Record<string, unknown>>).map(([key, childValue]) => [
+      key,
+      shouldRedactCloudWatchExceptionDetailTextField(key, childValue)
+        ? redactedExceptionTextValue
+        : redactCloudWatchExceptionDetailTextFields(childValue),
+    ]),
+  );
+}
+
+function sanitizeInternalErrorText(value: string): string {
+  const sanitizedValue = sanitizeBackendTelemetryValue(value);
+  if (typeof sanitizedValue !== "string") {
+    throw new Error("Expected sanitized internal error text to remain a string");
+  }
+
+  return sanitizedValue;
+}
+
+function shouldPreserveCloudWatchActionableErrorText(key: string, value: unknown): value is string {
+  return typeof value === "string" && cloudWatchActionableExceptionTextFieldNames.has(normalizeTelemetryKey(key));
+}
+
+function readSanitizedTelemetryEntry(key: string, value: unknown): SanitizedTelemetryValue {
+  const sanitizedObject = sanitizeBackendTelemetryValue({ [key]: value });
+  if (typeof sanitizedObject !== "object" || sanitizedObject === null || Array.isArray(sanitizedObject)) {
+    throw new Error("Expected sanitized telemetry entry to remain an object");
+  }
+
+  return (sanitizedObject as Readonly<Record<string, SanitizedTelemetryValue>>)[key];
+}
+
+function sanitizeCloudWatchLogEntry(key: string, value: unknown): SanitizedTelemetryValue {
+  if (shouldPreserveCloudWatchActionableErrorText(key, value)) {
+    return sanitizeInternalErrorText(value);
+  }
+
+  const sanitizedValue = readSanitizedTelemetryEntry(key, value);
+  if (typeof sanitizedValue !== "object" || sanitizedValue === null) {
+    return sanitizedValue;
+  }
+
+  return sanitizeCloudWatchLogValue(value);
+}
+
+function sanitizeCloudWatchLogValue(value: unknown): SanitizedTelemetryValue {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeCloudWatchLogValue(item));
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return sanitizeBackendTelemetryValue(value);
+  }
+
+  return Object.fromEntries(
+    Object.entries(value as Readonly<Record<string, unknown>>).map(([key, childValue]) => [
+      key,
+      sanitizeCloudWatchLogEntry(key, childValue),
+    ]),
+  );
+}
+
+function getLogRecordDetails(event: BackendLogEvent): unknown {
+  return "error" in event ? redactCloudWatchExceptionDetailTextFields(event.details) : event.details;
+}
+
+function createCloudWatchRecord(event: BackendLogEvent): SanitizedTelemetryValue {
+  const errorContext = "error" in event ? getBackendErrorLogDetails(event.error) : {};
+  const message = "message" in event ? { message: event.message } : {};
+  return sanitizeCloudWatchLogValue({
+    domain: "backend",
+    action: event.action,
+    ...event.scope,
+    ...(getLogRecordDetails(event) as Readonly<Record<string, unknown>>),
+    ...message,
+    ...errorContext,
+  });
+}
+
+function writeCloudWatchRecord(
+  event: BackendLogEvent,
+  severity: "breadcrumb" | "warning" | "exception",
+): void {
+  const serializedRecord = JSON.stringify(createCloudWatchRecord(event));
+  if (severity === "exception") {
+    console.error(serializedRecord);
+    return;
+  }
+
+  if (severity === "warning") {
+    console.warn(serializedRecord);
+    return;
+  }
+
+  console.log(serializedRecord);
+}
+
+function getScopeTagValue(value: string | null): string | undefined {
+  return value === null || value === "" ? undefined : value;
+}
+
+function setSentryScope(scope: Sentry.Scope, observationScope: BackendObservationScope): void {
+  scope.setTag("backend.service", observationScope.service);
+  const requestId = getScopeTagValue(observationScope.requestId);
+  const route = getScopeTagValue(observationScope.route);
+  const method = getScopeTagValue(observationScope.method);
+  const workspaceId = getScopeTagValue(observationScope.workspaceId);
+  const chatRequestId = getScopeTagValue(observationScope.chatRequestId);
+  const runId = getScopeTagValue(observationScope.runId);
+  const sessionId = getScopeTagValue(observationScope.sessionId);
+
+  if (requestId !== undefined) scope.setTag("requestId", requestId);
+  if (route !== undefined) scope.setTag("route", route);
+  if (method !== undefined) scope.setTag("method", method);
+  if (workspaceId !== undefined) scope.setTag("workspaceId", workspaceId);
+  if (chatRequestId !== undefined) scope.setTag("chatRequestId", chatRequestId);
+  if (runId !== undefined) scope.setTag("runId", runId);
+  if (sessionId !== undefined) scope.setTag("sessionId", sessionId);
+  if (observationScope.userId !== null && observationScope.userId !== "") {
+    scope.setUser({ id: observationScope.userId });
+    scope.setTag("userId", observationScope.userId);
+  }
+
+  scope.setContext("backend", sanitizeBackendTelemetryValue(redactExceptionTextFields(observationScope)) as BackendSentryContextData);
+}
+
+function getSentryData(event: BackendLogEvent): BackendSentryBreadcrumbData {
+  return sanitizeBackendTelemetryValue(redactExceptionTextFields({
+    scope: event.scope,
+    details: event.details,
+  })) as BackendSentryBreadcrumbData;
+}
+
+export function addBackendBreadcrumb(event: BackendBreadcrumbEvent): void {
+  writeCloudWatchRecord(event, "breadcrumb");
+  addBackendSentryBreadcrumb(event);
+}
+
+export function addBackendSentryBreadcrumb(event: BackendBreadcrumbEvent): void {
+  Sentry.addBreadcrumb({
+    category: "backend",
+    level: "info",
+    message: event.action,
+    data: getSentryData(event),
+  });
+}
+
+export function captureBackendWarning(event: BackendWarningEvent): void {
+  writeCloudWatchRecord(event, "warning");
+  Sentry.withScope((scope) => {
+    setSentryScope(scope, event.scope);
+    scope.setContext(
+      "backend.details",
+      sanitizeBackendTelemetryValue(redactExceptionTextFields(event.details)) as BackendSentryContextData,
+    );
+    scope.setTag(manualBackendWarningCaptureTagName, manualBackendCaptureTagValue);
+    scope.setTag(backendActionTagName, event.action);
+    scope.setFingerprint([event.action]);
+    Sentry.captureMessage(event.action, "warning");
+  });
+}
+
+export function captureBackendException(event: BackendExceptionEvent): void {
+  capturedExceptionSet.add(event.error);
+  writeCloudWatchRecord(event, "exception");
+  Sentry.withScope((scope) => {
+    setSentryScope(scope, event.scope);
+    scope.setContext(
+      "backend.details",
+      sanitizeBackendTelemetryValue(redactExceptionTextFields(event.details)) as BackendSentryContextData,
+    );
+    scope.setTag(manualBackendCaptureTagName, manualBackendCaptureTagValue);
+    Sentry.captureException(event.error);
+  });
+}
+
+export function getBackendTraceCarrier(): BackendTraceCarrier {
+  const traceData = Sentry.getTraceData({ propagateTraceparent: true });
+  return {
+    sentryTrace: traceData["sentry-trace"] ?? null,
+    baggage: traceData.baggage ?? null,
+  };
+}
+
+export function continueBackendTrace<Result>(
+  traceCarrier: BackendTraceCarrier | null,
+  callback: () => Result,
+): Result {
+  if (traceCarrier === null) {
+    return callback();
+  }
+
+  return Sentry.continueTrace({
+    sentryTrace: traceCarrier.sentryTrace ?? undefined,
+    baggage: traceCarrier.baggage ?? undefined,
+  }, callback);
+}
+
+export function startBackendSpan<Result>(
+  name: string,
+  operation: string,
+  callback: () => Result,
+): Result {
+  return Sentry.startSpan({ name, op: operation }, callback);
+}
+
+export function runWithBackendSentryIsolationScope<Result>(
+  scope: BackendObservationScope,
+  callback: () => Result,
+): Result {
+  return Sentry.withIsolationScope((isolationScope) => {
+    setSentryScope(isolationScope, scope);
+    return callback();
+  });
+}
+
+export function wrapBackendHandler<TEvent, TResult>(
+  handler: Handler<TEvent, TResult>,
+): Handler<TEvent, TResult> {
+  return Sentry.wrapHandler(handler);
+}
+
+export function wrapBackendStreamHandler<TEvent, TResult>(
+  handler: StreamifyHandler<TEvent, TResult>,
+): StreamifyHandler<TEvent, TResult> {
+  return Sentry.wrapHandler(handler);
+}
+
+export async function flushBackendSentry(timeoutMs: number): Promise<boolean> {
+  return Sentry.flush(timeoutMs);
+}
+
+export function createBackendObservationScope(
+  service: BackendService,
+  requestId: string | null,
+  route: string | null,
+  method: string | null,
+  userId: string | null,
+  workspaceId: string | null,
+  chatRequestId: string | null,
+  runId: string | null,
+  sessionId: string | null,
+): BackendObservationScope {
+  return {
+    service,
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    chatRequestId,
+    runId,
+    sessionId,
+  };
+}
+
+export function getBackendErrorLogDetails(error: unknown): BackendErrorLogDetails {
+  if (error instanceof Error) {
+    const stack = error.stack ?? null;
+    return {
+      errorClass: error.name,
+      errorMessage: sanitizeInternalErrorText(error.message),
+      errorStack: stack === null ? null : sanitizeInternalErrorText(stack),
+      ...parseErrorSourceLocation(stack),
+    };
+  }
+
+  return {
+    errorClass: "UnknownError",
+    errorMessage: sanitizeInternalErrorText(String(error)),
+    errorStack: null,
+    sourceFile: null,
+    sourceLine: null,
+    sourceColumn: null,
+  };
+}
+
+function parseErrorSourceLocation(stack: string | null): Pick<
+  BackendErrorLogDetails,
+  "sourceFile" | "sourceLine" | "sourceColumn"
+> {
+  if (stack === null) {
+    return {
+      sourceFile: null,
+      sourceLine: null,
+      sourceColumn: null,
+    };
+  }
+
+  const stackLines = stack.split("\n");
+  for (const stackLine of stackLines.slice(1)) {
+    const trimmedLine = stackLine.trim();
+    const match = /^\s*at .+ \((.+):(\d+):(\d+)\)$/.exec(trimmedLine)
+      ?? /^\s*at (.+):(\d+):(\d+)$/.exec(trimmedLine)
+      ?? /^(.+):(\d+):(\d+)$/.exec(trimmedLine);
+    if (match === null) {
+      continue;
+    }
+
+    return {
+      sourceFile: match[1] ?? null,
+      sourceLine: Number.parseInt(match[2] ?? "", 10),
+      sourceColumn: Number.parseInt(match[3] ?? "", 10),
+    };
+  }
+
+  return {
+    sourceFile: null,
+    sourceLine: null,
+    sourceColumn: null,
+  };
+}

--- a/apps/backend/src/routes/cards.ts
+++ b/apps/backend/src/routes/cards.ts
@@ -20,9 +20,16 @@ import {
   parseJsonBody,
 } from "../server/requestParsing";
 import {
-  logCloudRouteEvent,
   summarizeValidationIssues,
 } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendFailureDetails,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
 import { assertUserHasWorkspaceAccess } from "../workspaces";
 import type { AppEnv } from "../app";
 
@@ -53,6 +60,35 @@ const allowedCardQuerySortKeys: ReadonlyArray<CardQuerySortKey> = [
 
 function getInternalErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function createCardsScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string,
+  workspaceId: string,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+  );
+}
+
+function createFailureDetails(error: unknown): BackendFailureDetails {
+  return {
+    statusCode: error instanceof HttpError ? error.statusCode : 500,
+    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
+    message: getInternalErrorMessage(error),
+    validationIssues: summarizeValidationIssues(error),
+  };
 }
 
 function expectSortDirection(value: unknown): CardQuerySortDirection {
@@ -116,27 +152,28 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
 
     try {
       const result = await listWorkspaceTagsSummary(requestContext.userId, workspaceId);
-      logCloudRouteEvent("workspace_tags_list", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-        tagsCount: result.tags.length,
-        totalCards: result.totalCards,
-      }, false);
+      addBackendBreadcrumb({
+        action: "workspace_tags_list",
+        scope: createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        details: {
+          statusCode: 200,
+          tagsCount: result.tags.length,
+          totalCards: result.totalCards,
+        },
+      });
       return context.json(result satisfies WorkspaceTagsSummaryResponse);
     } catch (error) {
-      logCloudRouteEvent("workspace_tags_list_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: getInternalErrorMessage(error),
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
+        tagsCount: null,
+        totalCards: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_tags_list_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_tags_list_error", scope, details },
+      );
       throw error;
     }
   });
@@ -150,36 +187,38 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
 
     try {
       const result = await queryCardsPage(requestContext.userId, workspaceId, body);
-      logCloudRouteEvent("cards_query", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-        limit: body.limit,
-        sortsCount: body.sorts.length,
-        hasSearch: body.searchText !== null,
-        hasFilter: body.filter !== null,
-        resultsCount: result.cards.length,
-        totalCount: result.totalCount,
-        hasMore: result.nextCursor !== null,
-      }, false);
+      addBackendBreadcrumb({
+        action: "cards_query",
+        scope: createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        details: {
+          statusCode: 200,
+          limit: body.limit,
+          sortsCount: body.sorts.length,
+          hasSearch: body.searchText !== null,
+          hasFilter: body.filter !== null,
+          resultsCount: result.cards.length,
+          totalCount: result.totalCount,
+          hasMore: result.nextCursor !== null,
+        },
+      });
       return context.json(result);
     } catch (error) {
-      logCloudRouteEvent("cards_query_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
+      const scope = createCardsScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
         limit: body.limit,
         sortsCount: body.sorts.length,
         hasSearch: body.searchText !== null,
         hasFilter: body.filter !== null,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: getInternalErrorMessage(error),
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+        resultsCount: null,
+        totalCount: null,
+        hasMore: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "cards_query_error", error: normalizeCaughtError(error), scope, details },
+        { action: "cards_query_error", scope, details },
+      );
       throw error;
     }
   });

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -58,8 +58,16 @@ import {
   parseJsonBody,
 } from "../server/requestParsing";
 import type { AppEnv } from "../app";
-import { logCloudRouteEvent } from "../server/logging";
 import { isChatSessionRequestedSessionIdConflictError } from "../chat/errors";
+import {
+  captureBackendException,
+  captureBackendWarning,
+  createBackendObservationScope,
+  getBackendTraceCarrier,
+  normalizeCaughtError,
+  startBackendSpan,
+  type BackendTraceCarrier,
+} from "../observability/sentry";
 
 type ChatTextContentPart = Readonly<{
   type: "text";
@@ -459,24 +467,65 @@ function readChatResumeDiagnosticsHeaders(request: Request): ChatResumeDiagnosti
   };
 }
 
+type ChatResumeContractViolationDetails = Readonly<{
+  violationReason: string;
+  requestId: string | null;
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  resolvedLiveCursor: string | null;
+  snapshotRunState: string | null;
+  latestAssistantItemId: string | null;
+  latestAssistantItemOrder: number | null;
+  latestAssistantState: string | null;
+  inProgressAssistantItemId: string | null;
+  inProgressAssistantItemOrder: number | null;
+  terminationReason: string | null;
+}>;
+
 function logChatResumeContractViolation(
   request: Request,
   diagnostics: ChatResumeDiagnosticsHeaders,
-  payload: Record<string, unknown>,
+  details: ChatResumeContractViolationDetails,
 ): void {
-  logCloudRouteEvent("chat_resume_contract_violation", {
-    path: new URL(request.url).pathname,
-    method: request.method,
-    resumeAttemptId: diagnostics.resumeAttemptId,
-    clientPlatform: diagnostics.clientPlatform,
-    clientVersion: diagnostics.clientVersion,
-    ...payload,
-  }, true);
+  const path = new URL(request.url).pathname;
+  captureBackendWarning({
+    action: "chat_resume_contract_violation",
+    message: "Chat live resume contract violation.",
+    scope: createBackendObservationScope(
+      "backend-api",
+      details.requestId,
+      path,
+      request.method,
+      details.userId,
+      details.workspaceId,
+      null,
+      null,
+      details.sessionId,
+    ),
+    details: {
+      path,
+      method: request.method,
+      resumeAttemptId: diagnostics.resumeAttemptId,
+      clientPlatform: diagnostics.clientPlatform,
+      clientVersion: diagnostics.clientVersion,
+      violationReason: details.violationReason,
+      resolvedLiveCursor: details.resolvedLiveCursor,
+      snapshotRunState: details.snapshotRunState,
+      latestAssistantItemId: details.latestAssistantItemId,
+      latestAssistantItemOrder: details.latestAssistantItemOrder,
+      latestAssistantState: details.latestAssistantState,
+      inProgressAssistantItemId: details.inProgressAssistantItemId,
+      inProgressAssistantItemOrder: details.inProgressAssistantItemOrder,
+      terminationReason: details.terminationReason,
+    },
+  });
 }
 
 async function assertRunningSnapshotInvariant(
   request: Request,
   diagnostics: ChatResumeDiagnosticsHeaders,
+  requestId: string | null,
   snapshot: ChatSessionSnapshot,
   userId: string,
   workspaceId: string,
@@ -494,7 +543,7 @@ async function assertRunningSnapshotInvariant(
 
   logChatResumeContractViolation(request, diagnostics, {
     violationReason: "running_without_in_progress_item",
-    requestId: null,
+    requestId,
     userId,
     workspaceId,
     sessionId: snapshot.sessionId,
@@ -554,6 +603,8 @@ async function buildConversationEnvelopeWithActiveRun(
   snapshot: ChatSessionSnapshot,
   userId: string,
   workspaceId: string,
+  requestId: string | null,
+  traceContext: BackendTraceCarrier | null,
   createChatLiveStreamEnvelopeFn: typeof createChatLiveStreamEnvelope,
   resolveLiveCursorFn: typeof resolveLiveCursor,
   request: Request,
@@ -577,10 +628,10 @@ async function buildConversationEnvelopeWithActiveRun(
   const liveStream = snapshot.runState === "running"
     ? (snapshot.activeRunId === null
       ? null
-      : await createChatLiveStreamEnvelopeFn(userId, workspaceId, snapshot.sessionId, snapshot.activeRunId))
+      : await createChatLiveStreamEnvelopeFn(userId, workspaceId, snapshot.sessionId, snapshot.activeRunId, traceContext))
     : null;
   assertRunningLiveStreamInvariant(request, diagnostics, {
-    requestId: null,
+    requestId,
     userId,
     workspaceId,
     sessionId: snapshot.sessionId,
@@ -608,6 +659,8 @@ async function buildPaginatedConversationEnvelopeWithActiveRun(
   result: RecoveredPaginatedSession,
   userId: string,
   workspaceId: string,
+  requestId: string | null,
+  traceContext: BackendTraceCarrier | null,
   createChatLiveStreamEnvelopeFn: typeof createChatLiveStreamEnvelope,
   resolveLiveCursorFn: typeof resolveLiveCursor,
   request: Request,
@@ -618,6 +671,8 @@ async function buildPaginatedConversationEnvelopeWithActiveRun(
     result.snapshot,
     userId,
     workspaceId,
+    requestId,
+    traceContext,
     createChatLiveStreamEnvelopeFn,
     resolveLiveCursorFn,
     request,
@@ -638,6 +693,8 @@ async function buildStartConversationEnvelope(
     snapshot: ChatSessionSnapshot;
     userId: string;
     workspaceId: string;
+    requestId: string | null;
+    traceContext: BackendTraceCarrier | null;
     createChatLiveStreamEnvelopeFn: typeof createChatLiveStreamEnvelope;
     resolveLiveCursorFn: typeof resolveLiveCursor;
     interruptPreparedChatRunFn: typeof interruptPreparedChatRun;
@@ -651,6 +708,8 @@ async function buildStartConversationEnvelope(
       params.snapshot,
       params.userId,
       params.workspaceId,
+      params.requestId,
+      params.traceContext,
       params.createChatLiveStreamEnvelopeFn,
       params.resolveLiveCursorFn,
       params.request,
@@ -668,6 +727,18 @@ async function buildStartConversationEnvelope(
       ...(params.preparedRun.deduplicated ? { deduplicated: true } : {}),
     };
   } catch (error) {
+    if (!(error instanceof HttpError)) {
+      captureUnexpectedChatLiveEnvelopeError(
+        params.request,
+        params.requestId,
+        params.userId,
+        params.workspaceId,
+        params.snapshot.sessionId,
+        params.snapshot.activeRunId ?? params.preparedRun.runId,
+        error,
+      );
+    }
+
     const runIdToInterrupt = params.snapshot.activeRunId ?? params.preparedRun.runId;
     await params.interruptPreparedChatRunFn(
       params.userId,
@@ -682,6 +753,39 @@ async function buildStartConversationEnvelope(
 
     throw new HttpError(500, "Chat live resume contract violation", chatResumeContractViolationCode);
   }
+}
+
+function captureUnexpectedChatLiveEnvelopeError(
+  request: Request,
+  requestId: string | null,
+  userId: string,
+  workspaceId: string,
+  sessionId: string,
+  runId: string,
+  error: unknown,
+): void {
+  const path = new URL(request.url).pathname;
+  captureBackendException({
+    action: "request_failed",
+    error: normalizeCaughtError(error),
+    scope: createBackendObservationScope(
+      "backend-api",
+      requestId,
+      path,
+      request.method,
+      userId,
+      workspaceId,
+      null,
+      runId,
+      sessionId,
+    ),
+    details: {
+      statusCode: 500,
+      code: chatResumeContractViolationCode,
+      message: "Unexpected chat live envelope creation failure.",
+      validationIssues: [],
+    },
+  });
 }
 
 /**
@@ -776,6 +880,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
     const sessionId = parseOptionalSessionIdQuery(context.req.query("sessionId") ?? undefined);
     const limitParam = context.req.query("limit") ?? undefined;
     const resumeDiagnostics = readChatResumeDiagnosticsHeaders(context.req.raw);
+    const requestId = context.get("requestId") ?? null;
+    const traceContext = getBackendTraceCarrier();
 
     if (limitParam !== undefined) {
       const limit = Math.min(Math.max(Number.parseInt(limitParam, 10) || 7, 1), MAX_CHAT_PAGE_LIMIT);
@@ -799,6 +905,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
           result,
           requestContext.userId,
           workspaceId,
+          requestId,
+          traceContext,
           createChatLiveStreamEnvelopeFn,
           resolveLiveCursorFn,
           context.req.raw,
@@ -819,6 +927,7 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
         await assertRunningSnapshotInvariant(
           context.req.raw,
           resumeDiagnostics,
+          requestId,
           snapshot,
           requestContext.userId,
           workspaceId,
@@ -828,6 +937,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
           snapshot,
           requestContext.userId,
           workspaceId,
+          requestId,
+          traceContext,
           createChatLiveStreamEnvelopeFn,
           resolveLiveCursorFn,
           context.req.raw,
@@ -848,11 +959,13 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
     const body = parseChatRequestBody(await parseJsonBody(context.req.raw));
     const workspaceId = await resolveAccessibleChatWorkspaceIdFn(requestContext, body.workspaceId);
     const resumeDiagnostics = readChatResumeDiagnosticsHeaders(context.req.raw);
+    const requestId = context.get("requestId") ?? null;
+    const traceContext = getBackendTraceCarrier();
     context.header("X-Chat-Request-Id", body.clientRequestId);
 
     let preparedRun: PreparedChatRun;
     try {
-      preparedRun = await prepareChatRunFn(
+      preparedRun = await startBackendSpan("chat.prepare_run", "app.chat", () => prepareChatRunFn(
         requestContext.userId,
         workspaceId,
         body.sessionId,
@@ -862,17 +975,20 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
         // Older clients still omit uiLocale, so keep the null fallback until
         // every supported app version has migrated to the explicit field.
         body.uiLocale ?? null,
-      );
+      ));
     } catch (error) {
       return mapStoreError(error);
     }
 
     if (preparedRun.shouldInvokeWorker) {
-      await invokeChatWorkerFn({
+      await startBackendSpan("chat.worker.invoke", "faas.invoke", () => invokeChatWorkerFn({
         runId: preparedRun.runId,
         userId: requestContext.userId,
         workspaceId,
-      });
+        routeRequestId: requestId,
+        chatRequestId: body.clientRequestId,
+        sessionId: preparedRun.sessionId,
+      }));
     }
 
     try {
@@ -887,6 +1003,8 @@ export function createChatRoutes(options: ChatRoutesOptions): Hono<AppEnv> {
         snapshot,
         userId: requestContext.userId,
         workspaceId,
+        requestId,
+        traceContext,
         createChatLiveStreamEnvelopeFn,
         resolveLiveCursorFn,
         interruptPreparedChatRunFn,

--- a/apps/backend/src/routes/globalSnapshot.test.ts
+++ b/apps/backend/src/routes/globalSnapshot.test.ts
@@ -289,7 +289,7 @@ test("OPTIONS /v1/global/snapshot returns public preflight headers on the mounte
   assert.equal(response.status, 204);
   assert.equal(response.headers.get("access-control-allow-origin"), "*");
   assert.equal(response.headers.get("access-control-allow-methods"), "GET,OPTIONS");
-  assert.equal(response.headers.get("access-control-allow-headers"), "authorization");
+  assert.equal(response.headers.get("access-control-allow-headers"), "authorization,sentry-trace,baggage");
   assert.equal(response.headers.get("access-control-allow-credentials"), null);
   assert.notEqual(response.headers.get("x-request-id"), null);
 });

--- a/apps/backend/src/routes/globalSnapshot.ts
+++ b/apps/backend/src/routes/globalSnapshot.ts
@@ -6,7 +6,10 @@ import {
   isGlobalMetricsVisible,
   loadGlobalMetricsSnapshotFromS3,
 } from "../globalMetrics/storage";
-import { logCloudRouteEvent } from "../server/logging";
+import {
+  captureBackendWarning,
+  createBackendObservationScope,
+} from "../observability/sentry";
 
 export const globalSnapshotPath = "/global/snapshot";
 const globalMetricsSnapshotUnavailableCode = "GLOBAL_METRICS_SNAPSHOT_UNAVAILABLE";
@@ -61,13 +64,26 @@ export function createGlobalSnapshotRoutes(options: GlobalSnapshotRoutesOptions)
         throw error;
       }
 
-      logCloudRouteEvent("global_snapshot_error", {
-        requestId: context.get("requestId"),
-        route: context.req.path,
-        statusCode: error.statusCode,
-        code: error.code,
-        storageErrorMessage: error.message,
-      }, true);
+      captureBackendWarning({
+        action: "global_snapshot_error",
+        message: "Global metrics snapshot is unavailable.",
+        scope: createBackendObservationScope(
+          "backend-api",
+          context.get("requestId"),
+          context.req.path,
+          context.req.method,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ),
+        details: {
+          statusCode: error.statusCode,
+          code: error.code,
+          storageErrorMessage: error.message,
+        },
+      });
 
       return applyGlobalSnapshotCorsHeaders(context.json({
         error: globalMetricsSnapshotUnavailableMessage,

--- a/apps/backend/src/routes/guestAuth.ts
+++ b/apps/backend/src/routes/guestAuth.ts
@@ -15,7 +15,15 @@ import {
   expectRecord,
   parseJsonBody,
 } from "../server/requestParsing";
-import { logCloudRouteEvent, summarizeValidationIssues } from "../server/logging";
+import { summarizeValidationIssues } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendFailureDetails,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
 import { extractRequestAuthInputs, toAuthRequest } from "../requestSecurity";
 import type { AppEnv } from "../app";
 
@@ -106,6 +114,34 @@ function expectGuestAuthorizationToken(authorizationHeader: string | undefined):
   return guestToken;
 }
 
+function createGuestUpgradeScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    null,
+    null,
+    null,
+    null,
+  );
+}
+
+function createFailureDetails(error: unknown): BackendFailureDetails {
+  return {
+    statusCode: error instanceof HttpError ? error.statusCode : 500,
+    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
+    message: error instanceof Error ? error.message : String(error),
+    validationIssues: summarizeValidationIssues(error),
+  };
+}
+
 export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const authenticateRequestFn = options.authenticateRequestFn ?? authenticateRequest;
@@ -167,20 +203,22 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
 
     try {
       const result = await completeGuestUpgradeFn(guestToken, auth.subjectUserId, selection, capabilities);
-      logCloudRouteEvent("guest_upgrade_complete", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        selectionType: selection.type,
-        guestWorkspaceSyncedAndOutboxDrained: capabilities.guestWorkspaceSyncedAndOutboxDrained,
-        requiresGuestWorkspaceSyncedAndOutboxDrained: capabilities.requiresGuestWorkspaceSyncedAndOutboxDrained,
-        supportsDroppedEntities: capabilities.supportsDroppedEntities,
-        targetSubjectUserId: result.targetSubjectUserId,
-        guestSessionId: result.guestSessionId,
-        targetUserId: result.targetUserId,
-        targetWorkspaceId: result.targetWorkspaceId,
-        completionKind: result.outcome,
-      }, false);
+      addBackendBreadcrumb({
+        action: "guest_upgrade_complete",
+        scope: createGuestUpgradeScope(requestId, context.req.path, context.req.method, result.targetUserId),
+        details: {
+          statusCode: 200,
+          selectionType: selection.type,
+          guestWorkspaceSyncedAndOutboxDrained: capabilities.guestWorkspaceSyncedAndOutboxDrained,
+          requiresGuestWorkspaceSyncedAndOutboxDrained: capabilities.requiresGuestWorkspaceSyncedAndOutboxDrained,
+          supportsDroppedEntities: capabilities.supportsDroppedEntities,
+          targetSubjectUserId: result.targetSubjectUserId,
+          guestSessionId: result.guestSessionId,
+          targetUserId: result.targetUserId,
+          targetWorkspaceId: result.targetWorkspaceId,
+          completionKind: result.outcome,
+        },
+      });
 
       const response: GuestUpgradeCompleteEnvelope = result.droppedEntities === undefined
         ? {
@@ -192,19 +230,24 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
         };
       return context.json(response);
     } catch (error) {
-      logCloudRouteEvent("guest_upgrade_complete_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
+      const scope = createGuestUpgradeScope(requestId, context.req.path, context.req.method, auth.userId);
+      const details = {
         selectionType: selection.type,
         guestWorkspaceSyncedAndOutboxDrained: capabilities.guestWorkspaceSyncedAndOutboxDrained,
         requiresGuestWorkspaceSyncedAndOutboxDrained: capabilities.requiresGuestWorkspaceSyncedAndOutboxDrained,
         supportsDroppedEntities: capabilities.supportsDroppedEntities,
         targetSubjectUserId: auth.subjectUserId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: error instanceof Error ? error.message : String(error),
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+        guestSessionId: null,
+        targetUserId: auth.userId,
+        targetWorkspaceId: null,
+        completionKind: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "guest_upgrade_complete_error", error: normalizeCaughtError(error), scope, details },
+        { action: "guest_upgrade_complete_error", scope, details },
+      );
       throw error;
     }
   });

--- a/apps/backend/src/routes/sync.ts
+++ b/apps/backend/src/routes/sync.ts
@@ -26,10 +26,20 @@ import {
 } from "../server/requestContext";
 import { parseJsonBody } from "../server/requestParsing";
 import {
-  logCloudRouteEvent,
   summarizeValidationIssues,
 } from "../server/logging";
 import { withTransientDatabaseRetry } from "../dbTransient";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendFailureDetails,
+  type BackendObservationScope,
+  type BackendSyncConflictDetails,
+  type SyncPullDetails,
+  type SyncReviewHistoryPullDetails,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
 import type { AppEnv } from "../app";
 
 type SyncRoutesOptions = Readonly<{
@@ -63,7 +73,9 @@ function getRequestContextUserId(requestContext: RequestContext | null): string 
   return requestContext === null ? null : requestContext.userId;
 }
 
-function getSyncPullInputLogContext(input: SyncPullInput | null): Record<string, unknown> {
+function getSyncPullInputDetails(
+  input: SyncPullInput | null,
+): Pick<SyncPullDetails, "installationId" | "platform" | "appVersion" | "afterHotChangeId"> {
   if (input === null) {
     return {
       installationId: null,
@@ -81,9 +93,9 @@ function getSyncPullInputLogContext(input: SyncPullInput | null): Record<string,
   };
 }
 
-function getSyncReviewHistoryPullInputLogContext(
+function getSyncReviewHistoryPullInputDetails(
   input: SyncReviewHistoryPullInput | null,
-): Record<string, unknown> {
+): Pick<SyncReviewHistoryPullDetails, "installationId" | "platform" | "appVersion" | "afterReviewSequenceId"> {
   if (input === null) {
     return {
       installationId: null,
@@ -101,14 +113,14 @@ function getSyncReviewHistoryPullInputLogContext(
   };
 }
 
-function getSyncConflictLogContext(error: HttpError | unknown): Record<string, unknown> {
+function getSyncConflictLogContext(error: HttpError | unknown): BackendSyncConflictDetails {
   if (!(error instanceof HttpError)) {
-    return {};
+    return emptySyncConflictDetails();
   }
 
   const syncConflict = error.details?.syncConflict;
   if (syncConflict === undefined) {
-    return {};
+    return emptySyncConflictDetails();
   }
 
   return {
@@ -122,6 +134,50 @@ function getSyncConflictLogContext(error: HttpError | unknown): Record<string, u
     entryIndex: syncConflict.entryIndex ?? null,
     reviewEventIndex: syncConflict.reviewEventIndex ?? null,
     syncConflictRecoverable: syncConflict.recoverable,
+  };
+}
+
+function emptySyncConflictDetails(): BackendSyncConflictDetails {
+  return {
+    syncConflictPhase: null,
+    syncConflictEntityType: null,
+    syncConflictEntityId: null,
+    conflictingWorkspaceId: null,
+    constraint: null,
+    sqlState: null,
+    table: null,
+    entryIndex: null,
+    reviewEventIndex: null,
+    syncConflictRecoverable: null,
+  };
+}
+
+function createSyncScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string | null,
+  workspaceId: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+  );
+}
+
+function createFailureDetails(error: unknown): BackendFailureDetails {
+  return {
+    statusCode: error instanceof HttpError ? error.statusCode : 500,
+    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
+    message: getInternalErrorMessage(error),
+    validationIssues: summarizeValidationIssues(error),
   };
 }
 
@@ -143,36 +199,35 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
 
     try {
       const result = await processSyncPush(workspaceId, requestContext.userId, input);
-      logCloudRouteEvent("sync_push", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-        installationId: input.installationId,
-        platform: input.platform,
-        appVersion: input.appVersion ?? null,
-        operationsCount: input.operations.length,
-        entityTypes,
-      }, false);
+      addBackendBreadcrumb({
+        action: "sync_push",
+        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        details: {
+          statusCode: 200,
+          installationId: input.installationId,
+          platform: input.platform,
+          appVersion: input.appVersion ?? null,
+          operationsCount: input.operations.length,
+          entityTypes,
+        },
+      });
       return context.json(result);
     } catch (error) {
-      logCloudRouteEvent("sync_push_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
+      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
         installationId: input.installationId,
         platform: input.platform,
         appVersion: input.appVersion ?? null,
         operationsCount: input.operations.length,
         entityTypes,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: getInternalErrorMessage(error),
-        validationIssues: summarizeValidationIssues(error),
+        ...createFailureDetails(error),
         ...getSyncConflictLogContext(error),
-      }, true);
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "sync_push_error", error: normalizeCaughtError(error), scope, details },
+        { action: "sync_push_error", scope, details },
+      );
       throw error;
     }
   });
@@ -211,32 +266,45 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
           };
         },
       );
-      logCloudRouteEvent("sync_pull", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: routeState.requestContext.userId,
-        workspaceId: routeState.workspaceId,
-        installationId: routeState.input.installationId,
-        platform: routeState.input.platform,
-        appVersion: routeState.input.appVersion ?? null,
-        afterHotChangeId: routeState.input.afterHotChangeId,
-        nextHotChangeId: routeState.result.nextHotChangeId,
-        changesCount: routeState.result.changes.length,
-      }, false);
+      addBackendBreadcrumb({
+        action: "sync_pull",
+        scope: createSyncScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          routeState.requestContext.userId,
+          routeState.workspaceId,
+        ),
+        details: {
+          statusCode: 200,
+          installationId: routeState.input.installationId,
+          platform: routeState.input.platform,
+          appVersion: routeState.input.appVersion ?? null,
+          afterHotChangeId: routeState.input.afterHotChangeId,
+          nextHotChangeId: routeState.result.nextHotChangeId,
+          changesCount: routeState.result.changes.length,
+        },
+      });
       return context.json(routeState.result);
     } catch (error) {
-      logCloudRouteEvent("sync_pull_error", {
+      const scope = createSyncScope(
         requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: getRequestContextUserId(requestContext),
+        context.req.path,
+        context.req.method,
+        getRequestContextUserId(requestContext),
         workspaceId,
-        ...getSyncPullInputLogContext(input),
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: getInternalErrorMessage(error),
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      );
+      const details = {
+        ...getSyncPullInputDetails(input),
+        nextHotChangeId: null,
+        changesCount: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "sync_pull_error", error: normalizeCaughtError(error), scope, details },
+        { action: "sync_pull_error", scope, details },
+      );
       throw error;
     }
   });
@@ -250,34 +318,33 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
 
     try {
       const result = await processSyncBootstrap(workspaceId, requestContext.userId, input);
-      logCloudRouteEvent("sync_bootstrap", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-        installationId: input.installationId,
-        platform: input.platform,
-        appVersion: input.appVersion ?? null,
-        mode: input.mode,
-      }, false);
+      addBackendBreadcrumb({
+        action: "sync_bootstrap",
+        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        details: {
+          statusCode: 200,
+          installationId: input.installationId,
+          platform: input.platform,
+          appVersion: input.appVersion ?? null,
+          mode: input.mode,
+        },
+      });
       return context.json(result);
     } catch (error) {
-      logCloudRouteEvent("sync_bootstrap_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
+      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
         installationId: input.installationId,
         platform: input.platform,
         appVersion: input.appVersion ?? null,
         mode: input.mode,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: getInternalErrorMessage(error),
-        validationIssues: summarizeValidationIssues(error),
+        ...createFailureDetails(error),
         ...getSyncConflictLogContext(error),
-      }, true);
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "sync_bootstrap_error", error: normalizeCaughtError(error), scope, details },
+        { action: "sync_bootstrap_error", scope, details },
+      );
       throw error;
     }
   });
@@ -316,32 +383,45 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
           };
         },
       );
-      logCloudRouteEvent("sync_review_history_pull", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: routeState.requestContext.userId,
-        workspaceId: routeState.workspaceId,
-        installationId: routeState.input.installationId,
-        platform: routeState.input.platform,
-        appVersion: routeState.input.appVersion ?? null,
-        afterReviewSequenceId: routeState.input.afterReviewSequenceId,
-        nextReviewSequenceId: routeState.result.nextReviewSequenceId,
-        reviewEventsCount: routeState.result.reviewEvents.length,
-      }, false);
+      addBackendBreadcrumb({
+        action: "sync_review_history_pull",
+        scope: createSyncScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          routeState.requestContext.userId,
+          routeState.workspaceId,
+        ),
+        details: {
+          statusCode: 200,
+          installationId: routeState.input.installationId,
+          platform: routeState.input.platform,
+          appVersion: routeState.input.appVersion ?? null,
+          afterReviewSequenceId: routeState.input.afterReviewSequenceId,
+          nextReviewSequenceId: routeState.result.nextReviewSequenceId,
+          reviewEventsCount: routeState.result.reviewEvents.length,
+        },
+      });
       return context.json(routeState.result);
     } catch (error) {
-      logCloudRouteEvent("sync_review_history_pull_error", {
+      const scope = createSyncScope(
         requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: getRequestContextUserId(requestContext),
+        context.req.path,
+        context.req.method,
+        getRequestContextUserId(requestContext),
         workspaceId,
-        ...getSyncReviewHistoryPullInputLogContext(input),
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: getInternalErrorMessage(error),
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      );
+      const details = {
+        ...getSyncReviewHistoryPullInputDetails(input),
+        nextReviewSequenceId: null,
+        reviewEventsCount: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "sync_review_history_pull_error", error: normalizeCaughtError(error), scope, details },
+        { action: "sync_review_history_pull_error", scope, details },
+      );
       throw error;
     }
   });
@@ -355,36 +435,37 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
 
     try {
       const result = await processSyncReviewHistoryImport(workspaceId, requestContext.userId, input);
-      logCloudRouteEvent("sync_review_history_import", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-        installationId: input.installationId,
-        platform: input.platform,
-        appVersion: input.appVersion ?? null,
-        reviewEventsCount: input.reviewEvents.length,
-        importedCount: result.importedCount,
-        duplicateCount: result.duplicateCount,
-      }, false);
+      addBackendBreadcrumb({
+        action: "sync_review_history_import",
+        scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        details: {
+          statusCode: 200,
+          installationId: input.installationId,
+          platform: input.platform,
+          appVersion: input.appVersion ?? null,
+          reviewEventsCount: input.reviewEvents.length,
+          importedCount: result.importedCount,
+          duplicateCount: result.duplicateCount,
+        },
+      });
       return context.json(result);
     } catch (error) {
-      logCloudRouteEvent("sync_review_history_import_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
+      const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
         installationId: input.installationId,
         platform: input.platform,
         appVersion: input.appVersion ?? null,
         reviewEventsCount: input.reviewEvents.length,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        message: getInternalErrorMessage(error),
-        validationIssues: summarizeValidationIssues(error),
+        importedCount: null,
+        duplicateCount: null,
+        ...createFailureDetails(error),
         ...getSyncConflictLogContext(error),
-      }, true);
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "sync_review_history_import_error", error: normalizeCaughtError(error), scope, details },
+        { action: "sync_review_history_import_error", scope, details },
+      );
       throw error;
     }
   });

--- a/apps/backend/src/routes/system.ts
+++ b/apps/backend/src/routes/system.ts
@@ -25,7 +25,15 @@ import {
 } from "../requestSecurity";
 import { expectRecord, parseJsonBody } from "../server/requestParsing";
 import { loadRequestContextFromRequest } from "../server/requestContext";
-import { logCloudRouteEvent, summarizeValidationIssues } from "../server/logging";
+import { summarizeValidationIssues } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendFailureDetails,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
 import type { AppEnv } from "../app";
 
 type SystemRoutesOptions = Readonly<{
@@ -58,6 +66,34 @@ function assertProgressHumanTransport(transport: string): void {
       "PROGRESS_HUMAN_AUTH_REQUIRED",
     );
   }
+}
+
+function createSystemScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    null,
+    null,
+    null,
+    null,
+  );
+}
+
+function createFailureDetails(error: unknown): BackendFailureDetails {
+  return {
+    statusCode: error instanceof HttpError ? error.statusCode : 500,
+    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
+    message: error instanceof Error ? error.message : String(error),
+    validationIssues: summarizeValidationIssues(error),
+  };
 }
 
 export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
@@ -123,32 +159,39 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         timeZone: progressInput.timeZone,
       });
 
-      logCloudRouteEvent("me_progress_summary", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        authTransport: requestContext.transport,
-        timeZone: progress.timeZone,
-        currentStreakDays: progress.summary.currentStreakDays,
-        hasReviewedToday: progress.summary.hasReviewedToday,
-        lastReviewedOn: progress.summary.lastReviewedOn,
-        activeReviewDays: progress.summary.activeReviewDays,
-        generatedAt: progress.generatedAt,
-      }, false);
+      addBackendBreadcrumb({
+        action: "me_progress_summary",
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        details: {
+          statusCode: 200,
+          authTransport: requestContext.transport,
+          timeZone: progress.timeZone,
+          currentStreakDays: progress.summary.currentStreakDays,
+          hasReviewedToday: progress.summary.hasReviewedToday,
+          lastReviewedOn: progress.summary.lastReviewedOn,
+          activeReviewDays: progress.summary.activeReviewDays,
+          generatedAt: progress.generatedAt,
+        },
+      });
 
       return context.json(progress satisfies ProgressSummaryResponse);
     } catch (error) {
-      logCloudRouteEvent("me_progress_summary_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const details = {
         authTransport: requestContext.transport,
         timeZone: requestedParameters.timeZone,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+        currentStreakDays: null,
+        hasReviewedToday: null,
+        lastReviewedOn: null,
+        activeReviewDays: null,
+        generatedAt: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "me_progress_summary_error", error: normalizeCaughtError(error), scope, details },
+        { action: "me_progress_summary_error", scope, details },
+      );
       throw error;
     }
   });
@@ -171,30 +214,35 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         timeZone: progressInput.timeZone,
       });
 
-      logCloudRouteEvent("me_progress_review_schedule", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        authTransport: requestContext.transport,
-        timeZone: progress.timeZone,
-        bucketCount: progress.buckets.length,
-        totalCards: progress.totalCards,
-        generatedAt: progress.generatedAt,
-      }, false);
+      addBackendBreadcrumb({
+        action: "me_progress_review_schedule",
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        details: {
+          statusCode: 200,
+          authTransport: requestContext.transport,
+          timeZone: progress.timeZone,
+          bucketCount: progress.buckets.length,
+          totalCards: progress.totalCards,
+          generatedAt: progress.generatedAt,
+        },
+      });
 
       return context.json(progress satisfies ProgressReviewSchedule);
     } catch (error) {
-      logCloudRouteEvent("me_progress_review_schedule_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const details = {
         authTransport: requestContext.transport,
         timeZone: requestedParameters.timeZone,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+        bucketCount: null,
+        totalCards: null,
+        generatedAt: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "me_progress_review_schedule_error", error: normalizeCaughtError(error), scope, details },
+        { action: "me_progress_review_schedule_error", scope, details },
+      );
       throw error;
     }
   });
@@ -220,34 +268,39 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
       });
       const hasNonZeroReviewDays = progress.dailyReviews.some((day) => day.reviewCount > 0);
 
-      logCloudRouteEvent("me_progress_series", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        authTransport: requestContext.transport,
-        timeZone: progress.timeZone,
-        from: progress.from,
-        to: progress.to,
-        returnedDayCount: progress.dailyReviews.length,
-        hasNonZeroReviewDays,
-        generatedAt: progress.generatedAt,
-      }, false);
+      addBackendBreadcrumb({
+        action: "me_progress_series",
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        details: {
+          statusCode: 200,
+          authTransport: requestContext.transport,
+          timeZone: progress.timeZone,
+          from: progress.from,
+          to: progress.to,
+          returnedDayCount: progress.dailyReviews.length,
+          hasNonZeroReviewDays,
+          generatedAt: progress.generatedAt,
+        },
+      });
 
       return context.json(progress satisfies ProgressSeries);
     } catch (error) {
-      logCloudRouteEvent("me_progress_series_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const details = {
         authTransport: requestContext.transport,
         timeZone: requestedParameters.timeZone,
         from: requestedParameters.from,
         to: requestedParameters.to,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+        returnedDayCount: null,
+        hasNonZeroReviewDays: null,
+        generatedAt: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "me_progress_series_error", error: normalizeCaughtError(error), scope, details },
+        { action: "me_progress_series_error", scope, details },
+      );
       throw error;
     }
   });
@@ -286,24 +339,26 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         cognitoUsername: auth.cognitoUsername,
         confirmationText: body.confirmationText,
       });
-      logCloudRouteEvent("account_delete", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: auth.userId,
-        transport: auth.transport,
-      }, false);
+      addBackendBreadcrumb({
+        action: "account_delete",
+        scope: createSystemScope(requestId, context.req.path, context.req.method, auth.userId),
+        details: {
+          statusCode: 200,
+          transport: auth.transport,
+        },
+      });
       return context.json({ ok: true } as const);
     } catch (error) {
-      logCloudRouteEvent("account_delete_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: auth.userId,
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, auth.userId);
+      const details = {
         transport: auth.transport,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "account_delete_error", error: normalizeCaughtError(error), scope, details },
+        { action: "account_delete_error", scope, details },
+      );
       throw error;
     }
   });

--- a/apps/backend/src/routes/workspaces.ts
+++ b/apps/backend/src/routes/workspaces.ts
@@ -14,14 +14,8 @@ import {
 } from "../agent/apiKeys";
 import { parseOptionalCursorQuery, parseRequiredPageLimit } from "../pagination";
 import {
-  createWorkspaceForApiKeyConnection,
-  createWorkspaceForUser,
-  deleteWorkspaceForUser,
   listUserWorkspacesPageForSelectedWorkspace,
-  loadWorkspaceDeletePreviewForUser,
-  loadWorkspaceResetProgressPreviewForUser,
   renameWorkspaceForUser,
-  resetWorkspaceProgressForUser,
   selectWorkspaceForApiKeyConnection,
   selectWorkspaceForUser,
   type DeleteWorkspaceResult,
@@ -30,6 +24,16 @@ import {
   type WorkspaceResetProgressPreview,
   type WorkspaceSummary,
 } from "../workspaces";
+import {
+  createWorkspaceForApiKeyConnectionWithObservationScope,
+  createWorkspaceForUserWithObservationScope,
+} from "../workspaces/create";
+import {
+  deleteWorkspaceForUserWithObservationScope,
+  loadWorkspaceDeletePreviewForUserWithObservationScope,
+  loadWorkspaceResetProgressPreviewForUserWithObservationScope,
+  resetWorkspaceProgressForUserWithObservationScope,
+} from "../workspaces/management";
 import { HttpError } from "../errors";
 import {
   loadRequestContextFromRequest,
@@ -42,9 +46,16 @@ import {
   parseJsonBody,
 } from "../server/requestParsing";
 import {
-  logCloudRouteEvent,
   summarizeValidationIssues,
 } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendFailureDetails,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
 import type { AppEnv } from "../app";
 
 type WorkspaceRoutesOptions = Readonly<{
@@ -81,6 +92,35 @@ function parseCursorQueryParams(request: Request): CursorQueryParams {
   };
 }
 
+function createWorkspaceRouteScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string,
+  workspaceId: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+  );
+}
+
+function createFailureDetails(error: unknown): BackendFailureDetails {
+  return {
+    statusCode: error instanceof HttpError ? error.statusCode : 500,
+    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
+    message: error instanceof Error ? error.message : String(error),
+    validationIssues: summarizeValidationIssues(error),
+  };
+}
+
 export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
 
@@ -101,16 +141,17 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
           requestContext.selectedWorkspaceId,
           pageInput,
         );
-      logCloudRouteEvent("workspaces_list", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        selectedWorkspaceId: requestContext.selectedWorkspaceId,
-        workspacesCount: workspacesPage.workspaces.length,
-        limit: pageInput.limit,
-        hasNextCursor: workspacesPage.nextCursor !== null,
-      }, false);
+      addBackendBreadcrumb({
+        action: "workspaces_list",
+        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null),
+        details: {
+          statusCode: 200,
+          selectedWorkspaceId: requestContext.selectedWorkspaceId,
+          workspacesCount: workspacesPage.workspaces.length,
+          limit: pageInput.limit,
+          hasNextCursor: workspacesPage.nextCursor !== null,
+        },
+      });
       if (shouldUseAgentSetupEnvelope(requestContext.transport)) {
         return context.json(createAgentWorkspacesEnvelope(
           context.req.url,
@@ -123,15 +164,19 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
         nextCursor: workspacesPage.nextCursor,
       } satisfies WorkspacesPageResponse);
     } catch (error) {
-      logCloudRouteEvent("workspaces_list_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null);
+      const details = {
         selectedWorkspaceId: requestContext.selectedWorkspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+        workspacesCount: null,
+        limit: pageInput.limit,
+        hasNextCursor: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspaces_list_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspaces_list_error", scope, details },
+      );
       throw error;
     }
   });
@@ -143,33 +188,36 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
 
     try {
       const workspaceName = expectNonEmptyString(body.name, "name");
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null);
       const workspace = shouldUseAgentSetupEnvelope(requestContext.transport)
-        ? await createWorkspaceForApiKeyConnection(
+        ? await createWorkspaceForApiKeyConnectionWithObservationScope(
           requestContext.userId,
           requireAgentConnectionId(requestContext),
           workspaceName,
+          scope,
         )
-        : await createWorkspaceForUser(requestContext.userId, workspaceName);
-      logCloudRouteEvent("workspace_create", {
-        requestId,
-        route: context.req.path,
-        statusCode: 201,
-        userId: requestContext.userId,
-        workspaceId: workspace.workspaceId,
-      }, false);
+        : await createWorkspaceForUserWithObservationScope(requestContext.userId, workspaceName, scope);
+      addBackendBreadcrumb({
+        action: "workspace_create",
+        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspace.workspaceId),
+        details: {
+          statusCode: 201,
+        },
+      });
       if (shouldUseAgentSetupEnvelope(requestContext.transport)) {
         return context.json(createAgentWorkspaceReadyEnvelope(context.req.url, workspace), 201);
       }
       return context.json({ workspace }, 201);
     } catch (error) {
-      logCloudRouteEvent("workspace_create_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null);
+      const details = {
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_create_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_create_error", scope, details },
+      );
       throw error;
     }
   });
@@ -187,27 +235,27 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
           workspaceId,
         )
         : await selectWorkspaceForUser(requestContext.userId, workspaceId);
-      logCloudRouteEvent("workspace_select", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-      }, false);
+      addBackendBreadcrumb({
+        action: "workspace_select",
+        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        details: {
+          statusCode: 200,
+        },
+      });
       if (shouldUseAgentSetupEnvelope(requestContext.transport)) {
         return context.json(createAgentWorkspaceReadyEnvelope(context.req.url, workspace));
       }
       return context.json({ workspace });
     } catch (error) {
-      logCloudRouteEvent("workspace_select_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_select_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_select_error", scope, details },
+      );
       throw error;
     }
   });
@@ -227,24 +275,24 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
         workspaceName,
         requestContext.selectedWorkspaceId,
       );
-      logCloudRouteEvent("workspace_rename", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-      }, false);
+      addBackendBreadcrumb({
+        action: "workspace_rename",
+        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
+        details: {
+          statusCode: 200,
+        },
+      });
       return context.json({ workspace });
     } catch (error) {
-      logCloudRouteEvent("workspace_rename_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_rename_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_rename_error", scope, details },
+      );
       throw error;
     }
   });
@@ -256,26 +304,32 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     const requestId = context.get("requestId");
 
     try {
-      const preview = await loadWorkspaceDeletePreviewForUser(requestContext.userId, workspaceId);
-      logCloudRouteEvent("workspace_delete_preview", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const preview = await loadWorkspaceDeletePreviewForUserWithObservationScope(
+        requestContext.userId,
         workspaceId,
-        cardsCount: preview.activeCardCount,
-      }, false);
+        scope,
+      );
+      addBackendBreadcrumb({
+        action: "workspace_delete_preview",
+        scope,
+        details: {
+          statusCode: 200,
+          cardsCount: preview.activeCardCount,
+        },
+      });
       return context.json(preview satisfies WorkspaceDeletePreview);
     } catch (error) {
-      logCloudRouteEvent("workspace_delete_preview_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
+        cardsCount: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_delete_preview_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_delete_preview_error", scope, details },
+      );
       throw error;
     }
   });
@@ -296,31 +350,35 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     }
 
     try {
-      const response = await deleteWorkspaceForUser(
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const response = await deleteWorkspaceForUserWithObservationScope(
         requestContext.userId,
         workspaceId,
         body.confirmationText,
+        scope,
       );
-      logCloudRouteEvent("workspace_delete", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-        deletedCardsCount: response.deletedCardsCount,
-        nextWorkspaceId: response.workspace.workspaceId,
-      }, false);
+      addBackendBreadcrumb({
+        action: "workspace_delete",
+        scope,
+        details: {
+          statusCode: 200,
+          deletedCardsCount: response.deletedCardsCount,
+          nextWorkspaceId: response.workspace.workspaceId,
+        },
+      });
       return context.json(response satisfies WorkspaceDeleteResponse);
     } catch (error) {
-      logCloudRouteEvent("workspace_delete_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
+        deletedCardsCount: null,
+        nextWorkspaceId: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_delete_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_delete_error", scope, details },
+      );
       throw error;
     }
   });
@@ -332,26 +390,32 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     const requestId = context.get("requestId");
 
     try {
-      const preview = await loadWorkspaceResetProgressPreviewForUser(requestContext.userId, workspaceId);
-      logCloudRouteEvent("workspace_reset_progress_preview", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const preview = await loadWorkspaceResetProgressPreviewForUserWithObservationScope(
+        requestContext.userId,
         workspaceId,
-        cardsCount: preview.cardsToResetCount,
-      }, false);
+        scope,
+      );
+      addBackendBreadcrumb({
+        action: "workspace_reset_progress_preview",
+        scope,
+        details: {
+          statusCode: 200,
+          cardsCount: preview.cardsToResetCount,
+        },
+      });
       return context.json(preview satisfies WorkspaceResetProgressPreviewResponse);
     } catch (error) {
-      logCloudRouteEvent("workspace_reset_progress_preview_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
+        cardsCount: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_reset_progress_preview_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_reset_progress_preview_error", scope, details },
+      );
       throw error;
     }
   });
@@ -372,30 +436,33 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     }
 
     try {
-      const response = await resetWorkspaceProgressForUser(
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const response = await resetWorkspaceProgressForUserWithObservationScope(
         requestContext.userId,
         workspaceId,
         body.confirmationText,
+        scope,
       );
-      logCloudRouteEvent("workspace_reset_progress", {
-        requestId,
-        route: context.req.path,
-        statusCode: 200,
-        userId: requestContext.userId,
-        workspaceId,
-        cardsResetCount: response.cardsResetCount,
-      }, false);
+      addBackendBreadcrumb({
+        action: "workspace_reset_progress",
+        scope,
+        details: {
+          statusCode: 200,
+          cardsResetCount: response.cardsResetCount,
+        },
+      });
       return context.json(response satisfies WorkspaceResetProgressResponse);
     } catch (error) {
-      logCloudRouteEvent("workspace_reset_progress_error", {
-        requestId,
-        route: context.req.path,
-        statusCode: error instanceof HttpError ? error.statusCode : 500,
-        userId: requestContext.userId,
-        workspaceId,
-        code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-        validationIssues: summarizeValidationIssues(error),
-      }, true);
+      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
+      const details = {
+        cardsResetCount: null,
+        ...createFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_reset_progress_error", error: normalizeCaughtError(error), scope, details },
+        { action: "workspace_reset_progress_error", scope, details },
+      );
       throw error;
     }
   });

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -1,73 +1,31 @@
 import { AuthError } from "../auth";
 import { HttpError } from "../errors";
+import { sanitizeBackendTelemetryValue } from "../observability/sanitizer";
+import {
+  addBackendSentryBreadcrumb,
+  createBackendObservationScope,
+  getBackendErrorLogDetails,
+  type AdminQueryDetails,
+  type BackendObservationScope,
+  type BackendErrorLogDetails,
+} from "../observability/sentry";
 
 function getInternalErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-type ErrorSourceLocation = Readonly<{
-  sourceFile: string | null;
-  sourceLine: number | null;
-  sourceColumn: number | null;
+export type ErrorLogContext = BackendErrorLogDetails;
+
+type AdminQueryLogPayload = Readonly<{
+  requestId: string;
+}> & AdminQueryDetails;
+
+type CloudWatchAdminQueryDetails = Omit<AdminQueryDetails, "adminEmail"> & Readonly<{
+  adminEmail: string;
 }>;
 
-export type ErrorLogContext = Readonly<{
-  errorClass: string;
-  errorMessage: string;
-  errorStack: string | null;
-}> & ErrorSourceLocation;
-
-function parseErrorSourceLocation(stack: string | null): ErrorSourceLocation {
-  if (stack === null) {
-    return {
-      sourceFile: null,
-      sourceLine: null,
-      sourceColumn: null,
-    };
-  }
-
-  const stackLines = stack.split("\n");
-  for (const stackLine of stackLines.slice(1)) {
-    const trimmedLine = stackLine.trim();
-    const match = /^\s*at .+ \((.+):(\d+):(\d+)\)$/.exec(trimmedLine)
-      ?? /^\s*at (.+):(\d+):(\d+)$/.exec(trimmedLine)
-      ?? /^(.+):(\d+):(\d+)$/.exec(trimmedLine);
-    if (match === null) {
-      continue;
-    }
-
-    return {
-      sourceFile: match[1] ?? null,
-      sourceLine: Number.parseInt(match[2] ?? "", 10),
-      sourceColumn: Number.parseInt(match[3] ?? "", 10),
-    };
-  }
-
-  return {
-    sourceFile: null,
-    sourceLine: null,
-    sourceColumn: null,
-  };
-}
-
 export function getErrorLogContext(error: unknown): ErrorLogContext {
-  if (error instanceof Error) {
-    return {
-      errorClass: error.name,
-      errorMessage: error.message,
-      errorStack: error.stack ?? null,
-      ...parseErrorSourceLocation(error.stack ?? null),
-    };
-  }
-
-  return {
-    errorClass: "UnknownError",
-    errorMessage: String(error),
-    errorStack: null,
-    sourceFile: null,
-    sourceLine: null,
-    sourceColumn: null,
-  };
+  return getBackendErrorLogDetails(error);
 }
 
 function getDatabaseSqlState(error: unknown): string | null {
@@ -79,34 +37,22 @@ function getDatabaseSqlState(error: unknown): string | null {
   return typeof code === "string" && code !== "" ? code : null;
 }
 
-function readErrorStringField(error: unknown, fieldName: string): string | null {
-  if (typeof error !== "object" || error === null || !(fieldName in error)) {
-    return null;
+function redactAdminEmailForCloudWatch(adminEmail: string): string {
+  const sanitizedValue = sanitizeBackendTelemetryValue(adminEmail);
+  if (typeof sanitizedValue !== "string") {
+    throw new Error("Expected sanitized adminEmail to remain a string");
   }
 
-  const fieldValue = (error as Readonly<Record<string, unknown>>)[fieldName];
-  return typeof fieldValue === "string" && fieldValue !== "" ? fieldValue : null;
+  return sanitizedValue === adminEmail ? "<redacted-admin-email>" : sanitizedValue;
 }
 
-function getDatabaseErrorLogContext(error: unknown): Record<string, string | null> {
-  const sqlState = readErrorStringField(error, "sqlState");
-  const errorCode = readErrorStringField(error, "errorCode");
-  const databaseErrorClass = readErrorStringField(error, "databaseErrorClass");
-  const databaseErrorMessage = readErrorStringField(error, "databaseErrorMessage");
-  if (
-    sqlState === null
-    && errorCode === null
-    && databaseErrorClass === null
-    && databaseErrorMessage === null
-  ) {
-    return {};
-  }
-
+function createCloudWatchAdminQueryDetails(details: AdminQueryDetails): CloudWatchAdminQueryDetails {
   return {
-    sqlState,
-    errorCode,
-    databaseErrorClass,
-    databaseErrorMessage,
+    adminEmail: redactAdminEmailForCloudWatch(details.adminEmail),
+    statementCount: details.statementCount,
+    durationMs: details.durationMs,
+    success: details.success,
+    sqlFingerprint: details.sqlFingerprint,
   };
 }
 
@@ -140,9 +86,7 @@ export function logRequestError(
       ...baseRecord,
       statusCode: error.statusCode,
       code: error.code,
-      details: error.details,
-      validationIssues: error.details?.validationIssues ?? [],
-      ...getDatabaseErrorLogContext(error),
+      validationIssues: summarizeValidationIssues(error),
       ...errorContext,
     }));
     return;
@@ -157,34 +101,40 @@ export function logRequestError(
   }));
 }
 
-export function logCloudRouteEvent(
-  action: string,
-  payload: Record<string, unknown>,
-  isError: boolean,
-): void {
-  const logger = isError ? console.error : console.log;
-  logger(JSON.stringify({
-    domain: "backend",
-    action,
-    ...payload,
-  }));
-}
-
 export function logAdminQueryEvent(
-  payload: Readonly<{
-    requestId: string;
-    adminEmail: string;
-    statementCount: number;
-    durationMs: number;
-    success: boolean;
-    sqlFingerprint: string;
-  }>,
+  payload: AdminQueryLogPayload,
 ): void {
+  const scope: BackendObservationScope = createBackendObservationScope(
+    "backend-api",
+    payload.requestId,
+    "/admin/reports/query",
+    "POST",
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+  const details: AdminQueryDetails = {
+    adminEmail: payload.adminEmail,
+    statementCount: payload.statementCount,
+    durationMs: payload.durationMs,
+    success: payload.success,
+    sqlFingerprint: payload.sqlFingerprint,
+  };
+
   console.log(JSON.stringify({
     domain: "backend",
     action: "admin_query",
-    ...payload,
+    ...scope,
+    ...createCloudWatchAdminQueryDetails(details),
   }));
+
+  addBackendSentryBreadcrumb({
+    action: "admin_query",
+    scope,
+    details,
+  });
 }
 
 export function summarizeValidationIssues(

--- a/apps/backend/src/telemetry/langfuse.test.ts
+++ b/apps/backend/src/telemetry/langfuse.test.ts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BasicTracerProvider, Sampler } from "@opentelemetry/sdk-trace-base";
+import { NoopSpanProcessor, SamplingDecision } from "@opentelemetry/sdk-trace-base";
+import { LangfuseSpanProcessor } from "@langfuse/otel";
+import {
+  initializeBackendSentryWithDeps,
+  resetBackendSentryForTests,
+} from "../observability/sentry";
+import {
+  createLangfuseTracerProvider,
+  flushLangfuseTelemetry,
+  initializeLangfuseTelemetryWithDeps,
+  resetLangfuseTelemetryForTests,
+  sanitizeTelemetryValue,
+} from "./langfuse";
+
+const LANGFUSE_ENV_NAMES = [
+  "LANGFUSE_PUBLIC_KEY",
+  "LANGFUSE_SECRET_KEY",
+  "LANGFUSE_BASE_URL",
+  "SENTRY_DSN",
+] as const;
+
+type LangfuseEnvName = typeof LANGFUSE_ENV_NAMES[number];
+type EnvSnapshot = Readonly<Record<LangfuseEnvName, string | undefined>>;
+type SamplingSampler = Readonly<{
+  shouldSample: () => Readonly<{
+    decision: SamplingDecision;
+  }>;
+  toString: () => string;
+}>;
+type BasicTracerProviderConfig = Readonly<{
+  _config: Readonly<{
+    sampler: Sampler;
+  }>;
+}>;
+
+function snapshotEnv(): EnvSnapshot {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    SENTRY_DSN: process.env.SENTRY_DSN,
+  };
+}
+
+function writeOptionalEnv(name: LangfuseEnvName, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
+function restoreEnv(snapshot: EnvSnapshot): void {
+  for (const name of LANGFUSE_ENV_NAMES) {
+    writeOptionalEnv(name, snapshot[name]);
+  }
+}
+
+function configureLangfuseEnvWithSentryDsn(): void {
+  process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
+  process.env.LANGFUSE_SECRET_KEY = "sk-test";
+  process.env.LANGFUSE_BASE_URL = "https://langfuse.example.invalid";
+  process.env.SENTRY_DSN = "https://sentry.example.invalid/1";
+}
+
+function createTestLangfuseSpanProcessor(): LangfuseSpanProcessor {
+  return new LangfuseSpanProcessor({
+    publicKey: "pk-test",
+    secretKey: "sk-test",
+    baseUrl: "https://langfuse.example.invalid",
+    exportMode: "immediate",
+  });
+}
+
+function getTracerProviderSampler(provider: BasicTracerProvider): SamplingSampler {
+  const providerConfig = provider as unknown as BasicTracerProviderConfig;
+  return providerConfig._config.sampler as unknown as SamplingSampler;
+}
+
+test("Langfuse tracer provider always samples spans independent from active parents", () => {
+  const tracerProvider = createLangfuseTracerProvider(new NoopSpanProcessor());
+  const sampler = getTracerProviderSampler(tracerProvider);
+
+  assert.equal(sampler.toString(), "AlwaysOnSampler");
+  assert.equal(sampler.shouldSample().decision, SamplingDecision.RECORD_AND_SAMPLED);
+});
+
+test("Langfuse sanitizer preserves AI content while redacting credentials and emails", () => {
+  const sanitized = sanitizeTelemetryValue({
+    frontText: "What does async mean? Ask teacher@example.com",
+    backText: "It lets work continue while waiting for an operation.",
+    turnInput: [
+      {
+        type: "text",
+        text: "Create a card about PostgreSQL indexes.",
+      },
+    ],
+    localMessages: [
+      {
+        role: "user",
+        content: "Keep this raw user prompt for AI debugging.",
+      },
+    ],
+    model_output: "Use a B-tree index for equality lookups.",
+    output: {
+      content: "Tool returned the exact generated card content.",
+    },
+    authorization: "Bearer live-token-value",
+    cookie: "session=secret-cookie-value",
+    csrfToken: "csrf-token-value",
+    otp: "123456",
+    apiKey: "sk_12345678901234567890",
+    password: "password-value",
+    secret: "secret-value",
+    sessionId: "session-id-kept",
+    sessionToken: "session-token-value",
+    userId: "user-id-kept",
+    workspaceId: "workspace-id-kept",
+    outputTokens: 42,
+  });
+
+  assert.deepEqual(sanitized, {
+    frontText: "What does async mean? Ask <masked-email>",
+    backText: "It lets work continue while waiting for an operation.",
+    turnInput: [
+      {
+        type: "text",
+        text: "Create a card about PostgreSQL indexes.",
+      },
+    ],
+    localMessages: [
+      {
+        role: "user",
+        content: "Keep this raw user prompt for AI debugging.",
+      },
+    ],
+    model_output: "Use a B-tree index for equality lookups.",
+    output: {
+      content: "Tool returned the exact generated card content.",
+    },
+    authorization: "<redacted-secret>",
+    cookie: "<redacted-secret>",
+    csrfToken: "<redacted-secret>",
+    otp: "<redacted-secret>",
+    apiKey: "<redacted-secret>",
+    password: "<redacted-secret>",
+    secret: "<redacted-secret>",
+    sessionId: "session-id-kept",
+    sessionToken: "<redacted-secret>",
+    userId: "user-id-kept",
+    workspaceId: "workspace-id-kept",
+    outputTokens: 42,
+  });
+});
+
+test("Langfuse sanitizer preserves raw plain strings except emails", () => {
+  assert.equal(
+    sanitizeTelemetryValue("Prompt text with front/back card content and owner@example.com"),
+    "Prompt text with front/back card content and <masked-email>",
+  );
+});
+
+test("Langfuse starts its isolated tracer provider when Sentry DSN exists", () => {
+  const envSnapshot = snapshotEnv();
+  resetBackendSentryForTests();
+  resetLangfuseTelemetryForTests();
+  configureLangfuseEnvWithSentryDsn();
+
+  const spanProcessor = createTestLangfuseSpanProcessor();
+  const tracerProvider = {} as BasicTracerProvider;
+  let setProviderCount = 0;
+
+  try {
+    initializeLangfuseTelemetryWithDeps({
+      createLangfuseSpanProcessor: () => spanProcessor,
+      createLangfuseTracerProvider: (createdSpanProcessor) => {
+        assert.equal(createdSpanProcessor, spanProcessor);
+        return tracerProvider;
+      },
+      setLangfuseTracerProvider: (createdTracerProvider) => {
+        assert.equal(createdTracerProvider, tracerProvider);
+        setProviderCount += 1;
+      },
+    });
+
+    assert.equal(setProviderCount, 1);
+  } finally {
+    restoreEnv(envSnapshot);
+    resetBackendSentryForTests();
+    resetLangfuseTelemetryForTests();
+  }
+});
+
+test("Langfuse isolated provider starts after Sentry initializes with zero trace sample rate", () => {
+  const envSnapshot = snapshotEnv();
+  resetBackendSentryForTests();
+  resetLangfuseTelemetryForTests();
+  configureLangfuseEnvWithSentryDsn();
+
+  try {
+    initializeBackendSentryWithDeps(
+      "chat-live",
+      {
+        SENTRY_DSN: "https://sentry.example.invalid/1",
+        SENTRY_ENVIRONMENT: "production",
+        SENTRY_RELEASE: "abc123",
+        SENTRY_TRACES_SAMPLE_RATE: "0",
+      },
+      {
+        init: () => {},
+      },
+    );
+
+    const tracerProvider = {} as BasicTracerProvider;
+    let setProviderCount = 0;
+    initializeLangfuseTelemetryWithDeps({
+      createLangfuseSpanProcessor: () => createTestLangfuseSpanProcessor(),
+      createLangfuseTracerProvider: () => tracerProvider,
+      setLangfuseTracerProvider: (createdTracerProvider) => {
+        assert.equal(createdTracerProvider, tracerProvider);
+        setProviderCount += 1;
+      },
+    });
+
+    assert.equal(setProviderCount, 1);
+  } finally {
+    restoreEnv(envSnapshot);
+    resetBackendSentryForTests();
+    resetLangfuseTelemetryForTests();
+  }
+});
+
+test("Langfuse flush no-ops before telemetry starts", async () => {
+  resetLangfuseTelemetryForTests();
+
+  try {
+    await flushLangfuseTelemetry();
+  } finally {
+    resetLangfuseTelemetryForTests();
+  }
+});
+
+test("Langfuse flush force-flushes the isolated provider", async () => {
+  const envSnapshot = snapshotEnv();
+  resetLangfuseTelemetryForTests();
+  configureLangfuseEnvWithSentryDsn();
+
+  let flushCount = 0;
+  const tracerProvider = {
+    forceFlush: async (): Promise<void> => {
+      flushCount += 1;
+    },
+  } as BasicTracerProvider;
+
+  try {
+    initializeLangfuseTelemetryWithDeps({
+      createLangfuseSpanProcessor: () => createTestLangfuseSpanProcessor(),
+      createLangfuseTracerProvider: () => tracerProvider,
+      setLangfuseTracerProvider: () => {},
+    });
+
+    await flushLangfuseTelemetry();
+
+    assert.equal(flushCount, 1);
+  } finally {
+    restoreEnv(envSnapshot);
+    resetLangfuseTelemetryForTests();
+  }
+});
+
+test("Langfuse flush logs and swallows force-flush failures", async () => {
+  const envSnapshot = snapshotEnv();
+  const originalWarn = console.warn;
+  const warningRecords: Array<Readonly<Record<string, unknown>>> = [];
+  resetLangfuseTelemetryForTests();
+  configureLangfuseEnvWithSentryDsn();
+
+  const tracerProvider = {
+    forceFlush: async (): Promise<void> => {
+      throw new Error("Langfuse export failed");
+    },
+  } as BasicTracerProvider;
+
+  console.warn = (message?: unknown): void => {
+    if (typeof message !== "string") {
+      throw new Error("Expected Langfuse flush warning log to be a JSON string.");
+    }
+    warningRecords.push(JSON.parse(message) as Readonly<Record<string, unknown>>);
+  };
+
+  try {
+    initializeLangfuseTelemetryWithDeps({
+      createLangfuseSpanProcessor: () => createTestLangfuseSpanProcessor(),
+      createLangfuseTracerProvider: () => tracerProvider,
+      setLangfuseTracerProvider: () => {},
+    });
+
+    await flushLangfuseTelemetry();
+
+    assert.deepEqual(warningRecords, [
+      {
+        domain: "backend",
+        action: "langfuse_telemetry_flush_failed",
+        errorClass: "Error",
+        error: "Langfuse export failed",
+      },
+    ]);
+  } finally {
+    console.warn = originalWarn;
+    restoreEnv(envSnapshot);
+    resetLangfuseTelemetryForTests();
+  }
+});

--- a/apps/backend/src/telemetry/langfuse.ts
+++ b/apps/backend/src/telemetry/langfuse.ts
@@ -1,10 +1,26 @@
-import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
-import { NodeSDK } from "@opentelemetry/sdk-node";
+import type { ReadableSpan, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { AlwaysOnSampler, BasicTracerProvider } from "@opentelemetry/sdk-trace-base";
 import { LangfuseSpanProcessor, isDefaultExportSpan } from "@langfuse/otel";
 import type { LangfuseObservation } from "@langfuse/tracing";
-import { createTraceId, propagateAttributes, startObservation } from "@langfuse/tracing";
+import {
+  createTraceId,
+  propagateAttributes,
+  setLangfuseTracerProvider,
+  startObservation,
+} from "@langfuse/tracing";
 
 type TelemetryMetadata = Readonly<Record<string, string>>;
+type LangfuseSanitizedObject = Readonly<{
+  [key: string]: LangfuseSanitizedTelemetryValue;
+}>;
+type LangfuseSanitizedTelemetryValue =
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | ReadonlyArray<LangfuseSanitizedTelemetryValue>
+  | LangfuseSanitizedObject;
 
 type ChatTurnTelemetryParams = Readonly<{
   requestId: string;
@@ -41,31 +57,9 @@ type StartChatTranscriptionObservationDependencies = Readonly<{
 
 type InitializeLangfuseTelemetryDependencies = Readonly<{
   createLangfuseSpanProcessor: () => LangfuseSpanProcessor | null;
-  createNodeSdk: (spanProcessor: LangfuseSpanProcessor) => NodeSDK;
-  startNodeSdk: (sdk: NodeSDK) => void | Promise<void>;
+  createLangfuseTracerProvider: (spanProcessor: SpanProcessor) => BasicTracerProvider;
+  setLangfuseTracerProvider: typeof setLangfuseTracerProvider;
 }>;
-
-const MASK_PATTERNS: ReadonlyArray<Readonly<{
-  pattern: RegExp;
-  replacement: string;
-}>> = [
-  {
-    pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
-    replacement: "<masked-email>",
-  },
-  {
-    pattern: /\b(?:\+?\d[\d\s().-]{7,}\d)\b/g,
-    replacement: "<masked-phone>",
-  },
-  {
-    pattern: /\b(?:sk|pk|rk)_[A-Za-z0-9_-]{16,}\b/g,
-    replacement: "<masked-api-key>",
-  },
-  {
-    pattern: /\b\d{12,19}\b/g,
-    replacement: "<masked-number>",
-  },
-];
 
 const DEFAULT_START_CHAT_TURN_OBSERVATION_DEPENDENCIES: StartChatTurnObservationDependencies = {
   createTraceId,
@@ -81,16 +75,51 @@ const DEFAULT_START_CHAT_TRANSCRIPTION_OBSERVATION_DEPENDENCIES: StartChatTransc
 
 const DEFAULT_INITIALIZE_LANGFUSE_TELEMETRY_DEPENDENCIES: InitializeLangfuseTelemetryDependencies = {
   createLangfuseSpanProcessor,
-  createNodeSdk: (spanProcessor: LangfuseSpanProcessor): NodeSDK =>
-    new NodeSDK({
-      spanProcessors: [spanProcessor],
-    }),
-  startNodeSdk: (sdk: NodeSDK): void => {
-    void sdk.start();
-  },
+  createLangfuseTracerProvider,
+  setLangfuseTracerProvider,
 };
 
-let telemetrySdk: NodeSDK | null = null;
+const langfuseRedactedSecretValue = "<redacted-secret>";
+
+const langfuseSecretKeyFragments: ReadonlyArray<string> = [
+  "authorization",
+  "cookie",
+  "csrf",
+  "otp",
+  "password",
+  "secret",
+  "token",
+  "apikey",
+];
+
+const langfuseOperationalTokenMetricKeyNames: ReadonlySet<string> = new Set([
+  "completiontokens",
+  "inputtokens",
+  "outputtokens",
+  "prompttokens",
+  "tokencount",
+  "totaltokens",
+]);
+
+const langfuseMaskPatterns: ReadonlyArray<Readonly<{
+  pattern: RegExp;
+  replacement: string;
+}>> = [
+  {
+    pattern: /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
+    replacement: "<masked-email>",
+  },
+  {
+    pattern: /\b(?:sk|pk|rk)[_-][A-Za-z0-9_-]{16,}\b/g,
+    replacement: "<masked-api-key>",
+  },
+  {
+    pattern: /\b(Bearer|ApiKey|Guest|Live)\s+[A-Za-z0-9._~+/=-]{8,}\b/g,
+    replacement: "$1 <redacted-secret>",
+  },
+];
+
+let telemetryTracerProvider: BasicTracerProvider | null = null;
 let telemetryStarted = false;
 
 function getPresentConfigValueCount(
@@ -103,11 +132,40 @@ function metadataValue(value: string | number | boolean): string {
   return String(value).slice(0, 200);
 }
 
-function sanitizeString(value: string): string {
-  return MASK_PATTERNS.reduce(
+function normalizeLangfuseTelemetryKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function isLangfuseOperationalTokenMetricKey(key: string): boolean {
+  return langfuseOperationalTokenMetricKeyNames.has(normalizeLangfuseTelemetryKey(key));
+}
+
+function shouldRedactLangfuseSecretEntry(key: string, value: unknown): boolean {
+  if (typeof value === "number" && isLangfuseOperationalTokenMetricKey(key)) {
+    return false;
+  }
+
+  const normalizedKey = normalizeLangfuseTelemetryKey(key);
+  return typeof value !== "boolean"
+    && langfuseSecretKeyFragments.some((fragment) => normalizedKey.includes(fragment));
+}
+
+function maskLangfuseString(value: string): string {
+  return langfuseMaskPatterns.reduce(
     (currentValue, rule) => currentValue.replace(rule.pattern, rule.replacement),
     value,
   );
+}
+
+function sanitizeLangfuseTelemetryEntry(
+  key: string,
+  value: unknown,
+): LangfuseSanitizedTelemetryValue {
+  if (shouldRedactLangfuseSecretEntry(key, value)) {
+    return langfuseRedactedSecretValue;
+  }
+
+  return sanitizeTelemetryValue(value);
 }
 
 function logTelemetryFailure(
@@ -117,6 +175,18 @@ function logTelemetryFailure(
   console.error(JSON.stringify({
     domain: "backend",
     action,
+    error: error instanceof Error ? error.message : String(error),
+  }));
+}
+
+function logTelemetryWarning(
+  action: string,
+  error: unknown,
+): void {
+  console.warn(JSON.stringify({
+    domain: "backend",
+    action,
+    errorClass: error instanceof Error ? error.name : null,
     error: error instanceof Error ? error.message : String(error),
   }));
 }
@@ -210,9 +280,14 @@ export function isLangfuseConfigured(
   return getLangfuseConfig(env) !== null;
 }
 
-export function sanitizeTelemetryValue(value: unknown): unknown {
+// Langfuse intentionally keeps raw AI/product input and output for debugging while stripping credentials and emails.
+export function sanitizeTelemetryValue(value: unknown): LangfuseSanitizedTelemetryValue {
   if (typeof value === "string") {
-    return sanitizeString(value);
+    return maskLangfuseString(value);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return value;
   }
 
   if (Array.isArray(value)) {
@@ -223,14 +298,12 @@ export function sanitizeTelemetryValue(value: unknown): unknown {
     return Object.fromEntries(
       Object.entries(value).map(([key, childValue]) => [
         key,
-        key === "base64Data"
-          ? "<redacted-base64>"
-          : sanitizeTelemetryValue(childValue),
+        sanitizeLangfuseTelemetryEntry(key, childValue),
       ]),
     );
   }
 
-  return value;
+  return undefined;
 }
 
 export function createLangfuseSpanProcessor(): LangfuseSpanProcessor | null {
@@ -253,8 +326,16 @@ export function createLangfuseSpanProcessor(): LangfuseSpanProcessor | null {
   });
 }
 
+export function createLangfuseTracerProvider(spanProcessor: SpanProcessor): BasicTracerProvider {
+  return new BasicTracerProvider({
+    sampler: new AlwaysOnSampler(),
+    spanProcessors: [spanProcessor],
+  });
+}
+
 export function resetLangfuseTelemetryForTests(): void {
-  telemetrySdk = null;
+  setLangfuseTracerProvider(null);
+  telemetryTracerProvider = null;
   telemetryStarted = false;
 }
 
@@ -277,13 +358,25 @@ export function initializeLangfuseTelemetryWithDeps(
     return;
   }
 
-  telemetrySdk = dependencies.createNodeSdk(spanProcessor);
-  dependencies.startNodeSdk(telemetrySdk);
+  telemetryTracerProvider = dependencies.createLangfuseTracerProvider(spanProcessor);
+  dependencies.setLangfuseTracerProvider(telemetryTracerProvider);
   telemetryStarted = true;
 }
 
 export function initializeLangfuseTelemetry(): void {
   initializeLangfuseTelemetryWithDeps(DEFAULT_INITIALIZE_LANGFUSE_TELEMETRY_DEPENDENCIES);
+}
+
+export async function flushLangfuseTelemetry(): Promise<void> {
+  if (!telemetryStarted || telemetryTracerProvider === null) {
+    return;
+  }
+
+  try {
+    await telemetryTracerProvider.forceFlush();
+  } catch (error) {
+    logTelemetryWarning("langfuse_telemetry_flush_failed", error);
+  }
 }
 
 export async function startChatTurnObservationWithDeps(

--- a/apps/backend/src/workspaces/create.ts
+++ b/apps/backend/src/workspaces/create.ts
@@ -6,7 +6,14 @@ import {
   type DatabaseExecutor,
 } from "../db";
 import { HttpError } from "../errors";
-import { logCloudRouteEvent } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  normalizeCaughtError,
+  type BackendObservationScope,
+  type WorkspaceTransactionDetails,
+} from "../observability/sentry";
+import { markBackendExceptionWrapperAsReported } from "../observability/reporting";
 import {
   buildSystemWorkspaceReplicaId,
   ensureSystemWorkspaceReplicaInExecutor,
@@ -15,6 +22,7 @@ import { insertSyncChange } from "../syncChanges";
 import {
   createWorkspaceCreateFailedError,
   createWorkspaceInvariantError,
+  createWorkspaceTransactionScope,
   getDatabaseErrorDetails,
 } from "./shared";
 import { loadWorkspaceSummaryInExecutor } from "./queries";
@@ -60,32 +68,64 @@ function handleWorkspaceCreateFailure(
   userId: string,
   workspaceId: string,
   stage: WorkspaceCreateFailureStage,
+  observationScope: BackendObservationScope | null,
 ): never {
+  const scope = createWorkspaceTransactionScope(userId, workspaceId, observationScope);
   if (error instanceof HttpError) {
-    logCloudRouteEvent("workspace_create_transaction_error", {
+    const details: WorkspaceTransactionDetails = {
       userId,
       workspaceId,
       stage,
       code: error.code,
-    }, true);
+      cardsResetCount: null,
+      memberCount: null,
+      selectedWorkspaceIdBeforeDelete: null,
+      selectedWorkspaceIdAfterPreparation: null,
+      deletedCardsCount: null,
+      sqlState: null,
+      constraint: null,
+      table: null,
+      detail: null,
+    };
+    addBackendBreadcrumb({ action: "workspace_create_transaction_error", scope, details });
     throw error;
   }
 
   const databaseErrorDetails = getDatabaseErrorDetails(error);
-  logCloudRouteEvent("workspace_create_transaction_error", {
+  const details: WorkspaceTransactionDetails = {
     userId,
     workspaceId,
     stage,
     code: "WORKSPACE_CREATE_FAILED",
     ...databaseErrorDetails,
-  }, true);
-  throw createWorkspaceCreateFailedError();
+    cardsResetCount: null,
+    memberCount: null,
+    selectedWorkspaceIdBeforeDelete: null,
+    selectedWorkspaceIdAfterPreparation: null,
+    deletedCardsCount: null,
+  };
+  captureBackendException({
+    action: "workspace_create_transaction_error",
+    error: normalizeCaughtError(error),
+    scope,
+    details,
+  });
+  throw markBackendExceptionWrapperAsReported(createWorkspaceCreateFailedError());
 }
 
 export async function createWorkspaceInExecutor(
   executor: DatabaseExecutor,
   userId: string,
   name: string,
+): Promise<string> {
+  return createWorkspaceInExecutorWithObservationScope(executor, userId, name, null);
+}
+
+export async function createWorkspaceInExecutorWithObservationScope(
+  executor: DatabaseExecutor,
+  userId: string,
+  name: string,
+  observationScope: BackendObservationScope | null,
 ): Promise<string> {
   await ensureUserSettingsRowInExecutor(executor, userId);
 
@@ -170,13 +210,21 @@ export async function createWorkspaceInExecutor(
 
     return workspaceId;
   } catch (error) {
-    handleWorkspaceCreateFailure(error, userId, workspaceId, stage);
+    handleWorkspaceCreateFailure(error, userId, workspaceId, stage, observationScope);
   }
 }
 
 export async function createWorkspaceForUser(userId: string, name: string): Promise<WorkspaceSummary> {
+  return createWorkspaceForUserWithObservationScope(userId, name, null);
+}
+
+export async function createWorkspaceForUserWithObservationScope(
+  userId: string,
+  name: string,
+  observationScope: BackendObservationScope | null,
+): Promise<WorkspaceSummary> {
   return transactionWithUserScope({ userId }, async (executor) => {
-    const workspaceId = await createWorkspaceInExecutor(executor, userId, name);
+    const workspaceId = await createWorkspaceInExecutorWithObservationScope(executor, userId, name, observationScope);
     let stage: WorkspaceCreateFailureStage = "select_workspace";
 
     try {
@@ -185,7 +233,7 @@ export async function createWorkspaceForUser(userId: string, name: string): Prom
       stage = "load_workspace_summary";
       return loadWorkspaceSummaryInExecutor(executor, userId, workspaceId, workspaceId);
     } catch (error) {
-      handleWorkspaceCreateFailure(error, userId, workspaceId, stage);
+      handleWorkspaceCreateFailure(error, userId, workspaceId, stage, observationScope);
     }
   });
 }
@@ -195,8 +243,17 @@ export async function createWorkspaceForApiKeyConnection(
   connectionId: string,
   name: string,
 ): Promise<WorkspaceSummary> {
+  return createWorkspaceForApiKeyConnectionWithObservationScope(userId, connectionId, name, null);
+}
+
+export async function createWorkspaceForApiKeyConnectionWithObservationScope(
+  userId: string,
+  connectionId: string,
+  name: string,
+  observationScope: BackendObservationScope | null,
+): Promise<WorkspaceSummary> {
   return transactionWithUserScope({ userId }, async (executor) => {
-    const workspaceId = await createWorkspaceInExecutor(executor, userId, name);
+    const workspaceId = await createWorkspaceInExecutorWithObservationScope(executor, userId, name, observationScope);
     let stage: WorkspaceCreateFailureStage = "select_workspace";
 
     try {
@@ -205,7 +262,7 @@ export async function createWorkspaceForApiKeyConnection(
       stage = "load_workspace_summary";
       return loadWorkspaceSummaryInExecutor(executor, userId, workspaceId, workspaceId);
     } catch (error) {
-      handleWorkspaceCreateFailure(error, userId, workspaceId, stage);
+      handleWorkspaceCreateFailure(error, userId, workspaceId, stage, observationScope);
     }
   });
 }

--- a/apps/backend/src/workspaces/management.ts
+++ b/apps/backend/src/workspaces/management.ts
@@ -7,9 +7,16 @@ import {
 import { HttpError } from "../errors";
 import { CARD_COLUMNS, mapCard, recordCardSyncChange } from "../cards/shared";
 import type { CardRow } from "../cards/types";
-import { logCloudRouteEvent } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  normalizeCaughtError,
+  type BackendObservationScope,
+  type WorkspaceTransactionDetails,
+} from "../observability/sentry";
+import { markBackendExceptionWrapperAsReported } from "../observability/reporting";
 import { ensureSystemWorkspaceReplicaInExecutor } from "../syncIdentity";
-import { createWorkspaceInExecutor } from "./create";
+import { createWorkspaceInExecutorWithObservationScope } from "./create";
 import {
   listUserWorkspaceIdsInExecutor,
   loadActiveCardCountInExecutor,
@@ -30,6 +37,7 @@ import {
   createWorkspaceDeletePreviewFailedError,
   createWorkspaceResetProgressFailedError,
   createWorkspaceResetProgressPreviewFailedError,
+  createWorkspaceTransactionScope,
   getDatabaseErrorDetails,
 } from "./shared";
 import { persistSelectedWorkspaceForUserInExecutor } from "./state";
@@ -56,6 +64,108 @@ type WorkspaceResetProgressFailureStage =
   | "load_management_row"
   | "count_resettable_cards"
   | "reset_workspace_cards";
+
+type WorkspaceTransactionErrorAction =
+  | "workspace_delete_preview_transaction_error"
+  | "workspace_reset_progress_preview_transaction_error"
+  | "workspace_reset_progress_transaction_error"
+  | "workspace_delete_transaction_error";
+
+function createWorkspaceTransactionDetails(
+  userId: string,
+  workspaceId: string,
+  stage: string | null,
+  code: string | null,
+  cardsResetCount: number | null,
+  memberCount: number | null,
+  selectedWorkspaceIdBeforeDelete: string | null,
+  selectedWorkspaceIdAfterPreparation: string | null,
+  deletedCardsCount: number | null,
+  databaseErrorDetails: Readonly<{
+    sqlState: string | null;
+    constraint: string | null;
+    table: string | null;
+    detail: string | null;
+  }>,
+): WorkspaceTransactionDetails {
+  return {
+    userId,
+    workspaceId,
+    stage,
+    code,
+    cardsResetCount,
+    memberCount,
+    selectedWorkspaceIdBeforeDelete,
+    selectedWorkspaceIdAfterPreparation,
+    deletedCardsCount,
+    ...databaseErrorDetails,
+  };
+}
+
+function reportWorkspaceTransactionError(
+  action: WorkspaceTransactionErrorAction,
+  details: WorkspaceTransactionDetails,
+  observationScope: BackendObservationScope | null,
+): void {
+  const scope = createWorkspaceTransactionScope(details.userId, details.workspaceId, observationScope);
+  switch (action) {
+    case "workspace_delete_preview_transaction_error":
+      addBackendBreadcrumb({ action: "workspace_delete_preview_transaction_error", scope, details });
+      return;
+    case "workspace_reset_progress_preview_transaction_error":
+      addBackendBreadcrumb({ action: "workspace_reset_progress_preview_transaction_error", scope, details });
+      return;
+    case "workspace_reset_progress_transaction_error":
+      addBackendBreadcrumb({ action: "workspace_reset_progress_transaction_error", scope, details });
+      return;
+    case "workspace_delete_transaction_error":
+      addBackendBreadcrumb({ action: "workspace_delete_transaction_error", scope, details });
+      return;
+  }
+}
+
+function captureWorkspaceTransactionError(
+  action: WorkspaceTransactionErrorAction,
+  error: unknown,
+  details: WorkspaceTransactionDetails,
+  observationScope: BackendObservationScope | null,
+): void {
+  const scope = createWorkspaceTransactionScope(details.userId, details.workspaceId, observationScope);
+  switch (action) {
+    case "workspace_delete_preview_transaction_error":
+      captureBackendException({
+        action: "workspace_delete_preview_transaction_error",
+        error: normalizeCaughtError(error),
+        scope,
+        details,
+      });
+      return;
+    case "workspace_reset_progress_preview_transaction_error":
+      captureBackendException({
+        action: "workspace_reset_progress_preview_transaction_error",
+        error: normalizeCaughtError(error),
+        scope,
+        details,
+      });
+      return;
+    case "workspace_reset_progress_transaction_error":
+      captureBackendException({
+        action: "workspace_reset_progress_transaction_error",
+        error: normalizeCaughtError(error),
+        scope,
+        details,
+      });
+      return;
+    case "workspace_delete_transaction_error":
+      captureBackendException({
+        action: "workspace_delete_transaction_error",
+        error: normalizeCaughtError(error),
+        scope,
+        details,
+      });
+      return;
+  }
+}
 
 type DeletedWorkspaceRow = Readonly<{
   workspace_id: string;
@@ -97,6 +207,7 @@ async function prepareSelectedWorkspaceForDeletionInExecutor(
   executor: DatabaseExecutor,
   userId: string,
   deletedWorkspaceId: string,
+  observationScope: BackendObservationScope | null,
 ): Promise<Readonly<{
   selectedWorkspaceIdBeforeDelete: string | null;
   selectedWorkspaceIdAfterPreparation: string | null;
@@ -111,7 +222,7 @@ async function prepareSelectedWorkspaceForDeletionInExecutor(
 
   const accessibleWorkspaceIds = await listUserWorkspaceIdsInExecutor(executor, userId);
   const replacementWorkspaceId = accessibleWorkspaceIds.find((workspaceId) => workspaceId !== deletedWorkspaceId)
-    ?? await createWorkspaceInExecutor(executor, userId, AUTO_CREATED_WORKSPACE_NAME);
+    ?? await createWorkspaceInExecutorWithObservationScope(executor, userId, AUTO_CREATED_WORKSPACE_NAME, observationScope);
   await persistSelectedWorkspaceForUserInExecutor(executor, userId, replacementWorkspaceId);
 
   return {
@@ -158,6 +269,15 @@ export async function loadWorkspaceDeletePreviewInExecutor(
   userId: string,
   workspaceId: string,
 ): Promise<WorkspaceDeletePreview> {
+  return loadWorkspaceDeletePreviewInExecutorWithObservationScope(executor, userId, workspaceId, null);
+}
+
+async function loadWorkspaceDeletePreviewInExecutorWithObservationScope(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string,
+  observationScope: BackendObservationScope | null,
+): Promise<WorkspaceDeletePreview> {
   try {
     const managedWorkspace = await loadWorkspaceManagementRowInExecutor(executor, userId, workspaceId);
     assertWorkspaceOwner(managedWorkspace.role);
@@ -177,14 +297,24 @@ export async function loadWorkspaceDeletePreviewInExecutor(
       throw error;
     }
 
-    const databaseErrorDetails = getDatabaseErrorDetails(error);
-    logCloudRouteEvent("workspace_delete_preview_transaction_error", {
-      userId,
-      workspaceId,
-      code: "WORKSPACE_DELETE_PREVIEW_FAILED",
-      ...databaseErrorDetails,
-    }, true);
-    throw createWorkspaceDeletePreviewFailedError();
+    captureWorkspaceTransactionError(
+      "workspace_delete_preview_transaction_error",
+      error,
+      createWorkspaceTransactionDetails(
+        userId,
+        workspaceId,
+        null,
+        "WORKSPACE_DELETE_PREVIEW_FAILED",
+        null,
+        null,
+        null,
+        null,
+        null,
+        getDatabaseErrorDetails(error),
+      ),
+      observationScope,
+    );
+    throw markBackendExceptionWrapperAsReported(createWorkspaceDeletePreviewFailedError());
   }
 }
 
@@ -192,10 +322,19 @@ export async function loadWorkspaceDeletePreviewForUser(
   userId: string,
   workspaceId: string,
 ): Promise<WorkspaceDeletePreview> {
-  return transactionWithUserScope({ userId }, async (executor) => loadWorkspaceDeletePreviewInExecutor(
+  return loadWorkspaceDeletePreviewForUserWithObservationScope(userId, workspaceId, null);
+}
+
+export async function loadWorkspaceDeletePreviewForUserWithObservationScope(
+  userId: string,
+  workspaceId: string,
+  observationScope: BackendObservationScope | null,
+): Promise<WorkspaceDeletePreview> {
+  return transactionWithUserScope({ userId }, async (executor) => loadWorkspaceDeletePreviewInExecutorWithObservationScope(
     executor,
     userId,
     workspaceId,
+    observationScope,
   ));
 }
 
@@ -203,6 +342,15 @@ export async function loadWorkspaceResetProgressPreviewInExecutor(
   executor: DatabaseExecutor,
   userId: string,
   workspaceId: string,
+): Promise<WorkspaceResetProgressPreview> {
+  return loadWorkspaceResetProgressPreviewInExecutorWithObservationScope(executor, userId, workspaceId, null);
+}
+
+async function loadWorkspaceResetProgressPreviewInExecutorWithObservationScope(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string,
+  observationScope: BackendObservationScope | null,
 ): Promise<WorkspaceResetProgressPreview> {
   try {
     const managedWorkspace = await loadWorkspaceManagementRowInExecutor(executor, userId, workspaceId);
@@ -222,14 +370,24 @@ export async function loadWorkspaceResetProgressPreviewInExecutor(
       throw error;
     }
 
-    const databaseErrorDetails = getDatabaseErrorDetails(error);
-    logCloudRouteEvent("workspace_reset_progress_preview_transaction_error", {
-      userId,
-      workspaceId,
-      code: "WORKSPACE_RESET_PROGRESS_PREVIEW_FAILED",
-      ...databaseErrorDetails,
-    }, true);
-    throw createWorkspaceResetProgressPreviewFailedError();
+    captureWorkspaceTransactionError(
+      "workspace_reset_progress_preview_transaction_error",
+      error,
+      createWorkspaceTransactionDetails(
+        userId,
+        workspaceId,
+        null,
+        "WORKSPACE_RESET_PROGRESS_PREVIEW_FAILED",
+        null,
+        null,
+        null,
+        null,
+        null,
+        getDatabaseErrorDetails(error),
+      ),
+      observationScope,
+    );
+    throw markBackendExceptionWrapperAsReported(createWorkspaceResetProgressPreviewFailedError());
   }
 }
 
@@ -237,10 +395,19 @@ export async function loadWorkspaceResetProgressPreviewForUser(
   userId: string,
   workspaceId: string,
 ): Promise<WorkspaceResetProgressPreview> {
-  return transactionWithUserScope({ userId }, async (executor) => loadWorkspaceResetProgressPreviewInExecutor(
+  return loadWorkspaceResetProgressPreviewForUserWithObservationScope(userId, workspaceId, null);
+}
+
+export async function loadWorkspaceResetProgressPreviewForUserWithObservationScope(
+  userId: string,
+  workspaceId: string,
+  observationScope: BackendObservationScope | null,
+): Promise<WorkspaceResetProgressPreview> {
+  return transactionWithUserScope({ userId }, async (executor) => loadWorkspaceResetProgressPreviewInExecutorWithObservationScope(
     executor,
     userId,
     workspaceId,
+    observationScope,
   ));
 }
 
@@ -249,6 +416,7 @@ async function resetWorkspaceProgressInExecutor(
   userId: string,
   workspaceId: string,
   confirmationText: string,
+  observationScope: BackendObservationScope | null,
 ): Promise<ResetWorkspaceProgressResult> {
   assertResetWorkspaceProgressConfirmationText(confirmationText);
   let stage: WorkspaceResetProgressFailureStage = "load_management_row";
@@ -297,26 +465,48 @@ async function resetWorkspaceProgressInExecutor(
     };
   } catch (error) {
     if (error instanceof HttpError) {
-      logCloudRouteEvent("workspace_reset_progress_transaction_error", {
-        userId,
-        workspaceId,
-        cardsResetCount,
-        stage,
-        code: error.code,
-      }, true);
+      reportWorkspaceTransactionError(
+        "workspace_reset_progress_transaction_error",
+        createWorkspaceTransactionDetails(
+          userId,
+          workspaceId,
+          stage,
+          error.code,
+          cardsResetCount,
+          null,
+          null,
+          null,
+          null,
+          {
+            sqlState: null,
+            constraint: null,
+            table: null,
+            detail: null,
+          },
+        ),
+        observationScope,
+      );
       throw error;
     }
 
-    const databaseErrorDetails = getDatabaseErrorDetails(error);
-    logCloudRouteEvent("workspace_reset_progress_transaction_error", {
-      userId,
-      workspaceId,
-      cardsResetCount,
-      stage,
-      code: "WORKSPACE_RESET_PROGRESS_FAILED",
-      ...databaseErrorDetails,
-    }, true);
-    throw createWorkspaceResetProgressFailedError();
+    captureWorkspaceTransactionError(
+      "workspace_reset_progress_transaction_error",
+      error,
+      createWorkspaceTransactionDetails(
+        userId,
+        workspaceId,
+        stage,
+        "WORKSPACE_RESET_PROGRESS_FAILED",
+        cardsResetCount,
+        null,
+        null,
+        null,
+        null,
+        getDatabaseErrorDetails(error),
+      ),
+      observationScope,
+    );
+    throw markBackendExceptionWrapperAsReported(createWorkspaceResetProgressFailedError());
   }
 }
 
@@ -325,11 +515,21 @@ export async function resetWorkspaceProgressForUser(
   workspaceId: string,
   confirmationText: string,
 ): Promise<ResetWorkspaceProgressResult> {
+  return resetWorkspaceProgressForUserWithObservationScope(userId, workspaceId, confirmationText, null);
+}
+
+export async function resetWorkspaceProgressForUserWithObservationScope(
+  userId: string,
+  workspaceId: string,
+  confirmationText: string,
+  observationScope: BackendObservationScope | null,
+): Promise<ResetWorkspaceProgressResult> {
   return transactionWithUserScope({ userId }, async (executor) => resetWorkspaceProgressInExecutor(
     executor,
     userId,
     workspaceId,
     confirmationText,
+    observationScope,
   ));
 }
 
@@ -338,6 +538,16 @@ export async function deleteWorkspaceInExecutor(
   userId: string,
   workspaceId: string,
   confirmationText: string,
+): Promise<DeleteWorkspaceResult> {
+  return deleteWorkspaceInExecutorWithObservationScope(executor, userId, workspaceId, confirmationText, null);
+}
+
+async function deleteWorkspaceInExecutorWithObservationScope(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string,
+  confirmationText: string,
+  observationScope: BackendObservationScope | null,
 ): Promise<DeleteWorkspaceResult> {
   assertDeleteWorkspaceConfirmationText(confirmationText);
   let stage: WorkspaceDeleteFailureStage = "load_management_row";
@@ -354,6 +564,7 @@ export async function deleteWorkspaceInExecutor(
       executor,
       userId,
       workspaceId,
+      observationScope,
     );
     selectedWorkspaceIdBeforeDelete = selectionPreparation.selectedWorkspaceIdBeforeDelete;
     selectedWorkspaceIdAfterPreparation = selectionPreparation.selectedWorkspaceIdAfterPreparation;
@@ -385,32 +596,48 @@ export async function deleteWorkspaceInExecutor(
     };
   } catch (error) {
     if (error instanceof HttpError) {
-      logCloudRouteEvent("workspace_delete_transaction_error", {
-        userId,
-        workspaceId,
-        memberCount: managedWorkspace.member_count,
-        selectedWorkspaceIdBeforeDelete,
-        selectedWorkspaceIdAfterPreparation,
-        deletedCardsCount,
-        stage,
-        code: error.code,
-      }, true);
+      reportWorkspaceTransactionError(
+        "workspace_delete_transaction_error",
+        createWorkspaceTransactionDetails(
+          userId,
+          workspaceId,
+          stage,
+          error.code,
+          null,
+          managedWorkspace.member_count,
+          selectedWorkspaceIdBeforeDelete,
+          selectedWorkspaceIdAfterPreparation,
+          deletedCardsCount,
+          {
+            sqlState: null,
+            constraint: null,
+            table: null,
+            detail: null,
+          },
+        ),
+        observationScope,
+      );
       throw error;
     }
 
-    const databaseErrorDetails = getDatabaseErrorDetails(error);
-    logCloudRouteEvent("workspace_delete_transaction_error", {
-      userId,
-      workspaceId,
-      memberCount: managedWorkspace.member_count,
-      selectedWorkspaceIdBeforeDelete,
-      selectedWorkspaceIdAfterPreparation,
-      deletedCardsCount,
-      stage,
-      code: "WORKSPACE_DELETE_FAILED",
-      ...databaseErrorDetails,
-    }, true);
-    throw createWorkspaceDeleteFailedError();
+    captureWorkspaceTransactionError(
+      "workspace_delete_transaction_error",
+      error,
+      createWorkspaceTransactionDetails(
+        userId,
+        workspaceId,
+        stage,
+        "WORKSPACE_DELETE_FAILED",
+        null,
+        managedWorkspace.member_count,
+        selectedWorkspaceIdBeforeDelete,
+        selectedWorkspaceIdAfterPreparation,
+        deletedCardsCount,
+        getDatabaseErrorDetails(error),
+      ),
+      observationScope,
+    );
+    throw markBackendExceptionWrapperAsReported(createWorkspaceDeleteFailedError());
   }
 }
 
@@ -419,10 +646,20 @@ export async function deleteWorkspaceForUser(
   workspaceId: string,
   confirmationText: string,
 ): Promise<DeleteWorkspaceResult> {
-  return transactionWithUserScope({ userId }, async (executor) => deleteWorkspaceInExecutor(
+  return deleteWorkspaceForUserWithObservationScope(userId, workspaceId, confirmationText, null);
+}
+
+export async function deleteWorkspaceForUserWithObservationScope(
+  userId: string,
+  workspaceId: string,
+  confirmationText: string,
+  observationScope: BackendObservationScope | null,
+): Promise<DeleteWorkspaceResult> {
+  return transactionWithUserScope({ userId }, async (executor) => deleteWorkspaceInExecutorWithObservationScope(
     executor,
     userId,
     workspaceId,
     confirmationText,
+    observationScope,
   ));
 }

--- a/apps/backend/src/workspaces/shared.ts
+++ b/apps/backend/src/workspaces/shared.ts
@@ -1,4 +1,8 @@
 import { HttpError } from "../errors";
+import {
+  createBackendObservationScope,
+  type BackendObservationScope,
+} from "../observability/sentry";
 import { decodeOpaqueCursor } from "../pagination";
 import {
   deleteWorkspaceConfirmationText,
@@ -111,8 +115,26 @@ export function getDatabaseErrorDetails(error: unknown): DatabaseErrorDetails {
     sqlState: typeof errorRecord.code === "string" && errorRecord.code !== "" ? errorRecord.code : null,
     constraint: typeof errorRecord.constraint === "string" && errorRecord.constraint !== "" ? errorRecord.constraint : null,
     table: typeof errorRecord.table === "string" && errorRecord.table !== "" ? errorRecord.table : null,
-    detail: typeof errorRecord.detail === "string" && errorRecord.detail !== "" ? errorRecord.detail : null,
+    detail: null,
   };
+}
+
+export function createWorkspaceTransactionScope(
+  userId: string,
+  workspaceId: string,
+  observationScope: BackendObservationScope | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    observationScope?.service ?? "backend-api",
+    observationScope?.requestId ?? null,
+    observationScope?.route ?? null,
+    observationScope?.method ?? null,
+    userId,
+    workspaceId,
+    observationScope?.chatRequestId ?? null,
+    observationScope?.runId ?? null,
+    observationScope?.sessionId ?? null,
+  );
 }
 
 export function createWorkspaceDeleteFailedError(): HttpError {

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -39,6 +39,8 @@ Keep these values in root `.env` before running setup or deploy scripts:
 - `RESEND_ADMIN_API_KEY`
 - `OPENAI_API_KEY` when needed
 - `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, and optionally `LANGFUSE_BASE_URL` when Langfuse tracing is enabled
+- Required backend Sentry setup:
+  `SENTRY_DSN` for bootstrap-created AWS secret `flashcards-open-source-app/sentry-dsn`, or `SENTRY_DSN_SECRET_ARN` for an existing AWS Secrets Manager secret; `SENTRY_ENVIRONMENT`; `SENTRY_RELEASE` (CI should use the deployed GitHub SHA; manual/local context can use the target commit SHA); `SENTRY_TRACES_SAMPLE_RATE`; `SENTRY_ORG`; `SENTRY_BACKEND_PROJECT`; and `SENTRY_AUTH_TOKEN` for backend source map uploads
 - `DEMO_EMAIL_DOSTIP` and `DEMO_PASSWORD_DOSTIP` when review/demo bypass is enabled
 - `GUEST_AI_WEIGHTED_MONTHLY_TOKEN_CAP` when you want deployed guest AI enabled
 - `GLOBAL_METRICS_VISIBLE` when you want `GET /v1/global/snapshot` exposed externally; use the exact raw string `true`, and leave it unset or use any other value to keep the endpoint hidden
@@ -96,7 +98,7 @@ This script:
 - reads operator config from root `.env`
 - discovers AWS secret ARNs and ACM certificate ARNs
 - writes missing non-secret deploy config to GitHub repository variables
-- writes only a missing `AWS_DEPLOY_ROLE_ARN` as a GitHub secret
+- writes missing `AWS_DEPLOY_ROLE_ARN` and `SENTRY_AUTH_TOKEN` GitHub secrets; `SENTRY_AUTH_TOKEN` is required for backend source map uploads
 - leaves existing GitHub variables and secrets untouched
 
 The deploy workflow assembles its own `cdk.context.local.json` from those GitHub variables inside CI.

--- a/infra/aws/lib/api-gateway.ts
+++ b/infra/aws/lib/api-gateway.ts
@@ -9,6 +9,7 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import { Construct } from "constructs";
 import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
 import { createSafeApiGatewayAccessLogFormat } from "./api-gateway-access-log";
+import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
 
 export interface ApiGatewayProps {
   vpc: ec2.Vpc;
@@ -22,6 +23,10 @@ export interface ApiGatewayProps {
   langfusePublicKeySecretArn: string | undefined;
   langfuseSecretKeySecretArn: string | undefined;
   langfuseBaseUrl: string | undefined;
+  sentryDsnSecretArn: string | undefined;
+  sentryEnvironment: string | undefined;
+  sentryRelease: string | undefined;
+  sentryTracesSampleRate: string | undefined;
   demoEmailDostip: string | undefined;
   guestAiWeightedMonthlyTokenCap: string | undefined;
   globalMetricsVisible: boolean;
@@ -59,6 +64,7 @@ interface BackendFunctionProps {
   langfusePublicKeySecretArn: string | undefined;
   langfuseSecretKeySecretArn: string | undefined;
   langfuseBaseUrl: string | undefined;
+  sentryConfig: BackendSentryConfig;
   demoEmailDostip: string | undefined;
   guestAiWeightedMonthlyTokenCap: string | undefined;
   globalMetricsConfig: GlobalMetricsConfig | undefined;
@@ -71,6 +77,20 @@ interface GlobalMetricsConfig {
   snapshotObjectKey: string;
 }
 
+export interface BackendSentryConfig {
+  dsnSecretArn: string | undefined;
+  environment: string | undefined;
+  release: string | undefined;
+  tracesSampleRate: string | undefined;
+}
+
+interface ResolvedBackendSentryConfig {
+  dsnSecretArn: string;
+  environment: string;
+  release: string;
+  tracesSampleRate: string;
+}
+
 const chatResumeCorsHeaders = [
   "content-type",
   "authorization",
@@ -78,11 +98,14 @@ const chatResumeCorsHeaders = [
   "x-chat-resume-attempt-id",
   "x-client-platform",
   "x-client-version",
+  "sentry-trace",
+  "baggage",
 ] as const;
 
 const globalMetricsCorsPreflightOptions: apigw.CorsOptions = {
   allowOrigins: ["*"],
   allowMethods: ["GET", "OPTIONS"],
+  allowHeaders: ["authorization", "sentry-trace", "baggage"],
 };
 
 function createBrowserCorsPreflightOptions(allowedOrigins: string[]): apigw.CorsOptions {
@@ -104,6 +127,7 @@ const lambdaBundling: lambdaNodejs.BundlingOptions = {
       `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
       `mkdir -p ${outputDir}/api/dist`,
       `cp ${resolveFromRepoRoot("api", "dist", "openapi.json")} ${outputDir}/api/dist/openapi.json`,
+      createSentrySourceMapUploadCommand(outputDir),
     ],
   },
 };
@@ -164,6 +188,55 @@ function addGlobalMetricsEnvironment(
     actions: ["s3:GetObject"],
     resources: [config.snapshotBucket.arnForObjects(config.snapshotObjectKey)],
   }));
+}
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+function getResolvedBackendSentryConfig(config: BackendSentryConfig): ResolvedBackendSentryConfig | null {
+  if (!hasConfiguredValue(config.dsnSecretArn)) {
+    return null;
+  }
+
+  if (!hasConfiguredValue(config.environment)) {
+    throw new Error("sentryEnvironment is required when sentryDsnSecretArn is configured");
+  }
+  if (!hasConfiguredValue(config.release)) {
+    throw new Error("sentryRelease is required when sentryDsnSecretArn is configured");
+  }
+  if (!hasConfiguredValue(config.tracesSampleRate)) {
+    throw new Error("sentryTracesSampleRate is required when sentryDsnSecretArn is configured");
+  }
+
+  const tracesSampleRate = Number(config.tracesSampleRate);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("sentryTracesSampleRate must be a number between 0 and 1");
+  }
+
+  return {
+    dsnSecretArn: config.dsnSecretArn,
+    environment: config.environment,
+    release: config.release,
+    tracesSampleRate: config.tracesSampleRate,
+  };
+}
+
+function addBackendSentryEnvironment(
+  scope: Construct,
+  fn: lambdaNodejs.NodejsFunction,
+  config: BackendSentryConfig,
+  constructId: string,
+): void {
+  const resolvedConfig = getResolvedBackendSentryConfig(config);
+  if (resolvedConfig === null) {
+    return;
+  }
+
+  addLambdaSecretEnvironment(scope, fn, resolvedConfig.dsnSecretArn, `${constructId}SentryDsnSecret`, "SENTRY_DSN");
+  fn.addEnvironment("SENTRY_ENVIRONMENT", resolvedConfig.environment);
+  fn.addEnvironment("SENTRY_RELEASE", resolvedConfig.release);
+  fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", resolvedConfig.tracesSampleRate);
 }
 
 /**
@@ -236,6 +309,7 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
       "LANGFUSE_SECRET_KEY",
     );
   }
+  addBackendSentryEnvironment(scope, fn, props.sentryConfig, props.constructId);
   if (props.demoEmailDostip !== undefined && props.demoEmailDostip !== "") {
     fn.addEnvironment("DEMO_EMAIL_DOSTIP", props.demoEmailDostip);
   }
@@ -300,6 +374,12 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     langfusePublicKeySecretArn: props.langfusePublicKeySecretArn,
     langfuseSecretKeySecretArn: props.langfuseSecretKeySecretArn,
     langfuseBaseUrl: props.langfuseBaseUrl,
+    sentryConfig: {
+      dsnSecretArn: props.sentryDsnSecretArn,
+      environment: props.sentryEnvironment,
+      release: props.sentryRelease,
+      tracesSampleRate: props.sentryTracesSampleRate,
+    },
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: {
@@ -328,6 +408,12 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     langfusePublicKeySecretArn: props.langfusePublicKeySecretArn,
     langfuseSecretKeySecretArn: props.langfuseSecretKeySecretArn,
     langfuseBaseUrl: props.langfuseBaseUrl,
+    sentryConfig: {
+      dsnSecretArn: props.sentryDsnSecretArn,
+      environment: props.sentryEnvironment,
+      release: props.sentryRelease,
+      tracesSampleRate: props.sentryTracesSampleRate,
+    },
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
@@ -352,6 +438,12 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
     langfusePublicKeySecretArn: props.langfusePublicKeySecretArn,
     langfuseSecretKeySecretArn: props.langfuseSecretKeySecretArn,
     langfuseBaseUrl: props.langfuseBaseUrl,
+    sentryConfig: {
+      dsnSecretArn: props.sentryDsnSecretArn,
+      environment: props.sentryEnvironment,
+      release: props.sentryRelease,
+      tracesSampleRate: props.sentryTracesSampleRate,
+    },
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,

--- a/infra/aws/lib/global-metrics.ts
+++ b/infra/aws/lib/global-metrics.ts
@@ -9,12 +9,17 @@ import * as scheduler from "aws-cdk-lib/aws-scheduler";
 import { Construct } from "constructs";
 import * as path from "path";
 import { backendNodejsProjectPaths, infraAwsNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
 
 export interface GlobalMetricsProps {
   vpc: ec2.Vpc;
   lambdaSg: ec2.SecurityGroup;
   db: rds.DatabaseInstance;
   reportingDbSecret: cdk.aws_secretsmanager.ISecret;
+  sentryDsnSecretArn: string | undefined;
+  sentryEnvironment: string | undefined;
+  sentryRelease: string | undefined;
+  sentryTracesSampleRate: string | undefined;
 }
 
 export interface GlobalMetricsResult {
@@ -39,6 +44,7 @@ const lambdaBundling: lambdaNodejs.BundlingOptions = {
     beforeInstall: () => [],
     afterBundling: (_inputDir: string, outputDir: string) => [
       `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+      createSentrySourceMapUploadCommand(outputDir),
     ],
   },
 };
@@ -47,6 +53,43 @@ const freshnessCheckerBundling: lambdaNodejs.BundlingOptions = {
   minify: true,
   sourceMap: true,
 };
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+function addOptionalSentryEnvironment(
+  scope: Construct,
+  fn: lambdaNodejs.NodejsFunction,
+  props: GlobalMetricsProps,
+): void {
+  if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
+    return;
+  }
+  if (
+    !hasConfiguredValue(props.sentryEnvironment) ||
+    !hasConfiguredValue(props.sentryRelease) ||
+    !hasConfiguredValue(props.sentryTracesSampleRate)
+  ) {
+    throw new Error("sentryEnvironment, sentryRelease, and sentryTracesSampleRate are required when sentryDsnSecretArn is configured");
+  }
+
+  const tracesSampleRate = Number(props.sentryTracesSampleRate);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("sentryTracesSampleRate must be a number between 0 and 1");
+  }
+
+  const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+    scope,
+    "GlobalMetricsSnapshotSentryDsnSecret",
+    props.sentryDsnSecretArn,
+  );
+  secret.grantRead(fn);
+  fn.addEnvironment("SENTRY_DSN", secret.secretValue.unsafeUnwrap());
+  fn.addEnvironment("SENTRY_ENVIRONMENT", props.sentryEnvironment);
+  fn.addEnvironment("SENTRY_RELEASE", props.sentryRelease);
+  fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
+}
 
 export function globalMetrics(scope: Construct, props: GlobalMetricsProps): GlobalMetricsResult {
   const snapshotBucket = new s3.Bucket(scope, "GlobalMetricsSnapshotBucket", {
@@ -79,6 +122,7 @@ export function globalMetrics(scope: Construct, props: GlobalMetricsProps): Glob
   });
 
   props.reportingDbSecret.grantRead(snapshotFunction);
+  addOptionalSentryEnvironment(scope, snapshotFunction, props);
   snapshotFunction.addToRolePolicy(new iam.PolicyStatement({
     actions: ["s3:PutObject"],
     resources: [snapshotBucket.arnForObjects(globalMetricsSnapshotObjectKey)],

--- a/infra/aws/lib/migration-runner.ts
+++ b/infra/aws/lib/migration-runner.ts
@@ -5,6 +5,7 @@ import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as rds from "aws-cdk-lib/aws-rds";
 import { Construct } from "constructs";
 import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
 
 export interface MigrationRunnerProps {
   vpc: ec2.Vpc;
@@ -15,6 +16,10 @@ export interface MigrationRunnerProps {
   authDbSecret: cdk.aws_secretsmanager.Secret;
   reportingDbSecret: cdk.aws_secretsmanager.ISecret;
   adminEmails: string | undefined;
+  sentryDsnSecretArn: string | undefined;
+  sentryEnvironment: string | undefined;
+  sentryRelease: string | undefined;
+  sentryTracesSampleRate: string | undefined;
 }
 
 const dbAssetPaths = {
@@ -34,9 +39,47 @@ const lambdaBundling: lambdaNodejs.BundlingOptions = {
       `mkdir -p ${outputDir}/db/views`,
       `cp ${dbAssetPaths.migrations}/*.sql ${outputDir}/db/migrations/`,
       `cp ${dbAssetPaths.views}/*.sql ${outputDir}/db/views/`,
+      createSentrySourceMapUploadCommand(outputDir),
     ],
   },
 };
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+function addOptionalSentryEnvironment(
+  scope: Construct,
+  fn: lambdaNodejs.NodejsFunction,
+  props: MigrationRunnerProps,
+): void {
+  if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
+    return;
+  }
+  if (
+    !hasConfiguredValue(props.sentryEnvironment) ||
+    !hasConfiguredValue(props.sentryRelease) ||
+    !hasConfiguredValue(props.sentryTracesSampleRate)
+  ) {
+    throw new Error("sentryEnvironment, sentryRelease, and sentryTracesSampleRate are required when sentryDsnSecretArn is configured");
+  }
+
+  const tracesSampleRate = Number(props.sentryTracesSampleRate);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("sentryTracesSampleRate must be a number between 0 and 1");
+  }
+
+  const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+    scope,
+    "MigrationRunnerSentryDsnSecret",
+    props.sentryDsnSecretArn,
+  );
+  secret.grantRead(fn);
+  fn.addEnvironment("SENTRY_DSN", secret.secretValue.unsafeUnwrap());
+  fn.addEnvironment("SENTRY_ENVIRONMENT", props.sentryEnvironment);
+  fn.addEnvironment("SENTRY_RELEASE", props.sentryRelease);
+  fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
+}
 
 /**
  * Creates the migration Lambda that owns schema changes and runtime role
@@ -70,6 +113,7 @@ export function migrationRunner(scope: Construct, props: MigrationRunnerProps): 
   props.backendDbSecret.grantRead(migrationFn);
   props.authDbSecret.grantRead(migrationFn);
   props.reportingDbSecret.grantRead(migrationFn);
+  addOptionalSentryEnvironment(scope, migrationFn, props);
 
   return migrationFn;
 }

--- a/infra/aws/lib/sentry-source-maps.ts
+++ b/infra/aws/lib/sentry-source-maps.ts
@@ -1,0 +1,25 @@
+import { resolveFromRepoRoot } from "./nodejs-project-paths";
+
+const backendSentryCliPath = resolveFromRepoRoot("apps", "backend", "node_modules", ".bin", "sentry-cli");
+const sentrySourceMapUploadMaxAttempts = 3;
+
+export function createSentrySourceMapUploadCommand(outputDir: string): string {
+  return [
+    `if [ "$SENTRY_UPLOAD_BACKEND_SOURCEMAPS" != "true" ]; then`,
+    `echo "Sentry backend source map upload disabled. Set SENTRY_UPLOAD_BACKEND_SOURCEMAPS=true in GitHub Actions to enable it.";`,
+    `elif [ "$GITHUB_ACTIONS" != "true" ]; then`,
+    `echo "WARNING: SENTRY_UPLOAD_BACKEND_SOURCEMAPS=true ignored because backend source map upload is only enabled in GitHub Actions." >&2;`,
+    `else`,
+    `missing_sentry_env="";`,
+    `[ -n "$SENTRY_AUTH_TOKEN" ] || missing_sentry_env="$missing_sentry_env SENTRY_AUTH_TOKEN";`,
+    `[ -n "$SENTRY_ORG" ] || missing_sentry_env="$missing_sentry_env SENTRY_ORG";`,
+    `[ -n "$SENTRY_PROJECT" ] || missing_sentry_env="$missing_sentry_env SENTRY_PROJECT";`,
+    `[ -n "$SENTRY_RELEASE" ] || missing_sentry_env="$missing_sentry_env SENTRY_RELEASE";`,
+    `if [ -n "$missing_sentry_env" ]; then echo "Missing required Sentry source map upload environment variables:$missing_sentry_env" >&2; exit 1; fi;`,
+    `if [ ! -x "${backendSentryCliPath}" ]; then echo "Sentry CLI not found or not executable at ${backendSentryCliPath}. Run npm ci --prefix apps/backend before CDK deploy." >&2; exit 1; fi;`,
+    `run_sentry_command_with_retries() { sentry_command_name="$1"; shift; sentry_attempt=1; while true; do sentry_status=0; "$@" || sentry_status="$?"; if [ "$sentry_status" -eq 0 ]; then return 0; fi; if [ "$sentry_attempt" -ge "${sentrySourceMapUploadMaxAttempts}" ]; then echo "Sentry \${sentry_command_name} failed after \${sentry_attempt} attempts with exit status \${sentry_status}." >&2; return "$sentry_status"; fi; sentry_next_attempt=$((sentry_attempt + 1)); echo "WARNING: Sentry \${sentry_command_name} failed with exit status \${sentry_status}; retrying attempt \${sentry_next_attempt}/${sentrySourceMapUploadMaxAttempts}." >&2; sentry_attempt="$sentry_next_attempt"; sleep "$sentry_attempt"; done; };`,
+    `run_sentry_command_with_retries "source map inject" "${backendSentryCliPath}" sourcemaps inject "${outputDir}" || exit "$?";`,
+    `run_sentry_command_with_retries "source map upload" "${backendSentryCliPath}" sourcemaps upload "${outputDir}" --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" --release "$SENTRY_RELEASE" || exit "$?";`,
+    `fi`,
+  ].join(" ");
+}

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -35,6 +35,66 @@ function getOptionalRawContextValue(stack: cdk.Stack, key: string): string | und
   return value;
 }
 
+interface BackendSentryContext {
+  sentryDsnSecretArn: string;
+  sentryEnvironment: string;
+  sentryRelease: string;
+  sentryTracesSampleRate: string;
+}
+
+interface BackendSentryContextInput {
+  sentryDsnSecretArn: string | undefined;
+  sentryEnvironment: string | undefined;
+  sentryRelease: string | undefined;
+  sentryTracesSampleRate: string | undefined;
+}
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+function validateSentryTracesSampleRate(value: string): void {
+  const tracesSampleRate = Number(value);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("sentryTracesSampleRate must be a number between 0 and 1");
+  }
+}
+
+function validateBackendSentryContext(context: BackendSentryContextInput): BackendSentryContext {
+  const contextValues = [
+    ["sentryDsnSecretArn", context.sentryDsnSecretArn],
+    ["sentryEnvironment", context.sentryEnvironment],
+    ["sentryRelease", context.sentryRelease],
+    ["sentryTracesSampleRate", context.sentryTracesSampleRate],
+  ] as const;
+  const missingContextKeys = contextValues
+    .filter(([_key, value]) => !hasConfiguredValue(value))
+    .map(([key, _value]) => key);
+  if (missingContextKeys.length > 0) {
+    throw new Error(
+      `Backend Sentry context is required for stack configuration because AWS Lambda backend runtimes require SENTRY_DSN. Missing: ${missingContextKeys.join(", ")}`,
+    );
+  }
+
+  const { sentryDsnSecretArn, sentryEnvironment, sentryRelease, sentryTracesSampleRate } = context;
+  if (
+    !hasConfiguredValue(sentryDsnSecretArn) ||
+    !hasConfiguredValue(sentryEnvironment) ||
+    !hasConfiguredValue(sentryRelease) ||
+    !hasConfiguredValue(sentryTracesSampleRate)
+  ) {
+    throw new Error("Backend Sentry context validation failed unexpectedly.");
+  }
+
+  validateSentryTracesSampleRate(sentryTracesSampleRate);
+  return {
+    sentryDsnSecretArn,
+    sentryEnvironment,
+    sentryRelease,
+    sentryTracesSampleRate,
+  };
+}
+
 function parseCommaSeparatedValue(value: string): ReadonlyArray<string> {
   return value
     .split(",")
@@ -66,6 +126,12 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
     const langfusePublicKeySecretArn = getOptionalContextValue(this, "langfusePublicKeySecretArn");
     const langfuseSecretKeySecretArn = getOptionalContextValue(this, "langfuseSecretKeySecretArn");
     const langfuseBaseUrl = getOptionalContextValue(this, "langfuseBaseUrl");
+    const sentryContext = validateBackendSentryContext({
+      sentryDsnSecretArn: getOptionalContextValue(this, "sentryDsnSecretArn"),
+      sentryEnvironment: getOptionalContextValue(this, "sentryEnvironment"),
+      sentryRelease: getOptionalContextValue(this, "sentryRelease"),
+      sentryTracesSampleRate: getOptionalContextValue(this, "sentryTracesSampleRate"),
+    });
     const demoEmailDostip = getOptionalContextValue(this, "demoEmailDostip");
     const demoPasswordSecretArn = getOptionalContextValue(this, "demoPasswordSecretArn");
     const adminEmails = getOptionalContextValue(this, "adminEmails");
@@ -91,6 +157,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       lambdaSg: net.lambdaSg,
       db: dbResult.db,
       reportingDbSecret: dbResult.reportingDbSecret,
+      ...sentryContext,
     });
     let analyticsAccessResult: AnalyticsAccessResult | undefined;
     if (analyticsAccessRequested) {
@@ -149,6 +216,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       authDbSecret: dbResult.authDbSecret,
       reportingDbSecret: dbResult.reportingDbSecret,
       adminEmails,
+      ...sentryContext,
     });
     const api = apiGateway(this, {
       vpc: net.vpc,
@@ -162,6 +230,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       langfusePublicKeySecretArn,
       langfuseSecretKeySecretArn,
       langfuseBaseUrl,
+      ...sentryContext,
       demoEmailDostip,
       guestAiWeightedMonthlyTokenCap,
       globalMetricsVisible,

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,13 +6,21 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 CDK_DIR="${ROOT_DIR}/infra/aws"
+TEMP_DIR="$(mktemp -d)"
+SENTRY_DSN_SECRET_NAME="flashcards-open-source-app/sentry-dsn"
 
 # shellcheck disable=SC1091
-source "${SCRIPT_DIR}/lib/root-env.sh"
+source "${SCRIPT_DIR}/lib/deploy-config.sh"
 load_root_env
 
 REGION="${AWS_REGION:-}"
 STACK_NAME="FlashcardsOpenSourceApp"
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+
+trap cleanup EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -26,6 +34,78 @@ if [[ -z "$REGION" ]]; then
   echo "Usage: $0 --region <aws-region>" >&2
   exit 1
 fi
+
+create_sentry_dsn_secret() {
+  local secret_file=""
+
+  require_non_empty_value "${SENTRY_DSN:-}" "Set SENTRY_DSN in root .env before bootstrap, or set SENTRY_DSN_SECRET_ARN to an existing Secrets Manager secret ARN." >/dev/null
+
+  secret_file="$(mktemp "${TEMP_DIR}/sentry-dsn.XXXXXX")"
+  chmod 600 "$secret_file"
+  printf '%s' "${SENTRY_DSN}" > "$secret_file"
+
+  aws secretsmanager create-secret \
+    --name "$SENTRY_DSN_SECRET_NAME" \
+    --description "Sentry DSN for flashcards-open-source-app backend AWS Lambda runtimes" \
+    --secret-string "file://${secret_file}" \
+    --region "$REGION" \
+    --tags \
+      "Key=${DEPLOY_CONFIG_PROJECT_TAG_KEY},Value=${DEPLOY_CONFIG_PROJECT_TAG_VALUE}" \
+      "Key=${DEPLOY_CONFIG_PURPOSE_TAG_KEY},Value=sentry-dsn" \
+    --query ARN \
+    --output text
+}
+
+ensure_sentry_dsn_secret() {
+  local existing_secret_arn=""
+
+  if [[ -n "${SENTRY_DSN_SECRET_ARN:-}" ]]; then
+    export SENTRY_DSN_SECRET_ARN
+    echo "Using configured Sentry DSN secret ARN from SENTRY_DSN_SECRET_ARN."
+    return
+  fi
+
+  existing_secret_arn="$(find_secret_arn "$REGION" "$SENTRY_DSN_SECRET_NAME")"
+  if [[ -n "$existing_secret_arn" ]]; then
+    export SENTRY_DSN_SECRET_ARN="$existing_secret_arn"
+    echo "Using existing Sentry DSN secret in AWS Secrets Manager: ${SENTRY_DSN_SECRET_ARN}"
+    return
+  fi
+
+  SENTRY_DSN_SECRET_ARN="$(create_sentry_dsn_secret)"
+  export SENTRY_DSN_SECRET_ARN
+  echo "Created Sentry DSN secret in AWS Secrets Manager: ${SENTRY_DSN_SECRET_ARN}"
+}
+
+get_bootstrap_sentry_release() {
+  local git_sha=""
+
+  git_sha="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || true)"
+  if [[ -n "$git_sha" ]]; then
+    printf '%s\n' "$git_sha"
+    return
+  fi
+
+  printf 'local/bootstrap\n'
+}
+
+ensure_bootstrap_sentry_context_defaults() {
+  if [[ -z "${SENTRY_ENVIRONMENT:-}" ]]; then
+    export SENTRY_ENVIRONMENT="production"
+    echo "Using default SENTRY_ENVIRONMENT=production for bootstrap CDK context."
+  fi
+
+  if [[ -z "${SENTRY_RELEASE:-}" ]]; then
+    SENTRY_RELEASE="$(get_bootstrap_sentry_release)"
+    export SENTRY_RELEASE
+    echo "Using default SENTRY_RELEASE=${SENTRY_RELEASE} for bootstrap CDK context."
+  fi
+
+  if [[ -z "${SENTRY_TRACES_SAMPLE_RATE:-}" ]]; then
+    export SENTRY_TRACES_SAMPLE_RATE="0"
+    echo "Using default SENTRY_TRACES_SAMPLE_RATE=0 for bootstrap CDK context."
+  fi
+}
 
 echo "=== Install dependencies ==="
 npm ci --silent --prefix "${ROOT_DIR}/api"
@@ -42,6 +122,10 @@ bash "${ROOT_DIR}/scripts/setup-resend-secret.sh" --region "$REGION"
 
 echo "=== Configure optional AI secrets ==="
 bash "${ROOT_DIR}/scripts/setup-ai-secrets.sh" --region "$REGION"
+
+echo "=== Configure required Sentry DSN secret ==="
+ensure_sentry_dsn_secret
+ensure_bootstrap_sentry_context_defaults
 
 if [[ -n "${DEMO_PASSWORD_DOSTIP:-}" ]]; then
   echo "=== Configure optional review account auth secret ==="

--- a/scripts/generate-cdk-context.sh
+++ b/scripts/generate-cdk-context.sh
@@ -10,6 +10,7 @@ REGION_OVERRIDE=""
 DOMAIN_OVERRIDE=""
 ALERT_EMAIL_OVERRIDE=""
 GITHUB_REPO_OVERRIDE=""
+SENTRY_DSN_SECRET_NAME="flashcards-open-source-app/sentry-dsn"
 
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/deploy-config.sh"
@@ -31,6 +32,27 @@ DOMAIN_NAME="$(require_non_empty_value "${DOMAIN_OVERRIDE:-${DOMAIN_NAME:-}}" "S
 ALERT_EMAIL="$(require_non_empty_value "${ALERT_EMAIL_OVERRIDE:-${ALERT_EMAIL:-}}" "Set ALERT_EMAIL in root .env or pass --alert-email.")"
 GITHUB_REPO="$(require_non_empty_value "${GITHUB_REPO_OVERRIDE:-${GITHUB_REPO:-}}" "Set GITHUB_REPO in root .env or pass --github-repo.")"
 
+validate_sentry_traces_sample_rate() {
+  local value="$1"
+
+  python3 - "$value" <<'PY'
+import math
+import sys
+
+value = sys.argv[1]
+
+try:
+    traces_sample_rate = float(value)
+except ValueError:
+    print("ERROR: Set SENTRY_TRACES_SAMPLE_RATE to a number between 0 and 1.", file=sys.stderr)
+    sys.exit(1)
+
+if not math.isfinite(traces_sample_rate) or traces_sample_rate < 0 or traces_sample_rate > 1:
+    print("ERROR: Set SENTRY_TRACES_SAMPLE_RATE to a number between 0 and 1.", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
 API_CERTIFICATE_ARN="$(find_certificate_arn "${REGION}" "api.${DOMAIN_NAME}" "api-domain")"
 AUTH_CERTIFICATE_ARN="$(find_certificate_arn "${REGION}" "auth.${DOMAIN_NAME}" "auth-domain")"
 WEB_CERTIFICATE_ARN="$(find_certificate_arn "us-east-1" "app.${DOMAIN_NAME}" "web-domain")"
@@ -42,6 +64,12 @@ LANGFUSE_PUBLIC_KEY_SECRET_ARN="$(find_secret_arn "${REGION}" "flashcards-open-s
 LANGFUSE_SECRET_KEY_SECRET_ARN="$(find_secret_arn "${REGION}" "flashcards-open-source-app/langfuse-secret-key")"
 RESEND_SECRET_ARN="$(find_secret_arn "${REGION}" "flashcards-open-source-app/resend-api-key")"
 DEMO_PASSWORD_SECRET_ARN="$(find_secret_arn "${REGION}" "flashcards-open-source-app/demo-password-dostip")"
+SENTRY_DSN_SECRET_ARN="${SENTRY_DSN_SECRET_ARN:-$(find_secret_arn "${REGION}" "${SENTRY_DSN_SECRET_NAME}")}"
+SENTRY_ENVIRONMENT="$(require_non_empty_value "${SENTRY_ENVIRONMENT:-}" "Set SENTRY_ENVIRONMENT in root .env before generating a deploy CDK context.")"
+SENTRY_RELEASE="$(require_non_empty_value "${SENTRY_RELEASE:-}" "Set SENTRY_RELEASE in root .env before generating a deploy CDK context.")"
+SENTRY_TRACES_SAMPLE_RATE="$(require_non_empty_value "${SENTRY_TRACES_SAMPLE_RATE:-}" "Set SENTRY_TRACES_SAMPLE_RATE in root .env before generating a deploy CDK context.")"
+require_non_empty_value "${SENTRY_DSN_SECRET_ARN}" "Set SENTRY_DSN_SECRET_ARN in root .env or create the AWS secret ${SENTRY_DSN_SECRET_NAME} before generating a deploy CDK context." >/dev/null
+validate_sentry_traces_sample_rate "${SENTRY_TRACES_SAMPLE_RATE}"
 ANALYTICS_SSH_PUBLIC_KEYS="${ANALYTICS_SSH_PUBLIC_KEYS:-}"
 ANALYTICS_SSH_ALLOWED_CIDRS="${ANALYTICS_SSH_ALLOWED_CIDRS:-}"
 ANALYTICS_SSH_USERNAME="${ANALYTICS_SSH_USERNAME:-}"
@@ -75,6 +103,10 @@ export LANGFUSE_SECRET_KEY_SECRET_ARN
 export RESEND_SECRET_ARN
 export RESEND_SENDER_EMAIL
 export DEMO_PASSWORD_SECRET_ARN
+export SENTRY_DSN_SECRET_ARN
+export SENTRY_ENVIRONMENT
+export SENTRY_RELEASE
+export SENTRY_TRACES_SAMPLE_RATE
 export ANALYTICS_SSH_PUBLIC_KEYS
 export ANALYTICS_SSH_ALLOWED_CIDRS
 export ANALYTICS_SSH_USERNAME
@@ -107,6 +139,10 @@ values = {
     "resendSenderEmail": os.environ.get("RESEND_SENDER_EMAIL", ""),
     "demoEmailDostip": os.environ.get("DEMO_EMAIL_DOSTIP", ""),
     "demoPasswordSecretArn": os.environ.get("DEMO_PASSWORD_SECRET_ARN", ""),
+    "sentryDsnSecretArn": os.environ.get("SENTRY_DSN_SECRET_ARN", ""),
+    "sentryEnvironment": os.environ.get("SENTRY_ENVIRONMENT", ""),
+    "sentryRelease": os.environ.get("SENTRY_RELEASE", ""),
+    "sentryTracesSampleRate": os.environ.get("SENTRY_TRACES_SAMPLE_RATE", ""),
     "guestAiWeightedMonthlyTokenCap": os.environ.get("GUEST_AI_WEIGHTED_MONTHLY_TOKEN_CAP", ""),
     "adminEmails": os.environ.get("ADMIN_EMAILS", ""),
     "analyticsSshPublicKeys": os.environ.get("ANALYTICS_SSH_PUBLIC_KEYS", ""),

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 STACK_NAME="FlashcardsOpenSourceApp"
 REPO=""
+SENTRY_DSN_SECRET_NAME="flashcards-open-source-app/sentry-dsn"
 
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/lib/deploy-config.sh"
@@ -52,6 +53,54 @@ set_variable_if_missing() {
   gh variable set "$variable_name" --body "$variable_value" --repo "$REPO"
 }
 
+validate_sentry_traces_sample_rate() {
+  local value="$1"
+
+  python3 - "$value" <<'PY'
+import math
+import sys
+
+value = sys.argv[1]
+
+try:
+    traces_sample_rate = float(value)
+except ValueError:
+    print("ERROR: Set SENTRY_TRACES_SAMPLE_RATE to a number between 0 and 1.", file=sys.stderr)
+    sys.exit(1)
+
+if not math.isfinite(traces_sample_rate) or traces_sample_rate < 0 or traces_sample_rate > 1:
+    print("ERROR: Set SENTRY_TRACES_SAMPLE_RATE to a number between 0 and 1.", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+set_required_variable_if_missing() {
+  local variable_name="$1"
+  local variable_value="$2"
+  local error_message="$3"
+
+  if has_variable "$variable_name"; then
+    return
+  fi
+
+  variable_value="$(require_non_empty_value "$variable_value" "$error_message")"
+  gh variable set "$variable_name" --body "$variable_value" --repo "$REPO"
+}
+
+set_required_sentry_traces_sample_rate_variable_if_missing() {
+  local variable_name="$1"
+  local variable_value="$2"
+  local error_message="$3"
+
+  if has_variable "$variable_name"; then
+    return
+  fi
+
+  variable_value="$(require_non_empty_value "$variable_value" "$error_message")"
+  validate_sentry_traces_sample_rate "$variable_value"
+  gh variable set "$variable_name" --body "$variable_value" --repo "$REPO"
+}
+
 has_secret() {
   local secret_name="$1"
 
@@ -70,7 +119,20 @@ set_secret_if_missing() {
     return
   fi
 
-  gh secret set "$secret_name" --body "$secret_value" --repo "$REPO"
+  printf '%s' "$secret_value" | gh secret set "$secret_name" --repo "$REPO"
+}
+
+set_required_secret_if_missing() {
+  local secret_name="$1"
+  local secret_value="$2"
+  local error_message="$3"
+
+  if has_secret "$secret_name"; then
+    return
+  fi
+
+  secret_value="$(require_non_empty_value "$secret_value" "$error_message")"
+  printf '%s' "$secret_value" | gh secret set "$secret_name" --repo "$REPO"
 }
 
 get_output() {
@@ -97,10 +159,16 @@ LANGFUSE_PUBLIC_KEY_SECRET_ARN="$(find_secret_arn "$REGION" "flashcards-open-sou
 LANGFUSE_SECRET_KEY_SECRET_ARN="$(find_secret_arn "$REGION" "flashcards-open-source-app/langfuse-secret-key")"
 RESEND_SECRET_ARN="$(find_secret_arn "$REGION" "flashcards-open-source-app/resend-api-key")"
 DEMO_PASSWORD_SECRET_ARN="$(find_secret_arn "$REGION" "flashcards-open-source-app/demo-password-dostip")"
+SENTRY_DSN_SECRET_ARN="${SENTRY_DSN_SECRET_ARN:-$(find_secret_arn "$REGION" "$SENTRY_DSN_SECRET_NAME")}"
 DEMO_EMAIL_DOSTIP="${DEMO_EMAIL_DOSTIP:-}"
 GUEST_AI_QUOTA_CAP="${GUEST_AI_WEIGHTED_MONTHLY_TOKEN_CAP:-}"
 ADMIN_EMAILS="${ADMIN_EMAILS:-}"
 LANGFUSE_BASE_URL="${LANGFUSE_BASE_URL:-}"
+SENTRY_ENVIRONMENT="${SENTRY_ENVIRONMENT:-production}"
+SENTRY_TRACES_SAMPLE_RATE="${SENTRY_TRACES_SAMPLE_RATE:-0}"
+SENTRY_ORG="${SENTRY_ORG:-}"
+SENTRY_BACKEND_PROJECT="${SENTRY_BACKEND_PROJECT:-}"
+SENTRY_AUTH_TOKEN="${SENTRY_AUTH_TOKEN:-}"
 ANALYTICS_SSH_PUBLIC_KEYS="${ANALYTICS_SSH_PUBLIC_KEYS:-}"
 ANALYTICS_SSH_ALLOWED_CIDRS="${ANALYTICS_SSH_ALLOWED_CIDRS:-}"
 ANALYTICS_SSH_USERNAME="${ANALYTICS_SSH_USERNAME:-}"
@@ -139,6 +207,11 @@ set_variable_if_missing CDK_OPENAI_API_KEY_SECRET_ARN "$OPENAI_SECRET_ARN"
 set_variable_if_missing CDK_LANGFUSE_PUBLIC_KEY_SECRET_ARN "$LANGFUSE_PUBLIC_KEY_SECRET_ARN"
 set_variable_if_missing CDK_LANGFUSE_SECRET_KEY_SECRET_ARN "$LANGFUSE_SECRET_KEY_SECRET_ARN"
 set_variable_if_missing CDK_LANGFUSE_BASE_URL "$LANGFUSE_BASE_URL"
+set_required_variable_if_missing CDK_SENTRY_DSN_SECRET_ARN "$SENTRY_DSN_SECRET_ARN" "Set SENTRY_DSN_SECRET_ARN in root .env or create the AWS secret ${SENTRY_DSN_SECRET_NAME} before running setup-github.sh."
+set_required_variable_if_missing CDK_SENTRY_ENVIRONMENT "$SENTRY_ENVIRONMENT" "Set SENTRY_ENVIRONMENT in root .env before running setup-github.sh."
+set_required_sentry_traces_sample_rate_variable_if_missing CDK_SENTRY_TRACES_SAMPLE_RATE "$SENTRY_TRACES_SAMPLE_RATE" "Set SENTRY_TRACES_SAMPLE_RATE in root .env before running setup-github.sh."
+set_required_variable_if_missing SENTRY_ORG "$SENTRY_ORG" "Set SENTRY_ORG in root .env before running setup-github.sh."
+set_required_variable_if_missing SENTRY_BACKEND_PROJECT "$SENTRY_BACKEND_PROJECT" "Set SENTRY_BACKEND_PROJECT in root .env before running setup-github.sh."
 set_variable_if_missing CDK_DEMO_EMAIL_DOSTIP "$DEMO_EMAIL_DOSTIP"
 set_variable_if_missing CDK_DEMO_PASSWORD_SECRET_ARN "$DEMO_PASSWORD_SECRET_ARN"
 set_variable_if_missing CDK_GUEST_AI_WEIGHTED_MONTHLY_TOKEN_CAP "$GUEST_AI_QUOTA_CAP"
@@ -152,6 +225,7 @@ set_variable_if_missing CDK_ANALYTICS_SSH_ALLOWED_CIDRS "$ANALYTICS_SSH_ALLOWED_
 set_variable_if_missing CDK_ANALYTICS_SSH_USERNAME "$ANALYTICS_SSH_USERNAME"
 
 set_secret_if_missing AWS_DEPLOY_ROLE_ARN "$DEPLOY_ROLE_ARN"
+set_required_secret_if_missing SENTRY_AUTH_TOKEN "$SENTRY_AUTH_TOKEN" "Set SENTRY_AUTH_TOKEN in root .env before running setup-github.sh."
 
 echo "Global metrics visibility input: root .env GLOBAL_METRICS_VISIBLE -> GitHub variable CDK_GLOBAL_METRICS_VISIBLE."
 echo "Only the exact raw string 'true' exposes GET /v1/global/snapshot; any other value or an unset variable keeps it hidden."

--- a/scripts/write-ci-cdk-context.py
+++ b/scripts/write-ci-cdk-context.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import math
 import os
 import pathlib
 import re
@@ -13,6 +14,49 @@ def get_trimmed_env(name: str) -> str:
 
 def get_raw_env(name: str) -> str:
     return os.environ.get(name, "")
+
+
+def require_non_empty_context_value(values: dict[str, str], key: str, env_name: str) -> None:
+    if values.get(key, "") == "":
+        raise ValueError(f"{env_name} is required for CI AWS deploy context")
+
+
+def validate_sentry_traces_sample_rate(value: str) -> None:
+    try:
+        traces_sample_rate = float(value)
+    except ValueError as exc:
+        raise ValueError("CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE must be a number between 0 and 1") from exc
+
+    if not math.isfinite(traces_sample_rate) or traces_sample_rate < 0 or traces_sample_rate > 1:
+        raise ValueError("CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE must be a number between 0 and 1")
+
+
+def validate_required_backend_sentry_context(values: dict[str, str], aws_deploy_role_arn: str) -> None:
+    sentry_context_env_names = {
+        "sentryDsnSecretArn": "CDK_CONTEXT_SENTRY_DSN_SECRET_ARN",
+        "sentryEnvironment": "CDK_CONTEXT_SENTRY_ENVIRONMENT",
+        "sentryRelease": "CDK_CONTEXT_SENTRY_RELEASE",
+        "sentryTracesSampleRate": "CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE",
+    }
+
+    if aws_deploy_role_arn == "":
+        configured_values = [values[key] for key in sentry_context_env_names if values[key] != ""]
+        if len(configured_values) == 0:
+            return
+    else:
+        for key, env_name in sentry_context_env_names.items():
+            require_non_empty_context_value(values, key, env_name)
+
+    missing_env_names = [
+        env_name
+        for key, env_name in sentry_context_env_names.items()
+        if values[key] == ""
+    ]
+    if len(missing_env_names) > 0:
+        joined_missing_env_names = ", ".join(missing_env_names)
+        raise ValueError(f"Backend Sentry context must be configured all-or-none. Missing: {joined_missing_env_names}")
+
+    validate_sentry_traces_sample_rate(values["sentryTracesSampleRate"])
 
 
 def build_github_oidc_provider_arn(aws_deploy_role_arn: str) -> str:
@@ -59,8 +103,13 @@ def build_context_values(aws_deploy_role_arn: str) -> dict[str, str]:
         "region": get_trimmed_env("CDK_CONTEXT_REGION"),
         "resendApiKeySecretArn": get_trimmed_env("CDK_CONTEXT_RESEND_API_KEY_SECRET_ARN"),
         "resendSenderEmail": get_trimmed_env("CDK_CONTEXT_RESEND_SENDER_EMAIL"),
+        "sentryDsnSecretArn": get_trimmed_env("CDK_CONTEXT_SENTRY_DSN_SECRET_ARN"),
+        "sentryEnvironment": get_trimmed_env("CDK_CONTEXT_SENTRY_ENVIRONMENT"),
+        "sentryRelease": get_trimmed_env("CDK_CONTEXT_SENTRY_RELEASE"),
+        "sentryTracesSampleRate": get_trimmed_env("CDK_CONTEXT_SENTRY_TRACES_SAMPLE_RATE"),
         "webCertificateArnUsEast1": get_trimmed_env("CDK_CONTEXT_WEB_CERTIFICATE_ARN_US_EAST_1"),
     }
+    validate_required_backend_sentry_context(values, aws_deploy_role_arn)
     return {key: value for key, value in values.items() if value != ""}
 
 


### PR DESCRIPTION
## Summary
- add backend-only Sentry observability for API, chat worker, chat live, global metrics, and migration Lambda surfaces
- add typed backend observability events, sanitizer behavior, trace propagation, and Langfuse/Sentry OTel separation
- add CDK/GitHub Actions wiring for Sentry env vars and backend source map uploads

## Validation
- git --no-pager diff --check
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend
