### PR TITLE
[codex] Harden backend Sentry observability

### DIFF
--- a/apps/backend/src/admin/query.ts
+++ b/apps/backend/src/admin/query.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type pg from "pg";
 import { withTransientDatabaseRetry } from "../dbTransient";
 import { HttpError } from "../errors";
+import { createBackendObservationScope } from "../observability/sentry";
 import { logAdminQueryEvent } from "../server/logging";
 import { withReportingReadOnlyTransaction } from "./reportingDb";
 
@@ -510,6 +511,17 @@ export async function executeAdminQuery(
 ): Promise<AdminQueryResponse> {
   const executeStatementBatchFn = params.executeStatementBatchFn ?? executeReportingStatementBatch;
   const logAdminQueryEventFn = params.logAdminQueryEventFn ?? logAdminQueryEvent;
+  const observationScope = createBackendObservationScope(
+    "backend-api",
+    params.requestId,
+    "/admin/reports/query",
+    "POST",
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
   const sqlFingerprint = getAdminQueryFingerprint(params.sql);
   const startedAt = Date.now();
   let statementCount = 0;
@@ -528,6 +540,7 @@ export async function executeAdminQuery(
     const resultSets: Array<AdminQueryResultSet> = [];
     const statementResults = await withTransientDatabaseRetry(
       async () => executeStatementBatchFn(statementSqlList),
+      () => observationScope,
     );
     if (statementResults.length !== statementSqlList.length) {
       throw new Error("Admin query executor returned a mismatched number of statement results.");

--- a/apps/backend/src/admin/reportingDb.test.ts
+++ b/apps/backend/src/admin/reportingDb.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import pg from "pg";
+import {
+  initializeBackendSentryWithDeps,
+  resetBackendSentryForTests,
+} from "../observability/sentry";
 
 function createCodedError(code: string, message: string): Error & Readonly<{ code: string }> {
   const error = new Error(message) as Error & { code: string };
@@ -42,6 +46,7 @@ test("withReportingReadOnlyTransaction preserves original error when rollback cl
   process.env.REPORTING_DATABASE_URL = "postgresql://user:pass@localhost:5432/reporting";
   delete process.env.REPORTING_DB_SECRET_ARN;
   pg.Pool.prototype.connect = async (): Promise<pg.PoolClient> => client as pg.PoolClient;
+  initializeBackendSentryWithDeps("backend-api", {}, { init: () => {} });
   console.warn = (message?: unknown): void => {
     if (typeof message !== "string") {
       throw new Error("Expected rollback warning log to be a JSON string.");
@@ -62,6 +67,7 @@ test("withReportingReadOnlyTransaction preserves original error when rollback cl
   } finally {
     pg.Pool.prototype.connect = originalConnect;
     console.warn = originalWarn;
+    resetBackendSentryForTests();
     if (originalReportingDatabaseUrl === undefined) {
       delete process.env.REPORTING_DATABASE_URL;
     } else {
@@ -84,6 +90,15 @@ test("withReportingReadOnlyTransaction preserves original error when rollback cl
     {
       domain: "backend",
       action: "reporting_read_only_transaction_rollback_failed",
+      service: "backend-api",
+      requestId: null,
+      route: null,
+      method: null,
+      userId: null,
+      workspaceId: null,
+      chatRequestId: null,
+      runId: null,
+      sessionId: null,
       originalSqlState: "42601",
       originalErrorCode: "42601",
       originalErrorClass: "Error",

--- a/apps/backend/src/admin/reportingDb.ts
+++ b/apps/backend/src/admin/reportingDb.ts
@@ -4,6 +4,10 @@ import {
   logDatabasePoolError,
   toDatabaseBoundaryError,
 } from "../dbTransient";
+import {
+  captureBackendWarning,
+  createBackendRuntimeObservationScope,
+} from "../observability/sentry";
 import { getDatabaseCredentialsSecret } from "../secrets";
 
 const reportingPoolMaxConnections = 4;
@@ -75,18 +79,28 @@ async function executeReportingTransactionCommand(
 function logReportingRollbackFailure(originalError: unknown, rollbackError: unknown): void {
   const originalFields = getDatabaseErrorFields(originalError);
   const rollbackFields = getDatabaseErrorFields(rollbackError);
-  console.warn(JSON.stringify({
-    domain: "backend",
+  captureBackendWarning({
     action: "reporting_read_only_transaction_rollback_failed",
-    originalSqlState: originalFields.sqlState,
-    originalErrorCode: originalFields.errorCode,
-    originalErrorClass: originalFields.errorClass,
-    originalErrorMessage: originalFields.errorMessage,
-    rollbackSqlState: rollbackFields.sqlState,
-    rollbackErrorCode: rollbackFields.errorCode,
-    rollbackErrorClass: rollbackFields.errorClass,
-    rollbackErrorMessage: rollbackFields.errorMessage,
-  }));
+    scope: createBackendRuntimeObservationScope(),
+    details: {
+      originalSqlState: originalFields.sqlState,
+      originalErrorCode: originalFields.errorCode,
+      originalErrorClass: originalFields.errorClass,
+      originalErrorMessage: originalFields.errorMessage,
+      rollbackSqlState: rollbackFields.sqlState,
+      rollbackErrorCode: rollbackFields.errorCode,
+      rollbackErrorClass: rollbackFields.errorClass,
+      rollbackErrorMessage: rollbackFields.errorMessage,
+    },
+  });
+}
+
+function tryLogReportingRollbackFailure(originalError: unknown, rollbackError: unknown): void {
+  try {
+    logReportingRollbackFailure(originalError, rollbackError);
+  } catch {
+    // Observability must not mask the original reporting transaction failure.
+  }
 }
 
 async function rollbackReportingTransaction(client: pg.PoolClient): Promise<unknown | null> {
@@ -132,8 +146,8 @@ export async function withReportingReadOnlyTransaction<Result>(
   } catch (error) {
     const rollbackError = await rollbackReportingTransaction(client);
     if (rollbackError !== null) {
-      logReportingRollbackFailure(error, rollbackError);
       releaseError = toClientReleaseError(rollbackError);
+      tryLogReportingRollbackFailure(error, rollbackError);
       throw toDatabaseBoundaryError(error);
     }
 

--- a/apps/backend/src/cards/fsrs.ts
+++ b/apps/backend/src/cards/fsrs.ts
@@ -1,5 +1,9 @@
 import type { DatabaseExecutor } from "../db";
 import { HttpError } from "../errors";
+import {
+  captureBackendWarning,
+  createBackendObservationScope,
+} from "../observability/sentry";
 import { CARD_COLUMNS, REVIEWABLE_CARD_COLUMNS } from "./shared";
 import type { CardRow, FsrsStateSnapshot, ReviewableCardRow } from "./types";
 
@@ -62,14 +66,27 @@ export function assertConsistentFsrsState(card: FsrsStateSnapshot): void {
 }
 
 function logFsrsStateReset(workspaceId: string, cardId: string, reason: string): void {
-  console.error(JSON.stringify({
-    domain: "cards",
+  captureBackendWarning({
     action: "reset_invalid_fsrs_state",
-    workspaceId,
-    cardId,
-    reason,
-    repair: "reset",
-  }));
+    message: "Invalid FSRS state was reset.",
+    scope: createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      null,
+      workspaceId,
+      null,
+      null,
+      null,
+    ),
+    details: {
+      workspaceId,
+      cardId,
+      reason,
+      repair: "reset",
+    },
+  });
 }
 
 async function resetCardRow(

--- a/apps/backend/src/chat/tests/transcriptions.test.ts
+++ b/apps/backend/src/chat/tests/transcriptions.test.ts
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import * as Sentry from "@sentry/aws-serverless";
+import { HttpError } from "../../errors";
+import { transcribeChatAudioUploadWithDependencies } from "../transcriptions";
+
+type MutableSentryModule = typeof Sentry & {
+  addBreadcrumb: (
+    breadcrumb: Parameters<typeof Sentry.addBreadcrumb>[0],
+  ) => ReturnType<typeof Sentry.addBreadcrumb>;
+  captureMessage: (
+    message: Parameters<typeof Sentry.captureMessage>[0],
+    captureContext: Parameters<typeof Sentry.captureMessage>[1],
+  ) => ReturnType<typeof Sentry.captureMessage>;
+};
+
+type ConsoleMethod = "log" | "warn";
+
+type ProviderError = Error & Readonly<{
+  status: number;
+  requestID: string;
+}>;
+
+const sentryModule = require("@sentry/aws-serverless") as MutableSentryModule;
+
+function createProviderError(message: string, status: number, requestID: string): ProviderError {
+  return Object.assign(new Error(message), {
+    status,
+    requestID,
+  });
+}
+
+function withOpenAIKey<Result>(fn: () => Promise<Result>): Promise<Result> {
+  const originalOpenAIKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "test-openai-key";
+
+  return fn().finally(() => {
+    if (originalOpenAIKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+      return;
+    }
+
+    process.env.OPENAI_API_KEY = originalOpenAIKey;
+  });
+}
+
+function withCapturedConsole<Result>(
+  method: ConsoleMethod,
+  fn: () => Promise<Result>,
+): Promise<Readonly<{
+  messages: ReadonlyArray<string>;
+  result: Result;
+}>> {
+  const originalMethod = console[method];
+  const messages: Array<string> = [];
+  console[method] = (message?: unknown): void => {
+    messages.push(typeof message === "string" ? message : String(message));
+  };
+
+  return fn().then(
+    (result) => ({ messages, result }),
+    (error: unknown) => {
+      throw error;
+    },
+  ).finally(() => {
+    console[method] = originalMethod;
+  });
+}
+
+function createFailingTranscriptionClient(error: Error): Parameters<typeof transcribeChatAudioUploadWithDependencies>[2] {
+  return {
+    audio: {
+      transcriptions: {
+        create: async () => {
+          throw error;
+        },
+      },
+    },
+  };
+}
+
+async function assertTranscriptionHttpError(
+  error: Error,
+  statusCode: number,
+  code: string,
+): Promise<void> {
+  const upload = {
+    file: new File(["audio"], "private-user-recording.m4a", { type: "audio/m4a" }),
+    source: "web" as const,
+  };
+
+  await assert.rejects(
+    () => transcribeChatAudioUploadWithDependencies(
+      upload,
+      {
+        requestId: "request-1",
+        sessionId: "session-1",
+      },
+      createFailingTranscriptionClient(error),
+      {
+        getObservedOpenAIClient: () => {
+          throw new Error("Expected explicit transcription client.");
+        },
+      },
+    ),
+    (caughtError: unknown): boolean => {
+      assert.equal(caughtError instanceof HttpError, true);
+      if (caughtError instanceof HttpError === false) {
+        return false;
+      }
+
+      assert.equal(caughtError.statusCode, statusCode);
+      assert.equal(caughtError.code, code);
+      return true;
+    },
+  );
+}
+
+test("invalid chat transcription audio failures create a breadcrumb without a Sentry warning issue", async () => {
+  const originalAddBreadcrumb = sentryModule.addBreadcrumb;
+  const originalCaptureMessage = sentryModule.captureMessage;
+  let breadcrumbCount = 0;
+  let captureMessageCount = 0;
+  sentryModule.addBreadcrumb = () => {
+    breadcrumbCount += 1;
+  };
+  sentryModule.captureMessage = () => {
+    captureMessageCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const { messages } = await withCapturedConsole("log", async () => {
+      await withOpenAIKey(async () => {
+        await assertTranscriptionHttpError(
+          createProviderError("Audio processing failed for user@example.com", 422, "upstream-request-1"),
+          422,
+          "CHAT_TRANSCRIPTION_INVALID_AUDIO",
+        );
+      });
+    });
+
+    assert.equal(captureMessageCount, 0);
+    assert.equal(breadcrumbCount, 1);
+    assert.equal(messages.length, 1);
+    assert.deepEqual(JSON.parse(messages[0] ?? ""), {
+      domain: "backend",
+      action: "chat_transcription_invalid_audio",
+      service: "backend-api",
+      requestId: "request-1",
+      route: null,
+      method: null,
+      userId: null,
+      workspaceId: null,
+      chatRequestId: null,
+      runId: null,
+      sessionId: "session-1",
+      source: "web",
+      provider: "openai",
+      fileSize: 5,
+      fileExtension: "m4a",
+      mediaType: "audio/m4a",
+      upstreamStatus: 422,
+      upstreamRequestId: "upstream-request-1",
+      errorClass: "Error",
+      errorMessage: "Audio processing failed for <masked-email>",
+    });
+  } finally {
+    sentryModule.addBreadcrumb = originalAddBreadcrumb;
+    sentryModule.captureMessage = originalCaptureMessage;
+  }
+});
+
+test("unexpected chat transcription failures keep safe warning details", async () => {
+  const originalCaptureMessage = sentryModule.captureMessage;
+  let captureMessageCount = 0;
+  sentryModule.captureMessage = () => {
+    captureMessageCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const { messages } = await withCapturedConsole("warn", async () => {
+      await withOpenAIKey(async () => {
+        await assertTranscriptionHttpError(
+          createProviderError("Provider failed with user@example.com", 502, "upstream-request-2"),
+          503,
+          "CHAT_TRANSCRIPTION_UNAVAILABLE",
+        );
+      });
+    });
+
+    assert.equal(captureMessageCount, 1);
+    assert.equal(messages.length, 1);
+    const record = JSON.parse(messages[0] ?? "");
+    assert.equal(record.action, "chat_transcription_failed");
+    assert.equal(record.fileExtension, "m4a");
+    assert.equal(record.upstreamRequestId, "upstream-request-2");
+    assert.equal(record.errorMessage, "Provider failed with <masked-email>");
+    assert.equal("fileName" in record, false);
+    assert.equal("upstreamMessage" in record, false);
+    assert.equal("sanitizedMessage" in record, false);
+  } finally {
+    sentryModule.captureMessage = originalCaptureMessage;
+  }
+});

--- a/apps/backend/src/chat/transcriptions.ts
+++ b/apps/backend/src/chat/transcriptions.ts
@@ -5,6 +5,13 @@
 import { Buffer } from "node:buffer";
 import { toFile } from "openai";
 import { HttpError } from "../errors";
+import {
+  addBackendBreadcrumb,
+  captureBackendWarning,
+  createBackendObservationScope,
+  getBackendErrorLogDetails,
+  type ChatTranscriptionFailureDetails,
+} from "../observability/sentry";
 import { expectUuidString } from "../server/requestParsing";
 import { getObservedOpenAIClient } from "./openai/client";
 import {
@@ -52,21 +59,6 @@ const SUPPORTED_AUDIO_MEDIA_TYPES = new Set([
   "audio/x-wav",
   "audio/webm",
 ]);
-
-type ChatTranscriptionFailureDetails = Readonly<{
-  requestId: string;
-  sessionId: string;
-  source: ChatTranscriptionSource;
-  fileName: string;
-  fileSize: number;
-  fileExtension: string | null;
-  provider: string;
-  mediaType: string;
-  upstreamStatus: number | null;
-  upstreamMessage: string | null;
-  upstreamRequestId: string | null;
-  error: string;
-}>;
 
 type ChatTranscriptionDependencies = Readonly<{
   getObservedOpenAIClient: () => OpenAITranscriptionClient;
@@ -192,22 +184,43 @@ function isInvalidAudioFailure(error: unknown): boolean {
  * Logs transcription failures with structured provider metadata for debugging.
  */
 function logChatTranscriptionFailure(details: ChatTranscriptionFailureDetails): void {
-  console.error(JSON.stringify({
-    domain: "chat",
+  captureBackendWarning({
     action: "chat_transcription_failed",
-    requestId: details.requestId,
-    sessionId: details.sessionId,
-    source: details.source,
-    provider: details.provider,
-    fileName: details.fileName,
-    fileSize: details.fileSize,
-    fileExtension: details.fileExtension,
-    mediaType: details.mediaType,
-    upstreamStatus: details.upstreamStatus,
-    upstreamMessage: details.upstreamMessage,
-    upstreamRequestId: details.upstreamRequestId,
-    error: details.error,
-  }));
+    message: "Chat transcription failed.",
+    scope: createBackendObservationScope(
+      "backend-api",
+      details.requestId,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      details.sessionId,
+    ),
+    details,
+  });
+}
+
+/**
+ * Logs expected invalid audio provider failures without creating Sentry warning issues.
+ */
+function logChatTranscriptionInvalidAudio(details: ChatTranscriptionFailureDetails): void {
+  addBackendBreadcrumb({
+    action: "chat_transcription_invalid_audio",
+    scope: createBackendObservationScope(
+      "backend-api",
+      details.requestId,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      details.sessionId,
+    ),
+    details,
+  });
 }
 
 const DEFAULT_CHAT_TRANSCRIPTION_DEPENDENCIES: ChatTranscriptionDependencies = {
@@ -258,22 +271,23 @@ export async function transcribeChatAudioUploadWithDependencies(
     return trimmedText;
   } catch (error) {
     const metadata = getAIProviderFailureMetadata(error);
-    logChatTranscriptionFailure({
+    const errorDetails = getBackendErrorLogDetails(error);
+    const failureDetails: ChatTranscriptionFailureDetails = {
       requestId: requestContext.requestId,
       sessionId: requestContext.sessionId,
       source: upload.source,
       provider: "openai",
-      fileName: upload.file.name,
       fileSize: upload.file.size,
       fileExtension: normalizeFileExtension(upload.file.name),
       mediaType: upload.file.type.trim().toLowerCase(),
       upstreamStatus: metadata.upstreamStatus,
-      upstreamMessage: metadata.upstreamMessage,
       upstreamRequestId: metadata.upstreamRequestId,
-      error: metadata.originalMessage,
-    });
+      errorClass: errorDetails.errorClass,
+      errorMessage: errorDetails.errorMessage,
+    };
 
     if (isInvalidAudioFailure(error)) {
+      logChatTranscriptionInvalidAudio(failureDetails);
       throw new HttpError(
         422,
         CHAT_TRANSCRIPTION_INVALID_AUDIO_ERROR_MESSAGE,
@@ -281,6 +295,7 @@ export async function transcribeChatAudioUploadWithDependencies(
       );
     }
 
+    logChatTranscriptionFailure(failureDetails);
     const normalizedFailure = classifyChatTranscriptionFailure(error);
     throw new HttpError(
       normalizedFailure.statusCode,

--- a/apps/backend/src/dbCore.test.ts
+++ b/apps/backend/src/dbCore.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import pg from "pg";
 import { HttpError } from "./errors";
+import {
+  initializeBackendSentryWithDeps,
+  resetBackendSentryForTests,
+} from "./observability/sentry";
 
 type CodedError = Error & Readonly<{ code: string }>;
 
@@ -74,6 +78,7 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
   process.env.DATABASE_URL = "postgresql://user:pass@localhost:5432/test";
   delete process.env.DB_SECRET_ARN;
   (pg as unknown as { Pool: typeof pg.Pool }).Pool = FakePool as unknown as typeof pg.Pool;
+  initializeBackendSentryWithDeps("backend-api", {}, { init: () => {} });
   console.warn = (message?: unknown): void => {
     if (typeof message !== "string") {
       throw new Error("Expected rollback warning log to be a JSON string.");
@@ -181,6 +186,15 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
       {
         domain: "backend",
         action: "unsafe_transaction_rollback_failed",
+        service: "backend-api",
+        requestId: null,
+        route: null,
+        method: null,
+        userId: null,
+        workspaceId: null,
+        chatRequestId: null,
+        runId: null,
+        sessionId: null,
         originalSqlState: "23514",
         originalErrorCode: "23514",
         originalErrorClass: "Error",
@@ -194,6 +208,7 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
   } finally {
     (pg as unknown as { Pool: typeof pg.Pool }).Pool = originalPool;
     console.warn = originalWarn;
+    resetBackendSentryForTests();
     if (originalDatabaseUrl === undefined) {
       delete process.env.DATABASE_URL;
     } else {

--- a/apps/backend/src/dbCore.ts
+++ b/apps/backend/src/dbCore.ts
@@ -6,6 +6,10 @@ import {
   toDatabaseBoundaryError,
   toDatabaseCommitBoundaryError,
 } from "./dbTransient";
+import {
+  captureBackendWarning,
+  createBackendRuntimeObservationScope,
+} from "./observability/sentry";
 
 let pool: pg.Pool | undefined;
 
@@ -95,18 +99,28 @@ function toClientReleaseError(error: unknown): Error {
 function logUnsafeTransactionRollbackFailure(originalError: unknown, rollbackError: unknown): void {
   const originalFields = getDatabaseErrorFields(originalError);
   const rollbackFields = getDatabaseErrorFields(rollbackError);
-  console.warn(JSON.stringify({
-    domain: "backend",
+  captureBackendWarning({
     action: "unsafe_transaction_rollback_failed",
-    originalSqlState: originalFields.sqlState,
-    originalErrorCode: originalFields.errorCode,
-    originalErrorClass: originalFields.errorClass,
-    originalErrorMessage: originalFields.errorMessage,
-    rollbackSqlState: rollbackFields.sqlState,
-    rollbackErrorCode: rollbackFields.errorCode,
-    rollbackErrorClass: rollbackFields.errorClass,
-    rollbackErrorMessage: rollbackFields.errorMessage,
-  }));
+    scope: createBackendRuntimeObservationScope(),
+    details: {
+      originalSqlState: originalFields.sqlState,
+      originalErrorCode: originalFields.errorCode,
+      originalErrorClass: originalFields.errorClass,
+      originalErrorMessage: originalFields.errorMessage,
+      rollbackSqlState: rollbackFields.sqlState,
+      rollbackErrorCode: rollbackFields.errorCode,
+      rollbackErrorClass: rollbackFields.errorClass,
+      rollbackErrorMessage: rollbackFields.errorMessage,
+    },
+  });
+}
+
+function tryLogUnsafeTransactionRollbackFailure(originalError: unknown, rollbackError: unknown): void {
+  try {
+    logUnsafeTransactionRollbackFailure(originalError, rollbackError);
+  } catch {
+    // Observability must not mask the original transaction failure.
+  }
 }
 
 export async function applyUserDatabaseScopeInExecutor(
@@ -172,8 +186,8 @@ export async function unsafeTransaction<Result>(
     } catch (error) {
       const rollbackError = await rollbackTransaction(client);
       if (rollbackError !== null) {
-        logUnsafeTransactionRollbackFailure(error, rollbackError);
         releaseError = toClientReleaseError(rollbackError);
+        tryLogUnsafeTransactionRollbackFailure(error, rollbackError);
         throw toDatabaseBoundaryError(error);
       }
 

--- a/apps/backend/src/dbTransient.test.ts
+++ b/apps/backend/src/dbTransient.test.ts
@@ -10,6 +10,7 @@ import {
   toDatabaseCommitBoundaryError,
   toDatabaseCommitOutcomeUnknownError,
 } from "./dbTransient";
+import { createBackendObservationScope } from "./observability/sentry";
 
 function createCodedError(code: string, message: string): Error & Readonly<{ code: string }> {
   const error = new Error(message) as Error & { code: string };
@@ -90,16 +91,27 @@ test("toDatabaseCommitBoundaryError keeps non-transient commit failures on norma
 
 test("retryTransientDatabaseOperationWithDependencies retries transient DB errors with full jitter", async () => {
   const delays: Array<number> = [];
-  const warningRecords: Array<Readonly<Record<string, unknown>>> = [];
-  const originalWarn = console.warn;
+  const breadcrumbRecords: Array<Readonly<Record<string, unknown>>> = [];
+  const originalLog = console.log;
   let calls = 0;
+  const observationScope = createBackendObservationScope(
+    "chat-worker",
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
 
-  console.warn = (message?: unknown): void => {
+  console.log = (message?: unknown): void => {
     if (typeof message !== "string") {
-      throw new Error("Expected retry warning log to be a JSON string.");
+      throw new Error("Expected retry breadcrumb log to be a JSON string.");
     }
 
-    warningRecords.push(JSON.parse(message) as Readonly<Record<string, unknown>>);
+    breadcrumbRecords.push(JSON.parse(message) as Readonly<Record<string, unknown>>);
   };
 
   try {
@@ -112,6 +124,7 @@ test("retryTransientDatabaseOperationWithDependencies retries transient DB error
 
         return "ok";
       },
+      () => observationScope,
       {
         sleep: async (delayMs) => {
           delays.push(delayMs);
@@ -122,15 +135,24 @@ test("retryTransientDatabaseOperationWithDependencies retries transient DB error
 
     assert.equal(result, "ok");
   } finally {
-    console.warn = originalWarn;
+    console.log = originalLog;
   }
 
   assert.equal(calls, 3);
   assert.deepEqual(delays, [50, 100]);
-  assert.deepEqual(warningRecords, [
+  assert.deepEqual(breadcrumbRecords, [
     {
       domain: "backend",
       action: "database_transient_retry",
+      service: "chat-worker",
+      requestId: null,
+      route: null,
+      method: null,
+      userId: null,
+      workspaceId: null,
+      chatRequestId: null,
+      runId: null,
+      sessionId: null,
       attempt: 1,
       maxAttempts: 3,
       delayMs: 50,
@@ -142,6 +164,15 @@ test("retryTransientDatabaseOperationWithDependencies retries transient DB error
     {
       domain: "backend",
       action: "database_transient_retry",
+      service: "chat-worker",
+      requestId: null,
+      route: null,
+      method: null,
+      userId: null,
+      workspaceId: null,
+      chatRequestId: null,
+      runId: null,
+      sessionId: null,
       attempt: 2,
       maxAttempts: 3,
       delayMs: 100,
@@ -162,6 +193,17 @@ test("retryTransientDatabaseOperationWithDependencies does not retry non-transie
         calls += 1;
         throw createCodedError("23505", "duplicate key");
       },
+      () => createBackendObservationScope(
+        "backend-api",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
       {
         sleep: async () => {},
         random: () => 0.5,

--- a/apps/backend/src/dbTransient.ts
+++ b/apps/backend/src/dbTransient.ts
@@ -1,4 +1,10 @@
 import { HttpError } from "./errors";
+import {
+  addBackendBreadcrumb,
+  captureBackendWarning,
+  createBackendRuntimeObservationScope,
+  type BackendObservationScope,
+} from "./observability/sentry";
 
 const transientDatabaseSqlStates: ReadonlySet<string> = new Set([
   "40001",
@@ -37,6 +43,8 @@ type TransientDatabaseRetryDependencies = Readonly<{
   sleep: (delayMs: number) => Promise<void>;
   random: () => number;
 }>;
+
+type TransientDatabaseRetryObservationScopeProvider = () => BackendObservationScope;
 
 type DatabaseErrorFields = Readonly<{
   sqlState: string | null;
@@ -128,18 +136,34 @@ function toDatabaseBoundaryErrorFields(error: unknown): DatabaseBoundaryErrorFie
 }
 
 function logDatabaseTransientRetry(
+  getObservationScope: TransientDatabaseRetryObservationScopeProvider,
   attempt: number,
   delayMs: number,
   error: unknown,
 ): void {
-  console.warn(JSON.stringify({
-    domain: "backend",
+  addBackendBreadcrumb({
     action: "database_transient_retry",
-    attempt,
-    maxAttempts: transientDatabaseRetryMaxAttempts,
-    delayMs,
-    ...getDatabaseErrorFields(error),
-  }));
+    scope: getObservationScope(),
+    details: {
+      attempt,
+      maxAttempts: transientDatabaseRetryMaxAttempts,
+      delayMs,
+      ...getDatabaseErrorFields(error),
+    },
+  });
+}
+
+function tryLogDatabaseTransientRetry(
+  getObservationScope: TransientDatabaseRetryObservationScopeProvider,
+  attempt: number,
+  delayMs: number,
+  error: unknown,
+): void {
+  try {
+    logDatabaseTransientRetry(getObservationScope, attempt, delayMs, error);
+  } catch {
+    // Observability must not interrupt the transient database retry path.
+  }
 }
 
 export class TransientDatabaseHttpError extends HttpError implements DatabaseBoundaryErrorFields {
@@ -230,16 +254,23 @@ export function toDatabaseCommitBoundaryError(error: unknown): unknown {
 }
 
 export function logDatabasePoolError(poolName: string, error: unknown): void {
-  console.warn(JSON.stringify({
-    domain: "backend",
-    action: "database_pool_error",
-    poolName,
-    ...getDatabaseErrorFields(error),
-  }));
+  try {
+    captureBackendWarning({
+      action: "database_pool_error",
+      scope: createBackendRuntimeObservationScope(),
+      details: {
+        poolName,
+        ...getDatabaseErrorFields(error),
+      },
+    });
+  } catch {
+    // Pool error events are already reported by pg; observability must not throw from the event handler.
+  }
 }
 
 export async function retryTransientDatabaseOperationWithDependencies<Result>(
   operation: () => Promise<Result>,
+  getObservationScope: TransientDatabaseRetryObservationScopeProvider,
   dependencies: TransientDatabaseRetryDependencies,
 ): Promise<Result> {
   let attempt = 1;
@@ -259,7 +290,7 @@ export async function retryTransientDatabaseOperationWithDependencies<Result>(
       }
 
       const delayMs = calculateTransientDatabaseRetryDelayMs(attempt, dependencies.random);
-      logDatabaseTransientRetry(attempt, delayMs, error);
+      tryLogDatabaseTransientRetry(getObservationScope, attempt, delayMs, error);
       await dependencies.sleep(delayMs);
       attempt += 1;
     }
@@ -270,9 +301,14 @@ export async function retryTransientDatabaseOperationWithDependencies<Result>(
 
 export async function withTransientDatabaseRetry<Result>(
   operation: () => Promise<Result>,
+  getObservationScope: TransientDatabaseRetryObservationScopeProvider,
 ): Promise<Result> {
-  return retryTransientDatabaseOperationWithDependencies(operation, {
-    sleep,
-    random: Math.random,
-  });
+  return retryTransientDatabaseOperationWithDependencies(
+    operation,
+    getObservationScope,
+    {
+      sleep,
+      random: Math.random,
+    },
+  );
 }

--- a/apps/backend/src/globalMetrics/generation.ts
+++ b/apps/backend/src/globalMetrics/generation.ts
@@ -4,23 +4,28 @@ import {
   type GlobalMetricsSnapshotWriteResult,
 } from "./storage";
 import type { GlobalMetricsSnapshot } from "./snapshot";
+import type { BackendObservationScope } from "../observability/sentry";
 
 type GenerateAndWriteGlobalMetricsSnapshotDependencies = Readonly<{
   generateGlobalMetricsSnapshotFn: () => Promise<GlobalMetricsSnapshot>;
   writeGlobalMetricsSnapshotToS3Fn: (
+    observationScope: BackendObservationScope,
     snapshot: GlobalMetricsSnapshot,
   ) => Promise<GlobalMetricsSnapshotWriteResult>;
 }>;
 
 export async function generateAndWriteGlobalMetricsSnapshotWithDependencies(
+  observationScope: BackendObservationScope,
   dependencies: GenerateAndWriteGlobalMetricsSnapshotDependencies,
 ): Promise<GlobalMetricsSnapshotWriteResult> {
   const snapshot = await dependencies.generateGlobalMetricsSnapshotFn();
-  return dependencies.writeGlobalMetricsSnapshotToS3Fn(snapshot);
+  return dependencies.writeGlobalMetricsSnapshotToS3Fn(observationScope, snapshot);
 }
 
-export async function generateAndWriteGlobalMetricsSnapshot(): Promise<GlobalMetricsSnapshotWriteResult> {
-  return generateAndWriteGlobalMetricsSnapshotWithDependencies({
+export async function generateAndWriteGlobalMetricsSnapshot(
+  observationScope: BackendObservationScope,
+): Promise<GlobalMetricsSnapshotWriteResult> {
+  return generateAndWriteGlobalMetricsSnapshotWithDependencies(observationScope, {
     generateGlobalMetricsSnapshotFn: generateGlobalMetricsSnapshot,
     writeGlobalMetricsSnapshotToS3Fn: writeGlobalMetricsSnapshotToS3,
   });

--- a/apps/backend/src/globalMetrics/storage.ts
+++ b/apps/backend/src/globalMetrics/storage.ts
@@ -1,5 +1,9 @@
 import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { HttpError } from "../errors";
+import {
+  addBackendBreadcrumb,
+  type BackendObservationScope,
+} from "../observability/sentry";
 import { parseGlobalMetricsSnapshotJson, type GlobalMetricsSnapshot } from "./snapshot";
 
 export type GlobalMetricsStorageConfig = Readonly<{
@@ -91,6 +95,7 @@ async function runS3OperationWithRetries<Result>(params: Readonly<{
   operation: "get_object" | "put_object";
   bucketName: string;
   objectKey: string;
+  observationScope: BackendObservationScope;
   run: () => Promise<Result>;
 }>): Promise<Result> {
   let lastError: unknown = null;
@@ -104,17 +109,20 @@ async function runS3OperationWithRetries<Result>(params: Readonly<{
         break;
       }
 
-      console.warn(JSON.stringify({
-        domain: "backend",
+      addBackendBreadcrumb({
         action: "global_metrics_s3_retry",
-        operation: params.operation,
-        attempt,
-        bucketName: params.bucketName,
-        objectKey: params.objectKey,
-        errorName: getS3ErrorName(error),
-        errorMessage: getS3ErrorMessage(error),
-        statusCode: getS3ErrorStatusCode(error),
-      }));
+        scope: params.observationScope,
+        details: {
+          operation: params.operation,
+          attempt,
+          maxAttempts: maxS3AttemptCount,
+          bucketName: params.bucketName,
+          objectKey: params.objectKey,
+          statusCode: getS3ErrorStatusCode(error),
+          errorClass: getS3ErrorName(error),
+          errorMessage: getS3ErrorMessage(error),
+        },
+      });
     }
   }
 
@@ -142,6 +150,7 @@ function createGlobalMetricsSnapshotUnavailableError(
 }
 
 export async function loadGlobalMetricsSnapshotFromS3WithDependencies(
+  observationScope: BackendObservationScope,
   dependencies: LoadGlobalMetricsSnapshotDependencies,
 ): Promise<GlobalMetricsSnapshot> {
   let config: GlobalMetricsStorageConfig | null = null;
@@ -153,6 +162,7 @@ export async function loadGlobalMetricsSnapshotFromS3WithDependencies(
       operation: "get_object",
       bucketName: resolvedConfig.bucketName,
       objectKey: resolvedConfig.objectKey,
+      observationScope,
       run: async () => dependencies.s3Client.send(new GetObjectCommand({
         Bucket: resolvedConfig.bucketName,
         Key: resolvedConfig.objectKey,
@@ -170,8 +180,10 @@ export async function loadGlobalMetricsSnapshotFromS3WithDependencies(
   }
 }
 
-export async function loadGlobalMetricsSnapshotFromS3(): Promise<GlobalMetricsSnapshot> {
-  return loadGlobalMetricsSnapshotFromS3WithDependencies({
+export async function loadGlobalMetricsSnapshotFromS3(
+  observationScope: BackendObservationScope,
+): Promise<GlobalMetricsSnapshot> {
+  return loadGlobalMetricsSnapshotFromS3WithDependencies(observationScope, {
     s3Client: getGlobalMetricsS3Client(),
     getGlobalMetricsStorageConfigFn: getGlobalMetricsStorageConfig,
     parseGlobalMetricsSnapshotJsonFn: parseGlobalMetricsSnapshotJson,
@@ -179,6 +191,7 @@ export async function loadGlobalMetricsSnapshotFromS3(): Promise<GlobalMetricsSn
 }
 
 export async function writeGlobalMetricsSnapshotToS3WithDependencies(
+  observationScope: BackendObservationScope,
   snapshot: GlobalMetricsSnapshot,
   dependencies: WriteGlobalMetricsSnapshotDependencies,
 ): Promise<GlobalMetricsSnapshotWriteResult> {
@@ -189,6 +202,7 @@ export async function writeGlobalMetricsSnapshotToS3WithDependencies(
       operation: "put_object",
       bucketName: config.bucketName,
       objectKey: config.objectKey,
+      observationScope,
       run: async () => dependencies.s3Client.send(new PutObjectCommand({
         Bucket: config.bucketName,
         Key: config.objectKey,
@@ -210,9 +224,10 @@ export async function writeGlobalMetricsSnapshotToS3WithDependencies(
 }
 
 export async function writeGlobalMetricsSnapshotToS3(
+  observationScope: BackendObservationScope,
   snapshot: GlobalMetricsSnapshot,
 ): Promise<GlobalMetricsSnapshotWriteResult> {
-  return writeGlobalMetricsSnapshotToS3WithDependencies(snapshot, {
+  return writeGlobalMetricsSnapshotToS3WithDependencies(observationScope, snapshot, {
     s3Client: getGlobalMetricsS3Client(),
     getGlobalMetricsStorageConfigFn: getGlobalMetricsStorageConfig,
   });

--- a/apps/backend/src/guestAuth/merge.ts
+++ b/apps/backend/src/guestAuth/merge.ts
@@ -16,6 +16,10 @@ import {
   type SyncConflictEntityType,
 } from "../errors";
 import {
+  captureBackendWarning,
+  createBackendObservationScope,
+} from "../observability/sentry";
+import {
   compareLwwMetadata,
 } from "../lww";
 import {
@@ -121,14 +125,27 @@ function logGuestMergeFsrsStateReset(
   cardId: string,
   reason: string,
 ): void {
-  console.error(JSON.stringify({
-    domain: "cards",
+  captureBackendWarning({
     action: "reset_invalid_fsrs_state",
-    workspaceId,
-    cardId,
-    reason,
-    repair: "reset",
-  }));
+    message: "Invalid FSRS state was reset.",
+    scope: createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      null,
+      workspaceId,
+      null,
+      null,
+      null,
+    ),
+    details: {
+      workspaceId,
+      cardId,
+      reason,
+      repair: "reset",
+    },
+  });
 }
 
 function repairGuestCardSnapshotInput(
@@ -345,16 +362,29 @@ function logGuestMergeDroppedEntity(
   targetWorkspaceId: string,
   conflictingWorkspaceId: string,
 ): void {
-  console.error(JSON.stringify({
-    domain: "guest_auth",
+  captureBackendWarning({
     action: "guest_merge_drop_third_workspace_conflict",
-    entityType,
-    entityId,
-    sourceGuestWorkspaceId,
-    targetWorkspaceId,
-    conflictingWorkspaceId,
-    resolution: "drop_guest_entity",
-  }));
+    message: "Guest merge dropped an entity because its id belongs to a third workspace.",
+    scope: createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      null,
+      targetWorkspaceId,
+      null,
+      null,
+      null,
+    ),
+    details: {
+      entityType,
+      entityId,
+      sourceGuestWorkspaceId,
+      targetWorkspaceId,
+      conflictingWorkspaceId,
+      resolution: "drop_guest_entity",
+    },
+  });
 }
 
 function logGuestMergeDroppedReviewEventForMissingCard(
@@ -363,15 +393,28 @@ function logGuestMergeDroppedReviewEventForMissingCard(
   sourceGuestWorkspaceId: string,
   targetWorkspaceId: string,
 ): void {
-  console.error(JSON.stringify({
-    domain: "guest_auth",
+  captureBackendWarning({
     action: "guest_merge_drop_review_event_missing_target_card",
-    reviewEventId,
-    cardId,
-    sourceGuestWorkspaceId,
-    targetWorkspaceId,
-    resolution: "drop_guest_entity",
-  }));
+    message: "Guest merge dropped a review event because its target card was not merged.",
+    scope: createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      null,
+      targetWorkspaceId,
+      null,
+      null,
+      null,
+    ),
+    details: {
+      reviewEventId,
+      cardId,
+      sourceGuestWorkspaceId,
+      targetWorkspaceId,
+      resolution: "drop_guest_entity",
+    },
+  });
 }
 
 async function writeGuestEntityIntoTargetInExecutor(

--- a/apps/backend/src/guestAuth/upgrade.ts
+++ b/apps/backend/src/guestAuth/upgrade.ts
@@ -1,6 +1,10 @@
 import type { DatabaseExecutor } from "../db";
 import { HttpError } from "../errors";
 import {
+  captureBackendWarning,
+  createBackendObservationScope,
+} from "../observability/sentry";
+import {
   AUTO_CREATED_WORKSPACE_NAME,
   createWorkspaceInExecutor,
 } from "../workspaces";
@@ -67,14 +71,27 @@ function logSuspiciousGuestUpgradeReplay(
   targetSubjectUserId: string,
   historyTargetSubjectUserId: string | null,
 ): void {
-  console.error(JSON.stringify({
-    domain: "backend",
+  captureBackendWarning({
     action: "guest_upgrade_complete_suspicious",
-    reason,
-    guestSessionId,
-    targetSubjectUserId,
-    historyTargetSubjectUserId,
-  }));
+    message: "Guest upgrade completion hit a suspicious replay state.",
+    scope: createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      guestSessionId,
+    ),
+    details: {
+      reason,
+      guestSessionId,
+      targetSubjectUserId,
+      historyTargetSubjectUserId,
+    },
+  });
 }
 
 async function createGuestUpgradeReplayCompletionInExecutor(

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,8 +1,10 @@
 import { serve } from "@hono/node-server";
 import { createApp } from "./app";
+import { initializeBackendSentry } from "./observability/sentry";
 import { initializeLangfuseTelemetry } from "./telemetry/langfuse";
 
 async function main(): Promise<void> {
+  initializeBackendSentry("backend-api");
   initializeLangfuseTelemetry();
   const app = createApp("/v1");
   const port = Number.parseInt(process.env.PORT ?? "8080", 10);

--- a/apps/backend/src/lambda-chat-live.ts
+++ b/apps/backend/src/lambda-chat-live.ts
@@ -10,6 +10,7 @@ import type { LiveStreamParams } from "./chat/liveRequest";
 import {
   addBackendBreadcrumb,
   captureBackendException,
+  type BackendObservationScope,
   type ChatLiveBootstrapFailureDetails,
   continueBackendTrace,
   createBackendObservationScope,
@@ -146,6 +147,8 @@ type ChatLiveRuntime = Readonly<{
   flushLangfuseTelemetry: typeof import("./telemetry/langfuse").flushLangfuseTelemetry;
 }>;
 
+type FlushLangfuseTelemetry = ChatLiveRuntime["flushLangfuseTelemetry"];
+
 type ChatLiveBootstrapErrorBody = Readonly<{
   error: string;
   requestId: string;
@@ -181,6 +184,14 @@ function getChatLiveRuntime(): Promise<ChatLiveRuntime> {
   }
 
   return chatLiveRuntimePromise;
+}
+
+async function flushLiveTelemetry(
+  flushLangfuseTelemetry: FlushLangfuseTelemetry,
+  observationScope: BackendObservationScope,
+): Promise<void> {
+  await flushLangfuseTelemetry(observationScope);
+  await flushBackendSentry(2000);
 }
 
 function createLiveRequestUrl(event: APIGatewayProxyEventV2): URL {
@@ -263,6 +274,17 @@ async function liveStreamHandler(
   const clientPlatform = readApiGatewayHeader(event.headers, "x-client-platform");
   const clientVersion = readApiGatewayHeader(event.headers, "x-client-version");
   const method = event.requestContext.http.method;
+  const requestObservationScope = createBackendObservationScope(
+    "chat-live",
+    requestId,
+    event.rawPath,
+    method,
+    null,
+    null,
+    null,
+    url.searchParams.get("runId"),
+    url.searchParams.get("sessionId"),
+  );
 
   let params: LiveStreamParams;
 
@@ -270,17 +292,6 @@ async function liveStreamHandler(
     params = await handleLiveRequest(url, authorizationHeader, event.headers ?? {});
   } catch (error) {
     const errorResponse = createChatLiveErrorResponse(error, requestId);
-    const scope = createBackendObservationScope(
-      "chat-live",
-      requestId,
-      event.rawPath,
-      method,
-      null,
-      null,
-      null,
-      url.searchParams.get("runId"),
-      url.searchParams.get("sessionId"),
-    );
     const details = {
       statusCode: errorResponse.statusCode,
       path: event.rawPath,
@@ -297,13 +308,13 @@ async function liveStreamHandler(
       captureBackendException({
         action: "chat_live_request_error",
         error: normalizeCaughtError(error),
-        scope,
+        scope: requestObservationScope,
         details,
       });
     } else {
       addBackendBreadcrumb({
         action: "chat_live_request_error",
-        scope,
+        scope: requestObservationScope,
         details,
       });
     }
@@ -314,16 +325,21 @@ async function liveStreamHandler(
     const stream = awslambda.HttpResponseStream.from(responseStream, metadata);
     stream.write(JSON.stringify(errorResponse.body));
     stream.end();
-    if (errorResponse.statusCode >= 500) {
-      await Promise.all([
-        flushLangfuseTelemetry(),
-        flushBackendSentry(2000),
-      ]);
-    } else {
-      await flushLangfuseTelemetry();
-    }
+    await flushLiveTelemetry(flushLangfuseTelemetry, requestObservationScope);
     return;
   }
+
+  const streamObservationScope = createBackendObservationScope(
+    "chat-live",
+    requestId,
+    event.rawPath,
+    method,
+    params.userId,
+    params.workspaceId,
+    null,
+    params.runId,
+    params.sessionId,
+  );
 
   const metadata = {
     statusCode: 200,
@@ -338,17 +354,7 @@ async function liveStreamHandler(
 
   addBackendBreadcrumb({
     action: "chat_live_attach_start",
-    scope: createBackendObservationScope(
-      "chat-live",
-      requestId,
-      event.rawPath,
-      method,
-      params.userId,
-      params.workspaceId,
-      null,
-      params.runId,
-      params.sessionId,
-    ),
+    scope: streamObservationScope,
     details: {
       statusCode: 200,
       path: event.rawPath,
@@ -375,25 +381,12 @@ async function liveStreamHandler(
         requestId,
       }),
     ));
-    await Promise.all([
-      flushLangfuseTelemetry(),
-      flushBackendSentry(2000),
-    ]);
+    await flushLiveTelemetry(flushLangfuseTelemetry, streamObservationScope);
   } catch (error) {
     captureBackendException({
       action: "chat_live_stream_crashed",
       error: normalizeCaughtError(error),
-      scope: createBackendObservationScope(
-        "chat-live",
-        requestId,
-        event.rawPath,
-        method,
-        params.userId,
-        params.workspaceId,
-        null,
-        params.runId,
-        params.sessionId,
-      ),
+      scope: streamObservationScope,
       details: {
         statusCode: 500,
         path: event.rawPath,
@@ -409,10 +402,7 @@ async function liveStreamHandler(
         clientVersion: params.clientVersion ?? null,
       },
     });
-    await Promise.all([
-      flushLangfuseTelemetry(),
-      flushBackendSentry(2000),
-    ]);
+    await flushLiveTelemetry(flushLangfuseTelemetry, streamObservationScope);
     if (stream.destroyed === false && stream.writableEnded === false) {
       stream.end();
     }
@@ -423,7 +413,7 @@ const chatLiveStreamHandler: StreamifyHandler<APIGatewayProxyEventV2, void> = as
   event: APIGatewayProxyEventV2,
   responseStream: awslambda.HttpResponseStream,
 ): Promise<void> => {
-  let flushLangfuseTelemetry: (() => Promise<void>) | null = null;
+  let flushLangfuseTelemetry: ((observationScope: BackendObservationScope) => Promise<void>) | null = null;
   try {
     const runtime = await getChatLiveRuntime();
     flushLangfuseTelemetry = runtime.flushLangfuseTelemetry;
@@ -431,20 +421,21 @@ const chatLiveStreamHandler: StreamifyHandler<APIGatewayProxyEventV2, void> = as
   } catch (error) {
     const normalizedError = normalizeCaughtError(error);
     const requestId = getLiveRequestId(event);
+    const observationScope = createBackendObservationScope(
+      "chat-live",
+      requestId,
+      event.rawPath,
+      event.requestContext.http.method,
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
     captureBackendException({
       action: "chat_live_bootstrap_failed",
       error: normalizedError,
-      scope: createBackendObservationScope(
-        "chat-live",
-        requestId,
-        event.rawPath,
-        event.requestContext.http.method,
-        null,
-        null,
-        null,
-        null,
-        null,
-      ),
+      scope: observationScope,
       details: createChatLiveBootstrapFailureDetails(event, normalizedError),
     });
     try {
@@ -453,10 +444,7 @@ const chatLiveStreamHandler: StreamifyHandler<APIGatewayProxyEventV2, void> = as
       if (flushLangfuseTelemetry === null) {
         await flushBackendSentry(2000);
       } else {
-        await Promise.all([
-          flushLangfuseTelemetry(),
-          flushBackendSentry(2000),
-        ]);
+        await flushLiveTelemetry(flushLangfuseTelemetry, observationScope);
       }
     }
   }

--- a/apps/backend/src/lambda-chat-worker.ts
+++ b/apps/backend/src/lambda-chat-worker.ts
@@ -71,6 +71,17 @@ function createChatWorkerFailureDetails(
 
 const chatWorkerHandler: Handler<ChatWorkerEvent, void> = async (event, context) => {
   const lambdaRequestId = context.awsRequestId ?? null;
+  const observationScope = createBackendObservationScope(
+    "chat-worker",
+    lambdaRequestId,
+    null,
+    null,
+    event.userId,
+    event.workspaceId,
+    event.chatRequestId ?? null,
+    event.runId,
+    event.sessionId ?? null,
+  );
   let runtimeHttpError: HttpErrorClass | null = null;
   let runtime: ChatWorkerRuntime | null = null;
   try {
@@ -92,23 +103,13 @@ const chatWorkerHandler: Handler<ChatWorkerEvent, void> = async (event, context)
     captureBackendException({
       action: "chat_worker_failed",
       error: normalizedError,
-      scope: createBackendObservationScope(
-        "chat-worker",
-        lambdaRequestId,
-        null,
-        null,
-        event.userId,
-        event.workspaceId,
-        event.chatRequestId ?? null,
-        event.runId,
-        event.sessionId ?? null,
-      ),
+      scope: observationScope,
       details: createChatWorkerFailureDetails(event, lambdaRequestId, normalizedError, runtimeHttpError),
     });
     throw error;
   } finally {
     if (runtime !== null) {
-      await runtime.flushLangfuseTelemetry();
+      await runtime.flushLangfuseTelemetry(observationScope);
     }
   }
 };

--- a/apps/backend/src/lambda-global-metrics-snapshot.ts
+++ b/apps/backend/src/lambda-global-metrics-snapshot.ts
@@ -70,23 +70,24 @@ const globalMetricsSnapshotHandler: Handler<
   unknown,
   GlobalMetricsSnapshotResponse
 > = async (_event, context) => {
+  const observationScope = createBackendObservationScope(
+    "global-metrics-snapshot",
+    context.awsRequestId ?? null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
   try {
     const runtime = await getGlobalMetricsSnapshotRuntime();
-    const result = await runtime.generateAndWriteGlobalMetricsSnapshot();
+    const result = await runtime.generateAndWriteGlobalMetricsSnapshot(observationScope);
 
     addBackendBreadcrumb({
       action: "global_metrics_snapshot_generated",
-      scope: createBackendObservationScope(
-        "global-metrics-snapshot",
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-      ),
+      scope: observationScope,
       details: {
         bucketName: result.bucketName,
         objectKey: result.objectKey,
@@ -113,17 +114,7 @@ const globalMetricsSnapshotHandler: Handler<
     captureBackendException({
       action: "global_metrics_snapshot_failed",
       error: normalizedError,
-      scope: createBackendObservationScope(
-        "global-metrics-snapshot",
-        context.awsRequestId ?? null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-      ),
+      scope: observationScope,
       details: createGlobalMetricsSnapshotFailureDetails(normalizedError),
     });
     throw error;

--- a/apps/backend/src/lambda.ts
+++ b/apps/backend/src/lambda.ts
@@ -83,6 +83,18 @@ function getBackendApiRequestContext(event: LambdaEvent, context: Context): Back
 }
 
 const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => {
+  const requestContext = getBackendApiRequestContext(event, context);
+  const observationScope = createBackendObservationScope(
+    "backend-api",
+    requestContext.requestId,
+    requestContext.route,
+    requestContext.method,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
   let runtime: BackendApiRuntime | null = null;
   try {
     runtime = await getBackendApiRuntime();
@@ -90,21 +102,10 @@ const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => 
   } catch (error) {
     if (runtime === null) {
       const normalizedError = normalizeCaughtError(error);
-      const requestContext = getBackendApiRequestContext(event, context);
       captureBackendException({
         action: "request_failed",
         error: normalizedError,
-        scope: createBackendObservationScope(
-          "backend-api",
-          requestContext.requestId,
-          requestContext.route,
-          requestContext.method,
-          null,
-          null,
-          null,
-          null,
-          null,
-        ),
+        scope: observationScope,
         details: {
           statusCode: 500,
           code: "INTERNAL_ERROR",
@@ -116,7 +117,7 @@ const backendApiBootstrapHandler: BackendApiHandler = async (event, context) => 
     throw error;
   } finally {
     if (runtime !== null) {
-      await runtime.flushLangfuseTelemetry();
+      await runtime.flushLangfuseTelemetry(observationScope);
     }
   }
 };

--- a/apps/backend/src/observability/sentry.ts
+++ b/apps/backend/src/observability/sentry.ts
@@ -50,6 +50,10 @@ export type BackendFailureDetails = Readonly<{
   validationIssues: ReadonlyArray<BackendValidationIssueDetail>;
 }>;
 
+export type RequestErrorDetails = BackendFailureDetails & BackendErrorLogDetails & Readonly<{
+  sqlState: string | null;
+}>;
+
 export type BackendDatabaseDetails = Readonly<{
   sqlState: string | null;
   constraint: string | null;
@@ -193,6 +197,40 @@ export type GuestUpgradeCompleteDetails = Readonly<{
   targetUserId: string | null;
   targetWorkspaceId: string | null;
   completionKind: string | null;
+}>;
+
+export type ResetInvalidFsrsStateDetails = Readonly<{
+  workspaceId: string;
+  cardId: string;
+  reason: string;
+  repair: "reset";
+}>;
+
+export type GuestMergeDropThirdWorkspaceConflictDetails = Readonly<{
+  entityType: "card" | "deck" | "review_event";
+  entityId: string;
+  sourceGuestWorkspaceId: string;
+  targetWorkspaceId: string;
+  conflictingWorkspaceId: string;
+  resolution: "drop_guest_entity";
+}>;
+
+export type GuestMergeDropReviewEventMissingTargetCardDetails = Readonly<{
+  reviewEventId: string;
+  cardId: string;
+  sourceGuestWorkspaceId: string;
+  targetWorkspaceId: string;
+  resolution: "drop_guest_entity";
+}>;
+
+export type GuestUpgradeCompleteSuspiciousDetails = Readonly<{
+  reason:
+    | "deleted_session_subject_mismatch"
+    | "revoked_session_without_history"
+    | "revoked_session_subject_mismatch";
+  guestSessionId: string | null;
+  targetSubjectUserId: string;
+  historyTargetSubjectUserId: string | null;
 }>;
 
 export type WorkspacesListDetails = Readonly<{
@@ -357,6 +395,75 @@ export type ChatWorkerFailureDetails = Readonly<{
   message: string;
 }>;
 
+export type ChatTranscriptionFailureDetails = Readonly<{
+  requestId: string;
+  sessionId: string;
+  source: "android" | "ios" | "web";
+  provider: "openai";
+  fileSize: number;
+  fileExtension: string | null;
+  mediaType: string;
+  upstreamStatus: number | null;
+  upstreamRequestId: string | null;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type LangfuseTelemetryFlushFailureDetails = Readonly<{
+  errorClass: string;
+  errorMessage: string;
+  telemetryStarted: boolean;
+  hasTracerProvider: boolean;
+}>;
+
+export type LangfuseChatTurnExportFailureDetails = Readonly<{
+  requestId: string;
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  model: string;
+  turnIndex: number;
+  runState: string;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type LangfuseChatTurnStartFailureDetails = Readonly<{
+  requestId: string;
+  userId: string;
+  workspaceId: string;
+  sessionId: string;
+  model: string;
+  turnIndex: number;
+  runState: string;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type LangfuseChatTranscriptionExportFailureDetails = Readonly<{
+  requestId: string;
+  userId: string;
+  sessionId: string;
+  source: string;
+  fileExtension: string | null;
+  mediaType: string;
+  fileSize: number;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type LangfuseChatTranscriptionStartFailureDetails = Readonly<{
+  requestId: string;
+  userId: string;
+  sessionId: string;
+  source: string;
+  fileExtension: string | null;
+  mediaType: string;
+  fileSize: number;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
 export type GlobalMetricsSnapshotGeneratedDetails = Readonly<{
   bucketName: string;
   objectKey: string;
@@ -372,6 +479,46 @@ export type GlobalMetricsSnapshotFailureDetails = Readonly<{
   bucketName: string | null;
   objectKey: string | null;
   message: string;
+}>;
+
+export type DatabaseTransientRetryDetails = Readonly<{
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  sqlState: string | null;
+  errorCode: string | null;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type DatabasePoolErrorDetails = Readonly<{
+  poolName: string;
+  sqlState: string | null;
+  errorCode: string | null;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type DatabaseRollbackFailureDetails = Readonly<{
+  originalSqlState: string | null;
+  originalErrorCode: string | null;
+  originalErrorClass: string;
+  originalErrorMessage: string;
+  rollbackSqlState: string | null;
+  rollbackErrorCode: string | null;
+  rollbackErrorClass: string;
+  rollbackErrorMessage: string;
+}>;
+
+export type GlobalMetricsS3RetryDetails = Readonly<{
+  operation: "get_object" | "put_object";
+  attempt: number;
+  maxAttempts: number;
+  bucketName: string;
+  objectKey: string;
+  statusCode: number | null;
+  errorClass: string;
+  errorMessage: string;
 }>;
 
 export type MigrationFailureDetails = Readonly<{
@@ -391,7 +538,10 @@ type SyncConflictFailureDetailsFor<Details> = FailureDetailsFor<Details> & Backe
 
 export type BackendBreadcrumbEvent =
   | EventByAction<"admin_query", AdminQueryDetails>
+  | EventByAction<"request_error", RequestErrorDetails>
   | EventByAction<"global_metrics_snapshot_generated", GlobalMetricsSnapshotGeneratedDetails>
+  | EventByAction<"database_transient_retry", DatabaseTransientRetryDetails>
+  | EventByAction<"global_metrics_s3_retry", GlobalMetricsS3RetryDetails>
   | EventByAction<"sync_push", SyncPushDetails>
   | EventByAction<"sync_push_error", SyncConflictFailureDetailsFor<SyncPushDetails>>
   | EventByAction<"sync_pull", SyncPullDetails>
@@ -448,7 +598,8 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"chat_worker_provider_call_started", ChatWorkerLifecycleDetails>
   | EventByAction<"chat_worker_provider_call_aborted", ChatWorkerLifecycleDetails>
   | EventByAction<"chat_worker_terminal_state_persisted", ChatWorkerLifecycleDetails>
-  | EventByAction<"chat_worker_composer_suggestions_failed", ChatWorkerLifecycleDetails>;
+  | EventByAction<"chat_worker_composer_suggestions_failed", ChatWorkerLifecycleDetails>
+  | EventByAction<"chat_transcription_invalid_audio", ChatTranscriptionFailureDetails>;
 
 export type BackendWarningEvent =
   | (EventByAction<"global_snapshot_error", Readonly<{
@@ -456,10 +607,19 @@ export type BackendWarningEvent =
     code: string | null;
     storageErrorMessage: string;
   }>> & Readonly<{ message: string }>)
+  | EventByAction<"unsafe_transaction_rollback_failed", DatabaseRollbackFailureDetails>
+  | EventByAction<"database_pool_error", DatabasePoolErrorDetails>
+  | EventByAction<"reporting_read_only_transaction_rollback_failed", DatabaseRollbackFailureDetails>
   | (EventByAction<"chat_live_backlog_failed", ChatLiveLifecycleDetails> & Readonly<{ message: string }>)
   | (EventByAction<"chat_live_write_failed", ChatLiveLifecycleDetails> & Readonly<{ message: string }>)
   | (EventByAction<"chat_worker_terminal_state_persisted", ChatWorkerLifecycleDetails> & Readonly<{ message: string }>)
   | (EventByAction<"chat_worker_composer_suggestions_failed", ChatWorkerLifecycleDetails> & Readonly<{ message: string }>)
+  | (EventByAction<"chat_transcription_failed", ChatTranscriptionFailureDetails> & Readonly<{ message: string }>)
+  | EventByAction<"langfuse_telemetry_flush_failed", LangfuseTelemetryFlushFailureDetails>
+  | EventByAction<"langfuse_chat_turn_export_failed", LangfuseChatTurnExportFailureDetails>
+  | EventByAction<"langfuse_chat_turn_start_failed", LangfuseChatTurnStartFailureDetails>
+  | EventByAction<"langfuse_chat_transcription_export_failed", LangfuseChatTranscriptionExportFailureDetails>
+  | EventByAction<"langfuse_chat_transcription_start_failed", LangfuseChatTranscriptionStartFailureDetails>
   | (EventByAction<"chat_resume_contract_violation", Readonly<{
     path: string;
     method: string;
@@ -475,7 +635,22 @@ export type BackendWarningEvent =
     inProgressAssistantItemId: string | null;
     inProgressAssistantItemOrder: number | null;
     terminationReason: string | null;
-  }>> & Readonly<{ message: string }>);
+  }>> & Readonly<{ message: string }>)
+  | (EventByAction<"reset_invalid_fsrs_state", ResetInvalidFsrsStateDetails> & Readonly<{ message: string }>)
+  | (
+    EventByAction<"guest_merge_drop_third_workspace_conflict", GuestMergeDropThirdWorkspaceConflictDetails>
+    & Readonly<{ message: string }>
+  )
+  | (
+    EventByAction<
+      "guest_merge_drop_review_event_missing_target_card",
+      GuestMergeDropReviewEventMissingTargetCardDetails
+    >
+    & Readonly<{ message: string }>
+  )
+  | (EventByAction<"guest_upgrade_complete_suspicious", GuestUpgradeCompleteSuspiciousDetails> & Readonly<{
+    message: string;
+  }>);
 
 export type BackendExceptionEvent =
   | (EventByAction<"request_failed", BackendFailureDetails> & Readonly<{ error: Error }>)
@@ -543,6 +718,7 @@ type BackendSentryConfig =
   }>;
 
 const initializedServices = new Set<BackendService>();
+let currentBackendService: BackendService | null = null;
 const capturedExceptionSet = new WeakSet<Error>();
 const normalizedNonErrorObjectMap = new WeakMap<object, Error>();
 const normalizedNonErrorPrimitiveMap = new Map<NonErrorPrimitive, Error>();
@@ -730,6 +906,7 @@ export function initializeBackendSentryWithDeps(
   env: NodeJS.ProcessEnv,
   dependencies: InitializeBackendSentryDependencies,
 ): void {
+  currentBackendService = service;
   if (initializedServices.has(service)) {
     return;
   }
@@ -763,6 +940,7 @@ export function initializeBackendSentry(service: BackendService): void {
 
 export function resetBackendSentryForTests(): void {
   initializedServices.clear();
+  currentBackendService = null;
   backendSentryInitializedForOpenTelemetry = false;
 }
 
@@ -1104,6 +1282,24 @@ export function createBackendObservationScope(
     runId,
     sessionId,
   };
+}
+
+export function createBackendRuntimeObservationScope(): BackendObservationScope {
+  if (currentBackendService === null) {
+    throw new Error("Backend Sentry must be initialized before creating runtime observation scope.");
+  }
+
+  return createBackendObservationScope(
+    currentBackendService,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
 }
 
 export function getBackendErrorLogDetails(error: unknown): BackendErrorLogDetails {

--- a/apps/backend/src/routes/globalSnapshot.test.ts
+++ b/apps/backend/src/routes/globalSnapshot.test.ts
@@ -12,6 +12,7 @@ import {
   createGlobalMetricsSnapshotWindow,
   type GlobalMetricsSnapshot,
 } from "../globalMetrics/snapshot";
+import type { BackendObservationScope } from "../observability/sentry";
 import { createGlobalSnapshotRoutes, globalSnapshotPath } from "./globalSnapshot";
 
 function createSnapshotFixture(): GlobalMetricsSnapshot {
@@ -54,14 +55,14 @@ function createSnapshotFixture(): GlobalMetricsSnapshot {
 
 function createGlobalSnapshotTestApp(options: Readonly<{
   isGlobalMetricsVisible: boolean;
-  loadGlobalMetricsSnapshotFn: () => Promise<GlobalMetricsSnapshot>;
+  loadGlobalMetricsSnapshotFn: (observationScope: BackendObservationScope) => Promise<GlobalMetricsSnapshot>;
 }>): Hono<AppEnv> {
   return createMountedGlobalSnapshotTestApp(options);
 }
 
 function createMountedGlobalSnapshotTestApp(options: Readonly<{
   isGlobalMetricsVisible: boolean;
-  loadGlobalMetricsSnapshotFn: () => Promise<GlobalMetricsSnapshot>;
+  loadGlobalMetricsSnapshotFn: (observationScope: BackendObservationScope) => Promise<GlobalMetricsSnapshot>;
 }>): Hono<AppEnv> {
   const app = new Hono<AppEnv>({ strict: false }).basePath("/v1");
 
@@ -155,9 +156,13 @@ function createMountedAppTestCleanup(): () => void {
 
 test("GET /v1/global/snapshot returns the snapshot when visible", async () => {
   const snapshot = createSnapshotFixture();
+  let capturedObservationScope: BackendObservationScope | null = null;
   const app = createGlobalSnapshotTestApp({
     isGlobalMetricsVisible: true,
-    loadGlobalMetricsSnapshotFn: async () => snapshot,
+    loadGlobalMetricsSnapshotFn: async (observationScope) => {
+      capturedObservationScope = observationScope;
+      return snapshot;
+    },
   });
 
   const response = await app.request(
@@ -169,6 +174,17 @@ test("GET /v1/global/snapshot returns the snapshot when visible", async () => {
   assert.equal(response.headers.get("access-control-allow-origin"), "*");
   assert.equal(response.headers.get("access-control-allow-credentials"), null);
   assert.deepEqual(await response.json(), snapshot);
+  assert.deepEqual(capturedObservationScope, {
+    service: "backend-api",
+    requestId: "request-1",
+    route: "/v1/global/snapshot",
+    method: "GET",
+    userId: null,
+    workspaceId: null,
+    chatRequestId: null,
+    runId: null,
+    sessionId: null,
+  });
 });
 
 test("GET /v1/global/snapshot returns 404 when global metrics are not visible", async () => {

--- a/apps/backend/src/routes/globalSnapshot.ts
+++ b/apps/backend/src/routes/globalSnapshot.ts
@@ -9,6 +9,7 @@ import {
 import {
   captureBackendWarning,
   createBackendObservationScope,
+  type BackendObservationScope,
 } from "../observability/sentry";
 
 export const globalSnapshotPath = "/global/snapshot";
@@ -16,7 +17,7 @@ const globalMetricsSnapshotUnavailableCode = "GLOBAL_METRICS_SNAPSHOT_UNAVAILABL
 const globalMetricsSnapshotUnavailableMessage = "Global metrics snapshot is unavailable.";
 
 type GlobalSnapshotRoutesOptions = Readonly<{
-  loadGlobalMetricsSnapshotFn?: () => Promise<GlobalMetricsSnapshot>;
+  loadGlobalMetricsSnapshotFn?: (observationScope: BackendObservationScope) => Promise<GlobalMetricsSnapshot>;
   isGlobalMetricsVisibleFn?: () => boolean;
 }>;
 
@@ -56,8 +57,19 @@ export function createGlobalSnapshotRoutes(options: GlobalSnapshotRoutesOptions)
 
   app.get(globalSnapshotPath, async (context) => {
     assertGlobalMetricsVisible(isGlobalMetricsVisibleFn());
+    const observationScope = createBackendObservationScope(
+      "backend-api",
+      context.get("requestId"),
+      context.req.path,
+      context.req.method,
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
     try {
-      const response = context.json(await loadGlobalMetricsSnapshotFn());
+      const response = context.json(await loadGlobalMetricsSnapshotFn(observationScope));
       return applyGlobalSnapshotCorsHeaders(response);
     } catch (error) {
       if (!isGlobalMetricsSnapshotUnavailableError(error)) {
@@ -67,17 +79,7 @@ export function createGlobalSnapshotRoutes(options: GlobalSnapshotRoutesOptions)
       captureBackendWarning({
         action: "global_snapshot_error",
         message: "Global metrics snapshot is unavailable.",
-        scope: createBackendObservationScope(
-          "backend-api",
-          context.get("requestId"),
-          context.req.path,
-          context.req.method,
-          null,
-          null,
-          null,
-          null,
-          null,
-        ),
+        scope: observationScope,
         details: {
           statusCode: error.statusCode,
           code: error.code,

--- a/apps/backend/src/routes/sync.ts
+++ b/apps/backend/src/routes/sync.ts
@@ -265,6 +265,13 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
             result,
           };
         },
+        () => createSyncScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          workspaceId,
+        ),
       );
       addBackendBreadcrumb({
         action: "sync_pull",
@@ -382,6 +389,13 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
             result,
           };
         },
+        () => createSyncScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          workspaceId,
+        ),
       );
       addBackendBreadcrumb({
         action: "sync_review_history_pull",

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -2,12 +2,14 @@ import { AuthError } from "../auth";
 import { HttpError } from "../errors";
 import { sanitizeBackendTelemetryValue } from "../observability/sanitizer";
 import {
+  addBackendBreadcrumb,
   addBackendSentryBreadcrumb,
   createBackendObservationScope,
   getBackendErrorLogDetails,
   type AdminQueryDetails,
   type BackendObservationScope,
   type BackendErrorLogDetails,
+  type RequestErrorDetails,
 } from "../observability/sentry";
 
 function getInternalErrorMessage(error: unknown): string {
@@ -29,12 +31,81 @@ export function getErrorLogContext(error: unknown): ErrorLogContext {
 }
 
 function getDatabaseSqlState(error: unknown): string | null {
-  if (typeof error !== "object" || error === null || !("code" in error)) {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  if ("sqlState" in error) {
+    const sqlState = (error as Readonly<{ sqlState?: unknown }>).sqlState;
+    return typeof sqlState === "string" && sqlState !== "" ? sqlState : null;
+  }
+
+  if (!("code" in error)) {
     return null;
   }
 
   const code = (error as Readonly<{ code?: unknown }>).code;
-  return typeof code === "string" && code !== "" ? code : null;
+  return typeof code === "string" && /^[0-9A-Z]{5}$/.test(code) ? code : null;
+}
+
+function shouldLogRequestErrorAtErrorLevel(error: AuthError | HttpError | unknown): boolean {
+  if (error instanceof AuthError) {
+    return false;
+  }
+
+  if (error instanceof HttpError) {
+    return error.statusCode >= 500;
+  }
+
+  return true;
+}
+
+function getRequestErrorStatusCode(error: AuthError | HttpError | unknown): number {
+  if (error instanceof AuthError || error instanceof HttpError) {
+    return error.statusCode;
+  }
+
+  return 500;
+}
+
+function getRequestErrorCode(error: AuthError | HttpError | unknown): string | null {
+  if (error instanceof AuthError) {
+    return "AUTH_UNAUTHORIZED";
+  }
+
+  if (error instanceof HttpError) {
+    return error.code;
+  }
+
+  return "INTERNAL_ERROR";
+}
+
+function createRequestErrorDetails(error: AuthError | HttpError | unknown): RequestErrorDetails {
+  return {
+    statusCode: getRequestErrorStatusCode(error),
+    code: getRequestErrorCode(error),
+    message: getInternalErrorMessage(error),
+    validationIssues: summarizeValidationIssues(error),
+    sqlState: getDatabaseSqlState(error),
+    ...getErrorLogContext(error),
+  };
+}
+
+function createErrorLevelRequestErrorDetails(
+  details: RequestErrorDetails,
+): Omit<RequestErrorDetails, "message"> {
+  return {
+    statusCode: details.statusCode,
+    code: details.code,
+    validationIssues: details.validationIssues,
+    sqlState: details.sqlState,
+    errorClass: details.errorClass,
+    errorMessage: details.errorMessage,
+    errorStack: details.errorStack,
+    sourceFile: details.sourceFile,
+    sourceLine: details.sourceLine,
+    sourceColumn: details.sourceColumn,
+  };
 }
 
 function redactAdminEmailForCloudWatch(adminEmail: string): string {
@@ -62,7 +133,26 @@ export function logRequestError(
   method: string,
   error: AuthError | HttpError | unknown,
 ): void {
-  const errorContext = getErrorLogContext(error);
+  const details = createRequestErrorDetails(error);
+  if (shouldLogRequestErrorAtErrorLevel(error) === false) {
+    addBackendBreadcrumb({
+      action: "request_error",
+      scope: createBackendObservationScope(
+        "backend-api",
+        requestId,
+        path,
+        method,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ),
+      details,
+    });
+    return;
+  }
+
   const baseRecord = {
     domain: "backend",
     action: "request_error",
@@ -71,33 +161,9 @@ export function logRequestError(
     method,
   };
 
-  if (error instanceof AuthError) {
-    console.error(JSON.stringify({
-      ...baseRecord,
-      statusCode: error.statusCode,
-      code: "AUTH_UNAUTHORIZED",
-      ...errorContext,
-    }));
-    return;
-  }
-
-  if (error instanceof HttpError) {
-    console.error(JSON.stringify({
-      ...baseRecord,
-      statusCode: error.statusCode,
-      code: error.code,
-      validationIssues: summarizeValidationIssues(error),
-      ...errorContext,
-    }));
-    return;
-  }
-
   console.error(JSON.stringify({
     ...baseRecord,
-    statusCode: 500,
-    code: "INTERNAL_ERROR",
-    sqlState: getDatabaseSqlState(error),
-    ...errorContext,
+    ...createErrorLevelRequestErrorDetails(details),
   }));
 }
 

--- a/apps/backend/src/telemetry/langfuse.test.ts
+++ b/apps/backend/src/telemetry/langfuse.test.ts
@@ -4,6 +4,7 @@ import type { BasicTracerProvider, Sampler } from "@opentelemetry/sdk-trace-base
 import { NoopSpanProcessor, SamplingDecision } from "@opentelemetry/sdk-trace-base";
 import { LangfuseSpanProcessor } from "@langfuse/otel";
 import {
+  createBackendObservationScope,
   initializeBackendSentryWithDeps,
   resetBackendSentryForTests,
 } from "../observability/sentry";
@@ -238,7 +239,17 @@ test("Langfuse flush no-ops before telemetry starts", async () => {
   resetLangfuseTelemetryForTests();
 
   try {
-    await flushLangfuseTelemetry();
+    await flushLangfuseTelemetry(createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ));
   } finally {
     resetLangfuseTelemetryForTests();
   }
@@ -263,7 +274,17 @@ test("Langfuse flush force-flushes the isolated provider", async () => {
       setLangfuseTracerProvider: () => {},
     });
 
-    await flushLangfuseTelemetry();
+    await flushLangfuseTelemetry(createBackendObservationScope(
+      "backend-api",
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ));
 
     assert.equal(flushCount, 1);
   } finally {
@@ -299,14 +320,35 @@ test("Langfuse flush logs and swallows force-flush failures", async () => {
       setLangfuseTracerProvider: () => {},
     });
 
-    await flushLangfuseTelemetry();
+    await flushLangfuseTelemetry(createBackendObservationScope(
+      "chat-live",
+      "request-1",
+      "/v1/chat/live",
+      "GET",
+      "user-1",
+      "workspace-1",
+      "chat-request-1",
+      "run-1",
+      "session-1",
+    ));
 
     assert.deepEqual(warningRecords, [
       {
         domain: "backend",
         action: "langfuse_telemetry_flush_failed",
+        service: "chat-live",
+        requestId: "request-1",
+        route: "/v1/chat/live",
+        method: "GET",
+        userId: "user-1",
+        workspaceId: "workspace-1",
+        chatRequestId: "chat-request-1",
+        runId: "run-1",
+        sessionId: "session-1",
         errorClass: "Error",
-        error: "Langfuse export failed",
+        errorMessage: "Langfuse export failed",
+        telemetryStarted: true,
+        hasTracerProvider: true,
       },
     ]);
   } finally {

--- a/apps/backend/src/telemetry/langfuse.ts
+++ b/apps/backend/src/telemetry/langfuse.ts
@@ -8,6 +8,17 @@ import {
   setLangfuseTracerProvider,
   startObservation,
 } from "@langfuse/tracing";
+import {
+  captureBackendWarning,
+  createBackendObservationScope,
+  getBackendErrorLogDetails,
+  type BackendObservationScope,
+  type LangfuseChatTranscriptionExportFailureDetails,
+  type LangfuseChatTranscriptionStartFailureDetails,
+  type LangfuseChatTurnExportFailureDetails,
+  type LangfuseChatTurnStartFailureDetails,
+  type LangfuseTelemetryFlushFailureDetails,
+} from "../observability/sentry";
 
 type TelemetryMetadata = Readonly<Record<string, string>>;
 type LangfuseSanitizedObject = Readonly<{
@@ -168,27 +179,164 @@ function sanitizeLangfuseTelemetryEntry(
   return sanitizeTelemetryValue(value);
 }
 
-function logTelemetryFailure(
-  action: string,
-  error: unknown,
-): void {
-  console.error(JSON.stringify({
-    domain: "backend",
-    action,
-    error: error instanceof Error ? error.message : String(error),
-  }));
+function getLangfuseFailureErrorDetails(error: unknown): Readonly<{
+  errorClass: string;
+  errorMessage: string;
+}> {
+  const errorDetails = getBackendErrorLogDetails(error);
+  return {
+    errorClass: errorDetails.errorClass,
+    errorMessage: errorDetails.errorMessage,
+  };
 }
 
-function logTelemetryWarning(
-  action: string,
+function getFileExtension(fileName: string): string | null {
+  const lastDotIndex = fileName.lastIndexOf(".");
+  if (lastDotIndex <= 0 || lastDotIndex === fileName.length - 1) {
+    return null;
+  }
+
+  return fileName.slice(lastDotIndex + 1).toLowerCase();
+}
+
+function logTelemetryFlushFailure(
+  observationScope: BackendObservationScope,
   error: unknown,
 ): void {
-  console.warn(JSON.stringify({
-    domain: "backend",
-    action,
-    errorClass: error instanceof Error ? error.name : null,
-    error: error instanceof Error ? error.message : String(error),
-  }));
+  const details: LangfuseTelemetryFlushFailureDetails = {
+    ...getLangfuseFailureErrorDetails(error),
+    telemetryStarted,
+    hasTracerProvider: telemetryTracerProvider !== null,
+  };
+  captureBackendWarning({
+    action: "langfuse_telemetry_flush_failed",
+    scope: observationScope,
+    details,
+  });
+}
+
+function logChatTurnExportFailure(
+  params: ChatTurnTelemetryParams,
+  error: unknown,
+): void {
+  const details: LangfuseChatTurnExportFailureDetails = {
+    requestId: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+    model: params.model,
+    turnIndex: params.turnIndex,
+    runState: params.runState,
+    ...getLangfuseFailureErrorDetails(error),
+  };
+  captureBackendWarning({
+    action: "langfuse_chat_turn_export_failed",
+    scope: createBackendObservationScope(
+      "chat-worker",
+      params.requestId,
+      null,
+      null,
+      params.userId,
+      params.workspaceId,
+      null,
+      null,
+      params.sessionId,
+    ),
+    details,
+  });
+}
+
+function logChatTurnStartFailure(
+  params: ChatTurnTelemetryParams,
+  error: unknown,
+): void {
+  const details: LangfuseChatTurnStartFailureDetails = {
+    requestId: params.requestId,
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+    sessionId: params.sessionId,
+    model: params.model,
+    turnIndex: params.turnIndex,
+    runState: params.runState,
+    ...getLangfuseFailureErrorDetails(error),
+  };
+  captureBackendWarning({
+    action: "langfuse_chat_turn_start_failed",
+    scope: createBackendObservationScope(
+      "chat-worker",
+      params.requestId,
+      null,
+      null,
+      params.userId,
+      params.workspaceId,
+      null,
+      null,
+      params.sessionId,
+    ),
+    details,
+  });
+}
+
+function logChatTranscriptionExportFailure(
+  params: ChatTranscriptionTelemetryParams,
+  error: unknown,
+): void {
+  const details: LangfuseChatTranscriptionExportFailureDetails = {
+    requestId: params.requestId,
+    userId: params.userId,
+    sessionId: params.sessionId,
+    source: params.source,
+    fileExtension: getFileExtension(params.fileName),
+    mediaType: params.mediaType,
+    fileSize: params.fileSize,
+    ...getLangfuseFailureErrorDetails(error),
+  };
+  captureBackendWarning({
+    action: "langfuse_chat_transcription_export_failed",
+    scope: createBackendObservationScope(
+      "backend-api",
+      params.requestId,
+      null,
+      null,
+      params.userId,
+      null,
+      null,
+      null,
+      params.sessionId,
+    ),
+    details,
+  });
+}
+
+function logChatTranscriptionStartFailure(
+  params: ChatTranscriptionTelemetryParams,
+  error: unknown,
+): void {
+  const details: LangfuseChatTranscriptionStartFailureDetails = {
+    requestId: params.requestId,
+    userId: params.userId,
+    sessionId: params.sessionId,
+    source: params.source,
+    fileExtension: getFileExtension(params.fileName),
+    mediaType: params.mediaType,
+    fileSize: params.fileSize,
+    ...getLangfuseFailureErrorDetails(error),
+  };
+  captureBackendWarning({
+    action: "langfuse_chat_transcription_start_failed",
+    scope: createBackendObservationScope(
+      "backend-api",
+      params.requestId,
+      null,
+      null,
+      params.userId,
+      null,
+      null,
+      null,
+      params.sessionId,
+    ),
+    details,
+  });
 }
 
 function buildChatTurnMetadata(
@@ -221,7 +369,7 @@ function buildChatTranscriptionMetadata(
     userId: metadataValue(params.userId),
     sessionId: metadataValue(params.sessionId),
     source: metadataValue(params.source),
-    fileName: metadataValue(params.fileName),
+    fileExtension: metadataValue(getFileExtension(params.fileName) ?? "none"),
     mediaType: metadataValue(params.mediaType),
     fileSize: metadataValue(params.fileSize),
   };
@@ -367,7 +515,7 @@ export function initializeLangfuseTelemetry(): void {
   initializeLangfuseTelemetryWithDeps(DEFAULT_INITIALIZE_LANGFUSE_TELEMETRY_DEPENDENCIES);
 }
 
-export async function flushLangfuseTelemetry(): Promise<void> {
+export async function flushLangfuseTelemetry(observationScope: BackendObservationScope): Promise<void> {
   if (!telemetryStarted || telemetryTracerProvider === null) {
     return;
   }
@@ -375,7 +523,7 @@ export async function flushLangfuseTelemetry(): Promise<void> {
   try {
     await telemetryTracerProvider.forceFlush();
   } catch (error) {
-    logTelemetryWarning("langfuse_telemetry_flush_failed", error);
+    logTelemetryFlushFailure(observationScope, error);
   }
 }
 
@@ -451,11 +599,11 @@ export async function startChatTurnObservationWithDeps(
     }
 
     if (callbackStarted) {
-      logTelemetryFailure("langfuse_chat_turn_export_failed", error);
+      logChatTurnExportFailure(params, error);
       return;
     }
 
-    logTelemetryFailure("langfuse_chat_turn_start_failed", error);
+    logChatTurnStartFailure(params, error);
     await fn(null);
   }
 }
@@ -507,7 +655,7 @@ export async function startChatTranscriptionObservationWithDeps<Result>(
             input: {
               sessionId: params.sessionId,
               source: params.source,
-              fileName: params.fileName,
+              fileExtension: getFileExtension(params.fileName),
               mediaType: params.mediaType,
               fileSize: params.fileSize,
             },
@@ -548,14 +696,14 @@ export async function startChatTranscriptionObservationWithDeps<Result>(
     }
 
     if (callbackStarted) {
-      logTelemetryFailure("langfuse_chat_transcription_export_failed", error);
+      logChatTranscriptionExportFailure(params, error);
       if (callbackResult !== null) {
         return callbackResult;
       }
       return fn();
     }
 
-    logTelemetryFailure("langfuse_chat_transcription_start_failed", error);
+    logChatTranscriptionStartFailure(params, error);
     return fn();
   }
 }


### PR DESCRIPTION
## Summary
- harden backend Sentry/Langfuse observability paths and typed logging
- preserve CloudWatch JSON logs while routing warnings/exceptions through backend observability
- keep DB retry/rollback observability from masking runtime errors

## Validation
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend
- git --no-pager diff --check