### PR TITLE
[codex] Fix workspace sync delete race

### DIFF
--- a/apps/backend/src/guestAuthTestHarness/executor.ts
+++ b/apps/backend/src/guestAuthTestHarness/executor.ts
@@ -97,6 +97,11 @@ export function createGuestUpgradeExecutor(state: MutableState): DatabaseExecuto
 
 export function isGuestUpgradeMergeOnlyExecutorQuery(text: string): boolean {
   return text.includes("FROM sync.claim_installation")
+    || (
+      text.startsWith("SELECT")
+      && text.includes("FROM org.workspace_memberships AS memberships")
+      && text.includes("FOR KEY SHARE OF workspaces, memberships")
+    )
     || (text.startsWith("SELECT") && text.includes("FROM sync.workspace_replicas"))
     || text.includes("INSERT INTO sync.workspace_replicas")
     || text.includes("UPDATE sync.workspace_replicas")

--- a/apps/backend/src/guestAuthTestHarness/handlers/workspaces.ts
+++ b/apps/backend/src/guestAuthTestHarness/handlers/workspaces.ts
@@ -18,6 +18,29 @@ export function handleWorkspaceExecutorQuery<Row extends pg.QueryResultRow>(
 ): pg.QueryResult<Row> | null {
   const { scope, state } = context;
 
+  if (
+    text.startsWith("SELECT")
+    && text.includes("FROM org.workspace_memberships AS memberships")
+    && text.includes("FOR KEY SHARE OF workspaces, memberships")
+  ) {
+    const userId = params[0];
+    const workspaceId = params[1];
+    if (typeof userId !== "string" || typeof workspaceId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    scope.requireCurrentWorkspaceScope(userId, workspaceId);
+    if (!state.workspaceMemberships.has(membershipKey(userId, workspaceId))) {
+      return createQueryResult<Row>([]);
+    }
+
+    const workspace = state.workspaces.get(workspaceId);
+    const rows = workspace === undefined ? [] : [{
+      workspace_id: workspace.workspace_id,
+    } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
   if (text.startsWith("SELECT") && text.includes("FROM org.workspaces AS workspaces")) {
     const userId = params[0];
     const workspaceId = params[1];

--- a/apps/backend/src/observability/sentry.test.ts
+++ b/apps/backend/src/observability/sentry.test.ts
@@ -401,6 +401,162 @@ test("backend Sentry beforeSend redacts exception text and request query strings
   assert.equal(sanitized?.contexts?.rawRequest?.querystring, "<redacted-content>");
 });
 
+test("backend Sentry beforeSend preserves structural database exception diagnostics", () => {
+  resetBackendSentryForTests();
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+
+  initializeBackendSentryWithDeps(
+    "backend-api",
+    {
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0",
+    },
+    {
+      init: (options) => {
+        capturedInitOptions = options;
+      },
+    },
+  );
+
+  type DatabaseConstraintError = Error & {
+    code: string;
+    constraint: string;
+    table: string;
+  };
+
+  const databaseError = new Error(
+    "insert or update on table \"workspace_replicas\" violates foreign key constraint \"workspace_replicas_workspace_id_fkey\"",
+  ) as DatabaseConstraintError;
+  databaseError.name = "DatabaseError";
+  databaseError.code = "23503";
+  databaseError.constraint = "workspace_replicas_workspace_id_fkey";
+  databaseError.table = "workspace_replicas";
+
+  const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+  const beforeSend = requireBeforeSend(initOptions.beforeSend);
+  const sanitized = requireSynchronousSentryHookResult(beforeSend({
+    type: undefined,
+    message: databaseError.message,
+    exception: {
+      values: [
+        {
+          type: databaseError.name,
+          value: databaseError.message,
+          stacktrace: {
+            frames: [
+              {
+                context_line: "await executor.query(sql, [frontText]);",
+                vars: {
+                  frontText: "private question",
+                  backText: "private answer",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    request: {
+      headers: {
+        authorization: "Bearer token-value",
+      },
+    },
+    contexts: {
+      backend: {
+        prompt: "private prompt",
+        sqlState: "23503",
+        constraint: "workspace_replicas_workspace_id_fkey",
+        table: "workspace_replicas",
+      },
+      rawRequest: {
+        requestBody: {
+          frontText: "private question",
+          backText: "private answer",
+        },
+      },
+    },
+  }, { originalException: databaseError }));
+
+  assert.notEqual(sanitized, null);
+  if (sanitized === null) {
+    throw new Error("Expected backend Sentry beforeSend to keep the event.");
+  }
+  assert.match(sanitized.message ?? "", /SQLSTATE 23503/);
+  assert.match(sanitized.message ?? "", /workspace_replicas_workspace_id_fkey/);
+  assert.match(String(sanitized.exception?.values?.[0]?.value), /SQLSTATE 23503/);
+  assert.match(String(sanitized.exception?.values?.[0]?.value), /workspace_replicas_workspace_id_fkey/);
+  assert.equal(sanitized.tags?.["db.sql_state"], "23503");
+  assert.equal(sanitized.tags?.["db.constraint"], "workspace_replicas_workspace_id_fkey");
+  assert.equal(sanitized.tags?.["db.table"], "workspace_replicas");
+  assert.deepEqual(sanitized.request, { headers: "<redacted-content>" });
+  assert.equal(sanitized.contexts?.backend?.prompt, "<redacted-content>");
+  assert.equal(sanitized.contexts?.backend?.sqlState, "23503");
+  assert.equal(sanitized.contexts?.backend?.constraint, "workspace_replicas_workspace_id_fkey");
+  assert.equal(sanitized.contexts?.backend?.table, "workspace_replicas");
+  assert.equal(sanitized.contexts?.rawRequest?.requestBody, "<redacted-content>");
+  assert.deepEqual(sanitized.exception?.values?.[0]?.stacktrace?.frames?.[0], {
+    context_line: "<redacted-content>",
+    vars: "<redacted-content>",
+  });
+});
+
+test("backend Sentry beforeSend does not preserve content-bearing database exception messages", () => {
+  resetBackendSentryForTests();
+  let capturedInitOptions: CapturedSentryInitOptions | null = null;
+
+  initializeBackendSentryWithDeps(
+    "backend-api",
+    {
+      SENTRY_DSN: "https://example.invalid/1",
+      SENTRY_ENVIRONMENT: "production",
+      SENTRY_RELEASE: "abc123",
+      SENTRY_TRACES_SAMPLE_RATE: "0",
+    },
+    {
+      init: (options) => {
+        capturedInitOptions = options;
+      },
+    },
+  );
+
+  type DatabaseInputError = Error & {
+    code: string;
+  };
+
+  const databaseError = new Error("invalid input syntax for type uuid: \"private-user-text\"") as DatabaseInputError;
+  databaseError.name = "DatabaseError";
+  databaseError.code = "22P02";
+
+  const initOptions = requireCapturedSentryInitOptions(capturedInitOptions);
+  const beforeSend = requireBeforeSend(initOptions.beforeSend);
+  const sanitized = requireSynchronousSentryHookResult(beforeSend({
+    type: undefined,
+    message: databaseError.message,
+    exception: {
+      values: [
+        {
+          type: databaseError.name,
+          value: databaseError.message,
+          stacktrace: {
+            frames: [],
+          },
+        },
+      ],
+    },
+  }, { originalException: databaseError }));
+
+  assert.notEqual(sanitized, null);
+  if (sanitized === null) {
+    throw new Error("Expected backend Sentry beforeSend to keep the event.");
+  }
+  assert.equal(sanitized.message, "DatabaseError: SQLSTATE 22P02");
+  assert.equal(sanitized.exception?.values?.[0]?.value, "DatabaseError: SQLSTATE 22P02");
+  assert.doesNotMatch(sanitized.message ?? "", /private-user-text/);
+  assert.doesNotMatch(String(sanitized.exception?.values?.[0]?.value), /private-user-text/);
+});
+
 test("backend Sentry beforeSend preserves typed warning action title only", () => {
   resetBackendSentryForTests();
   let capturedInitOptions: CapturedSentryInitOptions | null = null;

--- a/apps/backend/src/observability/sentry.ts
+++ b/apps/backend/src/observability/sentry.ts
@@ -706,6 +706,18 @@ type BackendSentryIntegrationFactory = (
 ) => Array<BackendSentryIntegration>;
 type BackendSentryContextData = Parameters<Sentry.Scope["setContext"]>[1];
 type BackendSentryBreadcrumbData = NonNullable<Parameters<typeof Sentry.addBreadcrumb>[0]["data"]>;
+type SentryExceptionValue = Readonly<Record<string, unknown>> & Readonly<{
+  type?: unknown;
+  value?: unknown;
+}>;
+type DatabaseExceptionDiagnostics = Readonly<{
+  errorClass: string | null;
+  errorCode: string | null;
+  sqlState: string | null;
+  constraint: string | null;
+  table: string | null;
+  errorMessage: string | null;
+}>;
 
 type BackendSentryConfig =
   | Readonly<{ enabled: false }>
@@ -743,6 +755,14 @@ const exceptionTextFieldNames: ReadonlySet<string> = new Set([
 const cloudWatchActionableExceptionTextFieldNames: ReadonlySet<string> = new Set([
   "errormessage",
   "errorstack",
+]);
+const nonSqlStateDatabaseErrorCodes: ReadonlySet<string> = new Set([
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EPIPE",
+  "EAI_AGAIN",
+  "ENOTFOUND",
 ]);
 let backendSentryInitializedForOpenTelemetry = false;
 
@@ -825,12 +845,17 @@ function sanitizeSentryEvent(event: BackendSentryEvent, hint: BackendSentryEvent
 
   const manualBackendWarningMessage = getManualBackendWarningMessage(event);
   const sanitizedEvent = sanitizeBackendTelemetryValue(redactExceptionTextFields(event)) as unknown as typeof event;
+  const sanitizedEventWithDatabaseDiagnostics = restoreSentryDatabaseExceptionDiagnostics(
+    event,
+    sanitizedEvent,
+    hint,
+  );
   if (manualBackendWarningMessage === null) {
-    return sanitizedEvent;
+    return sanitizedEventWithDatabaseDiagnostics;
   }
 
   return {
-    ...sanitizedEvent,
+    ...sanitizedEventWithDatabaseDiagnostics,
     message: manualBackendWarningMessage,
   };
 }
@@ -987,6 +1012,164 @@ export function hasCapturedBackendException(error: Error): boolean {
 
 function normalizeTelemetryKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function readRecord(value: unknown): Readonly<Record<string, unknown>> | null {
+  return typeof value === "object" && value !== null
+    ? value as Readonly<Record<string, unknown>>
+    : null;
+}
+
+function readStringField(record: Readonly<Record<string, unknown>>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+function isSqlState(value: string): boolean {
+  return /^[A-Z0-9]{5}$/i.test(value) && nonSqlStateDatabaseErrorCodes.has(value) === false;
+}
+
+function readDatabaseExceptionDiagnostics(error: unknown): DatabaseExceptionDiagnostics | null {
+  const errorRecord = readRecord(error);
+  if (errorRecord === null) {
+    return null;
+  }
+
+  const code = readStringField(errorRecord, "code");
+  const sqlState = readStringField(errorRecord, "sqlState")
+    ?? readStringField(errorRecord, "sqlstate")
+    ?? (code !== null && isSqlState(code) ? code : null);
+  const diagnostics: DatabaseExceptionDiagnostics = {
+    errorClass: error instanceof Error && error.name.trim() !== "" ? error.name : null,
+    errorCode: readStringField(errorRecord, "errorCode") ?? code,
+    sqlState,
+    constraint: readStringField(errorRecord, "constraint"),
+    table: readStringField(errorRecord, "table"),
+    errorMessage: error instanceof Error ? error.message : readStringField(errorRecord, "message"),
+  };
+
+  if (
+    diagnostics.sqlState === null
+    && diagnostics.constraint === null
+    && diagnostics.table === null
+  ) {
+    return null;
+  }
+
+  return diagnostics;
+}
+
+function isSafeDatabaseExceptionMessage(
+  message: string,
+  diagnostics: DatabaseExceptionDiagnostics,
+): boolean {
+  return diagnostics.constraint !== null && message.includes(diagnostics.constraint);
+}
+
+function createDatabaseExceptionDiagnosticValue(
+  diagnostics: DatabaseExceptionDiagnostics,
+): string | null {
+  const diagnosticParts: Array<string> = [];
+  if (diagnostics.sqlState !== null) {
+    diagnosticParts.push(`SQLSTATE ${diagnostics.sqlState}`);
+  }
+  if (diagnostics.errorCode !== null && diagnostics.errorCode !== diagnostics.sqlState) {
+    diagnosticParts.push(`code ${diagnostics.errorCode}`);
+  }
+  if (diagnostics.constraint !== null) {
+    diagnosticParts.push(`constraint ${diagnostics.constraint}`);
+  }
+  if (diagnostics.table !== null) {
+    diagnosticParts.push(`table ${diagnostics.table}`);
+  }
+  if (diagnosticParts.length === 0) {
+    return null;
+  }
+
+  const label = diagnostics.errorClass ?? "DatabaseError";
+  if (
+    diagnostics.errorMessage !== null
+    && isSafeDatabaseExceptionMessage(diagnostics.errorMessage, diagnostics)
+  ) {
+    return `${label}: ${sanitizeInternalErrorText(diagnostics.errorMessage)} (${diagnosticParts.join(", ")})`;
+  }
+
+  return `${label}: ${diagnosticParts.join(", ")}`;
+}
+
+function createDatabaseDiagnosticTags(
+  diagnostics: DatabaseExceptionDiagnostics,
+): Readonly<Record<string, string>> {
+  const tags: Record<string, string> = {};
+  if (diagnostics.sqlState !== null) tags["db.sql_state"] = diagnostics.sqlState;
+  if (diagnostics.errorCode !== null) tags["db.error_code"] = diagnostics.errorCode;
+  if (diagnostics.constraint !== null) tags["db.constraint"] = diagnostics.constraint;
+  if (diagnostics.table !== null) tags["db.table"] = diagnostics.table;
+  return tags;
+}
+
+function restoreSentryExceptionValue(
+  value: SentryExceptionValue,
+  diagnosticValue: string,
+): SentryExceptionValue {
+  if (typeof value.value !== "string") {
+    return value;
+  }
+
+  return {
+    ...value,
+    value: diagnosticValue,
+  };
+}
+
+function restoreSentryDatabaseExceptionValues(
+  event: BackendSentryEvent,
+  diagnosticValue: string,
+): BackendSentryEvent {
+  const exceptionRecord = readRecord(event.exception);
+  const exceptionValues = exceptionRecord?.values;
+  if (Array.isArray(exceptionValues) === false) {
+    return event;
+  }
+
+  return {
+    ...event,
+    exception: {
+      ...event.exception,
+      values: exceptionValues.map((value) => {
+        const exceptionValue = readRecord(value);
+        return exceptionValue === null
+          ? value
+          : restoreSentryExceptionValue(exceptionValue as SentryExceptionValue, diagnosticValue);
+      }),
+    },
+  };
+}
+
+function restoreSentryDatabaseExceptionDiagnostics(
+  originalEvent: BackendSentryEvent,
+  sanitizedEvent: BackendSentryEvent,
+  hint: BackendSentryEventHint,
+): BackendSentryEvent {
+  const diagnostics = readDatabaseExceptionDiagnostics(hint.originalException);
+  if (diagnostics === null) {
+    return sanitizedEvent;
+  }
+
+  const diagnosticValue = createDatabaseExceptionDiagnosticValue(diagnostics);
+  if (diagnosticValue === null) {
+    return sanitizedEvent;
+  }
+
+  const eventWithExceptionValue = restoreSentryDatabaseExceptionValues(sanitizedEvent, diagnosticValue);
+  return {
+    ...eventWithExceptionValue,
+    message: typeof originalEvent.message === "string" ? diagnosticValue : eventWithExceptionValue.message,
+    tags: {
+      ...eventWithExceptionValue.tags,
+      ...createDatabaseDiagnosticTags(diagnostics),
+    },
+  };
 }
 
 function shouldRedactExceptionTextField(key: string, value: unknown): boolean {

--- a/apps/backend/src/sync/bootstrap.ts
+++ b/apps/backend/src/sync/bootstrap.ts
@@ -9,7 +9,7 @@ import {
   decodeOpaqueCursor,
   encodeOpaqueCursor,
 } from "../pagination";
-import { ensureWorkspaceReplica } from "../syncIdentity";
+import { ensureWorkspaceReplicaInExecutor } from "../syncIdentity";
 import { ensureWorkspaceSyncMetadataInExecutor } from "../syncChanges";
 import { annotateSyncConflictHttpError } from "./fork";
 import { applyWorkspaceSchedulerSettingsSnapshotInExecutor } from "../workspaceSchedulerSettings";
@@ -148,16 +148,15 @@ export async function processSyncBootstrap(
   userId: string,
   input: SyncBootstrapInput,
 ): Promise<SyncBootstrapPullResult | SyncBootstrapPushResult> {
-  const replicaId = await ensureWorkspaceReplica({
-    workspaceId,
-    userId,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-  });
-
   if (input.mode === "push") {
     return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+      const replicaId = await ensureWorkspaceReplicaInExecutor(executor, {
+        workspaceId,
+        userId,
+        installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
+      });
       await ensureWorkspaceSyncMetadataInExecutor(executor, workspaceId);
       const remoteIsEmpty = await loadRemoteEmptyState(executor, workspaceId);
       if (remoteIsEmpty === false) {
@@ -226,6 +225,13 @@ export async function processSyncBootstrap(
   }
 
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    await ensureWorkspaceReplicaInExecutor(executor, {
+      workspaceId,
+      userId,
+      installationId: input.installationId,
+      platform: input.platform,
+      appVersion: input.appVersion ?? null,
+    });
     await ensureWorkspaceSyncMetadataInExecutor(executor, workspaceId);
     const cursor = input.cursor === null
       ? {

--- a/apps/backend/src/sync/hotPull.ts
+++ b/apps/backend/src/sync/hotPull.ts
@@ -10,7 +10,7 @@ import type {
 } from "../decks";
 import { mapDeck } from "../decks";
 import { HttpError } from "../errors";
-import { ensureWorkspaceReplica } from "../syncIdentity";
+import { ensureWorkspaceReplicaInExecutor } from "../syncIdentity";
 import { ensureWorkspaceSyncMetadataInExecutor, loadMinAvailableHotChangeId } from "../syncChanges";
 import type { WorkspaceSchedulerSettings } from "../workspaceSchedulerSettings";
 import type { SyncPullInput } from "./input";
@@ -195,15 +195,14 @@ export async function processSyncPull(
   userId: string,
   input: SyncPullInput,
 ): Promise<SyncPullResult> {
-  await ensureWorkspaceReplica({
-    workspaceId,
-    userId,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-  });
-
   return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    await ensureWorkspaceReplicaInExecutor(executor, {
+      workspaceId,
+      userId,
+      installationId: input.installationId,
+      platform: input.platform,
+      appVersion: input.appVersion ?? null,
+    });
     await ensureWorkspaceSyncMetadataInExecutor(executor, workspaceId);
     const minAvailableHotChangeId = await loadMinAvailableHotChangeId(executor, workspaceId);
     if (input.afterHotChangeId > 0 && input.afterHotChangeId < minAvailableHotChangeId) {

--- a/apps/backend/src/sync/push.ts
+++ b/apps/backend/src/sync/push.ts
@@ -8,7 +8,7 @@ import {
 } from "../db";
 import { upsertDeckSnapshotInExecutor } from "../decks";
 import { normalizeIsoTimestamp } from "../lww";
-import { ensureWorkspaceReplica } from "../syncIdentity";
+import { ensureWorkspaceReplicaInExecutor } from "../syncIdentity";
 import { ensureWorkspaceSyncMetadataInExecutor } from "../syncChanges";
 import { applyWorkspaceSchedulerSettingsSnapshotInExecutor } from "../workspaceSchedulerSettings";
 import type {
@@ -285,17 +285,19 @@ export async function processSyncPush(
   userId: string,
   input: SyncPushInput,
 ): Promise<SyncPushResult> {
-  const replicaId = await ensureWorkspaceReplica({
-    workspaceId,
-    userId,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-  });
-
   const operationResults = await transactionWithWorkspaceScope(
     { userId, workspaceId },
-    async (executor) => processSyncPushOperationsInExecutor(executor, workspaceId, replicaId, input.operations),
+    async (executor) => {
+      const replicaId = await ensureWorkspaceReplicaInExecutor(executor, {
+        workspaceId,
+        userId,
+        installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
+      });
+
+      return processSyncPushOperationsInExecutor(executor, workspaceId, replicaId, input.operations);
+    },
   );
 
   return {

--- a/apps/backend/src/sync/reviewHistory.ts
+++ b/apps/backend/src/sync/reviewHistory.ts
@@ -1,11 +1,10 @@
 import { appendReviewEventSnapshotInExecutor } from "../cards";
 import {
-  queryWithWorkspaceScope,
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../db";
 import { HttpError } from "../errors";
-import { ensureWorkspaceReplica } from "../syncIdentity";
+import { ensureWorkspaceReplicaInExecutor } from "../syncIdentity";
 import { annotateSyncConflictHttpError } from "./fork";
 import type {
   SyncReviewHistoryImportInput,
@@ -118,38 +117,39 @@ export async function processSyncReviewHistoryPull(
   userId: string,
   input: SyncReviewHistoryPullInput,
 ): Promise<SyncReviewHistoryPullResult> {
-  await ensureWorkspaceReplica({
-    workspaceId,
-    userId,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
+  return transactionWithWorkspaceScope({ userId, workspaceId }, async (executor) => {
+    await ensureWorkspaceReplicaInExecutor(executor, {
+      workspaceId,
+      userId,
+      installationId: input.installationId,
+      platform: input.platform,
+      appVersion: input.appVersion ?? null,
+    });
+
+    const result = await executor.query<ReviewHistoryRow>(
+      [
+        "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, review_sequence",
+        "FROM content.review_events",
+        "WHERE workspace_id = $1 AND review_sequence > $2",
+        "ORDER BY review_sequence ASC",
+        "LIMIT $3",
+      ].join(" "),
+      [workspaceId, input.afterReviewSequenceId, input.limit + 1],
+    );
+
+    const hasMore = result.rows.length > input.limit;
+    const visibleRows = hasMore ? result.rows.slice(0, input.limit) : result.rows;
+    const reviewEvents = mapReviewHistoryRows(visibleRows);
+    const nextReviewSequenceId = visibleRows.length === 0
+      ? input.afterReviewSequenceId
+      : toNumber(visibleRows[visibleRows.length - 1].review_sequence) ?? input.afterReviewSequenceId;
+
+    return {
+      reviewEvents,
+      nextReviewSequenceId,
+      hasMore,
+    };
   });
-
-  const result = await queryWithWorkspaceScope<ReviewHistoryRow>(
-    { userId, workspaceId },
-    [
-      "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, review_sequence",
-      "FROM content.review_events",
-      "WHERE workspace_id = $1 AND review_sequence > $2",
-      "ORDER BY review_sequence ASC",
-      "LIMIT $3",
-    ].join(" "),
-    [workspaceId, input.afterReviewSequenceId, input.limit + 1],
-  );
-
-  const hasMore = result.rows.length > input.limit;
-  const visibleRows = hasMore ? result.rows.slice(0, input.limit) : result.rows;
-  const reviewEvents = mapReviewHistoryRows(visibleRows);
-  const nextReviewSequenceId = visibleRows.length === 0
-    ? input.afterReviewSequenceId
-    : toNumber(visibleRows[visibleRows.length - 1].review_sequence) ?? input.afterReviewSequenceId;
-
-  return {
-    reviewEvents,
-    nextReviewSequenceId,
-    hasMore,
-  };
 }
 
 export async function processSyncReviewHistoryImport(
@@ -157,16 +157,18 @@ export async function processSyncReviewHistoryImport(
   userId: string,
   input: SyncReviewHistoryImportInput,
 ): Promise<SyncReviewHistoryImportResult> {
-  const replicaId = await ensureWorkspaceReplica({
-    workspaceId,
-    userId,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-  });
-
   return transactionWithWorkspaceScope(
     { userId, workspaceId },
-    async (executor) => processSyncReviewHistoryImportInExecutor(executor, workspaceId, replicaId, input),
+    async (executor) => {
+      const replicaId = await ensureWorkspaceReplicaInExecutor(executor, {
+        workspaceId,
+        userId,
+        installationId: input.installationId,
+        platform: input.platform,
+        appVersion: input.appVersion ?? null,
+      });
+
+      return processSyncReviewHistoryImportInExecutor(executor, workspaceId, replicaId, input);
+    },
   );
 }

--- a/apps/backend/src/syncIdentity.test.ts
+++ b/apps/backend/src/syncIdentity.test.ts
@@ -5,6 +5,7 @@ import type { DatabaseExecutor } from "./db";
 import { HttpError } from "./errors";
 import {
   buildSystemWorkspaceReplicaId,
+  ensureBootstrapSystemWorkspaceReplicaInExecutor,
   ensureSystemWorkspaceReplicaInExecutor,
   ensureWorkspaceReplicaInExecutor,
 } from "./syncIdentity";
@@ -18,6 +19,7 @@ type RecordedQuery = Readonly<{
 
 type SyncIdentityExecutorOptions = Readonly<{
   claimStatus: ClaimStatus;
+  workspaceAccessAllowed: boolean;
   expectedWorkspaceReplicaInsertCount: number;
 }>;
 
@@ -69,6 +71,15 @@ function createSyncIdentityExecutor(
         } as unknown as Row]);
       }
 
+      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+        requireCurrentWorkspaceScope(String(params[0]), String(params[1]));
+        return createQueryResult<Row>(options.workspaceAccessAllowed
+          ? [{
+            workspace_id: params[1],
+          } as unknown as Row]
+          : []);
+      }
+
       if (text.includes("INSERT INTO sync.workspace_replicas")) {
         if (options.expectedWorkspaceReplicaInsertCount === 0) {
           throw new Error("Workspace replica insert was not expected");
@@ -100,6 +111,7 @@ test("ensureWorkspaceReplicaInExecutor accepts inserted, refreshed, and reassign
   for (const claimStatus of ["inserted", "refreshed", "reassigned"] as const) {
     const { executor, recordedQueries } = createSyncIdentityExecutor({
       claimStatus,
+      workspaceAccessAllowed: true,
       expectedWorkspaceReplicaInsertCount: 1,
     });
 
@@ -111,19 +123,23 @@ test("ensureWorkspaceReplicaInExecutor accepts inserted, refreshed, and reassign
       appVersion: "1.2.3",
     });
 
-    assert.equal(recordedQueries.length, 3);
+    assert.equal(recordedQueries.length, 4);
     assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
     assert.deepEqual(recordedQueries[0]!.params, ["user-b", "workspace-1"]);
-    assert.match(recordedQueries[1]!.text, /FROM sync\.claim_installation/);
-    assert.deepEqual(recordedQueries[1]!.params, ["installation-1", "ios", "user-b", "1.2.3"]);
-    assert.match(recordedQueries[2]!.text, /INSERT INTO sync\.workspace_replicas/);
-    assert.equal(replicaId, recordedQueries[2]!.params[0]);
+    assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
+    assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
+    assert.deepEqual(recordedQueries[1]!.params, ["user-b", "workspace-1"]);
+    assert.match(recordedQueries[2]!.text, /FROM sync\.claim_installation/);
+    assert.deepEqual(recordedQueries[2]!.params, ["installation-1", "ios", "user-b", "1.2.3"]);
+    assert.match(recordedQueries[3]!.text, /INSERT INTO sync\.workspace_replicas/);
+    assert.equal(replicaId, recordedQueries[3]!.params[0]);
   }
 });
 
 test("ensureWorkspaceReplicaInExecutor raises platform mismatch without touching workspace_replicas", async () => {
   const { executor, recordedQueries } = createSyncIdentityExecutor({
     claimStatus: "platform_mismatch",
+    workspaceAccessAllowed: true,
     expectedWorkspaceReplicaInsertCount: 0,
   });
 
@@ -143,9 +159,39 @@ test("ensureWorkspaceReplicaInExecutor raises platform mismatch without touching
     },
   );
 
+  assert.equal(recordedQueries.length, 3);
+  assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
+  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
+  assert.match(recordedQueries[2]!.text, /FROM sync\.claim_installation/);
+});
+
+test("ensureWorkspaceReplicaInExecutor raises workspace not found before registering replicas", async () => {
+  const { executor, recordedQueries } = createSyncIdentityExecutor({
+    claimStatus: "inserted",
+    workspaceAccessAllowed: false,
+    expectedWorkspaceReplicaInsertCount: 0,
+  });
+
+  await assert.rejects(
+    ensureWorkspaceReplicaInExecutor(executor, {
+      workspaceId: "workspace-1",
+      userId: "user-b",
+      installationId: "installation-1",
+      platform: "ios",
+      appVersion: "1.2.3",
+    }),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 404);
+      assert.equal(error.code, "WORKSPACE_NOT_FOUND");
+      return true;
+    },
+  );
+
   assert.equal(recordedQueries.length, 2);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /FROM sync\.claim_installation/);
+  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
+  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
 });
 
 test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", async () => {
@@ -167,6 +213,14 @@ test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", asyn
 
       if (text.includes("sync.claim_installation")) {
         throw new Error("System actors must not claim client installations");
+      }
+
+      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+        assert.equal(currentUserId, String(params[0]));
+        assert.equal(currentWorkspaceId, String(params[1]));
+        return createQueryResult<Row>([{
+          workspace_id: params[1],
+        } as unknown as Row]);
       }
 
       if (text.includes("INSERT INTO sync.workspace_replicas")) {
@@ -196,9 +250,11 @@ test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", asyn
   });
 
   assert.equal(replicaId, buildSystemWorkspaceReplicaId("workspace-1", "ai_chat", "chat-session-1"));
-  assert.equal(recordedQueries.length, 2);
+  assert.equal(recordedQueries.length, 3);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /INSERT INTO sync\.workspace_replicas/);
+  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
+  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
+  assert.match(recordedQueries[2]!.text, /INSERT INTO sync\.workspace_replicas/);
 });
 
 test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", async () => {
@@ -220,6 +276,14 @@ test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", as
 
       if (text.includes("sync.claim_installation")) {
         throw new Error("System actors must not claim client installations");
+      }
+
+      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+        assert.equal(currentUserId, String(params[0]));
+        assert.equal(currentWorkspaceId, String(params[1]));
+        return createQueryResult<Row>([{
+          workspace_id: params[1],
+        } as unknown as Row]);
       }
 
       if (text.includes("INSERT INTO sync.workspace_replicas")) {
@@ -249,10 +313,12 @@ test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", as
   });
 
   assert.equal(replicaId, buildSystemWorkspaceReplicaId("workspace-1", "workspace_reset", "reset-progress"));
-  assert.equal(recordedQueries.length, 2);
+  assert.equal(recordedQueries.length, 3);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /INSERT INTO sync\.workspace_replicas/);
-  assert.deepEqual(recordedQueries[1]!.params, [
+  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
+  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
+  assert.match(recordedQueries[2]!.text, /INSERT INTO sync\.workspace_replicas/);
+  assert.deepEqual(recordedQueries[2]!.params, [
     replicaId,
     "workspace-1",
     "user-b",
@@ -262,4 +328,92 @@ test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", as
     "system",
     null,
   ]);
+});
+
+test("ensureSystemWorkspaceReplicaInExecutor raises workspace not found before registering replicas", async () => {
+  const { executor, recordedQueries } = createSyncIdentityExecutor({
+    claimStatus: "inserted",
+    workspaceAccessAllowed: false,
+    expectedWorkspaceReplicaInsertCount: 0,
+  });
+
+  await assert.rejects(
+    ensureSystemWorkspaceReplicaInExecutor(executor, {
+      workspaceId: "workspace-1",
+      userId: "user-b",
+      actorKind: "ai_chat",
+      actorKey: "chat-session-1",
+      platform: "web",
+      appVersion: "1.2.3",
+    }),
+    (error: unknown): boolean => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 404);
+      assert.equal(error.code, "WORKSPACE_NOT_FOUND");
+      return true;
+    },
+  );
+
+  assert.equal(recordedQueries.length, 2);
+  assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
+  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
+  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
+});
+
+test("ensureBootstrapSystemWorkspaceReplicaInExecutor uses provided bootstrap replica without workspace access lock", async () => {
+  const recordedQueries: Array<RecordedQuery> = [];
+  let currentUserId: string | null = null;
+  let currentWorkspaceId: string | null = null;
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<string | number | boolean | Date | null | ReadonlyArray<string>>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+
+      if (text.includes("set_config('app.user_id'")) {
+        currentUserId = typeof params[0] === "string" ? params[0] : null;
+        currentWorkspaceId = typeof params[1] === "string" && params[1] !== "" ? params[1] : null;
+        return createQueryResult<Row>([]);
+      }
+
+      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+        throw new Error("Bootstrap replica creation must not require a pre-existing workspace access lock");
+      }
+
+      if (text.includes("sync.claim_installation")) {
+        throw new Error("System actors must not claim client installations");
+      }
+
+      if (text.includes("INSERT INTO sync.workspace_replicas")) {
+        assert.equal(currentUserId, String(params[2]));
+        assert.equal(currentWorkspaceId, String(params[1]));
+        return createQueryResult<Row>([{
+          replica_id: params[0],
+          platform: params[6],
+        } as unknown as Row]);
+      }
+
+      if (text.includes("UPDATE sync.workspace_replicas")) {
+        return createQueryResult<Row>([]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  const replicaId = buildSystemWorkspaceReplicaId("workspace-1", "workspace_seed", "workspace-seed");
+  const returnedReplicaId = await ensureBootstrapSystemWorkspaceReplicaInExecutor(executor, {
+    workspaceId: "workspace-1",
+    userId: "user-b",
+    actorKind: "workspace_seed",
+    actorKey: "workspace-seed",
+    platform: "system",
+    appVersion: "server-bootstrap",
+  }, replicaId);
+
+  assert.equal(returnedReplicaId, replicaId);
+  assert.equal(recordedQueries.length, 2);
+  assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
+  assert.match(recordedQueries[1]!.text, /INSERT INTO sync\.workspace_replicas/);
 });

--- a/apps/backend/src/syncIdentity.ts
+++ b/apps/backend/src/syncIdentity.ts
@@ -34,6 +34,10 @@ type WorkspaceReplicaRow = Readonly<{
   platform: WorkspaceReplicaPlatform;
 }>;
 
+type WorkspaceAccessLockRow = Readonly<{
+  workspace_id: string;
+}>;
+
 type EnsureClientWorkspaceReplicaParams = Readonly<{
   workspaceId: string;
   userId: string;
@@ -176,6 +180,27 @@ async function upsertWorkspaceReplicaInExecutor(
   );
 }
 
+async function lockWorkspaceAccessInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string,
+): Promise<void> {
+  const result = await executor.query<WorkspaceAccessLockRow>(
+    [
+      "SELECT workspaces.workspace_id",
+      "FROM org.workspace_memberships AS memberships",
+      "INNER JOIN org.workspaces AS workspaces ON workspaces.workspace_id = memberships.workspace_id",
+      "WHERE memberships.user_id = $1 AND memberships.workspace_id = $2",
+      "FOR KEY SHARE OF workspaces, memberships",
+    ].join(" "),
+    [userId, workspaceId],
+  );
+
+  if (result.rows[0] === undefined) {
+    throw new HttpError(404, "Workspace not found", "WORKSPACE_NOT_FOUND");
+  }
+}
+
 /**
  * Client-authenticated sync requests provide only installation identity. The
  * backend derives the immutable workspace replica and stamps it into canonical
@@ -189,6 +214,7 @@ export async function ensureWorkspaceReplicaInExecutor(
     userId: params.userId,
     workspaceId: params.workspaceId,
   });
+  await lockWorkspaceAccessInExecutor(executor, params.userId, params.workspaceId);
   await ensureInstallationInExecutor(
     executor,
     params.userId,
@@ -227,28 +253,50 @@ export async function ensureWorkspaceReplica(
 export async function ensureSystemWorkspaceReplica(
   params: EnsureSystemWorkspaceReplicaParams,
 ): Promise<string> {
-  const replicaId = buildSystemWorkspaceReplicaId(params.workspaceId, params.actorKind, params.actorKey);
-
   return transactionWithWorkspaceScope(
     { userId: params.userId, workspaceId: params.workspaceId },
-    async (executor) => ensureSystemWorkspaceReplicaInExecutor(executor, params, replicaId),
+    async (executor) => ensureSystemWorkspaceReplicaInExecutor(executor, params),
   );
 }
 
 export async function ensureSystemWorkspaceReplicaInExecutor(
   executor: DatabaseExecutor,
   params: EnsureSystemWorkspaceReplicaParams,
-  explicitReplicaId?: string,
 ): Promise<string> {
   await applyWorkspaceDatabaseScopeInExecutor(executor, {
     userId: params.userId,
     workspaceId: params.workspaceId,
   });
-  const replicaId = explicitReplicaId ?? buildSystemWorkspaceReplicaId(
+  await lockWorkspaceAccessInExecutor(executor, params.userId, params.workspaceId);
+
+  const replicaId = buildSystemWorkspaceReplicaId(
     params.workspaceId,
     params.actorKind,
     params.actorKey,
   );
+
+  return upsertWorkspaceReplicaInExecutor(
+    executor,
+    replicaId,
+    params.workspaceId,
+    params.userId,
+    params.actorKind,
+    null,
+    params.actorKey,
+    params.platform,
+    params.appVersion,
+  );
+}
+
+export async function ensureBootstrapSystemWorkspaceReplicaInExecutor(
+  executor: DatabaseExecutor,
+  params: EnsureSystemWorkspaceReplicaParams,
+  replicaId: string,
+): Promise<string> {
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: params.userId,
+    workspaceId: params.workspaceId,
+  });
 
   return upsertWorkspaceReplicaInExecutor(
     executor,

--- a/apps/backend/src/workspaces/create.ts
+++ b/apps/backend/src/workspaces/create.ts
@@ -16,7 +16,7 @@ import {
 import { markBackendExceptionWrapperAsReported } from "../observability/reporting";
 import {
   buildSystemWorkspaceReplicaId,
-  ensureSystemWorkspaceReplicaInExecutor,
+  ensureBootstrapSystemWorkspaceReplicaInExecutor,
 } from "../syncIdentity";
 import { insertSyncChange } from "../syncChanges";
 import {
@@ -163,7 +163,7 @@ export async function createWorkspaceInExecutorWithObservationScope(
     );
 
     stage = "create_bootstrap_replica";
-    await ensureSystemWorkspaceReplicaInExecutor(executor, {
+    await ensureBootstrapSystemWorkspaceReplicaInExecutor(executor, {
       workspaceId,
       userId,
       actorKind: "workspace_seed",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run src/appData/domain.test.ts src/localDb/core.migrations.test.ts src/localDb/reviews.test.ts src/localDb/progress.test.ts src/localDb/reviewSchedule.test.ts src/localDb/cards.test.ts src/screens/review/*.test.tsx src/appData/progress/progressSource.summarySeries.test.tsx src/appData/progress/progressSource.cache.test.tsx src/appData/progress/progressSource.reviewSchedule.test.tsx src/appData/progress/progressSource.lifecycle.test.tsx src/appData/progress/progressInvalidation.test.tsx src/api.test.ts",
+    "test": "vitest run src/appData/domain.test.ts src/appData/useWorkspaceSession.test.tsx src/localDb/core.migrations.test.ts src/localDb/reviews.test.ts src/localDb/progress.test.ts src/localDb/reviewSchedule.test.ts src/localDb/cards.test.ts src/screens/review/*.test.tsx src/appData/progress/progressSource.summarySeries.test.tsx src/appData/progress/progressSource.cache.test.tsx src/appData/progress/progressSource.reviewSchedule.test.tsx src/appData/progress/progressSource.lifecycle.test.tsx src/appData/progress/progressInvalidation.test.tsx src/api.test.ts",
     "test:e2e": "FLASHCARDS_E2E_TARGET=prod playwright test",
     "test:e2e:local": "node ./scripts/check-local-e2e-stack.mjs && FLASHCARDS_E2E_TARGET=local playwright test",
     "test:e2e:prod": "FLASHCARDS_E2E_TARGET=prod playwright test"

--- a/apps/web/src/appData/provider.tsx
+++ b/apps/web/src/appData/provider.tsx
@@ -250,6 +250,7 @@ export function AppDataProvider(props: Props): ReactElement {
     runSync: syncEngine.runSync,
     runSyncSilently: syncEngine.runSyncSilently,
     runSyncForWorkspace: syncEngine.runSyncForWorkspace,
+    discardWorkspaceSync: syncEngine.discardWorkspaceSync,
   });
 
   const value: AppDataContextValue = {

--- a/apps/web/src/appData/useSyncEngine.ts
+++ b/apps/web/src/appData/useSyncEngine.ts
@@ -6,6 +6,7 @@ import {
   type SetStateAction,
 } from "react";
 import {
+  ApiError,
   bootstrapPullSyncState,
   isAuthRedirectError,
   pullReviewHistorySync,
@@ -93,6 +94,8 @@ import type { SessionLoadState } from "./types";
 import type { SessionVerificationState } from "./warmStart";
 
 const syncPageSize = 200;
+const workspaceNotFoundErrorCode = "WORKSPACE_NOT_FOUND";
+const workspaceSyncDiscardedErrorName = "WorkspaceSyncDiscardedError";
 
 type UseSyncEngineParams = Readonly<{
   sessionLoadState: SessionLoadState;
@@ -110,6 +113,7 @@ type SyncEngine = Readonly<{
   runSync: () => Promise<void>;
   runSyncSilently: () => Promise<void>;
   runSyncForWorkspace: (workspace: WorkspaceSummary) => Promise<void>;
+  discardWorkspaceSync: (workspaceId: string) => void;
   refreshLocalData: () => Promise<void>;
   refreshWorkspaceView: (workspaceId: string) => Promise<void>;
   getCardById: (cardId: string) => Promise<Card>;
@@ -123,6 +127,17 @@ type SyncEngine = Readonly<{
   submitReviewItem: (cardId: string, rating: 0 | 1 | 2 | 3) => Promise<Card>;
   seedLinkedWorkspace: (request: TestSeedRequest) => Promise<TestSeedResult>;
 }>;
+
+type WorkspaceSyncDiscardedError = Error & Readonly<{
+  name: typeof workspaceSyncDiscardedErrorName;
+  workspaceId: string;
+}>;
+
+function createWorkspaceSyncDiscardedError(workspaceId: string): WorkspaceSyncDiscardedError {
+  const error = new Error(`Workspace sync was discarded: ${workspaceId}`);
+  error.name = workspaceSyncDiscardedErrorName;
+  return Object.assign(error, { workspaceId }) as WorkspaceSyncDiscardedError;
+}
 
 async function requireCard(workspaceId: string, cardId: string): Promise<Card> {
   const card = await loadCardById(workspaceId, cardId);
@@ -176,6 +191,18 @@ function isProgressReviewEventOperation(
 
 function isAcknowledgedPushStatus(status: SyncPushResult["operations"][number]["status"]): boolean {
   return status === "applied" || status === "ignored" || status === "duplicate";
+}
+
+function isWorkspaceSyncDiscardedError(error: unknown): error is WorkspaceSyncDiscardedError {
+  return error instanceof Error
+    && error.name === workspaceSyncDiscardedErrorName
+    && "workspaceId" in error;
+}
+
+function isWorkspaceNotFoundError(error: unknown): error is ApiError {
+  return error instanceof ApiError
+    && error.statusCode === 404
+    && error.code === workspaceNotFoundErrorCode;
 }
 
 async function doHotSyncEntriesAffectReviewSchedule(
@@ -259,6 +286,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   const syncPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
   const needsResyncWorkspaceIdsRef = useRef<Set<string>>(new Set());
   const syncingWorkspaceIdsRef = useRef<Set<string>>(new Set());
+  const discardedSyncWorkspaceIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     activeWorkspaceRef.current = activeWorkspace;
@@ -277,6 +305,28 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     const currentWorkspace = activeWorkspaceRef.current;
     setIsSyncing(currentWorkspace !== null && syncingWorkspaceIdsRef.current.has(currentWorkspace.workspaceId));
   }, [setIsSyncing]);
+
+  const discardWorkspaceSync = useCallback(function discardWorkspaceSync(workspaceId: string): void {
+    discardedSyncWorkspaceIdsRef.current.add(workspaceId);
+    needsResyncWorkspaceIdsRef.current.delete(workspaceId);
+    syncingWorkspaceIdsRef.current.delete(workspaceId);
+    refreshSyncIndicator();
+  }, [refreshSyncIndicator]);
+
+  const requireWorkspaceSyncNotDiscarded = useCallback(function requireWorkspaceSyncNotDiscarded(
+    workspaceId: string,
+  ): void {
+    if (discardedSyncWorkspaceIdsRef.current.has(workspaceId)) {
+      throw createWorkspaceSyncDiscardedError(workspaceId);
+    }
+  }, []);
+
+  const isStaleWorkspaceNotFoundError = useCallback(function isStaleWorkspaceNotFoundError(
+    workspaceId: string,
+    error: unknown,
+  ): boolean {
+    return isWorkspaceNotFoundError(error) && isVisibleWorkspace(workspaceId) === false;
+  }, [isVisibleWorkspace]);
 
   const refreshLocalMetadata = useCallback(async function refreshLocalMetadata(workspaceId: string): Promise<void> {
     const [workspaceSettings, cloudSettings] = await Promise.all([
@@ -343,6 +393,10 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     const workspaceId = workspace.workspaceId;
+    if (discardedSyncWorkspaceIdsRef.current.has(workspaceId)) {
+      return;
+    }
+
     const activeSync = syncPromisesRef.current.get(workspaceId);
     if (activeSync !== undefined) {
       needsResyncWorkspaceIdsRef.current.add(workspaceId);
@@ -356,13 +410,17 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       try {
         let didChangeProgressHistory = false;
         let didChangeReviewSchedule = false;
+        requireWorkspaceSyncNotDiscarded(workspaceId);
         const cloudSettings = await loadCloudSettings();
+        requireWorkspaceSyncNotDiscarded(workspaceId);
         const installationId = requireCloudInstallationId(cloudSettings);
         const hotStateHydrated = await hasHydratedHotState(workspaceId);
+        requireWorkspaceSyncNotDiscarded(workspaceId);
         if (hotStateHydrated === false) {
           let bootstrapCursor: string | null = null;
 
           while (true) {
+            requireWorkspaceSyncNotDiscarded(workspaceId);
             const bootstrapResult = await bootstrapPullSyncState(
               workspaceId,
               installationId,
@@ -371,10 +429,12 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
               bootstrapCursor,
               syncPageSize,
             );
+            requireWorkspaceSyncNotDiscarded(workspaceId);
 
             if (await doHotSyncEntriesAffectReviewSchedule(workspaceId, bootstrapResult.entries)) {
               didChangeReviewSchedule = true;
             }
+            requireWorkspaceSyncNotDiscarded(workspaceId);
 
             await applyHotSyncPage(
               workspaceId,
@@ -386,6 +446,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
                   markHotStateHydrated: true,
                 },
             );
+            requireWorkspaceSyncNotDiscarded(workspaceId);
 
             if (isVisibleWorkspace(workspaceId)) {
               const lastSettings = findLastWorkspaceSettingsEntry(bootstrapResult.entries);
@@ -400,10 +461,13 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
             }
           }
           await refreshWorkspaceView(workspaceId);
+          requireWorkspaceSyncNotDiscarded(workspaceId);
         }
 
         let currentOutbox = await listOutboxRecords(workspaceId);
+        requireWorkspaceSyncNotDiscarded(workspaceId);
         while (currentOutbox.length > 0) {
+          requireWorkspaceSyncNotDiscarded(workspaceId);
           const batch = currentOutbox.slice(0, 100);
           const batchIncludesProgressReviewEvents = batch.some(isProgressReviewEventOperation);
           const reviewScheduleOperationIds = new Set(
@@ -419,6 +483,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
               webAppVersion,
               batch.map((record) => record.operation),
             );
+            requireWorkspaceSyncNotDiscarded(workspaceId);
 
             for (const result of pushResult.operations) {
               if (isAcknowledgedPushStatus(result.status)) {
@@ -445,10 +510,13 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           }
 
           currentOutbox = await listOutboxRecords(workspaceId);
+          requireWorkspaceSyncNotDiscarded(workspaceId);
         }
 
         let afterHotChangeId = await loadLastAppliedHotChangeId(workspaceId);
+        requireWorkspaceSyncNotDiscarded(workspaceId);
         while (true) {
+          requireWorkspaceSyncNotDiscarded(workspaceId);
           const pullResult = await pullSyncChanges(
             workspaceId,
             installationId,
@@ -457,15 +525,18 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
             afterHotChangeId,
             syncPageSize,
           );
+          requireWorkspaceSyncNotDiscarded(workspaceId);
 
           if (await doHotSyncEntriesAffectReviewSchedule(workspaceId, pullResult.changes)) {
             didChangeReviewSchedule = true;
           }
+          requireWorkspaceSyncNotDiscarded(workspaceId);
 
           await applyHotSyncPage(workspaceId, pullResult.changes, {
             lastAppliedHotChangeId: pullResult.nextHotChangeId,
             markHotStateHydrated: false,
           });
+          requireWorkspaceSyncNotDiscarded(workspaceId);
 
           if (isVisibleWorkspace(workspaceId)) {
             const lastSettings = findLastWorkspaceSettingsEntry(pullResult.changes);
@@ -483,7 +554,9 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
         let afterReviewSequenceId = await loadLastAppliedReviewSequenceId(workspaceId);
         const reviewHistoryHydrated = await hasHydratedReviewHistory(workspaceId);
+        requireWorkspaceSyncNotDiscarded(workspaceId);
         while (true) {
+          requireWorkspaceSyncNotDiscarded(workspaceId);
           const reviewHistoryResult = await pullReviewHistorySync(
             workspaceId,
             installationId,
@@ -492,11 +565,13 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
             afterReviewSequenceId,
             syncPageSize,
           );
+          requireWorkspaceSyncNotDiscarded(workspaceId);
 
           await applyReviewHistorySyncPage(workspaceId, reviewHistoryResult.reviewEvents, {
             lastAppliedReviewSequenceId: reviewHistoryResult.nextReviewSequenceId,
             markReviewHistoryHydrated: reviewHistoryHydrated === false && reviewHistoryResult.hasMore === false,
           });
+          requireWorkspaceSyncNotDiscarded(workspaceId);
 
           if (reviewHistoryResult.reviewEvents.length > 0) {
             didChangeProgressHistory = true;
@@ -510,6 +585,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         }
 
         await refreshWorkspaceView(workspaceId);
+        requireWorkspaceSyncNotDiscarded(workspaceId);
         if (didChangeProgressHistory) {
           invalidateProgress();
         }
@@ -522,6 +598,20 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           throw error;
         }
 
+        if (isWorkspaceSyncDiscardedError(error)) {
+          return;
+        }
+
+        if (discardedSyncWorkspaceIdsRef.current.has(workspaceId)) {
+          return;
+        }
+
+        if (isStaleWorkspaceNotFoundError(workspaceId, error)) {
+          discardedSyncWorkspaceIdsRef.current.add(workspaceId);
+          needsResyncWorkspaceIdsRef.current.delete(workspaceId);
+          return;
+        }
+
         reportSyncError(getErrorMessage(error));
         throw error;
       } finally {
@@ -529,8 +619,9 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         syncingWorkspaceIdsRef.current.delete(workspaceId);
         refreshSyncIndicator();
 
-        if (needsResyncWorkspaceIdsRef.current.has(workspaceId)) {
-          needsResyncWorkspaceIdsRef.current.delete(workspaceId);
+        const needsResync = needsResyncWorkspaceIdsRef.current.has(workspaceId);
+        needsResyncWorkspaceIdsRef.current.delete(workspaceId);
+        if (needsResync && discardedSyncWorkspaceIdsRef.current.has(workspaceId) === false) {
           void runSyncForWorkspace(workspace);
         }
       }
@@ -542,9 +633,11 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     isVisibleWorkspace,
     refreshSyncIndicator,
     refreshWorkspaceView,
+    requireWorkspaceSyncNotDiscarded,
     reportGlobalSyncError,
     session,
     sessionVerificationState,
+    isStaleWorkspaceNotFoundError,
     setWorkspaceSettings,
   ]);
 
@@ -985,6 +1078,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     runSync,
     runSyncSilently,
     runSyncForWorkspace,
+    discardWorkspaceSync,
     refreshLocalData,
     refreshWorkspaceView,
     getCardById,

--- a/apps/web/src/appData/useWorkspaceSession.test.tsx
+++ b/apps/web/src/appData/useWorkspaceSession.test.tsx
@@ -27,6 +27,10 @@ type HarnessSnapshot = Readonly<{
   errorMessage: string;
 }>;
 
+type HarnessActions = Readonly<{
+  deleteWorkspace: (workspaceId: string, confirmationText: string) => Promise<void>;
+}>;
+
 type TestHarnessProps = Readonly<{
   initialSessionLoadState: SessionLoadState;
   initialSessionVerificationState: SessionVerificationState;
@@ -38,6 +42,8 @@ type TestHarnessProps = Readonly<{
   runSyncMock: Mock<() => Promise<void>>;
   runSyncSilentlyMock: Mock<() => Promise<void>>;
   runSyncForWorkspaceMock: Mock<(workspace: WorkspaceSummary) => Promise<void>>;
+  discardWorkspaceSyncMock: Mock<(workspaceId: string) => void>;
+  onActionsChange: ((actions: HarnessActions) => void) | null;
 }>;
 
 const reviewRouteUrl = "http://localhost:3000/review";
@@ -58,6 +64,13 @@ const seededWorkspace: WorkspaceSummary = {
   workspaceId: "workspace-1",
   name: "Personal",
   createdAt: "2026-04-10T00:00:00.000Z",
+  isSelected: true,
+};
+
+const replacementWorkspace: WorkspaceSummary = {
+  workspaceId: "workspace-2",
+  name: "Work",
+  createdAt: "2026-04-11T00:00:00.000Z",
   isSelected: true,
 };
 
@@ -137,6 +150,20 @@ function buildWorkspacesResponse(workspaces: ReadonlyArray<WorkspaceSummary>): R
   });
 }
 
+function buildDeleteWorkspaceResponse(deletedWorkspaceId: string, workspace: WorkspaceSummary): Response {
+  return new Response(JSON.stringify({
+    ok: true,
+    deletedWorkspaceId,
+    deletedCardsCount: 2,
+    workspace,
+  }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
 function TestHarness(props: TestHarnessProps): ReactElement {
   const {
     initialSessionLoadState,
@@ -149,6 +176,8 @@ function TestHarness(props: TestHarnessProps): ReactElement {
     runSyncMock,
     runSyncSilentlyMock,
     runSyncForWorkspaceMock,
+    discardWorkspaceSyncMock,
+    onActionsChange,
   } = props;
   const [sessionLoadState, setSessionLoadState] = useState<SessionLoadState>(initialSessionLoadState);
   const [sessionVerificationState, setSessionVerificationState] = useState<SessionVerificationState>(initialSessionVerificationState);
@@ -160,7 +189,7 @@ function TestHarness(props: TestHarnessProps): ReactElement {
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [cloudSettings, setCloudSettings] = useState<CloudSettings | null>(null);
 
-  useWorkspaceSession({
+  const actions = useWorkspaceSession({
     t: (key: TranslationKey): string => key,
     sessionLoadState,
     sessionVerificationState,
@@ -181,7 +210,18 @@ function TestHarness(props: TestHarnessProps): ReactElement {
     runSync: runSyncMock,
     runSyncSilently: runSyncSilentlyMock,
     runSyncForWorkspace: runSyncForWorkspaceMock,
+    discardWorkspaceSync: discardWorkspaceSyncMock,
   });
+
+  useEffect(() => {
+    if (onActionsChange === null) {
+      return;
+    }
+
+    onActionsChange({
+      deleteWorkspace: actions.deleteWorkspace,
+    });
+  }, [actions.deleteWorkspace, onActionsChange]);
 
   useEffect(() => {
     onStateChange({
@@ -330,6 +370,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncMock={runSyncMock}
           runSyncSilentlyMock={runSyncSilentlyMock}
           runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          onActionsChange={null}
         />,
       );
     });
@@ -386,6 +428,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncMock={vi.fn(async (): Promise<void> => {})}
           runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
           runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          onActionsChange={null}
         />,
       );
     });
@@ -430,6 +474,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncMock={vi.fn(async (): Promise<void> => {})}
           runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
           runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          onActionsChange={null}
         />,
       );
     });
@@ -483,6 +529,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncMock={runSyncMock}
           runSyncSilentlyMock={runSyncSilentlyMock}
           runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          onActionsChange={null}
         />,
       );
     });
@@ -538,6 +586,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncMock={vi.fn(async (): Promise<void> => {})}
           runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
           runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          onActionsChange={null}
         />,
       );
     });
@@ -550,5 +600,78 @@ describe("useWorkspaceSession bootstrap", () => {
     expect(redirectedUrl).toBeNull();
     expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).not.toBeNull();
     await expect(loadCloudSettings()).resolves.toEqual(seededCloudSettings);
+  });
+
+  it("discards deleted workspace sync before activating the replacement workspace", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+
+    const unselectedReplacementWorkspace: WorkspaceSummary = {
+      ...replacementWorkspace,
+      isSelected: false,
+    };
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace, unselectedReplacementWorkspace]))
+      .mockResolvedValueOnce(buildDeleteWorkspaceResponse("workspace-1", replacementWorkspace));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const refreshWorkspaceViewMock = vi.fn(async (_workspaceId: string): Promise<void> => {});
+    const runSyncMock = vi.fn(async (): Promise<void> => {});
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {});
+    const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {});
+    const discardWorkspaceSyncMock = vi.fn((_workspaceId: string): void => {});
+    let latestActions: HarnessActions | null = null;
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={refreshWorkspaceViewMock}
+          runSyncMock={runSyncMock}
+          runSyncSilentlyMock={runSyncSilentlyMock}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={discardWorkspaceSyncMock}
+          onActionsChange={(actions: HarnessActions): void => {
+            latestActions = actions;
+          }}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionLoadState).toBe("ready");
+      expect(latestState?.sessionVerificationState).toBe("verified");
+      expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    });
+
+    if (latestActions === null) {
+      throw new Error("Workspace session actions were not published");
+    }
+
+    await act(async () => {
+      await latestActions.deleteWorkspace("workspace-1", "delete Personal");
+    });
+
+    expect(discardWorkspaceSyncMock).toHaveBeenCalledWith("workspace-1");
+    expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(2);
+    expect(runSyncForWorkspaceMock).toHaveBeenLastCalledWith(replacementWorkspace);
+    expect(discardWorkspaceSyncMock.mock.invocationCallOrder[0]).toBeLessThan(
+      runSyncForWorkspaceMock.mock.invocationCallOrder[1],
+    );
+    expect(latestState?.activeWorkspace?.workspaceId).toBe("workspace-2");
+    expect(latestState?.availableWorkspaces.map((workspace) => workspace.workspaceId)).toEqual(["workspace-2"]);
+    await expect(loadCloudSettings()).resolves.toEqual(expect.objectContaining({
+      cloudState: "linked",
+      linkedWorkspaceId: "workspace-2",
+      linkedUserId: "user-1",
+    }));
   });
 });

--- a/apps/web/src/appData/useWorkspaceSession.ts
+++ b/apps/web/src/appData/useWorkspaceSession.ts
@@ -65,6 +65,7 @@ type UseWorkspaceSessionParams = Readonly<{
   runSync: () => Promise<void>;
   runSyncSilently: () => Promise<void>;
   runSyncForWorkspace: (workspace: WorkspaceSummary) => Promise<void>;
+  discardWorkspaceSync: (workspaceId: string) => void;
 }>;
 
 type WorkspaceSession = Readonly<{
@@ -206,6 +207,7 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
     runSync,
     runSyncSilently,
     runSyncForWorkspace,
+    discardWorkspaceSync,
   } = params;
   const resumePromiseRef = useRef<Promise<void> | null>(null);
 
@@ -646,6 +648,7 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
         deletedWorkspaceId: response.deletedWorkspaceId,
         replacementWorkspaceId: response.workspace.workspaceId,
       });
+      discardWorkspaceSync(response.deletedWorkspaceId);
       const nextWorkspaces = replaceWorkspaceSummary(
         availableWorkspaces.filter((workspace) => workspace.workspaceId !== response.deletedWorkspaceId),
         response.workspace,
@@ -676,7 +679,16 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
     } finally {
       setIsChoosingWorkspace(false);
     }
-  }, [activateWorkspace, availableWorkspaces, session, sessionVerificationState, t, setErrorMessage, setIsChoosingWorkspace]);
+  }, [
+    activateWorkspace,
+    availableWorkspaces,
+    discardWorkspaceSync,
+    session,
+    sessionVerificationState,
+    t,
+    setErrorMessage,
+    setIsChoosingWorkspace,
+  ]);
 
   const loadWorkspaceResetProgressPreview = useCallback(async function loadWorkspaceResetProgressPreview(
     workspaceId: string,


### PR DESCRIPTION
## Summary
- serialize sync replica registration with workspace deletion by locking workspace access inside sync transactions
- discard stale web sync work after workspace deletion and keep replacement activation ordered
- preserve safe database diagnostics in Sentry while keeping user content redacted
- include the workspace session regression test in the standard web test script

## Validation
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend
- npm test (apps/web)
- npm run build (apps/web)
- git --no-pager diff --check