### PR TITLE
[codex] Fix workspace access lifecycle locking

### DIFF
--- a/apps/backend/src/accountDeletion.ts
+++ b/apps/backend/src/accountDeletion.ts
@@ -3,6 +3,7 @@ import { transactionWithUserScope, type DatabaseExecutor } from "./db";
 import { isDeletedSubject, markDeletedSubjectInExecutor } from "./deletedSubjects";
 import { isConfiguredDemoEmail } from "./demoEmailAccess";
 import { HttpError } from "./errors";
+import { lockUserWorkspaceAccessLifecyclesInExecutor } from "./workspaceAccessLocks";
 
 export const deleteAccountConfirmationText: string = "delete my account";
 
@@ -72,7 +73,7 @@ async function deleteAccountDataInExecutor(
     [appUserId],
   );
   const workspaceRows = await executor.query<WorkspaceIdRow>(
-    "SELECT workspace_id FROM org.workspace_memberships WHERE user_id = $1 FOR UPDATE",
+    "SELECT workspace_id FROM org.workspace_memberships WHERE user_id = $1",
     [appUserId],
   );
   const workspaceIds = workspaceRows.rows.map((row) => row.workspace_id);
@@ -80,6 +81,13 @@ async function deleteAccountDataInExecutor(
   const soleMemberWorkspaceIds: Array<string> = [];
 
   if (workspaceIds.length > 0) {
+    await lockUserWorkspaceAccessLifecyclesInExecutor(executor, appUserId, workspaceIds);
+
+    await executor.query(
+      "SELECT workspace_id FROM org.workspace_memberships WHERE user_id = $1 FOR UPDATE",
+      [appUserId],
+    );
+
     const workspaceMembershipRows = await executor.query<WorkspaceMembershipRow>(
       [
         "SELECT workspace_id, user_id",

--- a/apps/backend/src/guestAuthTestHarness/executor.ts
+++ b/apps/backend/src/guestAuthTestHarness/executor.ts
@@ -97,10 +97,12 @@ export function createGuestUpgradeExecutor(state: MutableState): DatabaseExecuto
 
 export function isGuestUpgradeMergeOnlyExecutorQuery(text: string): boolean {
   return text.includes("FROM sync.claim_installation")
+    || (text.includes("pg_advisory_xact_lock") && text.includes("hashtextextended"))
     || (
       text.startsWith("SELECT")
-      && text.includes("FROM org.workspace_memberships AS memberships")
-      && text.includes("FOR KEY SHARE OF workspaces, memberships")
+      && text.includes("FROM org.workspaces AS workspaces")
+      && text.includes("security.user_has_workspace_access(workspaces.workspace_id)")
+      && text.includes("FOR KEY SHARE OF workspaces")
     )
     || (text.startsWith("SELECT") && text.includes("FROM sync.workspace_replicas"))
     || text.includes("INSERT INTO sync.workspace_replicas")

--- a/apps/backend/src/guestAuthTestHarness/handlers/workspaces.ts
+++ b/apps/backend/src/guestAuthTestHarness/handlers/workspaces.ts
@@ -18,10 +18,22 @@ export function handleWorkspaceExecutorQuery<Row extends pg.QueryResultRow>(
 ): pg.QueryResult<Row> | null {
   const { scope, state } = context;
 
+  if (text.includes("pg_advisory_xact_lock") && text.includes("hashtextextended")) {
+    const userId = params[0];
+    const workspaceId = params[1];
+    if (typeof userId !== "string" || typeof workspaceId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    scope.requireCurrentWorkspaceScope(userId, workspaceId);
+    return createQueryResult<Row>([]);
+  }
+
   if (
     text.startsWith("SELECT")
-    && text.includes("FROM org.workspace_memberships AS memberships")
-    && text.includes("FOR KEY SHARE OF workspaces, memberships")
+    && text.includes("FROM org.workspaces AS workspaces")
+    && text.includes("security.user_has_workspace_access(workspaces.workspace_id)")
+    && text.includes("FOR KEY SHARE OF workspaces")
   ) {
     const userId = params[0];
     const workspaceId = params[1];

--- a/apps/backend/src/syncIdentity.test.ts
+++ b/apps/backend/src/syncIdentity.test.ts
@@ -33,6 +33,17 @@ function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Ro
   };
 }
 
+function isWorkspaceAccessLockQuery(text: string): boolean {
+  return text.includes("FROM org.workspaces AS workspaces")
+    && text.includes("security.user_has_workspace_access(workspaces.workspace_id)")
+    && text.includes("FOR KEY SHARE OF workspaces");
+}
+
+function isWorkspaceAccessLifecycleLockQuery(text: string): boolean {
+  return text.includes("pg_advisory_xact_lock")
+    && text.includes("hashtextextended");
+}
+
 function createSyncIdentityExecutor(
   options: SyncIdentityExecutorOptions,
 ): Readonly<{
@@ -61,6 +72,11 @@ function createSyncIdentityExecutor(
         return createQueryResult<Row>([]);
       }
 
+      if (isWorkspaceAccessLifecycleLockQuery(text)) {
+        requireCurrentWorkspaceScope(String(params[0]), String(params[1]));
+        return createQueryResult<Row>([]);
+      }
+
       if (text.includes("FROM sync.claim_installation")) {
         return createQueryResult<Row>([{
           claim_status: options.claimStatus,
@@ -71,7 +87,7 @@ function createSyncIdentityExecutor(
         } as unknown as Row]);
       }
 
-      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+      if (isWorkspaceAccessLockQuery(text)) {
         requireCurrentWorkspaceScope(String(params[0]), String(params[1]));
         return createQueryResult<Row>(options.workspaceAccessAllowed
           ? [{
@@ -123,16 +139,17 @@ test("ensureWorkspaceReplicaInExecutor accepts inserted, refreshed, and reassign
       appVersion: "1.2.3",
     });
 
-    assert.equal(recordedQueries.length, 4);
+    assert.equal(recordedQueries.length, 5);
     assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
     assert.deepEqual(recordedQueries[0]!.params, ["user-b", "workspace-1"]);
-    assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
-    assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
+    assert.ok(isWorkspaceAccessLifecycleLockQuery(recordedQueries[1]!.text));
     assert.deepEqual(recordedQueries[1]!.params, ["user-b", "workspace-1"]);
-    assert.match(recordedQueries[2]!.text, /FROM sync\.claim_installation/);
-    assert.deepEqual(recordedQueries[2]!.params, ["installation-1", "ios", "user-b", "1.2.3"]);
-    assert.match(recordedQueries[3]!.text, /INSERT INTO sync\.workspace_replicas/);
-    assert.equal(replicaId, recordedQueries[3]!.params[0]);
+    assert.ok(isWorkspaceAccessLockQuery(recordedQueries[2]!.text));
+    assert.deepEqual(recordedQueries[2]!.params, ["user-b", "workspace-1"]);
+    assert.match(recordedQueries[3]!.text, /FROM sync\.claim_installation/);
+    assert.deepEqual(recordedQueries[3]!.params, ["installation-1", "ios", "user-b", "1.2.3"]);
+    assert.match(recordedQueries[4]!.text, /INSERT INTO sync\.workspace_replicas/);
+    assert.equal(replicaId, recordedQueries[4]!.params[0]);
   }
 });
 
@@ -159,10 +176,11 @@ test("ensureWorkspaceReplicaInExecutor raises platform mismatch without touching
     },
   );
 
-  assert.equal(recordedQueries.length, 3);
+  assert.equal(recordedQueries.length, 4);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
-  assert.match(recordedQueries[2]!.text, /FROM sync\.claim_installation/);
+  assert.ok(isWorkspaceAccessLifecycleLockQuery(recordedQueries[1]!.text));
+  assert.ok(isWorkspaceAccessLockQuery(recordedQueries[2]!.text));
+  assert.match(recordedQueries[3]!.text, /FROM sync\.claim_installation/);
 });
 
 test("ensureWorkspaceReplicaInExecutor raises workspace not found before registering replicas", async () => {
@@ -188,10 +206,10 @@ test("ensureWorkspaceReplicaInExecutor raises workspace not found before registe
     },
   );
 
-  assert.equal(recordedQueries.length, 2);
+  assert.equal(recordedQueries.length, 3);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
-  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
+  assert.ok(isWorkspaceAccessLifecycleLockQuery(recordedQueries[1]!.text));
+  assert.ok(isWorkspaceAccessLockQuery(recordedQueries[2]!.text));
 });
 
 test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", async () => {
@@ -215,7 +233,13 @@ test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", asyn
         throw new Error("System actors must not claim client installations");
       }
 
-      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+      if (isWorkspaceAccessLifecycleLockQuery(text)) {
+        assert.equal(currentUserId, String(params[0]));
+        assert.equal(currentWorkspaceId, String(params[1]));
+        return createQueryResult<Row>([]);
+      }
+
+      if (isWorkspaceAccessLockQuery(text)) {
         assert.equal(currentUserId, String(params[0]));
         assert.equal(currentWorkspaceId, String(params[1]));
         return createQueryResult<Row>([{
@@ -250,11 +274,11 @@ test("ensureSystemWorkspaceReplicaInExecutor does not claim installations", asyn
   });
 
   assert.equal(replicaId, buildSystemWorkspaceReplicaId("workspace-1", "ai_chat", "chat-session-1"));
-  assert.equal(recordedQueries.length, 3);
+  assert.equal(recordedQueries.length, 4);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
-  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
-  assert.match(recordedQueries[2]!.text, /INSERT INTO sync\.workspace_replicas/);
+  assert.ok(isWorkspaceAccessLifecycleLockQuery(recordedQueries[1]!.text));
+  assert.ok(isWorkspaceAccessLockQuery(recordedQueries[2]!.text));
+  assert.match(recordedQueries[3]!.text, /INSERT INTO sync\.workspace_replicas/);
 });
 
 test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", async () => {
@@ -278,7 +302,13 @@ test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", as
         throw new Error("System actors must not claim client installations");
       }
 
-      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+      if (isWorkspaceAccessLifecycleLockQuery(text)) {
+        assert.equal(currentUserId, String(params[0]));
+        assert.equal(currentWorkspaceId, String(params[1]));
+        return createQueryResult<Row>([]);
+      }
+
+      if (isWorkspaceAccessLockQuery(text)) {
         assert.equal(currentUserId, String(params[0]));
         assert.equal(currentWorkspaceId, String(params[1]));
         return createQueryResult<Row>([{
@@ -313,12 +343,12 @@ test("ensureSystemWorkspaceReplicaInExecutor accepts workspace_reset actors", as
   });
 
   assert.equal(replicaId, buildSystemWorkspaceReplicaId("workspace-1", "workspace_reset", "reset-progress"));
-  assert.equal(recordedQueries.length, 3);
+  assert.equal(recordedQueries.length, 4);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
-  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
-  assert.match(recordedQueries[2]!.text, /INSERT INTO sync\.workspace_replicas/);
-  assert.deepEqual(recordedQueries[2]!.params, [
+  assert.ok(isWorkspaceAccessLifecycleLockQuery(recordedQueries[1]!.text));
+  assert.ok(isWorkspaceAccessLockQuery(recordedQueries[2]!.text));
+  assert.match(recordedQueries[3]!.text, /INSERT INTO sync\.workspace_replicas/);
+  assert.deepEqual(recordedQueries[3]!.params, [
     replicaId,
     "workspace-1",
     "user-b",
@@ -354,10 +384,10 @@ test("ensureSystemWorkspaceReplicaInExecutor raises workspace not found before r
     },
   );
 
-  assert.equal(recordedQueries.length, 2);
+  assert.equal(recordedQueries.length, 3);
   assert.match(recordedQueries[0]!.text, /set_config\('app\.user_id'/);
-  assert.match(recordedQueries[1]!.text, /FROM org\.workspace_memberships AS memberships/);
-  assert.match(recordedQueries[1]!.text, /FOR KEY SHARE OF workspaces, memberships/);
+  assert.ok(isWorkspaceAccessLifecycleLockQuery(recordedQueries[1]!.text));
+  assert.ok(isWorkspaceAccessLockQuery(recordedQueries[2]!.text));
 });
 
 test("ensureBootstrapSystemWorkspaceReplicaInExecutor uses provided bootstrap replica without workspace access lock", async () => {
@@ -377,8 +407,12 @@ test("ensureBootstrapSystemWorkspaceReplicaInExecutor uses provided bootstrap re
         return createQueryResult<Row>([]);
       }
 
-      if (text.includes("FROM org.workspace_memberships AS memberships")) {
+      if (isWorkspaceAccessLockQuery(text)) {
         throw new Error("Bootstrap replica creation must not require a pre-existing workspace access lock");
+      }
+
+      if (isWorkspaceAccessLifecycleLockQuery(text)) {
+        throw new Error("Bootstrap replica creation must not require a workspace access lifecycle lock");
       }
 
       if (text.includes("sync.claim_installation")) {

--- a/apps/backend/src/syncIdentity.ts
+++ b/apps/backend/src/syncIdentity.ts
@@ -5,6 +5,7 @@ import {
   type DatabaseExecutor,
 } from "./db";
 import { HttpError } from "./errors";
+import { lockWorkspaceAccessLifecycleInExecutor } from "./workspaceAccessLocks";
 
 export type SyncClientPlatform = "ios" | "android" | "web";
 export type WorkspaceReplicaActorKind =
@@ -185,13 +186,16 @@ async function lockWorkspaceAccessInExecutor(
   userId: string,
   workspaceId: string,
 ): Promise<void> {
+  await lockWorkspaceAccessLifecycleInExecutor(executor, userId, workspaceId);
+
   const result = await executor.query<WorkspaceAccessLockRow>(
     [
       "SELECT workspaces.workspace_id",
-      "FROM org.workspace_memberships AS memberships",
-      "INNER JOIN org.workspaces AS workspaces ON workspaces.workspace_id = memberships.workspace_id",
-      "WHERE memberships.user_id = $1 AND memberships.workspace_id = $2",
-      "FOR KEY SHARE OF workspaces, memberships",
+      "FROM org.workspaces AS workspaces",
+      "WHERE security.current_user_id() = $1",
+      "AND workspaces.workspace_id = $2",
+      "AND security.user_has_workspace_access(workspaces.workspace_id)",
+      "FOR KEY SHARE OF workspaces",
     ].join(" "),
     [userId, workspaceId],
   );

--- a/apps/backend/src/workspaceAccessLocks.ts
+++ b/apps/backend/src/workspaceAccessLocks.ts
@@ -1,0 +1,28 @@
+import type { DatabaseExecutor } from "./db";
+
+function toUniqueSortedWorkspaceIds(workspaceIds: ReadonlyArray<string>): Array<string> {
+  return [...new Set(workspaceIds)].sort((left, right) => left.localeCompare(right));
+}
+
+export async function lockWorkspaceAccessLifecycleInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string,
+): Promise<void> {
+  await executor.query(
+    "SELECT pg_advisory_xact_lock(hashtextextended($1::text || ':' || $2::text, 0::bigint))",
+    [userId, workspaceId],
+  );
+}
+
+export async function lockUserWorkspaceAccessLifecyclesInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceIds: ReadonlyArray<string>,
+): Promise<void> {
+  const sortedWorkspaceIds = toUniqueSortedWorkspaceIds(workspaceIds);
+
+  for (const workspaceId of sortedWorkspaceIds) {
+    await lockWorkspaceAccessLifecycleInExecutor(executor, userId, workspaceId);
+  }
+}

--- a/apps/backend/src/workspaces/management.ts
+++ b/apps/backend/src/workspaces/management.ts
@@ -16,6 +16,7 @@ import {
 } from "../observability/sentry";
 import { markBackendExceptionWrapperAsReported } from "../observability/reporting";
 import { ensureSystemWorkspaceReplicaInExecutor } from "../syncIdentity";
+import { lockWorkspaceAccessLifecycleInExecutor } from "../workspaceAccessLocks";
 import { createWorkspaceInExecutorWithObservationScope } from "./create";
 import {
   listUserWorkspaceIdsInExecutor,
@@ -550,6 +551,7 @@ async function deleteWorkspaceInExecutorWithObservationScope(
   observationScope: BackendObservationScope | null,
 ): Promise<DeleteWorkspaceResult> {
   assertDeleteWorkspaceConfirmationText(confirmationText);
+  await lockWorkspaceAccessLifecycleInExecutor(executor, userId, workspaceId);
   let stage: WorkspaceDeleteFailureStage = "load_management_row";
   const managedWorkspace = await loadWorkspaceManagementRowInExecutor(executor, userId, workspaceId);
   assertWorkspaceOwner(managedWorkspace.role);


### PR DESCRIPTION
## Summary
- replace the sync replica join lock with a workspace-row access check plus a transaction advisory lifecycle lock
- serialize sync replica creation with account deletion and workspace deletion for the same user/workspace
- update backend sync identity and guest upgrade harness tests for the new lock query

## Root cause
The previous sync identity lock queried workspace memberships and workspaces together with row locks. In production that path could reject valid agent SQL mutations with WORKSPACE_NOT_FOUND. Splitting the access check from lifecycle serialization avoids the false 404 while still closing the race where access is deleted during replica registration.

## Validation
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend
- npm run build --prefix apps/backend
- git --no-pager diff --check