### PR TITLE
[codex] Fix AI chat bootstrap retry recovery

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatBootstrapCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatBootstrapCoordinator.kt
@@ -2,6 +2,7 @@ package com.flashcardsopensourceapp.feature.ai.runtime
 
 import com.flashcardsopensourceapp.data.local.ai.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.data.local.ai.AiChatRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.AiChatBootstrapResponse
 import com.flashcardsopensourceapp.data.local.model.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.AiChatPersistedState
@@ -88,6 +89,7 @@ internal class AiChatBootstrapCoordinator(
         }
 
         val bootstrapRequestToken = nextBootstrapRequestToken()
+        context.lastBootstrapFailureRetryable = false
         context.activeBootstrapJob?.cancel(
             cause = CancellationException("AI bootstrap restarted.")
         )
@@ -172,24 +174,8 @@ internal class AiChatBootstrapCoordinator(
                     throw AiChatBootstrapBlockedException(blockedSyncMessage)
                 }
 
-                val preparedSession = context.aiChatRepository.prepareSessionForAi(workspaceId = workspaceId)
-                if (
-                    isCurrentBootstrapRequest(
-                        expectedContext = accessContext,
-                        expectedRequestToken = bootstrapRequestToken,
-                        expectedJob = bootstrapJob
-                    ).not()
-                ) {
-                    logBootstrapSuperseded(
-                        workspaceId = workspaceId,
-                        expectedContext = accessContext,
-                        stage = "prepare_session"
-                    )
-                    return@launch
-                }
-
                 val remoteBootstrap = loadBootstrapRemoteResultWithRetry(
-                    preparedSession = preparedSession,
+                    workspaceId = workspaceId,
                     persistedState = persistedState,
                     bootstrapProvisionalSessionId = bootstrapProvisionalSessionId,
                     resumeDiagnostics = resumeDiagnostics,
@@ -244,6 +230,7 @@ internal class AiChatBootstrapCoordinator(
                 if (didApplyBootstrap.not()) {
                     return@launch
                 }
+                context.lastBootstrapFailureRetryable = false
                 if (
                     isCurrentBootstrapRequest(
                         expectedContext = accessContext,
@@ -289,6 +276,7 @@ internal class AiChatBootstrapCoordinator(
                     configuration = context.currentServerConfiguration(),
                     textProvider = context.textProvider
                 )
+                context.lastBootstrapFailureRetryable = isRetryableBootstrapFailure(error = error)
                 AiChatDiagnosticsLogger.error(
                     event = "conversation_bootstrap_failed",
                     fields = listOf(
@@ -457,8 +445,8 @@ internal class AiChatBootstrapCoordinator(
     }
 
     private suspend fun loadBootstrapRemoteResultWithRetry(
-        preparedSession: AiChatPreparedRemoteSession,
-        persistedState: com.flashcardsopensourceapp.data.local.model.AiChatPersistedState,
+        workspaceId: String,
+        persistedState: AiChatPersistedState,
         bootstrapProvisionalSessionId: String?,
         resumeDiagnostics: com.flashcardsopensourceapp.data.local.model.AiChatResumeDiagnostics?,
         accessContext: AiAccessContext,
@@ -471,6 +459,22 @@ internal class AiChatBootstrapCoordinator(
         var retryCount: Int = 0
         while (true) {
             try {
+                val preparedSession = context.aiChatRepository.prepareSessionForAi(workspaceId = workspaceId)
+                if (
+                    isCurrentBootstrapRequest(
+                        expectedContext = accessContext,
+                        expectedRequestToken = bootstrapRequestToken,
+                        expectedJob = bootstrapJob
+                    ).not()
+                ) {
+                    logBootstrapSuperseded(
+                        workspaceId = workspaceId,
+                        expectedContext = accessContext,
+                        stage = "prepare_session"
+                    )
+                    return null
+                }
+
                 val ensuredSession = resolveRemoteBootstrapSession(
                     preparedSession = preparedSession,
                     persistedState = persistedState,
@@ -487,7 +491,7 @@ internal class AiChatBootstrapCoordinator(
                     ).not()
                 ) {
                     logBootstrapSuperseded(
-                        workspaceId = preparedSession.workspaceId,
+                        workspaceId = workspaceId,
                         expectedContext = accessContext,
                         stage = "ensure_session"
                     )
@@ -508,7 +512,7 @@ internal class AiChatBootstrapCoordinator(
                     ).not()
                 ) {
                     logBootstrapSuperseded(
-                        workspaceId = preparedSession.workspaceId,
+                        workspaceId = workspaceId,
                         expectedContext = accessContext,
                         stage = "load_bootstrap"
                     )
@@ -525,7 +529,7 @@ internal class AiChatBootstrapCoordinator(
                     throw error
                 }
                 logBootstrapRetry(
-                    workspaceId = preparedSession.workspaceId,
+                    workspaceId = workspaceId,
                     accessContext = accessContext,
                     retryCount = retryCount,
                     error = error
@@ -540,7 +544,7 @@ internal class AiChatBootstrapCoordinator(
                     ).not()
                 ) {
                     logBootstrapSuperseded(
-                        workspaceId = preparedSession.workspaceId,
+                        workspaceId = workspaceId,
                         expectedContext = accessContext,
                         stage = "retry_delay"
                     )
@@ -839,11 +843,33 @@ internal fun shouldRetryBootstrap(error: Exception, retryCount: Int): Boolean {
     if (retryCount >= aiBootstrapMaxRetryCount) {
         return false
     }
+    return isRetryableBootstrapFailure(error = error)
+}
+
+internal fun isRetryableBootstrapFailure(error: Exception): Boolean {
+    if (error is CancellationException) {
+        return false
+    }
     val remoteError = error as? AiChatRemoteException
     if (remoteError != null) {
-        return shouldRetryRemoteBootstrapError(error = remoteError)
+        return shouldRetryHttpStatus(statusCode = remoteError.statusCode)
+    }
+    val cloudRemoteError = error as? CloudRemoteException ?: findCloudRemoteCause(error = error)
+    if (cloudRemoteError != null) {
+        return shouldRetryHttpStatus(statusCode = cloudRemoteError.statusCode)
     }
     return error is IOException && isLikelyTransientBootstrapIoException(error = error)
+}
+
+private fun findCloudRemoteCause(error: Throwable): CloudRemoteException? {
+    var currentCause: Throwable? = error.cause
+    while (currentCause != null) {
+        if (currentCause is CloudRemoteException) {
+            return currentCause
+        }
+        currentCause = currentCause.cause
+    }
+    return null
 }
 
 private fun isLikelyTransientBootstrapIoException(error: IOException): Boolean {
@@ -925,10 +951,10 @@ internal suspend fun createNewAiChatSessionWithBootstrapRetry(
     targetSessionId: String,
     retryEvent: String
 ): AiChatSessionSnapshot {
-    val preparedSession = context.aiChatRepository.prepareSessionForAi(workspaceId = workspaceId)
     var retryCount: Int = 0
     while (true) {
         try {
+            val preparedSession = context.aiChatRepository.prepareSessionForAi(workspaceId = workspaceId)
             return createNewAiChatSessionFromPreparedSessionOnce(
                 context = context,
                 preparedSession = preparedSession,
@@ -1014,9 +1040,9 @@ private fun logAiChatSessionProvisioningRetry(
     )
 }
 
-private fun shouldRetryRemoteBootstrapError(error: AiChatRemoteException): Boolean {
-    val statusCode = error.statusCode ?: return false
-    return statusCode == 408 || statusCode == 429 || statusCode in 500..599
+private fun shouldRetryHttpStatus(statusCode: Int?): Boolean {
+    val resolvedStatusCode = statusCode ?: return false
+    return resolvedStatusCode == 408 || resolvedStatusCode == 429 || resolvedStatusCode in 500..599
 }
 
 private fun nextBootstrapRetryDelayMillis(retryCount: Int): Long {

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeContext.kt
@@ -57,6 +57,7 @@ internal class AiChatRuntimeContext(
     var activeFreshSessionJob: Job? = null
     var activeFreshSessionTargetSessionId: String? = null
     var pendingWarmUpAfterWorkspaceSwitch: Boolean = false
+    var lastBootstrapFailureRetryable: Boolean = false
     var activeAccessContext: AiAccessContext? = null
     var isScreenVisible: Boolean = false
     var nextResumeAttemptId: Long = 0L

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeLifecycleCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeLifecycleCoordinator.kt
@@ -4,6 +4,7 @@ import com.flashcardsopensourceapp.data.local.ai.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.data.local.ai.AiChatRemoteException
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -149,9 +150,15 @@ internal class AiChatRuntimeLifecycleCoordinator(
         if (context.activeWarmUpJob != null) {
             return
         }
+        if (
+            currentState.conversationBootstrapState == AiConversationBootstrapState.FAILED
+            && context.lastBootstrapFailureRetryable.not()
+        ) {
+            return
+        }
 
-        var warmUpJob: Job? = null
-        warmUpJob = context.scope.launch {
+        lateinit var warmUpJob: Job
+        warmUpJob = context.scope.launch(start = CoroutineStart.LAZY) {
             try {
                 if (shouldPrepareGuestAccess(
                         accessContext = accessContext,
@@ -214,6 +221,7 @@ internal class AiChatRuntimeLifecycleCoordinator(
             }
         }
         context.activeWarmUpJob = warmUpJob
+        warmUpJob.start()
     }
 
     private fun retryBootstrapIfLoadingWithoutOwner(accessContext: AiAccessContext) {

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSessionCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatSessionCoordinator.kt
@@ -29,6 +29,7 @@ internal class AiChatSessionCoordinator(
         val currentState = context.runtimeStateMutable.value
         context.persistDraft(snapshot = currentState)
         val targetSessionId = makeAiChatSessionId()
+        context.lastBootstrapFailureRetryable = false
         context.runtimeStateMutable.update { state ->
             state.copy(
                 persistedState = state.persistedState.copy(
@@ -140,6 +141,7 @@ internal class AiChatSessionCoordinator(
                 throw CancellationException("AI pending session provisioning was superseded.")
             }
             persistEnsuredSessionState()
+            context.lastBootstrapFailureRetryable = false
             return AiChatSessionProvisioningResult(
                 sessionId = currentSessionId,
                 snapshot = snapshot
@@ -172,6 +174,7 @@ internal class AiChatSessionCoordinator(
                 )
             }
             persistEnsuredSessionState()
+            context.lastBootstrapFailureRetryable = false
         }
         return ensuredSession
     }
@@ -242,6 +245,7 @@ internal class AiChatSessionCoordinator(
                 ) {
                     return@launch
                 }
+                context.lastBootstrapFailureRetryable = false
                 context.runtimeStateMutable.update { state ->
                     updateComposerSuggestions(
                         state = state.copy(
@@ -305,6 +309,7 @@ internal class AiChatSessionCoordinator(
             configuration = currentServerConfiguration(),
             textProvider = context.textProvider
         )
+        context.lastBootstrapFailureRetryable = isRetryableBootstrapFailure(error = error)
 
         AiChatDiagnosticsLogger.error(
             event = "new_chat_failure_handled",

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeBootstrapProvisioningTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeBootstrapProvisioningTest.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
+import com.flashcardsopensourceapp.data.local.cloud.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.AiChatAttachment
 import com.flashcardsopensourceapp.data.local.model.AiChatComposerSuggestion
 import com.flashcardsopensourceapp.data.local.model.AiChatContentPart
@@ -13,6 +14,7 @@ import java.net.SocketException
 import java.net.SocketTimeoutException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -96,6 +98,42 @@ class AiChatRuntimeBootstrapProvisioningTest {
     }
 
     @Test
+    fun completedWarmUpJobIsNotRetainedWithEagerDispatcher() = runTest(UnconfinedTestDispatcher()) {
+        val repository = FakeAiChatRepository()
+        val context = makeRuntimeContext(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository()
+        )
+        context.activeAccessContext = makeAccessContext(workspaceId = defaultTestWorkspaceId).copy(
+            cloudState = CloudAccountState.LINKED
+        )
+        context.runtimeStateMutable.value = makeAiDraftState(
+            workspaceId = defaultTestWorkspaceId,
+            persistedState = makeDefaultAiChatPersistedState()
+        )
+        var bootstrapCalls: Int = 0
+        val coordinator = AiChatRuntimeLifecycleCoordinator(
+            context = context,
+            startConversationBootstrap = { _, _ ->
+                bootstrapCalls += 1
+            },
+            detachLiveStream = { _ -> },
+            cancelActiveDictation = { _ -> }
+        )
+
+        coordinator.warmUpLinkedSessionIfNeeded(resumeDiagnostics = null)
+
+        assertEquals(1, bootstrapCalls)
+        assertNull(context.activeWarmUpJob)
+
+        coordinator.warmUpLinkedSessionIfNeeded(resumeDiagnostics = null)
+
+        assertEquals(2, bootstrapCalls)
+        assertNull(context.activeWarmUpJob)
+    }
+
+    @Test
     fun bootstrapRetryReusesProvisionalSessionIdWhenProvisioningFailsTransiently() = runTest {
         val repository = FakeAiChatRepository()
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState()
@@ -123,7 +161,7 @@ class AiChatRuntimeBootstrapProvisioningTest {
             repository.createNewSessionRequests
         )
         assertEquals(
-            listOf(defaultTestWorkspaceId),
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
             repository.prepareSessionRequests
         )
         assertEquals(listOf("retry-session-1"), repository.loadBootstrapSessionIds)
@@ -134,11 +172,15 @@ class AiChatRuntimeBootstrapProvisioningTest {
     }
 
     @Test
-    fun bootstrapDoesNotRetryPrepareSessionTransientFailuresBeforeProvisioning() = runTest {
+    fun bootstrapRetriesPrepareSessionTransientFailuresBeforeProvisioning() = runTest {
         val repository = FakeAiChatRepository()
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState()
         repository.nextEnsureSessionId = "prepare-session-1"
         repository.prepareSessionErrors += SocketException("connection reset")
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "prepare-session-1",
+            activeRun = null
+        )
         val runtime = makeRuntimeWithCloudState(
             scope = this,
             repository = repository,
@@ -153,17 +195,49 @@ class AiChatRuntimeBootstrapProvisioningTest {
         advanceUntilIdle()
 
         assertEquals(
-            listOf(defaultTestWorkspaceId),
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
             repository.prepareSessionRequests
         )
-        assertTrue(repository.createNewSessionRequests.isEmpty())
-        assertTrue(repository.loadBootstrapSessionIds.isEmpty())
-        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
-        assertTrue(runtime.state.value.conversationBootstrapErrorPresentation.message.isNotEmpty())
+        assertEquals(listOf("prepare-session-1"), repository.createNewSessionRequests)
+        assertEquals(listOf("prepare-session-1"), repository.loadBootstrapSessionIds)
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+        assertEquals("prepare-session-1", runtime.state.value.persistedState.chatSessionId)
     }
 
     @Test
-    fun bootstrapRetriesOnlyPreparedRemoteCallsAfterPrepareSessionSucceeds() = runTest {
+    fun bootstrapRetriesPrepareSessionTransientCloudRemoteFailureBeforeProvisioning() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState()
+        repository.nextEnsureSessionId = "cloud-prepare-session-1"
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 503)
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "cloud-prepare-session-1",
+            activeRun = null
+        )
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.GUEST
+        )
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId)
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
+            repository.prepareSessionRequests
+        )
+        assertEquals(listOf("cloud-prepare-session-1"), repository.createNewSessionRequests)
+        assertEquals(listOf("cloud-prepare-session-1"), repository.loadBootstrapSessionIds)
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+    }
+
+    @Test
+    fun bootstrapRetriesPreparedRemoteCallsWithFreshPreparationAttempt() = runTest {
         val repository = FakeAiChatRepository()
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
             chatSessionId = "session-1"
@@ -186,7 +260,10 @@ class AiChatRuntimeBootstrapProvisioningTest {
         )
         advanceUntilIdle()
 
-        assertEquals(listOf(defaultTestWorkspaceId), repository.prepareSessionRequests)
+        assertEquals(
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
+            repository.prepareSessionRequests
+        )
         assertTrue(repository.ensureSessionRequests.isEmpty())
         assertEquals(2, repository.loadBootstrapCalls)
         assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
@@ -328,6 +405,101 @@ class AiChatRuntimeBootstrapProvisioningTest {
         assertEquals(listOf("session-1"), repository.loadBootstrapSessionIds)
         assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
         assertEquals("session-1", runtime.state.value.persistedState.chatSessionId)
+    }
+
+    @Test
+    fun visibleWarmUpDoesNotRetryPermanentBootstrapFailureButManualRetryStillWorks() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 400)
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.GUEST
+        )
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId)
+        )
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+        assertEquals(listOf(defaultTestWorkspaceId), repository.prepareSessionRequests)
+
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        runtime.onScreenHidden()
+        runtime.onScreenVisible()
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+        assertEquals(listOf(defaultTestWorkspaceId), repository.prepareSessionRequests)
+        assertEquals(0, repository.loadBootstrapCalls)
+
+        runtime.retryBootstrap()
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+        assertEquals(
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
+            repository.prepareSessionRequests
+        )
+        assertEquals(listOf("session-1"), repository.loadBootstrapSessionIds)
+    }
+
+    @Test
+    fun visibleWarmUpRetriesTransientBootstrapFailure() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 503)
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 503)
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 503)
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.GUEST
+        )
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId)
+        )
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+        assertEquals(
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId, defaultTestWorkspaceId),
+            repository.prepareSessionRequests
+        )
+
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        runtime.onScreenHidden()
+        runtime.onScreenVisible()
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+        assertEquals(
+            listOf(
+                defaultTestWorkspaceId,
+                defaultTestWorkspaceId,
+                defaultTestWorkspaceId,
+                defaultTestWorkspaceId
+            ),
+            repository.prepareSessionRequests
+        )
+        assertEquals(listOf("session-1"), repository.loadBootstrapSessionIds)
     }
 
     @Test
@@ -641,7 +813,12 @@ class AiChatRuntimeBootstrapProvisioningTest {
             repository.createNewSessionRequests
         )
         assertEquals(
-            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
+            listOf(
+                defaultTestWorkspaceId,
+                defaultTestWorkspaceId,
+                defaultTestWorkspaceId,
+                defaultTestWorkspaceId
+            ),
             repository.prepareSessionRequests
         )
         assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
@@ -709,6 +886,110 @@ class AiChatRuntimeBootstrapProvisioningTest {
         )
     }
 
+    @Test
+    fun visibleWarmUpRetriesTransientFreshConversationProvisioningFailure() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.GUEST
+        )
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId)
+        )
+        advanceUntilIdle()
+
+        repository.createNewSessionErrors += SocketException("connection reset")
+        repository.createNewSessionErrors += SocketTimeoutException("timeout")
+        repository.createNewSessionErrors += SocketException("still unavailable")
+        runtime.clearConversation()
+        advanceUntilIdle()
+
+        val freshSessionId = runtime.state.value.persistedState.chatSessionId
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+        assertEquals(
+            listOf(freshSessionId, freshSessionId, freshSessionId),
+            repository.createNewSessionRequests
+        )
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = freshSessionId,
+            activeRun = null
+        )
+
+        runtime.onScreenHidden()
+        runtime.onScreenVisible()
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+        assertEquals(
+            listOf(freshSessionId, freshSessionId, freshSessionId, freshSessionId),
+            repository.createNewSessionRequests
+        )
+        assertEquals(listOf("session-1", freshSessionId), repository.loadBootstrapSessionIds)
+    }
+
+    @Test
+    fun visibleWarmUpDoesNotRetryPermanentFreshConversationProvisioningFailure() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 503)
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 503)
+        repository.prepareSessionErrors += makeCloudRemoteException(statusCode = 503)
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.GUEST
+        )
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId)
+        )
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+
+        repository.createNewSessionErrors += makeCloudRemoteException(statusCode = 400)
+        runtime.clearConversation()
+        advanceUntilIdle()
+
+        val freshSessionId = runtime.state.value.persistedState.chatSessionId
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+        assertEquals(listOf(freshSessionId), repository.createNewSessionRequests)
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = freshSessionId,
+            activeRun = null
+        )
+
+        runtime.onScreenHidden()
+        runtime.onScreenVisible()
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+        assertEquals(listOf(freshSessionId), repository.createNewSessionRequests)
+        assertTrue(repository.loadBootstrapSessionIds.isEmpty())
+
+        runtime.retryBootstrap()
+        advanceUntilIdle()
+
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+        assertEquals(listOf(freshSessionId, freshSessionId), repository.createNewSessionRequests)
+        assertEquals(listOf(freshSessionId), repository.loadBootstrapSessionIds)
+    }
+
     private fun makeCloudContractMismatchException(message: String): Exception {
         val errorClass = Class.forName(
             "com.flashcardsopensourceapp.data.local.cloud.CloudContractMismatchException"
@@ -716,5 +997,16 @@ class AiChatRuntimeBootstrapProvisioningTest {
         val constructor = errorClass.getDeclaredConstructor(String::class.java, Throwable::class.java)
         constructor.isAccessible = true
         return constructor.newInstance(message, null) as Exception
+    }
+
+    private fun makeCloudRemoteException(statusCode: Int): CloudRemoteException {
+        return CloudRemoteException(
+            message = "Cloud request failed with status $statusCode.",
+            statusCode = statusCode,
+            responseBody = """{"message":"temporary"}""",
+            errorCode = null,
+            requestId = "request-$statusCode",
+            syncConflict = null
+        )
     }
 }

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatBootstrapErrorPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatBootstrapErrorPresentation.swift
@@ -103,6 +103,10 @@ func aiChatBootstrapShouldRetry(error: Error) -> Bool {
         return true
     }
 
+    if let setupStatusCode = aiChatBootstrapSetupHTTPStatus(error: error) {
+        return aiChatBootstrapCanRetryHTTPStatus(setupStatusCode)
+    }
+
     guard let serviceError = error as? AIChatServiceError else {
         return false
     }
@@ -316,6 +320,27 @@ private func aiChatFailureTechnicalDetails(
 
 private func aiChatBootstrapCanRetryHTTPStatus(_ statusCode: Int) -> Bool {
     statusCode == 408 || statusCode == 429 || (statusCode >= 500 && statusCode <= 599)
+}
+
+private func aiChatBootstrapSetupHTTPStatus(error: Error) -> Int? {
+    if let authError = error as? CloudAuthError {
+        return authError.statusCode
+    }
+
+    if let syncError = error as? CloudSyncError {
+        return syncError.statusCode
+    }
+
+    guard let guestAuthError = error as? GuestCloudAuthError else {
+        return nil
+    }
+
+    switch guestAuthError {
+    case .invalidResponse(_, let statusCode):
+        return statusCode
+    case .invalidBaseUrl, .invalidResponseBody:
+        return nil
+    }
 }
 
 private func isAIChatRetryableTransportFailure(error: Error) -> Bool {

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+RunOrchestration.swift
@@ -398,6 +398,7 @@ extension AIChatStore {
         self.chatSessionId = resolvedSessionId
         self.conversationScopeId = resolvedSessionId
         self.bootstrapPhase = .loading
+        self.lastBootstrapFailureWasRetryable = false
 
         let bootstrapContext = self.surfaceState.activeAccessContext ?? self.currentAccessContext()
         let preservesPendingLocalSessionDraft = self.shouldPreservePendingLocalSessionDraftOnBootstrapFailure()
@@ -420,6 +421,7 @@ extension AIChatStore {
                 }
                 self.applyBootstrap(bootstrapResult.response)
                 self.bootstrapPhase = .ready
+                self.lastBootstrapFailureWasRetryable = false
                 self.attachBootstrapLiveIfNeeded(
                     response: bootstrapResult.response,
                     session: bootstrapResult.session,
@@ -451,6 +453,7 @@ extension AIChatStore {
                 self.transitionToIdle()
                 self.activeAlert = nil
                 self.repairStatus = nil
+                self.lastBootstrapFailureWasRetryable = aiChatBootstrapShouldRetry(error: error)
                 self.bootstrapPhase = .failed(
                     makeAIChatBootstrapErrorPresentation(
                         error: error,
@@ -472,10 +475,10 @@ extension AIChatStore {
     private func loadBootstrapWithBoundedRetry(
         resumeAttemptDiagnostics: AIChatResumeAttemptDiagnostics?
     ) async throws -> AIChatBootstrapLoadResult {
-        let session = try await self.flashcardsStore.cloudSessionForAI()
         var attemptNumber = 0
         while true {
             do {
+                let session = try await self.flashcardsStore.cloudSessionForAI()
                 let explicitSessionId = try await self.ensureRemoteSessionIfNeeded(session: session)
                 let bootstrap = try await self.chatService.loadBootstrap(
                     session: session,

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore+Surface.swift
@@ -149,10 +149,31 @@ extension AIChatStore {
         ) && (didBecomeVisible || didAccessContextChange) {
             self.warmUpSessionIfNeeded()
         }
+
+        if self.shouldRestartFailedBootstrapOnVisibleSurface(activity: activity) {
+            self.retryLinkedBootstrap()
+        }
     }
 
     func retryLinkedBootstrap() {
         self.startLinkedBootstrap(forceReloadState: false, resumeAttemptDiagnostics: nil)
+    }
+
+    func shouldRestartFailedBootstrapOnVisibleSurface(activity: AIChatSurfaceActivity) -> Bool {
+        guard activity.isVisible else {
+            return false
+        }
+        guard case .failed = self.bootstrapPhase else {
+            return false
+        }
+        guard self.lastBootstrapFailureWasRetryable else {
+            return false
+        }
+        guard self.activeBootstrapTask == nil && self.activeNewSessionTask == nil else {
+            return false
+        }
+
+        return true
     }
 
     func currentAccessContext() -> AIChatAccessContext {
@@ -427,6 +448,7 @@ extension AIChatStore {
         self.activeResumeErrorAttemptSequence = nil
         self.activeLiveResumeAttemptSequence = nil
         self.requiresRemoteSessionProvisioning = false
+        self.lastBootstrapFailureWasRetryable = false
     }
 
     func resetConversationForNewSession(
@@ -467,6 +489,7 @@ extension AIChatStore {
         self.activeResumeErrorAttemptSequence = nil
         self.activeLiveResumeAttemptSequence = nil
         self.requiresRemoteSessionProvisioning = true
+        self.lastBootstrapFailureWasRetryable = false
         self.schedulePersistCurrentState()
     }
 
@@ -505,9 +528,7 @@ extension AIChatStore {
             }
 
             do {
-                let session = try await self.flashcardsStore.cloudSessionForAI()
                 let provisionedSessionId = try await self.provisionNewSessionWithBoundedBootstrapRetry(
-                    session: session,
                     sessionId: sessionId,
                     requestSequence: requestSequence,
                     accessContext: requestedAccessContext
@@ -539,6 +560,7 @@ extension AIChatStore {
 
                 self.activeAlert = nil
                 self.repairStatus = nil
+                self.lastBootstrapFailureWasRetryable = aiChatBootstrapShouldRetry(error: error)
                 self.bootstrapPhase = .failed(
                     makeAIChatBootstrapErrorPresentation(
                         error: error,
@@ -552,7 +574,6 @@ extension AIChatStore {
     }
 
     private func provisionNewSessionWithBoundedBootstrapRetry(
-        session: CloudLinkedSession,
         sessionId: String,
         requestSequence: Int,
         accessContext: AIChatAccessContext
@@ -568,6 +589,7 @@ extension AIChatStore {
             }
 
             do {
+                let session = try await self.flashcardsStore.cloudSessionForAI()
                 let provisionedSessionId = try await self.ensureRemoteSessionIfNeeded(session: session)
                 guard self.isCurrentNewSessionProvisioningRequest(
                     sequence: requestSequence,

--- a/apps/ios/Flashcards/Flashcards/AI/AIChatStore.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/AIChatStore.swift
@@ -189,6 +189,7 @@ final class AIChatStore {
     @ObservationIgnored var activeResumeErrorAttemptSequence: Int?
     @ObservationIgnored var activeLiveResumeAttemptSequence: Int?
     @ObservationIgnored var requiresRemoteSessionProvisioning: Bool
+    @ObservationIgnored var lastBootstrapFailureWasRetryable: Bool
     @ObservationIgnored var suppressDraftRestore: Bool
     @ObservationIgnored var optimisticOutgoingTurnState: AIChatOptimisticOutgoingTurnState?
 
@@ -755,6 +756,7 @@ final class AIChatStore {
         self.activeResumeErrorAttemptSequence = nil
         self.activeLiveResumeAttemptSequence = nil
         self.requiresRemoteSessionProvisioning = persistedState.requiresRemoteSessionProvisioning
+        self.lastBootstrapFailureWasRetryable = false
         self.optimisticOutgoingTurnState = restoredAIChatOptimisticOutgoingTurnState(
             messages: persistedState.messages
         )

--- a/apps/ios/Flashcards/Flashcards/Cloud/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/CloudSessionRuntime.swift
@@ -323,6 +323,17 @@ final class CloudSessionRuntime {
         self.state.activeCloudSession = linkedSession
     }
 
+    func clearActiveCloudSessionIfMatchingStableContext(linkedSession: CloudLinkedSession) {
+        guard let activeCloudSession = self.state.activeCloudSession else {
+            return
+        }
+        guard cloudLinkedSessionsMatchStableContext(activeCloudSession, linkedSession) else {
+            return
+        }
+
+        self.state.activeCloudSession = nil
+    }
+
     func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
         let cloudSyncService = try requireCloudSyncService(cloudSyncService: self.cloudSyncService)
         return try await self.runCloudSyncTask {
@@ -465,4 +476,15 @@ final class CloudSessionRuntime {
     func activeCloudSession() -> CloudLinkedSession? {
         self.state.activeCloudSession
     }
+}
+
+private func cloudLinkedSessionsMatchStableContext(
+    _ lhs: CloudLinkedSession,
+    _ rhs: CloudLinkedSession
+) -> Bool {
+    lhs.userId == rhs.userId
+        && lhs.workspaceId == rhs.workspaceId
+        && lhs.configurationMode == rhs.configurationMode
+        && lhs.apiBaseUrl == rhs.apiBaseUrl
+        && lhs.authorization.isGuest == rhs.authorization.isGuest
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudAccount.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudAccount.swift
@@ -180,6 +180,10 @@ extension FlashcardsStore {
 
         if isAlreadyGuestLinked {
             self.cloudRuntime.setActiveCloudSession(linkedSession: guestSession)
+            if case .failed = self.syncStatus {
+                try await self.performSameWorkspaceCloudRestore(linkedSession: guestSession, trigger: trigger)
+                return (guestSession, true)
+            }
             return (guestSession, false)
         }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudLink.swift
@@ -925,6 +925,7 @@ extension FlashcardsStore {
             )
             self.userDefaults.removeObject(forKey: pendingCloudServerBootstrapUserDefaultsKey)
         } catch {
+            self.cloudRuntime.clearActiveCloudSessionIfMatchingStableContext(linkedSession: linkedSession)
             logCloudFlowPhase(
                 phase: .linkedSync,
                 outcome: "failure",

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatBootstrapErrorPresentationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatBootstrapErrorPresentationTests.swift
@@ -220,6 +220,73 @@ final class AIChatBootstrapErrorPresentationTests: XCTestCase {
 
         XCTAssertFalse(aiChatBootstrapShouldRetry(error: error))
     }
+
+    func testTransientCloudSetupHTTPFailuresRetry() {
+        let statusCodes: [Int] = [408, 429, 500, 503, 599]
+
+        for statusCode in statusCodes {
+            XCTAssertTrue(
+                aiChatBootstrapShouldRetry(
+                    error: CloudAuthError.invalidResponse(
+                        makeCloudSetupErrorDetails(requestId: "cloud-auth-\(statusCode)"),
+                        statusCode
+                    )
+                )
+            )
+            XCTAssertTrue(
+                aiChatBootstrapShouldRetry(
+                    error: CloudSyncError.invalidResponse(
+                        makeCloudSetupErrorDetails(requestId: "cloud-sync-\(statusCode)"),
+                        statusCode
+                    )
+                )
+            )
+            XCTAssertTrue(
+                aiChatBootstrapShouldRetry(
+                    error: GuestCloudAuthError.invalidResponse(
+                        makeCloudSetupErrorDetails(requestId: "guest-auth-\(statusCode)"),
+                        statusCode
+                    )
+                )
+            )
+        }
+    }
+
+    func testPermanentCloudSetupHTTPFailuresDoNotRetry() {
+        let statusCodes: [Int] = [400, 401, 403, 404, 410]
+
+        for statusCode in statusCodes {
+            XCTAssertFalse(
+                aiChatBootstrapShouldRetry(
+                    error: CloudAuthError.invalidResponse(
+                        makeCloudSetupErrorDetails(requestId: "cloud-auth-\(statusCode)"),
+                        statusCode
+                    )
+                )
+            )
+            XCTAssertFalse(
+                aiChatBootstrapShouldRetry(
+                    error: CloudSyncError.invalidResponse(
+                        makeCloudSetupErrorDetails(requestId: "cloud-sync-\(statusCode)"),
+                        statusCode
+                    )
+                )
+            )
+            XCTAssertFalse(
+                aiChatBootstrapShouldRetry(
+                    error: GuestCloudAuthError.invalidResponse(
+                        makeCloudSetupErrorDetails(requestId: "guest-auth-\(statusCode)"),
+                        statusCode
+                    )
+                )
+            )
+        }
+    }
+
+    func testCancellationDoesNotRetry() {
+        XCTAssertFalse(aiChatBootstrapShouldRetry(error: CancellationError()))
+        XCTAssertFalse(aiChatBootstrapShouldRetry(error: URLError(.cancelled)))
+    }
 }
 
 private struct BootstrapSecretError: Error, CustomStringConvertible {
@@ -248,5 +315,14 @@ private func makeDiagnostics(
         decoderSummary: decoderSummary,
         continuationAttempt: nil,
         continuationToolCallIds: []
+    )
+}
+
+private func makeCloudSetupErrorDetails(requestId: String) -> CloudApiErrorDetails {
+    CloudApiErrorDetails(
+        message: "setup failed",
+        requestId: requestId,
+        code: "SETUP_FAILED",
+        syncConflict: nil
     )
 }

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRemoteSessionProvisioningTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRemoteSessionProvisioningTests.swift
@@ -128,7 +128,7 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
         XCTAssertEqual(store.bootstrapPhase, .ready)
     }
 
-    func testLinkedBootstrapDoesNotRetryTransientCloudSessionSetupBeforeProvisioning() async throws {
+    func testLinkedBootstrapRetriesTransientCloudSessionSetupBeforeProvisioning() async throws {
         let context = AIChatStoreTestSupport.Context.make()
         defer {
             context.tearDown()
@@ -140,6 +140,7 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
         let store = context.makeStore()
         store.acceptExternalProviderConsent()
         context.chatService.createNewSessionHandler = { request in
+            XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 2)
             guard let sessionId = request.sessionId, sessionId.isEmpty == false else {
                 throw LocalStoreError.validation("Expected an explicit AI chat session id after session setup retry.")
             }
@@ -159,18 +160,35 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
         store.startLinkedBootstrap(forceReloadState: false, resumeAttemptDiagnostics: nil)
         await AIChatStoreTestSupport.waitForBootstrapToSettle(store: store)
 
-        XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 1)
-        XCTAssertTrue(context.chatService.events.isEmpty)
-        XCTAssertTrue(context.chatService.createNewSessionSessionIds.isEmpty)
-        XCTAssertTrue(context.chatService.loadBootstrapSessionIds.isEmpty)
-        guard case .failed(let presentation) = store.bootstrapPhase else {
-            XCTFail("Expected bootstrap failure without retrying cloud session setup.")
-            return
+        let explicitSessionId = try XCTUnwrap(context.chatService.createNewSessionSessionIds.first ?? nil)
+        XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 2)
+        XCTAssertEqual(context.chatService.createNewSessionSessionIds, [explicitSessionId])
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [explicitSessionId])
+        XCTAssertEqual(store.bootstrapPhase, .ready)
+    }
+
+    func testFailedCloudSessionSetupClearsRefreshedActiveSessionForRetry() throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
         }
-        XCTAssertEqual(
-            presentation.message,
-            "The connection was interrupted while loading AI chat. Check your connection and try again."
+
+        try context.configureLinkedCloudSession()
+        let failedSession = try XCTUnwrap(context.flashcardsStore.cloudRuntime.activeCloudSession())
+        let refreshedSession = try context.flashcardsStore.cloudRuntime.sessionWithUpdatedBearerToken(
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token-1",
+                idToken: "token-2",
+                idTokenExpiresAt: "2099-01-01T00:00:00Z"
+            )
         )
+
+        XCTAssertNotEqual(refreshedSession, failedSession)
+        context.flashcardsStore.cloudRuntime.clearActiveCloudSessionIfMatchingStableContext(
+            linkedSession: failedSession
+        )
+
+        XCTAssertNil(context.flashcardsStore.cloudRuntime.activeCloudSession())
     }
 
     func testGuestBootstrapRetryReusesSameExplicitSessionIdBeforeLoadingBootstrap() async throws {
@@ -218,6 +236,46 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
             explicitSessionId,
             explicitSessionId
         ])
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [explicitSessionId])
+        XCTAssertEqual(store.chatSessionId, explicitSessionId)
+        XCTAssertEqual(store.bootstrapPhase, .ready)
+    }
+
+    func testGuestBootstrapRetryRerunsFailedSetupSyncBeforeProvisioning() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureGuestCloudSession()
+        context.flashcardsStore.syncStatus = .failed(message: "Previous guest setup sync failed.")
+        context.cloudSyncService.runLinkedSyncErrors = [URLError(.timedOut)]
+        let store = context.makeStore()
+        store.acceptExternalProviderConsent()
+        context.chatService.createNewSessionHandler = { request in
+            XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 2)
+            guard let sessionId = request.sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id after guest setup sync retry.")
+            }
+            return AIChatStoreTestSupport.makeNewSessionResponse(sessionId: sessionId)
+        }
+        context.chatService.loadBootstrapHandler = { sessionId in
+            guard let sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id during guest bootstrap load.")
+            }
+            return AIChatStoreTestSupport.makeConversationEnvelope(
+                sessionId: sessionId,
+                messages: [],
+                activeRun: nil
+            )
+        }
+
+        store.startLinkedBootstrap(forceReloadState: false, resumeAttemptDiagnostics: nil)
+        await AIChatStoreTestSupport.waitForBootstrapToSettle(store: store)
+
+        let explicitSessionId = try XCTUnwrap(context.chatService.createNewSessionSessionIds.first ?? nil)
+        XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 2)
+        XCTAssertEqual(context.chatService.createNewSessionSessionIds, [explicitSessionId])
         XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [explicitSessionId])
         XCTAssertEqual(store.chatSessionId, explicitSessionId)
         XCTAssertEqual(store.bootstrapPhase, .ready)
@@ -925,7 +983,7 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
         XCTAssertTrue(technicalDetails.contains("Reason: \(blockedMessage)"))
     }
 
-    func testFreshLocalSessionDoesNotRetryTransientCloudSessionSetupBeforeProvisioning() async throws {
+    func testFreshLocalSessionRetriesTransientCloudSessionSetupBeforeProvisioning() async throws {
         let context = AIChatStoreTestSupport.Context.make()
         defer {
             context.tearDown()
@@ -937,6 +995,7 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
         let store = context.makeStore()
         store.acceptExternalProviderConsent()
         context.chatService.createNewSessionHandler = { request in
+            XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 2)
             guard let sessionId = request.sessionId, sessionId.isEmpty == false else {
                 throw LocalStoreError.validation("Expected an explicit AI chat session id after session setup retry.")
             }
@@ -949,21 +1008,14 @@ final class AIChatStoreRemoteSessionProvisioningTests: XCTestCase {
         )
         await AIChatStoreTestSupport.waitForNewSessionToSettle(store: store)
 
-        XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 1)
-        XCTAssertTrue(context.chatService.events.isEmpty)
-        XCTAssertTrue(context.chatService.createNewSessionSessionIds.isEmpty)
+        let explicitSessionId = try XCTUnwrap(context.chatService.createNewSessionSessionIds.first ?? nil)
+        XCTAssertEqual(context.cloudSyncService.runLinkedSyncCallCount, 2)
+        XCTAssertEqual(context.chatService.createNewSessionSessionIds, [explicitSessionId])
         XCTAssertTrue(context.chatService.loadBootstrapSessionIds.isEmpty)
         XCTAssertFalse(store.chatSessionId.isEmpty)
-        XCTAssertTrue(store.requiresRemoteSessionProvisioning)
+        XCTAssertFalse(store.requiresRemoteSessionProvisioning)
         XCTAssertEqual(store.inputText, "Draft survives setup retry")
-        guard case .failed(let presentation) = store.bootstrapPhase else {
-            XCTFail("Expected failed bootstrap state without retrying cloud session setup.")
-            return
-        }
-        XCTAssertEqual(
-            presentation.message,
-            "The connection was interrupted while loading AI chat. Check your connection and try again."
-        )
+        XCTAssertEqual(store.bootstrapPhase, .ready)
     }
 
     func testSendPreemptsPendingFreshLocalSessionProvisioningRetry() async throws {

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreSurfaceVisibilityTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreSurfaceVisibilityTests.swift
@@ -33,4 +33,183 @@ final class AIChatStoreSurfaceVisibilityTests: XCTestCase {
 
         XCTAssertTrue(store.shouldKeepLiveAttached)
     }
+
+    func testVisibleSurfaceRestartsRetryableBootstrapFailure() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        store.acceptExternalProviderConsent()
+        let visibleActivity = self.makeLinkedSurfaceActivity(context: context, isVisible: true)
+        let hiddenActivity = self.makeLinkedSurfaceActivity(context: context, isVisible: false)
+        context.chatService.createNewSessionHandler = { request in
+            guard let sessionId = request.sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id during bootstrap.")
+            }
+
+            return AIChatStoreTestSupport.makeNewSessionResponse(sessionId: sessionId)
+        }
+        context.chatService.loadBootstrapHandler = { sessionId in
+            guard let sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id during initial bootstrap.")
+            }
+
+            return AIChatStoreTestSupport.makeConversationEnvelope(
+                sessionId: sessionId,
+                messages: [],
+                activeRun: nil
+            )
+        }
+
+        store.updateSurface(activity: visibleActivity)
+        await AIChatStoreTestSupport.waitForBootstrapToSettle(store: store)
+
+        let explicitSessionId = try XCTUnwrap(context.chatService.createNewSessionSessionIds.first ?? nil)
+        XCTAssertEqual(store.surfaceState.activeAccessContext, visibleActivity.accessContext)
+        XCTAssertEqual(store.bootstrapPhase, .ready)
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [explicitSessionId])
+
+        context.chatService.loadBootstrapHandler = { sessionId in
+            guard sessionId == explicitSessionId else {
+                throw LocalStoreError.validation("Expected failed bootstrap to reuse the active session id.")
+            }
+
+            throw URLError(.networkConnectionLost)
+        }
+
+        store.startLinkedBootstrap(forceReloadState: false, resumeAttemptDiagnostics: nil)
+        await AIChatStoreTestSupport.waitForBootstrapToSettle(store: store)
+
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [
+            explicitSessionId,
+            explicitSessionId,
+            explicitSessionId,
+            explicitSessionId
+        ])
+        guard case .failed = store.bootstrapPhase else {
+            XCTFail("Expected retryable bootstrap failure before visible-surface recovery.")
+            return
+        }
+
+        store.updateSurface(activity: hiddenActivity)
+        context.chatService.loadBootstrapHandler = { sessionId in
+            guard sessionId == explicitSessionId else {
+                throw LocalStoreError.validation("Expected bootstrap recovery to reuse the failed session id.")
+            }
+
+            return AIChatStoreTestSupport.makeConversationEnvelope(
+                sessionId: explicitSessionId,
+                messages: [],
+                activeRun: nil
+            )
+        }
+
+        store.updateSurface(activity: visibleActivity)
+        await AIChatStoreTestSupport.waitForBootstrapToSettle(store: store)
+
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [
+            explicitSessionId,
+            explicitSessionId,
+            explicitSessionId,
+            explicitSessionId,
+            explicitSessionId
+        ])
+        XCTAssertEqual(store.bootstrapPhase, .ready)
+        XCTAssertFalse(store.lastBootstrapFailureWasRetryable)
+    }
+
+    func testVisibleSurfaceDoesNotRestartPermanentBootstrapFailure() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        store.acceptExternalProviderConsent()
+        let visibleActivity = self.makeLinkedSurfaceActivity(context: context, isVisible: true)
+        let hiddenActivity = self.makeLinkedSurfaceActivity(context: context, isVisible: false)
+        context.chatService.createNewSessionHandler = { request in
+            guard let sessionId = request.sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id during bootstrap.")
+            }
+
+            return AIChatStoreTestSupport.makeNewSessionResponse(sessionId: sessionId)
+        }
+        context.chatService.loadBootstrapHandler = { sessionId in
+            guard let sessionId, sessionId.isEmpty == false else {
+                throw LocalStoreError.validation("Expected an explicit AI chat session id during initial bootstrap.")
+            }
+
+            return AIChatStoreTestSupport.makeConversationEnvelope(
+                sessionId: sessionId,
+                messages: [],
+                activeRun: nil
+            )
+        }
+
+        store.updateSurface(activity: visibleActivity)
+        await AIChatStoreTestSupport.waitForBootstrapToSettle(store: store)
+
+        let explicitSessionId = try XCTUnwrap(context.chatService.createNewSessionSessionIds.first ?? nil)
+        XCTAssertEqual(store.surfaceState.activeAccessContext, visibleActivity.accessContext)
+        XCTAssertEqual(store.bootstrapPhase, .ready)
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [explicitSessionId])
+
+        context.chatService.loadBootstrapHandler = { _ in
+            throw LocalStoreError.validation("Permanent bootstrap validation failure.")
+        }
+
+        store.startLinkedBootstrap(forceReloadState: false, resumeAttemptDiagnostics: nil)
+        await AIChatStoreTestSupport.waitForBootstrapToSettle(store: store)
+
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [
+            explicitSessionId,
+            explicitSessionId
+        ])
+        guard case .failed = store.bootstrapPhase else {
+            XCTFail("Expected permanent bootstrap failure before visible-surface sync.")
+            return
+        }
+
+        store.updateSurface(activity: hiddenActivity)
+        context.chatService.loadBootstrapHandler = { _ in
+            XCTFail("Permanent bootstrap failures should not be restarted by surface visibility.")
+            return AIChatStoreTestSupport.makeConversationEnvelope(
+                sessionId: explicitSessionId,
+                messages: [],
+                activeRun: nil
+            )
+        }
+
+        store.updateSurface(activity: visibleActivity)
+
+        XCTAssertNil(store.activeBootstrapTask)
+        XCTAssertEqual(context.chatService.loadBootstrapSessionIds, [
+            explicitSessionId,
+            explicitSessionId
+        ])
+        guard case .failed = store.bootstrapPhase else {
+            XCTFail("Expected permanent bootstrap failure to remain visible.")
+            return
+        }
+    }
+
+    private func makeLinkedSurfaceActivity(
+        context: AIChatStoreTestSupport.Context,
+        isVisible: Bool
+    ) -> AIChatSurfaceActivity {
+        AIChatSurfaceActivity(
+            isSceneActive: isVisible,
+            isAITabSelected: isVisible,
+            hasExternalProviderConsent: true,
+            workspaceId: context.flashcardsStore.workspace?.workspaceId,
+            cloudState: context.flashcardsStore.cloudSettings?.cloudState,
+            linkedUserId: context.flashcardsStore.cloudSettings?.linkedUserId,
+            activeWorkspaceId: context.flashcardsStore.cloudSettings?.activeWorkspaceId
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Retry AI chat bootstrap setup/session preparation as part of bounded bootstrap retry on iOS and Android.
- Restart retryable failed bootstrap states when the chat surface becomes visible again instead of requiring a manual retry first.
- Keep permanent failures from auto-retrying, and add focused coverage around retry classification and provisioning paths.

## Validation
- `git --no-pager diff --check`
- Fresh code review of the working tree with iOS, Android, and cross-platform subagents

Native simulator/emulator and Gradle/Xcode heavy runs were not run for this patch.