### PR TITLE
[codex] Capture web app operation failures

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -11,6 +11,7 @@ import {
 import { AppDataProvider, useAppData } from "./appData";
 import {
   ApiError,
+  ApiContractError,
   buildLoginUrl,
   buildLogoutLocalUrl,
   buildLogoutUrl,
@@ -22,6 +23,8 @@ import { ChatLayoutProvider, useChatLayout } from "./chat/ChatLayoutContext";
 import { ChatSessionControllerProvider } from "./chat/sessionController";
 import { ChatToggle } from "./chat/ChatToggle";
 import { type TranslationKey, useI18n } from "./i18n";
+import { captureApiContractError } from "./observability/apiContractObservation";
+import { captureAppOperationError } from "./observability/appOperationObservation";
 import { AppErrorBoundary, wrapRoutesComponent } from "./observability/instrument";
 import {
   accountAgentConnectionsRoute,
@@ -260,6 +263,7 @@ export function AppShell(): ReactElement {
     sessionVerificationState,
     isSessionVerified,
     sessionErrorMessage,
+    session,
     activeWorkspace,
     availableWorkspaces,
     isChoosingWorkspace,
@@ -303,11 +307,28 @@ export function AppShell(): ReactElement {
         return;
       }
 
+      captureApiContractError(error, {
+        feature: "auth",
+        sourceAction: "account_deletion_submit",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+      });
+      if (error instanceof ApiContractError === false) {
+        captureAppOperationError(error, {
+          feature: "auth",
+          operation: "account_deletion_submit",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: null,
+        });
+      }
       setAccountDeletionErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsAccountDeletionSubmitting(false);
     }
-  }, [isSessionVerified]);
+  }, [activeWorkspace?.workspaceId, cloudSettings?.installationId, isSessionVerified, session?.userId]);
 
   useEffect(() => subscribeToAccountDeletionPending(() => {
     setIsAccountDeletionPendingState(isAccountDeletionPending());

--- a/apps/web/src/observability/apiContractObservation.ts
+++ b/apps/web/src/observability/apiContractObservation.ts
@@ -4,7 +4,7 @@ import {
   type WebObservationScope,
 } from "./webObservability";
 
-export type ApiContractObservationFeature = "cards" | "review" | "progress" | "settings" | "sync";
+export type ApiContractObservationFeature = "auth" | "cards" | "review" | "progress" | "settings" | "sync";
 
 type ApiContractObservationContext = Readonly<{
   feature: ApiContractObservationFeature;
@@ -90,10 +90,6 @@ function captureApiContractErrorWithRoute(
       sourceAction: context.sourceAction,
     },
   });
-}
-
-export function isApiContractErrorForEndpoint(error: unknown, endpointSuffix: string): boolean {
-  return error instanceof ApiContractError && error.endpoint.endsWith(endpointSuffix);
 }
 
 export function captureApiContractError(error: unknown, context: ApiContractObservationContext): void {

--- a/apps/web/src/observability/appOperationObservation.ts
+++ b/apps/web/src/observability/appOperationObservation.ts
@@ -1,0 +1,148 @@
+import { ApiContractError, ApiError, AuthRedirectError } from "../api";
+import {
+  captureWebException,
+  normalizeCaughtError,
+  type WebAppOperation,
+  type WebObservationFeature,
+  type WebObservationScope,
+} from "./webObservability";
+
+type AppOperationObservationContext = Readonly<{
+  feature: WebObservationFeature;
+  operation: WebAppOperation;
+  userId: string | null;
+  workspaceId: string | null;
+  installationId: string | null;
+  entityId: string | null;
+  expectedErrorMessages?: ReadonlyArray<string>;
+}>;
+
+type ErrorMetadataCarrier = Readonly<{
+  requestId?: unknown;
+  redirectUrl?: unknown;
+  statusCode?: unknown;
+  code?: unknown;
+}>;
+
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function readStringMetadata(error: Error, key: keyof ErrorMetadataCarrier): string | null {
+  const metadataValue = (error as ErrorMetadataCarrier)[key];
+  return typeof metadataValue === "string" && metadataValue.trim() !== "" ? metadataValue : null;
+}
+
+function readNumberMetadata(error: Error, key: keyof ErrorMetadataCarrier): number | null {
+  const metadataValue = (error as ErrorMetadataCarrier)[key];
+  return typeof metadataValue === "number" && Number.isFinite(metadataValue) ? metadataValue : null;
+}
+
+function buildAppOperationScope(error: Error, context: AppOperationObservationContext): WebObservationScope {
+  return {
+    app: "web",
+    feature: context.feature,
+    userId: context.userId,
+    workspaceId: context.workspaceId,
+    installationId: context.installationId,
+    route: getCurrentRoute(),
+    requestId: readStringMetadata(error, "requestId"),
+    statusCode: readNumberMetadata(error, "statusCode"),
+    code: readStringMetadata(error, "code"),
+  };
+}
+
+function isExpectedAppProductErrorCode(code: string | null): boolean {
+  switch (code) {
+    case "ACCOUNT_DELETED":
+    case "ACCOUNT_DELETE_CONFIRMATION_INVALID":
+    case "ACCOUNT_DELETE_HUMAN_AUTH_REQUIRED":
+    case "AGENT_API_KEY_HUMAN_SESSION_REQUIRED":
+    case "AGENT_API_KEY_ID_INVALID":
+    case "AGENT_API_KEY_ID_REQUIRED":
+    case "AGENT_API_KEY_NOT_FOUND":
+    case "AUTH_UNAUTHORIZED":
+    case "GUEST_AUTH_INVALID":
+    case "SESSION_CSRF_TOKEN_INVALID":
+    case "WORKSPACE_DELETE_CONFIRMATION_INVALID":
+    case "WORKSPACE_DELETE_SHARED":
+    case "WORKSPACE_NOT_FOUND":
+    case "WORKSPACE_OWNER_REQUIRED":
+    case "WORKSPACE_RESET_PROGRESS_CONFIRMATION_INVALID":
+    case "WORKSPACE_RESET_SHARED":
+    case "WORKSPACE_SELECTION_REQUIRED":
+      return true;
+  }
+
+  return false;
+}
+
+function isExpectedAppValidationError(error: ApiError): boolean {
+  return error.statusCode === 400
+    && error.code === null
+    && error.responseBodyKind === "json";
+}
+
+function isExpectedAppApiError(error: ApiError): boolean {
+  if (error.statusCode >= 500) {
+    return false;
+  }
+
+  if (isExpectedAppProductErrorCode(error.code)) {
+    return true;
+  }
+
+  if (error.statusCode === 401) {
+    return true;
+  }
+
+  return isExpectedAppValidationError(error);
+}
+
+function isExpectedAppOperationError(error: Error, context: AppOperationObservationContext): boolean {
+  if (error instanceof ApiContractError) {
+    return false;
+  }
+
+  if (error instanceof AuthRedirectError) {
+    return true;
+  }
+
+  if (error instanceof ApiError) {
+    return isExpectedAppApiError(error);
+  }
+
+  if (context.expectedErrorMessages?.includes(error.message) === true) {
+    return true;
+  }
+
+  const redirectUrl = (error as ErrorMetadataCarrier).redirectUrl;
+  if (typeof redirectUrl === "string" && redirectUrl.trim() !== "") {
+    return true;
+  }
+
+  return error.message === "Browser session expired. Redirecting to sign in."
+    || error.message === "Card front text must not be empty"
+    || error.message === "Deck name must not be empty";
+}
+
+export function captureAppOperationError(caughtError: unknown, context: AppOperationObservationContext): void {
+  const error = normalizeCaughtError(caughtError);
+  if (isExpectedAppOperationError(error, context)) {
+    return;
+  }
+
+  captureWebException({
+    action: "app_operation_failed",
+    error,
+    scope: buildAppOperationScope(error, context),
+    details: {
+      operation: context.operation,
+      entityId: context.entityId,
+    },
+  });
+}

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -171,6 +171,42 @@ export type AuthResetCleanupFailureDetails = Readonly<{
   operation: "auth_reset_cleanup_failed";
 }>;
 
+export type WebAppOperation =
+  | "account_deletion_submit"
+  | "agent_connections_load"
+  | "agent_connection_revoke"
+  | "card_form_load"
+  | "card_save"
+  | "card_delete"
+  | "cards_list_load"
+  | "cards_page_load"
+  | "cards_inline_save"
+  | "review_data_load"
+  | "review_submit"
+  | "review_rollback_lookup"
+  | "review_replenish"
+  | "review_card_save"
+  | "review_card_delete"
+  | "review_schedule_preview"
+  | "deck_list_load"
+  | "deck_detail_load"
+  | "deck_save"
+  | "deck_delete"
+  | "tags_load"
+  | "workspace_overview_load"
+  | "workspace_rename"
+  | "workspace_delete_preview_load"
+  | "workspace_delete_preview_retry"
+  | "workspace_settings_load"
+  | "workspace_reset_preview_load"
+  | "workspace_reset_execute"
+  | "workspace_export";
+
+export type WebAppOperationFailureDetails = Readonly<{
+  operation: WebAppOperation;
+  entityId: string | null;
+}>;
+
 export type WebExceptionEvent =
   | Readonly<{
     action: "api_contract_failed";
@@ -225,6 +261,12 @@ export type WebExceptionEvent =
     error: Error;
     scope: WebObservationScope;
     details: AuthResetCleanupFailureDetails;
+  }>
+  | Readonly<{
+    action: "app_operation_failed";
+    error: Error;
+    scope: WebObservationScope;
+    details: WebAppOperationFailureDetails;
   }>;
 
 export type ApiContractWarningDetails = Readonly<{
@@ -335,10 +377,19 @@ export function captureWebException(event: WebExceptionEvent): void {
 
   Sentry.withScope((scope: Scope): void => {
     applyObservationScope(scope, event.scope, event.action);
+    scope.setFingerprint(buildExceptionFingerprint(event));
     scope.setContext("web.exception", detailsToContext(event.details));
     scope.setContext("web.error", errorMetadataToContext(readErrorMetadata(event.error)));
     Sentry.captureException(toSafeCapturedError(event.action, event.error));
   });
+}
+
+function buildExceptionFingerprint(event: WebExceptionEvent): Array<string> {
+  if (event.action === "app_operation_failed") {
+    return ["{{ default }}", event.action, event.details.operation];
+  }
+
+  return ["{{ default }}", event.action];
 }
 
 function isErrorMetadataObject(value: unknown): value is ErrorMetadataObject {

--- a/apps/web/src/screens/cards/CardFormScreen.tsx
+++ b/apps/web/src/screens/cards/CardFormScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useAppData } from "../../appData";
 import { useAiCardHandoff } from "../../chat/useAiCardHandoff";
@@ -6,6 +6,7 @@ import { useI18n } from "../../i18n";
 import { CardFormFields, isCardFormStateDirty, toCardFormState, type CardFormState } from "./CardForm";
 import type { Card, CreateCardInput, TagSuggestion, UpdateCardInput } from "../../types";
 import { loadWorkspaceTagsSummary } from "../../localDb/workspace";
+import { captureAppOperationError } from "../../observability/appOperationObservation";
 import { cardsRoute } from "../../routes";
 
 function toTagSuggestions(tags: Awaited<ReturnType<typeof loadWorkspaceTagsSummary>>["tags"]): ReadonlyArray<TagSuggestion> {
@@ -20,7 +21,17 @@ export function CardFormScreen(): ReactElement {
   const { cardId } = useParams();
   const navigate = useNavigate();
   const { t } = useI18n();
-  const { activeWorkspace, getCardById, createCardItem, updateCardItem, deleteCardItem, setErrorMessage, localReadVersion } = useAppData();
+  const {
+    activeWorkspace,
+    cloudSettings,
+    getCardById,
+    createCardItem,
+    updateCardItem,
+    deleteCardItem,
+    setErrorMessage,
+    localReadVersion,
+    session,
+  } = useAppData();
   const [currentCard, setCurrentCard] = useState<Card | null>(null);
   const [formState, setFormState] = useState<CardFormState>(toCardFormState(null));
   const [tagSuggestions, setTagSuggestions] = useState<ReadonlyArray<TagSuggestion>>([]);
@@ -29,8 +40,19 @@ export function CardFormScreen(): ReactElement {
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const [loadErrorMessage, setLoadErrorMessage] = useState<string>("");
   const [actionErrorMessage, setActionErrorMessage] = useState<string>("");
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
   const isCreateMode = cardId === undefined;
   const handoffCardToAi = useAiCardHandoff();
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
     setLoadErrorMessage("");
@@ -52,6 +74,17 @@ export function CardFormScreen(): ReactElement {
         setFormState(toCardFormState(loadedCard));
       }
     } catch (error) {
+      if (activeWorkspace !== null) {
+        const observationIdentity = observationIdentityRef.current;
+        captureAppOperationError(error, {
+          feature: "cards",
+          operation: "card_form_load",
+          userId: observationIdentity.userId,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: observationIdentity.installationId,
+          entityId: cardId ?? null,
+        });
+      }
       setLoadErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsLoading(false);
@@ -87,6 +120,14 @@ export function CardFormScreen(): ReactElement {
       setFormState(toCardFormState(savedCard));
       return savedCard;
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "cards",
+        operation: "card_save",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: cardId,
+      });
       setActionErrorMessage(error instanceof Error ? error.message : String(error));
       return null;
     } finally {
@@ -114,6 +155,14 @@ export function CardFormScreen(): ReactElement {
 
       navigate(cardsRoute);
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "cards",
+        operation: "card_save",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: cardId ?? null,
+      });
       setActionErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsSaving(false);
@@ -156,6 +205,14 @@ export function CardFormScreen(): ReactElement {
       await deleteCardItem(cardId);
       navigate(cardsRoute);
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "cards",
+        operation: "card_delete",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: cardId,
+      });
       setActionErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsDeleting(false);

--- a/apps/web/src/screens/cards/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/CardsScreen.tsx
@@ -8,6 +8,7 @@ import { CardTagsInput, type CardTagsInputHandle } from "./CardTagsInput";
 import { EditableCardEffortCell, EditableCardTagsCell, EditableCardTextCell } from "./CardsTableEditors";
 import { queryLocalCardsPage } from "../../localDb/cards";
 import { loadWorkspaceTagsSummary } from "../../localDb/workspace";
+import { captureAppOperationError } from "../../observability/appOperationObservation";
 import type { Card, CardFilter, CardQuerySort, CardQuerySortDirection, CardQuerySortKey, QueryCardsPage, TagSuggestion, UpdateCardInput } from "../../types";
 import {
   buildCardsLoadingRowPreview,
@@ -123,8 +124,9 @@ function mergeCardsPage(
 export function CardsScreen(): ReactElement {
   const {
     activeWorkspace,
+    cloudSettings,
     localReadVersion,
-    refreshLocalData,
+    session,
     updateCardItem,
     setErrorMessage,
   } = useAppData();
@@ -142,6 +144,13 @@ export function CardsScreen(): ReactElement {
   const filterWrapRef = useRef<HTMLDivElement | null>(null);
   const filterPopoverRef = useRef<HTMLDivElement | null>(null);
   const filterTagsInputRef = useRef<CardTagsInputHandle | null>(null);
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
   const requestSequenceRef = useRef<number>(0);
   const [tagSuggestions, setTagSuggestions] = useState<ReadonlyArray<TagSuggestion>>([]);
 
@@ -151,6 +160,10 @@ export function CardsScreen(): ReactElement {
   const draftFilterValue = draftCardFilter ?? createEmptyCardFilter();
   const cardsLoadingSnapshot = activeWorkspace === null ? null : readCardsLoadingSnapshot(activeWorkspace.workspaceId);
   const isInitialCardsLoad = cardsQueryState.isLoading && cardsQueryState.hasLoaded === false;
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -217,6 +230,15 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
+      const observationIdentity = observationIdentityRef.current;
+      captureAppOperationError(error, {
+        feature: "cards",
+        operation: "cards_list_load",
+        userId: observationIdentity.userId,
+        workspaceId: activeWorkspace.workspaceId,
+        installationId: observationIdentity.installationId,
+        entityId: null,
+      });
       setCardsQueryState((currentState) => ({
         ...currentState,
         hasLoaded: currentState.hasLoaded,
@@ -265,6 +287,15 @@ export function CardsScreen(): ReactElement {
         return;
       }
 
+      const observationIdentity = observationIdentityRef.current;
+      captureAppOperationError(error, {
+        feature: "cards",
+        operation: "cards_page_load",
+        userId: observationIdentity.userId,
+        workspaceId: activeWorkspace.workspaceId,
+        installationId: observationIdentity.installationId,
+        entityId: null,
+      });
       setCardsQueryState((currentState) => ({
         ...currentState,
         isLoadingMore: false,
@@ -346,11 +377,27 @@ export function CardsScreen(): ReactElement {
     setErrorMessage("");
 
     try {
-      await updateCardItem(card.cardId, patch);
-      await refreshLocalData();
-      await loadFirstPage();
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : String(error));
+      try {
+        await updateCardItem(card.cardId, patch);
+      } catch (error) {
+        const observationIdentity = observationIdentityRef.current;
+        captureAppOperationError(error, {
+          feature: "cards",
+          operation: "cards_inline_save",
+          userId: observationIdentity.userId,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: observationIdentity.installationId,
+          entityId: card.cardId,
+        });
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+        return;
+      }
+
+      try {
+        await loadFirstPage();
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+      }
     } finally {
       setSavingCardId("");
     }

--- a/apps/web/src/screens/review/ReviewScreen.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.tsx
@@ -5,6 +5,8 @@ import { useAppData, useReviewProgressBadge } from "../../appData";
 import { ALL_CARDS_REVIEW_FILTER, currentReviewCard, isCardDue } from "../../appData/domain";
 import { parseDueAtMillis } from "../../appData/dueAt";
 import { useI18n } from "../../i18n";
+import { captureAppOperationError } from "../../observability/appOperationObservation";
+import { normalizeCaughtError } from "../../observability/webObservability";
 import type { Card, WorkspaceSchedulerSettings } from "../../types";
 import { computeReviewSchedule, type ReviewRating } from "../../../../backend/src/schedule";
 import { classifyReviewContentPresentation } from "./reviewContentPresentation";
@@ -427,6 +429,7 @@ function ReviewCardSide(props: ReviewCardSideProps): ReactElement {
 export function ReviewScreen(): ReactElement {
   const {
     activeWorkspace,
+    cloudSettings,
     selectedReviewFilter,
     workspaceSettings,
     localReadVersion,
@@ -434,6 +437,7 @@ export function ReviewScreen(): ReactElement {
     getCardById,
     refreshLocalData,
     selectReviewFilter,
+    session,
     submitReviewItem,
     updateCardItem,
     deleteCardItem,
@@ -448,6 +452,7 @@ export function ReviewScreen(): ReactElement {
   const [isHardReminderVisible, setIsHardReminderVisible] = useState<boolean>(false);
   const [hardReminderLastShownAt, setHardReminderLastShownAt] = useState<number | null>(() => loadReviewHardReminderLastShownAt());
   const recentReviewRatingsRef = useRef<Array<ReviewRating>>([]);
+  const lastCapturedReviewButtonErrorKeyRef = useRef<string>("");
   const { message: reviewSpeechMessage, showMessage: showReviewSpeechMessage } = useTransientMessage(3000);
   const {
     activeReviewQueue,
@@ -465,10 +470,12 @@ export function ReviewScreen(): ReactElement {
   } = useReviewScreenData({
     activeWorkspaceId: activeWorkspace?.workspaceId ?? null,
     getCardById,
+    installationId: cloudSettings?.installationId ?? null,
     localReadVersion,
     selectedReviewFilter,
     setErrorMessage,
     submitReviewItem,
+    userId: session?.userId ?? null,
   });
   const {
     activeSide: activeSpeechSide,
@@ -515,11 +522,14 @@ export function ReviewScreen(): ReactElement {
     setIsEditorPresented,
   } = useReviewCardEditor({
     deleteCardItem,
+    installationId: cloudSettings?.installationId ?? null,
     queueCards,
     selectedCard: currentReviewCard(activeReviewQueue),
     setErrorMessage,
     t,
     updateCardItem,
+    userId: session?.userId ?? null,
+    workspaceId: activeWorkspace?.workspaceId ?? null,
   });
   const handoffCardToAi = useAiCardHandoff();
   const nowTimestamp = Date.now();
@@ -538,6 +548,7 @@ export function ReviewScreen(): ReactElement {
   const reviewButtonsNow = new Date();
   let reviewButtonOptions: Array<ReviewButtonOption> = [];
   let reviewButtonErrorMessage: string = "";
+  let reviewButtonScheduleError: Error | null = null;
 
   useEffect(() => {
     setIsAnswerVisible(false);
@@ -610,11 +621,50 @@ export function ReviewScreen(): ReactElement {
     try {
       reviewButtonOptions = buildReviewButtonOptions(selectedCard, workspaceSettings, reviewButtonsNow, t, formatCount);
     } catch (error) {
-      reviewButtonErrorMessage = error instanceof Error ? error.message : String(error);
+      reviewButtonScheduleError = normalizeCaughtError(error);
+      reviewButtonErrorMessage = reviewButtonScheduleError.message;
     }
   } else if (isAnswerVisible && selectedCard !== null) {
     reviewButtonErrorMessage = t("reviewScreen.errors.schedulerUnavailable");
   }
+
+  const reviewButtonErrorCaptureKey = reviewButtonScheduleError === null || selectedCard === null || workspaceSettings === null
+    ? ""
+    : [
+      selectedCard.cardId,
+      selectedCard.updatedAt,
+      workspaceSettings.algorithm,
+      reviewButtonScheduleError.name,
+      reviewButtonScheduleError.message,
+    ].join(":");
+
+  useEffect(() => {
+    if (
+      reviewButtonScheduleError === null
+      || selectedCard === null
+      || reviewButtonErrorCaptureKey === ""
+      || lastCapturedReviewButtonErrorKeyRef.current === reviewButtonErrorCaptureKey
+    ) {
+      return;
+    }
+
+    lastCapturedReviewButtonErrorKeyRef.current = reviewButtonErrorCaptureKey;
+    captureAppOperationError(reviewButtonScheduleError, {
+      feature: "review",
+      operation: "review_schedule_preview",
+      userId: session?.userId ?? null,
+      workspaceId: activeWorkspace?.workspaceId ?? null,
+      installationId: cloudSettings?.installationId ?? null,
+      entityId: selectedCard.cardId,
+    });
+  }, [
+    activeWorkspace?.workspaceId,
+    cloudSettings?.installationId,
+    reviewButtonErrorCaptureKey,
+    reviewButtonScheduleError,
+    selectedCard,
+    session?.userId,
+  ]);
 
   const leftReviewButtonOptions = reviewButtonOptions.slice(0, REVIEW_BUTTONS_PER_COLUMN);
   const rightReviewButtonOptions = reviewButtonOptions.slice(REVIEW_BUTTONS_PER_COLUMN, REVIEW_BUTTONS_PER_COLUMN * 2);

--- a/apps/web/src/screens/review/useReviewCardEditor.ts
+++ b/apps/web/src/screens/review/useReviewCardEditor.ts
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import type { TranslationKey } from "../../i18n";
+import { captureAppOperationError } from "../../observability/appOperationObservation";
 import { toCardFormState, type CardFormState } from "../cards/CardForm";
-import type { Card, TagSuggestion } from "../../types";
+import type { Card } from "../../types";
 
 type UseReviewCardEditorParams = Readonly<{
   deleteCardItem: (cardId: string) => Promise<Card>;
+  installationId: string | null;
   queueCards: ReadonlyArray<Card>;
   selectedCard: Card | null;
   setErrorMessage: (message: string) => void;
@@ -15,6 +17,8 @@ type UseReviewCardEditorParams = Readonly<{
     tags: ReadonlyArray<string>;
     effortLevel: Card["effortLevel"];
   }>) => Promise<Card>;
+  userId: string | null;
+  workspaceId: string | null;
 }>;
 
 export type UseReviewCardEditorResult = Readonly<{
@@ -34,11 +38,14 @@ export type UseReviewCardEditorResult = Readonly<{
 export function useReviewCardEditor(params: UseReviewCardEditorParams): UseReviewCardEditorResult {
   const {
     deleteCardItem,
+    installationId,
     queueCards,
     selectedCard,
     setErrorMessage,
     t,
     updateCardItem,
+    userId,
+    workspaceId,
   } = params;
   const [isEditorPresented, setIsEditorPresented] = useState<boolean>(false);
   const [editingCardId, setEditingCardId] = useState<string>("");
@@ -73,6 +80,14 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       });
       setIsEditorPresented(false);
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "review",
+        operation: "review_card_save",
+        userId,
+        workspaceId,
+        installationId,
+        entityId: editingCardId,
+      });
       setEditorErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsEditorSaving(false);
@@ -98,6 +113,14 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       });
       return savedCard;
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "review",
+        operation: "review_card_save",
+        userId,
+        workspaceId,
+        installationId,
+        entityId: editingCardId,
+      });
       setEditorErrorMessage(error instanceof Error ? error.message : String(error));
       return null;
     } finally {
@@ -123,6 +146,14 @@ export function useReviewCardEditor(params: UseReviewCardEditorParams): UseRevie
       await deleteCardItem(editingCardId);
       setIsEditorPresented(false);
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "review",
+        operation: "review_card_delete",
+        userId,
+        workspaceId,
+        installationId,
+        entityId: editingCardId,
+      });
       setEditorErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsEditorSaving(false);

--- a/apps/web/src/screens/review/useReviewScreenData.ts
+++ b/apps/web/src/screens/review/useReviewScreenData.ts
@@ -14,6 +14,7 @@ import {
   loadReviewTimelinePage,
 } from "../../localDb/reviews";
 import { loadWorkspaceTagsSummary } from "../../localDb/workspace";
+import { captureAppOperationError } from "../../observability/appOperationObservation";
 import type {
   Card,
   DeckSummary,
@@ -34,10 +35,12 @@ import { formatEffortLevelLabel } from "../shared/featureFormatting";
 type UseReviewScreenDataParams = Readonly<{
   activeWorkspaceId: string | null;
   getCardById: (cardId: string) => Promise<Card>;
+  installationId: string | null;
   localReadVersion: number;
   selectedReviewFilter: ReviewFilter;
   setErrorMessage: (message: string) => void;
   submitReviewItem: (cardId: string, rating: 0 | 1 | 2 | 3) => Promise<Card>;
+  userId: string | null;
 }>;
 
 type PendingReviewSnapshot = Readonly<{
@@ -508,10 +511,12 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const {
     activeWorkspaceId,
     getCardById,
+    installationId,
     localReadVersion,
     selectedReviewFilter,
     setErrorMessage,
     submitReviewItem,
+    userId,
   } = params;
   const { t } = useI18n();
   const [canonicalReviewQueue, setCanonicalReviewQueue] = useState<ReadonlyArray<Card>>([]);
@@ -540,11 +545,22 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const reviewSessionSignatureRef = useRef<ReviewSessionSignature | null>(null);
   const selectedReviewFilterKey = serializeReviewFilterKey(selectedReviewFilter);
   const selectedReviewFilterKeyRef = useRef<string>(selectedReviewFilterKey);
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
   const reviewLoadingSnapshot = activeWorkspaceId === null
     ? null
     : readReviewLoadingSnapshot(activeWorkspaceId, selectedReviewFilter);
   const isInitialReviewLoad = isReviewLoading && hasLoadedReviewData === false;
   const activeReviewQueue = buildDisplayedReviewQueue(canonicalReviewQueue, presentedCard);
+  observationIdentityRef.current = {
+    userId,
+    installationId,
+  };
 
   function setCanonicalReviewQueueState(nextCanonicalReviewQueue: ReadonlyArray<Card>): void {
     canonicalReviewQueueRef.current = nextCanonicalReviewQueue;
@@ -725,6 +741,17 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           return;
         }
 
+        if (activeWorkspaceId !== null) {
+          const observationIdentity = observationIdentityRef.current;
+          captureAppOperationError(error, {
+            feature: "review",
+            operation: "review_data_load",
+            userId: observationIdentity.userId,
+            workspaceId: activeWorkspaceId,
+            installationId: observationIdentity.installationId,
+            entityId: null,
+          });
+        }
         setReviewLoadErrorMessage(error instanceof Error ? error.message : String(error));
       } finally {
         if (!isCancelled && shouldShowBlockingLoader) {
@@ -769,6 +796,15 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     try {
       await submitReviewItem(submissionContext.cardId, rating);
     } catch (error) {
+      const observationIdentity = observationIdentityRef.current;
+      captureAppOperationError(error, {
+        feature: "review",
+        operation: "review_submit",
+        userId: observationIdentity.userId,
+        workspaceId: submissionContext.workspaceId,
+        installationId: observationIdentity.installationId,
+        entityId: submissionContext.cardId,
+      });
       const originalSubmitErrorMessage = toReviewErrorMessage(error);
       pendingReviewSnapshotsRef.current = removePendingReviewSnapshot(
         pendingReviewSnapshotsRef.current,
@@ -792,6 +828,15 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
       try {
         freshRollbackCard = await loadPresentedCardForPreservation(submissionContext.cardId, getCardById);
       } catch (lookupError) {
+        const observationIdentity = observationIdentityRef.current;
+        captureAppOperationError(lookupError, {
+          feature: "review",
+          operation: "review_rollback_lookup",
+          userId: observationIdentity.userId,
+          workspaceId: submissionContext.workspaceId,
+          installationId: observationIdentity.installationId,
+          entityId: submissionContext.cardId,
+        });
         rollbackLookupErrorMessage = toReviewErrorMessage(lookupError);
       }
       const currentResolvedReviewFilter = resolvedReviewFilterRef.current;
@@ -950,6 +995,15 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           return "stale";
         }
 
+        const observationIdentity = observationIdentityRef.current;
+        captureAppOperationError(error, {
+          feature: "review",
+          operation: "review_replenish",
+          userId: observationIdentity.userId,
+          workspaceId: submissionContext.workspaceId,
+          installationId: observationIdentity.installationId,
+          entityId: submissionContext.cardId,
+        });
         setErrorMessage(buildChunkReplenishmentFailureMessage(toReviewErrorMessage(error)));
         return "saved";
       }

--- a/apps/web/src/screens/settings/account/AgentConnectionsScreen.tsx
+++ b/apps/web/src/screens/settings/account/AgentConnectionsScreen.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState, type ReactElement } from "react";
-import { listAgentApiKeys, revokeAgentApiKey } from "../../../api";
+import { ApiContractError, listAgentApiKeys, revokeAgentApiKey } from "../../../api";
 import { useAppData } from "../../../appData";
 import { useI18n } from "../../../i18n";
 import { captureApiContractError } from "../../../observability/apiContractObservation";
+import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import type { AgentApiKeyConnection } from "../../../types";
 import { SettingsShell } from "../SettingsShared";
 
@@ -39,6 +40,16 @@ export function AgentConnectionsScreen(): ReactElement {
         workspaceId: activeWorkspace?.workspaceId ?? null,
         installationId: cloudSettings?.installationId ?? null,
       });
+      if (error instanceof ApiContractError === false) {
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "agent_connections_load",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: null,
+        });
+      }
       setErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsLoading(false);
@@ -66,6 +77,16 @@ export function AgentConnectionsScreen(): ReactElement {
         workspaceId: activeWorkspace?.workspaceId ?? null,
         installationId: cloudSettings?.installationId ?? null,
       });
+      if (error instanceof ApiContractError === false) {
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "agent_connection_revoke",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace?.workspaceId ?? null,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: connectionId,
+        });
+      }
       setErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setBusyConnectionId(null);

--- a/apps/web/src/screens/settings/workspace/TagsScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/TagsScreen.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, type ReactElement } from "react";
+import { useEffect, useRef, useState, type ReactElement } from "react";
 import { useAppData } from "../../../appData";
 import { useI18n } from "../../../i18n";
 import { loadWorkspaceTagsSummary } from "../../../localDb/workspace";
+import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import type { WorkspaceTagsSummary } from "../../../types";
 
 const emptyTagsSummary: WorkspaceTagsSummary = {
@@ -10,11 +11,22 @@ const emptyTagsSummary: WorkspaceTagsSummary = {
 };
 
 export function TagsScreen(): ReactElement {
-  const { activeWorkspace, localReadVersion, refreshLocalData } = useAppData();
+  const { activeWorkspace, cloudSettings, localReadVersion, refreshLocalData, session } = useAppData();
   const { t, formatCount, formatNumber } = useI18n();
   const [tagsSummary, setTagsSummary] = useState<WorkspaceTagsSummary>(emptyTagsSummary);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   useEffect(() => {
     let isCancelled = false;
@@ -39,6 +51,17 @@ export function TagsScreen(): ReactElement {
           return;
         }
 
+        if (activeWorkspace !== null) {
+          const observationIdentity = observationIdentityRef.current;
+          captureAppOperationError(error, {
+            feature: "settings",
+            operation: "tags_load",
+            userId: observationIdentity.userId,
+            workspaceId: activeWorkspace.workspaceId,
+            installationId: observationIdentity.installationId,
+            entityId: null,
+          });
+        }
         setErrorMessage(error instanceof Error ? error.message : String(error));
       } finally {
         if (!isCancelled) {

--- a/apps/web/src/screens/settings/workspace/WorkspaceExportScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/WorkspaceExportScreen.tsx
@@ -1,11 +1,12 @@
 import { useState, type ReactElement } from "react";
 import { useAppData } from "../../../appData";
 import { useI18n } from "../../../i18n";
+import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import { exportWorkspaceCardsCsv } from "../../../workspaceExport";
 import { SettingsShell } from "../SettingsShared";
 
 export function WorkspaceExportScreen(): ReactElement {
-  const { activeWorkspace } = useAppData();
+  const { activeWorkspace, cloudSettings, session } = useAppData();
   const { t } = useI18n();
   const [isExporting, setIsExporting] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
@@ -32,6 +33,14 @@ export function WorkspaceExportScreen(): ReactElement {
       });
       setSuccessMessage(t("workspaceExport.success"));
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "settings",
+        operation: "workspace_export",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace.workspaceId,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: activeWorkspace.workspaceId,
+      });
       setErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsExporting(false);

--- a/apps/web/src/screens/settings/workspace/WorkspaceOverviewScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/WorkspaceOverviewScreen.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState, type FormEvent, type ReactElement } from "react";
-import { loadWorkspaceDeletePreview } from "../../../api";
+import { useEffect, useRef, useState, type FormEvent, type ReactElement } from "react";
+import { ApiContractError, loadWorkspaceDeletePreview } from "../../../api";
 import { useAppData } from "../../../appData";
 import { useI18n } from "../../../i18n";
 import { loadWorkspaceOverviewSnapshot } from "../../../localDb/workspace";
-import { captureApiContractError, isApiContractErrorForEndpoint } from "../../../observability/apiContractObservation";
+import { captureApiContractError } from "../../../observability/apiContractObservation";
+import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import type { WorkspaceDeletePreview, WorkspaceOverviewSnapshot } from "../../../types";
 import { SettingsShell } from "../SettingsShared";
 
@@ -41,6 +42,17 @@ export function WorkspaceOverviewScreen(): ReactElement {
   const [deletePreviewErrorMessage, setDeletePreviewErrorMessage] = useState<string>("");
   const [deleteConfirmationValue, setDeleteConfirmationValue] = useState<string>("");
   const [isDeleteSubmitting, setIsDeleteSubmitting] = useState<boolean>(false);
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   useEffect(() => {
     let isCancelled = false;
@@ -72,6 +84,17 @@ export function WorkspaceOverviewScreen(): ReactElement {
           return;
         }
 
+        if (activeWorkspace !== null) {
+          const observationIdentity = observationIdentityRef.current;
+          captureAppOperationError(error, {
+            feature: "settings",
+            operation: "workspace_overview_load",
+            userId: observationIdentity.userId,
+            workspaceId: activeWorkspace.workspaceId,
+            installationId: observationIdentity.installationId,
+            entityId: activeWorkspace.workspaceId,
+          });
+        }
         setErrorMessage(error instanceof Error ? error.message : String(error));
       } finally {
         if (!isCancelled) {
@@ -129,6 +152,21 @@ export function WorkspaceOverviewScreen(): ReactElement {
     try {
       await renameWorkspace(activeWorkspace.workspaceId, trimmedWorkspaceName);
     } catch (error) {
+      if (error instanceof ApiContractError === false) {
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "workspace_rename",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace.workspaceId,
+          expectedErrorMessages: [
+            t("app.sessionUnavailable"),
+            t("app.sessionRestoringActionLocked"),
+            t("settingsCurrentWorkspace.workspaceNameRequired"),
+          ],
+        });
+      }
       setRenameErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsRenameSubmitting(false);
@@ -156,13 +194,22 @@ export function WorkspaceOverviewScreen(): ReactElement {
       const preview = await loadWorkspaceDeletePreview(activeWorkspace.workspaceId);
       setDeletePreview(preview);
     } catch (error) {
-      if (isApiContractErrorForEndpoint(error, "/delete-preview")) {
+      if (error instanceof ApiContractError) {
         captureApiContractError(error, {
           feature: "settings",
           sourceAction: "workspace_delete_preview_load",
           userId: session?.userId ?? null,
           workspaceId: activeWorkspace.workspaceId,
           installationId: cloudSettings?.installationId ?? null,
+        });
+      } else {
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "workspace_delete_preview_load",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace.workspaceId,
         });
       }
       setDeletePreviewErrorMessage(error instanceof Error ? error.message : String(error));
@@ -182,13 +229,22 @@ export function WorkspaceOverviewScreen(): ReactElement {
       const preview = await loadWorkspaceDeletePreview(activeWorkspace.workspaceId);
       setDeletePreview(preview);
     } catch (error) {
-      if (isApiContractErrorForEndpoint(error, "/delete-preview")) {
+      if (error instanceof ApiContractError) {
         captureApiContractError(error, {
           feature: "settings",
           sourceAction: "workspace_delete_preview_retry",
           userId: session?.userId ?? null,
           workspaceId: activeWorkspace.workspaceId,
           installationId: cloudSettings?.installationId ?? null,
+        });
+      } else {
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "workspace_delete_preview_retry",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace.workspaceId,
         });
       }
       setDeletePreviewErrorMessage(error instanceof Error ? error.message : String(error));

--- a/apps/web/src/screens/settings/workspace/WorkspaceSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/WorkspaceSettingsScreen.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState, type ReactElement } from "react";
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import { ApiContractError } from "../../../api";
 import { useAppData } from "../../../appData";
 import { useI18n } from "../../../i18n";
 import { resetWorkspaceProgressConfirmationText, type WorkspaceResetProgressPreview } from "../../../types";
@@ -12,7 +13,8 @@ import {
 } from "../../../routes";
 import { loadDecksListSnapshot } from "../../../localDb/decks";
 import { loadWorkspaceTagsSummary } from "../../../localDb/workspace";
-import { captureApiContractError, isApiContractErrorForEndpoint } from "../../../observability/apiContractObservation";
+import { captureApiContractError } from "../../../observability/apiContractObservation";
+import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import { SettingsActionCard, SettingsGroup, SettingsNavigationCard, SettingsShell } from "../SettingsShared";
 
 type ResetDialogState = "confirmation" | "preview-loading" | "preview-ready" | "executing";
@@ -42,6 +44,13 @@ export function WorkspaceSettingsScreen(): ReactElement {
   const [resetErrorMessage, setResetErrorMessage] = useState<string>("");
   const [isResetPreviewLoading, setIsResetPreviewLoading] = useState<boolean>(false);
   const [isResetExecuting, setIsResetExecuting] = useState<boolean>(false);
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
 
   const isResetAvailable = isSessionVerified
     && cloudSettings?.cloudState === "linked"
@@ -67,6 +76,10 @@ export function WorkspaceSettingsScreen(): ReactElement {
     one: t("settingsWorkspace.countLabels.tag.one"),
     other: t("settingsWorkspace.countLabels.tag.other"),
   });
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   useEffect(() => {
     let isCancelled = false;
@@ -95,6 +108,17 @@ export function WorkspaceSettingsScreen(): ReactElement {
           return;
         }
 
+        if (activeWorkspace !== null) {
+          const observationIdentity = observationIdentityRef.current;
+          captureAppOperationError(error, {
+            feature: "settings",
+            operation: "workspace_settings_load",
+            userId: observationIdentity.userId,
+            workspaceId: activeWorkspace.workspaceId,
+            installationId: observationIdentity.installationId,
+            entityId: activeWorkspace.workspaceId,
+          });
+        }
         setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     }
@@ -165,13 +189,27 @@ export function WorkspaceSettingsScreen(): ReactElement {
       const preview = await loadWorkspaceResetProgressPreview(activeWorkspace.workspaceId);
       setResetPreview(preview);
     } catch (error) {
-      if (isApiContractErrorForEndpoint(error, "/reset-progress-preview")) {
+      if (error instanceof ApiContractError) {
         captureApiContractError(error, {
           feature: "settings",
           sourceAction: "workspace_reset_progress_preview_load",
           userId: session?.userId ?? null,
           workspaceId: activeWorkspace.workspaceId,
           installationId: cloudSettings?.installationId ?? null,
+        });
+      } else {
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "workspace_reset_preview_load",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace.workspaceId,
+          expectedErrorMessages: [
+            t("app.sessionUnavailable"),
+            t("app.sessionRestoringActionLocked"),
+            t("settingsWorkspace.resetProgress.availabilityHint"),
+          ],
         });
       }
       setResetErrorMessage(error instanceof Error ? error.message : String(error));
@@ -195,13 +233,27 @@ export function WorkspaceSettingsScreen(): ReactElement {
         setAppErrorMessage(error instanceof Error ? error.message : String(error));
       });
     } catch (error) {
-      if (isApiContractErrorForEndpoint(error, "/reset-progress")) {
+      if (error instanceof ApiContractError) {
         captureApiContractError(error, {
           feature: "settings",
           sourceAction: "workspace_reset_progress_execute",
           userId: session?.userId ?? null,
           workspaceId: activeWorkspace.workspaceId,
           installationId: cloudSettings?.installationId ?? null,
+        });
+      } else {
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "workspace_reset_execute",
+          userId: session?.userId ?? null,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: cloudSettings?.installationId ?? null,
+          entityId: activeWorkspace.workspaceId,
+          expectedErrorMessages: [
+            t("app.sessionUnavailable"),
+            t("app.sessionRestoringActionLocked"),
+            t("settingsWorkspace.resetProgress.availabilityHint"),
+          ],
         });
       }
       setResetErrorMessage(error instanceof Error ? error.message : String(error));

--- a/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useAppData } from "../../../../appData";
 import { ALL_CARDS_REVIEW_FILTER, isCardDue } from "../../../../appData/domain";
@@ -7,7 +7,8 @@ import { useI18n } from "../../../../i18n";
 import { buildSettingsDeckEditRoute, reviewRoute, settingsDecksRoute } from "../../../../routes";
 import { loadCardsMatchingDeck } from "../../../../localDb/cards";
 import { loadDeckById, loadDecksListSnapshot } from "../../../../localDb/decks";
-import type { Card, Deck, ReviewFilter } from "../../../../types";
+import { captureAppOperationError } from "../../../../observability/appOperationObservation";
+import type { Card, ReviewFilter } from "../../../../types";
 import { formatDeckFilterSummary, formatEffortLevelLabel, formatNullableDateTime, formatTagSummary } from "../../../shared/featureFormatting";
 
 type DeckDetailState = Readonly<{
@@ -29,8 +30,10 @@ export function DeckDetailScreen(): ReactElement {
   const { t, formatCount, formatDateTime, formatNumber } = useI18n();
   const {
     activeWorkspace,
+    cloudSettings,
     deleteDeckItem,
     openReview,
+    session,
     setErrorMessage,
     localReadVersion,
     refreshLocalData,
@@ -39,9 +42,20 @@ export function DeckDetailScreen(): ReactElement {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [screenErrorMessage, setScreenErrorMessage] = useState<string>("");
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
 
   const currentDeckId = deckId ?? "";
   const nowTimestamp = Date.now();
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
     if (deckId === undefined) {
@@ -100,6 +114,17 @@ export function DeckDetailScreen(): ReactElement {
         emptyMessage: t("deckDetail.empty.deckCards"),
       });
     } catch (error) {
+      if (activeWorkspace !== null) {
+        const observationIdentity = observationIdentityRef.current;
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "deck_detail_load",
+          userId: observationIdentity.userId,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: observationIdentity.installationId,
+          entityId: deckId,
+        });
+      }
       setScreenErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsLoading(false);
@@ -128,6 +153,14 @@ export function DeckDetailScreen(): ReactElement {
       await deleteDeckItem(deckId);
       navigate(settingsDecksRoute);
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "settings",
+        operation: "deck_delete",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: deckId,
+      });
       setScreenErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsDeleting(false);

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ChangeEvent, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useAppData } from "../../../../appData";
 import { ALL_CARDS_DECK_SLUG, buildDeckFilterDefinition, EFFORT_LEVELS } from "../../../../deckFilters";
@@ -6,6 +6,7 @@ import { useI18n } from "../../../../i18n";
 import { buildSettingsDeckDetailRoute, settingsDecksRoute } from "../../../../routes";
 import { CardFormTagsField } from "../../../cards/CardFormTagsField";
 import { loadWorkspaceTagsSummary } from "../../../../localDb/workspace";
+import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type { EffortLevel, TagSuggestion, UpdateDeckInput } from "../../../../types";
 import { formatDeckFilterSummary, formatEffortLevelLabel } from "../../../shared/featureFormatting";
 
@@ -40,8 +41,10 @@ export function DeckFormScreen(): ReactElement {
   const { t } = useI18n();
   const {
     activeWorkspace,
+    cloudSettings,
     createDeckItem,
     getDeckById,
+    session,
     updateDeckItem,
     setErrorMessage,
     localReadVersion,
@@ -51,12 +54,23 @@ export function DeckFormScreen(): ReactElement {
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [screenErrorMessage, setScreenErrorMessage] = useState<string>("");
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
   const filterDefinition = buildDeckFilterDefinition(formState.effortLevels, formState.tags);
   const nameFieldId = "deck-name";
   const tagsFieldId = "deck-tags-input";
   const isCreateMode = deckId === undefined;
   const screenTitle = isCreateMode ? t("deckForm.title.new") : t("deckForm.title.edit");
   const backHref = isCreateMode || deckId === undefined ? settingsDecksRoute : buildSettingsDeckDetailRoute(deckId);
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
     setIsLoading(true);
@@ -91,6 +105,17 @@ export function DeckFormScreen(): ReactElement {
         });
       }
     } catch (error) {
+      if (activeWorkspace !== null && deckId !== ALL_CARDS_DECK_SLUG) {
+        const observationIdentity = observationIdentityRef.current;
+        captureAppOperationError(error, {
+          feature: "settings",
+          operation: "deck_detail_load",
+          userId: observationIdentity.userId,
+          workspaceId: activeWorkspace.workspaceId,
+          installationId: observationIdentity.installationId,
+          entityId: deckId ?? null,
+        });
+      }
       setScreenErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsLoading(false);
@@ -126,6 +151,14 @@ export function DeckFormScreen(): ReactElement {
         navigate(buildSettingsDeckDetailRoute(updatedDeck.deckId));
       }
     } catch (error) {
+      captureAppOperationError(error, {
+        feature: "settings",
+        operation: "deck_save",
+        userId: session?.userId ?? null,
+        workspaceId: activeWorkspace?.workspaceId ?? null,
+        installationId: cloudSettings?.installationId ?? null,
+        entityId: deckId ?? null,
+      });
       setErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setIsSaving(false);

--- a/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DecksScreen.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, type ReactElement } from "react";
+import { useEffect, useRef, useState, type ReactElement } from "react";
 import { Link } from "react-router-dom";
 import { useAppData } from "../../../../appData";
 import { ALL_CARDS_DECK_SLUG } from "../../../../deckFilters";
 import { useI18n } from "../../../../i18n";
 import { buildSettingsDeckDetailRoute, settingsDeckNewRoute } from "../../../../routes";
 import { loadDecksListSnapshot } from "../../../../localDb/decks";
+import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type { DeckCardStats, DecksListSnapshot } from "../../../../types";
 import { formatDeckFilterSummary } from "../../../shared/featureFormatting";
 
@@ -52,11 +53,22 @@ const emptyDecksSnapshot: DecksListSnapshot = {
 };
 
 export function DecksScreen(): ReactElement {
-  const { activeWorkspace, localReadVersion, refreshLocalData } = useAppData();
+  const { activeWorkspace, cloudSettings, localReadVersion, refreshLocalData, session } = useAppData();
   const { t, formatNumber } = useI18n();
   const [decksSnapshot, setDecksSnapshot] = useState<DecksListSnapshot>(emptyDecksSnapshot);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [errorMessage, setErrorMessage] = useState<string>("");
+  const observationIdentityRef = useRef<Readonly<{
+    userId: string | null;
+    installationId: string | null;
+  }>>({
+    userId: null,
+    installationId: null,
+  });
+  observationIdentityRef.current = {
+    userId: session?.userId ?? null,
+    installationId: cloudSettings?.installationId ?? null,
+  };
 
   useEffect(() => {
     let isCancelled = false;
@@ -81,6 +93,17 @@ export function DecksScreen(): ReactElement {
           return;
         }
 
+        if (activeWorkspace !== null) {
+          const observationIdentity = observationIdentityRef.current;
+          captureAppOperationError(error, {
+            feature: "settings",
+            operation: "deck_list_load",
+            userId: observationIdentity.userId,
+            workspaceId: activeWorkspace.workspaceId,
+            installationId: observationIdentity.installationId,
+            entityId: null,
+          });
+        }
         setErrorMessage(error instanceof Error ? error.message : String(error));
       } finally {
         if (!isCancelled) {


### PR DESCRIPTION
## Summary
- add typed app-operation observability capture for web screens
- route unexpected app operation/API failures through the observability facade with Sentry context
- keep expected product states filtered and add operation-aware Sentry fingerprinting

## Validation
- npm run build --prefix apps/web
- npm run test --prefix apps/web
- git --no-pager diff --check