### PR TITLE
[codex] Refactor web sync engine

### DIFF
--- a/apps/web/src/appData/syncCloudSettings.ts
+++ b/apps/web/src/appData/syncCloudSettings.ts
@@ -1,0 +1,18 @@
+import { loadCloudSettings } from "../localDb/cloudSettings";
+import type { CloudSettings } from "../types";
+
+export function requireCloudInstallationId(cloudSettings: CloudSettings | null): string {
+  if (cloudSettings === null) {
+    throw new Error("Cloud settings are not loaded");
+  }
+
+  if (cloudSettings.installationId.trim() === "") {
+    throw new Error("Cloud settings installationId is not loaded");
+  }
+
+  return cloudSettings.installationId;
+}
+
+export async function loadRequiredCloudInstallationId(): Promise<string> {
+  return requireCloudInstallationId(await loadCloudSettings());
+}

--- a/apps/web/src/appData/syncErrorObservation.ts
+++ b/apps/web/src/appData/syncErrorObservation.ts
@@ -1,0 +1,174 @@
+import {
+  ApiContractError,
+  ApiError,
+  isAuthRedirectError,
+} from "../api";
+import { captureApiContractError } from "../observability/apiContractObservation";
+import {
+  captureWebException,
+  type WebObservationScope,
+} from "../observability/webObservability";
+
+const workspaceNotFoundErrorCode = "WORKSPACE_NOT_FOUND";
+const workspaceSyncDiscardedErrorName = "WorkspaceSyncDiscardedError";
+
+export type WorkspaceSyncDiscardedError = Error & Readonly<{
+  name: typeof workspaceSyncDiscardedErrorName;
+  workspaceId: string;
+}>;
+
+export type SyncFailureObservationInput = Readonly<{
+  error: Error;
+  userId: string;
+  workspaceId: string;
+  installationId: string | null;
+}>;
+
+export function createWorkspaceSyncDiscardedError(workspaceId: string): WorkspaceSyncDiscardedError {
+  const error = new Error(`Workspace sync was discarded: ${workspaceId}`);
+  error.name = workspaceSyncDiscardedErrorName;
+  return Object.assign(error, { workspaceId }) as WorkspaceSyncDiscardedError;
+}
+
+export function isWorkspaceSyncDiscardedError(error: unknown): error is WorkspaceSyncDiscardedError {
+  return error instanceof Error
+    && error.name === workspaceSyncDiscardedErrorName
+    && "workspaceId" in error;
+}
+
+export function isWorkspaceNotFoundError(error: unknown): error is ApiError {
+  return error instanceof ApiError
+    && error.statusCode === 404
+    && error.code === workspaceNotFoundErrorCode;
+}
+
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildSyncObservationScope(
+  error: Error,
+  userId: string,
+  workspaceId: string,
+  installationId: string | null,
+): WebObservationScope {
+  const requestMetadata = error instanceof ApiError || error instanceof ApiContractError
+    ? {
+      requestId: error.requestId,
+      statusCode: error.statusCode,
+      code: error.code,
+    }
+    : {
+      requestId: null,
+      statusCode: null,
+      code: null,
+    };
+
+  return {
+    app: "web",
+    feature: "sync",
+    userId,
+    workspaceId,
+    installationId,
+    route: getCurrentRoute(),
+    requestId: requestMetadata.requestId,
+    statusCode: requestMetadata.statusCode,
+    code: requestMetadata.code,
+  };
+}
+
+function isExpectedSyncProductErrorCode(code: string | null): boolean {
+  switch (code) {
+    case "ACCOUNT_DELETED":
+    case "AUTH_UNAUTHORIZED":
+    case "GUEST_AUTH_INVALID":
+    case "SESSION_CSRF_TOKEN_INVALID":
+    case "SYNC_BOOTSTRAP_NOT_EMPTY":
+    case "SYNC_BOOTSTRAP_REQUIRED":
+    case "SYNC_INVALID_INPUT":
+    case "SYNC_WORKSPACE_FORK_REQUIRED":
+    case "WORKSPACE_NOT_FOUND":
+    case "WORKSPACE_SELECTION_REQUIRED":
+      return true;
+  }
+
+  return false;
+}
+
+function isExpectedSyncValidationError(error: ApiError): boolean {
+  return error.statusCode === 400
+    && error.code === null
+    && error.responseBodyKind === "json";
+}
+
+function shouldCaptureUnexpectedSyncError(error: Error): boolean {
+  if (error instanceof ApiContractError) {
+    return true;
+  }
+
+  if (isAuthRedirectError(error)) {
+    return false;
+  }
+
+  if (error instanceof ApiError) {
+    if (error.statusCode >= 500) {
+      return true;
+    }
+
+    if (isExpectedSyncProductErrorCode(error.code)) {
+      return false;
+    }
+
+    if (error.statusCode === 401) {
+      return false;
+    }
+
+    if (isExpectedSyncValidationError(error)) {
+      return false;
+    }
+
+    if (error.statusCode >= 400 && error.statusCode < 500) {
+      return true;
+    }
+  }
+
+  return true;
+}
+
+function captureUnexpectedSyncError(input: SyncFailureObservationInput): void {
+  if (shouldCaptureUnexpectedSyncError(input.error) === false) {
+    return;
+  }
+
+  captureWebException({
+    action: "sync_failed",
+    error: input.error,
+    scope: buildSyncObservationScope(
+      input.error,
+      input.userId,
+      input.workspaceId,
+      input.installationId,
+    ),
+    details: {
+      operation: "sync_workspace_refresh",
+      workspaceId: input.workspaceId,
+    },
+  });
+}
+
+export function observeSyncFailure(input: SyncFailureObservationInput): void {
+  captureApiContractError(input.error, {
+    feature: "sync",
+    sourceAction: "sync_workspace_refresh",
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    installationId: input.installationId,
+  });
+  if (input.error instanceof ApiContractError === false) {
+    captureUnexpectedSyncError(input);
+  }
+}

--- a/apps/web/src/appData/syncLocalMutations.ts
+++ b/apps/web/src/appData/syncLocalMutations.ts
@@ -1,0 +1,325 @@
+import { computeReviewSchedule, type ReviewRating } from "../../../backend/src/schedule";
+import { loadCardById, putCard } from "../localDb/cards";
+import { loadCloudSettings } from "../localDb/cloudSettings";
+import { loadDeckById, putDeck } from "../localDb/decks";
+import { putOutboxRecord, type PersistedOutboxRecord } from "../localDb/outbox";
+import { putReviewEvent } from "../localDb/reviews";
+import { loadWorkspaceSettings } from "../localDb/workspace";
+import type {
+  Card,
+  CreateCardInput,
+  CreateDeckInput,
+  Deck,
+  UpdateCardInput,
+  UpdateDeckInput,
+} from "../types";
+import {
+  buildCardUpsertOperation,
+  buildDeck,
+  buildDeckUpsertOperation,
+  buildDeletedCard,
+  buildDeletedDeck,
+  buildInitialCard,
+  buildReviewEvent,
+  buildReviewEventAppendOperation,
+  buildReviewedCard,
+  buildUpdatedCard,
+  buildUpdatedDeck,
+  doesCardMutationAffectReviewSchedule,
+  normalizeCreateCardInput,
+  normalizeCreateDeckInput,
+  normalizeUpdateCardInput,
+  normalizeUpdateDeckInput,
+  toReviewableCardState,
+} from "./domain";
+import {
+  loadRequiredCloudInstallationId,
+  requireCloudInstallationId,
+} from "./syncCloudSettings";
+
+export type LocalReviewRating = 0 | 1 | 2 | 3;
+
+export type LocalCardMutationResult = Readonly<{
+  card: Card;
+  didChangeProgressHistory: boolean;
+  didChangeReviewSchedule: boolean;
+}>;
+
+export type LocalDeckMutationResult = Readonly<{
+  deck: Deck;
+}>;
+
+export type CreateCardLocallyInput = Readonly<{
+  workspaceId: string;
+  input: CreateCardInput;
+  clientUpdatedAt: string;
+}>;
+
+export type CreateDeckLocallyInput = Readonly<{
+  workspaceId: string;
+  input: CreateDeckInput;
+  clientUpdatedAt: string;
+}>;
+
+export type UpdateCardLocallyInput = Readonly<{
+  workspaceId: string;
+  cardId: string;
+  input: UpdateCardInput;
+  clientUpdatedAt: string;
+}>;
+
+export type UpdateDeckLocallyInput = Readonly<{
+  workspaceId: string;
+  deckId: string;
+  input: UpdateDeckInput;
+  clientUpdatedAt: string;
+}>;
+
+export type DeleteCardLocallyInput = Readonly<{
+  workspaceId: string;
+  cardId: string;
+  clientUpdatedAt: string;
+}>;
+
+export type DeleteDeckLocallyInput = Readonly<{
+  workspaceId: string;
+  deckId: string;
+  clientUpdatedAt: string;
+}>;
+
+export type SubmitReviewLocallyInput = Readonly<{
+  workspaceId: string;
+  cardId: string;
+  rating: LocalReviewRating;
+  reviewedAtClient: string;
+}>;
+
+export async function requireCard(workspaceId: string, cardId: string): Promise<Card> {
+  const card = await loadCardById(workspaceId, cardId);
+  if (card === null) {
+    throw new Error(`Card not found: ${cardId}`);
+  }
+
+  return card;
+}
+
+export async function requireDeck(workspaceId: string, deckId: string): Promise<Deck> {
+  const deck = await loadDeckById(workspaceId, deckId);
+  if (deck === null) {
+    throw new Error(`Deck not found: ${deckId}`);
+  }
+
+  return deck;
+}
+
+export async function createCardLocally(input: CreateCardLocallyInput): Promise<LocalCardMutationResult> {
+  const normalizedInput = normalizeCreateCardInput(input.input);
+  const operationId = crypto.randomUUID().toLowerCase();
+  const installationId = await loadRequiredCloudInstallationId();
+  const nextCard = buildInitialCard(normalizedInput, input.clientUpdatedAt, installationId, operationId);
+  const didChangeReviewSchedule = doesCardMutationAffectReviewSchedule(null, nextCard);
+  const nextOutboxRecord: PersistedOutboxRecord = {
+    operationId,
+    workspaceId: input.workspaceId,
+    createdAt: input.clientUpdatedAt,
+    attemptCount: 0,
+    lastError: "",
+    affectsReviewSchedule: didChangeReviewSchedule,
+    operation: buildCardUpsertOperation(nextCard),
+  };
+
+  await putCard(input.workspaceId, nextCard);
+  await putOutboxRecord(nextOutboxRecord);
+  return {
+    card: nextCard,
+    didChangeProgressHistory: false,
+    didChangeReviewSchedule,
+  };
+}
+
+export async function createDeckLocally(input: CreateDeckLocallyInput): Promise<LocalDeckMutationResult> {
+  const normalizedInput = normalizeCreateDeckInput(input.input);
+  const operationId = crypto.randomUUID().toLowerCase();
+  const installationId = await loadRequiredCloudInstallationId();
+  const nextDeck = {
+    ...buildDeck(normalizedInput, input.clientUpdatedAt, installationId, operationId),
+    workspaceId: input.workspaceId,
+  };
+  const nextOutboxRecord: PersistedOutboxRecord = {
+    operationId,
+    workspaceId: input.workspaceId,
+    createdAt: input.clientUpdatedAt,
+    attemptCount: 0,
+    lastError: "",
+    operation: buildDeckUpsertOperation(nextDeck),
+  };
+
+  await putDeck(nextDeck);
+  await putOutboxRecord(nextOutboxRecord);
+  return {
+    deck: nextDeck,
+  };
+}
+
+export async function updateCardLocally(input: UpdateCardLocallyInput): Promise<LocalCardMutationResult> {
+  const existingCard = await requireCard(input.workspaceId, input.cardId);
+  const normalizedInput = normalizeUpdateCardInput(input.input);
+  const operationId = crypto.randomUUID().toLowerCase();
+  const installationId = await loadRequiredCloudInstallationId();
+  const nextCard = buildUpdatedCard(existingCard, normalizedInput, input.clientUpdatedAt, installationId, operationId);
+  const didChangeReviewSchedule = doesCardMutationAffectReviewSchedule(existingCard, nextCard);
+  const nextOutboxRecord: PersistedOutboxRecord = {
+    operationId,
+    workspaceId: input.workspaceId,
+    createdAt: input.clientUpdatedAt,
+    attemptCount: 0,
+    lastError: "",
+    affectsReviewSchedule: didChangeReviewSchedule,
+    operation: buildCardUpsertOperation(nextCard),
+  };
+
+  await putCard(input.workspaceId, nextCard);
+  await putOutboxRecord(nextOutboxRecord);
+  return {
+    card: nextCard,
+    didChangeProgressHistory: false,
+    didChangeReviewSchedule,
+  };
+}
+
+export async function updateDeckLocally(input: UpdateDeckLocallyInput): Promise<LocalDeckMutationResult> {
+  const existingDeck = await requireDeck(input.workspaceId, input.deckId);
+  const normalizedInput = normalizeUpdateDeckInput(input.input);
+  const operationId = crypto.randomUUID().toLowerCase();
+  const installationId = await loadRequiredCloudInstallationId();
+  const nextDeck = buildUpdatedDeck(existingDeck, normalizedInput, input.clientUpdatedAt, installationId, operationId);
+  const nextOutboxRecord: PersistedOutboxRecord = {
+    operationId,
+    workspaceId: input.workspaceId,
+    createdAt: input.clientUpdatedAt,
+    attemptCount: 0,
+    lastError: "",
+    operation: buildDeckUpsertOperation(nextDeck),
+  };
+
+  await putDeck(nextDeck);
+  await putOutboxRecord(nextOutboxRecord);
+  return {
+    deck: nextDeck,
+  };
+}
+
+export async function deleteCardLocally(input: DeleteCardLocallyInput): Promise<LocalCardMutationResult> {
+  const existingCard = await requireCard(input.workspaceId, input.cardId);
+  const operationId = crypto.randomUUID().toLowerCase();
+  const installationId = await loadRequiredCloudInstallationId();
+  const nextCard = buildDeletedCard(existingCard, input.clientUpdatedAt, installationId, operationId);
+  const didChangeReviewSchedule = doesCardMutationAffectReviewSchedule(existingCard, nextCard);
+  const nextOutboxRecord: PersistedOutboxRecord = {
+    operationId,
+    workspaceId: input.workspaceId,
+    createdAt: input.clientUpdatedAt,
+    attemptCount: 0,
+    lastError: "",
+    affectsReviewSchedule: didChangeReviewSchedule,
+    operation: buildCardUpsertOperation(nextCard),
+  };
+
+  await putCard(input.workspaceId, nextCard);
+  await putOutboxRecord(nextOutboxRecord);
+  return {
+    card: nextCard,
+    didChangeProgressHistory: false,
+    didChangeReviewSchedule,
+  };
+}
+
+export async function deleteDeckLocally(input: DeleteDeckLocallyInput): Promise<LocalDeckMutationResult> {
+  const existingDeck = await requireDeck(input.workspaceId, input.deckId);
+  const operationId = crypto.randomUUID().toLowerCase();
+  const installationId = await loadRequiredCloudInstallationId();
+  const nextDeck = buildDeletedDeck(existingDeck, input.clientUpdatedAt, installationId, operationId);
+  const nextOutboxRecord: PersistedOutboxRecord = {
+    operationId,
+    workspaceId: input.workspaceId,
+    createdAt: input.clientUpdatedAt,
+    attemptCount: 0,
+    lastError: "",
+    operation: buildDeckUpsertOperation(nextDeck),
+  };
+
+  await putDeck(nextDeck);
+  await putOutboxRecord(nextOutboxRecord);
+  return {
+    deck: nextDeck,
+  };
+}
+
+export async function submitReviewLocally(input: SubmitReviewLocallyInput): Promise<LocalCardMutationResult> {
+  const [existingCard, schedulerSettings, cloudSettings] = await Promise.all([
+    requireCard(input.workspaceId, input.cardId),
+    loadWorkspaceSettings(input.workspaceId),
+    loadCloudSettings(),
+  ]);
+  if (schedulerSettings === null) {
+    throw new Error("Workspace scheduler settings are not loaded");
+  }
+
+  const reviewEventId = crypto.randomUUID().toLowerCase();
+  const clientEventId = crypto.randomUUID().toLowerCase();
+  const cardOperationId = crypto.randomUUID().toLowerCase();
+  const installationId = requireCloudInstallationId(cloudSettings);
+  const schedule = computeReviewSchedule(
+    toReviewableCardState(existingCard),
+    {
+      algorithm: schedulerSettings.algorithm,
+      desiredRetention: schedulerSettings.desiredRetention,
+      learningStepsMinutes: schedulerSettings.learningStepsMinutes,
+      relearningStepsMinutes: schedulerSettings.relearningStepsMinutes,
+      maximumIntervalDays: schedulerSettings.maximumIntervalDays,
+      enableFuzz: schedulerSettings.enableFuzz,
+    },
+    input.rating as ReviewRating,
+    new Date(input.reviewedAtClient),
+  );
+
+  const nextCard = buildReviewedCard(existingCard, schedule, input.reviewedAtClient, installationId, cardOperationId);
+  const nextReviewEvent = buildReviewEvent(
+    input.workspaceId,
+    input.cardId,
+    installationId,
+    input.rating,
+    input.reviewedAtClient,
+    reviewEventId,
+    clientEventId,
+  );
+
+  const reviewEventOutboxRecord: PersistedOutboxRecord = {
+    operationId: reviewEventId,
+    workspaceId: input.workspaceId,
+    createdAt: input.reviewedAtClient,
+    attemptCount: 0,
+    lastError: "",
+    operation: buildReviewEventAppendOperation(nextReviewEvent),
+  };
+  const didChangeReviewSchedule = doesCardMutationAffectReviewSchedule(existingCard, nextCard);
+  const cardOutboxRecord: PersistedOutboxRecord = {
+    operationId: cardOperationId,
+    workspaceId: input.workspaceId,
+    createdAt: input.reviewedAtClient,
+    attemptCount: 0,
+    lastError: "",
+    affectsReviewSchedule: didChangeReviewSchedule,
+    operation: buildCardUpsertOperation(nextCard),
+  };
+
+  await putReviewEvent(nextReviewEvent);
+  await putCard(input.workspaceId, nextCard);
+  await putOutboxRecord(reviewEventOutboxRecord);
+  await putOutboxRecord(cardOutboxRecord);
+  return {
+    card: nextCard,
+    didChangeProgressHistory: true,
+    didChangeReviewSchedule,
+  };
+}

--- a/apps/web/src/appData/syncRemote.ts
+++ b/apps/web/src/appData/syncRemote.ts
@@ -1,0 +1,328 @@
+import {
+  bootstrapPullSyncState,
+  pullReviewHistorySync,
+  pullSyncChanges,
+  pushSyncOperations,
+} from "../api";
+import { webAppVersion } from "../clientIdentity";
+import { loadCardsByIds } from "../localDb/cards";
+import {
+  deleteOutboxRecord,
+  isScheduleRelevantCardOutboxRecord,
+  listOutboxRecords,
+  putOutboxRecord,
+  type PersistedOutboxRecord,
+} from "../localDb/outbox";
+import {
+  applyHotSyncPage,
+  applyReviewHistorySyncPage,
+  hasHydratedHotState,
+  hasHydratedReviewHistory,
+  loadLastAppliedHotChangeId,
+  loadLastAppliedReviewSequenceId,
+} from "../localDb/workspace";
+import type {
+  SyncBootstrapEntry,
+  SyncChange,
+  SyncPushResult,
+  WorkspaceSchedulerSettings,
+} from "../types";
+import {
+  doesCardMutationAffectReviewSchedule,
+  getErrorMessage,
+} from "./domain";
+
+const syncPageSize = 200;
+
+type HotSyncEntry = SyncBootstrapEntry | SyncChange;
+type CardHotSyncEntry = Extract<HotSyncEntry, Readonly<{ entityType: "card" }>>;
+
+export type RemoteSyncFlags = Readonly<{
+  didChangeProgressHistory: boolean;
+  didChangeReviewSchedule: boolean;
+}>;
+
+export type WorkspaceRemoteSyncInput = Readonly<{
+  workspaceId: string;
+  installationId: string;
+  requireWorkspaceSyncNotDiscarded: (workspaceId: string) => void;
+  publishWorkspaceSettings: (workspaceId: string, settings: WorkspaceSchedulerSettings) => void;
+  refreshWorkspaceView: (workspaceId: string) => Promise<void>;
+}>;
+
+function createEmptyRemoteSyncFlags(): RemoteSyncFlags {
+  return {
+    didChangeProgressHistory: false,
+    didChangeReviewSchedule: false,
+  };
+}
+
+function mergeRemoteSyncFlags(leftFlags: RemoteSyncFlags, rightFlags: RemoteSyncFlags): RemoteSyncFlags {
+  return {
+    didChangeProgressHistory: leftFlags.didChangeProgressHistory || rightFlags.didChangeProgressHistory,
+    didChangeReviewSchedule: leftFlags.didChangeReviewSchedule || rightFlags.didChangeReviewSchedule,
+  };
+}
+
+function findLastWorkspaceSettingsEntry(
+  entries: ReadonlyArray<HotSyncEntry>,
+): WorkspaceSchedulerSettings | null {
+  let lastSettings: WorkspaceSchedulerSettings | null = null;
+
+  for (const entry of entries) {
+    if (entry.entityType === "workspace_scheduler_settings") {
+      lastSettings = entry.payload;
+    }
+  }
+
+  return lastSettings;
+}
+
+function publishWorkspaceSettingsFromEntries(
+  input: WorkspaceRemoteSyncInput,
+  entries: ReadonlyArray<HotSyncEntry>,
+): void {
+  const lastSettings = findLastWorkspaceSettingsEntry(entries);
+  if (lastSettings !== null) {
+    input.publishWorkspaceSettings(input.workspaceId, lastSettings);
+  }
+}
+
+function isProgressReviewEventOperation(
+  record: PersistedOutboxRecord,
+): boolean {
+  return record.operation.entityType === "review_event" && record.operation.action === "append";
+}
+
+function isAcknowledgedPushStatus(status: SyncPushResult["operations"][number]["status"]): boolean {
+  return status === "applied" || status === "ignored" || status === "duplicate";
+}
+
+function isCardHotSyncEntry(entry: HotSyncEntry): entry is CardHotSyncEntry {
+  return entry.entityType === "card";
+}
+
+async function doHotSyncEntriesAffectReviewSchedule(
+  workspaceId: string,
+  entries: ReadonlyArray<HotSyncEntry>,
+): Promise<boolean> {
+  const cardEntries = entries.filter(isCardHotSyncEntry);
+  if (cardEntries.length === 0) {
+    return false;
+  }
+
+  const existingCards = await loadCardsByIds(
+    workspaceId,
+    cardEntries.map((entry) => entry.payload.cardId),
+  );
+
+  return cardEntries.some((entry) => doesCardMutationAffectReviewSchedule(
+    existingCards.get(entry.payload.cardId) ?? null,
+    entry.payload,
+  ));
+}
+
+async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
+  const hotStateHydrated = await hasHydratedHotState(input.workspaceId);
+  input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+  if (hotStateHydrated) {
+    return createEmptyRemoteSyncFlags();
+  }
+
+  let didChangeReviewSchedule = false;
+  let bootstrapCursor: string | null = null;
+
+  while (true) {
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+    const bootstrapResult = await bootstrapPullSyncState(
+      input.workspaceId,
+      input.installationId,
+      "web",
+      webAppVersion,
+      bootstrapCursor,
+      syncPageSize,
+    );
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+
+    if (await doHotSyncEntriesAffectReviewSchedule(input.workspaceId, bootstrapResult.entries)) {
+      didChangeReviewSchedule = true;
+    }
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+
+    await applyHotSyncPage(
+      input.workspaceId,
+      bootstrapResult.entries,
+      bootstrapResult.hasMore
+        ? null
+        : {
+          lastAppliedHotChangeId: bootstrapResult.bootstrapHotChangeId,
+          markHotStateHydrated: true,
+        },
+    );
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+    publishWorkspaceSettingsFromEntries(input, bootstrapResult.entries);
+
+    bootstrapCursor = bootstrapResult.nextCursor;
+    if (bootstrapResult.hasMore === false) {
+      break;
+    }
+  }
+
+  await input.refreshWorkspaceView(input.workspaceId);
+  input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+  return {
+    didChangeProgressHistory: false,
+    didChangeReviewSchedule,
+  };
+}
+
+async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
+  let currentOutbox = await listOutboxRecords(input.workspaceId);
+  input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+  let didChangeProgressHistory = false;
+  let didChangeReviewSchedule = false;
+
+  while (currentOutbox.length > 0) {
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+    const batch = currentOutbox.slice(0, 100);
+    const batchIncludesProgressReviewEvents = batch.some(isProgressReviewEventOperation);
+    const reviewScheduleOperationIds = new Set(
+      batch
+        .filter(isScheduleRelevantCardOutboxRecord)
+        .map((record) => record.operationId),
+    );
+    try {
+      const pushResult = await pushSyncOperations(
+        input.workspaceId,
+        input.installationId,
+        "web",
+        webAppVersion,
+        batch.map((record) => record.operation),
+      );
+      input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+
+      for (const result of pushResult.operations) {
+        if (isAcknowledgedPushStatus(result.status)) {
+          await deleteOutboxRecord(input.workspaceId, result.operationId);
+          if (reviewScheduleOperationIds.has(result.operationId)) {
+            didChangeReviewSchedule = true;
+          }
+        }
+      }
+
+      if (batchIncludesProgressReviewEvents) {
+        didChangeProgressHistory = true;
+      }
+    } catch (error) {
+      const errorMessage = getErrorMessage(error);
+      for (const record of batch) {
+        await putOutboxRecord({
+          ...record,
+          attemptCount: record.attemptCount + 1,
+          lastError: errorMessage,
+        });
+      }
+      throw error;
+    }
+
+    currentOutbox = await listOutboxRecords(input.workspaceId);
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+  }
+
+  return {
+    didChangeProgressHistory,
+    didChangeReviewSchedule,
+  };
+}
+
+async function pullHotChanges(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
+  let afterHotChangeId = await loadLastAppliedHotChangeId(input.workspaceId);
+  input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+  let didChangeReviewSchedule = false;
+
+  while (true) {
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+    const pullResult = await pullSyncChanges(
+      input.workspaceId,
+      input.installationId,
+      "web",
+      webAppVersion,
+      afterHotChangeId,
+      syncPageSize,
+    );
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+
+    if (await doHotSyncEntriesAffectReviewSchedule(input.workspaceId, pullResult.changes)) {
+      didChangeReviewSchedule = true;
+    }
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+
+    await applyHotSyncPage(input.workspaceId, pullResult.changes, {
+      lastAppliedHotChangeId: pullResult.nextHotChangeId,
+      markHotStateHydrated: false,
+    });
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+    publishWorkspaceSettingsFromEntries(input, pullResult.changes);
+
+    afterHotChangeId = pullResult.nextHotChangeId;
+
+    if (pullResult.hasMore === false) {
+      break;
+    }
+  }
+
+  return {
+    didChangeProgressHistory: false,
+    didChangeReviewSchedule,
+  };
+}
+
+async function pullReviewHistory(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
+  let afterReviewSequenceId = await loadLastAppliedReviewSequenceId(input.workspaceId);
+  const reviewHistoryHydrated = await hasHydratedReviewHistory(input.workspaceId);
+  input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+  let didChangeProgressHistory = false;
+
+  while (true) {
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+    const reviewHistoryResult = await pullReviewHistorySync(
+      input.workspaceId,
+      input.installationId,
+      "web",
+      webAppVersion,
+      afterReviewSequenceId,
+      syncPageSize,
+    );
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+
+    await applyReviewHistorySyncPage(input.workspaceId, reviewHistoryResult.reviewEvents, {
+      lastAppliedReviewSequenceId: reviewHistoryResult.nextReviewSequenceId,
+      markReviewHistoryHydrated: reviewHistoryHydrated === false && reviewHistoryResult.hasMore === false,
+    });
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+
+    if (reviewHistoryResult.reviewEvents.length > 0) {
+      didChangeProgressHistory = true;
+    }
+
+    afterReviewSequenceId = reviewHistoryResult.nextReviewSequenceId;
+
+    if (reviewHistoryResult.hasMore === false) {
+      break;
+    }
+  }
+
+  return {
+    didChangeProgressHistory,
+    didChangeReviewSchedule: false,
+  };
+}
+
+export async function runWorkspaceRemoteSync(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
+  let syncFlags = createEmptyRemoteSyncFlags();
+  syncFlags = mergeRemoteSyncFlags(syncFlags, await bootstrapHotState(input));
+  syncFlags = mergeRemoteSyncFlags(syncFlags, await pushOutbox(input));
+  syncFlags = mergeRemoteSyncFlags(syncFlags, await pullHotChanges(input));
+  syncFlags = mergeRemoteSyncFlags(syncFlags, await pullReviewHistory(input));
+  return syncFlags;
+}

--- a/apps/web/src/appData/syncSeed.ts
+++ b/apps/web/src/appData/syncSeed.ts
@@ -1,0 +1,167 @@
+import {
+  hasHydratedHotState,
+  hasHydratedReviewHistory,
+  loadWorkspaceSettings,
+} from "../localDb/workspace";
+import type { WorkspaceSummary } from "../types";
+import type {
+  TestSeedCardInput,
+  TestSeedCardResult,
+  TestSeedRequest,
+  TestSeedResult,
+} from "./testSeedBridge";
+import {
+  createCardLocally,
+  submitReviewLocally,
+} from "./syncLocalMutations";
+
+export type WorkspaceSeedReadiness = Readonly<{
+  workspaceSettingsLoaded: boolean;
+  hotStateHydrated: boolean;
+  reviewHistoryHydrated: boolean;
+}>;
+
+export type EnsureWorkspaceSeedReadyInput = Readonly<{
+  workspace: WorkspaceSummary;
+  waitForWorkspaceSyncToSettle: (workspaceId: string) => Promise<void>;
+  refreshWorkspaceView: (workspaceId: string) => Promise<void>;
+  runSyncForWorkspace: (workspace: WorkspaceSummary) => Promise<void>;
+}>;
+
+export type SeedWorkspaceLocallyInput = Readonly<{
+  workspaceId: string;
+  request: TestSeedRequest;
+}>;
+
+export type SeedWorkspaceLocallyResult = Readonly<{
+  seedResult: TestSeedResult;
+  didChangeProgressHistory: boolean;
+  didChangeReviewSchedule: boolean;
+}>;
+
+function requireSeedTimestamp(label: string, value: string): number {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    throw new Error(`${label} must be a valid ISO timestamp: ${value}`);
+  }
+
+  return timestamp;
+}
+
+function validateSeedCardInput(card: TestSeedCardInput, cardIndex: number): void {
+  const createdAtTimestamp = requireSeedTimestamp(`Seed card ${cardIndex} createdAt`, card.createdAt);
+  let previousTimestamp = createdAtTimestamp;
+
+  for (const [reviewIndex, review] of card.reviews.entries()) {
+    const currentTimestamp = requireSeedTimestamp(
+      `Seed card ${cardIndex} review ${reviewIndex} reviewedAtClient`,
+      review.reviewedAtClient,
+    );
+
+    if (currentTimestamp <= previousTimestamp) {
+      throw new Error(
+        `Seed card ${cardIndex} review ${reviewIndex} reviewedAtClient must be later than the previous mutation timestamp`,
+      );
+    }
+
+    previousTimestamp = currentTimestamp;
+  }
+}
+
+export function validateSeedRequest(request: TestSeedRequest): void {
+  for (const [cardIndex, card] of request.cards.entries()) {
+    validateSeedCardInput(card, cardIndex);
+  }
+}
+
+function isWorkspaceSeedReady(readiness: WorkspaceSeedReadiness): boolean {
+  return readiness.workspaceSettingsLoaded && readiness.hotStateHydrated && readiness.reviewHistoryHydrated;
+}
+
+async function loadWorkspaceSeedReadiness(workspaceId: string): Promise<WorkspaceSeedReadiness> {
+  const [workspaceSettings, hotStateHydrated, reviewHistoryHydrated] = await Promise.all([
+    loadWorkspaceSettings(workspaceId),
+    hasHydratedHotState(workspaceId),
+    hasHydratedReviewHistory(workspaceId),
+  ]);
+
+  return {
+    workspaceSettingsLoaded: workspaceSettings !== null,
+    hotStateHydrated,
+    reviewHistoryHydrated,
+  };
+}
+
+export async function ensureWorkspaceSeedReady(input: EnsureWorkspaceSeedReadyInput): Promise<void> {
+  const workspaceId = input.workspace.workspaceId;
+
+  await input.waitForWorkspaceSyncToSettle(workspaceId);
+
+  let readiness = await loadWorkspaceSeedReadiness(workspaceId);
+  if (isWorkspaceSeedReady(readiness)) {
+    await input.refreshWorkspaceView(workspaceId);
+    return;
+  }
+
+  await input.runSyncForWorkspace(input.workspace);
+  await input.waitForWorkspaceSyncToSettle(workspaceId);
+  await input.refreshWorkspaceView(workspaceId);
+
+  readiness = await loadWorkspaceSeedReadiness(workspaceId);
+  if (isWorkspaceSeedReady(readiness)) {
+    return;
+  }
+
+  throw new Error(
+    `Workspace bootstrap is not ready for deterministic seed data: `
+    + `workspaceId=${workspaceId} `
+    + `workspaceSettingsLoaded=${String(readiness.workspaceSettingsLoaded)} `
+    + `hotStateHydrated=${String(readiness.hotStateHydrated)} `
+    + `reviewHistoryHydrated=${String(readiness.reviewHistoryHydrated)}`,
+  );
+}
+
+export async function seedWorkspaceLocally(input: SeedWorkspaceLocallyInput): Promise<SeedWorkspaceLocallyResult> {
+  validateSeedRequest(input.request);
+
+  const seededCards: Array<TestSeedCardResult> = [];
+  let didChangeProgressHistory = false;
+
+  for (const seedCard of input.request.cards) {
+    let nextCard = (await createCardLocally({
+      workspaceId: input.workspaceId,
+      input: seedCard,
+      clientUpdatedAt: seedCard.createdAt,
+    })).card;
+
+    for (const review of seedCard.reviews) {
+      const reviewResult = await submitReviewLocally({
+        workspaceId: input.workspaceId,
+        cardId: nextCard.cardId,
+        rating: review.rating,
+        reviewedAtClient: review.reviewedAtClient,
+      });
+      nextCard = reviewResult.card;
+      if (reviewResult.didChangeProgressHistory) {
+        didChangeProgressHistory = true;
+      }
+    }
+
+    seededCards.push({
+      cardId: nextCard.cardId,
+      frontText: nextCard.frontText,
+      createdAt: seedCard.createdAt,
+      dueAt: nextCard.dueAt,
+      reviewsApplied: seedCard.reviews.length,
+    });
+  }
+
+  return {
+    seedResult: {
+      workspaceId: input.workspaceId,
+      cards: seededCards,
+    },
+    didChangeProgressHistory,
+    didChangeReviewSchedule: input.request.cards.length > 0,
+  };
+}

--- a/apps/web/src/appData/useSyncEngine.ts
+++ b/apps/web/src/appData/useSyncEngine.ts
@@ -6,43 +6,12 @@ import {
   type SetStateAction,
 } from "react";
 import {
-  ApiContractError,
-  ApiError,
-  bootstrapPullSyncState,
   isAuthRedirectError,
-  pullReviewHistorySync,
-  pullSyncChanges,
-  pushSyncOperations,
 } from "../api";
-import { webAppVersion } from "../clientIdentity";
-import { captureApiContractError } from "../observability/apiContractObservation";
-import {
-  loadCardById,
-  loadCardsByIds,
-  putCard,
-} from "../localDb/cards";
 import {
   loadCloudSettings,
 } from "../localDb/cloudSettings";
 import {
-  loadDeckById,
-  putDeck,
-} from "../localDb/decks";
-import {
-  deleteOutboxRecord,
-  isScheduleRelevantCardOutboxRecord,
-  listOutboxRecords,
-  putOutboxRecord,
-  type PersistedOutboxRecord,
-} from "../localDb/outbox";
-import { putReviewEvent } from "../localDb/reviews";
-import {
-  applyHotSyncPage,
-  applyReviewHistorySyncPage,
-  hasHydratedHotState,
-  hasHydratedReviewHistory,
-  loadLastAppliedHotChangeId,
-  loadLastAppliedReviewSequenceId,
   loadWorkspaceSettings,
 } from "../localDb/workspace";
 import type {
@@ -52,57 +21,54 @@ import type {
   CreateDeckInput,
   Deck,
   SessionInfo,
-  SyncBootstrapEntry,
-  SyncPushResult,
   UpdateCardInput,
   UpdateDeckInput,
   WorkspaceSchedulerSettings,
   WorkspaceSummary,
 } from "../types";
 import {
-  captureWebException,
   normalizeCaughtError,
-  type WebObservationScope,
 } from "../observability/webObservability";
-// Keep local web review scheduling aligned with the backend source of truth and
-// the mirrored native copies:
-// - apps/backend/src/schedule.ts
-// - apps/ios/Flashcards/Flashcards/FsrsScheduler.swift
-// - apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FsrsScheduler.kt
-import { computeReviewSchedule, type ReviewRating } from "../../../backend/src/schedule";
 import {
-  buildCardUpsertOperation,
-  buildDeck,
-  buildDeckUpsertOperation,
-  buildDeletedCard,
-  buildDeletedDeck,
-  buildInitialCard,
-  buildReviewEvent,
-  buildReviewEventAppendOperation,
-  buildReviewedCard,
-  buildUpdatedCard,
-  buildUpdatedDeck,
-  doesCardMutationAffectReviewSchedule,
   getErrorMessage,
-  normalizeCreateCardInput,
-  normalizeCreateDeckInput,
-  normalizeUpdateCardInput,
-  normalizeUpdateDeckInput,
   nowIso,
-  toReviewableCardState,
 } from "./domain";
 import {
   invalidateLocalProgress,
   invalidateLocalReviewSchedule,
   invalidateProgress,
 } from "./progress/progressInvalidation";
-import type { TestSeedCardInput, TestSeedRequest, TestSeedResult } from "./testSeedBridge";
+import {
+  requireCloudInstallationId,
+} from "./syncCloudSettings";
+import {
+  createWorkspaceSyncDiscardedError,
+  isWorkspaceNotFoundError,
+  isWorkspaceSyncDiscardedError,
+  observeSyncFailure,
+} from "./syncErrorObservation";
+import {
+  createCardLocally,
+  createDeckLocally,
+  deleteCardLocally,
+  deleteDeckLocally,
+  requireCard,
+  requireDeck,
+  submitReviewLocally,
+  updateCardLocally,
+  updateDeckLocally,
+} from "./syncLocalMutations";
+import {
+  runWorkspaceRemoteSync,
+} from "./syncRemote";
+import {
+  ensureWorkspaceSeedReady,
+  seedWorkspaceLocally,
+  validateSeedRequest,
+} from "./syncSeed";
+import type { TestSeedRequest, TestSeedResult } from "./testSeedBridge";
 import type { SessionLoadState } from "./types";
 import type { SessionVerificationState } from "./warmStart";
-
-const syncPageSize = 200;
-const workspaceNotFoundErrorCode = "WORKSPACE_NOT_FOUND";
-const workspaceSyncDiscardedErrorName = "WorkspaceSyncDiscardedError";
 
 type UseSyncEngineParams = Readonly<{
   sessionLoadState: SessionLoadState;
@@ -134,266 +100,6 @@ type SyncEngine = Readonly<{
   submitReviewItem: (cardId: string, rating: 0 | 1 | 2 | 3) => Promise<Card>;
   seedLinkedWorkspace: (request: TestSeedRequest) => Promise<TestSeedResult>;
 }>;
-
-type WorkspaceSyncDiscardedError = Error & Readonly<{
-  name: typeof workspaceSyncDiscardedErrorName;
-  workspaceId: string;
-}>;
-
-function createWorkspaceSyncDiscardedError(workspaceId: string): WorkspaceSyncDiscardedError {
-  const error = new Error(`Workspace sync was discarded: ${workspaceId}`);
-  error.name = workspaceSyncDiscardedErrorName;
-  return Object.assign(error, { workspaceId }) as WorkspaceSyncDiscardedError;
-}
-
-async function requireCard(workspaceId: string, cardId: string): Promise<Card> {
-  const card = await loadCardById(workspaceId, cardId);
-  if (card === null) {
-    throw new Error(`Card not found: ${cardId}`);
-  }
-
-  return card;
-}
-
-async function requireDeck(workspaceId: string, deckId: string): Promise<Deck> {
-  const deck = await loadDeckById(workspaceId, deckId);
-  if (deck === null) {
-    throw new Error(`Deck not found: ${deckId}`);
-  }
-
-  return deck;
-}
-
-function requireCloudInstallationId(cloudSettings: CloudSettings | null): string {
-  if (cloudSettings === null) {
-    throw new Error("Cloud settings are not loaded");
-  }
-
-  if (cloudSettings.installationId.trim() === "") {
-    throw new Error("Cloud settings installationId is not loaded");
-  }
-
-  return cloudSettings.installationId;
-}
-
-function findLastWorkspaceSettingsEntry(
-  entries: ReadonlyArray<SyncBootstrapEntry>,
-): WorkspaceSchedulerSettings | null {
-  let lastSettings: WorkspaceSchedulerSettings | null = null;
-
-  for (const entry of entries) {
-    if (entry.entityType === "workspace_scheduler_settings") {
-      lastSettings = entry.payload;
-    }
-  }
-
-  return lastSettings;
-}
-
-function isProgressReviewEventOperation(
-  record: PersistedOutboxRecord,
-): boolean {
-  return record.operation.entityType === "review_event" && record.operation.action === "append";
-}
-
-function isAcknowledgedPushStatus(status: SyncPushResult["operations"][number]["status"]): boolean {
-  return status === "applied" || status === "ignored" || status === "duplicate";
-}
-
-function isWorkspaceSyncDiscardedError(error: unknown): error is WorkspaceSyncDiscardedError {
-  return error instanceof Error
-    && error.name === workspaceSyncDiscardedErrorName
-    && "workspaceId" in error;
-}
-
-function isWorkspaceNotFoundError(error: unknown): error is ApiError {
-  return error instanceof ApiError
-    && error.statusCode === 404
-    && error.code === workspaceNotFoundErrorCode;
-}
-
-function getCurrentRoute(): string | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
-}
-
-function buildSyncObservationScope(
-  error: Error,
-  userId: string,
-  workspaceId: string,
-  installationId: string | null,
-): WebObservationScope {
-  const requestMetadata = error instanceof ApiError || error instanceof ApiContractError
-    ? {
-      requestId: error.requestId,
-      statusCode: error.statusCode,
-      code: error.code,
-    }
-    : {
-      requestId: null,
-      statusCode: null,
-      code: null,
-    };
-
-  return {
-    app: "web",
-    feature: "sync",
-    userId,
-    workspaceId,
-    installationId,
-    route: getCurrentRoute(),
-    requestId: requestMetadata.requestId,
-    statusCode: requestMetadata.statusCode,
-    code: requestMetadata.code,
-  };
-}
-
-function isExpectedSyncProductErrorCode(code: string | null): boolean {
-  switch (code) {
-    case "ACCOUNT_DELETED":
-    case "AUTH_UNAUTHORIZED":
-    case "GUEST_AUTH_INVALID":
-    case "SESSION_CSRF_TOKEN_INVALID":
-    case "SYNC_BOOTSTRAP_NOT_EMPTY":
-    case "SYNC_BOOTSTRAP_REQUIRED":
-    case "SYNC_INVALID_INPUT":
-    case "SYNC_WORKSPACE_FORK_REQUIRED":
-    case "WORKSPACE_NOT_FOUND":
-    case "WORKSPACE_SELECTION_REQUIRED":
-      return true;
-  }
-
-  return false;
-}
-
-function isExpectedSyncValidationError(error: ApiError): boolean {
-  return error.statusCode === 400
-    && error.code === null
-    && error.responseBodyKind === "json";
-}
-
-function shouldCaptureUnexpectedSyncError(error: Error): boolean {
-  if (error instanceof ApiContractError) {
-    return true;
-  }
-
-  if (isAuthRedirectError(error)) {
-    return false;
-  }
-
-  if (error instanceof ApiError) {
-    if (error.statusCode >= 500) {
-      return true;
-    }
-
-    if (isExpectedSyncProductErrorCode(error.code)) {
-      return false;
-    }
-
-    if (error.statusCode === 401) {
-      return false;
-    }
-
-    if (isExpectedSyncValidationError(error)) {
-      return false;
-    }
-
-    if (error.statusCode >= 400 && error.statusCode < 500) {
-      return true;
-    }
-  }
-
-  return true;
-}
-
-function captureUnexpectedSyncError(
-  error: Error,
-  userId: string,
-  workspaceId: string,
-  installationId: string | null,
-): void {
-  if (shouldCaptureUnexpectedSyncError(error) === false) {
-    return;
-  }
-
-  captureWebException({
-    action: "sync_failed",
-    error,
-    scope: buildSyncObservationScope(error, userId, workspaceId, installationId),
-    details: {
-      operation: "sync_workspace_refresh",
-      workspaceId,
-    },
-  });
-}
-
-async function doHotSyncEntriesAffectReviewSchedule(
-  workspaceId: string,
-  entries: ReadonlyArray<SyncBootstrapEntry>,
-): Promise<boolean> {
-  const cardEntries = entries.filter((entry) => entry.entityType === "card");
-  if (cardEntries.length === 0) {
-    return false;
-  }
-
-  const existingCards = await loadCardsByIds(
-    workspaceId,
-    cardEntries.map((entry) => entry.payload.cardId),
-  );
-
-  return cardEntries.some((entry) => doesCardMutationAffectReviewSchedule(
-    existingCards.get(entry.payload.cardId) ?? null,
-    entry.payload,
-  ));
-}
-
-function requireSeedTimestamp(label: string, value: string): number {
-  const timestamp = Date.parse(value);
-  if (Number.isNaN(timestamp)) {
-    throw new Error(`${label} must be a valid ISO timestamp: ${value}`);
-  }
-
-  return timestamp;
-}
-
-function validateSeedCardInput(card: TestSeedCardInput, cardIndex: number): void {
-  const createdAtTimestamp = requireSeedTimestamp(`Seed card ${cardIndex} createdAt`, card.createdAt);
-  let previousTimestamp = createdAtTimestamp;
-
-  for (const [reviewIndex, review] of card.reviews.entries()) {
-    const currentTimestamp = requireSeedTimestamp(
-      `Seed card ${cardIndex} review ${reviewIndex} reviewedAtClient`,
-      review.reviewedAtClient,
-    );
-
-    if (currentTimestamp <= previousTimestamp) {
-      throw new Error(
-        `Seed card ${cardIndex} review ${reviewIndex} reviewedAtClient must be later than the previous mutation timestamp`,
-      );
-    }
-
-    previousTimestamp = currentTimestamp;
-  }
-}
-
-function validateSeedRequest(request: TestSeedRequest): void {
-  for (const [cardIndex, card] of request.cards.entries()) {
-    validateSeedCardInput(card, cardIndex);
-  }
-}
-
-type WorkspaceSeedReadiness = Readonly<{
-  workspaceSettingsLoaded: boolean;
-  hotStateHydrated: boolean;
-  reviewHistoryHydrated: boolean;
-}>;
-
-function isWorkspaceSeedReady(readiness: WorkspaceSeedReadiness): boolean {
-  return readiness.workspaceSettingsLoaded && readiness.hotStateHydrated && readiness.reviewHistoryHydrated;
-}
 
 export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   const {
@@ -471,6 +177,15 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
   }, [bumpLocalReadVersion, isVisibleWorkspace, refreshLocalMetadata]);
 
+  const publishWorkspaceSettings = useCallback(function publishWorkspaceSettings(
+    workspaceId: string,
+    workspaceSettings: WorkspaceSchedulerSettings,
+  ): void {
+    if (isVisibleWorkspace(workspaceId)) {
+      setWorkspaceSettings(workspaceSettings);
+    }
+  }, [isVisibleWorkspace, setWorkspaceSettings]);
+
   const reportGlobalSyncError = useCallback(function reportGlobalSyncError(errorMessage: string): void {
     setErrorMessage(errorMessage);
   }, [setErrorMessage]);
@@ -489,22 +204,6 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
       await activeSync;
     }
-  }, []);
-
-  const loadWorkspaceSeedReadiness = useCallback(async function loadWorkspaceSeedReadiness(
-    workspaceId: string,
-  ): Promise<WorkspaceSeedReadiness> {
-    const [workspaceSettings, hotStateHydrated, reviewHistoryHydrated] = await Promise.all([
-      loadWorkspaceSettings(workspaceId),
-      hasHydratedHotState(workspaceId),
-      hasHydratedReviewHistory(workspaceId),
-    ]);
-
-    return {
-      workspaceSettingsLoaded: workspaceSettings !== null,
-      hotStateHydrated,
-      reviewHistoryHydrated,
-    };
   }, []);
 
   const runSyncForWorkspaceInternal = useCallback(async function runSyncForWorkspaceInternal(
@@ -534,189 +233,25 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     const syncTask = (async (): Promise<void> => {
       let syncInstallationId: string | null = null;
       try {
-        let didChangeProgressHistory = false;
-        let didChangeReviewSchedule = false;
         requireWorkspaceSyncNotDiscarded(workspaceId);
         const cloudSettings = await loadCloudSettings();
         requireWorkspaceSyncNotDiscarded(workspaceId);
         const installationId = requireCloudInstallationId(cloudSettings);
         syncInstallationId = installationId;
-        const hotStateHydrated = await hasHydratedHotState(workspaceId);
-        requireWorkspaceSyncNotDiscarded(workspaceId);
-        if (hotStateHydrated === false) {
-          let bootstrapCursor: string | null = null;
-
-          while (true) {
-            requireWorkspaceSyncNotDiscarded(workspaceId);
-            const bootstrapResult = await bootstrapPullSyncState(
-              workspaceId,
-              installationId,
-              "web",
-              webAppVersion,
-              bootstrapCursor,
-              syncPageSize,
-            );
-            requireWorkspaceSyncNotDiscarded(workspaceId);
-
-            if (await doHotSyncEntriesAffectReviewSchedule(workspaceId, bootstrapResult.entries)) {
-              didChangeReviewSchedule = true;
-            }
-            requireWorkspaceSyncNotDiscarded(workspaceId);
-
-            await applyHotSyncPage(
-              workspaceId,
-              bootstrapResult.entries,
-              bootstrapResult.hasMore
-                ? null
-                : {
-                  lastAppliedHotChangeId: bootstrapResult.bootstrapHotChangeId,
-                  markHotStateHydrated: true,
-                },
-            );
-            requireWorkspaceSyncNotDiscarded(workspaceId);
-
-            if (isVisibleWorkspace(workspaceId)) {
-              const lastSettings = findLastWorkspaceSettingsEntry(bootstrapResult.entries);
-              if (lastSettings !== null) {
-                setWorkspaceSettings(lastSettings);
-              }
-            }
-
-            bootstrapCursor = bootstrapResult.nextCursor;
-            if (bootstrapResult.hasMore === false) {
-              break;
-            }
-          }
-          await refreshWorkspaceView(workspaceId);
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-        }
-
-        let currentOutbox = await listOutboxRecords(workspaceId);
-        requireWorkspaceSyncNotDiscarded(workspaceId);
-        while (currentOutbox.length > 0) {
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-          const batch = currentOutbox.slice(0, 100);
-          const batchIncludesProgressReviewEvents = batch.some(isProgressReviewEventOperation);
-          const reviewScheduleOperationIds = new Set(
-            batch
-              .filter(isScheduleRelevantCardOutboxRecord)
-              .map((record) => record.operationId),
-          );
-          try {
-            const pushResult = await pushSyncOperations(
-              workspaceId,
-              installationId,
-              "web",
-              webAppVersion,
-              batch.map((record) => record.operation),
-            );
-            requireWorkspaceSyncNotDiscarded(workspaceId);
-
-            for (const result of pushResult.operations) {
-              if (isAcknowledgedPushStatus(result.status)) {
-                await deleteOutboxRecord(workspaceId, result.operationId);
-                if (reviewScheduleOperationIds.has(result.operationId)) {
-                  didChangeReviewSchedule = true;
-                }
-              }
-            }
-
-            if (batchIncludesProgressReviewEvents) {
-              didChangeProgressHistory = true;
-            }
-          } catch (error) {
-            const errorMessage = getErrorMessage(error);
-            for (const record of batch) {
-              await putOutboxRecord({
-                ...record,
-                attemptCount: record.attemptCount + 1,
-                lastError: errorMessage,
-              });
-            }
-            throw error;
-          }
-
-          currentOutbox = await listOutboxRecords(workspaceId);
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-        }
-
-        let afterHotChangeId = await loadLastAppliedHotChangeId(workspaceId);
-        requireWorkspaceSyncNotDiscarded(workspaceId);
-        while (true) {
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-          const pullResult = await pullSyncChanges(
-            workspaceId,
-            installationId,
-            "web",
-            webAppVersion,
-            afterHotChangeId,
-            syncPageSize,
-          );
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-
-          if (await doHotSyncEntriesAffectReviewSchedule(workspaceId, pullResult.changes)) {
-            didChangeReviewSchedule = true;
-          }
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-
-          await applyHotSyncPage(workspaceId, pullResult.changes, {
-            lastAppliedHotChangeId: pullResult.nextHotChangeId,
-            markHotStateHydrated: false,
-          });
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-
-          if (isVisibleWorkspace(workspaceId)) {
-            const lastSettings = findLastWorkspaceSettingsEntry(pullResult.changes);
-            if (lastSettings !== null) {
-              setWorkspaceSettings(lastSettings);
-            }
-          }
-
-          afterHotChangeId = pullResult.nextHotChangeId;
-
-          if (pullResult.hasMore === false) {
-            break;
-          }
-        }
-
-        let afterReviewSequenceId = await loadLastAppliedReviewSequenceId(workspaceId);
-        const reviewHistoryHydrated = await hasHydratedReviewHistory(workspaceId);
-        requireWorkspaceSyncNotDiscarded(workspaceId);
-        while (true) {
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-          const reviewHistoryResult = await pullReviewHistorySync(
-            workspaceId,
-            installationId,
-            "web",
-            webAppVersion,
-            afterReviewSequenceId,
-            syncPageSize,
-          );
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-
-          await applyReviewHistorySyncPage(workspaceId, reviewHistoryResult.reviewEvents, {
-            lastAppliedReviewSequenceId: reviewHistoryResult.nextReviewSequenceId,
-            markReviewHistoryHydrated: reviewHistoryHydrated === false && reviewHistoryResult.hasMore === false,
-          });
-          requireWorkspaceSyncNotDiscarded(workspaceId);
-
-          if (reviewHistoryResult.reviewEvents.length > 0) {
-            didChangeProgressHistory = true;
-          }
-
-          afterReviewSequenceId = reviewHistoryResult.nextReviewSequenceId;
-
-          if (reviewHistoryResult.hasMore === false) {
-            break;
-          }
-        }
+        const syncFlags = await runWorkspaceRemoteSync({
+          workspaceId,
+          installationId,
+          requireWorkspaceSyncNotDiscarded,
+          publishWorkspaceSettings,
+          refreshWorkspaceView,
+        });
 
         await refreshWorkspaceView(workspaceId);
         requireWorkspaceSyncNotDiscarded(workspaceId);
-        if (didChangeProgressHistory) {
+        if (syncFlags.didChangeProgressHistory) {
           invalidateProgress();
         }
-        if (didChangeReviewSchedule) {
+        if (syncFlags.didChangeReviewSchedule) {
           invalidateLocalReviewSchedule();
         }
         setErrorMessage("");
@@ -740,21 +275,12 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         }
 
         const normalizedError = normalizeCaughtError(error);
-        captureApiContractError(normalizedError, {
-          feature: "sync",
-          sourceAction: "sync_workspace_refresh",
+        observeSyncFailure({
+          error: normalizedError,
           userId: session.userId,
           workspaceId,
           installationId: syncInstallationId,
         });
-        if (normalizedError instanceof ApiContractError === false) {
-          captureUnexpectedSyncError(
-            normalizedError,
-            session.userId,
-            workspaceId,
-            syncInstallationId,
-          );
-        }
         reportSyncError(getErrorMessage(error));
         throw error;
       } finally {
@@ -773,15 +299,13 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     syncPromisesRef.current.set(workspaceId, syncTask);
     return syncTask;
   }, [
-    isVisibleWorkspace,
+    publishWorkspaceSettings,
     refreshSyncIndicator,
     refreshWorkspaceView,
     requireWorkspaceSyncNotDiscarded,
-    reportGlobalSyncError,
     session,
     sessionVerificationState,
     isStaleWorkspaceNotFoundError,
-    setWorkspaceSettings,
   ]);
 
   const runSyncForWorkspace = useCallback(async function runSyncForWorkspace(
@@ -805,42 +329,6 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     await runSyncForWorkspaceInternal(activeWorkspace, ignoreSyncError);
   }, [activeWorkspace, ignoreSyncError, runSyncForWorkspaceInternal]);
-
-  const ensureWorkspaceSeedReady = useCallback(async function ensureWorkspaceSeedReady(
-    workspace: WorkspaceSummary,
-  ): Promise<void> {
-    const workspaceId = workspace.workspaceId;
-
-    await waitForWorkspaceSyncToSettle(workspaceId);
-
-    let readiness = await loadWorkspaceSeedReadiness(workspaceId);
-    if (isWorkspaceSeedReady(readiness)) {
-      await refreshWorkspaceView(workspaceId);
-      return;
-    }
-
-    await runSyncForWorkspace(workspace);
-    await waitForWorkspaceSyncToSettle(workspaceId);
-    await refreshWorkspaceView(workspaceId);
-
-    readiness = await loadWorkspaceSeedReadiness(workspaceId);
-    if (isWorkspaceSeedReady(readiness)) {
-      return;
-    }
-
-    throw new Error(
-      `Workspace bootstrap is not ready for deterministic seed data: `
-      + `workspaceId=${workspaceId} `
-      + `workspaceSettingsLoaded=${String(readiness.workspaceSettingsLoaded)} `
-      + `hotStateHydrated=${String(readiness.hotStateHydrated)} `
-      + `reviewHistoryHydrated=${String(readiness.reviewHistoryHydrated)}`,
-    );
-  }, [
-    loadWorkspaceSeedReadiness,
-    refreshWorkspaceView,
-    runSyncForWorkspace,
-    waitForWorkspaceSyncToSettle,
-  ]);
 
   useEffect(() => {
     if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null || activeWorkspace === null) {
@@ -879,146 +367,37 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
 
-  const createCardItemLocally = useCallback(async function createCardItemLocally(
-    input: CreateCardInput,
-    clientUpdatedAt: string,
-  ): Promise<Card> {
-    if (activeWorkspaceId === null) {
-      throw new Error("Workspace is unavailable");
-    }
-
-    const normalizedInput = normalizeCreateCardInput(input);
-    const operationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(await loadCloudSettings());
-    const nextCard = buildInitialCard(normalizedInput, clientUpdatedAt, installationId, operationId);
-    const affectsReviewSchedule = doesCardMutationAffectReviewSchedule(null, nextCard);
-    const nextOutboxRecord: PersistedOutboxRecord = {
-      operationId,
-      workspaceId: activeWorkspaceId,
-      createdAt: clientUpdatedAt,
-      attemptCount: 0,
-      lastError: "",
-      affectsReviewSchedule,
-      operation: buildCardUpsertOperation(nextCard),
-    };
-
-    await putCard(activeWorkspaceId, nextCard);
-    await putOutboxRecord(nextOutboxRecord);
-    return nextCard;
-  }, [activeWorkspaceId]);
-
-  const submitReviewItemLocally = useCallback(async function submitReviewItemLocally(
-    cardId: string,
-    rating: 0 | 1 | 2 | 3,
-    reviewedAtClient: string,
-  ): Promise<Card> {
-    if (activeWorkspaceId === null) {
-      throw new Error("Workspace is unavailable");
-    }
-
-    const [existingCard, schedulerSettings, cloudSettings] = await Promise.all([
-      requireCard(activeWorkspaceId, cardId),
-      loadWorkspaceSettings(activeWorkspaceId),
-      loadCloudSettings(),
-    ]);
-    if (schedulerSettings === null) {
-      throw new Error("Workspace scheduler settings are not loaded");
-    }
-
-    const reviewEventId = crypto.randomUUID().toLowerCase();
-    const clientEventId = crypto.randomUUID().toLowerCase();
-    const cardOperationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(cloudSettings);
-    const schedule = computeReviewSchedule(
-      toReviewableCardState(existingCard),
-      {
-        algorithm: schedulerSettings.algorithm,
-        desiredRetention: schedulerSettings.desiredRetention,
-        learningStepsMinutes: schedulerSettings.learningStepsMinutes,
-        relearningStepsMinutes: schedulerSettings.relearningStepsMinutes,
-        maximumIntervalDays: schedulerSettings.maximumIntervalDays,
-        enableFuzz: schedulerSettings.enableFuzz,
-      },
-      rating as ReviewRating,
-      new Date(reviewedAtClient),
-    );
-
-    const nextCard = buildReviewedCard(existingCard, schedule, reviewedAtClient, installationId, cardOperationId);
-    const nextReviewEvent = buildReviewEvent(
-      activeWorkspaceId,
-      cardId,
-      installationId,
-      rating,
-      reviewedAtClient,
-      reviewEventId,
-      clientEventId,
-    );
-
-    const reviewEventOutboxRecord: PersistedOutboxRecord = {
-      operationId: reviewEventId,
-      workspaceId: activeWorkspaceId,
-      createdAt: reviewedAtClient,
-      attemptCount: 0,
-      lastError: "",
-      operation: buildReviewEventAppendOperation(nextReviewEvent),
-    };
-
-    const cardOutboxRecord: PersistedOutboxRecord = {
-      operationId: cardOperationId,
-      workspaceId: activeWorkspaceId,
-      createdAt: reviewedAtClient,
-      attemptCount: 0,
-      lastError: "",
-      affectsReviewSchedule: doesCardMutationAffectReviewSchedule(existingCard, nextCard),
-      operation: buildCardUpsertOperation(nextCard),
-    };
-
-    await putReviewEvent(nextReviewEvent);
-    await putCard(activeWorkspaceId, nextCard);
-    await putOutboxRecord(reviewEventOutboxRecord);
-    await putOutboxRecord(cardOutboxRecord);
-    return nextCard;
-  }, [activeWorkspaceId]);
-
   const createCardItem = useCallback(async function createCardItem(input: CreateCardInput): Promise<Card> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const nextCard = await createCardItemLocally(input, nowIso());
+    const mutationResult = await createCardLocally({
+      workspaceId: activeWorkspaceId,
+      input,
+      clientUpdatedAt: nowIso(),
+    });
     bumpLocalReadVersion();
-    invalidateLocalReviewSchedule();
+    if (mutationResult.didChangeReviewSchedule) {
+      invalidateLocalReviewSchedule();
+    }
     void runSyncForWorkspace(activeWorkspace);
-    return nextCard;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, createCardItemLocally, runSyncForWorkspace]);
+    return mutationResult.card;
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
 
   const createDeckItem = useCallback(async function createDeckItem(input: CreateDeckInput): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const normalizedInput = normalizeCreateDeckInput(input);
-    const clientUpdatedAt = nowIso();
-    const operationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(await loadCloudSettings());
-    const nextDeck = {
-      ...buildDeck(normalizedInput, clientUpdatedAt, installationId, operationId),
+    const mutationResult = await createDeckLocally({
       workspaceId: activeWorkspaceId,
-    };
-    const nextOutboxRecord: PersistedOutboxRecord = {
-      operationId,
-      workspaceId: activeWorkspaceId,
-      createdAt: clientUpdatedAt,
-      attemptCount: 0,
-      lastError: "",
-      operation: buildDeckUpsertOperation(nextDeck),
-    };
-
-    await putDeck(nextDeck);
-    await putOutboxRecord(nextOutboxRecord);
+      input,
+      clientUpdatedAt: nowIso(),
+    });
     bumpLocalReadVersion();
     void runSyncForWorkspace(activeWorkspace);
-    return nextDeck;
+    return mutationResult.deck;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
 
   const updateCardItem = useCallback(async function updateCardItem(cardId: string, input: UpdateCardInput): Promise<Card> {
@@ -1026,31 +405,18 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    const existingCard = await requireCard(activeWorkspaceId, cardId);
-    const normalizedInput = normalizeUpdateCardInput(input);
-    const clientUpdatedAt = nowIso();
-    const operationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(await loadCloudSettings());
-    const nextCard = buildUpdatedCard(existingCard, normalizedInput, clientUpdatedAt, installationId, operationId);
-    const affectsReviewSchedule = doesCardMutationAffectReviewSchedule(existingCard, nextCard);
-    const nextOutboxRecord: PersistedOutboxRecord = {
-      operationId,
+    const mutationResult = await updateCardLocally({
       workspaceId: activeWorkspaceId,
-      createdAt: clientUpdatedAt,
-      attemptCount: 0,
-      lastError: "",
-      affectsReviewSchedule,
-      operation: buildCardUpsertOperation(nextCard),
-    };
-
-    await putCard(activeWorkspaceId, nextCard);
-    await putOutboxRecord(nextOutboxRecord);
+      cardId,
+      input,
+      clientUpdatedAt: nowIso(),
+    });
     bumpLocalReadVersion();
-    if (affectsReviewSchedule) {
+    if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     void runSyncForWorkspace(activeWorkspace);
-    return nextCard;
+    return mutationResult.card;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
 
   const updateDeckItem = useCallback(async function updateDeckItem(deckId: string, input: UpdateDeckInput): Promise<Deck> {
@@ -1058,26 +424,15 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    const existingDeck = await requireDeck(activeWorkspaceId, deckId);
-    const normalizedInput = normalizeUpdateDeckInput(input);
-    const clientUpdatedAt = nowIso();
-    const operationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(await loadCloudSettings());
-    const nextDeck = buildUpdatedDeck(existingDeck, normalizedInput, clientUpdatedAt, installationId, operationId);
-    const nextOutboxRecord: PersistedOutboxRecord = {
-      operationId,
+    const mutationResult = await updateDeckLocally({
       workspaceId: activeWorkspaceId,
-      createdAt: clientUpdatedAt,
-      attemptCount: 0,
-      lastError: "",
-      operation: buildDeckUpsertOperation(nextDeck),
-    };
-
-    await putDeck(nextDeck);
-    await putOutboxRecord(nextOutboxRecord);
+      deckId,
+      input,
+      clientUpdatedAt: nowIso(),
+    });
     bumpLocalReadVersion();
     void runSyncForWorkspace(activeWorkspace);
-    return nextDeck;
+    return mutationResult.deck;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
 
   const deleteCardItem = useCallback(async function deleteCardItem(cardId: string): Promise<Card> {
@@ -1085,30 +440,17 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    const existingCard = await requireCard(activeWorkspaceId, cardId);
-    const clientUpdatedAt = nowIso();
-    const operationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(await loadCloudSettings());
-    const nextCard = buildDeletedCard(existingCard, clientUpdatedAt, installationId, operationId);
-    const affectsReviewSchedule = doesCardMutationAffectReviewSchedule(existingCard, nextCard);
-    const nextOutboxRecord: PersistedOutboxRecord = {
-      operationId,
+    const mutationResult = await deleteCardLocally({
       workspaceId: activeWorkspaceId,
-      createdAt: clientUpdatedAt,
-      attemptCount: 0,
-      lastError: "",
-      affectsReviewSchedule,
-      operation: buildCardUpsertOperation(nextCard),
-    };
-
-    await putCard(activeWorkspaceId, nextCard);
-    await putOutboxRecord(nextOutboxRecord);
+      cardId,
+      clientUpdatedAt: nowIso(),
+    });
     bumpLocalReadVersion();
-    if (affectsReviewSchedule) {
+    if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     void runSyncForWorkspace(activeWorkspace);
-    return nextCard;
+    return mutationResult.card;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
 
   const deleteDeckItem = useCallback(async function deleteDeckItem(deckId: string): Promise<Deck> {
@@ -1116,25 +458,14 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    const existingDeck = await requireDeck(activeWorkspaceId, deckId);
-    const clientUpdatedAt = nowIso();
-    const operationId = crypto.randomUUID().toLowerCase();
-    const installationId = requireCloudInstallationId(await loadCloudSettings());
-    const nextDeck = buildDeletedDeck(existingDeck, clientUpdatedAt, installationId, operationId);
-    const nextOutboxRecord: PersistedOutboxRecord = {
-      operationId,
+    const mutationResult = await deleteDeckLocally({
       workspaceId: activeWorkspaceId,
-      createdAt: clientUpdatedAt,
-      attemptCount: 0,
-      lastError: "",
-      operation: buildDeckUpsertOperation(nextDeck),
-    };
-
-    await putDeck(nextDeck);
-    await putOutboxRecord(nextOutboxRecord);
+      deckId,
+      clientUpdatedAt: nowIso(),
+    });
     bumpLocalReadVersion();
     void runSyncForWorkspace(activeWorkspace);
-    return nextDeck;
+    return mutationResult.deck;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
 
   const submitReviewItem = useCallback(async function submitReviewItem(
@@ -1145,13 +476,18 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    const nextCard = await submitReviewItemLocally(cardId, rating, nowIso());
+    const mutationResult = await submitReviewLocally({
+      workspaceId: activeWorkspaceId,
+      cardId,
+      rating,
+      reviewedAtClient: nowIso(),
+    });
     bumpLocalReadVersion();
     invalidateLocalProgress();
     invalidateLocalReviewSchedule();
     void runSyncForWorkspace(activeWorkspace);
-    return nextCard;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace, submitReviewItemLocally]);
+    return mutationResult.card;
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
 
   const seedLinkedWorkspace = useCallback(async function seedLinkedWorkspace(
     request: TestSeedRequest,
@@ -1167,54 +503,39 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     }
 
     validateSeedRequest(request);
-    await ensureWorkspaceSeedReady(activeWorkspace);
-
-    const seededCards: Array<TestSeedResult["cards"][number]> = [];
-    let didChangeProgressHistory = false;
-
-    for (const seedCard of request.cards) {
-      let nextCard = await createCardItemLocally(seedCard, seedCard.createdAt);
-
-      for (const review of seedCard.reviews) {
-        nextCard = await submitReviewItemLocally(nextCard.cardId, review.rating, review.reviewedAtClient);
-        didChangeProgressHistory = true;
-      }
-
-      seededCards.push({
-        cardId: nextCard.cardId,
-        frontText: nextCard.frontText,
-        createdAt: seedCard.createdAt,
-        dueAt: nextCard.dueAt,
-        reviewsApplied: seedCard.reviews.length,
-      });
-    }
+    await ensureWorkspaceSeedReady({
+      workspace: activeWorkspace,
+      waitForWorkspaceSyncToSettle,
+      refreshWorkspaceView,
+      runSyncForWorkspace,
+    });
+    const seedMutationResult = await seedWorkspaceLocally({
+      workspaceId: activeWorkspaceId,
+      request,
+    });
 
     bumpLocalReadVersion();
-    if (request.cards.length > 0) {
+    if (seedMutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
-    if (didChangeProgressHistory) {
+    if (seedMutationResult.didChangeProgressHistory) {
       invalidateLocalProgress();
     }
 
     await runSyncForWorkspace(activeWorkspace);
     await waitForWorkspaceSyncToSettle(activeWorkspaceId);
 
-    return {
-      workspaceId: activeWorkspaceId,
-      cards: seededCards,
-    };
+    return seedMutationResult.seedResult;
   }, [
     activeWorkspace,
     activeWorkspaceId,
     bumpLocalReadVersion,
-    createCardItemLocally,
+    refreshWorkspaceView,
     runSyncForWorkspace,
     session,
     sessionLoadState,
     sessionVerificationState,
-    ensureWorkspaceSeedReady,
-    submitReviewItemLocally,
+    waitForWorkspaceSyncToSettle,
   ]);
 
   return {


### PR DESCRIPTION
## Summary

- Split `useSyncEngine` internals into focused sync, local mutation, error observation, seed, and cloud settings modules.
- Keep the AppData provider contract and public hook shape unchanged.
- Preserve sync ordering, outbox handling, invalidation behavior, and deterministic seed behavior.

## Validation

- `npm run build` in `apps/web`
- `npm run test` in `apps/web`