### PR TITLE
[codex] refactor chat http routes

### DIFF
--- a/apps/backend/src/chat/http/contract.ts
+++ b/apps/backend/src/chat/http/contract.ts
@@ -1,13 +1,13 @@
 import {
   type ChatComposerSuggestionsLocale,
   normalizeChatComposerSuggestionsUiLocale,
-} from "./composerSuggestions";
-import { HttpError } from "../errors";
+} from "../composerSuggestions";
+import { HttpError } from "../../errors";
 import {
   expectNonEmptyString,
   expectRecord,
   expectUuidString,
-} from "../server/requestParsing";
+} from "../../server/requestParsing";
 
 type ChatTextContentPart = Readonly<{
   type: "text";

--- a/apps/backend/src/chat/http/dependencies.ts
+++ b/apps/backend/src/chat/http/dependencies.ts
@@ -1,27 +1,27 @@
-import type { AuthTransport } from "../auth";
-import { HttpError } from "../errors";
+import type { AuthTransport } from "../../auth";
+import { HttpError } from "../../errors";
 import {
   loadRequestContextFromRequest,
   resolveAccessibleChatWorkspaceId,
   type RequestContext,
   type WorkspaceRequestContext,
-} from "../server/requestContext";
-import { createChatLiveStreamEnvelope } from "./live/auth";
+} from "../../server/requestContext";
+import { createChatLiveStreamEnvelope } from "../live/auth";
 import {
   getRecoveredChatSessionSnapshot,
   getRecoveredPaginatedSession,
   interruptPreparedChatRun,
   prepareChatRun,
   requestChatRunCancellation,
-} from "./runs";
+} from "../runs";
 import {
   createFreshChatSession,
   getChatSessionId,
   listChatMessagesLatest,
   rolloverToFreshChatSession,
-} from "./store";
-import { invokeChatWorkerOrPersistFailure } from "./worker/invoke";
-import { resolveLiveCursor } from "./routeEnvelopes";
+} from "../store";
+import { invokeChatWorkerOrPersistFailure } from "../worker/invoke";
+import { resolveLiveCursor } from "./envelopes";
 
 export type ChatRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;

--- a/apps/backend/src/chat/http/diagnostics.ts
+++ b/apps/backend/src/chat/http/diagnostics.ts
@@ -1,10 +1,10 @@
-import { HttpError } from "../errors";
+import { HttpError } from "../../errors";
 import {
   captureBackendException,
   captureBackendWarning,
   createBackendObservationScope,
   normalizeCaughtError,
-} from "../observability/sentry";
+} from "../../observability/sentry";
 
 export const chatResumeContractViolationCode = "CHAT_LIVE_RESUME_CONTRACT_VIOLATION";
 

--- a/apps/backend/src/chat/http/envelopes.ts
+++ b/apps/backend/src/chat/http/envelopes.ts
@@ -4,28 +4,28 @@ import {
   buildConversationEnvelopeFromSnapshot,
   type ChatAcceptedConversationEnvelope,
   type ChatConversationEnvelope,
-} from "./contract";
+} from "../contract";
 import {
   createChatLiveStreamEnvelope,
   type ChatLiveStreamEnvelope,
-} from "./live/auth";
+} from "../live/auth";
 import {
   interruptPreparedChatRun,
   type PreparedChatRun,
   type RecoveredPaginatedSession,
-} from "./runs";
+} from "../runs";
 import {
   listChatMessagesLatest,
   type ChatSessionSnapshot,
-} from "./store";
-import { HttpError } from "../errors";
-import type { BackendTraceCarrier } from "../observability/sentry";
+} from "../store";
+import { HttpError } from "../../errors";
+import type { BackendTraceCarrier } from "../../observability/sentry";
 import {
   captureUnexpectedChatLiveEnvelopeError,
   createChatResumeContractViolationError,
   logChatResumeContractViolation,
   type ChatResumeDiagnosticsHeaders,
-} from "./routeDiagnostics";
+} from "./diagnostics";
 
 export async function resolveLiveCursor(
   userId: string,

--- a/apps/backend/src/chat/http/errors.ts
+++ b/apps/backend/src/chat/http/errors.ts
@@ -1,9 +1,9 @@
-import { HttpError } from "../errors";
-import { isChatSessionRequestedSessionIdConflictError } from "./errors";
+import { HttpError } from "../../errors";
+import { isChatSessionRequestedSessionIdConflictError } from "../errors";
 import {
   ChatSessionConflictError,
   ChatSessionNotFoundError,
-} from "./store";
+} from "../store";
 
 const chatSessionIdConflictCode = "CHAT_SESSION_ID_CONFLICT";
 

--- a/apps/backend/src/chat/http/handlers.ts
+++ b/apps/backend/src/chat/http/handlers.ts
@@ -1,45 +1,45 @@
 import type { Handler } from "hono";
-import type { AppEnv } from "../app";
+import type { AppEnv } from "../../app";
 import {
   type ChatComposerSuggestionsLocale,
   localizeInitialChatComposerSuggestions,
   type ChatComposerSuggestion,
-} from "./composerSuggestions";
-import { getChatConfig } from "./config";
-import type { ChatStopResponse } from "./contract";
+} from "../composerSuggestions";
+import { getChatConfig } from "../config";
+import type { ChatStopResponse } from "../contract";
 import {
   getBackendTraceCarrier,
   startBackendSpan,
-} from "../observability/sentry";
-import { parseOptionalWorkspaceIdParam } from "../server/requestContext";
-import { parseJsonBody } from "../server/requestParsing";
+} from "../../observability/sentry";
+import { parseOptionalWorkspaceIdParam } from "../../server/requestContext";
+import { parseJsonBody } from "../../server/requestParsing";
 import {
   parseChatPageQuery,
   parseChatRequestBody,
   parseNewChatRequestBody,
   parseOptionalSessionIdQuery,
   parseStopChatRequestBody,
-} from "./routeContract";
+} from "./contract";
 import {
   loadSupportedRequestContext,
   type ChatRouteDependencies,
-} from "./routeDependencies";
+} from "./dependencies";
 import {
   assertRunningSnapshotInvariant,
   buildConversationEnvelopeWithActiveRun,
   buildPaginatedConversationEnvelopeWithActiveRun,
   buildStartConversationEnvelope,
-} from "./routeEnvelopes";
-import { mapStoreError } from "./routeErrors";
-import { readChatResumeDiagnosticsHeaders } from "./routeDiagnostics";
+} from "./envelopes";
+import { mapStoreError } from "./errors";
+import { readChatResumeDiagnosticsHeaders } from "./diagnostics";
 import type {
   ChatRunStopState,
   PreparedChatRun,
-} from "./runs";
+} from "../runs";
 import {
   ChatSessionNotFoundError,
   type ChatSessionSnapshot,
-} from "./store";
+} from "../store";
 
 type ChatNewResponse = Readonly<{
   ok: true;

--- a/apps/backend/src/chat/http/index.ts
+++ b/apps/backend/src/chat/http/index.ts
@@ -1,0 +1,19 @@
+export type {
+  ChatContentPart,
+  ChatRequestBody,
+} from "./contract";
+export {
+  parseChatRequestBody,
+  parseNewChatRequestBody,
+  parseStopChatRequestBody,
+} from "./contract";
+export {
+  createChatRouteDependencies,
+  type ChatRoutesOptions,
+} from "./dependencies";
+export {
+  createGetChatHandler,
+  createPostChatHandler,
+  createPostChatNewHandler,
+  createPostChatStopHandler,
+} from "./handlers";

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -6,25 +6,23 @@ import { Hono } from "hono";
 import type { AppEnv } from "../app";
 import {
   createChatRouteDependencies,
-  type ChatRoutesOptions,
-} from "../chat/routeDependencies";
-import {
   createGetChatHandler,
   createPostChatHandler,
   createPostChatNewHandler,
   createPostChatStopHandler,
-} from "../chat/routeHandlers";
+  type ChatRoutesOptions,
+} from "../chat/http";
 
 export type {
   ChatContentPart,
   ChatRequestBody,
-} from "../chat/routeContract";
+} from "../chat/http";
 
 export {
   parseChatRequestBody,
   parseNewChatRequestBody,
   parseStopChatRequestBody,
-} from "../chat/routeContract";
+} from "../chat/http";
 
 /**
  * Mounts the backend-owned `/chat` routes for history, start, new-session, and stop operations.


### PR DESCRIPTION
## Summary

- Move chat HTTP route internals under apps/backend/src/chat/http with a facade.

- Keep apps/backend/src/routes/chat.ts as the public Hono route mount and stable re-export surface.


## Validation

- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend




