### PR TITLE
[codex] Fix auth failure reporting

### DIFF
--- a/apps/backend/src/observability/reporting.test.ts
+++ b/apps/backend/src/observability/reporting.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import * as Sentry from "@sentry/aws-serverless";
+import { AuthError } from "../auth";
+import { HttpError } from "../errors";
+import { createBackendFailureDetails } from "../server/logging";
 import { captureBackendException } from "./sentry/capture";
 import { normalizeCaughtError } from "./sentry/errorNormalization";
 import { createBackendObservationScope } from "./sentry/scope";
@@ -17,6 +19,97 @@ test("normalizeCaughtError preserves Error and converts non-Error throws", () =>
   const normalized = normalizeCaughtError("string failure");
   assert.equal(normalized.name, "NonErrorThrow");
   assert.equal(normalized.message, "string failure");
+});
+
+test("createBackendFailureDetails maps auth errors to unauthorized failures", () => {
+  const details = createBackendFailureDetails(new AuthError(401, "Invalid token"));
+
+  assert.equal(details.statusCode, 401);
+  assert.equal(details.code, "AUTH_UNAUTHORIZED");
+  assert.equal(details.message, "Invalid token");
+  assert.deepEqual(details.validationIssues, []);
+});
+
+test("backend reporting records auth errors as breadcrumbs", () => {
+  const originalCaptureException = sentryModule.captureException;
+  let captureExceptionCount = 0;
+  sentryModule.captureException = () => {
+    captureExceptionCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const error = new AuthError(401, "Invalid token");
+    const scope = createBackendObservationScope(
+      "backend-api",
+      "request-auth",
+      "/sync/pull",
+      "POST",
+      null,
+      null,
+      null,
+      null,
+      null,
+    );
+    const details = {
+      installationId: null,
+      platform: null,
+      appVersion: null,
+      afterHotChangeId: null,
+      nextHotChangeId: null,
+      changesCount: null,
+      ...createBackendFailureDetails(error),
+    };
+    const breadcrumbMessages = withCapturedConsole("log", () => {
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "sync_pull_error", error, scope, details },
+        { action: "sync_pull_error", scope, details },
+      );
+    });
+
+    assert.equal(captureExceptionCount, 0);
+    assert.equal(JSON.parse(breadcrumbMessages[0] ?? "").action, "sync_pull_error");
+  } finally {
+    sentryModule.captureException = originalCaptureException;
+  }
+});
+
+test("backend reporting keeps non-server http errors as breadcrumbs", () => {
+  const originalCaptureException = sentryModule.captureException;
+  let captureExceptionCount = 0;
+  sentryModule.captureException = () => {
+    captureExceptionCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const error = new HttpError(409, "Select a workspace", "WORKSPACE_SELECTION_REQUIRED");
+    const scope = createBackendObservationScope(
+      "backend-api",
+      "request-http",
+      "/workspaces",
+      "POST",
+      "user-1",
+      null,
+      null,
+      null,
+      null,
+    );
+    const details = createBackendFailureDetails(error);
+    const breadcrumbMessages = withCapturedConsole("log", () => {
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "workspace_create_error", error, scope, details },
+        { action: "workspace_create_error", scope, details },
+      );
+    });
+
+    assert.equal(captureExceptionCount, 0);
+    assert.equal(JSON.parse(breadcrumbMessages[0] ?? "").code, "WORKSPACE_SELECTION_REQUIRED");
+  } finally {
+    sentryModule.captureException = originalCaptureException;
+  }
 });
 
 test("backend reporting does not recapture already captured exceptions", () => {

--- a/apps/backend/src/observability/reporting.ts
+++ b/apps/backend/src/observability/reporting.ts
@@ -1,3 +1,4 @@
+import { AuthError } from "../auth";
 import { HttpError } from "../errors";
 import {
   addBackendBreadcrumb,
@@ -11,7 +12,11 @@ import type {
 
 const reportedBackendExceptionWrappers = new WeakSet<Error>();
 
-function isExpectedHttpError(error: unknown): boolean {
+function isExpectedRequestError(error: unknown): boolean {
+  if (error instanceof AuthError) {
+    return true;
+  }
+
   return error instanceof HttpError && error.statusCode < 500;
 }
 
@@ -29,7 +34,7 @@ export function reportBackendExceptionOrBreadcrumb(
   exceptionEvent: BackendExceptionEvent,
   breadcrumbEvent: BackendBreadcrumbEvent,
 ): void {
-  if (isExpectedHttpError(error)) {
+  if (isExpectedRequestError(error)) {
     addBackendBreadcrumb(breadcrumbEvent);
     return;
   }

--- a/apps/backend/src/routes/cards.ts
+++ b/apps/backend/src/routes/cards.ts
@@ -19,14 +19,11 @@ import {
   expectRecord,
   parseJsonBody,
 } from "../server/requestParsing";
-import {
-  summarizeValidationIssues,
-} from "../server/logging";
+import { createBackendFailureDetails } from "../server/logging";
 import {
   addBackendBreadcrumb,
   createBackendObservationScope,
   normalizeCaughtError,
-  type BackendFailureDetails,
   type BackendObservationScope,
 } from "../observability/sentry";
 import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
@@ -58,10 +55,6 @@ const allowedCardQuerySortKeys: ReadonlyArray<CardQuerySortKey> = [
   "createdAt",
 ];
 
-function getInternalErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 function createCardsScope(
   requestId: string,
   route: string,
@@ -80,15 +73,6 @@ function createCardsScope(
     null,
     null,
   );
-}
-
-function createFailureDetails(error: unknown): BackendFailureDetails {
-  return {
-    statusCode: error instanceof HttpError ? error.statusCode : 500,
-    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-    message: getInternalErrorMessage(error),
-    validationIssues: summarizeValidationIssues(error),
-  };
 }
 
 function expectSortDirection(value: unknown): CardQuerySortDirection {
@@ -167,7 +151,7 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
       const details = {
         tagsCount: null,
         totalCards: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -212,7 +196,7 @@ export function createCardsRoutes(options: CardsRoutesOptions): Hono<AppEnv> {
         resultsCount: null,
         totalCount: null,
         hasMore: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,

--- a/apps/backend/src/routes/guestAuth.ts
+++ b/apps/backend/src/routes/guestAuth.ts
@@ -15,12 +15,11 @@ import {
   expectRecord,
   parseJsonBody,
 } from "../server/requestParsing";
-import { summarizeValidationIssues } from "../server/logging";
+import { createBackendFailureDetails } from "../server/logging";
 import {
   addBackendBreadcrumb,
   createBackendObservationScope,
   normalizeCaughtError,
-  type BackendFailureDetails,
   type BackendObservationScope,
 } from "../observability/sentry";
 import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
@@ -133,15 +132,6 @@ function createGuestUpgradeScope(
   );
 }
 
-function createFailureDetails(error: unknown): BackendFailureDetails {
-  return {
-    statusCode: error instanceof HttpError ? error.statusCode : 500,
-    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-    message: error instanceof Error ? error.message : String(error),
-    validationIssues: summarizeValidationIssues(error),
-  };
-}
-
 export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const authenticateRequestFn = options.authenticateRequestFn ?? authenticateRequest;
@@ -241,7 +231,7 @@ export function createGuestAuthRoutes(options: GuestAuthRoutesOptions = {}): Hon
         targetUserId: auth.userId,
         targetWorkspaceId: null,
         completionKind: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,

--- a/apps/backend/src/routes/sync.ts
+++ b/apps/backend/src/routes/sync.ts
@@ -26,14 +26,13 @@ import {
 } from "../server/requestContext";
 import { parseJsonBody } from "../server/requestParsing";
 import {
-  summarizeValidationIssues,
+  createBackendFailureDetails,
 } from "../server/logging";
 import { withTransientDatabaseRetry } from "../dbTransient";
 import {
   addBackendBreadcrumb,
   createBackendObservationScope,
   normalizeCaughtError,
-  type BackendFailureDetails,
   type BackendObservationScope,
   type BackendSyncConflictDetails,
   type SyncPullDetails,
@@ -64,10 +63,6 @@ type SyncReviewHistoryPullRouteState = Readonly<{
   input: SyncReviewHistoryPullInput;
   result: SyncReviewHistoryPullResult;
 }>;
-
-function getInternalErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
 
 function getRequestContextUserId(requestContext: RequestContext | null): string | null {
   return requestContext === null ? null : requestContext.userId;
@@ -172,15 +167,6 @@ function createSyncScope(
   );
 }
 
-function createFailureDetails(error: unknown): BackendFailureDetails {
-  return {
-    statusCode: error instanceof HttpError ? error.statusCode : 500,
-    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-    message: getInternalErrorMessage(error),
-    validationIssues: summarizeValidationIssues(error),
-  };
-}
-
 export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
@@ -220,7 +206,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         appVersion: input.appVersion ?? null,
         operationsCount: input.operations.length,
         entityTypes,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
         ...getSyncConflictLogContext(error),
       };
       reportBackendExceptionOrBreadcrumb(
@@ -305,7 +291,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         ...getSyncPullInputDetails(input),
         nextHotChangeId: null,
         changesCount: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -344,7 +330,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         platform: input.platform,
         appVersion: input.appVersion ?? null,
         mode: input.mode,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
         ...getSyncConflictLogContext(error),
       };
       reportBackendExceptionOrBreadcrumb(
@@ -429,7 +415,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         ...getSyncReviewHistoryPullInputDetails(input),
         nextReviewSequenceId: null,
         reviewEventsCount: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -472,7 +458,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
         reviewEventsCount: input.reviewEvents.length,
         importedCount: null,
         duplicateCount: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
         ...getSyncConflictLogContext(error),
       };
       reportBackendExceptionOrBreadcrumb(

--- a/apps/backend/src/routes/system.ts
+++ b/apps/backend/src/routes/system.ts
@@ -25,12 +25,11 @@ import {
 } from "../requestSecurity";
 import { expectRecord, parseJsonBody } from "../server/requestParsing";
 import { loadRequestContextFromRequest } from "../server/requestContext";
-import { summarizeValidationIssues } from "../server/logging";
+import { createBackendFailureDetails } from "../server/logging";
 import {
   addBackendBreadcrumb,
   createBackendObservationScope,
   normalizeCaughtError,
-  type BackendFailureDetails,
   type BackendObservationScope,
 } from "../observability/sentry";
 import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
@@ -85,15 +84,6 @@ function createSystemScope(
     null,
     null,
   );
-}
-
-function createFailureDetails(error: unknown): BackendFailureDetails {
-  return {
-    statusCode: error instanceof HttpError ? error.statusCode : 500,
-    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-    message: error instanceof Error ? error.message : String(error),
-    validationIssues: summarizeValidationIssues(error),
-  };
 }
 
 export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
@@ -185,7 +175,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         lastReviewedOn: null,
         activeReviewDays: null,
         generatedAt: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -236,7 +226,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         bucketCount: null,
         totalCards: null,
         generatedAt: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -294,7 +284,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         returnedDayCount: null,
         hasNonZeroReviewDays: null,
         generatedAt: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -352,7 +342,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
       const scope = createSystemScope(requestId, context.req.path, context.req.method, auth.userId);
       const details = {
         transport: auth.transport,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,

--- a/apps/backend/src/routes/workspaces.ts
+++ b/apps/backend/src/routes/workspaces.ts
@@ -45,14 +45,11 @@ import {
   expectRecord,
   parseJsonBody,
 } from "../server/requestParsing";
-import {
-  summarizeValidationIssues,
-} from "../server/logging";
+import { createBackendFailureDetails } from "../server/logging";
 import {
   addBackendBreadcrumb,
   createBackendObservationScope,
   normalizeCaughtError,
-  type BackendFailureDetails,
   type BackendObservationScope,
 } from "../observability/sentry";
 import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
@@ -112,15 +109,6 @@ function createWorkspaceRouteScope(
   );
 }
 
-function createFailureDetails(error: unknown): BackendFailureDetails {
-  return {
-    statusCode: error instanceof HttpError ? error.statusCode : 500,
-    code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
-    message: error instanceof Error ? error.message : String(error),
-    validationIssues: summarizeValidationIssues(error),
-  };
-}
-
 export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
 
@@ -170,7 +158,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
         workspacesCount: null,
         limit: pageInput.limit,
         hasNextCursor: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -211,7 +199,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     } catch (error) {
       const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null);
       const details = {
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -249,7 +237,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     } catch (error) {
       const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
       const details = {
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -286,7 +274,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
     } catch (error) {
       const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
       const details = {
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -323,7 +311,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
       const details = {
         cardsCount: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -372,7 +360,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       const details = {
         deletedCardsCount: null,
         nextWorkspaceId: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -409,7 +397,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
       const details = {
         cardsCount: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,
@@ -456,7 +444,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
       const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
       const details = {
         cardsResetCount: null,
-        ...createFailureDetails(error),
+        ...createBackendFailureDetails(error),
       };
       reportBackendExceptionOrBreadcrumb(
         error,

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -9,6 +9,7 @@ import {
   type AdminQueryDetails,
   type BackendObservationScope,
   type BackendErrorLogDetails,
+  type BackendFailureDetails,
   type RequestErrorDetails,
 } from "../observability/sentry";
 
@@ -80,12 +81,18 @@ function getRequestErrorCode(error: AuthError | HttpError | unknown): string | n
   return "INTERNAL_ERROR";
 }
 
-function createRequestErrorDetails(error: AuthError | HttpError | unknown): RequestErrorDetails {
+export function createBackendFailureDetails(error: AuthError | HttpError | unknown): BackendFailureDetails {
   return {
     statusCode: getRequestErrorStatusCode(error),
     code: getRequestErrorCode(error),
     message: getInternalErrorMessage(error),
     validationIssues: summarizeValidationIssues(error),
+  };
+}
+
+function createRequestErrorDetails(error: AuthError | HttpError | unknown): RequestErrorDetails {
+  return {
+    ...createBackendFailureDetails(error),
     sqlState: getDatabaseSqlState(error),
     ...getErrorLogContext(error),
   };


### PR DESCRIPTION
## Summary
- classify backend AuthError route failures as expected breadcrumbs instead of Sentry exceptions
- reuse shared backend failure detail mapping across route telemetry
- add reporting tests for AuthError and non-server HttpError paths

## Validation
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend