### PR TITLE
Handle Sentry test environments and auth JWKS backoff

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/FlashcardsAndroidTestRunner.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/FlashcardsAndroidTestRunner.kt
@@ -1,13 +1,31 @@
 package com.flashcardsopensourceapp.app
 
+import android.app.Application
+import android.content.Context
 import android.os.Bundle
 import androidx.test.runner.AndroidJUnitRunner
+import com.flashcardsopensourceapp.app.observability.androidSentryEnvironmentOverrideArgumentKey
+import com.flashcardsopensourceapp.app.observability.setAndroidSentryEnvironmentOverride
+import com.flashcardsopensourceapp.app.observability.setDefaultAndroidSentryEnvironmentOverride
 
 private const val includeManualOnlyArgumentKey: String = "includeManualOnly"
+private const val defaultInstrumentationSentryEnvironment: String = "ci-instrumentation"
 
 class FlashcardsAndroidTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(
+        cl: ClassLoader,
+        className: String,
+        context: Context
+    ): Application {
+        setDefaultAndroidSentryEnvironmentOverride(environment = defaultInstrumentationSentryEnvironment)
+        return super.newApplication(cl, className, context)
+    }
+
     override fun onCreate(arguments: Bundle) {
         val runnerArguments = Bundle(arguments)
+        val sentryEnvironmentOverride = sentryEnvironmentOverride(arguments = runnerArguments)
+        setAndroidSentryEnvironmentOverride(environment = sentryEnvironmentOverride)
+        runnerArguments.putString(androidSentryEnvironmentOverrideArgumentKey, sentryEnvironmentOverride)
         val includeManualOnly = runnerArguments
             .getString(includeManualOnlyArgumentKey)
             ?.toBooleanStrictOrNull()
@@ -26,4 +44,12 @@ class FlashcardsAndroidTestRunner : AndroidJUnitRunner() {
 
         super.onCreate(runnerArguments)
     }
+}
+
+private fun sentryEnvironmentOverride(arguments: Bundle): String {
+    return arguments
+        .getString(androidSentryEnvironmentOverrideArgumentKey)
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+        ?: defaultInstrumentationSentryEnvironment
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidObservabilityStartup.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidObservabilityStartup.kt
@@ -84,6 +84,11 @@ private fun configureSentryOptions(
 }
 
 private fun sentryEnvironment(): String {
+    val overrideEnvironment = androidSentryEnvironmentOverride()
+    if (overrideEnvironment != null) {
+        return overrideEnvironment
+    }
+
     val configuredEnvironment = BuildConfig.ANDROID_SENTRY_ENVIRONMENT.trim()
     if (configuredEnvironment.isNotEmpty()) {
         return configuredEnvironment

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidSentryEnvironmentOverride.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidSentryEnvironmentOverride.kt
@@ -1,0 +1,20 @@
+package com.flashcardsopensourceapp.app.observability
+
+const val androidSentryEnvironmentOverrideArgumentKey: String = "flashcardsSentryEnvironmentOverride"
+
+@Volatile
+private var androidSentryEnvironmentOverrideValue: String? = null
+
+fun setAndroidSentryEnvironmentOverride(environment: String?) {
+    androidSentryEnvironmentOverrideValue = environment?.trim()?.takeIf(String::isNotEmpty)
+}
+
+fun setDefaultAndroidSentryEnvironmentOverride(environment: String) {
+    if (androidSentryEnvironmentOverrideValue == null) {
+        setAndroidSentryEnvironmentOverride(environment = environment)
+    }
+}
+
+internal fun androidSentryEnvironmentOverride(): String? {
+    return androidSentryEnvironmentOverrideValue
+}

--- a/apps/backend/src/app.test.ts
+++ b/apps/backend/src/app.test.ts
@@ -5,6 +5,10 @@ import {
   createAgentInstructions,
   getHttpErrorResponseHeaders,
 } from "./app";
+import {
+  authVerificationRetryAfterSeconds,
+  authVerificationTemporarilyUnavailableCode,
+} from "./auth";
 import { resetAuthConfigForTests } from "./authConfig";
 import { HttpError } from "./errors";
 import { resetGuestAiQuotaConfigForTests } from "./guestAiQuotaConfig";
@@ -56,10 +60,30 @@ test("getHttpErrorResponseHeaders adds Retry-After for service unavailable", () 
   );
 });
 
+test("getHttpErrorResponseHeaders adds Retry-After for temporary auth verification failures", () => {
+  assert.deepEqual(
+    getHttpErrorResponseHeaders(
+      new HttpError(
+        503,
+        "Authentication verification is temporarily unavailable. Retry shortly.",
+        authVerificationTemporarilyUnavailableCode,
+      ),
+    ),
+    [["Retry-After", authVerificationRetryAfterSeconds.toString()]],
+  );
+});
+
 test("createAgentInstructions tells API-key agents to honor Retry-After on service unavailable", () => {
   assert.equal(
     createAgentInstructions("SERVICE_UNAVAILABLE", 503),
     "Retry the same request after the Retry-After delay. If it fails again, treat it as a server-side error and stop changing the request. Use requestId when debugging.",
+  );
+});
+
+test("createAgentInstructions tells agents to retry temporary auth verification failures", () => {
+  assert.equal(
+    createAgentInstructions(authVerificationTemporarilyUnavailableCode, 503),
+    "Retry the same authenticated request after the Retry-After delay without changing the token. If it keeps failing, sign in again and use requestId when debugging.",
   );
 });
 
@@ -96,6 +120,35 @@ test("app error handler returns Retry-After for service unavailable responses", 
   assert.equal(response.headers.get("retry-after"), "1");
   assert.equal(payload.error, "Service is temporarily unavailable. Retry shortly.");
   assert.equal(payload.code, "SERVICE_UNAVAILABLE");
+  assert.notEqual(payload.requestId, "");
+});
+
+test("app error handler returns Retry-After for temporary auth verification failures", async () => {
+  process.env.AUTH_MODE = "none";
+  process.env.ALLOW_INSECURE_LOCAL_AUTH = "true";
+  resetAuthConfigForTests();
+  resetGuestAiQuotaConfigForTests();
+
+  const app = createApp("/v1");
+  app.get("/auth-verification-temporary-error", () => {
+    throw new HttpError(
+      503,
+      "Authentication verification is temporarily unavailable. Retry shortly.",
+      authVerificationTemporarilyUnavailableCode,
+    );
+  });
+
+  const response = await app.request("http://localhost/v1/auth-verification-temporary-error");
+  const payload = await response.json() as Readonly<{
+    error: string;
+    code: string | null;
+    requestId: string;
+  }>;
+
+  assert.equal(response.status, 503);
+  assert.equal(response.headers.get("retry-after"), authVerificationRetryAfterSeconds.toString());
+  assert.equal(payload.error, "Authentication verification is temporarily unavailable. Retry shortly.");
+  assert.equal(payload.code, authVerificationTemporarilyUnavailableCode);
   assert.notEqual(payload.requestId, "");
 });
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -2,7 +2,11 @@ import { cors } from "hono/cors";
 import { Hono } from "hono";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { AuthError } from "./auth";
+import {
+  AuthError,
+  authVerificationRetryAfterSeconds,
+  authVerificationTemporarilyUnavailableCode,
+} from "./auth";
 import { getAuthConfig } from "./authConfig";
 import { createPublicHttpErrorDetails, HttpError, type PublicHttpErrorDetails } from "./errors";
 import { createChatRoutes } from "./routes/chat";
@@ -91,6 +95,8 @@ export function createAgentInstructions(code: string | null, statusCode: number)
   switch (code) {
     case "SERVICE_UNAVAILABLE":
       return "Retry the same request after the Retry-After delay. If it fails again, treat it as a server-side error and stop changing the request. Use requestId when debugging.";
+    case authVerificationTemporarilyUnavailableCode:
+      return "Retry the same authenticated request after the Retry-After delay without changing the token. If it keeps failing, sign in again and use requestId when debugging.";
     case "AUTH_UNAUTHORIZED":
     case "AGENT_API_KEY_INVALID":
       return "Use a valid non-revoked API key in the Authorization header as: ApiKey $FLASHCARDS_OPEN_SOURCE_API_KEY after exporting it once. If needed, restart from GET /v1/agent.";
@@ -124,6 +130,10 @@ export function createAgentInstructions(code: string | null, statusCode: number)
 export function getHttpErrorResponseHeaders(error: HttpError): ReadonlyArray<readonly [string, string]> {
   if (error.statusCode === 503 && error.code === "SERVICE_UNAVAILABLE") {
     return [["Retry-After", "1"]];
+  }
+
+  if (error.statusCode === 503 && error.code === authVerificationTemporarilyUnavailableCode) {
+    return [["Retry-After", authVerificationRetryAfterSeconds.toString()]];
   }
 
   return [];
@@ -168,6 +178,10 @@ function shouldCaptureRequestFailureException(error: unknown): boolean {
   }
 
   if (error instanceof HttpError) {
+    if (error.code === authVerificationTemporarilyUnavailableCode) {
+      return false;
+    }
+
     if (error.code === "CHAT_LIVE_RESUME_CONTRACT_VIOLATION") {
       return false;
     }

--- a/apps/backend/src/auth.test.ts
+++ b/apps/backend/src/auth.test.ts
@@ -1,26 +1,49 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { FetchError, JwksValidationError, JwtExpiredError, JwtInvalidSignatureError, KidNotFoundInJwksError } from "aws-jwt-verify/error";
+import {
+  FetchError,
+  JwksValidationError,
+  JwtExpiredError,
+  JwtInvalidSignatureError,
+  KidNotFoundInJwksError,
+  WaitPeriodNotYetEndedJwkError,
+} from "aws-jwt-verify/error";
 import { Hono } from "hono";
 import { type ContentfulStatusCode } from "hono/utils/http-status";
-import { isTerminalJwtAuthFailure, AuthError } from "./auth.js";
+import {
+  authVerificationTemporarilyUnavailableCode,
+  createJwtAuthBoundaryError,
+  isTerminalJwtAuthFailure,
+  AuthError,
+} from "./auth.js";
 import { HttpError } from "./errors.js";
 import type { AppEnv } from "./app.js";
 import { createSystemRoutes } from "./routes/system.js";
 
-test("isTerminalJwtAuthFailure returns true for expired and invalid-signature tokens", () => {
+test("isTerminalJwtAuthFailure returns true for invalid client tokens", () => {
   assert.equal(isTerminalJwtAuthFailure(new JwtExpiredError("expired", "exp", "now")), true);
   assert.equal(isTerminalJwtAuthFailure(new JwtInvalidSignatureError("invalid signature")), true);
+  assert.equal(isTerminalJwtAuthFailure(new KidNotFoundInJwksError("kid missing")), true);
 });
 
-test("isTerminalJwtAuthFailure returns false for JWKS and transport failures", () => {
+test("isTerminalJwtAuthFailure returns false for JWKS fetch and validation failures", () => {
   assert.equal(isTerminalJwtAuthFailure(new FetchError("https://example.com/jwks", "network down")), false);
-  assert.equal(isTerminalJwtAuthFailure(new KidNotFoundInJwksError("kid missing")), false);
   assert.equal(isTerminalJwtAuthFailure(new JwksValidationError("jwks invalid")), false);
+  assert.equal(isTerminalJwtAuthFailure(new WaitPeriodNotYetEndedJwkError("jwks wait period active")), false);
 });
 
 test("isTerminalJwtAuthFailure returns false for unknown errors", () => {
   assert.equal(isTerminalJwtAuthFailure(new Error("unexpected verifier failure")), false);
+});
+
+test("createJwtAuthBoundaryError returns retryable 503 for JWKS backoff", () => {
+  const error = createJwtAuthBoundaryError(
+    new WaitPeriodNotYetEndedJwkError("jwks wait period active"),
+  );
+
+  assert.ok(error instanceof HttpError);
+  assert.equal(error.statusCode, 503);
+  assert.equal(error.code, authVerificationTemporarilyUnavailableCode);
 });
 
 test("GET /me returns 500 when session verification fails with a non-terminal verifier error", async () => {

--- a/apps/backend/src/auth.ts
+++ b/apps/backend/src/auth.ts
@@ -2,18 +2,24 @@ import { CognitoJwtVerifier } from "aws-jwt-verify";
 import {
   CognitoJwtInvalidClientIdError,
   CognitoJwtInvalidTokenUseError,
+  KidNotFoundInJwksError,
   JwtInvalidClaimError,
   JwtInvalidSignatureAlgorithmError,
   JwtInvalidSignatureError,
   JwtParseError,
   JwtWithoutValidKidError,
+  WaitPeriodNotYetEndedJwkError,
 } from "aws-jwt-verify/error";
 import { authenticateAgentApiKey } from "./agent/apiKeys";
 import { getAuthConfig } from "./authConfig";
 import { unsafeQuery } from "./dbUnsafe";
+import { HttpError } from "./errors";
 import { authenticateGuestSession } from "./guestAuth";
 
 export type AuthTransport = "none" | "bearer" | "session" | "api_key" | "guest";
+
+export const authVerificationTemporarilyUnavailableCode = "AUTH_VERIFICATION_TEMPORARILY_UNAVAILABLE";
+export const authVerificationRetryAfterSeconds = 10;
 
 export type AuthResult = Readonly<{
   userId: string;
@@ -49,7 +55,25 @@ export function isTerminalJwtAuthFailure(error: unknown): boolean {
     || error instanceof JwtInvalidClaimError
     || error instanceof CognitoJwtInvalidTokenUseError
     || error instanceof CognitoJwtInvalidClientIdError
-    || error instanceof JwtWithoutValidKidError;
+    || error instanceof JwtWithoutValidKidError
+    || error instanceof KidNotFoundInJwksError;
+}
+
+export function createJwtAuthBoundaryError(error: unknown): AuthError | HttpError | null {
+  if (isTerminalJwtAuthFailure(error)) {
+    const message = error instanceof Error ? error.message : String(error);
+    return new AuthError(401, `Invalid token: ${message}`);
+  }
+
+  if (error instanceof WaitPeriodNotYetEndedJwkError) {
+    return new HttpError(
+      503,
+      "Authentication verification is temporarily unavailable. Retry shortly.",
+      authVerificationTemporarilyUnavailableCode,
+    );
+  }
+
+  return null;
 }
 
 let verifier: ReturnType<typeof CognitoJwtVerifier.create> | undefined;
@@ -139,9 +163,9 @@ async function verifyIdToken(token: string): Promise<AuthenticatedUserIdentity> 
     const payload = await getVerifier().verify(token);
     return extractVerifiedIdTokenIdentity(payload as VerifiedIdTokenPayload);
   } catch (err) {
-    if (isTerminalJwtAuthFailure(err)) {
-      const message = err instanceof Error ? err.message : String(err);
-      throw new AuthError(401, `Invalid token: ${message}`);
+    const boundaryError = createJwtAuthBoundaryError(err);
+    if (boundaryError !== null) {
+      throw boundaryError;
     }
 
     throw err;

--- a/apps/backend/src/observability/reporting.test.ts
+++ b/apps/backend/src/observability/reporting.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import * as Sentry from "@sentry/aws-serverless";
+import { authVerificationTemporarilyUnavailableCode } from "../auth";
+import { HttpError } from "../errors";
 import { captureBackendException } from "./sentry/capture";
 import { normalizeCaughtError } from "./sentry/errorNormalization";
 import { createBackendObservationScope } from "./sentry/scope";
@@ -148,6 +150,79 @@ test("backend reporting recognizes repeated normalized non-Error throws", () => 
 
     assert.equal(appDetectedPreviousReport, true);
     assert.equal(captureExceptionCount, 1);
+  } finally {
+    sentryModule.captureException = originalCaptureException;
+  }
+});
+
+test("backend reporting treats temporary auth verification failures as expected", () => {
+  const originalCaptureException = sentryModule.captureException;
+  let captureExceptionCount = 0;
+  sentryModule.captureException = () => {
+    captureExceptionCount += 1;
+    return "event-id";
+  };
+
+  try {
+    const error = new HttpError(
+      503,
+      "Authentication verification is temporarily unavailable. Retry shortly.",
+      authVerificationTemporarilyUnavailableCode,
+    );
+    const scope = createBackendObservationScope(
+      "backend-api",
+      "request-3",
+      "/workspaces/workspace-1/sync/pull",
+      "POST",
+      "user-3",
+      "workspace-1",
+      null,
+      null,
+      null,
+    );
+    const event = {
+      action: "sync_pull_error",
+      error,
+      scope,
+      details: {
+        statusCode: 503,
+        installationId: null,
+        platform: null,
+        appVersion: null,
+        afterHotChangeId: null,
+        nextHotChangeId: null,
+        changesCount: null,
+        code: authVerificationTemporarilyUnavailableCode,
+        message: error.message,
+        validationIssues: [],
+      },
+    } as const;
+
+    const breadcrumbMessages = withCapturedConsole("log", () => {
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        event,
+        {
+          action: "sync_pull_error",
+          scope,
+          details: {
+            statusCode: 503,
+            installationId: null,
+            platform: null,
+            appVersion: null,
+            afterHotChangeId: null,
+            nextHotChangeId: null,
+            changesCount: null,
+            code: authVerificationTemporarilyUnavailableCode,
+            message: error.message,
+            validationIssues: [],
+          },
+        },
+      );
+    });
+
+    assert.equal(captureExceptionCount, 0);
+    assert.equal(JSON.parse(breadcrumbMessages[0] ?? "").action, "sync_pull_error");
   } finally {
     sentryModule.captureException = originalCaptureException;
   }

--- a/apps/backend/src/observability/reporting.ts
+++ b/apps/backend/src/observability/reporting.ts
@@ -1,3 +1,4 @@
+import { authVerificationTemporarilyUnavailableCode } from "../auth";
 import { HttpError } from "../errors";
 import {
   addBackendBreadcrumb,
@@ -12,7 +13,11 @@ import type {
 const reportedBackendExceptionWrappers = new WeakSet<Error>();
 
 function isExpectedHttpError(error: unknown): boolean {
-  return error instanceof HttpError && error.statusCode < 500;
+  if (error instanceof HttpError === false) {
+    return false;
+  }
+
+  return error.statusCode < 500 || error.code === authVerificationTemporarilyUnavailableCode;
 }
 
 export function markBackendExceptionWrapperAsReported(error: Error): Error {

--- a/apps/backend/src/server/logging.ts
+++ b/apps/backend/src/server/logging.ts
@@ -1,4 +1,4 @@
-import { AuthError } from "../auth";
+import { AuthError, authVerificationTemporarilyUnavailableCode } from "../auth";
 import { HttpError } from "../errors";
 import { sanitizeBackendTelemetryValue } from "../observability/sanitizer";
 import {
@@ -54,6 +54,10 @@ function shouldLogRequestErrorAtErrorLevel(error: AuthError | HttpError | unknow
   }
 
   if (error instanceof HttpError) {
+    if (error.code === authVerificationTemporarilyUnavailableCode) {
+      return false;
+    }
+
     return error.statusCode >= 500;
   }
 

--- a/apps/ios/Flashcards/Flashcards/ObservabilitySupport.swift
+++ b/apps/ios/Flashcards/Flashcards/ObservabilitySupport.swift
@@ -358,7 +358,8 @@ private enum SentryObservabilityAdapter {
 
     static func configure(bundle: Bundle, processInfo: ProcessInfo) {
         let configuration: SentryRuntimeConfiguration = loadSentryRuntimeConfiguration(
-            bundle: bundle
+            bundle: bundle,
+            processInfo: processInfo
         )
         if let invalidTracesSampleRate: String = configuration.invalidTracesSampleRate {
             self.writeLocalRecord(
@@ -424,7 +425,6 @@ private enum SentryObservabilityAdapter {
                 "tracesSampleRate": String(configuration.tracesSampleRate)
             ]
         )
-        _ = processInfo
     }
 
     static func setIdentity(_ identity: ObservabilityIdentity?) {
@@ -1186,6 +1186,8 @@ private struct ExceptionPayload {
 
 private let filteredDiagnosticValue: String = "[Filtered]"
 private let sanitizedNSErrorFallbackDomain: String = "FlashcardsObservabilitySanitizedError"
+private let sentryEnvironmentInfoPlistKey: String = "FLASHCARDS_SENTRY_ENVIRONMENT"
+private let sentryEnvironmentOverrideKey: String = "FLASHCARDS_SENTRY_ENVIRONMENT_OVERRIDE"
 
 private func appSpecificObservabilityHash(_ value: String, namespace: String) -> String {
     let hashInput: String = "\(appBundleIdentifier()):observability:\(namespace):\(value)"
@@ -1258,18 +1260,12 @@ private func safeDiagnosticIdentifier(_ value: String) -> String {
     return trimmedValue
 }
 
-private func loadSentryRuntimeConfiguration(bundle: Bundle) -> SentryRuntimeConfiguration {
+private func loadSentryRuntimeConfiguration(bundle: Bundle, processInfo: ProcessInfo) -> SentryRuntimeConfiguration {
     let dsn: String = loadOptionalInfoPlistString(
         bundle: bundle,
         key: "FLASHCARDS_SENTRY_DSN"
     )
-    let environment: String = nonEmptyString(
-        loadOptionalInfoPlistString(
-            bundle: bundle,
-            key: "FLASHCARDS_SENTRY_ENVIRONMENT"
-        ),
-        fallback: "local"
-    )
+    let environment: String = loadSentryEnvironment(bundle: bundle, processInfo: processInfo)
     let rawTracesSampleRate: String = nonEmptyString(
         loadOptionalInfoPlistString(
             bundle: bundle,
@@ -1300,6 +1296,24 @@ private func loadSentryRuntimeConfiguration(bundle: Bundle) -> SentryRuntimeConf
         marketingVersion: marketingVersion,
         buildNumber: buildNumber,
         tracePropagationTargets: makeTracePropagationTargets(bundle: bundle)
+    )
+}
+
+private func loadSentryEnvironment(bundle: Bundle, processInfo: ProcessInfo) -> String {
+    let overrideValue: String = nonEmptyString(
+        processInfo.environment[sentryEnvironmentOverrideKey] ?? "",
+        fallback: ""
+    )
+    if overrideValue.isEmpty == false {
+        return overrideValue
+    }
+
+    return nonEmptyString(
+        loadOptionalInfoPlistString(
+            bundle: bundle,
+            key: sentryEnvironmentInfoPlistKey
+        ),
+        fallback: "local"
     )
 }
 

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeConfiguration.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeConfiguration.swift
@@ -9,6 +9,9 @@ enum LiveSmokeConfiguration {
     static let reviewInitialProbeTimeoutSeconds: TimeInterval = 15
     static let reviewInteractionTimeoutSeconds: TimeInterval = 10
     static let reviewEmailEnvironmentKey: String = "FLASHCARDS_LIVE_REVIEW_EMAIL"
+    static let sentryEnvironmentOverrideKey: String = "FLASHCARDS_SENTRY_ENVIRONMENT_OVERRIDE"
+    static let liveSmokeSentryEnvironmentOverrideValue: String = "ci-simulator"
+    static let marketingScreenshotSentryEnvironmentOverrideValue: String = "marketing-screenshot-simulator"
     static let launchScenarioEnvironmentKey: String = "FLASHCARDS_UI_TEST_LAUNCH_SCENARIO"
     static let selectedTabEnvironmentKey: String = "FLASHCARDS_UI_TEST_SELECTED_TAB"
     static let appNotificationTapTypeEnvironmentKey: String = "FLASHCARDS_UI_TEST_APP_NOTIFICATION_TAP_TYPE"

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeLaunching.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/LiveSmokeLaunching.swift
@@ -267,6 +267,8 @@ extension LiveSmokeTestCase {
         self.currentLaunchLocalization = request.launchLocalization
         self.app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.launchScenarioEnvironmentKey)
         self.app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.appNotificationTapTypeEnvironmentKey)
+        self.app.launchEnvironment[LiveSmokeConfiguration.sentryEnvironmentOverrideKey] =
+            LiveSmokeConfiguration.liveSmokeSentryEnvironmentOverrideValue
         self.app.launchEnvironment[LiveSmokeConfiguration.selectedTabEnvironmentKey] = request.selectedTab.rawValue
         self.app.launchArguments = self.strippingAppleLocalizationLaunchArguments(
             arguments: self.app.launchArguments

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
@@ -384,6 +384,8 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
         app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.launchScenarioEnvironmentKey)
         app.launchEnvironment.removeValue(forKey: LiveSmokeConfiguration.appNotificationTapTypeEnvironmentKey)
         app.launchEnvironment.removeValue(forKey: MarketingScreenshotEnvironment.aiHandoffCardKey)
+        app.launchEnvironment[LiveSmokeConfiguration.sentryEnvironmentOverrideKey] =
+            LiveSmokeConfiguration.marketingScreenshotSentryEnvironmentOverrideValue
         app.launchEnvironment[LiveSmokeConfiguration.selectedTabEnvironmentKey] = selectedTab.rawValue
         app.launchEnvironment[LiveSmokeConfiguration.launchScenarioEnvironmentKey] = launchScenario.rawValue
         app.launchEnvironment[MarketingScreenshotEnvironment.localizationKey] = localeFixture.localizationCode

--- a/scripts/capture-android-marketing-screenshots.sh
+++ b/scripts/capture-android-marketing-screenshots.sh
@@ -7,6 +7,7 @@ android_dir="$repo_root/apps/android"
 locale_prefix="${FLASHCARDS_MARKETING_LOCALE_PREFIX:-en}"
 script_class="com.flashcardsopensourceapp.app.marketing.screenshots.MarketingAllScreenshotsScript"
 cleanup_script_class="com.flashcardsopensourceapp.app.marketing.screenshots.MarketingScreenshotGuestCleanupScript"
+sentry_environment_override="marketing-screenshot-instrumentation"
 output_dir="$repo_root/apps/android/docs/media/play-store-screenshots"
 remote_screenshot_dir="/sdcard/Download/flashcards-marketing-screenshots"
 file_names=(
@@ -44,6 +45,7 @@ run_marketing_guest_cleanup() {
           "-Pandroid.testInstrumentationRunnerArguments.includeManualOnly=true" \
           "-Pandroid.testInstrumentationRunnerArguments.clearPackageData=false" \
           "-Pandroid.testInstrumentationRunnerArguments.marketingLocalePrefix=$locale_prefix" \
+          "-Pandroid.testInstrumentationRunnerArguments.flashcardsSentryEnvironmentOverride=$sentry_environment_override" \
           "-Pandroid.testInstrumentationRunnerArguments.class=$cleanup_script_class"
     )
 }
@@ -70,6 +72,7 @@ echo "Running the unified Android marketing screenshot flow."
   "-Pandroid.testInstrumentationRunnerArguments.includeManualOnly=true" \
   "-Pandroid.testInstrumentationRunnerArguments.clearPackageData=false" \
   "-Pandroid.testInstrumentationRunnerArguments.marketingLocalePrefix=$locale_prefix" \
+  "-Pandroid.testInstrumentationRunnerArguments.flashcardsSentryEnvironmentOverride=$sentry_environment_override" \
   "-Pandroid.testInstrumentationRunnerArguments.class=$script_class"
 
 mkdir -p "$output_dir"


### PR DESCRIPTION
## Summary

- route iOS and Android test/screenshot Sentry events into non-production environments
- map JWKS verifier backoff to a retryable auth verification 503 with Retry-After
- keep retryable auth verification failures out of exception capture while preserving breadcrumbs

## Validation

- node --test --import tsx src/observability/reporting.test.ts src/auth.test.ts src/app.test.ts
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend
- git diff --check
- bash -n scripts/capture-android-marketing-screenshots.sh

Android Gradle/instrumentation and iOS simulator-backed checks were not run locally because repository rules require explicit permission for those heavy runs.