### PR TITLE
[codex] Fix Android cloud package imports

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreContractTest.kt
@@ -14,6 +14,9 @@ import com.flashcardsopensourceapp.data.local.database.TagEntity
 import com.flashcardsopensourceapp.data.local.database.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.database.WorkspaceSchedulerSettingsEntity
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
+import com.flashcardsopensourceapp.data.local.cloud.identity.forkedCardId
+import com.flashcardsopensourceapp.data.local.cloud.identity.forkedDeckId
+import com.flashcardsopensourceapp.data.local.cloud.identity.forkedReviewEventId
 import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapEntry
 import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryEvent
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/identity/WorkspaceIdentityLocalStore.kt
@@ -14,6 +14,7 @@ import com.flashcardsopensourceapp.data.local.database.WorkspaceSchedulerSetting
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.sync.ReviewHistoryChangePublisher
 import com.flashcardsopensourceapp.data.local.cloud.sync.ReviewHistoryChangedEvent
+import com.flashcardsopensourceapp.data.local.cloud.sync.emptySyncStateEntity
 import com.flashcardsopensourceapp.data.local.cloud.wire.toRemoteValue
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.SyncEntityType


### PR DESCRIPTION
## Summary
- import the moved sync-state helper from the new cloud.sync package
- import workspace fork ID helpers in the moved SyncLocalStore instrumentation test package

## Root cause
PR #173 split Android local cloud code into identity, sync, remote, and wire packages. Two files still referenced moved helpers as if they were in the same package.

## Verification
- git --no-pager diff --check
- targeted static search for unqualified moved helper usage

Gradle was not run per repository instruction.