### PR TITLE
[codex] Fix iOS test Sentry environment

### DIFF
--- a/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/xcshareddata/xcschemes/Flashcards Open Source App.xcscheme
+++ b/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/xcshareddata/xcschemes/Flashcards Open Source App.xcscheme
@@ -64,6 +64,13 @@
             ReferencedContainer = "container:Flashcards Open Source App.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FLASHCARDS_SENTRY_ENVIRONMENT_OVERRIDE"
+            value = "ci-simulator"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO"


### PR DESCRIPTION
## Summary
- set FLASHCARDS_SENTRY_ENVIRONMENT_OVERRIDE=ci-simulator for the shared iOS scheme TestAction
- keep archive and release Sentry environment behavior unchanged

## Validation
- xmllint --noout on the shared xcscheme
- XPath check confirms the override exists once
- XPath checks confirm both iOS test targets remain enabled

## Notes
- local simulator-backed tests were not run per repository rules