### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,7 +8,7 @@
       "name": "flashcards-open-source-app-api",
       "version": "1.4.0",
       "devDependencies": {
-        "@redocly/cli": "^2.31.1"
+        "@redocly/cli": "^2.31.2"
       },
       "engines": {
         "node": "24.x"
@@ -359,14 +359,13 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -377,9 +376,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -422,9 +421,9 @@
       }
     },
     "node_modules/@redocly/cli": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.31.1.tgz",
-      "integrity": "sha512-eOyKMW3udQwIH2TvgRNeNtgzenNR8PHbvON4oYbr7uAQ2XGJnq9X24fsSgiZIuSFTm+XqMDmf888B5yMnFaxgQ==",
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.31.2.tgz",
+      "integrity": "sha512-MqO0I6UvB4d7VOTOrYAbVwS+AgUZ4Bxp7d2vCbUseiEYGxArvkzXtwWNLfNKryXvUrVB8kfmvLuRp7LLHFvvDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -433,8 +432,8 @@
         "@opentelemetry/sdk-trace-node": "2.6.1",
         "@opentelemetry/semantic-conventions": "1.40.0",
         "@redocly/cli-otel": "0.3.1",
-        "@redocly/openapi-core": "2.31.1",
-        "@redocly/respect-core": "2.31.1",
+        "@redocly/openapi-core": "2.31.2",
+        "@redocly/respect-core": "2.31.2",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
@@ -497,9 +496,9 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.31.1.tgz",
-      "integrity": "sha512-sPf5eS8oh4EYFAzha/JWSZ0eInhFaGoO4MaF8wkZEiL4lTpZPLN7D9RABWcXn/9xTljIQsX+bEBY3rhN44UhGg==",
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.31.2.tgz",
+      "integrity": "sha512-qKXAdKTRKqWArIWbMOHOELJGgfISMFD5pK0w5CaklH8LAn5M6BbyCocqz52IqMMUIiEyAsqb46a4vtuqPhLZwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -520,16 +519,16 @@
       }
     },
     "node_modules/@redocly/respect-core": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.31.1.tgz",
-      "integrity": "sha512-KW/ismQ6/v95GPWTKhWTO0Lp7UIhPKJU7Gc1GFTpRJRxbM3Ail2eJ/I0jpPlMr4geze+O2zQV0h9jI4co6hhIQ==",
+      "version": "2.31.2",
+      "resolved": "https://registry.npmjs.org/@redocly/respect-core/-/respect-core-2.31.2.tgz",
+      "integrity": "sha512-M5zQV9M8uazCl46EVKKjWPo7M8EFNHFQOdovhqH+IfdAop5kHPi1fR1xSwrckak84XON0a+CqPU7z7+YCON0Bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@noble/hashes": "^1.8.0",
         "@redocly/ajv": "^8.18.1",
-        "@redocly/openapi-core": "2.31.1",
+        "@redocly/openapi-core": "2.31.2",
         "ajv": "npm:@redocly/ajv@8.18.1",
         "better-ajv-errors": "^2.0.3",
         "colorette": "^2.0.20",
@@ -1624,9 +1623,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
-      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -1635,14 +1634,14 @@
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/api/package.json
+++ b/api/package.json
@@ -7,10 +7,11 @@
     "lint": "redocly lint src/openapi.yaml"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.31.1"
+    "@redocly/cli": "^2.31.2"
   },
   "overrides": {
-    "fast-xml-parser": "5.8.0"
+    "fast-xml-parser": "5.8.0",
+    "protobufjs": "^7.5.8"
   },
   "engines": {
     "node": "24.x"

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/d3": "^7.4.3",
-        "@types/react": "^19.2.14",
+        "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
         "typescript": "^6.0.3",
@@ -180,9 +180,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -200,9 +197,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -220,9 +214,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -240,9 +231,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -260,9 +248,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -280,9 +265,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -672,9 +654,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/d3": "^7.4.3",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "typescript": "^6.0.3",

--- a/apps/android/ci/Dockerfile
+++ b/apps/android/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:568.0.0-stable
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:569.0.0-stable
 
 ARG ANDROID_CMDLINE_TOOLS_VERSION=14742923
 ARG ANDROID_BUILD_TOOLS_VERSION=37.0.0

--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ splashscreen = "1.2.0"
 activityCompose = "1.13.0"
 lifecycle = "2.10.0"
 navigationCompose = "2.9.8"
-composeBom = "2026.05.00"
+composeBom = "2026.05.01"
 room = "2.8.4"
 work = "2.11.2"
 adaptive = "1.2.0"
@@ -23,7 +23,7 @@ securityCrypto = "1.1.0"
 json = "20251224"
 okhttp = "5.3.2"
 sentry = "8.41.0"
-sentryAndroidGradlePlugin = "6.6.0"
+sentryAndroidGradlePlugin = "6.7.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -8,16 +8,16 @@
       "name": "flashcards-auth",
       "version": "1.4.0",
       "dependencies": {
-        "@aws-sdk/client-secrets-manager": "^3.1049.0",
+        "@aws-sdk/client-secrets-manager": "^3.1050.0",
         "@hono/node-server": "^2.0.3",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.19",
+        "hono": "^4.12.21",
         "pg": "^8.21.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
-        "tsx": "^4.22.2",
+        "tsx": "^4.22.3",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -88,9 +88,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1049.0.tgz",
-      "integrity": "sha512-SHj5WzvYis2OBhbGY83WyFluUMl4DU6ZuJPrlAECfvr2lkRI4uiLd7a3MSmdZ5FlINcURLrPqhyHdzvZHCy3qw==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1050.0.tgz",
+      "integrity": "sha512-mVOzxK4inCJgbGSQTeENYaACA9qGikru07b3HJyrKEeLVhuLKmo5csVzvKuz++ROdhX9gR7WzzJkoDOO5Xy/EQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1096,9 +1096,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
-      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1275,9 +1275,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
-      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -10,16 +10,16 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@aws-sdk/client-secrets-manager": "^3.1049.0",
+    "@aws-sdk/client-secrets-manager": "^3.1050.0",
     "@hono/node-server": "^2.0.3",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.19",
+    "hono": "^4.12.21",
     "pg": "^8.21.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
-    "tsx": "^4.22.2",
+    "tsx": "^4.22.3",
     "typescript": "^6.0.3"
   },
   "engines": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -8,10 +8,10 @@
       "name": "flashcards-open-source-app-backend",
       "version": "1.4.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity-provider": "^3.1049.0",
-        "@aws-sdk/client-lambda": "^3.1049.0",
-        "@aws-sdk/client-s3": "^3.1049.0",
-        "@aws-sdk/client-secrets-manager": "^3.1049.0",
+        "@aws-sdk/client-cognito-identity-provider": "^3.1050.0",
+        "@aws-sdk/client-lambda": "^3.1050.0",
+        "@aws-sdk/client-s3": "^3.1050.0",
+        "@aws-sdk/client-secrets-manager": "^3.1050.0",
         "@hono/node-server": "^2.0.3",
         "@langfuse/openai": "^5.3.0",
         "@langfuse/otel": "^5.3.0",
@@ -20,7 +20,7 @@
         "@opentelemetry/sdk-trace-base": "^2.7.1",
         "@sentry/aws-serverless": "^10.53.1",
         "aws-jwt-verify": "^5.1.1",
-        "hono": "^4.12.19",
+        "hono": "^4.12.21",
         "openai": "^6.38.0",
         "pg": "^8.21.0",
         "zod": "^4.4.3"
@@ -30,7 +30,7 @@
         "@types/aws-lambda": "^8.10.161",
         "@types/node": "^24.12.4",
         "@types/pg": "^8.20.0",
-        "tsx": "^4.22.2",
+        "tsx": "^4.22.3",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1049.0.tgz",
-      "integrity": "sha512-XiGPYS1a6C7zdW/msza5dnYqHP+/J8hSWtvOf4GXZF+Uxpsl3E1UTcVTWnAOep74iAazLg+97OJYuqDb78k2Vg==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity-provider/-/client-cognito-identity-provider-3.1050.0.tgz",
+      "integrity": "sha512-gYjUUyG5h90cKFl+xvNo9aM4wCpk6ZeUeZMNd1VKiOnaDel49QfNDZEXtvNi2Z/6ZW3rzXjxNmRmJNe7yPrYyQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -261,9 +261,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1049.0.tgz",
-      "integrity": "sha512-aMN6q+BLouSD6LDbSxXoqH3X55yacDFOH9+7RbUABFbo5NFMZCLtswbNE8UI6unk9fIUMA6V9YEm64SHmfIhaA==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1050.0.tgz",
+      "integrity": "sha512-KlpBFZzvvzj6ShPCAmGi9Pm2Q50qDHRu1TJEg+rtpnPQln+pU8usnK2F6ied97pqtHSrLv0wOi7TUaVpTXr2+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -282,9 +282,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1049.0.tgz",
-      "integrity": "sha512-e5ToFwYeHSfkKDPs/G0yhO7vxvfVOF6DhmlvI2xFi4m12NvjxPhaA2Y35QMaYLrw/oGPXmu9McfKnBm/oXYXbg==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1050.0.tgz",
+      "integrity": "sha512-9kgtv+bXZQrOIJT2INPPBCezrJu1FlgGrzEat/ut4A4V53IT00LynsBZgp12eFKbjJuNCeTo7iPSKjPsX8ub+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1049.0.tgz",
-      "integrity": "sha512-SHj5WzvYis2OBhbGY83WyFluUMl4DU6ZuJPrlAECfvr2lkRI4uiLd7a3MSmdZ5FlINcURLrPqhyHdzvZHCy3qw==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.1050.0.tgz",
+      "integrity": "sha512-mVOzxK4inCJgbGSQTeENYaACA9qGikru07b3HJyrKEeLVhuLKmo5csVzvKuz++ROdhX9gR7WzzJkoDOO5Xy/EQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -3129,9 +3129,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
-      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3408,9 +3408,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
-      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,10 +11,10 @@
     "test": "npm run bundle --prefix ../../api && node scripts/run-tests.mjs"
   },
   "dependencies": {
-    "@aws-sdk/client-cognito-identity-provider": "^3.1049.0",
-    "@aws-sdk/client-lambda": "^3.1049.0",
-    "@aws-sdk/client-s3": "^3.1049.0",
-    "@aws-sdk/client-secrets-manager": "^3.1049.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.1050.0",
+    "@aws-sdk/client-lambda": "^3.1050.0",
+    "@aws-sdk/client-s3": "^3.1050.0",
+    "@aws-sdk/client-secrets-manager": "^3.1050.0",
     "@hono/node-server": "^2.0.3",
     "@langfuse/openai": "^5.3.0",
     "@langfuse/otel": "^5.3.0",
@@ -23,7 +23,7 @@
     "@opentelemetry/sdk-trace-base": "^2.7.1",
     "@sentry/aws-serverless": "^10.53.1",
     "aws-jwt-verify": "^5.1.1",
-    "hono": "^4.12.19",
+    "hono": "^4.12.21",
     "openai": "^6.38.0",
     "pg": "^8.21.0",
     "zod": "^4.4.3"
@@ -33,7 +33,7 @@
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
-    "tsx": "^4.22.2",
+    "tsx": "^4.22.3",
     "typescript": "^6.0.3"
   },
   "overrides": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "@sentry/vite-plugin": "^5.3.0",
-        "@types/react": "^19.2.14",
+        "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
         "fake-indexeddb": "^6.2.5",
@@ -725,9 +725,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -745,9 +742,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,9 +759,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,9 +776,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -805,9 +793,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -825,9 +810,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,9 +1311,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@sentry/vite-plugin": "^5.3.0",
-    "@types/react": "^19.2.14",
+    "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "fake-indexeddb": "^6.2.5",

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.4.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.0",
-        "@aws-sdk/client-cloudwatch": "^3.1049.0",
-        "@aws-sdk/client-s3": "^3.1049.0",
-        "aws-cdk-lib": "^2.254.0",
+        "@aws-sdk/client-cloudwatch": "^3.1050.0",
+        "@aws-sdk/client-s3": "^3.1050.0",
+        "aws-cdk-lib": "^2.256.0",
         "constructs": "^10.6.0"
       },
       "devDependencies": {
         "@types/node": "^24.12.4",
-        "aws-cdk": "^2.1122.0",
+        "aws-cdk": "^2.1123.0",
         "esbuild": "^0.28.0",
         "typescript": "^6.0.3"
       },
@@ -37,24 +37,24 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.23.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.23.0.tgz",
-      "integrity": "sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==",
+      "version": "53.25.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.25.0.tgz",
+      "integrity": "sha512-E6Fw6VsG/b8cVwvmbtD9AEkzBWgTaKa6IHNn7CGLli4rdrodnsMmmxwj5Ttml2A82b5coWdNmqsr5nZ0ltKWMw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -62,7 +62,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -503,9 +503,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1049.0.tgz",
-      "integrity": "sha512-pxzt53Ch0luCqnSaWNI7vL8MjvF5WFTRV/VzyuHoWOydbaC3RQT2i5DcAW7hjaYQmmRItQnvazTeO+obsBR+4Q==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.1050.0.tgz",
+      "integrity": "sha512-evD5bHN7NsmBx3P/+2szAsivxGRisC4YVcGhUsZK8p2X+83XSoYtXIrY8xpP4EdOmUNeB9na9WuiMMKETeB/uA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -628,9 +628,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1049.0.tgz",
-      "integrity": "sha512-e5ToFwYeHSfkKDPs/G0yhO7vxvfVOF6DhmlvI2xFi4m12NvjxPhaA2Y35QMaYLrw/oGPXmu9McfKnBm/oXYXbg==",
+      "version": "3.1050.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1050.0.tgz",
+      "integrity": "sha512-9kgtv+bXZQrOIJT2INPPBCezrJu1FlgGrzEat/ut4A4V53IT00LynsBZgp12eFKbjJuNCeTo7iPSKjPsX8ub+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -2275,9 +2275,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1122.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1122.0.tgz",
-      "integrity": "sha512-AI2Ks9qioWLvBPD4IoEtTet3wUG/o/q6U3WR3VCQKH5sNYLLPALo8o9sermNpMnfd1OQkqhL20tp4cEyojrIZg==",
+      "version": "2.1123.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1123.0.tgz",
+      "integrity": "sha512-s4kN0Dk75TMAqnITGuWk39hzGeHAUhCcYx4Yf2eWT1QSMsOnHs4seOmeL8eXpk8oSp19NJOyF4m6XBP6fux+7A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2288,9 +2288,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.254.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
-      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
+      "version": "2.256.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.256.0.tgz",
+      "integrity": "sha512-MtA5XOSWs+yDA42lW9cO8i+IeCHQt2EwmdPyqWf3li6mF/ptzNxnFjth6rFa5Ms+8v2VzB5cdAS+Ly1ZDGs3fg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -2309,8 +2309,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.3",
-        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -2331,28 +2331,18 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.3",
+      "version": "2.2.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -13,14 +13,14 @@
   },
   "dependencies": {
     "@aws-crypto/client-node": "^5.0.0",
-    "@aws-sdk/client-cloudwatch": "^3.1049.0",
-    "@aws-sdk/client-s3": "^3.1049.0",
-    "aws-cdk-lib": "^2.254.0",
+    "@aws-sdk/client-cloudwatch": "^3.1050.0",
+    "@aws-sdk/client-s3": "^3.1050.0",
+    "aws-cdk-lib": "^2.256.0",
     "constructs": "^10.6.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
-    "aws-cdk": "^2.1122.0",
+    "aws-cdk": "^2.1123.0",
     "esbuild": "^0.28.0",
     "typescript": "^6.0.3"
   },


### PR DESCRIPTION
## What changed
- updated the small set of stale npm dependencies and lockfiles in `api`, `apps/admin`, `apps/auth`, `apps/backend`, `apps/web`, and `infra/aws`
- updated the Android CI Google Cloud CLI base image and the Android version catalog pins for Compose BOM and the Sentry Android Gradle plugin
- added an `api` transitive override for `protobufjs` to clear the remaining audit finding without taking a broader toolchain change

## Why it changed
- the repository had minor dependency and toolchain drift relative to the current stable releases that still fit the repo's existing platform constraints
- this keeps the repo aligned while preserving the intentional Node 24 / AWS Lambda runtime policy and avoiding unnecessary major upgrades

## Impact
- Node, web, backend, auth, infra, and Android CI dependency metadata are now aligned to the latest safe stable targets reviewed in this run
- validation passed for the allowed non-mobile scope: installs, API lint, admin build, auth build/tests, backend lint/build, web build/tests, infra build/tests, and diff sanity
- heavy Android Gradle validation and iOS simulator-backed checks were intentionally not run because repo policy requires explicit approval for those runs

## Residual
- `infra/aws` still carries the upstream `brace-expansion` advisory bundled through the latest available `aws-cdk-lib` stable line
