### PR TITLE
Fix workspace lock ordering

### DIFF
--- a/apps/backend/src/accountDeletion.test.ts
+++ b/apps/backend/src/accountDeletion.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import {
+  deleteAccountConfirmationText,
+  deleteAccountForAuthenticatedUser,
+} from "./accountDeletion";
+import type {
+  DatabaseExecutor,
+  SqlValue,
+  UserDatabaseScope,
+} from "./db";
+
+type RecordedQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<SqlValue>;
+}>;
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+test("deleteAccountForAuthenticatedUser locks shared workspace membership lifecycles before membership rows", async () => {
+  const appUserId = "user-1";
+  const workspaceA = "11111111-1111-4111-8111-111111111111";
+  const workspaceB = "22222222-2222-4222-8222-222222222222";
+  const recordedQueries: Array<RecordedQuery> = [];
+  const executor: DatabaseExecutor = {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      recordedQueries.push({
+        text,
+        params: [...params],
+      });
+
+      if (text === "SELECT email FROM org.user_settings WHERE user_id = $1 FOR UPDATE") {
+        return createQueryResult<Row>([{ email: "review@example.com" } as unknown as Row]);
+      }
+
+      if (text === "SELECT workspace_id FROM org.workspace_memberships WHERE user_id = $1") {
+        return createQueryResult<Row>([
+          { workspace_id: workspaceB } as unknown as Row,
+          { workspace_id: workspaceA } as unknown as Row,
+        ]);
+      }
+
+      if (
+        text === "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 1::bigint))"
+        || text === "SELECT pg_advisory_xact_lock(hashtextextended($1::text || ':' || $2::text, 0::bigint))"
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (text === "SELECT workspace_id FROM org.workspace_memberships WHERE user_id = $1 FOR UPDATE") {
+        return createQueryResult<Row>([]);
+      }
+
+      if (text.includes("FROM org.workspace_memberships") && text.includes("FOR UPDATE")) {
+        return createQueryResult<Row>([
+          { workspace_id: workspaceA, user_id: appUserId } as unknown as Row,
+          { workspace_id: workspaceB, user_id: appUserId } as unknown as Row,
+        ]);
+      }
+
+      if (
+        text === "DELETE FROM org.workspaces WHERE workspace_id = ANY($1::uuid[])"
+        || text === "SELECT auth.delete_user_auth_artifacts($1, $2)"
+        || text === "DELETE FROM org.user_settings WHERE user_id = $1"
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
+  };
+
+  await deleteAccountForAuthenticatedUser(
+    {
+      appUserId,
+      authSubjectUserId: "subject-1",
+      email: "review@example.com",
+      cognitoUsername: null,
+      confirmationText: deleteAccountConfirmationText,
+    },
+    {
+      transactionWithUserScope: async <Result>(
+        _scope: UserDatabaseScope,
+        callback: (transactionExecutor: DatabaseExecutor) => Promise<Result>,
+      ): Promise<Result> => callback(executor),
+      deleteCognitoUser: async () => {
+        throw new Error("Demo account deletion must not delete Cognito identity.");
+      },
+      isDeletedSubject: async () => false,
+      isConfiguredDemoEmail: () => true,
+    },
+  );
+
+  const membershipLifecycleLockIndices = recordedQueries
+    .map((query, index) => ({ query, index }))
+    .filter(({ query }) => (
+      query.text === "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 1::bigint))"
+    ));
+  const ownMembershipLockIndex = recordedQueries.findIndex((query) => (
+    query.text === "SELECT workspace_id FROM org.workspace_memberships WHERE user_id = $1 FOR UPDATE"
+  ));
+  const allMembershipRowsLockIndex = recordedQueries.findIndex((query) => (
+    query.text.includes("FROM org.workspace_memberships")
+    && query.text.includes("WHERE workspace_id = ANY($1::uuid[])")
+    && query.text.includes("FOR UPDATE")
+  ));
+
+  assert.deepEqual(
+    membershipLifecycleLockIndices.map(({ query }) => query.params[0]),
+    [workspaceA, workspaceB],
+  );
+  assert.notEqual(ownMembershipLockIndex, -1);
+  assert.notEqual(allMembershipRowsLockIndex, -1);
+  assert.ok(membershipLifecycleLockIndices.every(({ index }) => index < ownMembershipLockIndex));
+  assert.ok(membershipLifecycleLockIndices.every(({ index }) => index < allMembershipRowsLockIndex));
+});

--- a/apps/backend/src/accountDeletion.ts
+++ b/apps/backend/src/accountDeletion.ts
@@ -3,7 +3,10 @@ import { transactionWithUserScope, type DatabaseExecutor } from "./db";
 import { isDeletedSubject, markDeletedSubjectInExecutor } from "./deletedSubjects";
 import { isConfiguredDemoEmail } from "./demoEmailAccess";
 import { HttpError } from "./errors";
-import { lockUserWorkspaceAccessLifecyclesInExecutor } from "./workspaceAccessLocks";
+import {
+  lockUserWorkspaceAccessLifecyclesInExecutor,
+  lockWorkspaceMembershipLifecyclesInExecutor,
+} from "./workspaceAccessLocks";
 
 export const deleteAccountConfirmationText: string = "delete my account";
 
@@ -81,6 +84,7 @@ async function deleteAccountDataInExecutor(
   const soleMemberWorkspaceIds: Array<string> = [];
 
   if (workspaceIds.length > 0) {
+    await lockWorkspaceMembershipLifecyclesInExecutor(executor, workspaceIds);
     await lockUserWorkspaceAccessLifecyclesInExecutor(executor, appUserId, workspaceIds);
 
     await executor.query(

--- a/apps/backend/src/guestAuth/delete.ts
+++ b/apps/backend/src/guestAuth/delete.ts
@@ -12,7 +12,7 @@ import {
   deleteUserSettingsInExecutor,
   deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor,
   hasCognitoIdentityMappingForUserInExecutor,
-  loadGuestSessionInExecutor,
+  loadGuestSessionWithUserSettingsLockInExecutor,
   loadGuestWorkspaceIdInExecutor,
   revokeGuestSessionInExecutor,
 } from "./store";
@@ -62,7 +62,7 @@ export async function deleteGuestSessionInExecutor(
   executor: DatabaseExecutor,
   guestToken: string,
 ): Promise<void> {
-  const guestSession = await loadGuestSessionInExecutor(executor, guestToken, true);
+  const guestSession = await loadGuestSessionWithUserSettingsLockInExecutor(executor, guestToken);
   if (await hasCognitoIdentityMappingForUserInExecutor(executor, guestSession.userId)) {
     throw new HttpError(
       409,

--- a/apps/backend/src/guestAuth/merge.ts
+++ b/apps/backend/src/guestAuth/merge.ts
@@ -11,6 +11,7 @@ import {
   applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
 } from "../db";
+import { lockWorkspaceAccessLifecycleInExecutor } from "../workspaceAccessLocks";
 import {
   HttpError,
   type SyncConflictEntityType,
@@ -731,6 +732,17 @@ export async function mergeGuestWorkspaceIntoTargetInExecutor(
     supportsDroppedEntities: boolean;
   }>,
 ): Promise<GuestMergeResult> {
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: params.guestUserId,
+    workspaceId: params.guestWorkspaceId,
+  });
+  await lockWorkspaceAccessLifecycleInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: params.targetUserId,
+    workspaceId: params.targetWorkspaceId,
+  });
+  await lockWorkspaceAccessLifecycleInExecutor(executor, params.targetUserId, params.targetWorkspaceId);
+
   const upgradeId = randomUUID().toLowerCase();
   const guestReplicas = await loadGuestReplicasInExecutor(executor, params.guestUserId, params.guestWorkspaceId);
   const guestCards = await loadGuestCardsInExecutor(executor, params.guestUserId, params.guestWorkspaceId);

--- a/apps/backend/src/guestAuth/store.ts
+++ b/apps/backend/src/guestAuth/store.ts
@@ -12,6 +12,11 @@ import type {
   WorkspaceReplicaActorKind,
   WorkspaceReplicaPlatform,
 } from "../syncIdentity";
+import { lockWorkspaceAccessLifecycleInExecutor } from "../workspaceAccessLocks";
+import {
+  lockUserSettingsForWorkspaceLifecycleInExecutor,
+  UserSettingsRowNotFoundError,
+} from "../workspaces/state";
 import type {
   GuestUpgradeCompletion,
   GuestUpgradeDroppedEntities,
@@ -46,6 +51,10 @@ type WorkspaceSummaryRow = Readonly<{
   name: string;
   created_at: Date | string;
 }>;
+
+function createGuestSessionInvalidError(): HttpError {
+  return new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
+}
 
 type WorkspaceReplicaRow = Readonly<{
   replica_id: string;
@@ -321,6 +330,37 @@ export async function loadGuestSessionRecordInExecutor(
   return row === undefined ? null : mapGuestSessionRecord(row);
 }
 
+export async function loadGuestSessionRecordWithUserSettingsLockInExecutor(
+  executor: DatabaseExecutor,
+  guestToken: string,
+): Promise<GuestSessionRecord | null> {
+  const unlockedSession = await loadGuestSessionRecordInExecutor(executor, guestToken, false);
+  if (unlockedSession === null) {
+    return null;
+  }
+
+  try {
+    await lockUserSettingsForWorkspaceLifecycleInExecutor(executor, unlockedSession.userId);
+  } catch (error) {
+    if (error instanceof UserSettingsRowNotFoundError) {
+      return null;
+    }
+
+    throw error;
+  }
+
+  const lockedSession = await loadGuestSessionRecordInExecutor(executor, guestToken, true);
+  if (
+    lockedSession === null
+    || lockedSession.sessionId !== unlockedSession.sessionId
+    || lockedSession.userId !== unlockedSession.userId
+  ) {
+    return null;
+  }
+
+  return lockedSession;
+}
+
 export async function loadGuestSessionInExecutor(
   executor: DatabaseExecutor,
   guestToken: string,
@@ -328,7 +368,19 @@ export async function loadGuestSessionInExecutor(
 ): Promise<GuestSessionRecord> {
   const session = await loadGuestSessionRecordInExecutor(executor, guestToken, lockForUpdate);
   if (session === null || session.revokedAt !== null) {
-    throw new HttpError(401, "Guest session is invalid.", "GUEST_AUTH_INVALID");
+    throw createGuestSessionInvalidError();
+  }
+
+  return session;
+}
+
+export async function loadGuestSessionWithUserSettingsLockInExecutor(
+  executor: DatabaseExecutor,
+  guestToken: string,
+): Promise<GuestSessionRecord> {
+  const session = await loadGuestSessionRecordWithUserSettingsLockInExecutor(executor, guestToken);
+  if (session === null || session.revokedAt !== null) {
+    throw createGuestSessionInvalidError();
   }
 
   return session;
@@ -640,6 +692,7 @@ export async function deleteGuestWorkspaceContentInExecutor(
     userId: guestUserId,
     workspaceId: guestWorkspaceId,
   });
+  await lockWorkspaceAccessLifecycleInExecutor(executor, guestUserId, guestWorkspaceId);
 
   await executor.query(
     "DELETE FROM content.review_events WHERE workspace_id = $1",
@@ -758,7 +811,7 @@ export async function selectWorkspaceForUserInExecutor(
   userId: string,
   workspaceId: string,
 ): Promise<void> {
-  await applyUserDatabaseScopeInExecutor(executor, { userId });
+  await lockUserSettingsForWorkspaceLifecycleInExecutor(executor, userId);
   await executor.query(
     "UPDATE org.user_settings SET workspace_id = $1 WHERE user_id = $2",
     [workspaceId, userId],
@@ -782,7 +835,11 @@ export async function deleteWorkspaceInExecutor(
   guestUserId: string,
   guestWorkspaceId: string,
 ): Promise<void> {
-  await applyUserDatabaseScopeInExecutor(executor, { userId: guestUserId });
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: guestUserId,
+    workspaceId: guestWorkspaceId,
+  });
+  await lockWorkspaceAccessLifecycleInExecutor(executor, guestUserId, guestWorkspaceId);
   await executor.query(
     "DELETE FROM org.workspaces WHERE workspace_id = $1",
     [guestWorkspaceId],
@@ -794,7 +851,11 @@ export async function deleteGuestWorkspaceIfOwnedBySoleMemberInExecutor(
   guestUserId: string,
   guestWorkspaceId: string,
 ): Promise<boolean> {
-  await applyUserDatabaseScopeInExecutor(executor, { userId: guestUserId });
+  await applyWorkspaceDatabaseScopeInExecutor(executor, {
+    userId: guestUserId,
+    workspaceId: guestWorkspaceId,
+  });
+  await lockWorkspaceAccessLifecycleInExecutor(executor, guestUserId, guestWorkspaceId);
   const result = await executor.query<DeletedGuestWorkspaceRow>(
     [
       "DELETE FROM org.workspaces AS workspaces",

--- a/apps/backend/src/guestAuth/tests/cleanup.test.ts
+++ b/apps/backend/src/guestAuth/tests/cleanup.test.ts
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor } from "../../db";
 import { HttpError } from "../../errors";
 import {
   deleteGuestSessionInExecutor,
@@ -11,7 +13,13 @@ import {
   createGuestUpgradeExecutor,
   createMergeState,
   membershipKey,
+  type GuestUpgradeExecutorParam,
 } from "../../guestAuthTestHarness";
+
+type RecordedGuestCleanupQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<GuestUpgradeExecutorParam>;
+}>;
 
 test("deleteGuestSessionInExecutor revokes and removes guest server state", async () => {
   const guestToken = "guest-token-delete";
@@ -31,7 +39,20 @@ test("deleteGuestSessionInExecutor revokes and removes guest server state", asyn
     targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
   });
 
-  const executor = createGuestUpgradeExecutor(state);
+  const recordedQueries: Array<RecordedGuestCleanupQuery> = [];
+  const baseExecutor = createGuestUpgradeExecutor(state);
+  const executor: DatabaseExecutor = {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<GuestUpgradeExecutorParam>,
+    ): Promise<pg.QueryResult<Row>> => {
+      recordedQueries.push({
+        text,
+        params: [...params],
+      });
+      return baseExecutor.query<Row>(text, params);
+    },
+  };
   await deleteGuestSessionInExecutor(executor, guestToken);
 
   assert.equal(state.guestSession, null);
@@ -41,6 +62,31 @@ test("deleteGuestSessionInExecutor revokes and removes guest server state", asyn
     state.workspaceReplicas.some((replica) => replica.workspace_id === guestWorkspaceId),
     false,
   );
+
+  const sourceWorkspaceLockIndex = recordedQueries.findIndex((query) => (
+    query.text === "SELECT pg_advisory_xact_lock(hashtextextended($1::text || ':' || $2::text, 0::bigint))"
+    && query.params[0] === guestUserId
+    && query.params[1] === guestWorkspaceId
+  ));
+  const guestUserSettingsLockIndex = recordedQueries.findIndex((query) => (
+    query.text === "SELECT user_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE"
+    && query.params[0] === guestUserId
+  ));
+  const lockedGuestSessionIndex = recordedQueries.findIndex((query) => (
+    query.text.includes("FROM auth.guest_sessions")
+    && query.text.includes("FOR UPDATE")
+  ));
+  const sourceWorkspaceDeleteIndex = recordedQueries.findIndex((query) => (
+    query.text.startsWith("DELETE FROM org.workspaces AS workspaces")
+    && query.params[0] === guestWorkspaceId
+    && query.params[1] === guestUserId
+  ));
+  assert.notEqual(guestUserSettingsLockIndex, -1);
+  assert.notEqual(lockedGuestSessionIndex, -1);
+  assert.notEqual(sourceWorkspaceLockIndex, -1);
+  assert.notEqual(sourceWorkspaceDeleteIndex, -1);
+  assert.ok(guestUserSettingsLockIndex < lockedGuestSessionIndex);
+  assert.ok(sourceWorkspaceLockIndex < sourceWorkspaceDeleteIndex);
 });
 
 test("cleanupGuestSessionSourceInExecutor re-scopes to the guest user before checking cleanup invariants", async () => {

--- a/apps/backend/src/guestAuth/tests/merge.test.ts
+++ b/apps/backend/src/guestAuth/tests/merge.test.ts
@@ -15,6 +15,11 @@ import {
   type GuestUpgradeExecutorParam,
 } from "../../guestAuthTestHarness";
 
+type RecordedGuestUpgradeQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<GuestUpgradeExecutorParam>;
+}>;
+
 test("completeGuestUpgradeInExecutor reassigns guest installation ownership during merge", async () => {
   const guestToken = "guest-token-1";
   const guestUserId = "guest-user";
@@ -71,6 +76,107 @@ test("completeGuestUpgradeInExecutor reassigns guest installation ownership duri
   assert.equal(targetReplica?.user_id, targetUserId);
 });
 
+test("completeGuestUpgradeInExecutor locks source and target workspaces in merge order", async () => {
+  const guestToken = "guest-token-lock-order";
+  const guestUserId = "z-guest-user-lock-order";
+  const guestWorkspaceId = "guest-workspace-lock-order";
+  const targetUserId = "a-linked-user-lock-order";
+  const targetWorkspaceId = "target-workspace-lock-order";
+  const installationId = "installation-lock-order";
+  const targetSubject = "cognito-subject-lock-order";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-lock-order",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId: "guest-replica-lock-order",
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  const recordedQueries: Array<RecordedGuestUpgradeQuery> = [];
+  const baseExecutor = createGuestUpgradeExecutor(state);
+  const executor: DatabaseExecutor = {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<GuestUpgradeExecutorParam>,
+    ): Promise<pg.QueryResult<Row>> => {
+      recordedQueries.push({
+        text,
+        params: [...params],
+      });
+      return baseExecutor.query<Row>(text, params);
+    },
+  };
+
+  await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    {
+      type: "existing",
+      workspaceId: targetWorkspaceId,
+    },
+    DROPPED_ENTITIES_UNSUPPORTED,
+  );
+
+  const targetUserSettingsLockIndex = recordedQueries.findIndex((query) => (
+    query.text === "SELECT user_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE"
+    && query.params[0] === targetUserId
+  ));
+  const guestUserSettingsLockIndex = recordedQueries.findIndex((query) => (
+    query.text === "SELECT user_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE"
+    && query.params[0] === guestUserId
+  ));
+  const lockedGuestSessionIndex = recordedQueries.findIndex((query) => (
+    query.text.includes("FROM auth.guest_sessions")
+    && query.text.includes("FOR UPDATE")
+  ));
+  const targetWorkspaceLockIndex = recordedQueries.findIndex((query) => (
+    query.text === "SELECT pg_advisory_xact_lock(hashtextextended($1::text || ':' || $2::text, 0::bigint))"
+    && query.params[0] === targetUserId
+    && query.params[1] === targetWorkspaceId
+  ));
+  const sourceWorkspaceLockIndex = recordedQueries.findIndex((query) => (
+    query.text === "SELECT pg_advisory_xact_lock(hashtextextended($1::text || ':' || $2::text, 0::bigint))"
+    && query.params[0] === guestUserId
+    && query.params[1] === guestWorkspaceId
+  ));
+  const sourceReplicaReadIndex = recordedQueries.findIndex((query) => (
+    query.text.includes("FROM sync.workspace_replicas")
+    && query.params[0] === guestWorkspaceId
+  ));
+  const targetSchedulerReadIndex = recordedQueries.findIndex((query) => (
+    query.text.includes("FROM org.workspaces")
+    && query.text.includes("fsrs_algorithm")
+    && query.params[0] === targetWorkspaceId
+  ));
+  const sourceContentDeleteIndex = recordedQueries.findIndex((query) => (
+    query.text === "DELETE FROM content.review_events WHERE workspace_id = $1"
+    && query.params[0] === guestWorkspaceId
+  ));
+
+  assert.notEqual(guestUserSettingsLockIndex, -1);
+  assert.notEqual(lockedGuestSessionIndex, -1);
+  assert.notEqual(targetUserSettingsLockIndex, -1);
+  assert.notEqual(targetWorkspaceLockIndex, -1);
+  assert.notEqual(sourceWorkspaceLockIndex, -1);
+  assert.notEqual(sourceReplicaReadIndex, -1);
+  assert.notEqual(targetSchedulerReadIndex, -1);
+  assert.notEqual(sourceContentDeleteIndex, -1);
+  assert.ok(targetUserSettingsLockIndex < guestUserSettingsLockIndex);
+  assert.ok(guestUserSettingsLockIndex < lockedGuestSessionIndex);
+  assert.ok(targetUserSettingsLockIndex < lockedGuestSessionIndex);
+  assert.ok(targetUserSettingsLockIndex < targetWorkspaceLockIndex);
+  assert.ok(sourceWorkspaceLockIndex < targetWorkspaceLockIndex);
+  assert.ok(sourceWorkspaceLockIndex < sourceReplicaReadIndex);
+  assert.ok(targetWorkspaceLockIndex < targetSchedulerReadIndex);
+  assert.ok(sourceWorkspaceLockIndex < sourceContentDeleteIndex);
+});
+
 test("completeGuestUpgradeInExecutor rejects selecting the guest workspace as the merge target", async () => {
   const guestToken = "guest-token-same-workspace";
   const guestUserId = "guest-user";
@@ -117,6 +223,55 @@ test("completeGuestUpgradeInExecutor rejects selecting the guest workspace as th
   assert.equal(state.guestSession?.revoked_at, null);
   assert.equal(state.guestUpgradeHistory.length, 0);
   assert.equal(state.installations.get(installationId)?.user_id, guestUserId);
+  assert.equal(state.workspaces.has(guestWorkspaceId), true);
+});
+
+test("completeGuestUpgradeInExecutor returns a typed account error when target user settings are missing", async () => {
+  const guestToken = "guest-token-missing-target-settings";
+  const guestUserId = "guest-user-missing-target-settings";
+  const guestWorkspaceId = "guest-workspace-missing-target-settings";
+  const targetUserId = "linked-user-missing-target-settings";
+  const targetWorkspaceId = "target-workspace-missing-target-settings";
+  const targetSubject = "cognito-subject-missing-target-settings";
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-missing-target-settings",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId: "guest-replica-missing-target-settings",
+    installationId: "installation-missing-target-settings",
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.userSettings.delete(targetUserId);
+
+  const executor = createGuestUpgradeExecutor(state);
+
+  await assert.rejects(
+    completeGuestUpgradeInExecutor(
+      executor,
+      guestToken,
+      targetSubject,
+      {
+        type: "existing",
+        workspaceId: targetWorkspaceId,
+      },
+      DROPPED_ENTITIES_UNSUPPORTED,
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.statusCode, 409);
+      assert.equal(error.code, "GUEST_UPGRADE_ACCOUNT_REQUIRED");
+      return true;
+    },
+  );
+
+  assert.equal(state.guestSession?.revoked_at, null);
+  assert.equal(state.guestUpgradeHistory.length, 0);
+  assert.equal(state.userSettings.has(guestUserId), true);
   assert.equal(state.workspaces.has(guestWorkspaceId), true);
 });
 

--- a/apps/backend/src/guestAuth/upgrade.ts
+++ b/apps/backend/src/guestAuth/upgrade.ts
@@ -8,13 +8,17 @@ import {
   AUTO_CREATED_WORKSPACE_NAME,
   createWorkspaceInExecutor,
 } from "../workspaces";
+import {
+  lockUserSettingsForWorkspaceLifecycleInExecutor,
+  UserSettingsRowNotFoundError,
+} from "../workspaces/state";
 import { cleanupGuestSessionSourceInExecutor } from "./delete";
 import { mergeGuestWorkspaceIntoTargetInExecutor } from "./merge";
 import {
   assertTargetWorkspaceAccessInExecutor,
   bindIdentityMappingInExecutor,
-  loadGuestSessionInExecutor,
   loadGuestSessionRecordInExecutor,
+  loadGuestSessionWithUserSettingsLockInExecutor,
   loadGuestUpgradeReplayByGuestTokenInExecutor,
   loadGuestUpgradeReplayInExecutor,
   loadGuestWorkspaceIdInExecutor,
@@ -24,6 +28,7 @@ import {
   recordGuestUpgradeHistoryInExecutor,
   selectWorkspaceForUserInExecutor,
   updateUserEmailInExecutor,
+  type GuestSessionRecord,
 } from "./store";
 import { hashGuestToken } from "./shared";
 import type {
@@ -51,6 +56,14 @@ function createGuestWorkspaceNotDrainedError(): HttpError {
   );
 }
 
+function createGuestUpgradeAccountRequiredError(): HttpError {
+  return new HttpError(409, "Create or sign in to the destination account first.", "GUEST_UPGRADE_ACCOUNT_REQUIRED");
+}
+
+function toUniqueSortedUserIds(userIds: ReadonlyArray<string>): Array<string> {
+  return [...new Set(userIds)].sort((left, right) => left.localeCompare(right));
+}
+
 function assertGuestWorkspaceSyncedAndOutboxDrained(
   capabilities: GuestUpgradeCompleteCapabilities,
 ): void {
@@ -60,6 +73,61 @@ function assertGuestWorkspaceSyncedAndOutboxDrained(
   ) {
     throw createGuestWorkspaceNotDrainedError();
   }
+}
+
+async function lockGuestUpgradeUserSettingsRowsInExecutor(
+  executor: DatabaseExecutor,
+  guestUserId: string,
+  targetUserId: string,
+): Promise<boolean> {
+  const userIds = toUniqueSortedUserIds([guestUserId, targetUserId]);
+
+  for (const userId of userIds) {
+    try {
+      await lockUserSettingsForWorkspaceLifecycleInExecutor(executor, userId);
+    } catch (error) {
+      if (error instanceof UserSettingsRowNotFoundError) {
+        if (error.userId === guestUserId) {
+          return false;
+        }
+
+        if (error.userId === targetUserId) {
+          throw createGuestUpgradeAccountRequiredError();
+        }
+      }
+
+      throw error;
+    }
+  }
+
+  return true;
+}
+
+async function lockGuestSessionAfterUserSettingsInExecutor(
+  executor: DatabaseExecutor,
+  guestToken: string,
+  unlockedSession: GuestSessionRecord,
+  targetUserId: string,
+): Promise<GuestSessionRecord | null> {
+  const lockedUserSettings = await lockGuestUpgradeUserSettingsRowsInExecutor(
+    executor,
+    unlockedSession.userId,
+    targetUserId,
+  );
+  if (!lockedUserSettings) {
+    return null;
+  }
+
+  const lockedSession = await loadGuestSessionRecordInExecutor(executor, guestToken, true);
+  if (
+    lockedSession === null
+    || lockedSession.sessionId !== unlockedSession.sessionId
+    || lockedSession.userId !== unlockedSession.userId
+  ) {
+    return null;
+  }
+
+  return lockedSession;
 }
 
 function logSuspiciousGuestUpgradeReplay(
@@ -257,7 +325,7 @@ export async function prepareGuestUpgradeInExecutor(
   cognitoSubject: string,
   email: string | null,
 ): Promise<GuestUpgradePreparation> {
-  const guestSession = await loadGuestSessionInExecutor(executor, guestToken, true);
+  const guestSession = await loadGuestSessionWithUserSettingsLockInExecutor(executor, guestToken);
   const existingMappedUserId = await loadIdentityMappingInExecutor(executor, cognitoSubject);
 
   if (existingMappedUserId === null || existingMappedUserId === guestSession.userId) {
@@ -295,9 +363,9 @@ export async function completeGuestUpgradeInExecutor(
   selection: GuestUpgradeSelection,
   capabilities: GuestUpgradeCompleteCapabilities,
 ): Promise<GuestUpgradeCompletion> {
-  // Phase 1: load and lock the guest session.
-  const guestSession = await loadGuestSessionRecordInExecutor(executor, guestToken, true);
-  if (guestSession === null) {
+  // Phase 1: load the guest session identity before taking user row locks.
+  const unlockedGuestSession = await loadGuestSessionRecordInExecutor(executor, guestToken, false);
+  if (unlockedGuestSession === null) {
     return resolveDeletedGuestUpgradeReplayInExecutor(
       executor,
       guestToken,
@@ -309,11 +377,41 @@ export async function completeGuestUpgradeInExecutor(
   // Phase 2: resolve the mapped target user.
   const targetUserId = await loadIdentityMappingInExecutor(executor, cognitoSubject);
   if (targetUserId === null) {
-    throw new HttpError(409, "Create or sign in to the destination account first.", "GUEST_UPGRADE_ACCOUNT_REQUIRED");
+    const guestSession = await lockGuestSessionAfterUserSettingsInExecutor(
+      executor,
+      guestToken,
+      unlockedGuestSession,
+      unlockedGuestSession.userId,
+    );
+    if (guestSession === null) {
+      return resolveDeletedGuestUpgradeReplayInExecutor(
+        executor,
+        guestToken,
+        cognitoSubject,
+        capabilities,
+      );
+    }
+
+    throw createGuestUpgradeAccountRequiredError();
   }
 
   // Phase 3: short-circuit revoked-session replay.
-  if (guestSession.revokedAt !== null) {
+  if (unlockedGuestSession.revokedAt !== null) {
+    const guestSession = await lockGuestSessionAfterUserSettingsInExecutor(
+      executor,
+      guestToken,
+      unlockedGuestSession,
+      unlockedGuestSession.userId,
+    );
+    if (guestSession === null) {
+      return resolveDeletedGuestUpgradeReplayInExecutor(
+        executor,
+        guestToken,
+        cognitoSubject,
+        capabilities,
+      );
+    }
+
     return resolveRevokedGuestUpgradeReplayInExecutor(
       executor,
       guestSession.sessionId,
@@ -329,7 +427,31 @@ export async function completeGuestUpgradeInExecutor(
   // the bound flow before those merge-only capabilities existed; there are no
   // dropped entities to report because all rows already belong to the final
   // user/workspace.
-  if (targetUserId === guestSession.userId) {
+  if (targetUserId === unlockedGuestSession.userId) {
+    const guestSession = await lockGuestSessionAfterUserSettingsInExecutor(
+      executor,
+      guestToken,
+      unlockedGuestSession,
+      targetUserId,
+    );
+    if (guestSession === null) {
+      return resolveDeletedGuestUpgradeReplayInExecutor(
+        executor,
+        guestToken,
+        cognitoSubject,
+        capabilities,
+      );
+    }
+
+    if (guestSession.revokedAt !== null) {
+      return resolveRevokedGuestUpgradeReplayInExecutor(
+        executor,
+        guestSession.sessionId,
+        cognitoSubject,
+        capabilities,
+      );
+    }
+
     const guestWorkspaceId = await loadGuestWorkspaceIdInExecutor(executor, guestSession.userId);
     return {
       workspace: await loadWorkspaceSummaryInExecutor(executor, guestSession.userId, guestWorkspaceId),
@@ -341,12 +463,37 @@ export async function completeGuestUpgradeInExecutor(
     };
   }
 
-  // Phase 5: enforce the merge precondition for clients that declare the new
+  // Phase 5: lock source and target user rows in deterministic order, then lock the guest session.
+  const guestSession = await lockGuestSessionAfterUserSettingsInExecutor(
+    executor,
+    guestToken,
+    unlockedGuestSession,
+    targetUserId,
+  );
+  if (guestSession === null) {
+    return resolveDeletedGuestUpgradeReplayInExecutor(
+      executor,
+      guestToken,
+      cognitoSubject,
+      capabilities,
+    );
+  }
+
+  if (guestSession.revokedAt !== null) {
+    return resolveRevokedGuestUpgradeReplayInExecutor(
+      executor,
+      guestSession.sessionId,
+      cognitoSubject,
+      capabilities,
+    );
+  }
+
+  // Phase 6: enforce the merge precondition for clients that declare the new
   // drain protocol. Omitted capability fields are the legacy shipped-client
   // route shape and must remain compatible until those clients are out of support.
   assertGuestWorkspaceSyncedAndOutboxDrained(capabilities);
 
-  // Phase 6: resolve explicit source and destination workspace ids.
+  // Phase 7: resolve explicit source and destination workspace ids.
   const guestUpgradeResolution = await resolveGuestUpgradeTargetInExecutor(
     executor,
     guestSession.userId,
@@ -354,7 +501,7 @@ export async function completeGuestUpgradeInExecutor(
     selection,
   );
 
-  // Phase 7: merge already-synced guest cloud state into the destination workspace.
+  // Phase 8: merge already-synced guest cloud state into the destination workspace.
   const guestUpgradeMerge = await mergeGuestWorkspaceIntoTargetInExecutor(
     executor,
     {
@@ -370,21 +517,21 @@ export async function completeGuestUpgradeInExecutor(
     },
   );
 
-  // Phase 8: record durable merge history and replica aliases.
+  // Phase 9: record durable merge history and replica aliases.
   // This is legacy/idempotency-only compatibility for shipped clients that can
   // replay completion or resend stale replica-bound operations after the guest
   // session is gone. Remove only after those clients are explicitly out of
   // support.
   await recordGuestUpgradeHistoryInExecutor(executor, guestUpgradeMerge.history);
 
-  // Phase 9: persist the selected target workspace.
+  // Phase 10: persist the selected target workspace.
   await persistGuestUpgradeTargetSelectionInExecutor(
     executor,
     guestUpgradeResolution.targetUserId,
     guestUpgradeResolution.targetWorkspaceId,
   );
 
-  // Phase 10: revoke and delete guest source rows.
+  // Phase 11: revoke and delete guest source rows.
   await cleanupGuestSessionSourceInExecutor(
     executor,
     guestSession.userId,
@@ -392,7 +539,7 @@ export async function completeGuestUpgradeInExecutor(
     guestUpgradeResolution.guestWorkspaceId,
   );
 
-  // Phase 11: load the final workspace summary for the response.
+  // Phase 12: load the final workspace summary for the response.
   return {
     workspace: await loadWorkspaceSummaryInExecutor(
       executor,

--- a/apps/backend/src/guestAuthTestHarness/handlers/userSettings.ts
+++ b/apps/backend/src/guestAuthTestHarness/handlers/userSettings.ts
@@ -24,8 +24,25 @@ export function handleUserSettingsExecutorQuery<Row extends pg.QueryResultRow>(
 
   if (text === "SELECT workspace_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE") {
     const userId = params[0];
-    const row = typeof userId === "string" ? state.userSettings.get(userId) ?? null : null;
+    if (typeof userId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    scope.requireCurrentUserScope(userId);
+    const row = state.userSettings.get(userId) ?? null;
     const rows = row === null ? [] : [{ workspace_id: row.workspace_id } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
+  if (text === "SELECT user_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE") {
+    const userId = params[0];
+    if (typeof userId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    scope.requireCurrentUserScope(userId);
+    const row = state.userSettings.get(userId) ?? null;
+    const rows = row === null ? [] : [{ user_id: row.user_id } as unknown as Row];
     return createQueryResult<Row>(rows);
   }
 

--- a/apps/backend/src/routes/workspaces.test.ts
+++ b/apps/backend/src/routes/workspaces.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { AppEnv } from "../app";
+import { isTransientDatabaseError } from "../dbTransient";
+import { HttpError } from "../errors";
+import type { RequestContext } from "../server/requestContext";
+import type { WorkspaceSummary } from "../workspaces";
+import { createWorkspaceRoutes } from "./workspaces";
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+
+function createCodedError(code: string, message: string): Error & Readonly<{ code: string }> {
+  const error = new Error(message) as Error & { code: string };
+  error.code = code;
+  return error;
+}
+
+function createRequestContext(): RequestContext {
+  return {
+    userId: "user-1",
+    subjectUserId: "subject-1",
+    selectedWorkspaceId: workspaceId,
+    email: "user@example.com",
+    locale: "en",
+    userSettingsCreatedAt: "2026-04-17T00:00:00.000Z",
+    transport: "bearer",
+    connectionId: null,
+  };
+}
+
+function createWorkspaceTestApp(routes: Hono<AppEnv>): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-1");
+    await next();
+  });
+  app.onError((error, context) => {
+    if (error instanceof HttpError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: error.message,
+        requestId: context.get("requestId"),
+        code: error.code,
+      });
+    }
+
+    context.status(500);
+    return context.json({
+      error: "Request failed. Try again.",
+      requestId: context.get("requestId"),
+      code: "INTERNAL_ERROR",
+    });
+  });
+  app.route("/", routes);
+  return app;
+}
+
+async function retryTransientOnce<Result>(operation: () => Promise<Result>): Promise<Result> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isTransientDatabaseError(error)) {
+      throw error;
+    }
+  }
+
+  return operation();
+}
+
+test("POST /workspaces retries transient database failures during workspace creation", async () => {
+  let loadCalls = 0;
+  let createCalls = 0;
+  const workspace: WorkspaceSummary = {
+    workspaceId,
+    name: "Study",
+    createdAt: "2026-04-17T00:00:00.000Z",
+    isSelected: true,
+  };
+  const routes = createWorkspaceRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => {
+      loadCalls += 1;
+      return {
+        requestAuthInputs: {} as never,
+        requestContext: createRequestContext(),
+      };
+    },
+    createWorkspaceForUserWithObservationScopeFn: async (userId, name, scope) => {
+      createCalls += 1;
+      assert.equal(userId, "user-1");
+      assert.equal(name, "Study");
+      assert.equal(scope?.requestId, "request-1");
+
+      if (createCalls === 1) {
+        throw createCodedError("40P01", "deadlock detected");
+      }
+
+      return workspace;
+    },
+    withTransientDatabaseRetryFn: retryTransientOnce,
+  });
+  const app = createWorkspaceTestApp(routes);
+
+  const response = await app.request("http://localhost/workspaces", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: " Study ",
+    }),
+  });
+
+  assert.equal(response.status, 201);
+  assert.deepEqual(await response.json(), {
+    workspace,
+  });
+  assert.equal(loadCalls, 2);
+  assert.equal(createCalls, 2);
+});

--- a/apps/backend/src/routes/workspaces.ts
+++ b/apps/backend/src/routes/workspaces.ts
@@ -39,6 +39,7 @@ import {
   loadRequestContextFromRequest,
   parseWorkspaceIdParam,
   requireAgentConnectionId,
+  type RequestContext,
 } from "../server/requestContext";
 import {
   expectNonEmptyString,
@@ -46,6 +47,7 @@ import {
   parseJsonBody,
 } from "../server/requestParsing";
 import { createBackendFailureDetails } from "../server/logging";
+import { withTransientDatabaseRetry } from "../dbTransient";
 import {
   addBackendBreadcrumb,
   createBackendObservationScope,
@@ -57,6 +59,10 @@ import type { AppEnv } from "../app";
 
 type WorkspaceRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
+  loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
+  createWorkspaceForApiKeyConnectionWithObservationScopeFn?: typeof createWorkspaceForApiKeyConnectionWithObservationScope;
+  createWorkspaceForUserWithObservationScopeFn?: typeof createWorkspaceForUserWithObservationScope;
+  withTransientDatabaseRetryFn?: typeof withTransientDatabaseRetry;
 }>;
 
 type CursorQueryParams = Readonly<{
@@ -81,6 +87,15 @@ type AgentApiKeyConnectionsPageResponse = Readonly<{
   instructions: string;
 }>;
 
+type WorkspaceCreateRouteState = Readonly<{
+  requestContext: RequestContext;
+  workspace: WorkspaceSummary;
+}>;
+
+function getRequestContextUserId(requestContext: RequestContext | null): string | null {
+  return requestContext === null ? null : requestContext.userId;
+}
+
 function parseCursorQueryParams(request: Request): CursorQueryParams {
   const url = new URL(request.url);
   return {
@@ -93,7 +108,7 @@ function createWorkspaceRouteScope(
   requestId: string,
   route: string,
   method: string,
-  userId: string,
+  userId: string | null,
   workspaceId: string | null,
 ): BackendObservationScope {
   return createBackendObservationScope(
@@ -111,9 +126,15 @@ function createWorkspaceRouteScope(
 
 export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
+  const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
+  const createWorkspaceForApiKeyConnectionWithObservationScopeFn = options.createWorkspaceForApiKeyConnectionWithObservationScopeFn
+    ?? createWorkspaceForApiKeyConnectionWithObservationScope;
+  const createWorkspaceForUserWithObservationScopeFn = options.createWorkspaceForUserWithObservationScopeFn
+    ?? createWorkspaceForUserWithObservationScope;
+  const withTransientDatabaseRetryFn = options.withTransientDatabaseRetryFn ?? withTransientDatabaseRetry;
 
   app.get("/workspaces", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     const requestId = context.get("requestId");
     const pageInput = parseCursorQueryParams(context.req.raw);
 
@@ -170,34 +191,80 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.post("/workspaces", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
     const requestId = context.get("requestId");
-    const body = expectRecord(await parseJsonBody(context.req.raw));
+    let requestContext: RequestContext | null = null;
+    let body: Record<string, unknown> | null = null;
+
+    async function loadBody(): Promise<Record<string, unknown>> {
+      if (body === null) {
+        body = expectRecord(await parseJsonBody(context.req.raw));
+      }
+
+      return body;
+    }
 
     try {
-      const workspaceName = expectNonEmptyString(body.name, "name");
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null);
-      const workspace = shouldUseAgentSetupEnvelope(requestContext.transport)
-        ? await createWorkspaceForApiKeyConnectionWithObservationScope(
-          requestContext.userId,
-          requireAgentConnectionId(requestContext),
-          workspaceName,
-          scope,
-        )
-        : await createWorkspaceForUserWithObservationScope(requestContext.userId, workspaceName, scope);
+      const routeState = await withTransientDatabaseRetryFn(
+        async (): Promise<WorkspaceCreateRouteState> => {
+          const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+          const currentRequestContext = loadedContext.requestContext;
+          requestContext = currentRequestContext;
+          const loadedBody = await loadBody();
+          const workspaceName = expectNonEmptyString(loadedBody.name, "name");
+          const scope = createWorkspaceRouteScope(
+            requestId,
+            context.req.path,
+            context.req.method,
+            currentRequestContext.userId,
+            null,
+          );
+          const workspace = shouldUseAgentSetupEnvelope(currentRequestContext.transport)
+            ? await createWorkspaceForApiKeyConnectionWithObservationScopeFn(
+              currentRequestContext.userId,
+              requireAgentConnectionId(currentRequestContext),
+              workspaceName,
+              scope,
+            )
+            : await createWorkspaceForUserWithObservationScopeFn(currentRequestContext.userId, workspaceName, scope);
+
+          return {
+            requestContext: currentRequestContext,
+            workspace,
+          };
+        },
+        () => createWorkspaceRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          null,
+        ),
+      );
       addBackendBreadcrumb({
         action: "workspace_create",
-        scope: createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, workspace.workspaceId),
+        scope: createWorkspaceRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          routeState.requestContext.userId,
+          routeState.workspace.workspaceId,
+        ),
         details: {
           statusCode: 201,
         },
       });
-      if (shouldUseAgentSetupEnvelope(requestContext.transport)) {
-        return context.json(createAgentWorkspaceReadyEnvelope(context.req.url, workspace), 201);
+      if (shouldUseAgentSetupEnvelope(routeState.requestContext.transport)) {
+        return context.json(createAgentWorkspaceReadyEnvelope(context.req.url, routeState.workspace), 201);
       }
-      return context.json({ workspace }, 201);
+      return context.json({ workspace: routeState.workspace }, 201);
     } catch (error) {
-      const scope = createWorkspaceRouteScope(requestId, context.req.path, context.req.method, requestContext.userId, null);
+      const scope = createWorkspaceRouteScope(
+        requestId,
+        context.req.path,
+        context.req.method,
+        getRequestContextUserId(requestContext),
+        null,
+      );
       const details = {
         ...createBackendFailureDetails(error),
       };
@@ -211,7 +278,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.post("/workspaces/:workspaceId/select", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     const workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
     const requestId = context.get("requestId");
 
@@ -249,7 +316,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.post("/workspaces/:workspaceId/rename", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     requireHumanManagedConnectionAccess(requestContext.transport);
     const workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
     const requestId = context.get("requestId");
@@ -286,7 +353,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.get("/workspaces/:workspaceId/delete-preview", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     requireHumanManagedConnectionAccess(requestContext.transport);
     const workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
     const requestId = context.get("requestId");
@@ -323,7 +390,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.post("/workspaces/:workspaceId/delete", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     requireHumanManagedConnectionAccess(requestContext.transport);
     const workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
     const requestId = context.get("requestId");
@@ -372,7 +439,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.get("/workspaces/:workspaceId/reset-progress-preview", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     requireHumanManagedConnectionAccess(requestContext.transport);
     const workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
     const requestId = context.get("requestId");
@@ -409,7 +476,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.post("/workspaces/:workspaceId/reset-progress", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     requireHumanManagedConnectionAccess(requestContext.transport);
     const workspaceId = parseWorkspaceIdParam(context.req.param("workspaceId"));
     const requestId = context.get("requestId");
@@ -456,7 +523,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.get("/agent-api-keys", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     requireHumanManagedConnectionAccess(requestContext.transport);
     const pageInput = parseCursorQueryParams(context.req.raw);
     const connectionsPage = await listAgentApiKeyConnectionsPageForUser(requestContext.userId, pageInput);
@@ -467,7 +534,7 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   app.post("/agent-api-keys/:connectionId/revoke", async (context) => {
-    const { requestContext } = await loadRequestContextFromRequest(context.req.raw, options.allowedOrigins);
+    const { requestContext } = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
     requireHumanManagedConnectionAccess(requestContext.transport);
     const connectionId = parseConnectionId(context.req.param("connectionId"));
     const connection = await revokeAgentApiKeyConnectionForUser(requestContext.userId, connectionId);

--- a/apps/backend/src/workspaceAccessLocks.ts
+++ b/apps/backend/src/workspaceAccessLocks.ts
@@ -26,3 +26,17 @@ export async function lockUserWorkspaceAccessLifecyclesInExecutor(
     await lockWorkspaceAccessLifecycleInExecutor(executor, userId, workspaceId);
   }
 }
+
+export async function lockWorkspaceMembershipLifecyclesInExecutor(
+  executor: DatabaseExecutor,
+  workspaceIds: ReadonlyArray<string>,
+): Promise<void> {
+  const sortedWorkspaceIds = toUniqueSortedWorkspaceIds(workspaceIds);
+
+  for (const workspaceId of sortedWorkspaceIds) {
+    await executor.query(
+      "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 1::bigint))",
+      [workspaceId],
+    );
+  }
+}

--- a/apps/backend/src/workspaces/create.ts
+++ b/apps/backend/src/workspaces/create.ts
@@ -27,6 +27,7 @@ import {
 } from "./shared";
 import { loadWorkspaceSummaryInExecutor } from "./queries";
 import {
+  lockUserSettingsForWorkspaceLifecycleInExecutor,
   persistSelectedWorkspaceForApiKeyConnectionInExecutor,
   persistSelectedWorkspaceForUserInExecutor,
 } from "./state";
@@ -128,6 +129,7 @@ export async function createWorkspaceInExecutorWithObservationScope(
   observationScope: BackendObservationScope | null,
 ): Promise<string> {
   await ensureUserSettingsRowInExecutor(executor, userId);
+  await lockUserSettingsForWorkspaceLifecycleInExecutor(executor, userId);
 
   const workspaceId = randomUUID();
   const bootstrapTimestamp = new Date().toISOString();

--- a/apps/backend/src/workspaces/management.ts
+++ b/apps/backend/src/workspaces/management.ts
@@ -41,7 +41,10 @@ import {
   createWorkspaceTransactionScope,
   getDatabaseErrorDetails,
 } from "./shared";
-import { persistSelectedWorkspaceForUserInExecutor } from "./state";
+import {
+  lockUserSettingsForWorkspaceLifecycleInExecutor,
+  persistSelectedWorkspaceForUserInExecutor,
+} from "./state";
 import {
   AUTO_CREATED_WORKSPACE_NAME,
   deleteWorkspaceConfirmationText,
@@ -551,6 +554,7 @@ async function deleteWorkspaceInExecutorWithObservationScope(
   observationScope: BackendObservationScope | null,
 ): Promise<DeleteWorkspaceResult> {
   assertDeleteWorkspaceConfirmationText(confirmationText);
+  await lockUserSettingsForWorkspaceLifecycleInExecutor(executor, userId);
   await lockWorkspaceAccessLifecycleInExecutor(executor, userId, workspaceId);
   let stage: WorkspaceDeleteFailureStage = "load_management_row";
   const managedWorkspace = await loadWorkspaceManagementRowInExecutor(executor, userId, workspaceId);

--- a/apps/backend/src/workspaces/selection.ts
+++ b/apps/backend/src/workspaces/selection.ts
@@ -16,6 +16,7 @@ import {
 } from "./queries";
 import { createWorkspaceInvariantError } from "./shared";
 import {
+  lockUserSettingsForWorkspaceLifecycleInExecutor,
   persistSelectedWorkspaceForApiKeyConnectionInExecutor,
   persistSelectedWorkspaceForUserInExecutor,
 } from "./state";
@@ -87,6 +88,7 @@ export async function setSelectedWorkspaceForApiKeyConnection(
 
 export async function selectWorkspaceForUser(userId: string, workspaceId: string): Promise<WorkspaceSummary> {
   return transactionWithUserScope({ userId }, async (executor) => {
+    await lockUserSettingsForWorkspaceLifecycleInExecutor(executor, userId);
     await assertUserHasWorkspaceMembershipInExecutor(executor, userId, workspaceId);
     await persistSelectedWorkspaceForUserInExecutor(executor, userId, workspaceId);
     return loadWorkspaceSummaryInExecutor(executor, userId, workspaceId, workspaceId);

--- a/apps/backend/src/workspaces/state.ts
+++ b/apps/backend/src/workspaces/state.ts
@@ -5,6 +5,35 @@ type AgentApiKeySelectionRow = Readonly<{
   connection_id: string;
 }>;
 
+type UserSettingsLockRow = Readonly<{
+  user_id: string;
+}>;
+
+export class UserSettingsRowNotFoundError extends Error {
+  readonly userId: string;
+
+  constructor(userId: string) {
+    super("User settings row not found while locking workspace lifecycle.");
+    this.name = "UserSettingsRowNotFoundError";
+    this.userId = userId;
+  }
+}
+
+export async function lockUserSettingsForWorkspaceLifecycleInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+): Promise<void> {
+  await applyUserDatabaseScopeInExecutor(executor, { userId });
+  const result = await executor.query<UserSettingsLockRow>(
+    "SELECT user_id FROM org.user_settings WHERE user_id = $1 FOR UPDATE",
+    [userId],
+  );
+
+  if (result.rows.length === 0) {
+    throw new UserSettingsRowNotFoundError(userId);
+  }
+}
+
 export async function persistSelectedWorkspaceForUserInExecutor(
   executor: DatabaseExecutor,
   userId: string,


### PR DESCRIPTION
## Summary
- Retry transient database failures during workspace creation while preserving route contracts.
- Add deterministic user_settings and workspace lifecycle lock ordering across workspace creation, selection, deletion, guest upgrade, and account deletion paths.
- Add focused regression coverage for retry behavior and lock ordering.

## Validation
- git --no-pager diff --check origin/main..HEAD
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend
