### PR TITLE
[codex] Fix Android CI review route build

### DIFF
--- a/.github/workflows/android-ci-reusable.yml
+++ b/.github/workflows/android-ci-reusable.yml
@@ -9,6 +9,10 @@ on:
       android_version_code:
         required: true
         type: string
+      run_data_local_instrumentation:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -72,6 +76,7 @@ jobs:
     name: Android emulator data:local instrumentation
     needs:
       - build
+    if: ${{ inputs.run_data_local_instrumentation }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,25 @@
+name: Android CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/android/**'
+      - '!apps/android/README.md'
+      - '!apps/android/docs/**'
+      - 'cloudbuild.android.yaml'
+      - 'scripts/run-android-ci.sh'
+      - '.github/workflows/android-ci-reusable.yml'
+      - '.github/workflows/android-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  android_ci:
+    name: Android CI
+    uses: ./.github/workflows/android-ci-reusable.yml
+    with:
+      target_ref: ${{ github.ref }}
+      android_version_code: '1'
+      run_data_local_instrumentation: false

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost


### PR DESCRIPTION
## Summary
- remove the invalid Compose `matchParentSize` import that broke Android compilation
- add a pull-request Android CI workflow using the existing reusable CI job
- keep release behavior unchanged while skipping emulator instrumentation on PR CI

## Root cause
The Android release run failed during `:feature:review:compileDebugKotlin` because `ReviewRoute.kt` imported `androidx.compose.foundation.layout.matchParentSize`, which is not a valid top-level import in this Compose setup.

## Validation
- `git --no-pager diff --check`
- `git --no-pager diff --cached --check`
- parsed `.github/workflows/android-ci.yml` and `.github/workflows/android-ci-reusable.yml` with Ruby Psych

Gradle was not run locally because repository instructions require explicit permission for local `./gradlew` runs.