### PR TITLE
[codex] Fix Android test animation build

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/TestAnimationsRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/TestAnimationsRoute.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack


### PR DESCRIPTION
## Summary
- remove the invalid Compose `matchParentSize` import from the new Android test animations route
- keep the existing `Modifier.matchParentSize()` usage inside the `Box` scope

## Root cause
PR #187 added `TestAnimationsRoute.kt` with the same invalid top-level `androidx.compose.foundation.layout.matchParentSize` import that previously broke `ReviewRoute.kt`. The current `main` Android Release failed at `:feature:review:compileDebugKotlin` on that import.

## Validation
- `rg -n "import androidx\.compose\.foundation\.layout\.matchParentSize" apps/android || true`
- `git --no-pager diff --check`
- `git --no-pager diff --cached --check`

Gradle was not run locally because repository instructions require explicit permission for local `./gradlew` runs.