### PR TITLE
Fix Android test animation preview build

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/TestAnimationsRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/TestAnimationsRoute.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
@@ -111,7 +110,7 @@ fun TestAnimationsRoute(
             }
 
             ReviewReactionOverlay(
-                modifier = Modifier.matchParentSize(),
+                modifier = Modifier.fillMaxSize(),
                 events = activeReviewReactionEvents,
                 motionMode = reviewReactionMotionMode,
                 onEventFinished = { eventId: String ->


### PR DESCRIPTION
## Summary
- remove the invalid Compose `matchParentSize` import from the Android test animations preview
- size the review reaction overlay with `fillMaxSize()` so the feature build compiles

## Validation
- `git --no-pager diff --check`
- cloud Android workflow will validate after merge