### PR TITLE
[codex] Remove test animation preview stage

### DIFF
--- a/apps/web/src/screens/settings/SettingsShared.tsx
+++ b/apps/web/src/screens/settings/SettingsShared.tsx
@@ -19,6 +19,7 @@ type SettingsShellProps = Readonly<{
   subtitle: string;
   activeTab: SettingsTab;
   children: ReactNode;
+  panelClassName?: string;
 }>;
 
 type SettingsNavigationCardProps = Readonly<{
@@ -113,14 +114,17 @@ const settingsTabs: ReadonlyArray<SettingsTabItem> = [
 ] as const;
 
 export function SettingsShell(props: SettingsShellProps): ReactElement {
-  const { title, subtitle, activeTab, children } = props;
+  const { title, subtitle, activeTab, children, panelClassName } = props;
   const { t } = useI18n();
   const { isTestModeEnabled } = useTestMode();
   const visibleSettingsTabs = settingsTabs.filter((tab) => tab.requiresTestMode === false || isTestModeEnabled);
+  const settingsPanelClassName = panelClassName === undefined
+    ? "panel settings-panel"
+    : `panel settings-panel ${panelClassName}`;
 
   return (
     <main className="container settings-page">
-      <section className="panel settings-panel">
+      <section className={settingsPanelClassName}>
         <nav className="settings-switcher" aria-label={t("settingsTabs.ariaLabel")} data-active-tab={activeTab}>
           {visibleSettingsTabs.map((tab) => (
             <NavLink

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -174,38 +174,34 @@ export function TestAnimationsScreen(): ReactElement {
       title={t("settingsTest.animations.screenTitle")}
       subtitle={t("settingsTest.animations.screenSubtitle")}
       activeTab="test"
+      panelClassName="settings-panel-test-animations"
     >
-      <div className="settings-test-animation-preview" data-testid="test-animations-screen">
-        <div className="settings-test-animation-stage">
-          <ReviewRatingReactionLayer events={activeReviewReactionEvents} />
-        </div>
-
-        <div className="settings-test-animation-list">
-          {reviewReactionRatings.map((rating) => (
-            <SettingsGroup key={rating} title={reviewRatingTitle(rating, t)}>
-              <div className="settings-test-animation-rows">
-                {reviewReactionVariantDistributionEntries(rating).map((entry) => (
-                  <button
-                    key={entry.id}
-                    className="settings-test-animation-row content-card"
-                    type="button"
-                    aria-label={testAnimationAccessibilityLabel(entry, formatNumber, t)}
-                    data-review-reaction-rating={entry.rating}
-                    data-review-reaction-variant={entry.variant}
-                    data-testid="test-animation-row"
-                    onClick={() => playAnimation(entry)}
-                  >
-                    <span className="settings-test-animation-name">{entry.variant}</span>
-                    <span className="badge">
-                      {testAnimationProbabilityText(entry, formatNumber, t)}
-                    </span>
-                  </button>
-                ))}
-              </div>
-            </SettingsGroup>
-          ))}
-        </div>
+      <div className="settings-test-animation-list" data-testid="test-animations-screen">
+        {reviewReactionRatings.map((rating) => (
+          <SettingsGroup key={rating} title={reviewRatingTitle(rating, t)}>
+            <div className="settings-test-animation-rows">
+              {reviewReactionVariantDistributionEntries(rating).map((entry) => (
+                <button
+                  key={entry.id}
+                  className="settings-test-animation-row content-card"
+                  type="button"
+                  aria-label={testAnimationAccessibilityLabel(entry, formatNumber, t)}
+                  data-review-reaction-rating={entry.rating}
+                  data-review-reaction-variant={entry.variant}
+                  data-testid="test-animation-row"
+                  onClick={() => playAnimation(entry)}
+                >
+                  <span className="settings-test-animation-name">{entry.variant}</span>
+                  <span className="badge">
+                    {testAnimationProbabilityText(entry, formatNumber, t)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </SettingsGroup>
+        ))}
       </div>
+      <ReviewRatingReactionLayer events={activeReviewReactionEvents} />
     </SettingsShell>
   );
 }

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -155,25 +155,28 @@
   outline-offset: 4px;
 }
 
-.settings-test-animation-preview {
-  display: grid;
-  gap: 18px;
+.settings-panel-test-animations {
+  position: relative;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  height: min(880px, calc(100dvh - 76px));
+  min-height: min(760px, calc(100dvh - 76px));
+  max-height: calc(100dvh - 72px);
+  overflow: hidden;
 }
 
-.settings-test-animation-stage {
-  position: sticky;
-  top: 12px;
-  z-index: 2;
-  height: clamp(160px, 28vh, 260px);
-  overflow: hidden;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--radius-md);
-  background: rgba(20, 20, 24, 0.72);
+.chat-layout-shell-sidebar-open .settings-panel-test-animations {
+  height: var(--chat-shell-pane-height);
+  min-height: var(--chat-shell-pane-height);
+  max-height: none;
 }
 
 .settings-test-animation-list {
   display: grid;
   gap: 18px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-inline-end: 4px;
+  scrollbar-gutter: stable;
 }
 
 .settings-test-animation-rows {


### PR DESCRIPTION
## Summary
- remove the dedicated test animation preview stage
- render review reaction animations directly over the settings test screen panel
- keep the animation panel bounds aligned with the review screen, including chat-sidebar sizing

## Validation
- npm run build
- browser check against a local mock API: test animation layer is inside the settings panel, old stage classes are absent, and active reaction events fill the panel bounds