### PR TITLE
[codex] Fix web reauth data preservation

### DIFF
--- a/apps/web/src/accountDeletion.test.ts
+++ b/apps/web/src/accountDeletion.test.ts
@@ -2,32 +2,16 @@
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  clearAuthResetRequired,
   clearAllLocalBrowserData,
-  isAuthResetRequired,
-  markAuthResetRequired,
-  runPendingAuthResetCleanup,
+  clearBrowserReauthRequired,
+  isBrowserReauthRequired,
+  markBrowserReauthRequired,
 } from "./accountDeletion";
 import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "./i18n/runtime";
 import { loadCloudSettings, putCloudSettings } from "./localDb/cloudSettings";
 import { clearWebSyncCache } from "./localDb/cache";
 import type { CloudSettings } from "./types";
-
-const observabilityMocks = vi.hoisted(() => ({
-  addWebBreadcrumbMock: vi.fn(),
-  captureWebExceptionMock: vi.fn(),
-  captureWebWarningMock: vi.fn(),
-  setWebObservabilityUserMock: vi.fn(),
-}));
-
-vi.mock("./observability/webObservability", () => ({
-  addWebBreadcrumb: observabilityMocks.addWebBreadcrumbMock,
-  captureWebException: observabilityMocks.captureWebExceptionMock,
-  captureWebWarning: observabilityMocks.captureWebWarningMock,
-  normalizeCaughtError: (error: unknown): Error => error instanceof Error ? error : new Error(`Caught non-Error value of type ${typeof error}`),
-  setWebObservabilityUser: observabilityMocks.setWebObservabilityUserMock,
-}));
 
 const seededCloudSettings: CloudSettings = {
   installationId: "installation-1",
@@ -73,11 +57,15 @@ function seedLocalBrowserState(): void {
   window.localStorage.setItem("flashcards-chat-drafts::workspace-1", JSON.stringify({
     version: 1,
   }));
+  window.localStorage.setItem("flashcards-auth-reset-required", "1");
+  markBrowserReauthRequired();
 }
 
 function expectLocalBrowserStateCleared(): void {
   expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).toBeNull();
   expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+  expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBeNull();
+  expect(isBrowserReauthRequired()).toBe(false);
   expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
   expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
 }
@@ -99,72 +87,44 @@ beforeEach(async () => {
     value: createStorageMock(),
   });
   window.localStorage.clear();
-  clearAuthResetRequired();
-  observabilityMocks.addWebBreadcrumbMock.mockReset();
-  observabilityMocks.captureWebExceptionMock.mockReset();
-  observabilityMocks.captureWebWarningMock.mockReset();
-  observabilityMocks.setWebObservabilityUserMock.mockReset();
+  clearBrowserReauthRequired();
 });
 
 afterEach(async () => {
   window.localStorage.clear();
-  clearAuthResetRequired();
+  clearBrowserReauthRequired();
   vi.restoreAllMocks();
   await clearWebSyncCache();
 });
 
 describe("account deletion local cleanup helpers", () => {
-  it("clears browser-local state before rethrowing a blocked IndexedDB deletion", async () => {
+  it("keeps the reauth guard when IndexedDB cleanup is blocked", async () => {
     seedLocalBrowserState();
     mockBlockedDeleteDatabase();
 
     await expect(clearAllLocalBrowserData()).rejects.toThrow("Failed to delete IndexedDB: delete request was blocked");
-    expectLocalBrowserStateCleared();
+    expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).toBeNull();
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+    expect(window.localStorage.getItem("flashcards-browser-reauth-required")).toBe("1");
+    expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBe("1");
+    expect(isBrowserReauthRequired()).toBe(true);
+    expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
+    expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
   });
 
-  it("completes a pending auth reset cleanup and clears the marker after full success", async () => {
+  it("clears reauth markers and IndexedDB only during explicit local data cleanup", async () => {
     seedLocalBrowserState();
     await putCloudSettings(seededCloudSettings);
-    markAuthResetRequired();
 
-    await expect(runPendingAuthResetCleanup()).resolves.toEqual({
-      completed: true,
-      error: null,
-    });
+    await expect(clearAllLocalBrowserData()).resolves.toBeUndefined();
 
     expectLocalBrowserStateCleared();
-    expect(isAuthResetRequired()).toBe(false);
     await expect(loadCloudSettings()).resolves.toBeNull();
   });
 
-  it("preserves the pending auth reset marker when IndexedDB cleanup is blocked", async () => {
-    seedLocalBrowserState();
-    markAuthResetRequired();
-    mockBlockedDeleteDatabase();
+  it("treats the legacy auth reset marker as reauth required", () => {
+    window.localStorage.setItem("flashcards-auth-reset-required", "1");
 
-    const cleanupResult = await runPendingAuthResetCleanup();
-
-    expect(cleanupResult.completed).toBe(false);
-    expect(cleanupResult.error?.message).toBe("Failed to delete IndexedDB: delete request was blocked");
-    expectLocalBrowserStateCleared();
-    expect(isAuthResetRequired()).toBe(true);
-    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith({
-      action: "auth_reset_cleanup_deferred",
-      scope: {
-        app: "web",
-        feature: "auth",
-        userId: null,
-        workspaceId: null,
-        installationId: "installation-1",
-        route: "/",
-        requestId: null,
-        statusCode: null,
-        code: null,
-      },
-      details: {
-        eventName: "auth_reset_cleanup_deferred",
-        errorMessage: "Failed to delete IndexedDB: delete request was blocked",
-      },
-    });
+    expect(isBrowserReauthRequired()).toBe(true);
   });
 });

--- a/apps/web/src/accountDeletion.ts
+++ b/apps/web/src/accountDeletion.ts
@@ -1,16 +1,12 @@
 import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "./i18n/runtime";
 import { clearWebSyncCache } from "./localDb/cache";
-import {
-  addWebBreadcrumb,
-  captureWebException,
-  type WebObservationScope,
-} from "./observability/webObservability";
 import { TEST_MODE_STORAGE_KEY } from "./testMode";
 
 export const deleteAccountConfirmationText: string = "delete my account";
 
 const AUTH_RESET_REQUIRED_KEY = "flashcards-auth-reset-required";
+const BROWSER_REAUTH_REQUIRED_KEY = "flashcards-browser-reauth-required";
 const ACCOUNT_DELETION_PENDING_KEY = "flashcards-account-deletion-pending";
 const ACCOUNT_DELETION_CSRF_TOKEN_KEY = "flashcards-account-deletion-csrf-token";
 const ACCOUNT_DELETION_EVENT_NAME = "flashcards-account-deletion-pending-change";
@@ -25,11 +21,7 @@ const PRESERVED_BROWSER_LOCAL_STORAGE_KEYS: ReadonlyArray<string> = [
 ];
 
 type AccountDeletionListener = () => void;
-
-type AuthResetCleanupResult = Readonly<{
-  completed: boolean;
-  error: Error | null;
-}>;
+type BrowserStorageKeyPredicate = (storageKey: string) => boolean;
 
 function getBrowserStorage(): Storage | null {
   const storageValue = window.localStorage;
@@ -46,55 +38,6 @@ function getBrowserStorage(): Storage | null {
 
 function dispatchAccountDeletionChange(): void {
   window.dispatchEvent(new Event(ACCOUNT_DELETION_EVENT_NAME));
-}
-
-function getCurrentRoute(): string | null {
-  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
-}
-
-function loadExistingInstallationId(browserStorage: Storage | null): string | null {
-  const installationId = browserStorage?.getItem(INSTALLATION_ID_STORAGE_KEY) ?? null;
-  if (installationId === null || installationId.trim() === "") {
-    return null;
-  }
-
-  return installationId;
-}
-
-function buildAuthResetCleanupScope(): WebObservationScope {
-  return {
-    app: "web",
-    feature: "auth",
-    userId: null,
-    workspaceId: null,
-    installationId: loadExistingInstallationId(getBrowserStorage()),
-    route: getCurrentRoute(),
-    requestId: null,
-    statusCode: null,
-    code: null,
-  };
-}
-
-function addAuthResetCleanupDeferredBreadcrumb(error: Error): void {
-  addWebBreadcrumb({
-    action: "auth_reset_cleanup_deferred",
-    scope: buildAuthResetCleanupScope(),
-    details: {
-      eventName: "auth_reset_cleanup_deferred",
-      errorMessage: error.message,
-    },
-  });
-}
-
-function captureAuthResetCleanupFailure(error: Error): void {
-  captureWebException({
-    action: "auth_reset_cleanup_failed",
-    error,
-    scope: buildAuthResetCleanupScope(),
-    details: {
-      operation: "auth_reset_cleanup_failed",
-    },
-  });
 }
 
 export function isAccountDeletionPending(): boolean {
@@ -169,11 +112,7 @@ function normalizeCleanupError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-function isBlockedIndexedDbDeleteError(error: Error): boolean {
-  return error.message === "Failed to delete IndexedDB: delete request was blocked";
-}
-
-function clearUserScopedBrowserStorage(browserStorage: Storage): void {
+function clearUserScopedBrowserStorage(browserStorage: Storage, shouldRemoveStorageKey: BrowserStorageKeyPredicate): void {
   const storageKeysToRemove: Array<string> = [];
   for (let index = 0; index < browserStorage.length; index += 1) {
     const storageKey = browserStorage.key(index);
@@ -181,7 +120,7 @@ function clearUserScopedBrowserStorage(browserStorage: Storage): void {
       continue;
     }
 
-    if (shouldRemoveAppLocalStorageKey(storageKey)) {
+    if (shouldRemoveStorageKey(storageKey)) {
       storageKeysToRemove.push(storageKey);
     }
   }
@@ -192,10 +131,6 @@ function clearUserScopedBrowserStorage(browserStorage: Storage): void {
 }
 
 function shouldRemoveAppLocalStorageKey(storageKey: string): boolean {
-  if (storageKey === AUTH_RESET_REQUIRED_KEY) {
-    return false;
-  }
-
   if (PRESERVED_BROWSER_LOCAL_STORAGE_KEYS.includes(storageKey)) {
     return false;
   }
@@ -203,27 +138,49 @@ function shouldRemoveAppLocalStorageKey(storageKey: string): boolean {
   return storageKey.startsWith(APP_LOCAL_STORAGE_PREFIX) || APP_LOCAL_STORAGE_KEYS.includes(storageKey);
 }
 
+function isReauthMarkerStorageKey(storageKey: string): boolean {
+  return storageKey === BROWSER_REAUTH_REQUIRED_KEY || storageKey === AUTH_RESET_REQUIRED_KEY;
+}
+
+function shouldRemoveAppLocalStorageKeyAfterIncompleteIndexedDbCleanup(storageKey: string): boolean {
+  if (isReauthMarkerStorageKey(storageKey)) {
+    return false;
+  }
+
+  return shouldRemoveAppLocalStorageKey(storageKey);
+}
+
+export function markBrowserReauthRequired(): void {
+  getBrowserStorage()?.setItem(BROWSER_REAUTH_REQUIRED_KEY, "1");
+}
+
+export function isBrowserReauthRequired(): boolean {
+  const browserStorage = getBrowserStorage();
+  return browserStorage?.getItem(BROWSER_REAUTH_REQUIRED_KEY) === "1"
+    || browserStorage?.getItem(AUTH_RESET_REQUIRED_KEY) === "1";
+}
+
+export function clearBrowserReauthRequired(): void {
+  const browserStorage = getBrowserStorage();
+  browserStorage?.removeItem(BROWSER_REAUTH_REQUIRED_KEY);
+  browserStorage?.removeItem(AUTH_RESET_REQUIRED_KEY);
+}
+
 export function markAuthResetRequired(): void {
-  getBrowserStorage()?.setItem(AUTH_RESET_REQUIRED_KEY, "1");
+  markBrowserReauthRequired();
 }
 
 export function isAuthResetRequired(): boolean {
-  return getBrowserStorage()?.getItem(AUTH_RESET_REQUIRED_KEY) === "1";
+  return isBrowserReauthRequired();
 }
 
 export function clearAuthResetRequired(): void {
-  getBrowserStorage()?.removeItem(AUTH_RESET_REQUIRED_KEY);
+  clearBrowserReauthRequired();
 }
 
 /**
  * Clears browser-local user state aggressively after logout, account deletion,
- * or an unrecoverable session recovery failure.
- *
- * Once refresh-based auth recovery fails, the web client intentionally stops
- * trusting every user-bound browser artifact, including warm state, sync
- * caches, and resumable account-deletion markers. The next interactive login
- * must start from a full bootstrap instead of inheriting data that may belong
- * to a different human user on the same browser.
+ * or a confirmed account switch.
  *
  * The stable installation id, explicit locale preference, and hidden test-mode
  * flag are intentionally retained because they are browser-scoped preferences
@@ -242,42 +199,13 @@ export async function clearAllLocalBrowserData(): Promise<void> {
   }
 
   if (browserStorage !== null) {
-    clearUserScopedBrowserStorage(browserStorage);
+    const shouldRemoveStorageKey = indexedDbError === null
+      ? shouldRemoveAppLocalStorageKey
+      : shouldRemoveAppLocalStorageKeyAfterIncompleteIndexedDbCleanup;
+    clearUserScopedBrowserStorage(browserStorage, shouldRemoveStorageKey);
   }
 
   if (indexedDbError !== null) {
     throw indexedDbError;
-  }
-}
-
-export async function runPendingAuthResetCleanup(): Promise<AuthResetCleanupResult> {
-  if (isAuthResetRequired() === false) {
-    return {
-      completed: true,
-      error: null,
-    };
-  }
-
-  try {
-    await clearAllLocalBrowserData();
-    clearAuthResetRequired();
-    return {
-      completed: true,
-      error: null,
-    };
-  } catch (error) {
-    const normalizedError = normalizeCleanupError(error);
-    if (isBlockedIndexedDbDeleteError(normalizedError)) {
-      // Future improvement: notify sibling tabs via BroadcastChannel or a
-      // storage signal so they release IndexedDB handles and join the reset.
-      addAuthResetCleanupDeferredBreadcrumb(normalizedError);
-    } else {
-      captureAuthResetCleanupFailure(normalizedError);
-    }
-
-    return {
-      completed: false,
-      error: normalizedError,
-    };
   }
 }

--- a/apps/web/src/api/ApiTestSupport.ts
+++ b/apps/web/src/api/ApiTestSupport.ts
@@ -56,6 +56,8 @@ export function seedLocalBrowserState(): void {
 export function expectLocalBrowserStateCleared(): void {
   expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).toBeNull();
   expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+  expect(window.localStorage.getItem("flashcards-browser-reauth-required")).toBeNull();
+  expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBeNull();
   expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
   expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
 }
@@ -63,6 +65,17 @@ export function expectLocalBrowserStateCleared(): void {
 export function expectLocalBrowserStatePreserved(): void {
   expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).not.toBeNull();
   expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).not.toBeNull();
+  expect(window.localStorage.getItem("flashcards-browser-reauth-required")).toBeNull();
+  expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBeNull();
+  expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
+  expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
+}
+
+export function expectLocalBrowserStatePreservedForReauth(): void {
+  expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).not.toBeNull();
+  expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).not.toBeNull();
+  expect(window.localStorage.getItem("flashcards-browser-reauth-required")).toBe("1");
+  expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBeNull();
   expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
   expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
 }

--- a/apps/web/src/api/transport.test.ts
+++ b/apps/web/src/api/transport.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { isAuthResetRequired } from "../accountDeletion";
+import { isBrowserReauthRequired } from "../accountDeletion";
 import { ApiContractError } from "../apiContracts/core";
 import { persistLocalePreference } from "../i18n/runtime";
 import type { NewChatSessionResponse } from "../types";
@@ -9,8 +9,8 @@ import {
   createNewChatSessionResponse,
   createSessionResponse,
   createStorageMock,
-  expectLocalBrowserStateCleared,
   expectLocalBrowserStatePreserved,
+  expectLocalBrowserStatePreservedForReauth,
   mockBlockedDeleteDatabase,
   seedLocalBrowserState,
   setNavigatorLanguages,
@@ -23,28 +23,6 @@ import {
   setNavigationHandlerForTests,
 } from "./transport";
 
-const observabilityMocks = vi.hoisted(() => ({
-  addWebBreadcrumbMock: vi.fn(),
-  captureWebExceptionMock: vi.fn(),
-  captureWebWarningMock: vi.fn(),
-  setWebObservabilityUserMock: vi.fn(),
-}));
-
-vi.mock("../observability/webObservability", () => ({
-  addWebBreadcrumb: observabilityMocks.addWebBreadcrumbMock,
-  captureWebException: observabilityMocks.captureWebExceptionMock,
-  captureWebWarning: observabilityMocks.captureWebWarningMock,
-  normalizeCaughtError: (error: unknown): Error => error instanceof Error ? error : new Error(`Caught non-Error value of type ${typeof error}`),
-  setWebObservabilityUser: observabilityMocks.setWebObservabilityUserMock,
-}));
-
-function resetObservabilityMocks(): void {
-  observabilityMocks.addWebBreadcrumbMock.mockReset();
-  observabilityMocks.captureWebExceptionMock.mockReset();
-  observabilityMocks.captureWebWarningMock.mockReset();
-  observabilityMocks.setWebObservabilityUserMock.mockReset();
-}
-
 async function createTransportBackedChatSession(sessionId: string): Promise<NewChatSessionResponse> {
   return createNewChatSession(sessionId, "workspace-1", "en");
 }
@@ -56,7 +34,6 @@ beforeEach(() => {
   });
   window.localStorage.clear();
   resetApiClientStateForTests();
-  resetObservabilityMocks();
 });
 
 afterEach(() => {
@@ -86,12 +63,10 @@ describe("session transport auth recovery", () => {
     await expect(getSession()).rejects.toBeInstanceOf(AuthRedirectError);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
     expect(new URL(redirectedUrl).searchParams.get("locale")).toBe("ar");
-    await vi.waitFor(() => {
-      expectLocalBrowserStateCleared();
-      expect(isAuthResetRequired()).toBe(false);
-    });
+    expectLocalBrowserStatePreservedForReauth();
+    expect(isBrowserReauthRequired()).toBe(true);
   });
 
   it("treats a second 401 after refresh recovery as an auth redirect", async () => {
@@ -112,20 +87,18 @@ describe("session transport auth recovery", () => {
     await expect(getSession()).rejects.toBeInstanceOf(AuthRedirectError);
 
     expect(fetchMock).toHaveBeenCalledTimes(4);
-    expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
     expect(new URL(redirectedUrl).pathname).toBe("/login");
-    await vi.waitFor(() => {
-      expectLocalBrowserStateCleared();
-      expect(isAuthResetRequired()).toBe(false);
-    });
+    expectLocalBrowserStatePreservedForReauth();
+    expect(isBrowserReauthRequired()).toBe(true);
   });
 
-  it("surfaces a refresh-service 500 without redirecting to login", async () => {
+  it("retries transient refresh-service failures before surfacing the final error", async () => {
     seedLocalBrowserState();
+    vi.spyOn(Math, "random").mockReturnValue(0);
     const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
-    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
-      .mockResolvedValueOnce(new Response(null, { status: 401 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({
+    function createRefreshFailureResponse(): Response {
+      return new Response(JSON.stringify({
         error: "Authentication failed. Try again.",
         code: "INTERNAL_ERROR",
         requestId: "body-refresh-request-id",
@@ -135,7 +108,13 @@ describe("session transport auth recovery", () => {
           "Content-Type": "application/json",
           "X-Request-Id": "header-refresh-request-id",
         },
-      }));
+      });
+    }
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(createRefreshFailureResponse())
+      .mockResolvedValueOnce(createRefreshFailureResponse())
+      .mockResolvedValueOnce(createRefreshFailureResponse());
     vi.stubGlobal("fetch", fetchMock);
 
     let redirectedUrl = "";
@@ -152,7 +131,7 @@ describe("session transport auth recovery", () => {
       responseBodyKind: "json",
     } satisfies Partial<ApiError>);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(deleteDatabaseSpy).not.toHaveBeenCalled();
     expect(redirectedUrl).toBe("");
     expectLocalBrowserStatePreserved();
@@ -257,15 +236,13 @@ describe("session transport auth recovery", () => {
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
     expect(redirectedUrls).toHaveLength(1);
-    await vi.waitFor(() => {
-      expectLocalBrowserStateCleared();
-      expect(isAuthResetRequired()).toBe(false);
-    });
+    expectLocalBrowserStatePreservedForReauth();
+    expect(isBrowserReauthRequired()).toBe(true);
   });
 
-  it("redirects to login even when IndexedDB cleanup is blocked", async () => {
+  it("redirects to login without attempting IndexedDB cleanup", async () => {
     seedLocalBrowserState();
     const deleteDatabaseSpy = mockBlockedDeleteDatabase();
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
@@ -281,30 +258,10 @@ describe("session transport auth recovery", () => {
     await expect(getSession()).rejects.toBeInstanceOf(AuthRedirectError);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
     expect(new URL(redirectedUrl).pathname).toBe("/login");
-    await vi.waitFor(() => {
-      expectLocalBrowserStateCleared();
-      expect(isAuthResetRequired()).toBe(true);
-    });
-    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith({
-      action: "auth_reset_cleanup_deferred",
-      scope: {
-        app: "web",
-        feature: "auth",
-        userId: null,
-        workspaceId: null,
-        installationId: "installation-1",
-        route: "/",
-        requestId: null,
-        statusCode: null,
-        code: null,
-      },
-      details: {
-        eventName: "auth_reset_cleanup_deferred",
-        errorMessage: "Failed to delete IndexedDB: delete request was blocked",
-      },
-    });
+    expectLocalBrowserStatePreservedForReauth();
+    expect(isBrowserReauthRequired()).toBe(true);
   });
 });
 

--- a/apps/web/src/api/transport.ts
+++ b/apps/web/src/api/transport.ts
@@ -1,5 +1,5 @@
 import { parseSessionInfoResponse } from "../apiContracts/account";
-import { markAuthResetRequired, runPendingAuthResetCleanup } from "../accountDeletion";
+import { markBrowserReauthRequired } from "../accountDeletion";
 import { getAppConfig } from "../config";
 import type { SessionInfo } from "../types";
 import { buildLoginUrl, getPreferredAuthUiLocale } from "./authUrls";
@@ -23,6 +23,17 @@ export type RequestOptions = Readonly<{
 }>;
 
 const refreshSessionEndpoint = "POST /api/refresh-session";
+const refreshSessionMaximumAttemptCount = 3;
+const refreshSessionBaseRetryDelayMs = 100;
+const refreshSessionMaximumRetryDelayMs = 500;
+const transientRefreshSessionStatusCodes: ReadonlySet<number> = new Set([
+  408,
+  429,
+  500,
+  502,
+  503,
+  504,
+]);
 
 let sessionCsrfToken: string | null = null;
 let sessionCsrfState: SessionCsrfState = "unknown";
@@ -30,25 +41,14 @@ let sessionRecoveryPromise: Promise<void> | null = null;
 let sessionCsrfRecoveryPromise: Promise<void> | null = null;
 let sessionTransportReadyPromise: Promise<void> | null = null;
 let redirectInFlight = false;
-let authRedirectPreparationPromise: Promise<void> | null = null;
 let navigationHandler: NavigateToUrl | null = null;
 
 /**
- * Browser-local app state is discarded only once the client has already
- * concluded that silent session recovery failed and an interactive login is
- * required. Successful refresh paths never call this hook.
+ * A terminal browser-auth failure locks warm start until `/me` confirms which
+ * account owns the browser. Local IndexedDB data is intentionally preserved.
  */
 function prepareForAuthRedirect(): void {
-  markAuthResetRequired();
-  if (authRedirectPreparationPromise !== null) {
-    return;
-  }
-
-  authRedirectPreparationPromise = runPendingAuthResetCleanup()
-    .then((): void => undefined)
-    .finally(() => {
-      authRedirectPreparationPromise = null;
-    });
+  markBrowserReauthRequired();
 }
 
 export const allowAuthRecovery: RequestOptions = {
@@ -83,7 +83,6 @@ export function resetApiClientStateForTests(): void {
   sessionCsrfRecoveryPromise = null;
   sessionTransportReadyPromise = null;
   redirectInFlight = false;
-  authRedirectPreparationPromise = null;
   navigationHandler = null;
 }
 
@@ -216,43 +215,30 @@ async function loadSessionInfoWithoutRecovery(): Promise<SessionInfo> {
   return session;
 }
 
-/**
- * Calls the auth service refresh endpoint with shared cookies and returns
- * `false` only when the refresh token is no longer valid.
- */
-async function refreshBrowserSession(): Promise<boolean> {
-  const config = getAppConfig();
-  let response: Response;
+function isTransientRefreshSessionStatus(statusCode: number): boolean {
+  return transientRefreshSessionStatusCodes.has(statusCode);
+}
 
-  try {
-    response = await fetch(`${config.authBaseUrl}/api/refresh-session`, {
-      method: "POST",
-      credentials: "include",
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new ApiError({
-      statusCode: 0,
-      message: `The auth service is unavailable. Try again. (/api/refresh-session; ${message})`,
-      code: null,
-      requestId: null,
-      endpoint: refreshSessionEndpoint,
-      responseBodyKind: "empty",
-    });
-  }
+function hasRemainingRefreshAttempt(attemptIndex: number): boolean {
+  return attemptIndex < refreshSessionMaximumAttemptCount - 1;
+}
 
-  if (response.ok) {
-    return true;
-  }
+function createRefreshSessionNetworkError(error: unknown): ApiError {
+  const message = error instanceof Error ? error.message : String(error);
+  return new ApiError({
+    statusCode: 0,
+    message: `The auth service is unavailable. Try again. (/api/refresh-session; ${message})`,
+    code: null,
+    requestId: null,
+    endpoint: refreshSessionEndpoint,
+    responseBodyKind: "empty",
+  });
+}
 
-  if (response.status === 401) {
-    resetSessionState();
-    return false;
-  }
-
+async function createRefreshSessionResponseError(response: Response): Promise<ApiError> {
   const payload = await readJsonResponse(response);
   const fallbackMessage = typeof payload.value === "string" ? payload.value : `Request failed with status ${response.status}`;
-  throw new ApiError({
+  return new ApiError({
     statusCode: response.status,
     message: getJsonErrorMessage(payload.value, fallbackMessage),
     code: payload.code,
@@ -260,6 +246,69 @@ async function refreshBrowserSession(): Promise<boolean> {
     endpoint: refreshSessionEndpoint,
     responseBodyKind: payload.bodyKind,
   });
+}
+
+function createRefreshSessionRetryDelay(attemptIndex: number): number {
+  const exponentialDelayMs = refreshSessionBaseRetryDelayMs * (2 ** attemptIndex);
+  const cappedDelayMs = Math.min(exponentialDelayMs, refreshSessionMaximumRetryDelayMs);
+  return Math.floor(Math.random() * cappedDelayMs);
+}
+
+function waitForRefreshSessionRetry(attemptIndex: number): Promise<void> {
+  const delayMs = createRefreshSessionRetryDelay(attemptIndex);
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, delayMs);
+  });
+}
+
+/**
+ * Calls the auth service refresh endpoint with shared cookies and returns
+ * `false` only when the refresh token is no longer valid.
+ */
+async function refreshBrowserSession(): Promise<boolean> {
+  const config = getAppConfig();
+  let lastNetworkError: ApiError | null = null;
+
+  for (let attemptIndex = 0; attemptIndex < refreshSessionMaximumAttemptCount; attemptIndex += 1) {
+    let response: Response;
+
+    try {
+      response = await fetch(`${config.authBaseUrl}/api/refresh-session`, {
+        method: "POST",
+        credentials: "include",
+      });
+    } catch (error) {
+      lastNetworkError = createRefreshSessionNetworkError(error);
+      if (hasRemainingRefreshAttempt(attemptIndex)) {
+        await waitForRefreshSessionRetry(attemptIndex);
+        continue;
+      }
+
+      throw lastNetworkError;
+    }
+
+    if (response.ok) {
+      return true;
+    }
+
+    if (response.status === 401) {
+      resetSessionState();
+      return false;
+    }
+
+    if (isTransientRefreshSessionStatus(response.status) && hasRemainingRefreshAttempt(attemptIndex)) {
+      await waitForRefreshSessionRetry(attemptIndex);
+      continue;
+    }
+
+    throw await createRefreshSessionResponseError(response);
+  }
+
+  if (lastNetworkError !== null) {
+    throw lastNetworkError;
+  }
+
+  throw new Error("Refresh session retry loop exited without a result");
 }
 
 /**

--- a/apps/web/src/appData/provider.tsx
+++ b/apps/web/src/appData/provider.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
   type ReactElement,
 } from "react";
@@ -117,6 +118,7 @@ export function AppDataProvider(props: Props): ReactElement {
   const [isSyncing, setIsSyncing] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [selectedReviewFilterState, setSelectedReviewFilterState] = useState<ReviewFilter>(loadSelectedReviewFilter);
+  const shouldSkipSelectedReviewFilterPersistRef = useRef<boolean>(false);
 
   const syncEngine = useSyncEngine({
     sessionLoadState,
@@ -131,6 +133,11 @@ export function AppDataProvider(props: Props): ReactElement {
   });
 
   useEffect(() => {
+    if (shouldSkipSelectedReviewFilterPersistRef.current) {
+      shouldSkipSelectedReviewFilterPersistRef.current = false;
+      return;
+    }
+
     window.localStorage.setItem(SELECTED_REVIEW_FILTER_STORAGE_KEY, JSON.stringify(selectedReviewFilterState));
   }, [selectedReviewFilterState]);
 
@@ -217,6 +224,18 @@ export function AppDataProvider(props: Props): ReactElement {
     setSelectedReviewFilterState(reviewFilter);
   }, [selectedReviewFilterState]);
 
+  const resetUserScopedUiState = useCallback(function resetUserScopedUiState(): void {
+    if (isReviewFilterEqual(selectedReviewFilterState, ALL_CARDS_REVIEW_FILTER) === false) {
+      shouldSkipSelectedReviewFilterPersistRef.current = true;
+    }
+
+    setSelectedReviewFilterState(ALL_CARDS_REVIEW_FILTER);
+    setWorkspaceSettings(null);
+    setLocalReadVersion(0);
+    setLocalCardCount(0);
+    setIsSyncing(false);
+  }, [selectedReviewFilterState]);
+
   const openReview = useCallback(function openReview(reviewFilter: ReviewFilter): void {
     setSelectedReviewFilterState(reviewFilter);
   }, []);
@@ -251,6 +270,8 @@ export function AppDataProvider(props: Props): ReactElement {
     runSyncSilently: syncEngine.runSyncSilently,
     runSyncForWorkspace: syncEngine.runSyncForWorkspace,
     discardWorkspaceSync: syncEngine.discardWorkspaceSync,
+    discardAllSyncWork: syncEngine.discardAllSyncWork,
+    resetUserScopedUiState,
   });
 
   const value: AppDataContextValue = {

--- a/apps/web/src/appData/syncRemote.ts
+++ b/apps/web/src/appData/syncRemote.ts
@@ -168,6 +168,7 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
     }
   }
 
+  input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   await input.refreshWorkspaceView(input.workspaceId);
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   return {
@@ -203,6 +204,7 @@ async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFl
 
       for (const result of pushResult.operations) {
         if (isAcknowledgedPushStatus(result.status)) {
+          input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
           await deleteOutboxRecord(input.workspaceId, result.operationId);
           if (reviewScheduleOperationIds.has(result.operationId)) {
             didChangeReviewSchedule = true;
@@ -214,8 +216,10 @@ async function pushOutbox(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFl
         didChangeProgressHistory = true;
       }
     } catch (error) {
+      input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
       const errorMessage = getErrorMessage(error);
       for (const record of batch) {
+        input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
         await putOutboxRecord({
           ...record,
           attemptCount: record.attemptCount + 1,

--- a/apps/web/src/appData/useSyncEngine.ts
+++ b/apps/web/src/appData/useSyncEngine.ts
@@ -87,6 +87,7 @@ type SyncEngine = Readonly<{
   runSyncSilently: () => Promise<void>;
   runSyncForWorkspace: (workspace: WorkspaceSummary) => Promise<void>;
   discardWorkspaceSync: (workspaceId: string) => void;
+  discardAllSyncWork: (runWhileDiscarding: () => Promise<void>) => Promise<void>;
   refreshLocalData: () => Promise<void>;
   refreshWorkspaceView: (workspaceId: string) => Promise<void>;
   getCardById: (cardId: string) => Promise<Card>;
@@ -115,9 +116,14 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   } = params;
   const activeWorkspaceRef = useRef<WorkspaceSummary | null>(activeWorkspace);
   const syncPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
+  const localReadPromisesRef = useRef<Set<Promise<unknown>>>(new Set());
+  const localMutationPromisesRef = useRef<Set<Promise<unknown>>>(new Set());
   const needsResyncWorkspaceIdsRef = useRef<Set<string>>(new Set());
   const syncingWorkspaceIdsRef = useRef<Set<string>>(new Set());
   const discardedSyncWorkspaceIdsRef = useRef<Set<string>>(new Set());
+  const syncGenerationRef = useRef<number>(0);
+  const isDiscardingAllSyncWorkRef = useRef<boolean>(false);
+  const discardAllSyncWorkPromiseRef = useRef<Promise<void> | null>(null);
 
   useEffect(() => {
     activeWorkspaceRef.current = activeWorkspace;
@@ -144,10 +150,46 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     refreshSyncIndicator();
   }, [refreshSyncIndicator]);
 
+  const discardAllSyncWork = useCallback(async function discardAllSyncWork(
+    runWhileDiscarding: () => Promise<void>,
+  ): Promise<void> {
+    const activeDiscard = discardAllSyncWorkPromiseRef.current;
+    if (activeDiscard !== null) {
+      return activeDiscard;
+    }
+
+    const discardTask = (async (): Promise<void> => {
+      isDiscardingAllSyncWorkRef.current = true;
+      const activeSyncTasks = [...syncPromisesRef.current.values()];
+      const activeLocalReadTasks = [...localReadPromisesRef.current.values()];
+      const activeLocalMutationTasks = [...localMutationPromisesRef.current.values()];
+      syncGenerationRef.current += 1;
+      syncPromisesRef.current.clear();
+      needsResyncWorkspaceIdsRef.current.clear();
+      syncingWorkspaceIdsRef.current.clear();
+      discardedSyncWorkspaceIdsRef.current.clear();
+      refreshSyncIndicator();
+
+      try {
+        await Promise.allSettled([...activeSyncTasks, ...activeLocalReadTasks, ...activeLocalMutationTasks]);
+        await runWhileDiscarding();
+      } finally {
+        discardAllSyncWorkPromiseRef.current = null;
+        isDiscardingAllSyncWorkRef.current = false;
+      }
+    })();
+    discardAllSyncWorkPromiseRef.current = discardTask;
+    return discardTask;
+  }, [refreshSyncIndicator]);
+
   const requireWorkspaceSyncNotDiscarded = useCallback(function requireWorkspaceSyncNotDiscarded(
     workspaceId: string,
+    syncGeneration: number,
   ): void {
-    if (discardedSyncWorkspaceIdsRef.current.has(workspaceId)) {
+    if (
+      syncGeneration !== syncGenerationRef.current
+      || discardedSyncWorkspaceIdsRef.current.has(workspaceId)
+    ) {
       throw createWorkspaceSyncDiscardedError(workspaceId);
     }
   }, []);
@@ -159,19 +201,48 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     return isWorkspaceNotFoundError(error) && isVisibleWorkspace(workspaceId) === false;
   }, [isVisibleWorkspace]);
 
+  const runLocalDataRead = useCallback(async function runLocalDataRead<ResultType>(
+    createReadTask: () => Promise<ResultType>,
+  ): Promise<ResultType> {
+    if (isDiscardingAllSyncWorkRef.current) {
+      throw new Error("Workspace is unavailable");
+    }
+
+    const readTask: Promise<ResultType> = Promise.resolve().then(createReadTask);
+    const trackedReadTask = readTask.finally(() => {
+      localReadPromisesRef.current.delete(trackedReadTask);
+    });
+    localReadPromisesRef.current.add(trackedReadTask);
+    return trackedReadTask;
+  }, []);
+
   const refreshLocalMetadata = useCallback(async function refreshLocalMetadata(workspaceId: string): Promise<void> {
-    const [workspaceSettings, cloudSettings] = await Promise.all([
+    if (isDiscardingAllSyncWorkRef.current) {
+      return;
+    }
+
+    const metadataGeneration = syncGenerationRef.current;
+    const [workspaceSettings, cloudSettings] = await runLocalDataRead(() => Promise.all([
       loadWorkspaceSettings(workspaceId),
       loadCloudSettings(),
-    ]);
+    ]));
+    if (metadataGeneration !== syncGenerationRef.current || isDiscardingAllSyncWorkRef.current) {
+      return;
+    }
+
     setCloudSettings(cloudSettings);
     if (isVisibleWorkspace(workspaceId)) {
       setWorkspaceSettings(workspaceSettings);
     }
-  }, [isVisibleWorkspace, setCloudSettings, setWorkspaceSettings]);
+  }, [isVisibleWorkspace, runLocalDataRead, setCloudSettings, setWorkspaceSettings]);
 
   const refreshWorkspaceView = useCallback(async function refreshWorkspaceView(workspaceId: string): Promise<void> {
+    const metadataGeneration = syncGenerationRef.current;
     await refreshLocalMetadata(workspaceId);
+    if (metadataGeneration !== syncGenerationRef.current) {
+      return;
+    }
+
     if (isVisibleWorkspace(workspaceId)) {
       bumpLocalReadVersion();
     }
@@ -212,11 +283,12 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
   ): Promise<void> {
     // Local writes may happen during warm start, but remote sync stays paused
     // until auth verification confirms which account owns this browser state.
-    if (session === null || sessionVerificationState !== "verified") {
+    if (isDiscardingAllSyncWorkRef.current || session === null || sessionVerificationState !== "verified") {
       return;
     }
 
     const workspaceId = workspace.workspaceId;
+    const syncGeneration = syncGenerationRef.current;
     if (discardedSyncWorkspaceIdsRef.current.has(workspaceId)) {
       return;
     }
@@ -232,22 +304,37 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
 
     const syncTask = (async (): Promise<void> => {
       let syncInstallationId: string | null = null;
+      const requireCurrentWorkspaceSync = function requireCurrentWorkspaceSync(currentWorkspaceId: string): void {
+        requireWorkspaceSyncNotDiscarded(currentWorkspaceId, syncGeneration);
+      };
+      const publishCurrentWorkspaceSettings = function publishCurrentWorkspaceSettings(
+        currentWorkspaceId: string,
+        workspaceSettings: WorkspaceSchedulerSettings,
+      ): void {
+        requireCurrentWorkspaceSync(currentWorkspaceId);
+        publishWorkspaceSettings(currentWorkspaceId, workspaceSettings);
+      };
+      const refreshCurrentWorkspaceView = async function refreshCurrentWorkspaceView(currentWorkspaceId: string): Promise<void> {
+        requireCurrentWorkspaceSync(currentWorkspaceId);
+        await refreshWorkspaceView(currentWorkspaceId);
+        requireCurrentWorkspaceSync(currentWorkspaceId);
+      };
+
       try {
-        requireWorkspaceSyncNotDiscarded(workspaceId);
+        requireCurrentWorkspaceSync(workspaceId);
         const cloudSettings = await loadCloudSettings();
-        requireWorkspaceSyncNotDiscarded(workspaceId);
+        requireCurrentWorkspaceSync(workspaceId);
         const installationId = requireCloudInstallationId(cloudSettings);
         syncInstallationId = installationId;
         const syncFlags = await runWorkspaceRemoteSync({
           workspaceId,
           installationId,
-          requireWorkspaceSyncNotDiscarded,
-          publishWorkspaceSettings,
-          refreshWorkspaceView,
+          requireWorkspaceSyncNotDiscarded: requireCurrentWorkspaceSync,
+          publishWorkspaceSettings: publishCurrentWorkspaceSettings,
+          refreshWorkspaceView: refreshCurrentWorkspaceView,
         });
 
-        await refreshWorkspaceView(workspaceId);
-        requireWorkspaceSyncNotDiscarded(workspaceId);
+        await refreshCurrentWorkspaceView(workspaceId);
         if (syncFlags.didChangeProgressHistory) {
           invalidateProgress();
         }
@@ -256,6 +343,10 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         }
         setErrorMessage("");
       } catch (error) {
+        if (syncGeneration !== syncGenerationRef.current) {
+          return;
+        }
+
         if (isAuthRedirectError(error)) {
           throw error;
         }
@@ -284,14 +375,16 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         reportSyncError(getErrorMessage(error));
         throw error;
       } finally {
-        syncPromisesRef.current.delete(workspaceId);
-        syncingWorkspaceIdsRef.current.delete(workspaceId);
-        refreshSyncIndicator();
+        if (syncGeneration === syncGenerationRef.current) {
+          syncPromisesRef.current.delete(workspaceId);
+          syncingWorkspaceIdsRef.current.delete(workspaceId);
+          refreshSyncIndicator();
 
-        const needsResync = needsResyncWorkspaceIdsRef.current.has(workspaceId);
-        needsResyncWorkspaceIdsRef.current.delete(workspaceId);
-        if (needsResync && discardedSyncWorkspaceIdsRef.current.has(workspaceId) === false) {
-          void runSyncForWorkspace(workspace);
+          const needsResync = needsResyncWorkspaceIdsRef.current.has(workspaceId);
+          needsResyncWorkspaceIdsRef.current.delete(workspaceId);
+          if (needsResync && discardedSyncWorkspaceIdsRef.current.has(workspaceId) === false) {
+            void runSyncForWorkspace(workspace);
+          }
         }
       }
     })();
@@ -354,119 +447,137 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    return requireCard(activeWorkspace.workspaceId, cardId);
-  }, [activeWorkspace]);
+    return runLocalDataRead(() => requireCard(activeWorkspace.workspaceId, cardId));
+  }, [activeWorkspace, runLocalDataRead]);
 
   const getDeckById = useCallback(async function getDeckById(deckId: string): Promise<Deck> {
     if (activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    return requireDeck(activeWorkspace.workspaceId, deckId);
-  }, [activeWorkspace]);
+    return runLocalDataRead(() => requireDeck(activeWorkspace.workspaceId, deckId));
+  }, [activeWorkspace, runLocalDataRead]);
 
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
+
+  const requireLocalWorkspaceMutationReady = useCallback(function requireLocalWorkspaceMutationReady(): void {
+    if (isDiscardingAllSyncWorkRef.current) {
+      throw new Error("Workspace is unavailable");
+    }
+  }, []);
+
+  const runLocalWorkspaceMutation = useCallback(async function runLocalWorkspaceMutation<T>(
+    createMutationTask: () => Promise<T>,
+  ): Promise<T> {
+    requireLocalWorkspaceMutationReady();
+    const mutationTask = createMutationTask();
+    const trackedMutationTask = mutationTask.finally(() => {
+      localMutationPromisesRef.current.delete(trackedMutationTask);
+    });
+    localMutationPromisesRef.current.add(trackedMutationTask);
+    return trackedMutationTask;
+  }, [requireLocalWorkspaceMutationReady]);
 
   const createCardItem = useCallback(async function createCardItem(input: CreateCardInput): Promise<Card> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await createCardLocally({
+    const mutationResult = await runLocalWorkspaceMutation(() => createCardLocally({
       workspaceId: activeWorkspaceId,
       input,
       clientUpdatedAt: nowIso(),
-    });
+    }));
     bumpLocalReadVersion();
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     void runSyncForWorkspace(activeWorkspace);
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const createDeckItem = useCallback(async function createDeckItem(input: CreateDeckInput): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await createDeckLocally({
+    const mutationResult = await runLocalWorkspaceMutation(() => createDeckLocally({
       workspaceId: activeWorkspaceId,
       input,
       clientUpdatedAt: nowIso(),
-    });
+    }));
     bumpLocalReadVersion();
     void runSyncForWorkspace(activeWorkspace);
     return mutationResult.deck;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const updateCardItem = useCallback(async function updateCardItem(cardId: string, input: UpdateCardInput): Promise<Card> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await updateCardLocally({
+    const mutationResult = await runLocalWorkspaceMutation(() => updateCardLocally({
       workspaceId: activeWorkspaceId,
       cardId,
       input,
       clientUpdatedAt: nowIso(),
-    });
+    }));
     bumpLocalReadVersion();
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     void runSyncForWorkspace(activeWorkspace);
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const updateDeckItem = useCallback(async function updateDeckItem(deckId: string, input: UpdateDeckInput): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await updateDeckLocally({
+    const mutationResult = await runLocalWorkspaceMutation(() => updateDeckLocally({
       workspaceId: activeWorkspaceId,
       deckId,
       input,
       clientUpdatedAt: nowIso(),
-    });
+    }));
     bumpLocalReadVersion();
     void runSyncForWorkspace(activeWorkspace);
     return mutationResult.deck;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const deleteCardItem = useCallback(async function deleteCardItem(cardId: string): Promise<Card> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await deleteCardLocally({
+    const mutationResult = await runLocalWorkspaceMutation(() => deleteCardLocally({
       workspaceId: activeWorkspaceId,
       cardId,
       clientUpdatedAt: nowIso(),
-    });
+    }));
     bumpLocalReadVersion();
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
     void runSyncForWorkspace(activeWorkspace);
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const deleteDeckItem = useCallback(async function deleteDeckItem(deckId: string): Promise<Deck> {
     if (activeWorkspaceId === null || activeWorkspace === null) {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await deleteDeckLocally({
+    const mutationResult = await runLocalWorkspaceMutation(() => deleteDeckLocally({
       workspaceId: activeWorkspaceId,
       deckId,
       clientUpdatedAt: nowIso(),
-    });
+    }));
     bumpLocalReadVersion();
     void runSyncForWorkspace(activeWorkspace);
     return mutationResult.deck;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const submitReviewItem = useCallback(async function submitReviewItem(
     cardId: string,
@@ -476,18 +587,18 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
-    const mutationResult = await submitReviewLocally({
+    const mutationResult = await runLocalWorkspaceMutation(() => submitReviewLocally({
       workspaceId: activeWorkspaceId,
       cardId,
       rating,
       reviewedAtClient: nowIso(),
-    });
+    }));
     bumpLocalReadVersion();
     invalidateLocalProgress();
     invalidateLocalReviewSchedule();
     void runSyncForWorkspace(activeWorkspace);
     return mutationResult.card;
-  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runSyncForWorkspace]);
+  }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
   const seedLinkedWorkspace = useCallback(async function seedLinkedWorkspace(
     request: TestSeedRequest,
@@ -498,21 +609,22 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       || sessionLoadState !== "ready"
       || sessionVerificationState !== "verified"
       || session === null
+      || isDiscardingAllSyncWorkRef.current
     ) {
       throw new Error("Linked workspace is not ready for deterministic seed data");
     }
 
     validateSeedRequest(request);
-    await ensureWorkspaceSeedReady({
+    await runLocalDataRead(() => ensureWorkspaceSeedReady({
       workspace: activeWorkspace,
       waitForWorkspaceSyncToSettle,
       refreshWorkspaceView,
       runSyncForWorkspace,
-    });
-    const seedMutationResult = await seedWorkspaceLocally({
+    }));
+    const seedMutationResult = await runLocalWorkspaceMutation(() => seedWorkspaceLocally({
       workspaceId: activeWorkspaceId,
       request,
-    });
+    }));
 
     bumpLocalReadVersion();
     if (seedMutationResult.didChangeReviewSchedule) {
@@ -531,6 +643,8 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     activeWorkspaceId,
     bumpLocalReadVersion,
     refreshWorkspaceView,
+    runLocalDataRead,
+    runLocalWorkspaceMutation,
     runSyncForWorkspace,
     session,
     sessionLoadState,
@@ -543,6 +657,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     runSyncSilently,
     runSyncForWorkspace,
     discardWorkspaceSync,
+    discardAllSyncWork,
     refreshLocalData,
     refreshWorkspaceView,
     getCardById,

--- a/apps/web/src/appData/useWorkspaceSession.test.tsx
+++ b/apps/web/src/appData/useWorkspaceSession.test.tsx
@@ -3,11 +3,14 @@ import "fake-indexeddb/auto";
 import { act, useEffect, useState, type ReactElement } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
-import { isAuthResetRequired, markAuthResetRequired } from "../accountDeletion";
+import {
+  isBrowserReauthRequired,
+  markBrowserReauthRequired,
+} from "../accountDeletion";
 import { setNavigationHandlerForTests, resetApiClientStateForTests } from "../api";
 import { INSTALLATION_ID_STORAGE_KEY } from "../clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "../i18n/runtime";
-import { WARM_START_SNAPSHOT_STORAGE_KEY } from "./warmStart";
+import { loadWarmStartSnapshot, WARM_START_SNAPSHOT_STORAGE_KEY } from "./warmStart";
 import { useWorkspaceSession } from "./useWorkspaceSession";
 import { putCloudSettings, loadCloudSettings } from "../localDb/cloudSettings";
 import type { CloudSettings, SessionInfo, WorkspaceSummary } from "../types";
@@ -46,6 +49,8 @@ type HarnessActions = Readonly<{
   deleteWorkspace: (workspaceId: string, confirmationText: string) => Promise<void>;
 }>;
 
+type DiscardAllSyncWorkForTest = (runWhileDiscarding: () => Promise<void>) => Promise<void>;
+
 type TestHarnessProps = Readonly<{
   initialSessionLoadState: SessionLoadState;
   initialSessionVerificationState: SessionVerificationState;
@@ -58,7 +63,15 @@ type TestHarnessProps = Readonly<{
   runSyncSilentlyMock: Mock<() => Promise<void>>;
   runSyncForWorkspaceMock: Mock<(workspace: WorkspaceSummary) => Promise<void>>;
   discardWorkspaceSyncMock: Mock<(workspaceId: string) => void>;
+  discardAllSyncWorkMock: Mock<DiscardAllSyncWorkForTest>;
+  resetUserScopedUiStateMock: Mock<() => void>;
   onActionsChange: ((actions: HarnessActions) => void) | null;
+}>;
+
+type DeferredVoidPromise = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
 }>;
 
 const reviewRouteUrl = "http://localhost:3000/review";
@@ -124,19 +137,34 @@ function createStorageMock(): Storage {
   };
 }
 
-function mockBlockedDeleteDatabase(): ReturnType<typeof vi.spyOn> {
-  return vi.spyOn(indexedDB, "deleteDatabase").mockImplementation(() => {
-    const request = {} as IDBOpenDBRequest;
-    queueMicrotask(() => {
-      request.onblocked?.(new Event("blocked"));
-    });
-    return request;
+function createDeferredVoidPromise(): DeferredVoidPromise {
+  let resolvePromise: (() => void) | null = null;
+  let rejectPromise: ((error: Error) => void) | null = null;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  if (resolvePromise === null || rejectPromise === null) {
+    throw new Error("Deferred promise handlers were not initialized");
+  }
+
+  return {
+    promise,
+    resolve: resolvePromise,
+    reject: rejectPromise,
+  };
+}
+
+function createDiscardAllSyncWorkMock(): Mock<DiscardAllSyncWorkForTest> {
+  return vi.fn(async (runWhileDiscarding: () => Promise<void>): Promise<void> => {
+    await runWhileDiscarding();
   });
 }
 
-function buildSessionResponse(selectedWorkspaceId: string | null, csrfToken: string): Response {
+function buildSessionResponseForUser(userId: string, selectedWorkspaceId: string | null, csrfToken: string): Response {
   return new Response(JSON.stringify({
-    userId: "user-1",
+    userId,
     selectedWorkspaceId,
     authTransport: "session",
     csrfToken,
@@ -151,6 +179,10 @@ function buildSessionResponse(selectedWorkspaceId: string | null, csrfToken: str
       "Content-Type": "application/json",
     },
   });
+}
+
+function buildSessionResponse(selectedWorkspaceId: string | null, csrfToken: string): Response {
+  return buildSessionResponseForUser("user-1", selectedWorkspaceId, csrfToken);
 }
 
 function buildWorkspacesResponse(workspaces: ReadonlyArray<WorkspaceSummary>): Response {
@@ -192,6 +224,8 @@ function TestHarness(props: TestHarnessProps): ReactElement {
     runSyncSilentlyMock,
     runSyncForWorkspaceMock,
     discardWorkspaceSyncMock,
+    discardAllSyncWorkMock,
+    resetUserScopedUiStateMock,
     onActionsChange,
   } = props;
   const [sessionLoadState, setSessionLoadState] = useState<SessionLoadState>(initialSessionLoadState);
@@ -226,6 +260,8 @@ function TestHarness(props: TestHarnessProps): ReactElement {
     runSyncSilently: runSyncSilentlyMock,
     runSyncForWorkspace: runSyncForWorkspaceMock,
     discardWorkspaceSync: discardWorkspaceSyncMock,
+    discardAllSyncWork: discardAllSyncWorkMock,
+    resetUserScopedUiState: resetUserScopedUiStateMock,
   });
 
   useEffect(() => {
@@ -318,6 +354,7 @@ describe("useWorkspaceSession bootstrap", () => {
     });
     window.localStorage.clear();
     resetApiClientStateForTests();
+    document.cookie = "logged_in=; Max-Age=0; Path=/";
     window.history.replaceState({}, document.title, reviewRouteUrl);
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -347,14 +384,24 @@ describe("useWorkspaceSession bootstrap", () => {
     redirectedUrl = null;
     setNavigationHandlerForTests(null);
     resetApiClientStateForTests();
+    document.cookie = "logged_in=; Max-Age=0; Path=/";
     window.localStorage.clear();
     vi.restoreAllMocks();
     await clearWebSyncCache();
   });
 
-  it("redirects after unrecoverable bootstrap auth failure, clears local browser state, and skips the generic error state", async () => {
+  it("suppresses warm start while browser reauth is required", () => {
+    seedWarmStartSnapshot();
+    document.cookie = "logged_in=1; Path=/";
+    markBrowserReauthRequired();
+
+    expect(loadWarmStartSnapshot()).toBeNull();
+  });
+
+  it("redirects after unrecoverable bootstrap auth failure, preserves local data, and skips the generic error state", async () => {
     seedBrowserStorage();
     await seedIndexedDbState();
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
 
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
@@ -390,6 +437,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncSilentlyMock={runSyncSilentlyMock}
           runSyncForWorkspaceMock={runSyncForWorkspaceMock}
           discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
           onActionsChange={null}
         />,
       );
@@ -406,26 +455,25 @@ describe("useWorkspaceSession bootstrap", () => {
     expect(latestState?.availableWorkspaces).toEqual([]);
     expect(redirectedUrl).not.toBeNull();
     expect(new URL(redirectedUrl as string).searchParams.get("redirect_uri")).toBe(reviewRouteUrl);
-    await vi.waitFor(() => {
-      expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).toBeNull();
-      expect(window.localStorage.getItem("selected-review-filter")).toBeNull();
-      expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
-      expect(window.localStorage.getItem("flashcards-ai-chat-config")).toBeNull();
-      expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
-      expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("es-MX");
-      expect(isAuthResetRequired()).toBe(false);
-    });
-    await vi.waitFor(async () => {
-      expect(await loadCloudSettings()).toBeNull();
-    });
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).not.toBeNull();
+    expect(window.localStorage.getItem("selected-review-filter")).not.toBeNull();
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).not.toBeNull();
+    expect(window.localStorage.getItem("flashcards-ai-chat-config")).not.toBeNull();
+    expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
+    expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("es-MX");
+    expect(isBrowserReauthRequired()).toBe(true);
+    await expect(loadCloudSettings()).resolves.toEqual(seededCloudSettings);
     expect(refreshWorkspaceViewMock).not.toHaveBeenCalled();
     expect(runSyncForWorkspaceMock).not.toHaveBeenCalled();
   });
 
-  it("retries and clears a pending auth reset before continuing bootstrap", async () => {
+  it("clears a same-user reauth marker without deleting local data during bootstrap", async () => {
     seedBrowserStorage();
     await seedIndexedDbState();
-    markAuthResetRequired();
+    markBrowserReauthRequired();
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
+    const resetUserScopedUiStateMock = vi.fn((): void => {});
 
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
@@ -448,6 +496,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
           runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
           discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={resetUserScopedUiStateMock}
           onActionsChange={null}
         />,
       );
@@ -459,21 +509,24 @@ describe("useWorkspaceSession bootstrap", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).toBeNull();
-    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).not.toBeNull();
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).not.toBeNull();
     expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
     expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("es-MX");
-    expect(isAuthResetRequired()).toBe(false);
+    expect(isBrowserReauthRequired()).toBe(false);
+    expect(resetUserScopedUiStateMock).not.toHaveBeenCalled();
   });
 
-  it("keeps a pending auth reset marker when IndexedDB cleanup is blocked during bootstrap", async () => {
+  it("clears local data only after bootstrap confirms a different user", async () => {
     seedBrowserStorage();
     await seedIndexedDbState();
-    markAuthResetRequired();
-    const deleteDatabaseSpy = mockBlockedDeleteDatabase();
+    markBrowserReauthRequired();
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
+    const resetUserScopedUiStateMock = vi.fn((): void => {});
 
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
-      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildSessionResponseForUser("user-2", "workspace-1", "csrf-refresh"))
       .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -493,6 +546,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
           runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
           discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={resetUserScopedUiStateMock}
           onActionsChange={null}
         />,
       );
@@ -505,29 +560,69 @@ describe("useWorkspaceSession bootstrap", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(deleteDatabaseSpy.mock.invocationCallOrder[0]).toBeGreaterThan(
+      fetchMock.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).toBeNull();
     expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
     expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
     expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("es-MX");
-    expect(isAuthResetRequired()).toBe(true);
-    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith({
-      action: "auth_reset_cleanup_deferred",
-      scope: {
-        app: "web",
-        feature: "auth",
-        userId: null,
-        workspaceId: null,
-        installationId: "installation-1",
-        route: "/review",
-        requestId: null,
-        statusCode: null,
-        code: null,
-      },
-      details: {
-        eventName: "auth_reset_cleanup_deferred",
-        errorMessage: "Failed to delete IndexedDB: delete request was blocked",
-      },
+    expect(isBrowserReauthRequired()).toBe(false);
+    expect(resetUserScopedUiStateMock).toHaveBeenCalledTimes(1);
+    await expect(loadCloudSettings()).resolves.toEqual(expect.objectContaining({
+      linkedUserId: "user-2",
+      linkedWorkspaceId: "workspace-1",
+    }));
+  });
+
+  it("clears reauth data when local ownership is unknown", async () => {
+    seedBrowserStorage();
+    markBrowserReauthRequired();
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
+    const resetUserScopedUiStateMock = vi.fn((): void => {});
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={vi.fn(async (): Promise<void> => {})}
+          runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
+          runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={resetUserScopedUiStateMock}
+          onActionsChange={null}
+        />,
+      );
     });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionLoadState).toBe("ready");
+      expect(latestState?.sessionVerificationState).toBe("verified");
+    });
+
+    expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+    expect(isBrowserReauthRequired()).toBe(false);
+    expect(resetUserScopedUiStateMock).toHaveBeenCalledTimes(1);
+    await expect(loadCloudSettings()).resolves.toEqual(expect.objectContaining({
+      linkedUserId: "user-1",
+      linkedWorkspaceId: "workspace-1",
+    }));
   });
 
   it("recovers an expired session during bootstrap and continues normal workspace initialization", async () => {
@@ -563,6 +658,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncSilentlyMock={runSyncSilentlyMock}
           runSyncForWorkspaceMock={runSyncForWorkspaceMock}
           discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
           onActionsChange={null}
         />,
       );
@@ -587,6 +684,240 @@ describe("useWorkspaceSession bootstrap", () => {
       linkedWorkspaceId: "workspace-1",
       linkedUserId: "user-1",
     }));
+  });
+
+  it("clears a reauth marker after resume confirms the same user", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]))
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-resume"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {});
+    const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {});
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={vi.fn(async (): Promise<void> => {})}
+          runSyncSilentlyMock={runSyncSilentlyMock}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
+          onActionsChange={null}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionVerificationState).toBe("verified");
+      expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    });
+    await flushEffects();
+
+    markBrowserReauthRequired();
+    expect(isBrowserReauthRequired()).toBe(true);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await vi.waitFor(() => {
+      expect(runSyncSilentlyMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(latestState?.session?.userId).toBe("user-1");
+    expect(latestState?.session?.csrfToken).toBe("csrf-resume");
+    expect(isBrowserReauthRequired()).toBe(false);
+  });
+
+  it("clears local data when resume confirms a different user", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
+    const syncDiscardDeferred = createDeferredVoidPromise();
+    const discardAllSyncWorkMock = vi.fn(async (
+      runWhileDiscarding: () => Promise<void>,
+    ): Promise<void> => {
+      await syncDiscardDeferred.promise;
+      await runWhileDiscarding();
+    });
+    const resetUserScopedUiStateMock = vi.fn((): void => {});
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]))
+      .mockResolvedValueOnce(buildSessionResponseForUser("user-2", "workspace-2", "csrf-user-2"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([replacementWorkspace]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {});
+    const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {});
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={vi.fn(async (): Promise<void> => {})}
+          runSyncSilentlyMock={runSyncSilentlyMock}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={discardAllSyncWorkMock}
+          resetUserScopedUiStateMock={resetUserScopedUiStateMock}
+          onActionsChange={null}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.session?.userId).toBe("user-1");
+      expect(latestState?.sessionVerificationState).toBe("verified");
+      expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    });
+    await flushEffects();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await vi.waitFor(() => {
+      expect(discardAllSyncWorkMock).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(latestState?.session).toBeNull();
+      expect(latestState?.activeWorkspace).toBeNull();
+      expect(latestState?.availableWorkspaces).toEqual([]);
+      expect(latestState?.sessionLoadState).toBe("loading");
+      expect(latestState?.sessionVerificationState).toBe("unverified");
+    });
+    expect(deleteDatabaseSpy).not.toHaveBeenCalled();
+
+    syncDiscardDeferred.resolve();
+    await act(async () => {
+      await syncDiscardDeferred.promise;
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.session?.userId).toBe("user-2");
+      expect(latestState?.activeWorkspace?.workspaceId).toBe("workspace-2");
+      expect(latestState?.sessionVerificationState).toBe("verified");
+    });
+
+    expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    expect(discardAllSyncWorkMock.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteDatabaseSpy.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(resetUserScopedUiStateMock).toHaveBeenCalledTimes(1);
+    expect(observabilityMocks.setWebObservabilityUserMock).toHaveBeenCalledWith({ id: "user-2" });
+    expect(runSyncSilentlyMock).not.toHaveBeenCalled();
+    expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(2);
+    expect(window.localStorage.getItem(WARM_START_SNAPSHOT_STORAGE_KEY)).toBeNull();
+    await expect(loadCloudSettings()).resolves.toEqual(expect.objectContaining({
+      linkedUserId: "user-2",
+      linkedWorkspaceId: "workspace-2",
+    }));
+  });
+
+  it("shows an error when resume account switch bootstrap fails", async () => {
+    seedBrowserStorage();
+    await seedIndexedDbState();
+    const discardAllSyncWorkMock = createDiscardAllSyncWorkMock();
+    const resetUserScopedUiStateMock = vi.fn((): void => {});
+
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(buildSessionResponse("workspace-1", "csrf-refresh"))
+      .mockResolvedValueOnce(buildWorkspacesResponse([seededWorkspace]))
+      .mockResolvedValueOnce(buildSessionResponseForUser("user-2", "workspace-2", "csrf-user-2"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        error: "Switch bootstrap failed",
+      }), {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const runSyncSilentlyMock = vi.fn(async (): Promise<void> => {});
+    const oldBootstrapDeferred = createDeferredVoidPromise();
+    const runSyncForWorkspaceMock = vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {
+      if (runSyncForWorkspaceMock.mock.calls.length === 1) {
+        await oldBootstrapDeferred.promise;
+      }
+    });
+
+    await act(async () => {
+      root?.render(
+        <TestHarness
+          initialSessionLoadState="ready"
+          initialSessionVerificationState="unverified"
+          initialSession={seededSession}
+          initialActiveWorkspace={seededWorkspace}
+          initialAvailableWorkspaces={[seededWorkspace]}
+          onStateChange={(snapshot: HarnessSnapshot): void => {
+            latestState = snapshot;
+          }}
+          refreshWorkspaceViewMock={vi.fn(async (): Promise<void> => {})}
+          runSyncMock={vi.fn(async (): Promise<void> => {})}
+          runSyncSilentlyMock={runSyncSilentlyMock}
+          runSyncForWorkspaceMock={runSyncForWorkspaceMock}
+          discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={discardAllSyncWorkMock}
+          resetUserScopedUiStateMock={resetUserScopedUiStateMock}
+          onActionsChange={null}
+        />,
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.session?.userId).toBe("user-1");
+      expect(latestState?.sessionVerificationState).toBe("verified");
+      expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+    });
+    await flushEffects();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await vi.waitFor(() => {
+      expect(latestState?.sessionLoadState).toBe("error");
+      expect(latestState?.sessionErrorMessage).toBe("Switch bootstrap failed");
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(discardAllSyncWorkMock).toHaveBeenCalledTimes(1);
+    expect(resetUserScopedUiStateMock).toHaveBeenCalledTimes(1);
+    expect(observabilityMocks.setWebObservabilityUserMock).toHaveBeenCalledWith({ id: "user-2" });
+    expect(runSyncSilentlyMock).not.toHaveBeenCalled();
+    expect(runSyncForWorkspaceMock).toHaveBeenCalledTimes(1);
+
+    oldBootstrapDeferred.resolve();
+    await flushEffects();
+    expect(latestState?.sessionLoadState).toBe("error");
+    expect(latestState?.sessionErrorMessage).toBe("Switch bootstrap failed");
   });
 
   it("shows the generic bootstrap error state for real backend failures instead of redirecting", async () => {
@@ -620,6 +951,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncSilentlyMock={vi.fn(async (): Promise<void> => {})}
           runSyncForWorkspaceMock={vi.fn(async (_workspace: WorkspaceSummary): Promise<void> => {})}
           discardWorkspaceSyncMock={vi.fn((_workspaceId: string): void => {})}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
           onActionsChange={null}
         />,
       );
@@ -672,6 +1005,8 @@ describe("useWorkspaceSession bootstrap", () => {
           runSyncSilentlyMock={runSyncSilentlyMock}
           runSyncForWorkspaceMock={runSyncForWorkspaceMock}
           discardWorkspaceSyncMock={discardWorkspaceSyncMock}
+          discardAllSyncWorkMock={createDiscardAllSyncWorkMock()}
+          resetUserScopedUiStateMock={vi.fn((): void => {})}
           onActionsChange={(actions: HarnessActions): void => {
             latestActions = actions;
           }}

--- a/apps/web/src/appData/useWorkspaceSession.ts
+++ b/apps/web/src/appData/useWorkspaceSession.ts
@@ -20,9 +20,10 @@ import {
   resetWorkspaceProgress as resetWorkspaceProgressRequest,
 } from "../api";
 import {
+  clearBrowserReauthRequired,
   clearAllLocalBrowserData,
   consumeAccountDeletedMarker,
-  runPendingAuthResetCleanup,
+  isBrowserReauthRequired,
 } from "../accountDeletion";
 import { getStableInstallationId } from "../clientIdentity";
 import { loadCloudSettings, putCloudSettings } from "../localDb/cloudSettings";
@@ -78,6 +79,8 @@ type UseWorkspaceSessionParams = Readonly<{
   runSyncSilently: () => Promise<void>;
   runSyncForWorkspace: (workspace: WorkspaceSummary) => Promise<void>;
   discardWorkspaceSync: (workspaceId: string) => void;
+  discardAllSyncWork: (runWhileDiscarding: () => Promise<void>) => Promise<void>;
+  resetUserScopedUiState: () => void;
 }>;
 
 type WorkspaceSession = Readonly<{
@@ -125,10 +128,17 @@ type WorkspaceTransitionEventName =
 
 type WorkspaceTransitionFailureEventName =
   | "session_bootstrap_failed"
+  | "session_account_switch_failed"
   | "workspace_activate_bootstrap_failed"
   | "workspace_select_client_failed"
   | "workspace_create_client_failed"
   | "workspace_delete_client_failed";
+
+const sessionAccountSwitchErrorName = "SessionAccountSwitchError";
+
+type SessionAccountSwitchError = Error & Readonly<{
+  name: typeof sessionAccountSwitchErrorName;
+}>;
 
 function buildLinkingReadyCloudSettings(session: SessionInfo): CloudSettings {
   return {
@@ -152,6 +162,26 @@ function buildLinkedCloudSettings(session: SessionInfo, workspaceId: string): Cl
     onboardingCompleted: true,
     updatedAt: new Date().toISOString(),
   };
+}
+
+function shouldClearLocalDataForVerifiedSession(
+  persistedCloudSettings: CloudSettings | null,
+  currentSession: SessionInfo,
+  wasBrowserReauthRequired: boolean,
+): boolean {
+  if (persistedCloudSettings === null) {
+    return wasBrowserReauthRequired;
+  }
+
+  if (persistedCloudSettings.linkedUserId === currentSession.userId) {
+    return false;
+  }
+
+  if (persistedCloudSettings.linkedUserId === null) {
+    return wasBrowserReauthRequired;
+  }
+
+  return true;
 }
 
 function replaceWorkspaceSummary(
@@ -185,6 +215,16 @@ function consumeLoggedOutMarker(): boolean {
 
 function createRemoteActionLockedError(t: (key: TranslationKey) => string): Error {
   return new Error(t("app.sessionRestoringActionLocked"));
+}
+
+function createSessionAccountSwitchError(errorMessage: string): SessionAccountSwitchError {
+  const error = new Error(errorMessage);
+  error.name = sessionAccountSwitchErrorName;
+  return error as SessionAccountSwitchError;
+}
+
+function isSessionAccountSwitchError(error: unknown): error is SessionAccountSwitchError {
+  return error instanceof Error && error.name === sessionAccountSwitchErrorName;
 }
 
 function getCurrentRoute(): string | null {
@@ -263,7 +303,11 @@ function captureWorkspaceTransitionError(
   caughtError: unknown,
 ): void {
   const error = normalizeCaughtError(caughtError);
-  const scope = buildWorkspaceObservationScope(event === "session_bootstrap_failed" ? "auth" : "workspace", details, error);
+  const scope = buildWorkspaceObservationScope(
+    event === "session_bootstrap_failed" || event === "session_account_switch_failed" ? "auth" : "workspace",
+    details,
+    error,
+  );
 
   if (error instanceof ApiContractError) {
     captureWebException({
@@ -287,6 +331,19 @@ function captureWorkspaceTransitionError(
       scope,
       details: {
         operation: "session_bootstrap_failed",
+        verificationState: details.sessionVerificationState ?? null,
+      },
+    });
+    return;
+  }
+
+  if (event === "session_account_switch_failed") {
+    captureWebException({
+      action: "session_account_switch_failed",
+      error,
+      scope,
+      details: {
+        operation: "session_account_switch_failed",
         verificationState: details.sessionVerificationState ?? null,
       },
     });
@@ -354,8 +411,32 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
     runSyncSilently,
     runSyncForWorkspace,
     discardWorkspaceSync,
+    discardAllSyncWork,
+    resetUserScopedUiState,
   } = params;
   const resumePromiseRef = useRef<Promise<void> | null>(null);
+  const workspaceBootstrapGenerationRef = useRef<number>(0);
+
+  const clearConfirmedUserScopedState = useCallback(async function clearConfirmedUserScopedState(): Promise<void> {
+    workspaceBootstrapGenerationRef.current += 1;
+    setSession(null);
+    setActiveWorkspace(null);
+    setAvailableWorkspaces([]);
+    setCloudSettings(null);
+    setSessionLoadState("loading");
+    setSessionVerificationState("unverified");
+    resetUserScopedUiState();
+    await discardAllSyncWork(clearAllLocalBrowserData);
+  }, [
+    discardAllSyncWork,
+    resetUserScopedUiState,
+    setActiveWorkspace,
+    setAvailableWorkspaces,
+    setCloudSettings,
+    setSession,
+    setSessionLoadState,
+    setSessionVerificationState,
+  ]);
 
   const publishSelectedWorkspace = useCallback(function publishSelectedWorkspace(
     currentSession: SessionInfo,
@@ -383,6 +464,11 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
   const bootstrapWorkspaceInBackground = useCallback(function bootstrapWorkspaceInBackground(
     workspace: WorkspaceSummary,
   ): void {
+    const bootstrapGeneration = workspaceBootstrapGenerationRef.current;
+    const isCurrentBootstrapGeneration = function isCurrentBootstrapGeneration(): boolean {
+      return bootstrapGeneration === workspaceBootstrapGenerationRef.current;
+    };
+
     logWorkspaceTransition("workspace_activate_bootstrap_started", {
       workspaceId: workspace.workspaceId,
     });
@@ -391,12 +477,20 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
       try {
         await refreshWorkspaceView(workspace.workspaceId);
         await runSyncForWorkspace(workspace);
+        if (isCurrentBootstrapGeneration() === false) {
+          return;
+        }
+
         setSessionErrorMessage("");
         setErrorMessage("");
         logWorkspaceTransition("workspace_activate_bootstrap_succeeded", {
           workspaceId: workspace.workspaceId,
         });
       } catch (error) {
+        if (isCurrentBootstrapGeneration() === false) {
+          return;
+        }
+
         if (isAuthRedirectError(error)) {
           logWorkspaceTransition("workspace_activate_bootstrap_redirected", {
             workspaceId: workspace.workspaceId,
@@ -508,14 +602,12 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
     setErrorMessage("");
 
     try {
-      await runPendingAuthResetCleanup();
-
       if (consumeLoggedOutMarker()) {
-        await clearAllLocalBrowserData();
+        await clearConfirmedUserScopedState();
       }
 
       if (consumeAccountDeletedMarker()) {
-        await clearAllLocalBrowserData();
+        await clearConfirmedUserScopedState();
         setSession(null);
         setWebObservabilityUser(null);
         setSessionLoadState("deleted");
@@ -524,21 +616,15 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
         return;
       }
 
+      const wasBrowserReauthRequired = isBrowserReauthRequired();
       const currentSession = await getSession();
       setWebObservabilityUser({ id: currentSession.userId });
       const persistedCloudSettings = await loadCloudSettings();
-      if (
-        persistedCloudSettings !== null
-        && persistedCloudSettings.linkedUserId !== null
-        && persistedCloudSettings.linkedUserId !== currentSession.userId
-      ) {
-        setSession(null);
-        setActiveWorkspace(null);
-        setAvailableWorkspaces([]);
-        setSessionLoadState("loading");
-        await clearAllLocalBrowserData();
+      if (shouldClearLocalDataForVerifiedSession(persistedCloudSettings, currentSession, wasBrowserReauthRequired)) {
+        await clearConfirmedUserScopedState();
       }
 
+      clearBrowserReauthRequired();
       const linkingReadyCloudSettings = buildLinkingReadyCloudSettings(currentSession);
       await putCloudSettings(linkingReadyCloudSettings);
       setCloudSettings(linkingReadyCloudSettings);
@@ -568,6 +654,7 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
       setSessionErrorMessage(nextErrorMessage);
     }
   }, [
+    clearConfirmedUserScopedState,
     resolveInitialWorkspace,
     session,
     sessionLoadState,
@@ -920,13 +1007,40 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
   }, []);
 
   const revalidateActiveSession = useCallback(async function revalidateActiveSession(): Promise<boolean> {
-    if (sessionLoadState !== "ready" || sessionVerificationState !== "verified") {
+    if (sessionLoadState !== "ready" || sessionVerificationState !== "verified" || session === null) {
       return false;
     }
 
     try {
       const currentSession = await revalidateSessionRequest();
+      if (currentSession.userId !== session.userId) {
+        try {
+          setWebObservabilityUser({ id: currentSession.userId });
+          await clearConfirmedUserScopedState();
+          clearBrowserReauthRequired();
+          const linkingReadyCloudSettings = buildLinkingReadyCloudSettings(currentSession);
+          await putCloudSettings(linkingReadyCloudSettings);
+          setCloudSettings(linkingReadyCloudSettings);
+          await resolveInitialWorkspace(currentSession);
+          setSessionVerificationState("verified");
+          setSessionErrorMessage("");
+          setErrorMessage("");
+          return false;
+        } catch (error) {
+          const nextErrorMessage = getErrorMessage(error);
+          captureWorkspaceTransitionError("session_account_switch_failed", {
+            errorMessage: nextErrorMessage,
+            sessionVerificationState,
+          }, error);
+          setSessionLoadState("error");
+          setSessionErrorMessage(nextErrorMessage);
+          setErrorMessage(nextErrorMessage);
+          throw createSessionAccountSwitchError(nextErrorMessage);
+        }
+      }
+
       setSession(currentSession);
+      clearBrowserReauthRequired();
       setSessionErrorMessage("");
       setErrorMessage("");
       return true;
@@ -937,7 +1051,19 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
 
       throw error;
     }
-  }, [sessionLoadState, sessionVerificationState, setSession, setSessionErrorMessage]);
+  }, [
+    clearConfirmedUserScopedState,
+    resolveInitialWorkspace,
+    session,
+    sessionLoadState,
+    sessionVerificationState,
+    setCloudSettings,
+    setErrorMessage,
+    setSession,
+    setSessionErrorMessage,
+    setSessionLoadState,
+    setSessionVerificationState,
+  ]);
 
   const runResumeAttempt = useCallback(async function runResumeAttempt(): Promise<void> {
     const isSessionValid = await revalidateActiveSession();
@@ -966,6 +1092,10 @@ export function useWorkspaceSession(params: UseWorkspaceSessionParams): Workspac
           return;
         } catch (error) {
           if (isAuthRedirectError(error)) {
+            return;
+          }
+
+          if (isSessionAccountSwitchError(error)) {
             return;
           }
 

--- a/apps/web/src/appData/warmStart.ts
+++ b/apps/web/src/appData/warmStart.ts
@@ -1,3 +1,4 @@
+import { isBrowserReauthRequired } from "../accountDeletion";
 import type { SessionInfo, WorkspaceSummary } from "../types";
 
 export type SessionVerificationState = "unverified" | "verified";
@@ -129,6 +130,10 @@ export function hasLoggedInCookie(): boolean {
  * browser session is revalidated in the background.
  */
 export function loadWarmStartSnapshot(): WarmStartSnapshot | null {
+  if (isBrowserReauthRequired()) {
+    return null;
+  }
+
   if (hasLoggedInCookie() === false) {
     return null;
   }

--- a/apps/web/src/localDb/core.migrations.test.ts
+++ b/apps/web/src/localDb/core.migrations.test.ts
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
 import "fake-indexeddb/auto";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { malformedDueAtBucketMillis, nullDueAtBucketMillis } from "../appData/dueAt";
 import { clearWebSyncCache } from "./cache";
-import { getAllFromStore, openDatabase, type StoredCard } from "./core";
+import { closeDatabaseAfter, deleteDatabase, getAllFromStore, openDatabase, type StoredCard } from "./core";
 import { listOutboxRecords, type PersistedOutboxRecord } from "./outbox";
 import { loadReviewQueueSnapshot } from "./reviews";
 import { makeCard, workspaceId } from "./testSupport";
@@ -17,6 +17,31 @@ type LegacyStoredCard = Omit<StoredCard, "dueAt" | "dueAtMillis" | "dueAtBucketM
 const webSyncDatabaseName = "flashcards-web-sync";
 const legacyNullDueAtBucketMillis = -1;
 const legacyMalformedDueAtBucketMillis = -2;
+
+type DeferredVoid = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}>;
+
+function createDeferredVoid(): DeferredVoid {
+  let resolvePromise: (() => void) | null = null;
+  let rejectPromise: ((error: Error) => void) | null = null;
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
+  });
+
+  if (resolvePromise === null || rejectPromise === null) {
+    throw new Error("Failed to create deferred promise");
+  }
+
+  return {
+    promise,
+    resolve: resolvePromise,
+    reject: rejectPromise,
+  };
+}
 
 function createLegacyCardsStore(database: IDBDatabase): void {
   const cardsStore = database.createObjectStore("cards", { keyPath: ["workspaceId", "cardId"] });
@@ -213,6 +238,36 @@ async function loadCardsStoreIndexNamesForTest(): Promise<ReadonlyArray<string>>
 }
 
 describe("localDb core migrations", () => {
+  it("waits for managed IndexedDB operations before deleting browser data", async () => {
+    await clearWebSyncCache();
+    const readStarted = createDeferredVoid();
+    const releaseRead = createDeferredVoid();
+    const readTask = closeDatabaseAfter(async () => {
+      readStarted.resolve();
+      await releaseRead.promise;
+    });
+    await readStarted.promise;
+
+    const deleteDatabaseSpy = vi.spyOn(indexedDB, "deleteDatabase");
+    const deleteTask = deleteDatabase();
+
+    try {
+      expect(deleteDatabaseSpy).not.toHaveBeenCalled();
+      await expect(closeDatabaseAfter(async () => undefined)).rejects.toThrow(
+        "IndexedDB is unavailable while browser data is being reset",
+      );
+
+      releaseRead.resolve();
+      await readTask;
+      await deleteTask;
+      expect(deleteDatabaseSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      releaseRead.resolve();
+      await Promise.allSettled([readTask, deleteTask]);
+      deleteDatabaseSpy.mockRestore();
+    }
+  });
+
   it("migrates legacy dueAt into numeric due fields and keeps pending card upserts uploadable", async () => {
     await clearWebSyncCache();
     const nowTimestamp = Date.parse("2026-03-10T12:00:00.100Z");

--- a/apps/web/src/localDb/core.ts
+++ b/apps/web/src/localDb/core.ts
@@ -80,6 +80,9 @@ export type DatabaseStores =
 
 const databaseName = "flashcards-web-sync";
 const databaseVersion = 12;
+const activeDatabaseOperationPromises = new Set<Promise<unknown>>();
+let isDatabaseDeleteInProgress = false;
+let activeDatabaseDeletePromise: Promise<void> | null = null;
 
 type StoredCardDueAtMigrationRecord = Omit<StoredCard, "dueAt" | "dueAtMillis" | "dueAtBucketMillis"> & Readonly<{
   dueAt?: string | null;
@@ -369,6 +372,21 @@ export function openDatabase(): Promise<IDBDatabase> {
   });
 }
 
+function trackDatabaseOperation<ResultType>(
+  createOperationTask: () => Promise<ResultType>,
+): Promise<ResultType> {
+  if (isDatabaseDeleteInProgress) {
+    throw new Error("IndexedDB is unavailable while browser data is being reset");
+  }
+
+  const operationTask: Promise<ResultType> = Promise.resolve().then(createOperationTask);
+  const trackedOperationTask = operationTask.finally(() => {
+    activeDatabaseOperationPromises.delete(trackedOperationTask);
+  });
+  activeDatabaseOperationPromises.add(trackedOperationTask);
+  return trackedOperationTask;
+}
+
 export function runReadonly<RequestResult>(
   database: IDBDatabase,
   storeName: DatabaseStores,
@@ -433,26 +451,30 @@ export async function getFromStore<RecordType>(
 export async function closeDatabaseAfter<ResultType>(
   callback: (database: IDBDatabase) => Promise<ResultType>,
 ): Promise<ResultType> {
-  const database = await openDatabase();
-  try {
-    return await callback(database);
-  } finally {
-    database.close();
-  }
+  return trackDatabaseOperation(async () => {
+    const database = await openDatabase();
+    try {
+      return await callback(database);
+    } finally {
+      database.close();
+    }
+  });
 }
 
 export async function closeDatabaseAfterWrite(
   callback: (database: IDBDatabase) => Promise<void>,
 ): Promise<void> {
-  const database = await openDatabase();
-  try {
-    await callback(database);
-  } finally {
-    database.close();
-  }
+  await trackDatabaseOperation(async () => {
+    const database = await openDatabase();
+    try {
+      await callback(database);
+    } finally {
+      database.close();
+    }
+  });
 }
 
-export function deleteDatabase(): Promise<void> {
+function requestDeleteDatabase(): Promise<void> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.deleteDatabase(databaseName);
 
@@ -468,6 +490,26 @@ export function deleteDatabase(): Promise<void> {
       reject(new Error("Failed to delete IndexedDB: delete request was blocked"));
     };
   });
+}
+
+export function deleteDatabase(): Promise<void> {
+  const activeDelete = activeDatabaseDeletePromise;
+  if (activeDelete !== null) {
+    return activeDelete;
+  }
+
+  const deleteTask = (async (): Promise<void> => {
+    isDatabaseDeleteInProgress = true;
+    try {
+      await Promise.allSettled([...activeDatabaseOperationPromises]);
+      await requestDeleteDatabase();
+    } finally {
+      activeDatabaseDeletePromise = null;
+      isDatabaseDeleteInProgress = false;
+    }
+  })();
+  activeDatabaseDeletePromise = deleteTask;
+  return deleteTask;
 }
 
 export type StoredEntity = StoredCard | Deck | ReviewEvent | ProgressDailyCountRecord;

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -139,6 +139,11 @@ export type SessionBootstrapFailureDetails = Readonly<{
   verificationState: string | null;
 }>;
 
+export type SessionAccountSwitchFailureDetails = Readonly<{
+  operation: "session_account_switch_failed";
+  verificationState: string | null;
+}>;
+
 export type ChatSnapshotFailureDetails = Readonly<{
   sessionId: string;
   workspaceId: string | null;
@@ -231,6 +236,12 @@ export type WebExceptionEvent =
     error: Error;
     scope: WebObservationScope;
     details: SessionBootstrapFailureDetails;
+  }>
+  | Readonly<{
+    action: "session_account_switch_failed";
+    error: Error;
+    scope: WebObservationScope;
+    details: SessionAccountSwitchFailureDetails;
   }>
   | Readonly<{
     action: "chat_snapshot_failed";


### PR DESCRIPTION
## Summary

- Replace auth-expiry cleanup with a non-destructive browser reauth marker for the web app.
- Suppress warm start while reauth is required, then reuse IndexedDB after `/me` confirms the same user.
- Keep destructive cleanup for explicit logout, account deletion, and confirmed account switches.
- Add bounded retry for transient refresh-session failures and fail fast on terminal auth failures.
- Add IndexedDB cleanup coordination so destructive cleanup waits for active local DB work.

## Validation

- `git diff --check`
- `npm run test` from `apps/web` (247 passed)
- `npm run build` from `apps/web`