### PR TITLE
[codex] Filter retryable iOS cloud sync transport failures

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Support/AIChatBootstrapErrorPresentation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Support/AIChatBootstrapErrorPresentation.swift
@@ -344,29 +344,7 @@ private func aiChatBootstrapSetupHTTPStatus(error: Error) -> Int? {
 }
 
 private func isAIChatRetryableTransportFailure(error: Error) -> Bool {
-    guard let urlErrorCode = aiChatBootstrapURLErrorCode(error: error, remainingDepth: 4) else {
-        return false
-    }
-
-    return aiChatBootstrapCanRetryURLErrorCode(urlErrorCode)
-}
-
-private func aiChatBootstrapCanRetryURLErrorCode(_ code: URLError.Code) -> Bool {
-    switch code {
-    case .timedOut,
-         .cannotFindHost,
-         .cannotConnectToHost,
-         .dnsLookupFailed,
-         .networkConnectionLost,
-         .notConnectedToInternet,
-         .internationalRoamingOff,
-         .callIsActive,
-         .dataNotAllowed,
-         .cannotLoadFromNetwork:
-        return true
-    default:
-        return false
-    }
+    return isRetryableNetworkTransportFailure(error: error)
 }
 
 private func aiChatBootstrapShouldShowNetworkMessage(_ code: URLError.Code) -> Bool {
@@ -384,24 +362,7 @@ private func aiChatBootstrapShouldShowNetworkMessage(_ code: URLError.Code) -> B
 }
 
 private func aiChatBootstrapURLErrorCode(error: Error, remainingDepth: Int) -> URLError.Code? {
-    if let urlError = error as? URLError {
-        return urlError.code
-    }
-
-    let nsError = error as NSError
-    if nsError.domain == NSURLErrorDomain {
-        return URLError.Code(rawValue: nsError.code)
-    }
-
-    guard remainingDepth > 0 else {
-        return nil
-    }
-
-    guard let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error else {
-        return nil
-    }
-
-    return aiChatBootstrapURLErrorCode(error: underlyingError, remainingDepth: remainingDepth - 1)
+    return flashcardsURLErrorCode(error: error, remainingDepth: remainingDepth)
 }
 
 private func aiChatBootstrapURLErrorTechnicalDetails(code: URLError.Code) -> String {

--- a/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudSync.swift
@@ -458,6 +458,9 @@ extension FlashcardsStore {
     }
 
     private func shouldCaptureCloudSyncFailure(error: Error, trigger: CloudSyncTrigger) -> Bool {
+        if isRetryableNetworkTransportFailure(error: error) {
+            return false
+        }
         if trigger.surfacesGlobalErrorMessage {
             return true
         }

--- a/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
@@ -39,6 +39,53 @@ func isRequestCancellationError(error: Error) -> Bool {
     return isRequestCancellationError(error: underlyingError)
 }
 
+func flashcardsURLErrorCode(error: Error, remainingDepth: Int) -> URLError.Code? {
+    if let urlError = error as? URLError {
+        return urlError.code
+    }
+
+    let nsError: NSError = error as NSError
+    if nsError.domain == NSURLErrorDomain {
+        return URLError.Code(rawValue: nsError.code)
+    }
+
+    guard remainingDepth > 0 else {
+        return nil
+    }
+
+    guard let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error else {
+        return nil
+    }
+
+    return flashcardsURLErrorCode(error: underlyingError, remainingDepth: remainingDepth - 1)
+}
+
+func isRetryableNetworkTransportFailure(error: Error) -> Bool {
+    guard let urlErrorCode: URLError.Code = flashcardsURLErrorCode(error: error, remainingDepth: 4) else {
+        return false
+    }
+
+    return isRetryableNetworkTransportFailure(code: urlErrorCode)
+}
+
+func isRetryableNetworkTransportFailure(code: URLError.Code) -> Bool {
+    switch code {
+    case .timedOut,
+         .cannotFindHost,
+         .cannotConnectToHost,
+         .dnsLookupFailed,
+         .networkConnectionLost,
+         .notConnectedToInternet,
+         .internationalRoamingOff,
+         .callIsActive,
+         .dataNotAllowed,
+         .cannotLoadFromNetwork:
+        return true
+    default:
+        return false
+    }
+}
+
 func makeCloudAuthInlineErrorPresentation(
     error: Error,
     context: CloudAuthInlineErrorContext
@@ -74,21 +121,5 @@ private func makeCloudAuthTransportFailureMessage(context: CloudAuthInlineErrorC
 }
 
 private func isCloudAuthTransportFailure(error: Error) -> Bool {
-    if error is URLError {
-        return true
-    }
-
-    return isCloudAuthTransportFailure(nsError: error as NSError)
-}
-
-private func isCloudAuthTransportFailure(nsError: NSError) -> Bool {
-    if nsError.domain == NSURLErrorDomain {
-        return true
-    }
-
-    if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
-        return isCloudAuthTransportFailure(nsError: underlyingError)
-    }
-
-    return false
+    return flashcardsURLErrorCode(error: error, remainingDepth: 4) != nil
 }


### PR DESCRIPTION
## Summary
- add shared iOS URL transport failure classification
- stop capturing retryable cloud sync network failures as Sentry exceptions
- reuse the classifier in AI chat bootstrap retry handling

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift apps/ios/Flashcards/Flashcards/AI/Support/AIChatBootstrapErrorPresentation.swift apps/ios/Flashcards/Flashcards/Cloud/FlashcardsStore+CloudSync.swift

Note: a generic iOS xcodebuild compile check could not run locally because Xcode reported no eligible destination for the scheme.