### PR TITLE
[codex] Fix iOS AI stop diagnostics

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+LifecycleLogging.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+LifecycleLogging.swift
@@ -23,8 +23,8 @@ private func logAIChatStoreLifecycleEvent(action: String, metadata: [String: Str
         clientRequestId: metadata["clientRequestId"].flatMap(aiChatStoreNonPlaceholderString),
         sessionId: sessionId,
         runId: runId,
-        cloudState: nil,
-        configurationMode: nil
+        cloudState: metadata["cloudState"].flatMap(CloudAccountState.init(rawValue:)),
+        configurationMode: metadata["configurationMode"].flatMap(CloudServiceConfigurationMode.init(rawValue:))
     )
     let observation = AIChatLifecycleObservation(
         action: actionValue,
@@ -58,7 +58,8 @@ private func logAIChatStoreLifecycleEvent(action: String, metadata: [String: Str
         isStopped: metadata["isStopped"].flatMap(aiChatStoreBool),
         outcome: metadata["outcome"].flatMap(aiChatStoreNonPlaceholderString),
         reason: metadata["reason"].flatMap(aiChatStoreNonPlaceholderString),
-        errorSummary: nil
+        errorSummary: metadata["errorSummary"].flatMap(aiChatStoreNonPlaceholderString)
+            ?? metadata["error"].flatMap(aiChatStoreNonPlaceholderString)
     )
 
     if aiChatStoreLifecycleEventIsWarning(actionValue) {

--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+RunOrchestration.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+RunOrchestration.swift
@@ -12,6 +12,84 @@ enum AIChatAcceptedEnvelopeReconciliation: Equatable, Sendable {
     case reloadCanonicalConversation
 }
 
+func shouldAttemptRemoteAIChatStop(
+    initialComposerPhase: AIChatComposerPhase,
+    hadActiveSendTask: Bool,
+    stopRunId: String?
+) -> Bool {
+    if aiChatNonEmptyRunId(runId: stopRunId) != nil {
+        return true
+    }
+
+    if hadActiveSendTask {
+        return true
+    }
+
+    switch initialComposerPhase {
+    case .startingRun, .running:
+        return true
+    case .idle, .preparingSend, .stopping:
+        return false
+    }
+}
+
+func makeAIChatStopFailureMetadata(
+    error: Error,
+    sessionId: String,
+    runId: String?,
+    workspaceId: String?,
+    cloudState: CloudAccountState?,
+    configurationMode: CloudServiceConfigurationMode?
+) -> [String: String] {
+    var metadata: [String: String] = [
+        "chatSessionId": sessionId,
+        "failureKind": "stop_request_failed",
+        "errorSummary": Flashcards.errorMessage(error: error)
+    ]
+
+    if let runId = aiChatNonEmptyRunId(runId: runId) {
+        metadata["runId"] = runId
+    }
+    if let workspaceId, workspaceId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+        metadata["workspaceId"] = workspaceId
+    }
+    if let cloudState {
+        metadata["cloudState"] = cloudState.rawValue
+    }
+    if let configurationMode {
+        metadata["configurationMode"] = configurationMode.rawValue
+    }
+
+    if let diagnosticError = error as? any AIChatFailureDiagnosticProviding {
+        let diagnostics = diagnosticError.diagnostics
+        metadata["clientRequestId"] = diagnostics.clientRequestId
+        metadata["stage"] = diagnostics.stage.rawValue
+        metadata["errorKind"] = diagnostics.errorKind.rawValue
+        if let backendRequestId = diagnostics.backendRequestId,
+           backendRequestId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            metadata["backendRequestId"] = backendRequestId
+        }
+        if let statusCode = diagnostics.statusCode {
+            metadata["statusCode"] = String(statusCode)
+        }
+    }
+
+    if let serviceError = error as? AIChatServiceError,
+       case .invalidResponse(let errorDetails, _, _) = serviceError {
+        if let backendCode = errorDetails.code,
+           backendCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            metadata["backendCode"] = backendCode
+        }
+        if metadata["backendRequestId"] == nil,
+           let backendRequestId = errorDetails.requestId,
+           backendRequestId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            metadata["backendRequestId"] = backendRequestId
+        }
+    }
+
+    return metadata
+}
+
 extension AIChatStore {
     func warmUpSessionIfNeeded() {
         guard self.isChatInteractive else {
@@ -140,12 +218,23 @@ extension AIChatStore {
 
     func cancelStreaming() {
         let stopRunId: String? = aiChatNonEmptyRunId(runId: self.activeRunId)
+        let initialComposerPhase = self.composerPhase
+        let hadActiveSendTask = self.activeSendTask != nil
+        let shouldAttemptRemoteStop = shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: initialComposerPhase,
+            hadActiveSendTask: hadActiveSendTask,
+            stopRunId: stopRunId
+        )
         self.activeSendTask?.cancel()
         self.activeSendTask = nil
         Task {
             await self.runtime.detach()
         }
-        self.transitionToStopping(runId: stopRunId)
+        if shouldAttemptRemoteStop {
+            self.transitionToStopping(runId: stopRunId)
+        } else {
+            self.transitionToIdle()
+        }
         self.repairStatus = nil
         self.clearOptimisticAssistantStatusIfNeeded()
 
@@ -155,6 +244,9 @@ extension AIChatStore {
         )
         self.chatSessionId = sessionId
         self.conversationScopeId = sessionId
+        guard shouldAttemptRemoteStop else {
+            return
+        }
         guard sessionId.isEmpty == false else {
             self.transitionToIdle()
             self.schedulePersistCurrentState()
@@ -162,6 +254,7 @@ extension AIChatStore {
         }
 
         Task {
+            var stopSession: CloudLinkedSession?
             defer {
                 if self.composerPhase == .stopping {
                     self.transitionToIdle()
@@ -170,6 +263,7 @@ extension AIChatStore {
             }
             do {
                 let session = try await self.flashcardsStore.cloudSessionForAI()
+                stopSession = session
                 let stopResponse = try await self.chatService.stopRun(
                     session: session,
                     sessionId: sessionId,
@@ -197,10 +291,14 @@ extension AIChatStore {
             } catch {
                 logAIChatStoreEvent(
                     action: "ai_stop_failed",
-                    metadata: [
-                        "chatSessionId": sessionId,
-                        "error": Flashcards.errorMessage(error: error)
-                    ]
+                    metadata: makeAIChatStopFailureMetadata(
+                        error: error,
+                        sessionId: sessionId,
+                        runId: stopRunId,
+                        workspaceId: stopSession?.workspaceId ?? self.flashcardsStore.workspace?.workspaceId,
+                        cloudState: self.flashcardsStore.cloudSettings?.cloudState,
+                        configurationMode: stopSession?.configurationMode
+                    )
                 )
             }
         }

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
@@ -3,6 +3,115 @@ import XCTest
 
 @MainActor
 final class AIChatStoreRunStopTests: XCTestCase {
+    func testRemoteStopDecisionSkipsOnlyIdleDefensiveCancel() {
+        XCTAssertFalse(shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: .idle,
+            hadActiveSendTask: false,
+            stopRunId: nil
+        ))
+        XCTAssertFalse(shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: .preparingSend,
+            hadActiveSendTask: false,
+            stopRunId: nil
+        ))
+        XCTAssertFalse(shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: .stopping,
+            hadActiveSendTask: false,
+            stopRunId: nil
+        ))
+        XCTAssertTrue(shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: .idle,
+            hadActiveSendTask: true,
+            stopRunId: nil
+        ))
+        XCTAssertTrue(shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: .startingRun,
+            hadActiveSendTask: false,
+            stopRunId: nil
+        ))
+        XCTAssertTrue(shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: .running,
+            hadActiveSendTask: false,
+            stopRunId: nil
+        ))
+        XCTAssertTrue(shouldAttemptRemoteAIChatStop(
+            initialComposerPhase: .idle,
+            hadActiveSendTask: false,
+            stopRunId: "run-1"
+        ))
+    }
+
+    func testIdleDefensiveCancelDoesNotPersistPreviousConversationIntoNewHistoryScope() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.messages = [
+            AIChatStoreTestSupport.makeUserTextMessage(
+                id: "message-1",
+                text: "Old workspace question",
+                timestamp: "2026-04-08T10:00:00Z"
+            )
+        ]
+        store.persistStateSynchronously(state: store.currentPersistedState())
+
+        try context.configureLinkedCloudSession(workspaceId: "workspace-2")
+        let nextWorkspaceHistoryId = context.linkedHistoryWorkspaceId(workspaceId: "workspace-2")
+
+        store.cancelStreaming()
+        await store.waitForPendingStatePersistence()
+
+        let nextWorkspaceState = context.historyStore.loadState(workspaceId: nextWorkspaceHistoryId)
+        XCTAssertEqual(nextWorkspaceState.chatSessionId, "")
+        XCTAssertEqual(nextWorkspaceState.messages, [])
+        XCTAssertEqual(store.composerPhase, .idle)
+    }
+
+    func testActiveCancelSendsRemoteStopWithRunId() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession()
+        let store = context.makeStore()
+        let activeRun = AIChatStoreTestSupport.makeActiveRun()
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.transitionToStreaming(
+            activeRun: AIChatActiveRunSession(
+                sessionId: "session-1",
+                conversationScopeId: "session-1",
+                runId: activeRun.runId,
+                liveStream: activeRun.live.stream,
+                liveCursor: activeRun.live.cursor,
+                streamEpoch: nil
+            )
+        )
+        store.persistStateSynchronously(state: store.currentPersistedState())
+
+        store.cancelStreaming()
+
+        let didSettle = await AIChatStoreTestSupport.waitForCondition(
+            description: "active run stop request",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.chatService.stopRunRequests.count == 1
+                    && store.composerPhase == .idle
+            }
+        )
+
+        XCTAssertTrue(didSettle)
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.sessionId }, ["session-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.runId }, ["run-1"])
+    }
+
     func testNoopStopClearsStoppingAndReloadsBootstrap() async throws {
         let context = AIChatStoreTestSupport.Context.make()
         defer {
@@ -89,9 +198,8 @@ final class AIChatStoreRunStopTests: XCTestCase {
 
         try context.configureLinkedCloudSession()
         let store = context.makeStore()
-        // Drain the constructor's defensive cancelStreaming pipeline before
-        // the test sets up its own race, otherwise its incidental stopRun
-        // call counts toward stopRunRequests and confuses the gate timing.
+        // Drain the constructor's defensive cancelStreaming persistence before
+        // the test sets up its own race.
         await store.waitForPendingStatePersistence()
 
         let runA = AIChatStoreTestSupport.makeActiveRun()


### PR DESCRIPTION
## Summary
- skip no-op remote AI stop calls for idle defensive cleanup
- keep real active or pending stop calls intact
- enrich ai_stop_failed warning metadata with structured diagnostics
- add targeted AI chat stop coverage

## Validation
- git --no-pager diff --check

## Not run
- iOS simulator-backed XCTest, per repository restriction unless explicitly allowed