### PR TITLE
[codex] Add Android guest sign-in review prompt

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AppStateResetRule.kt
@@ -16,6 +16,7 @@ import org.junit.rules.ExternalResource
 private val testOnlyPreferenceNames: List<String> = listOf(
     "flashcards-test-mode",
     "flashcards-review-preferences",
+    guestSignInAfterReviewPromptPreferencesName,
     "flashcards-ai-chat-preferences",
     "flashcards-ai-chat-history",
     "flashcards-ai-chat-guest-session"

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptDialogTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptDialogTest.kt
@@ -1,0 +1,130 @@
+package com.flashcardsopensourceapp.app
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.navigation.SettingsAccountSignInEmailDestination
+import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
+import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInEmailRoute
+import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInUiState
+import com.flashcardsopensourceapp.feature.settings.cloud.cloudSignInEmailFieldTag
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GuestSignInAfterReviewPromptDialogTest : FirebaseAppInstrumentationTimeoutTest() {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun laterDismissesDialog() {
+        var isVisible by mutableStateOf(value = true)
+        var laterCalls = 0
+
+        composeRule.setContent {
+            FlashcardsTheme {
+                if (isVisible) {
+                    GuestSignInAfterReviewPromptDialog(
+                        onSignIn = {},
+                        onLater = {
+                            laterCalls += 1
+                            isVisible = false
+                        }
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag(
+            testTag = guestSignInAfterReviewPromptTag,
+            useUnmergedTree = true
+        ).assertIsDisplayed()
+        composeRule.onNodeWithTag(
+            testTag = guestSignInAfterReviewPromptLaterButtonTag,
+            useUnmergedTree = true
+        ).performClick()
+
+        composeRule.waitUntil(timeoutMillis = 5_000L) {
+            laterCalls == 1 &&
+                composeRule.onAllNodesWithTag(
+                    testTag = guestSignInAfterReviewPromptTag,
+                    useUnmergedTree = true
+                ).fetchSemanticsNodes().isEmpty()
+        }
+        assertEquals(1, laterCalls)
+    }
+
+    @Test
+    fun signInNavigatesToExistingEmailSignInRoute() {
+        var signInCalls = 0
+
+        composeRule.setContent {
+            FlashcardsTheme {
+                val navController = rememberNavController()
+
+                NavHost(
+                    navController = navController,
+                    startDestination = "home"
+                ) {
+                    composable(route = "home") {
+                        GuestSignInAfterReviewPromptDialog(
+                            onSignIn = {
+                                signInCalls += 1
+                                navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                            },
+                            onLater = {}
+                        )
+                    }
+                    composable(route = SettingsAccountSignInEmailDestination.route) {
+                        CloudSignInEmailRoute(
+                            uiState = CloudSignInUiState(
+                                email = "",
+                                code = "",
+                                isGuestUpgrade = true,
+                                isSendingCode = false,
+                                isVerifyingCode = false,
+                                errorMessage = "",
+                                errorTechnicalDetails = null,
+                                challengeEmail = null
+                            ),
+                            onEmailChange = {},
+                            onSendCode = {},
+                            onBack = {
+                                navController.popBackStack()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag(
+            testTag = guestSignInAfterReviewPromptSignInButtonTag,
+            useUnmergedTree = true
+        ).performClick()
+        composeRule.waitUntil(timeoutMillis = 5_000L) {
+            signInCalls == 1 &&
+                composeRule.onAllNodesWithTag(
+                    testTag = cloudSignInEmailFieldTag,
+                    useUnmergedTree = true
+                ).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNodeWithTag(
+            testTag = cloudSignInEmailFieldTag,
+            useUnmergedTree = true
+        ).assertIsDisplayed()
+        assertEquals(1, signInCalls)
+    }
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -50,6 +50,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.di.AppStartupState
@@ -58,6 +59,7 @@ import com.flashcardsopensourceapp.app.navigation.AppNotificationTapHandoffReque
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
 import com.flashcardsopensourceapp.app.navigation.ReviewDestination
+import com.flashcardsopensourceapp.app.navigation.SettingsAccountSignInEmailDestination
 import com.flashcardsopensourceapp.app.navigation.TopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.currentVisibleAppScreen
 import com.flashcardsopensourceapp.app.navigation.currentTopLevelDestination
@@ -107,6 +109,8 @@ fun FlashcardsApp(
         }
 
         val navController = rememberNavController()
+        val currentBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute: String? = currentBackStackEntry?.destination?.route
         val applicationContext = LocalContext.current.applicationContext
         val lifecycleOwner = LocalLifecycleOwner.current
         val currentDestination = currentTopLevelDestination(navController = navController)
@@ -138,6 +142,14 @@ fun FlashcardsApp(
         val accountDeletionState by appGraph.cloudAccountRepository.observeAccountDeletionState().collectAsStateWithLifecycle(
             initialValue = AccountDeletionState.Hidden
         )
+        val guestSignInAfterReviewPromptUiState by appGraph.guestSignInAfterReviewPromptController
+            .observeUiState()
+            .collectAsStateWithLifecycle(
+                initialValue = GuestSignInAfterReviewPromptUiState(
+                    isVisible = false,
+                    reviewCount = 0
+                )
+            )
         val syncStatusSnapshot by appGraph.syncRepository.observeSyncStatus().collectAsStateWithLifecycle(
             initialValue = SyncStatusSnapshot(
                 status = SyncStatus.Idle,
@@ -163,6 +175,12 @@ fun FlashcardsApp(
         )
         val currentCanRunImmediateAutoSync by rememberUpdatedState(newValue = canRunImmediateAutoSync)
         val currentVisibleAppScreenState by rememberUpdatedState(newValue = currentVisibleAppScreen)
+        val guestSignInAfterReviewPromptContext = GuestSignInAfterReviewPromptContext(
+            isAuthFlowActive = isGuestSignInAfterReviewPromptAuthRoute(route = currentRoute),
+            isAppModalActive = isGuestSignInAfterReviewPromptModalActive(
+                accountDeletionState = accountDeletionState
+            )
+        )
 
         LaunchedEffect(appGraph.appMessageBus, snackbarHostState) {
             appGraph.appMessageBus.messages.collect { message ->
@@ -173,6 +191,20 @@ fun FlashcardsApp(
         LaunchedEffect(currentVisibleAppScreen) {
             appGraph.visibleAppScreenController.updateVisibleAppScreen(
                 screen = currentVisibleAppScreen
+            )
+        }
+
+        LaunchedEffect(
+            guestSignInAfterReviewPromptContext,
+            cloudSettings.cloudState,
+            isAppResumed
+        ) {
+            if (isAppResumed.not()) {
+                return@LaunchedEffect
+            }
+
+            appGraph.guestSignInAfterReviewPromptController.updateAppContext(
+                context = guestSignInAfterReviewPromptContext
             )
         }
 
@@ -385,6 +417,21 @@ fun FlashcardsApp(
                         appGraph.cloudAccountRepository.retryPendingAccountDeletion()
                     }
                 )
+                if (
+                    guestSignInAfterReviewPromptUiState.isVisible &&
+                    guestSignInAfterReviewPromptContext.isAuthFlowActive.not() &&
+                    guestSignInAfterReviewPromptContext.isAppModalActive.not()
+                ) {
+                    GuestSignInAfterReviewPromptDialog(
+                        onSignIn = {
+                            appGraph.guestSignInAfterReviewPromptController.acceptPrompt()
+                            navController.navigate(route = SettingsAccountSignInEmailDestination.route)
+                        },
+                        onLater = {
+                            appGraph.guestSignInAfterReviewPromptController.dismissForLater()
+                        }
+                    )
+                }
             }
         }
     }
@@ -416,6 +463,14 @@ private fun isProgressContextRefreshBroadcastAction(action: String?): Boolean {
 
         else -> false
     }
+}
+
+private fun isGuestSignInAfterReviewPromptAuthRoute(route: String?): Boolean {
+    return route?.startsWith(prefix = SettingsAccountSignInEmailDestination.route) == true
+}
+
+private fun isGuestSignInAfterReviewPromptModalActive(accountDeletionState: AccountDeletionState): Boolean {
+    return accountDeletionState != AccountDeletionState.Hidden
 }
 
 @Composable

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptController.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptController.kt
@@ -1,0 +1,125 @@
+package com.flashcardsopensourceapp.app
+
+import com.flashcardsopensourceapp.data.local.model.CloudSettings
+import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
+import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class GuestSignInAfterReviewPromptUiState(
+    val isVisible: Boolean,
+    val reviewCount: Int
+)
+
+class GuestSignInAfterReviewPromptController(
+    appScope: CoroutineScope,
+    private val cloudAccountRepository: CloudAccountRepository,
+    private val reviewRepository: ReviewRepository,
+    private val promptStore: GuestSignInAfterReviewPromptStore
+) {
+    private val uiStateMutable = MutableStateFlow(
+        GuestSignInAfterReviewPromptUiState(
+            isVisible = false,
+            reviewCount = 0
+        )
+    )
+    private val contextMutable = MutableStateFlow(
+        GuestSignInAfterReviewPromptContext(
+            isAuthFlowActive = false,
+            isAppModalActive = false
+        )
+    )
+    private val reevaluationRequests = Channel<Unit>(capacity = Channel.CONFLATED)
+
+    init {
+        appScope.launch {
+            reevaluationRequests.receiveAsFlow().collect {
+                reevaluate()
+            }
+        }
+    }
+
+    fun observeUiState(): StateFlow<GuestSignInAfterReviewPromptUiState> {
+        return uiStateMutable.asStateFlow()
+    }
+
+    fun updateAppContext(context: GuestSignInAfterReviewPromptContext) {
+        contextMutable.value = context
+        requestReevaluation()
+    }
+
+    fun requestReevaluation() {
+        reevaluationRequests.trySend(Unit)
+    }
+
+    fun dismissForLater() {
+        val currentUiState: GuestSignInAfterReviewPromptUiState = uiStateMutable.value
+        if (currentUiState.isVisible.not()) {
+            return
+        }
+
+        promptStore.recordSnoozed(
+            nowMillis = System.currentTimeMillis(),
+            reviewCount = currentUiState.reviewCount
+        )
+        uiStateMutable.value = currentUiState.copy(isVisible = false)
+    }
+
+    fun acceptPrompt() {
+        val currentUiState: GuestSignInAfterReviewPromptUiState = uiStateMutable.value
+        if (currentUiState.isVisible.not()) {
+            return
+        }
+
+        promptStore.recordAccepted(nowMillis = System.currentTimeMillis())
+        uiStateMutable.value = currentUiState.copy(isVisible = false)
+    }
+
+    private suspend fun reevaluate() {
+        val nowMillis: Long = System.currentTimeMillis()
+        val context: GuestSignInAfterReviewPromptContext = contextMutable.value
+        val cloudSettings: CloudSettings = cloudAccountRepository.observeCloudSettings().first()
+        val reviewCount: Int = reviewRepository.countRecordedReviewsInCurrentWorkspace()
+        val promptState: GuestSignInAfterReviewPromptState = promptStore.loadState()
+        val shouldShowPrompt: Boolean = isGuestSignInAfterReviewPromptVisible(
+            cloudState = cloudSettings.cloudState,
+            reviewedCount = reviewCount,
+            promptState = promptState,
+            nowMillis = nowMillis,
+            context = context
+        )
+
+        if (shouldShowPrompt.not()) {
+            uiStateMutable.update { state ->
+                state.copy(
+                    isVisible = false,
+                    reviewCount = reviewCount
+                )
+            }
+            return
+        }
+
+        val currentUiState: GuestSignInAfterReviewPromptUiState = uiStateMutable.value
+        if (currentUiState.isVisible) {
+            uiStateMutable.value = currentUiState.copy(reviewCount = reviewCount)
+            return
+        }
+
+        promptStore.recordShown(
+            nowMillis = nowMillis,
+            reviewCount = reviewCount
+        )
+        uiStateMutable.value = GuestSignInAfterReviewPromptUiState(
+            isVisible = true,
+            reviewCount = reviewCount
+        )
+    }
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptDialog.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptDialog.kt
@@ -1,0 +1,48 @@
+package com.flashcardsopensourceapp.app
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+
+const val guestSignInAfterReviewPromptTag: String = "guest_sign_in_after_review_prompt"
+const val guestSignInAfterReviewPromptSignInButtonTag: String =
+    "guest_sign_in_after_review_prompt_sign_in_button"
+const val guestSignInAfterReviewPromptLaterButtonTag: String =
+    "guest_sign_in_after_review_prompt_later_button"
+
+@Composable
+internal fun GuestSignInAfterReviewPromptDialog(
+    onSignIn: () -> Unit,
+    onLater: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onLater,
+        confirmButton = {
+            TextButton(
+                onClick = onSignIn,
+                modifier = Modifier.testTag(tag = guestSignInAfterReviewPromptSignInButtonTag)
+            ) {
+                Text(stringResource(id = R.string.guest_sign_in_after_review_prompt_sign_in))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onLater,
+                modifier = Modifier.testTag(tag = guestSignInAfterReviewPromptLaterButtonTag)
+            ) {
+                Text(stringResource(id = R.string.guest_sign_in_after_review_prompt_later))
+            }
+        },
+        title = {
+            Text(stringResource(id = R.string.guest_sign_in_after_review_prompt_title))
+        },
+        text = {
+            Text(stringResource(id = R.string.guest_sign_in_after_review_prompt_body))
+        },
+        modifier = Modifier.testTag(tag = guestSignInAfterReviewPromptTag)
+    )
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptPolicy.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptPolicy.kt
@@ -1,0 +1,44 @@
+package com.flashcardsopensourceapp.app
+
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+
+const val guestSignInAfterReviewPromptReviewThreshold: Int = 20
+const val guestSignInAfterReviewPromptSnoozeMillis: Long = 7L * 24L * 60L * 60L * 1_000L
+
+data class GuestSignInAfterReviewPromptState(
+    val lastShownAtMillis: Long?,
+    val snoozedUntilMillis: Long?,
+    val lastShownReviewCount: Int?,
+    val acceptedAtMillis: Long?
+)
+
+data class GuestSignInAfterReviewPromptContext(
+    val isAuthFlowActive: Boolean,
+    val isAppModalActive: Boolean
+)
+
+fun isGuestSignInAfterReviewPromptVisible(
+    cloudState: CloudAccountState,
+    reviewedCount: Int,
+    promptState: GuestSignInAfterReviewPromptState,
+    nowMillis: Long,
+    context: GuestSignInAfterReviewPromptContext
+): Boolean {
+    if (cloudState != CloudAccountState.GUEST) {
+        return false
+    }
+    if (reviewedCount < guestSignInAfterReviewPromptReviewThreshold) {
+        return false
+    }
+    if (promptState.acceptedAtMillis != null) {
+        return false
+    }
+    if (promptState.snoozedUntilMillis != null && promptState.snoozedUntilMillis > nowMillis) {
+        return false
+    }
+    if (context.isAuthFlowActive || context.isAppModalActive) {
+        return false
+    }
+
+    return true
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptStore.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptStore.kt
@@ -1,0 +1,74 @@
+package com.flashcardsopensourceapp.app
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+const val guestSignInAfterReviewPromptPreferencesName: String =
+    "guest_sign_in_after_review_prompt_preferences"
+
+private const val lastShownAtMillisKey: String = "lastShownAtMillis"
+private const val snoozedUntilMillisKey: String = "snoozedUntilMillis"
+private const val lastShownReviewCountKey: String = "lastShownReviewCount"
+private const val acceptedAtMillisKey: String = "acceptedAtMillis"
+
+interface GuestSignInAfterReviewPromptStore {
+    fun loadState(): GuestSignInAfterReviewPromptState
+    fun recordShown(nowMillis: Long, reviewCount: Int)
+    fun recordSnoozed(nowMillis: Long, reviewCount: Int)
+    fun recordAccepted(nowMillis: Long)
+}
+
+class SharedPreferencesGuestSignInAfterReviewPromptStore(
+    context: Context
+) : GuestSignInAfterReviewPromptStore {
+    private val preferences: SharedPreferences = context.getSharedPreferences(
+        guestSignInAfterReviewPromptPreferencesName,
+        Context.MODE_PRIVATE
+    )
+
+    override fun loadState(): GuestSignInAfterReviewPromptState {
+        return GuestSignInAfterReviewPromptState(
+            lastShownAtMillis = loadLongOrNull(key = lastShownAtMillisKey),
+            snoozedUntilMillis = loadLongOrNull(key = snoozedUntilMillisKey),
+            lastShownReviewCount = loadIntOrNull(key = lastShownReviewCountKey),
+            acceptedAtMillis = loadLongOrNull(key = acceptedAtMillisKey)
+        )
+    }
+
+    override fun recordShown(nowMillis: Long, reviewCount: Int) {
+        preferences.edit(commit = true) {
+            putLong(lastShownAtMillisKey, nowMillis)
+            putInt(lastShownReviewCountKey, reviewCount)
+        }
+    }
+
+    override fun recordSnoozed(nowMillis: Long, reviewCount: Int) {
+        preferences.edit(commit = true) {
+            putLong(snoozedUntilMillisKey, nowMillis + guestSignInAfterReviewPromptSnoozeMillis)
+            putInt(lastShownReviewCountKey, reviewCount)
+        }
+    }
+
+    override fun recordAccepted(nowMillis: Long) {
+        preferences.edit(commit = true) {
+            putLong(acceptedAtMillisKey, nowMillis)
+        }
+    }
+
+    private fun loadLongOrNull(key: String): Long? {
+        if (preferences.contains(key).not()) {
+            return null
+        }
+
+        return preferences.getLong(key, 0L)
+    }
+
+    private fun loadIntOrNull(key: String): Int? {
+        if (preferences.contains(key).not()) {
+            return null
+        }
+
+        return preferences.getInt(key, 0)
+    }
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -3,10 +3,12 @@ package com.flashcardsopensourceapp.app.di
 import android.content.Context
 import android.util.Log
 import com.flashcardsopensourceapp.app.AutoSyncController
+import com.flashcardsopensourceapp.app.GuestSignInAfterReviewPromptController
 import com.flashcardsopensourceapp.app.navigation.AppPackageInfo
 import com.flashcardsopensourceapp.app.navigation.loadPackageInfo
 import com.flashcardsopensourceapp.app.ProgressContextRefreshController
 import com.flashcardsopensourceapp.app.observability.renderSanitizedThrowableLogFields
+import com.flashcardsopensourceapp.app.SharedPreferencesGuestSignInAfterReviewPromptStore
 import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
@@ -134,6 +136,9 @@ class AppGraph(
     private val aiChatHistoryStore = AiChatHistoryStore(context = context)
     private val guestAiSessionStore = GuestAiSessionStore(context = context)
     val reviewPreferencesStore: ReviewPreferencesStore = SharedPreferencesReviewPreferencesStore(context = context)
+    private val guestSignInAfterReviewPromptStore = SharedPreferencesGuestSignInAfterReviewPromptStore(
+        context = context
+    )
     private val notificationsStore = SharedPreferencesReviewNotificationsStore(context = context)
     val reviewNotificationsStore: ReviewNotificationsStore = notificationsStore
     val strictRemindersStore: StrictRemindersStore = notificationsStore
@@ -249,6 +254,12 @@ class AppGraph(
         preferencesStore = cloudPreferencesStore,
         syncLocalStore = syncLocalStore,
         localProgressCacheStore = localProgressCacheStore
+    )
+    val guestSignInAfterReviewPromptController = GuestSignInAfterReviewPromptController(
+        appScope = appScope,
+        cloudAccountRepository = cloudAccountRepository,
+        reviewRepository = reviewRepository,
+        promptStore = guestSignInAfterReviewPromptStore
     )
     val progressRepository: ProgressRepository = LocalProgressRepository(
         appScope = appScope,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ReviewNavGraph.kt
@@ -68,6 +68,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                         reviewedAtMillis = reviewedAtMillis,
                         nowMillis = System.currentTimeMillis()
                     )
+                    appGraph.guestSignInAfterReviewPromptController.requestReevaluation()
                 },
                 onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
                 reviewPreferencesStore = appGraph.reviewPreferencesStore,
@@ -179,6 +180,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                         reviewedAtMillis = reviewedAtMillis,
                         nowMillis = System.currentTimeMillis()
                     )
+                    appGraph.guestSignInAfterReviewPromptController.requestReevaluation()
                 },
                 onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
                 reviewPreferencesStore = appGraph.reviewPreferencesStore,

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="account_deletion_in_progress_message">Your account deletion is in progress. Keep this screen open until it finishes.</string>
     <string name="account_deletion_failed_message">The delete request did not finish yet. Retry to keep the account deletion moving forward.</string>
     <string name="account_deletion_retry">Retry deletion</string>
+    <string name="guest_sign_in_after_review_prompt_title">Save your progress</string>
+    <string name="guest_sign_in_after_review_prompt_body">Sign in with email so these cards and review progress are not lost.</string>
+    <string name="guest_sign_in_after_review_prompt_sign_in">Sign in</string>
+    <string name="guest_sign_in_after_review_prompt_later">Later</string>
     <string name="review_notification_channel_name">Review reminders</string>
     <string name="review_notification_channel_description">Study reminders with cards from your review queue.</string>
 </resources>

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptPolicyTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptPolicyTest.kt
@@ -1,0 +1,140 @@
+package com.flashcardsopensourceapp.app
+
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GuestSignInAfterReviewPromptPolicyTest {
+    @Test
+    fun guestWithNineteenReviewsIsHidden() {
+        assertFalse(
+            isGuestSignInAfterReviewPromptVisible(
+                cloudState = CloudAccountState.GUEST,
+                reviewedCount = 19,
+                promptState = emptyPromptState(),
+                nowMillis = 1_000L,
+                context = unblockedContext()
+            )
+        )
+    }
+
+    @Test
+    fun guestWithTwentyReviewsIsVisible() {
+        assertTrue(
+            isGuestSignInAfterReviewPromptVisible(
+                cloudState = CloudAccountState.GUEST,
+                reviewedCount = 20,
+                promptState = emptyPromptState(),
+                nowMillis = 1_000L,
+                context = unblockedContext()
+            )
+        )
+    }
+
+    @Test
+    fun nonGuestCloudStatesAreHidden() {
+        listOf(
+            CloudAccountState.DISCONNECTED,
+            CloudAccountState.LINKING_READY,
+            CloudAccountState.LINKED
+        ).forEach { cloudState ->
+            assertFalse(
+                isGuestSignInAfterReviewPromptVisible(
+                    cloudState = cloudState,
+                    reviewedCount = 20,
+                    promptState = emptyPromptState(),
+                    nowMillis = 1_000L,
+                    context = unblockedContext()
+                )
+            )
+        }
+    }
+
+    @Test
+    fun authAndModalContextAreHidden() {
+        listOf(
+            GuestSignInAfterReviewPromptContext(
+                isAuthFlowActive = true,
+                isAppModalActive = false
+            ),
+            GuestSignInAfterReviewPromptContext(
+                isAuthFlowActive = false,
+                isAppModalActive = true
+            )
+        ).forEach { context ->
+            assertFalse(
+                isGuestSignInAfterReviewPromptVisible(
+                    cloudState = CloudAccountState.GUEST,
+                    reviewedCount = 20,
+                    promptState = emptyPromptState(),
+                    nowMillis = 1_000L,
+                    context = context
+                )
+            )
+        }
+    }
+
+    @Test
+    fun snoozeSuppressesUntilExpiry() {
+        val snoozedState = GuestSignInAfterReviewPromptState(
+            lastShownAtMillis = 1_000L,
+            snoozedUntilMillis = 2_000L,
+            lastShownReviewCount = 20,
+            acceptedAtMillis = null
+        )
+
+        assertFalse(
+            isGuestSignInAfterReviewPromptVisible(
+                cloudState = CloudAccountState.GUEST,
+                reviewedCount = 20,
+                promptState = snoozedState,
+                nowMillis = 1_999L,
+                context = unblockedContext()
+            )
+        )
+        assertTrue(
+            isGuestSignInAfterReviewPromptVisible(
+                cloudState = CloudAccountState.GUEST,
+                reviewedCount = 20,
+                promptState = snoozedState,
+                nowMillis = 2_000L,
+                context = unblockedContext()
+            )
+        )
+    }
+
+    @Test
+    fun acceptedStateIsHidden() {
+        assertFalse(
+            isGuestSignInAfterReviewPromptVisible(
+                cloudState = CloudAccountState.GUEST,
+                reviewedCount = 20,
+                promptState = GuestSignInAfterReviewPromptState(
+                    lastShownAtMillis = 1_000L,
+                    snoozedUntilMillis = null,
+                    lastShownReviewCount = 20,
+                    acceptedAtMillis = 1_500L
+                ),
+                nowMillis = 2_000L,
+                context = unblockedContext()
+            )
+        )
+    }
+
+    private fun emptyPromptState(): GuestSignInAfterReviewPromptState {
+        return GuestSignInAfterReviewPromptState(
+            lastShownAtMillis = null,
+            snoozedUntilMillis = null,
+            lastShownReviewCount = null,
+            acceptedAtMillis = null
+        )
+    }
+
+    private fun unblockedContext(): GuestSignInAfterReviewPromptContext {
+        return GuestSignInAfterReviewPromptContext(
+            isAuthFlowActive = false,
+            isAppModalActive = false
+        )
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/DatabaseDaos.kt
@@ -766,6 +766,9 @@ interface ReviewLogDao {
     @Query("SELECT COUNT(*) FROM review_logs")
     suspend fun countReviewLogs(): Int
 
+    @Query("SELECT COUNT(*) FROM review_logs WHERE workspaceId = :workspaceId")
+    suspend fun countReviewLogs(workspaceId: String): Int
+
     @Query(
         """
         SELECT EXISTS(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/LocalReviewRepository.kt
@@ -280,6 +280,15 @@ class LocalReviewRepository(
         return database.reviewLogDao().countReviewLogs()
     }
 
+    override suspend fun countRecordedReviewsInCurrentWorkspace(): Int {
+        val workspace: WorkspaceEntity = loadCurrentWorkspaceOrNull(
+            database = database,
+            preferencesStore = preferencesStore
+        ) ?: return 0
+
+        return database.reviewLogDao().countReviewLogs(workspaceId = workspace.workspaceId)
+    }
+
     override suspend fun loadReviewCardForRollback(selectedFilter: ReviewFilter, cardId: String): ReviewCard? {
         val workspace: WorkspaceEntity = loadCurrentWorkspaceOrNull(
             database = database,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -103,6 +103,8 @@ interface ReviewRepository {
 
     suspend fun countRecordedReviews(): Int
 
+    suspend fun countRecordedReviewsInCurrentWorkspace(): Int
+
     suspend fun loadReviewCardForRollback(selectedFilter: ReviewFilter, cardId: String): ReviewCard?
 
     suspend fun recordReview(cardId: String, rating: ReviewRating, reviewedAtMillis: Long)


### PR DESCRIPTION
## Summary
- Add an app-level Android prompt that asks guest users to sign in after 20 completed reviews.
- Persist prompt state locally in SharedPreferences with show, snooze, and accepted timestamps.
- Count completed reviews from active-workspace review logs and route the prompt into the existing email sign-in flow.

## Validation
- Not run locally: Android Gradle runs are resource-heavy and require explicit approval in this repo.
