### PR TITLE
[codex] Add guest sign-in prompt after reviews

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -1,8 +1,90 @@
 import SwiftUI
 
+private struct GuestSignInAfterReviewPromptRecheckTaskID: Hashable {
+    let isSceneActive: Bool
+    let cloudState: CloudAccountState?
+    let reviewedCount: Int
+    let promptState: GuestSignInAfterReviewPromptState
+    let isModalOrAuthFlowActive: Bool
+}
+
 struct RootTabView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
+
+    @State private var isGuestSignInCloudSignInPresented: Bool = false
+
+    private var isGuestSignInAfterReviewPromptBlockedByModal: Bool {
+        self.isGuestSignInCloudSignInPresented
+            || store.activeCloudSignInSheetCount > 0
+            || store.accountDeletionState != .hidden
+            || store.accountDeletionSuccessMessage != nil
+            || store.reviewSubmissionFailure != nil
+            || store.isReviewNotificationPrePromptPresented
+            || store.isReviewHardReminderPresented
+    }
+
+    private var guestSignInAfterReviewPromptRecheckTaskID: GuestSignInAfterReviewPromptRecheckTaskID {
+        GuestSignInAfterReviewPromptRecheckTaskID(
+            isSceneActive: self.scenePhase == .active,
+            cloudState: store.cloudSettings?.cloudState,
+            reviewedCount: store.homeSnapshot.reviewedCount,
+            promptState: store.guestSignInAfterReviewPromptState,
+            isModalOrAuthFlowActive: self.isGuestSignInAfterReviewPromptBlockedByModal
+        )
+    }
+
+    @MainActor
+    private func reconcileGuestSignInAfterReviewPrompt() {
+        self.store.reconcileGuestSignInAfterReviewPrompt(
+            isModalOrAuthFlowActive: self.isGuestSignInAfterReviewPromptBlockedByModal,
+            now: Date()
+        )
+    }
+
+    @MainActor
+    private func waitForGuestSignInAfterReviewPromptRecheckIfNeeded() async {
+        guard self.scenePhase == .active else {
+            return
+        }
+
+        let now = Date()
+        guard let recheckDate = nextGuestSignInAfterReviewPromptRecheckDate(
+            cloudState: store.cloudSettings?.cloudState,
+            reviewedCount: store.homeSnapshot.reviewedCount,
+            promptState: store.guestSignInAfterReviewPromptState,
+            now: now,
+            isModalOrAuthFlowActive: self.isGuestSignInAfterReviewPromptBlockedByModal
+        ) else {
+            return
+        }
+
+        let secondsUntilRecheck = recheckDate.timeIntervalSince(now)
+        guard secondsUntilRecheck > 0 else {
+            self.reconcileGuestSignInAfterReviewPrompt()
+            return
+        }
+
+        let nanosecondsPerSecond: Double = 1_000_000_000
+        let maximumSleepSeconds = Double(UInt64.max) / nanosecondsPerSecond
+        let sleepNanoseconds = UInt64(min(secondsUntilRecheck, maximumSleepSeconds) * nanosecondsPerSecond)
+
+        do {
+            try await Task.sleep(nanoseconds: sleepNanoseconds)
+        } catch is CancellationError {
+            return
+        } catch {
+            assertionFailure("Unexpected guest sign-in prompt recheck sleep failure: \(error)")
+            return
+        }
+
+        guard Task.isCancelled == false else {
+            return
+        }
+
+        self.reconcileGuestSignInAfterReviewPrompt()
+    }
 
     @MainActor
     private func prepareTabForPresentationIfNeeded(nextTab: AppTab) {
@@ -170,6 +252,10 @@ struct RootTabView: View {
         .tabBarMinimizeBehavior(.never)
         .task {
             store.prepareVisibleTabForPresentation(tab: navigation.selectedTab, now: Date())
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .task(id: self.guestSignInAfterReviewPromptRecheckTaskID) {
+            await self.waitForGuestSignInAfterReviewPromptRecheckIfNeeded()
         }
         .overlay {
             ZStack {
@@ -210,6 +296,95 @@ struct RootTabView: View {
                     extendsFastPolling: true,
                     allowsVisibleChangeBanner: true,
                     surfacesGlobalErrorMessage: false
+                )
+            )
+        }
+        .onChange(of: store.cloudSettings?.cloudState) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: store.guestSignInAfterReviewPromptReconciliationToken) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: store.activeCloudSignInSheetCount) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: self.scenePhase) { _, nextPhase in
+            if nextPhase == .active {
+                self.reconcileGuestSignInAfterReviewPrompt()
+            }
+        }
+        .onChange(of: store.accountDeletionState) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: store.accountDeletionSuccessMessage) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: store.reviewSubmissionFailure != nil) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: store.isReviewNotificationPrePromptPresented) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: store.isReviewHardReminderPresented) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .onChange(of: self.isGuestSignInCloudSignInPresented) { _, _ in
+            self.reconcileGuestSignInAfterReviewPrompt()
+        }
+        .sheet(isPresented: self.$isGuestSignInCloudSignInPresented) {
+            CloudSignInSheet()
+                .environment(store)
+        }
+        .alert(
+            String(
+                localized: "root_tab.guest_sign_in_after_review_prompt.title",
+                defaultValue: "Save your progress",
+                table: "Foundation",
+                comment: "Guest sign-in prompt title after reviewing enough cards"
+            ),
+            isPresented: Binding(
+                get: {
+                    store.isGuestSignInAfterReviewPromptPresented
+                },
+                set: { isPresented in
+                    if isPresented == false {
+                        store.dismissGuestSignInAfterReviewPrompt()
+                    }
+                }
+            )
+        ) {
+            Button(
+                String(
+                    localized: "root_tab.guest_sign_in_after_review_prompt.later",
+                    defaultValue: "Later",
+                    table: "Foundation",
+                    comment: "Guest sign-in prompt secondary button"
+                ),
+                role: .cancel
+            ) {
+                store.snoozeGuestSignInAfterReviewPrompt(
+                    reviewedCount: store.homeSnapshot.reviewedCount,
+                    now: Date()
+                )
+            }
+            Button(
+                String(
+                    localized: "root_tab.guest_sign_in_after_review_prompt.sign_in",
+                    defaultValue: "Sign in",
+                    table: "Foundation",
+                    comment: "Guest sign-in prompt primary button"
+                )
+            ) {
+                store.acceptGuestSignInAfterReviewPrompt(now: Date())
+                self.isGuestSignInCloudSignInPresented = true
+            }
+        } message: {
+            Text(
+                String(
+                    localized: "root_tab.guest_sign_in_after_review_prompt.message",
+                    defaultValue: "Sign in with email so these cards and review progress are not lost.",
+                    table: "Foundation",
+                    comment: "Guest sign-in prompt body after reviewing enough cards"
                 )
             )
         }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudIdentity.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudIdentity.swift
@@ -37,6 +37,7 @@ extension FlashcardsStore {
         self.userDefaults.removeObject(forKey: reviewNotificationLastActiveAtUserDefaultsKey)
         self.userDefaults.removeObject(forKey: accountDeletionPendingUserDefaultsKey)
         self.userDefaults.removeObject(forKey: aiChatExternalProviderConsentUserDefaultsKey)
+        self.clearGuestSignInAfterReviewPromptState()
         self.cachedAIChatStore?.clearLocalHistory()
         clearStoredAIChatHistories(userDefaults: self.userDefaults)
         self.reviewRuntime = ReviewQueueRuntime(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudSync.swift
@@ -293,6 +293,9 @@ extension FlashcardsStore {
         if bootstrapRefreshOutcome.didChange || didRefreshReviewState {
             self.localReadVersion += 1
         }
+        if bootstrapRefreshOutcome.homeSnapshotChanged {
+            self.requestGuestSignInAfterReviewPromptReconciliation()
+        }
         await self.handleProgressSyncCompletion(
             now: now,
             syncResult: syncResult
@@ -331,6 +334,9 @@ extension FlashcardsStore {
         }
         if bootstrapRefreshOutcome.didChange || didResetVolatileReviewSelection {
             self.localReadVersion += 1
+        }
+        if bootstrapRefreshOutcome.homeSnapshotChanged {
+            self.requestGuestSignInAfterReviewPromptReconciliation()
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
@@ -113,6 +113,7 @@ extension FlashcardsStore {
         self.refreshReviewState(now: now)
         self.reconcileReviewNotifications(trigger: .workspaceChanged, now: now)
         self.reconcileStrictReminders(trigger: .workspaceChanged, now: now)
+        self.requestGuestSignInAfterReviewPromptReconciliation()
     }
 
     @discardableResult

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
@@ -92,6 +92,10 @@ final class FlashcardsStore {
     var strictRemindersSettings: StrictRemindersSettings
     var notificationPermissionPromptState: NotificationPermissionPromptState
     var isReviewNotificationPrePromptPresented: Bool
+    var guestSignInAfterReviewPromptState: GuestSignInAfterReviewPromptState
+    var isGuestSignInAfterReviewPromptPresented: Bool
+    var guestSignInAfterReviewPromptReconciliationToken: Int
+    var activeCloudSignInSheetCount: Int
     var accountDeletionState: AccountDeletionState
     var accountDeletionSuccessMessage: String?
     var uiTestLaunchPreparationStatus: FlashcardsUITestLaunchPreparationStatus
@@ -361,6 +365,13 @@ final class FlashcardsStore {
             decoder: decoder
         )
         self.isReviewNotificationPrePromptPresented = false
+        self.guestSignInAfterReviewPromptState = loadGuestSignInAfterReviewPromptState(
+            userDefaults: userDefaults,
+            decoder: decoder
+        )
+        self.isGuestSignInAfterReviewPromptPresented = false
+        self.guestSignInAfterReviewPromptReconciliationToken = 0
+        self.activeCloudSignInSheetCount = 0
         self.accountDeletionState = .hidden
         self.accountDeletionSuccessMessage = nil
         self.uiTestLaunchPreparationStatus = .hidden

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -3541,6 +3541,242 @@
         }
       }
     },
+    "root_tab.guest_sign_in_after_review_prompt.later" : {
+      "comment" : "Guest sign-in prompt secondary button",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لاحقًا"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Später"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Later"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más tarde"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Más tarde"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बाद में"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "後で"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Позже"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "稍后"
+          }
+        }
+      }
+    },
+    "root_tab.guest_sign_in_after_review_prompt.message" : {
+      "comment" : "Guest sign-in prompt body after reviewing enough cards",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سجّل الدخول بالبريد الإلكتروني حتى لا تفقد هذه البطاقات وتقدّم المراجعة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melde dich mit E-Mail an, damit diese Karten und dein Wiederholungsfortschritt nicht verloren gehen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in with email so these cards and review progress are not lost."
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicia sesión con tu correo para que estas tarjetas y tu progreso de repaso no se pierdan."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicia sesión con tu correo para que estas tarjetas y tu progreso de repaso no se pierdan."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ईमेल से साइन इन करें ताकि ये कार्ड और समीक्षा प्रगति खो न जाएँ।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メールでサインインして、これらのカードと復習の進捗を失わないようにしましょう。"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Войдите по электронной почте, чтобы не потерять эти карточки и прогресс повторения."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用电子邮件登录，以免这些卡片和复习进度丢失。"
+          }
+        }
+      }
+    },
+    "root_tab.guest_sign_in_after_review_prompt.sign_in" : {
+      "comment" : "Guest sign-in prompt primary button",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسجيل الدخول"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anmelden"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sign in"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesión"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iniciar sesión"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "साइन इन करें"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サインイン"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Войти"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录"
+          }
+        }
+      }
+    },
+    "root_tab.guest_sign_in_after_review_prompt.title" : {
+      "comment" : "Guest sign-in prompt title after reviewing enough cards",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "احفظ تقدمك"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortschritt sichern"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save your progress"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guarda tu progreso"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guarda tu progreso"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अपनी प्रगति सहेजें"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進捗を保存"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сохраните свой прогресс"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存你的进度"
+          }
+        }
+      }
+    },
     "progress.screen.loading" : {
       "comment" : "Progress loading state",
       "localizations" : {

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -198,6 +198,10 @@ extension FlashcardsStore {
         self.recordSuccessfulStrictReminderReview(reviewedAt: reviewedAt, now: now)
         let reviewCount = self.loadReviewNotificationPromptReviewCount(persistedReviewCount: nextCount)
         Task { @MainActor in
+            defer {
+                self.requestGuestSignInAfterReviewPromptReconciliation()
+            }
+
             let permissionStatus = await resolveReviewNotificationPermissionStatus()
             guard permissionStatus == .notRequested else {
                 return

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
@@ -21,6 +21,22 @@ private struct CloudOtpSheetState: Identifiable, Hashable {
     }
 }
 
+@MainActor
+extension FlashcardsStore {
+    func beginCloudSignInSheetPresentation() {
+        self.activeCloudSignInSheetCount += 1
+    }
+
+    func endCloudSignInSheetPresentation() {
+        guard self.activeCloudSignInSheetCount > 0 else {
+            assertionFailure("Cloud sign-in sheet presentation ended without a matching begin.")
+            return
+        }
+
+        self.activeCloudSignInSheetCount -= 1
+    }
+}
+
 enum CloudPostAuthRetryAction: Hashable {
     case prepareLink(verifiedContext: CloudVerifiedAuthContext)
     case completeLink(linkContext: CloudWorkspaceLinkContext, selection: CloudWorkspaceLinkSelection)
@@ -179,6 +195,7 @@ struct CloudSignInSheet: View {
     @State private var authErrorPresentation: CloudAuthInlineErrorPresentation?
     @State private var isSendingCode: Bool = false
     @State private var isLogoutConfirmationPresented: Bool = false
+    @State private var hasRecordedActivePresentation: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -308,7 +325,11 @@ struct CloudSignInSheet: View {
                 Text(aiSettingsLocalized("settings.account.status.logoutAlertMessage", "All local workspaces and synced data will be removed from this device."))
             }
             .onAppear {
+                self.recordActivePresentationIfNeeded()
                 self.scheduleEmailFieldFocus()
+            }
+            .onDisappear {
+                self.clearActivePresentationIfNeeded()
             }
         }
         .accessibilityIdentifier(UITestIdentifier.cloudSignInScreen)
@@ -322,6 +343,24 @@ struct CloudSignInSheet: View {
         DispatchQueue.main.async {
             self.isEmailFieldFocused = true
         }
+    }
+
+    private func recordActivePresentationIfNeeded() {
+        guard self.hasRecordedActivePresentation == false else {
+            return
+        }
+
+        self.hasRecordedActivePresentation = true
+        self.store.beginCloudSignInSheetPresentation()
+    }
+
+    private func clearActivePresentationIfNeeded() {
+        guard self.hasRecordedActivePresentation else {
+            return
+        }
+
+        self.hasRecordedActivePresentation = false
+        self.store.endCloudSignInSheetPresentation()
     }
 
     private func sendCode() {

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+@MainActor
+extension FlashcardsStore {
+    func reconcileGuestSignInAfterReviewPrompt(
+        isModalOrAuthFlowActive: Bool,
+        now: Date
+    ) {
+        guard self.isGuestSignInAfterReviewPromptPresented == false else {
+            return
+        }
+        guard shouldPresentGuestSignInAfterReviewPrompt(
+            cloudState: self.cloudSettings?.cloudState,
+            reviewedCount: self.homeSnapshot.reviewedCount,
+            promptState: self.guestSignInAfterReviewPromptState,
+            now: now,
+            isModalOrAuthFlowActive: isModalOrAuthFlowActive
+        ) else {
+            return
+        }
+
+        self.markGuestSignInAfterReviewPromptShown(
+            reviewedCount: self.homeSnapshot.reviewedCount,
+            now: now
+        )
+        self.isGuestSignInAfterReviewPromptPresented = true
+    }
+
+    func requestGuestSignInAfterReviewPromptReconciliation() {
+        self.guestSignInAfterReviewPromptReconciliationToken = self.guestSignInAfterReviewPromptReconciliationToken &+ 1
+    }
+
+    func dismissGuestSignInAfterReviewPrompt() {
+        self.isGuestSignInAfterReviewPromptPresented = false
+    }
+
+    func acceptGuestSignInAfterReviewPrompt(now: Date) {
+        self.updateGuestSignInAfterReviewPromptState(
+            state: makeAcceptedGuestSignInAfterReviewPromptState(
+                promptState: self.guestSignInAfterReviewPromptState,
+                now: now
+            )
+        )
+        self.isGuestSignInAfterReviewPromptPresented = false
+    }
+
+    func snoozeGuestSignInAfterReviewPrompt(reviewedCount: Int, now: Date) {
+        self.updateGuestSignInAfterReviewPromptState(
+            state: makeSnoozedGuestSignInAfterReviewPromptState(
+                promptState: self.guestSignInAfterReviewPromptState,
+                reviewedCount: reviewedCount,
+                now: now
+            )
+        )
+        self.isGuestSignInAfterReviewPromptPresented = false
+    }
+
+    func clearGuestSignInAfterReviewPromptState() {
+        self.guestSignInAfterReviewPromptState = makeDefaultGuestSignInAfterReviewPromptState()
+        self.isGuestSignInAfterReviewPromptPresented = false
+        self.userDefaults.removeObject(forKey: guestSignInAfterReviewPromptUserDefaultsKey)
+    }
+
+    private func markGuestSignInAfterReviewPromptShown(reviewedCount: Int, now: Date) {
+        self.updateGuestSignInAfterReviewPromptState(
+            state: makeGuestSignInAfterReviewPromptShownState(
+                promptState: self.guestSignInAfterReviewPromptState,
+                reviewedCount: reviewedCount,
+                now: now
+            )
+        )
+    }
+
+    private func updateGuestSignInAfterReviewPromptState(state: GuestSignInAfterReviewPromptState) {
+        self.guestSignInAfterReviewPromptState = state
+
+        do {
+            let data: Data = try self.encoder.encode(state)
+            self.userDefaults.set(data, forKey: guestSignInAfterReviewPromptUserDefaultsKey)
+        } catch {
+            self.userDefaults.removeObject(forKey: guestSignInAfterReviewPromptUserDefaultsKey)
+        }
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/GuestSignInAfterReviewPromptSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/GuestSignInAfterReviewPromptSupport.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+let guestSignInAfterReviewPromptUserDefaultsKey: String = "guest-sign-in-after-review-prompt-v1"
+let guestSignInAfterReviewPromptReviewThreshold: Int = 20
+let guestSignInAfterReviewPromptReviewIncreaseThreshold: Int = 10
+let guestSignInAfterReviewPromptSnoozeSeconds: TimeInterval = 7 * 24 * 60 * 60
+
+struct GuestSignInAfterReviewPromptState: Codable, Hashable, Sendable {
+    let lastShownAt: Date?
+    let snoozedUntil: Date?
+    let lastShownReviewCount: Int?
+    let acceptedAt: Date?
+}
+
+func makeDefaultGuestSignInAfterReviewPromptState() -> GuestSignInAfterReviewPromptState {
+    GuestSignInAfterReviewPromptState(
+        lastShownAt: nil,
+        snoozedUntil: nil,
+        lastShownReviewCount: nil,
+        acceptedAt: nil
+    )
+}
+
+func shouldPresentGuestSignInAfterReviewPrompt(
+    cloudState: CloudAccountState?,
+    reviewedCount: Int,
+    promptState: GuestSignInAfterReviewPromptState,
+    now: Date,
+    isModalOrAuthFlowActive: Bool
+) -> Bool {
+    guard cloudState == .guest else {
+        return false
+    }
+    guard reviewedCount >= guestSignInAfterReviewPromptReviewThreshold else {
+        return false
+    }
+    guard promptState.acceptedAt == nil else {
+        return false
+    }
+    guard isModalOrAuthFlowActive == false else {
+        return false
+    }
+    if let snoozedUntil = promptState.snoozedUntil {
+        guard now >= snoozedUntil else {
+            return false
+        }
+        if let lastShownReviewCount = promptState.lastShownReviewCount {
+            return reviewedCount >= lastShownReviewCount + guestSignInAfterReviewPromptReviewIncreaseThreshold
+        }
+    }
+
+    return true
+}
+
+func nextGuestSignInAfterReviewPromptRecheckDate(
+    cloudState: CloudAccountState?,
+    reviewedCount: Int,
+    promptState: GuestSignInAfterReviewPromptState,
+    now: Date,
+    isModalOrAuthFlowActive: Bool
+) -> Date? {
+    guard cloudState == .guest else {
+        return nil
+    }
+    guard reviewedCount >= guestSignInAfterReviewPromptReviewThreshold else {
+        return nil
+    }
+    guard promptState.acceptedAt == nil else {
+        return nil
+    }
+    guard isModalOrAuthFlowActive == false else {
+        return nil
+    }
+    guard let snoozedUntil = promptState.snoozedUntil, now < snoozedUntil else {
+        return nil
+    }
+    if let lastShownReviewCount = promptState.lastShownReviewCount {
+        guard reviewedCount >= lastShownReviewCount + guestSignInAfterReviewPromptReviewIncreaseThreshold else {
+            return nil
+        }
+    }
+
+    return snoozedUntil
+}
+
+func makeGuestSignInAfterReviewPromptShownState(
+    promptState: GuestSignInAfterReviewPromptState,
+    reviewedCount: Int,
+    now: Date
+) -> GuestSignInAfterReviewPromptState {
+    GuestSignInAfterReviewPromptState(
+        lastShownAt: now,
+        snoozedUntil: nil,
+        lastShownReviewCount: reviewedCount,
+        acceptedAt: promptState.acceptedAt
+    )
+}
+
+func makeAcceptedGuestSignInAfterReviewPromptState(
+    promptState: GuestSignInAfterReviewPromptState,
+    now: Date
+) -> GuestSignInAfterReviewPromptState {
+    GuestSignInAfterReviewPromptState(
+        lastShownAt: promptState.lastShownAt,
+        snoozedUntil: promptState.snoozedUntil,
+        lastShownReviewCount: promptState.lastShownReviewCount,
+        acceptedAt: now
+    )
+}
+
+func makeSnoozedGuestSignInAfterReviewPromptState(
+    promptState: GuestSignInAfterReviewPromptState,
+    reviewedCount: Int,
+    now: Date
+) -> GuestSignInAfterReviewPromptState {
+    GuestSignInAfterReviewPromptState(
+        lastShownAt: now,
+        snoozedUntil: now.addingTimeInterval(guestSignInAfterReviewPromptSnoozeSeconds),
+        lastShownReviewCount: reviewedCount,
+        acceptedAt: promptState.acceptedAt
+    )
+}
+
+func loadGuestSignInAfterReviewPromptState(
+    userDefaults: UserDefaults,
+    decoder: JSONDecoder
+) -> GuestSignInAfterReviewPromptState {
+    guard let data = userDefaults.data(forKey: guestSignInAfterReviewPromptUserDefaultsKey) else {
+        return makeDefaultGuestSignInAfterReviewPromptState()
+    }
+
+    do {
+        return try decoder.decode(GuestSignInAfterReviewPromptState.self, from: data)
+    } catch {
+        userDefaults.removeObject(forKey: guestSignInAfterReviewPromptUserDefaultsKey)
+        return makeDefaultGuestSignInAfterReviewPromptState()
+    }
+}


### PR DESCRIPTION
## Summary

- Add a guest-only native sign-in prompt after the iOS reviewed-count threshold is reached.
- Persist prompt metadata locally in UserDefaults and clear it on cloud identity reset.
- Reuse the existing CloudSignInSheet and block the prompt behind active modal/auth flows.
- Add supported Foundation.xcstrings entries for the new prompt copy.

## Validation

- `xcrun swiftc -parse apps/ios/Flashcards/Flashcards/App/RootTabView.swift apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudSync.swift apps/ios/Flashcards/Flashcards/FlashcardsStore.swift apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift apps/ios/Flashcards/Flashcards/Settings/Account/GuestSignInAfterReviewPromptSupport.swift apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudIdentity.swift`
- `git --no-pager diff --check HEAD~1..HEAD`
- `python3 -m json.tool apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings >/dev/null`

Simulator-backed tests were not run.