### PR TITLE
[codex] Fix Android review log DAO test fake

### DIFF
--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -307,6 +307,10 @@ private class FakeReviewLogDao(
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }
 
+    override suspend fun countReviewLogs(workspaceId: String): Int {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
     override suspend fun hasReviewLogsBetween(startMillis: Long, endMillis: Long): Boolean {
         return hasReviewLogsBetween
     }


### PR DESCRIPTION
## Summary
- Add the missing workspace-scoped `countReviewLogs` override to the strict reminders test fake.

## Validation
- `git diff --check HEAD~1..HEAD`
- Android Gradle was not run locally because this repository requires explicit approval for local Gradle runs.