### PR TITLE
Add Android cloud credential recovery

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -202,7 +202,7 @@ class AppGraph(
         operationCoordinator = cloudOperationCoordinator,
         resetCoordinator = cloudIdentityResetCoordinator,
         guestSessionStore = guestAiSessionStore,
-        aiChatRemoteService = aiChatRemoteService,
+        guestSessionCreator = aiChatRemoteService,
         appVersion = appPackageInfo.versionName
     )
 

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudGuestSessionCoordinatorTest.kt
@@ -2,12 +2,17 @@ package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.ai.GuestCloudSessionCreator
 import com.flashcardsopensourceapp.data.local.cloud.PendingGuestUpgradeState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -59,6 +64,219 @@ class CloudGuestSessionCoordinatorTest {
         assertNull(environment.cloudPreferencesStore.currentCloudSettings().linkedEmail)
         assertNull(environment.cloudPreferencesStore.loadCredentials())
         assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+    }
+
+    @Test
+    fun linkedStateWithMissingCredentialsMarksRecoveryAndPreservesLocalData() = runBlocking {
+        val preservationState = seedCredentialRecoveryLocalData()
+        val coordinator = environment.createCloudGuestSessionCoordinator(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.LINKED,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = preservationState.workspaceId,
+            linkedEmail = "user@example.com",
+            activeWorkspaceId = preservationState.workspaceId
+        )
+
+        coordinator.reconcilePersistedCloudState()
+
+        val recoveryState = requireNotNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState()) {
+            "Expected missing linked credentials to create recovery state."
+        }
+        assertEquals(CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING, recoveryState.reason)
+        assertEquals(CloudAccountState.LINKED, recoveryState.previousCloudState)
+        assertEquals(preservationState.installationId, recoveryState.installationId)
+        assertEquals("user-1", recoveryState.linkedUserId)
+        assertEquals(preservationState.workspaceId, recoveryState.linkedWorkspaceId)
+        assertEquals(preservationState.workspaceId, recoveryState.activeWorkspaceId)
+        assertEquals("user@example.com", recoveryState.linkedEmail)
+        assertEquals(CloudServiceConfigurationMode.OFFICIAL, recoveryState.configurationMode)
+        assertEquals("https://api.flashcards-open-source-app.com/v1", recoveryState.apiBaseUrl)
+        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(preservationState.installationId, environment.cloudPreferencesStore.currentCloudSettings().installationId)
+        assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+    }
+
+    @Test
+    fun linkedStateWithInvalidActiveWorkspaceAndMissingCredentialsMarksRecovery() = runBlocking {
+        val preservationState = seedCredentialRecoveryLocalData()
+        val coordinator = environment.createCloudGuestSessionCoordinator(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.LINKED,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = preservationState.workspaceId,
+            linkedEmail = "user@example.com",
+            activeWorkspaceId = "missing-workspace"
+        )
+
+        coordinator.reconcilePersistedCloudState()
+
+        val recoveryState = requireNotNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState()) {
+            "Expected missing linked credentials to create recovery state after active workspace normalization."
+        }
+        assertEquals(CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING, recoveryState.reason)
+        assertEquals(preservationState.workspaceId, recoveryState.linkedWorkspaceId)
+        assertEquals(preservationState.workspaceId, recoveryState.activeWorkspaceId)
+        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+    }
+
+    @Test
+    fun guestStateWithMissingSessionMarksRecoveryAndPreservesLocalData() = runBlocking {
+        val preservationState = seedCredentialRecoveryLocalData()
+        val coordinator = environment.createCloudGuestSessionCoordinator(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = preservationState.workspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = preservationState.workspaceId
+        )
+
+        coordinator.reconcilePersistedCloudState()
+
+        val recoveryState = requireNotNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState()) {
+            "Expected missing guest session to create recovery state."
+        }
+        assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, recoveryState.reason)
+        assertEquals(CloudAccountState.GUEST, recoveryState.previousCloudState)
+        assertEquals(preservationState.installationId, recoveryState.installationId)
+        assertEquals("guest-user", recoveryState.linkedUserId)
+        assertEquals(preservationState.workspaceId, recoveryState.linkedWorkspaceId)
+        assertEquals(preservationState.workspaceId, recoveryState.activeWorkspaceId)
+        assertNull(recoveryState.linkedEmail)
+        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(preservationState.installationId, environment.cloudPreferencesStore.currentCloudSettings().installationId)
+        assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+    }
+
+    @Test
+    fun guestStateWithInvalidActiveWorkspaceAndMissingSessionMarksRecovery() = runBlocking {
+        val preservationState = seedCredentialRecoveryLocalData()
+        val coordinator = environment.createCloudGuestSessionCoordinator(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = preservationState.workspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = "missing-workspace"
+        )
+
+        coordinator.reconcilePersistedCloudState()
+
+        val recoveryState = requireNotNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState()) {
+            "Expected missing guest session to create recovery state after active workspace normalization."
+        }
+        assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, recoveryState.reason)
+        assertEquals(preservationState.workspaceId, recoveryState.linkedWorkspaceId)
+        assertEquals(preservationState.workspaceId, recoveryState.activeWorkspaceId)
+        assertCredentialRecoveryPreservedLocalData(preservationState = preservationState)
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(preservationState.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+    }
+
+    @Test
+    fun activeRecoveryBlocksGuestSessionAutoCreation() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.GUEST_SESSION_MISSING,
+            previousCloudState = CloudAccountState.GUEST,
+            installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val guestSessionCreator = RecordingGuestSessionCreator(
+            session = createStoredGuestAiSession(
+                workspaceId = "new-guest-workspace",
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "new-guest-token",
+                userId = "new-guest-user"
+            )
+        )
+        val coordinator = environment.createCloudGuestSessionCoordinatorWithGuestSessionCreator(
+            remoteGateway = FakeCloudRemoteGateway.standard(),
+            guestSessionCreator = guestSessionCreator
+        )
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+
+        try {
+            coordinator.ensureGuestCloudSession(workspaceId = localWorkspaceId)
+            throw AssertionError("Expected active recovery to block guest session creation.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
+
+        assertEquals(0, guestSessionCreator.createGuestSessionCalls)
+        assertNull(
+            environment.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )
+        )
+    }
+
+    @Test
+    fun credentialRecoveryStatePersistsAcrossStoreRestart() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+
+        val restartedRuntime = environment.createRestartedCloudGuestSessionRuntime(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+
+        assertEquals(recoveryState, restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+    }
+
+    @Test
+    fun corruptCredentialRecoveryStateDoesNotPreventStoreRestartAndThrowsWhenLoaded() = runBlocking {
+        val metadataPreferences = environment.context.getSharedPreferences(
+            "flashcards-cloud-metadata",
+            Context.MODE_PRIVATE
+        )
+        assertTrue(
+            metadataPreferences.edit()
+                .putString("cloud-credential-recovery-state", "{")
+                .commit()
+        )
+
+        val restartedRuntime = environment.createRestartedCloudGuestSessionRuntime(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+
+        try {
+            restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState()
+            throw AssertionError("Expected corrupt recovery state to throw when loaded.")
+        } catch (error: IllegalStateException) {
+            assertTrue(error.message?.contains("Cloud credential recovery state is corrupt") == true)
+        }
     }
 
     @Test
@@ -325,5 +543,62 @@ class CloudGuestSessionCoordinatorTest {
                 configuration = makeOfficialCloudServiceConfiguration()
             )?.workspaceId
         )
+    }
+
+    private suspend fun seedCredentialRecoveryLocalData(): CredentialRecoveryPreservationState {
+        val workspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = workspaceId)
+        val card = requireNotNull(environment.database.cardDao().loadCard(cardId = cardId)) {
+            "Expected seeded card."
+        }
+        environment.database.outboxDao().insertOutboxEntry(
+            createSyncCardOutboxEntry(
+                outboxEntryId = "outbox-recovery-$workspaceId",
+                workspaceId = workspaceId,
+                installationId = installationId,
+                card = card,
+                createdAtMillis = 300L
+            )
+        )
+        return CredentialRecoveryPreservationState(
+            workspaceId = workspaceId,
+            installationId = installationId,
+            cardId = cardId
+        )
+    }
+
+    private suspend fun assertCredentialRecoveryPreservedLocalData(
+        preservationState: CredentialRecoveryPreservationState
+    ) {
+        assertEquals(
+            preservationState.workspaceId,
+            environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId
+        )
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = preservationState.workspaceId).count())
+        assertNotNull(environment.database.cardDao().loadCard(cardId = preservationState.cardId))
+        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = preservationState.workspaceId))
+        assertEquals(1, environment.database.outboxDao().countOutboxEntries())
+    }
+}
+
+private data class CredentialRecoveryPreservationState(
+    val workspaceId: String,
+    val installationId: String,
+    val cardId: String
+)
+
+private class RecordingGuestSessionCreator(
+    private val session: StoredGuestAiSession
+) : GuestCloudSessionCreator {
+    var createGuestSessionCalls: Int = 0
+
+    override suspend fun createGuestSession(
+        apiBaseUrl: String,
+        configurationMode: CloudServiceConfigurationMode
+    ): StoredGuestAiSession {
+        createGuestSessionCalls += 1
+        return session
     }
 }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityResetCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityResetCoordinatorTest.kt
@@ -5,6 +5,8 @@ import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.AiChatPersistedState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.effectiveAiChatServerConfig
 import com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration
@@ -67,6 +69,20 @@ class CloudIdentityResetCoordinatorTest {
                 userId = "guest-user"
             )
         )
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(
+            recoveryState = CloudCredentialRecoveryState(
+                reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+                previousCloudState = CloudAccountState.LINKED,
+                installationId = initialInstallationId,
+                linkedUserId = "user-1",
+                linkedWorkspaceId = initialLocalWorkspaceId,
+                activeWorkspaceId = initialLocalWorkspaceId,
+                linkedEmail = "user@example.com",
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                detectedAtMillis = 500L
+            )
+        )
         environment.cloudPreferencesStore.markAccountDeletionInProgress()
 
         environment.resetCoordinator.resetLocalStateForCloudIdentityChange()
@@ -76,6 +92,7 @@ class CloudIdentityResetCoordinatorTest {
         }
 
         assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
         assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(resetWorkspace.workspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
         assertNotEquals(initialLocalWorkspaceId, resetWorkspace.workspaceId)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestEnvironment.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudIdentityTestEnvironment.kt
@@ -9,6 +9,7 @@ import com.flashcardsopensourceapp.data.local.ai.AiChatPreferencesStore
 import com.flashcardsopensourceapp.data.local.ai.AiChatRemoteService
 import com.flashcardsopensourceapp.data.local.ai.AiCoroutineDispatchers
 import com.flashcardsopensourceapp.data.local.ai.GuestAiSessionStore
+import com.flashcardsopensourceapp.data.local.ai.GuestCloudSessionCreator
 import com.flashcardsopensourceapp.data.local.bootstrap.ensureLocalWorkspaceShell
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
@@ -191,7 +192,7 @@ internal class CloudIdentityTestEnvironment private constructor(
             operationCoordinator = restartedOperationCoordinator,
             resetCoordinator = restartedResetCoordinator,
             guestSessionStore = restartedGuestAiSessionStore,
-            aiChatRemoteService = aiChatRemoteService,
+            guestSessionCreator = aiChatRemoteService,
             appVersion = appVersion
         )
         return RestartedCloudGuestSessionRuntime(
@@ -216,6 +217,16 @@ internal class CloudIdentityTestEnvironment private constructor(
     }
 
     fun createCloudGuestSessionCoordinator(remoteGateway: CloudRemoteGateway): CloudGuestSessionCoordinator {
+        return createCloudGuestSessionCoordinatorWithGuestSessionCreator(
+            remoteGateway = remoteGateway,
+            guestSessionCreator = aiChatRemoteService
+        )
+    }
+
+    fun createCloudGuestSessionCoordinatorWithGuestSessionCreator(
+        remoteGateway: CloudRemoteGateway,
+        guestSessionCreator: GuestCloudSessionCreator
+    ): CloudGuestSessionCoordinator {
         return CloudGuestSessionCoordinator(
             database = database,
             preferencesStore = cloudPreferencesStore,
@@ -224,7 +235,7 @@ internal class CloudIdentityTestEnvironment private constructor(
             operationCoordinator = operationCoordinator,
             resetCoordinator = resetCoordinator,
             guestSessionStore = guestAiSessionStore,
-            aiChatRemoteService = aiChatRemoteService,
+            guestSessionCreator = guestSessionCreator,
             appVersion = appVersion
         )
     }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositorySignInPreparationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositorySignInPreparationTest.kt
@@ -2,12 +2,16 @@ package com.flashcardsopensourceapp.data.local.cloudidentity
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -114,6 +118,394 @@ class LocalCloudAccountRepositorySignInPreparationTest {
         assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
         assertEquals("workspace-2", linkContext.preferredWorkspaceId)
         assertNull(environment.cloudPreferencesStore.loadCredentials())
+    }
+
+    @Test
+    fun prepareVerifiedSignInPrefersRecoveredWorkspaceDuringLinkedCredentialRecovery() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = localWorkspaceId,
+                        name = "Recovered",
+                        createdAtMillis = 100L,
+                        isSelected = false
+                    ),
+                    createCloudWorkspaceSummary(
+                        workspaceId = "workspace-selected",
+                        name = "Selected",
+                        createdAtMillis = 200L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        assertEquals(localWorkspaceId, linkContext.preferredWorkspaceId)
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+    }
+
+    @Test
+    fun linkedCredentialRecoveryRejectsFormerLinkedWorkspaceWhenActiveWorkspaceDiffers() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val linkedWorkspaceId = "workspace-linked"
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = linkedWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = linkedWorkspaceId,
+                        name = "Former Linked",
+                        createdAtMillis = 100L,
+                        isSelected = true
+                    ),
+                    createCloudWorkspaceSummary(
+                        workspaceId = localWorkspaceId,
+                        name = "Recovered",
+                        createdAtMillis = 200L,
+                        isSelected = false
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        assertEquals(localWorkspaceId, linkContext.preferredWorkspaceId)
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = linkedWorkspaceId)
+            )
+            throw AssertionError("Expected completeCloudLink to reject the former linked workspace.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
+    }
+
+    @Test
+    fun linkedCredentialRecoveryCanCreateNewWorkspaceWhenRecoveredWorkspaceIsUnavailable() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = "workspace-other",
+                        name = "Other",
+                        createdAtMillis = 200L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+        val selectedWorkspace = repository.completeCloudLink(
+            linkContext = linkContext,
+            selection = CloudWorkspaceLinkSelection.CreateNew
+        )
+
+        assertEquals(localWorkspaceId, linkContext.preferredWorkspaceId)
+        assertEquals("workspace-new", selectedWorkspace.workspaceId)
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(1, remoteGateway.createWorkspaceCalls)
+        assertEquals(emptyList<String>(), remoteGateway.bootstrapPullWorkspaceIds)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals("workspace-new", environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals("workspace-new", environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        val migratedCards = environment.database.cardDao().loadCards(workspaceId = "workspace-new")
+        assertEquals(1, migratedCards.count())
+        assertEquals("Question", migratedCards.single().frontText)
+        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = "workspace-new"))
+    }
+
+    @Test
+    fun prepareVerifiedSignInIgnoresStoredGuestSessionDuringCredentialRecovery() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = "stale-guest-workspace",
+            session = createStoredGuestAiSession(
+                workspaceId = "stale-guest-workspace",
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                guestToken = "stale-guest-token",
+                userId = "stale-guest-user"
+            )
+        )
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(
+            recoveryState = CloudCredentialRecoveryState(
+                reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+                previousCloudState = CloudAccountState.LINKED,
+                installationId = installationId,
+                linkedUserId = "user-1",
+                linkedWorkspaceId = localWorkspaceId,
+                activeWorkspaceId = localWorkspaceId,
+                linkedEmail = "user@example.com",
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                detectedAtMillis = 500L
+            )
+        )
+
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        assertNull(linkContext.guestUpgradeMode)
+        assertEquals(0, remoteGateway.prepareGuestUpgradeCalls)
+        assertEquals(
+            CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            environment.cloudPreferencesStore.loadCloudCredentialRecoveryState()?.reason
+        )
+    }
+
+    @Test
+    fun completeCloudLinkKeepsLinkedCredentialRecoveryWhenSignedInAccountDiffers() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-2",
+                email = "other@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = "workspace-other",
+                        name = "Other",
+                        createdAtMillis = 200L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = "workspace-other")
+            )
+            throw AssertionError("Expected completeCloudLink to preserve recovery for another account.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
+
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
+    }
+
+    @Test
+    fun completeCloudLinkKeepsLinkedCredentialRecoveryWhenWorkspaceDiffers() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = localWorkspaceId,
+                        name = "Recovered",
+                        createdAtMillis = 100L,
+                        isSelected = false
+                    ),
+                    createCloudWorkspaceSummary(
+                        workspaceId = "workspace-other",
+                        name = "Other",
+                        createdAtMillis = 200L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = "workspace-other")
+            )
+            throw AssertionError("Expected completeCloudLink to preserve recovery for another workspace.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
+
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
+    }
+
+    @Test
+    fun completeCloudLinkPreservesGuestRecoveryDataWhenRemoteWorkspaceIsNotEmpty() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val remoteWorkspaceId = "workspace-remote"
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.GUEST_SESSION_MISSING,
+            previousCloudState = CloudAccountState.GUEST,
+            installationId = installationId,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(false),
+            bootstrapPushErrors = emptyList()
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        val selectedWorkspace = repository.completeCloudLink(
+            linkContext = linkContext,
+            selection = CloudWorkspaceLinkSelection.Existing(workspaceId = remoteWorkspaceId)
+        )
+
+        assertEquals(remoteWorkspaceId, selectedWorkspace.workspaceId)
+        assertEquals(1, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertEquals(emptyList<String>(), remoteGateway.bootstrapPullWorkspaceIds)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(remoteWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
+        assertEquals(remoteWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals(remoteWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        val migratedCards = environment.database.cardDao().loadCards(workspaceId = remoteWorkspaceId)
+        assertEquals(1, migratedCards.count())
+        assertEquals("Question", migratedCards.single().frontText)
+        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = remoteWorkspaceId))
     }
 
     @Test

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteService.kt
@@ -145,7 +145,7 @@ class AiChatRemoteService private constructor(
     okHttpClient: OkHttpClient,
     private val observability: AppObservability,
     private val observationVersions: AiChatHttpObservationVersions
-) {
+) : GuestCloudSessionCreator {
     constructor(
         dispatchers: AiCoroutineDispatchers,
         liveRemoteService: AiChatLiveRemoteService,
@@ -206,7 +206,7 @@ class AiChatRemoteService private constructor(
         .readTimeout(120, TimeUnit.SECONDS)
         .build()
 
-    suspend fun createGuestSession(
+    override suspend fun createGuestSession(
         apiBaseUrl: String,
         configurationMode: CloudServiceConfigurationMode
     ): StoredGuestAiSession = withContext(dispatchers.io) {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/GuestCloudSessionCreator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/GuestCloudSessionCreator.kt
@@ -1,0 +1,11 @@
+package com.flashcardsopensourceapp.data.local.ai
+
+import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
+import com.flashcardsopensourceapp.data.local.model.StoredGuestAiSession
+
+interface GuestCloudSessionCreator {
+    suspend fun createGuestSession(
+        apiBaseUrl: String,
+        configurationMode: CloudServiceConfigurationMode
+    ): StoredGuestAiSession
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
@@ -9,6 +9,8 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableString
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeCompletion
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntity
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeDroppedEntityType
@@ -24,9 +26,11 @@ import com.flashcardsopensourceapp.data.local.model.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.makeCustomCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -49,6 +53,7 @@ private const val updatedAtMillisKey: String = "updated-at-millis"
 private const val accountDeletionStatusKey: String = "account-deletion-status"
 private const val accountDeletionFailureMessageKey: String = "account-deletion-failure-message"
 private const val customOriginKey: String = "custom-origin"
+private const val cloudCredentialRecoveryStateKey: String = "cloud-credential-recovery-state"
 private const val refreshTokenKey: String = "refresh-token"
 private const val idTokenKey: String = "id-token"
 private const val idTokenExpiresAtMillisKey: String = "id-token-expires-at-millis"
@@ -81,6 +86,7 @@ class CloudPreferencesStore(
     private val cloudSettingsState = MutableStateFlow(loadLegacyCloudSettingsEntity().toCloudSettings())
     private val accountDeletionState = MutableStateFlow(loadAccountDeletionState())
     private val serverConfigurationState = MutableStateFlow(loadServerConfiguration())
+    private val cloudCredentialRecoveryStateJson = MutableStateFlow(loadCloudCredentialRecoveryStateJsonFromPreferences())
     private val localOutboxWriteGate = Mutex()
     private var localOutboxWriteBlockReason: String? = null
     private var activeLocalOutboxMutationTransactions: Int = 0
@@ -98,6 +104,12 @@ class CloudPreferencesStore(
         return accountDeletionState.asStateFlow()
     }
 
+    fun observeCloudCredentialRecoveryState(): Flow<CloudCredentialRecoveryState?> {
+        return cloudCredentialRecoveryStateJson.map { rawValue ->
+            decodeCloudCredentialRecoveryStateFromRawValue(rawValue = rawValue)
+        }
+    }
+
     fun currentCloudSettings(): CloudSettings {
         return cloudSettingsState.value
     }
@@ -108,6 +120,28 @@ class CloudPreferencesStore(
 
     fun currentAccountDeletionState(): AccountDeletionState {
         return accountDeletionState.value
+    }
+
+    fun loadCloudCredentialRecoveryState(): CloudCredentialRecoveryState? {
+        return decodeCloudCredentialRecoveryStateFromRawValue(rawValue = cloudCredentialRecoveryStateJson.value)
+    }
+
+    fun saveCloudCredentialRecoveryState(recoveryState: CloudCredentialRecoveryState) {
+        val rawValue = encodeCloudCredentialRecoveryState(recoveryState = recoveryState).toString()
+        metadataPreferences.edit(commit = true) {
+            putString(
+                cloudCredentialRecoveryStateKey,
+                rawValue
+            )
+        }
+        cloudCredentialRecoveryStateJson.value = rawValue
+    }
+
+    fun clearCloudCredentialRecoveryState() {
+        metadataPreferences.edit(commit = true) {
+            remove(cloudCredentialRecoveryStateKey)
+        }
+        cloudCredentialRecoveryStateJson.value = null
     }
 
     fun loadCredentials(): StoredCloudCredentials? {
@@ -394,6 +428,23 @@ class CloudPreferencesStore(
                     ?: "Account deletion failed."
             )
             else -> AccountDeletionState.Hidden
+        }
+    }
+
+    private fun loadCloudCredentialRecoveryStateJsonFromPreferences(): String? {
+        return metadataPreferences.getString(cloudCredentialRecoveryStateKey, null)
+    }
+
+    private fun decodeCloudCredentialRecoveryStateFromRawValue(rawValue: String?): CloudCredentialRecoveryState? {
+        rawValue ?: return null
+        return try {
+            decodeCloudCredentialRecoveryState(jsonObject = JSONObject(rawValue))
+        } catch (error: JSONException) {
+            throw cloudCredentialRecoveryStateCorruptError(cause = error)
+        } catch (error: IllegalArgumentException) {
+            throw cloudCredentialRecoveryStateCorruptError(cause = error)
+        } catch (error: IllegalStateException) {
+            throw cloudCredentialRecoveryStateCorruptError(cause = error)
         }
     }
 
@@ -698,6 +749,43 @@ private fun decodeNullableGuestUpgradeCompletion(jsonObject: JSONObject): CloudG
     } else {
         decodeGuestUpgradeCompletion(jsonObject = jsonObject.getJSONObject("completion"))
     }
+}
+
+private fun encodeCloudCredentialRecoveryState(recoveryState: CloudCredentialRecoveryState): JSONObject {
+    return JSONObject()
+        .put("reason", recoveryState.reason.name)
+        .put("previousCloudState", recoveryState.previousCloudState.name)
+        .put("installationId", recoveryState.installationId)
+        .putNullableString(key = "linkedUserId", value = recoveryState.linkedUserId)
+        .putNullableString(key = "linkedWorkspaceId", value = recoveryState.linkedWorkspaceId)
+        .putNullableString(key = "activeWorkspaceId", value = recoveryState.activeWorkspaceId)
+        .putNullableString(key = "linkedEmail", value = recoveryState.linkedEmail)
+        .put("configurationMode", recoveryState.configurationMode.name)
+        .put("apiBaseUrl", recoveryState.apiBaseUrl)
+        .put("detectedAtMillis", recoveryState.detectedAtMillis)
+}
+
+private fun decodeCloudCredentialRecoveryState(jsonObject: JSONObject): CloudCredentialRecoveryState {
+    return CloudCredentialRecoveryState(
+        reason = CloudCredentialRecoveryReason.valueOf(jsonObject.getString("reason")),
+        previousCloudState = CloudAccountState.valueOf(jsonObject.getString("previousCloudState")),
+        installationId = jsonObject.getString("installationId"),
+        linkedUserId = jsonObject.getNullableString(key = "linkedUserId"),
+        linkedWorkspaceId = jsonObject.getNullableString(key = "linkedWorkspaceId"),
+        activeWorkspaceId = jsonObject.getNullableString(key = "activeWorkspaceId"),
+        linkedEmail = jsonObject.getNullableString(key = "linkedEmail"),
+        configurationMode = CloudServiceConfigurationMode.valueOf(jsonObject.getString("configurationMode")),
+        apiBaseUrl = jsonObject.getString("apiBaseUrl"),
+        detectedAtMillis = jsonObject.getLong("detectedAtMillis")
+    )
+}
+
+private fun cloudCredentialRecoveryStateCorruptError(cause: Throwable): IllegalStateException {
+    return IllegalStateException(
+        "Cloud credential recovery state is corrupt and cannot be resumed. " +
+            "Sign in again to resolve cloud credential recovery. Cause='${cause.message}'.",
+        cause
+    )
 }
 
 private fun encodeGuestUpgradeReconciliation(reconciliation: CloudGuestUpgradeReconciliation): JSONObject {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
@@ -241,6 +241,33 @@ data class CloudSettings(
     val updatedAtMillis: Long
 )
 
+enum class CloudCredentialRecoveryReason {
+    LINKED_CREDENTIALS_MISSING,
+    GUEST_SESSION_MISSING
+}
+
+data class CloudCredentialRecoveryState(
+    val reason: CloudCredentialRecoveryReason,
+    val previousCloudState: CloudAccountState,
+    val installationId: String,
+    val linkedUserId: String?,
+    val linkedWorkspaceId: String?,
+    val activeWorkspaceId: String?,
+    val linkedEmail: String?,
+    val configurationMode: CloudServiceConfigurationMode,
+    val apiBaseUrl: String,
+    val detectedAtMillis: Long
+)
+
+const val cloudCredentialRecoveryRequiredMessage: String =
+    "Cloud credential recovery is required before cloud access can continue."
+
+class CloudCredentialRecoveryRequiredException(
+    val recoveryState: CloudCredentialRecoveryState
+) : IllegalStateException(
+    cloudCredentialRecoveryRequiredMessage
+)
+
 sealed interface AccountDeletionState {
     data object Hidden : AccountDeletionState
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -19,6 +19,7 @@ import com.flashcardsopensourceapp.data.local.model.CloudSendCodeResult
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkContext
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.CloudProgressSummary
@@ -132,6 +133,7 @@ interface CloudAccountRepository {
     fun observeCloudSettings(): Flow<CloudSettings>
     fun observeAccountDeletionState(): Flow<AccountDeletionState>
     fun observeServerConfiguration(): Flow<CloudServiceConfiguration>
+    fun observeCloudCredentialRecoveryState(): Flow<CloudCredentialRecoveryState?>
     suspend fun beginAccountDeletion()
     suspend fun resumePendingAccountDeletionIfNeeded()
     suspend fun retryPendingAccountDeletion()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/CloudGuestSessionCoordinator.kt
@@ -1,7 +1,7 @@
 package com.flashcardsopensourceapp.data.local.repository.cloudsync
 
-import com.flashcardsopensourceapp.data.local.ai.AiChatRemoteService
 import com.flashcardsopensourceapp.data.local.ai.GuestAiSessionStore
+import com.flashcardsopensourceapp.data.local.ai.GuestCloudSessionCreator
 import com.flashcardsopensourceapp.data.local.bootstrap.ensureLocalWorkspaceShell
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
@@ -11,6 +11,9 @@ import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.WorkspaceEntity
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
@@ -42,7 +45,7 @@ class CloudGuestSessionCoordinator(
     private val operationCoordinator: CloudOperationCoordinator,
     private val resetCoordinator: CloudIdentityResetCoordinator,
     private val guestSessionStore: GuestAiSessionStore,
-    private val aiChatRemoteService: AiChatRemoteService,
+    private val guestSessionCreator: GuestCloudSessionCreator,
     private val appVersion: String
 ) {
     suspend fun reconcilePersistedCloudStateForStartup() {
@@ -101,15 +104,10 @@ class CloudGuestSessionCoordinator(
             )
         }
 
-        val currentCloudSettings = preferencesStore.currentCloudSettings()
+        var currentCloudSettings = preferencesStore.currentCloudSettings()
         if (hasInvalidActiveWorkspaceId(cloudSettings = currentCloudSettings)) {
             normalizeActiveWorkspaceIdToLocalShell()
-            return CloudIdentityReconciliationResult(
-                cloudSettings = preferencesStore.currentCloudSettings(),
-                restoredGuestSession = null,
-                guestRestoreRequiresSync = false,
-                didRunSync = false
-            )
+            currentCloudSettings = preferencesStore.currentCloudSettings()
         }
 
         if (currentCloudSettings.cloudState == CloudAccountState.LINKING_READY) {
@@ -134,6 +132,10 @@ class CloudGuestSessionCoordinator(
         return when (reconciledCloudSettings.cloudState) {
             CloudAccountState.LINKED -> {
                 if (storedCredentials == null) {
+                    markCloudCredentialRecoveryRequired(
+                        reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+                        cloudSettings = reconciledCloudSettings
+                    )
                     resetCoordinator.disconnectCloudIdentityPreservingLocalState()
                     CloudIdentityReconciliationResult(
                         cloudSettings = preferencesStore.currentCloudSettings(),
@@ -142,6 +144,7 @@ class CloudGuestSessionCoordinator(
                         didRunSync = false
                     )
                 } else {
+                    preferencesStore.clearCloudCredentialRecoveryState()
                     CloudIdentityReconciliationResult(
                         cloudSettings = reconciledCloudSettings,
                         restoredGuestSession = null,
@@ -153,6 +156,10 @@ class CloudGuestSessionCoordinator(
 
             CloudAccountState.GUEST -> {
                 if (storedGuestSession == null) {
+                    markCloudCredentialRecoveryRequired(
+                        reason = CloudCredentialRecoveryReason.GUEST_SESSION_MISSING,
+                        cloudSettings = reconciledCloudSettings
+                    )
                     resetCoordinator.disconnectCloudIdentityPreservingLocalState()
                     CloudIdentityReconciliationResult(
                         cloudSettings = preferencesStore.currentCloudSettings(),
@@ -165,6 +172,7 @@ class CloudGuestSessionCoordinator(
                         session = storedGuestSession,
                         workspaceId = storedGuestSession.workspaceId
                     )
+                    preferencesStore.clearCloudCredentialRecoveryState()
                     CloudIdentityReconciliationResult(
                         cloudSettings = preferencesStore.currentCloudSettings(),
                         restoredGuestSession = storedGuestSession,
@@ -204,6 +212,10 @@ class CloudGuestSessionCoordinator(
             )
         }
 
+        val activeRecoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+        if (activeRecoveryState?.reason == CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = activeRecoveryState)
+        }
         val configuration = preferencesStore.currentServerConfiguration()
         val existingSession = loadGuestSessionForCurrentConfiguration(
             workspaceId = workspaceId,
@@ -215,21 +227,47 @@ class CloudGuestSessionCoordinator(
             require(createSessionIfMissing) {
                 "Guest AI session is unavailable."
             }
+            if (activeRecoveryState != null) {
+                throw CloudCredentialRecoveryRequiredException(recoveryState = activeRecoveryState)
+            }
             // A missing stored session here means we already crossed a full
             // local identity reset boundary such as logout or account deletion.
             // The recreated guest session must therefore be treated as a brand
             // new guest identity, not as a continuation of any older guest
             // account that may have been linked previously.
-            aiChatRemoteService.createGuestSession(
+            guestSessionCreator.createGuestSession(
                 apiBaseUrl = configuration.apiBaseUrl,
                 configurationMode = configuration.mode
             )
         }
+        val shouldSync = finishGuestCloudLinkNonCancellableLocked(
+            session = resolvedSession,
+            workspaceId = workspaceId
+        )
+        preferencesStore.clearCloudCredentialRecoveryState()
         return GuestCloudSessionRestoreResult(
             session = resolvedSession,
-            shouldSync = finishGuestCloudLinkNonCancellableLocked(
-                session = resolvedSession,
-                workspaceId = workspaceId
+            shouldSync = shouldSync
+        )
+    }
+
+    private fun markCloudCredentialRecoveryRequired(
+        reason: CloudCredentialRecoveryReason,
+        cloudSettings: CloudSettings
+    ) {
+        val configuration = preferencesStore.currentServerConfiguration()
+        preferencesStore.saveCloudCredentialRecoveryState(
+            recoveryState = CloudCredentialRecoveryState(
+                reason = reason,
+                previousCloudState = cloudSettings.cloudState,
+                installationId = cloudSettings.installationId,
+                linkedUserId = cloudSettings.linkedUserId,
+                linkedWorkspaceId = cloudSettings.linkedWorkspaceId,
+                activeWorkspaceId = cloudSettings.activeWorkspaceId,
+                linkedEmail = cloudSettings.linkedEmail,
+                configurationMode = configuration.mode,
+                apiBaseUrl = configuration.apiBaseUrl,
+                detectedAtMillis = System.currentTimeMillis()
             )
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/CloudIdentityResetCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/CloudIdentityResetCoordinator.kt
@@ -35,6 +35,7 @@ class CloudIdentityResetCoordinator(
         withContext(Dispatchers.IO) {
             resetMutex.withLock {
                 cloudPreferencesStore.clearCredentials()
+                cloudPreferencesStore.clearCloudCredentialRecoveryState()
                 aiChatPreferencesStore.clearConsent()
                 aiChatHistoryStore.clearAllState()
                 guestAiSessionStore.clearAllSessions()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalCloudAccountRepository.kt
@@ -11,6 +11,9 @@ import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
@@ -59,6 +62,10 @@ class LocalCloudAccountRepository(
 
     override fun observeServerConfiguration(): Flow<CloudServiceConfiguration> {
         return preferencesStore.observeServerConfiguration()
+    }
+
+    override fun observeCloudCredentialRecoveryState(): Flow<CloudCredentialRecoveryState?> {
+        return preferencesStore.observeCloudCredentialRecoveryState()
     }
 
     override suspend fun beginAccountDeletion() {
@@ -147,8 +154,10 @@ class LocalCloudAccountRepository(
                 guestToken = guestSession.guestToken
             )
         }
-        val preferredWorkspaceId = resolvePreferredPostAuthWorkspaceId(
-            workspaces = accountSnapshot.workspaces
+        val preferredWorkspaceId = resolvePostAuthPreferredWorkspaceId(
+            recoveryState = preferencesStore.loadCloudCredentialRecoveryState(),
+            configuration = configuration,
+            accountSnapshot = accountSnapshot
         )
         return CloudWorkspaceLinkContext(
             userId = accountSnapshot.userId,
@@ -169,19 +178,36 @@ class LocalCloudAccountRepository(
             if (resumedGuestUpgrade != null) {
                 return@runExclusive resumedGuestUpgrade
             }
+            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
             val authenticatedSession = authenticatedSession(linkContext = linkContext)
+            requireCloudLinkMatchesCredentialRecovery(
+                recoveryState = recoveryState,
+                authenticatedSession = authenticatedSession
+            )
+            requireWorkspaceSelectionMatchesCredentialRecovery(
+                recoveryState = recoveryState,
+                selection = selection
+            )
             val selectedWorkspace = resolveWorkspaceSelection(
                 linkContext = linkContext,
                 authenticatedSession = authenticatedSession,
                 selection = selection
             )
             clearGuestSessionsIfNeeded()
-            applyLinkedWorkspace(
-                accountSnapshot = authenticatedSession.accountSnapshot,
-                bearerToken = authenticatedSession.credentials.idToken,
-                selectedWorkspace = selectedWorkspace
-            )
+            if (recoveryState != null) {
+                applyLinkedWorkspacePreservingLocalData(
+                    accountSnapshot = authenticatedSession.accountSnapshot,
+                    selectedWorkspace = selectedWorkspace
+                )
+            } else {
+                applyLinkedWorkspace(
+                    accountSnapshot = authenticatedSession.accountSnapshot,
+                    bearerToken = authenticatedSession.credentials.idToken,
+                    selectedWorkspace = selectedWorkspace
+                )
+            }
             preferencesStore.saveCredentials(authenticatedSession.credentials)
+            preferencesStore.clearCloudCredentialRecoveryState()
             selectedWorkspace
         }
     }
@@ -677,6 +703,110 @@ class LocalCloudAccountRepository(
         }
     }
 
+    private fun requireCloudLinkMatchesCredentialRecovery(
+        recoveryState: CloudCredentialRecoveryState?,
+        authenticatedSession: AuthenticatedCloudSession
+    ) {
+        if (recoveryState?.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
+            return
+        }
+        if (
+            recoveryState.configurationMode != authenticatedSession.configuration.mode ||
+            recoveryState.apiBaseUrl != authenticatedSession.configuration.apiBaseUrl
+        ) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+        }
+
+        val linkedUserId = recoveryState.linkedUserId
+        if (linkedUserId != null) {
+            if (authenticatedSession.accountSnapshot.userId != linkedUserId) {
+                throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+            }
+            return
+        }
+
+        val linkedEmail = recoveryState.linkedEmail
+        if (
+            linkedEmail != null &&
+            authenticatedSession.accountSnapshot.email.equals(linkedEmail, ignoreCase = true).not()
+        ) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+        }
+    }
+
+    private fun resolvePostAuthPreferredWorkspaceId(
+        recoveryState: CloudCredentialRecoveryState?,
+        configuration: CloudServiceConfiguration,
+        accountSnapshot: CloudAccountSnapshot
+    ): String? {
+        val recoveryWorkspaceId = resolveCredentialRecoveryPreferredWorkspaceId(
+            recoveryState = recoveryState,
+            configuration = configuration,
+            accountSnapshot = accountSnapshot
+        )
+        return recoveryWorkspaceId ?: resolvePreferredPostAuthWorkspaceId(
+            workspaces = accountSnapshot.workspaces
+        )
+    }
+
+    private fun resolveCredentialRecoveryPreferredWorkspaceId(
+        recoveryState: CloudCredentialRecoveryState?,
+        configuration: CloudServiceConfiguration,
+        accountSnapshot: CloudAccountSnapshot
+    ): String? {
+        if (recoveryState?.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
+            return null
+        }
+        if (
+            recoveryState.configurationMode != configuration.mode ||
+            recoveryState.apiBaseUrl != configuration.apiBaseUrl
+        ) {
+            return null
+        }
+
+        val linkedUserId = recoveryState.linkedUserId
+        if (linkedUserId != null && accountSnapshot.userId != linkedUserId) {
+            return null
+        }
+
+        val linkedEmail = recoveryState.linkedEmail
+        if (
+            linkedUserId == null &&
+            linkedEmail != null &&
+            accountSnapshot.email.equals(linkedEmail, ignoreCase = true).not()
+        ) {
+            return null
+        }
+
+        return recoveredWorkspaceId(recoveryState = recoveryState)
+    }
+
+    private fun requireWorkspaceSelectionMatchesCredentialRecovery(
+        recoveryState: CloudCredentialRecoveryState?,
+        selection: CloudWorkspaceLinkSelection
+    ) {
+        if (recoveryState?.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
+            return
+        }
+        val recoveredWorkspaceId = recoveredWorkspaceId(recoveryState = recoveryState)
+        if (recoveredWorkspaceId == null) {
+            return
+        }
+
+        val selectedWorkspaceId = when (selection) {
+            is CloudWorkspaceLinkSelection.Existing -> selection.workspaceId
+            CloudWorkspaceLinkSelection.CreateNew -> return
+        }
+        if (selectedWorkspaceId != recoveredWorkspaceId) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+        }
+    }
+
+    private fun recoveredWorkspaceId(recoveryState: CloudCredentialRecoveryState): String? {
+        return recoveryState.activeWorkspaceId?.takeIf { workspaceId -> workspaceId.isNotBlank() }
+            ?: recoveryState.linkedWorkspaceId?.takeIf { workspaceId -> workspaceId.isNotBlank() }
+    }
+
     private suspend fun fetchCloudAccount(
         credentials: StoredCloudCredentials,
         configuration: CloudServiceConfiguration
@@ -795,6 +925,29 @@ class LocalCloudAccountRepository(
             bearerToken = bearerToken,
             selectedWorkspace = selectedWorkspace
         )
+        migrateLocalShellToLinkedWorkspace(
+            accountSnapshot = accountSnapshot,
+            selectedWorkspace = selectedWorkspace,
+            remoteWorkspaceIsEmpty = remoteWorkspaceIsEmpty
+        )
+    }
+
+    private suspend fun applyLinkedWorkspacePreservingLocalData(
+        accountSnapshot: CloudAccountSnapshot,
+        selectedWorkspace: CloudWorkspaceSummary
+    ) {
+        migrateLocalShellToLinkedWorkspace(
+            accountSnapshot = accountSnapshot,
+            selectedWorkspace = selectedWorkspace,
+            remoteWorkspaceIsEmpty = true
+        )
+    }
+
+    private suspend fun migrateLocalShellToLinkedWorkspace(
+        accountSnapshot: CloudAccountSnapshot,
+        selectedWorkspace: CloudWorkspaceSummary,
+        remoteWorkspaceIsEmpty: Boolean
+    ) {
         val localLinkedWorkspace = syncLocalStore.migrateLocalShellToLinkedWorkspace(
             workspace = selectedWorkspace,
             remoteWorkspaceIsEmpty = remoteWorkspaceIsEmpty
@@ -1001,6 +1154,10 @@ class LocalCloudAccountRepository(
     }
 
     private suspend fun activeGuestSession(configuration: CloudServiceConfiguration): StoredGuestAiSession? {
+        if (preferencesStore.loadCloudCredentialRecoveryState() != null) {
+            return null
+        }
+
         val cloudSettings = preferencesStore.currentCloudSettings()
         val guestWorkspaceId = cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId
         if (cloudSettings.cloudState == CloudAccountState.GUEST && guestWorkspaceId != null) {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalSyncRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalSyncRepository.kt
@@ -9,6 +9,7 @@ import com.flashcardsopensourceapp.data.local.database.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.StoredCloudCredentials
@@ -129,6 +130,20 @@ class LocalSyncRepository(
             val reconciliation = cloudGuestSessionCoordinator.reconcilePersistedCloudStateLocked()
             val cloudSettings = reconciliation.cloudSettings
             val failureWorkspaceId = cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId
+            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+            if (recoveryState != null) {
+                val error = CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+                syncStatusState.value = SyncStatusSnapshot(
+                    status = SyncStatus.Failed(error.message ?: "Cloud credential recovery is required."),
+                    lastSuccessfulSyncAtMillis = syncStatusState.value.lastSuccessfulSyncAtMillis,
+                    lastErrorMessage = error.message ?: "Cloud credential recovery is required."
+                )
+                emitAutoSyncFailure(
+                    autoSyncRequest = autoSyncRequest,
+                    error = error
+                )
+                throw error
+            }
             if (reconciliation.didRunSync) {
                 syncStatusState.value = SyncStatusSnapshot(
                     status = SyncStatus.Idle,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/PendingGuestUpgradeRecovery.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/PendingGuestUpgradeRecovery.kt
@@ -116,6 +116,7 @@ private suspend fun finalizePendingGuestUpgradeRecovery(
         completion = completion
     )
     preferencesStore.saveCredentials(pendingGuestUpgradeState.credentials)
+    preferencesStore.clearCloudCredentialRecoveryState()
     requireNoPendingGuestUpgradeOutbox(
         syncLocalStore = syncLocalStore,
         workspaceId = completion.workspace.workspaceId

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudAccountUiSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudAccountUiSupport.kt
@@ -136,6 +136,14 @@ internal fun buildAutomaticWorkspaceSelection(
     preferredWorkspaceId: String?,
     workspaces: List<CloudWorkspaceSummary>
 ): CloudWorkspaceLinkSelection? {
+    if (preferredWorkspaceId != null) {
+        return if (workspaces.any { workspace -> workspace.workspaceId == preferredWorkspaceId }) {
+            CloudWorkspaceLinkSelection.Existing(workspaceId = preferredWorkspaceId)
+        } else {
+            null
+        }
+    }
+
     if (workspaces.isEmpty()) {
         return CloudWorkspaceLinkSelection.CreateNew
     }
@@ -144,14 +152,6 @@ internal fun buildAutomaticWorkspaceSelection(
         return CloudWorkspaceLinkSelection.Existing(
             workspaceId = workspaces.first().workspaceId
         )
-    }
-
-    if (preferredWorkspaceId != null) {
-        return if (workspaces.any { workspace -> workspace.workspaceId == preferredWorkspaceId }) {
-            CloudWorkspaceLinkSelection.Existing(workspaceId = preferredWorkspaceId)
-        } else {
-            null
-        }
     }
 
     val selectedWorkspaceIds = workspaces.filter(CloudWorkspaceSummary::isSelected)

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.CloudProgressSeries
@@ -76,13 +77,15 @@ class CloudSignInViewModelTest {
             credentials = firstCredentials,
             email = "first@example.com",
             workspaceId = "workspace-first",
-            workspaceName = "Workspace First"
+            workspaceName = "Workspace First",
+            preferredWorkspaceId = "workspace-first"
         )
         val secondLinkContext = makeLinkContext(
             credentials = secondCredentials,
             email = "second@example.com",
             workspaceId = "workspace-second",
-            workspaceName = "Workspace Second"
+            workspaceName = "Workspace Second",
+            preferredWorkspaceId = "workspace-second"
         )
         val blockedFirstPrepare = CompletableDeferred<CloudWorkspaceLinkContext>()
         repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = firstCredentials))
@@ -115,6 +118,46 @@ class CloudSignInViewModelTest {
         assertEquals("second@example.com", viewModel.postAuthUiState.value.verifiedEmail)
         assertEquals("Workspace Second", viewModel.postAuthUiState.value.pendingWorkspaceTitle)
         assertEquals("workspace-second", viewModel.postAuthUiState.value.workspaces.first().workspaceId)
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun unavailablePreferredWorkspaceKeepsPostAuthChooser() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-1")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    preferredWorkspaceId = "workspace-recovered"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        val outcome = viewModel.sendCode()
+        advanceUntilIdle()
+
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, outcome)
+        assertEquals(CloudPostAuthMode.CHOOSE_WORKSPACE, viewModel.postAuthUiState.value.mode)
+        assertNull(viewModel.postAuthUiState.value.pendingWorkspaceTitle)
+        assertEquals(false, viewModel.postAuthUiState.value.workspaces.first().isSelected)
 
         postAuthCollection.cancel()
     }
@@ -234,7 +277,8 @@ class CloudSignInViewModelTest {
         credentials: StoredCloudCredentials,
         email: String,
         workspaceId: String,
-        workspaceName: String
+        workspaceName: String,
+        preferredWorkspaceId: String
     ): CloudWorkspaceLinkContext {
         return CloudWorkspaceLinkContext(
             userId = "user-$workspaceId",
@@ -249,7 +293,7 @@ class CloudSignInViewModelTest {
                 )
             ),
             guestUpgradeMode = null,
-            preferredWorkspaceId = workspaceId
+            preferredWorkspaceId = preferredWorkspaceId
         )
     }
 }
@@ -268,6 +312,7 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
     )
     private val accountDeletionState = MutableStateFlow<AccountDeletionState>(AccountDeletionState.Hidden)
     private val serverConfiguration = MutableStateFlow(makeOfficialCloudServiceConfiguration())
+    private val cloudCredentialRecoveryState = MutableStateFlow<CloudCredentialRecoveryState?>(null)
     private val sendCodeResults = ArrayDeque<CloudSendCodeResult>()
     private val sendCodeErrors = ArrayDeque<Exception>()
     private val verifyCodeErrors = ArrayDeque<Exception>()
@@ -302,6 +347,10 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
 
     override fun observeServerConfiguration(): Flow<CloudServiceConfiguration> {
         return serverConfiguration
+    }
+
+    override fun observeCloudCredentialRecoveryState(): Flow<CloudCredentialRecoveryState?> {
+        return cloudCredentialRecoveryState
     }
 
     override suspend fun beginAccountDeletion() {


### PR DESCRIPTION
## Summary
- add persisted Android cloud credential recovery state for missing linked credentials or guest sessions
- block silent guest recreation while recovery is active
- preserve local data when recovery resolves through sign-in
- add focused repository/coordinator regression coverage

## Validation
- git --no-pager diff --check
- Review only; Gradle was not run per repository guidance before publishing.