### PR TITLE
[codex] Fix Android credential recovery sync blocking

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalSyncRepositoryDisconnectedStateTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalSyncRepositoryDisconnectedStateTest.kt
@@ -5,10 +5,13 @@ import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.database.CardEntity
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.SyncStatus
+import com.flashcardsopensourceapp.data.local.model.cloudCredentialRecoveryRequiredMessage
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
@@ -206,7 +209,7 @@ class LocalSyncRepositoryDisconnectedStateTest {
     }
 
     @Test
-    fun syncDisconnectsInvalidGuestStateWhenStoredGuestSessionIsMissing() = runBlocking {
+    fun syncBlocksCredentialRecoveryWhenStoredGuestSessionIsMissing() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
         val initialInstallationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
         val syncRepository = environment.createSyncRepository(
@@ -222,17 +225,106 @@ class LocalSyncRepositoryDisconnectedStateTest {
 
         try {
             syncRepository.syncNow()
-        } catch (_: IllegalStateException) {
+            throw AssertionError("Expected missing guest session to require credential recovery.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, error.recoveryState.reason)
         }
 
         val localWorkspace = requireNotNull(environment.database.workspaceDao().loadAnyWorkspace()) {
             "Expected a local workspace after guest normalization."
         }
+        val recoveryState = requireNotNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState()) {
+            "Expected missing guest session to persist credential recovery state."
+        }
+        val syncStatus = syncRepository.observeSyncStatus().first().status
         assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
         assertEquals(localWorkspaceId, localWorkspace.workspaceId)
         assertEquals(initialInstallationId, environment.cloudPreferencesStore.currentCloudSettings().installationId)
-        assertTrue(syncRepository.observeSyncStatus().first().status is SyncStatus.Failed)
+        assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, recoveryState.reason)
+        assertTrue(syncStatus is SyncStatus.Blocked)
+        val blockedStatus = syncStatus as SyncStatus.Blocked
+        assertEquals(cloudCredentialRecoveryRequiredMessage, blockedStatus.message)
+        assertEquals(initialInstallationId, blockedStatus.installationId)
+    }
+
+    @Test
+    fun syncDoesNotKeepCredentialRecoveryBlockedAfterRecoveryClears() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val initialInstallationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = localWorkspaceId
+        )
+
+        try {
+            syncRepository.syncNow()
+            throw AssertionError("Expected missing guest session to require credential recovery.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, error.recoveryState.reason)
+        }
+
+        environment.cloudPreferencesStore.saveCredentials(
+            createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+        environment.cloudPreferencesStore.clearCloudCredentialRecoveryState()
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.LINKED,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            activeWorkspaceId = localWorkspaceId
+        )
+
+        syncRepository.syncNow()
+
+        assertEquals(initialInstallationId, environment.cloudPreferencesStore.currentCloudSettings().installationId)
+        assertEquals(SyncStatus.Idle, syncRepository.observeSyncStatus().first().status)
+        assertTrue(remoteGateway.syncRequestEvents.isNotEmpty())
+    }
+
+    @Test
+    fun syncPrefersCredentialRecoveryWhenStoredGuestSessionIsMissingAndSyncStateIsBlocked() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val initialInstallationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        val syncRepository = environment.createSyncRepository(remoteGateway = remoteGateway)
+        environment.database.syncStateDao().insertSyncState(
+            syncStateEntityWithEmptyProgress(workspaceId = localWorkspaceId).copy(
+                lastSyncError = "Old persisted sync block.",
+                blockedInstallationId = initialInstallationId
+            )
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = localWorkspaceId
+        )
+
+        try {
+            syncRepository.syncNow()
+            throw AssertionError("Expected credential recovery to take precedence over the old persisted block.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, error.recoveryState.reason)
+        }
+
+        val recoveryState = requireNotNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState()) {
+            "Expected missing guest session to persist credential recovery state."
+        }
+        val syncStatus = syncRepository.observeSyncStatus().first().status
+        assertEquals(CloudCredentialRecoveryReason.GUEST_SESSION_MISSING, recoveryState.reason)
+        assertTrue(syncStatus is SyncStatus.Blocked)
+        val blockedStatus = syncStatus as SyncStatus.Blocked
+        assertEquals(cloudCredentialRecoveryRequiredMessage, blockedStatus.message)
+        assertEquals(initialInstallationId, blockedStatus.installationId)
+        assertTrue(remoteGateway.syncRequestEvents.isEmpty())
     }
 
     @Test

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalSyncRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalSyncRepository.kt
@@ -10,11 +10,13 @@ import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.SyncStatusSnapshot
+import com.flashcardsopensourceapp.data.local.model.cloudCredentialRecoveryRequiredMessage
 import com.flashcardsopensourceapp.data.local.model.shouldRefreshCloudIdToken
 import com.flashcardsopensourceapp.data.local.repository.AutoSyncCompletion
 import com.flashcardsopensourceapp.data.local.repository.AutoSyncEvent
@@ -56,15 +58,24 @@ class LocalSyncRepository(
         return combine(
             syncStatusState.asStateFlow(),
             preferencesStore.observeCloudSettings(),
+            preferencesStore.observeCloudCredentialRecoveryState(),
             observePersistedSyncStatus()
-        ) { inMemorySnapshot, cloudSettings, persistedSnapshot ->
-            mergeSyncStatusSnapshots(
+        ) { inMemorySnapshot, cloudSettings, recoveryState, persistedSnapshot ->
+            val mergedSnapshot = mergeSyncStatusSnapshots(
                 inMemorySnapshot = sanitizeInMemorySyncStatus(
                     snapshot = inMemorySnapshot,
                     cloudState = cloudSettings.cloudState
                 ),
                 persistedSnapshot = persistedSnapshot
             )
+            if (recoveryState != null) {
+                credentialRecoveryBlockedSnapshot(
+                    recoveryState = recoveryState,
+                    lastSuccessfulSyncAtMillis = mergedSnapshot.lastSuccessfulSyncAtMillis
+                )
+            } else {
+                mergedSnapshot
+            }
         }
     }
 
@@ -86,18 +97,34 @@ class LocalSyncRepository(
 
     private suspend fun performSync(autoSyncRequest: AutoSyncRequest?) {
         operationCoordinator.runExclusive {
-            val currentCloudSettings = preferencesStore.currentCloudSettings()
-            val previousCloudState = currentCloudSettings.cloudState
+            val initialCloudSettings = preferencesStore.currentCloudSettings()
+            val previousCloudState = initialCloudSettings.cloudState
+            emitAutoSyncRequested(autoSyncRequest = autoSyncRequest)
+            if (preferencesStore.currentAccountDeletionState() != AccountDeletionState.Hidden) {
+                emitAutoSyncSuccess(autoSyncRequest = autoSyncRequest)
+                return@runExclusive
+            }
+            val reconciliation = cloudGuestSessionCoordinator.reconcilePersistedCloudStateLocked()
+            val cloudSettings = reconciliation.cloudSettings
+            val failureWorkspaceId = cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId
+            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+            if (recoveryState != null) {
+                val error = CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+                emitAutoSyncFailure(
+                    autoSyncRequest = autoSyncRequest,
+                    error = error
+                )
+                throw error
+            }
             val currentSnapshot = sanitizeInMemorySyncStatus(
                 snapshot = syncStatusState.value,
-                cloudState = currentCloudSettings.cloudState
+                cloudState = cloudSettings.cloudState
             )
             if (currentSnapshot != syncStatusState.value) {
                 syncStatusState.value = currentSnapshot
             }
             val currentStatus = currentSnapshot.status
-            emitAutoSyncRequested(autoSyncRequest = autoSyncRequest)
-            val persistedSyncStatus = loadPersistedSyncStatus(cloudSettings = currentCloudSettings)
+            val persistedSyncStatus = loadPersistedSyncStatus(cloudSettings = cloudSettings)
             val persistedBlockedStatus = persistedSyncStatus?.status as? SyncStatus.Blocked
             if (persistedBlockedStatus != null) {
                 syncStatusState.value = persistedSyncStatus
@@ -109,7 +136,7 @@ class LocalSyncRepository(
                 throw error
             }
             if (currentStatus is SyncStatus.Blocked) {
-                if (currentStatus.installationId == currentCloudSettings.installationId) {
+                if (currentStatus.installationId == cloudSettings.installationId) {
                     val error = IllegalStateException(currentStatus.message)
                     emitAutoSyncFailure(
                         autoSyncRequest = autoSyncRequest,
@@ -122,27 +149,6 @@ class LocalSyncRepository(
                     lastSuccessfulSyncAtMillis = syncStatusState.value.lastSuccessfulSyncAtMillis,
                     lastErrorMessage = ""
                 )
-            }
-            if (preferencesStore.currentAccountDeletionState() != AccountDeletionState.Hidden) {
-                emitAutoSyncSuccess(autoSyncRequest = autoSyncRequest)
-                return@runExclusive
-            }
-            val reconciliation = cloudGuestSessionCoordinator.reconcilePersistedCloudStateLocked()
-            val cloudSettings = reconciliation.cloudSettings
-            val failureWorkspaceId = cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId
-            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
-            if (recoveryState != null) {
-                val error = CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
-                syncStatusState.value = SyncStatusSnapshot(
-                    status = SyncStatus.Failed(error.message ?: "Cloud credential recovery is required."),
-                    lastSuccessfulSyncAtMillis = syncStatusState.value.lastSuccessfulSyncAtMillis,
-                    lastErrorMessage = error.message ?: "Cloud credential recovery is required."
-                )
-                emitAutoSyncFailure(
-                    autoSyncRequest = autoSyncRequest,
-                    error = error
-                )
-                throw error
             }
             if (reconciliation.didRunSync) {
                 syncStatusState.value = SyncStatusSnapshot(
@@ -413,6 +419,20 @@ private fun sanitizeInMemorySyncStatus(
     return snapshot.copy(
         status = SyncStatus.Idle,
         lastErrorMessage = ""
+    )
+}
+
+private fun credentialRecoveryBlockedSnapshot(
+    recoveryState: CloudCredentialRecoveryState,
+    lastSuccessfulSyncAtMillis: Long?
+): SyncStatusSnapshot {
+    return SyncStatusSnapshot(
+        status = SyncStatus.Blocked(
+            message = cloudCredentialRecoveryRequiredMessage,
+            installationId = recoveryState.installationId
+        ),
+        lastSuccessfulSyncAtMillis = lastSuccessfulSyncAtMillis,
+        lastErrorMessage = cloudCredentialRecoveryRequiredMessage
     )
 }
 


### PR DESCRIPTION
## Summary
- keep Android credential recovery derived from persisted recovery state instead of sticky in-memory sync status
- check credential recovery before old persisted sync blocks can stop reconciliation
- tighten Android module-boundary tests for recovery exception and stale block precedence

## Validation
- git --no-pager diff --check
- Gradle/emulator tests not run locally per repository instruction requiring explicit approval
