### PR TITLE
[codex] Implement iOS post-auth recovery matrix

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -18,6 +18,9 @@ extension FlashcardsStore {
                 throw LocalStoreError.uninitialized("Flashcards store is unavailable")
             }
 
+            if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
+                try self.throwIfGuestLocalRecoveryRequired()
+            }
             guard let guestUpgradeMode = linkContext.guestUpgradeMode else {
                 throw LocalStoreError.uninitialized("Guest upgrade context is unavailable")
             }
@@ -130,6 +133,30 @@ extension FlashcardsStore {
 
         try self.markPendingGuestUpgradeGuestSessionMissing(detectedAt: detectedAt)
         try self.throwIfCloudCredentialRecoveryRequired()
+    }
+
+    func pendingGuestUpgradePostAuthRecoveryRoute(
+        apiBaseUrl: String,
+        detectedAt: Date
+    ) throws -> CloudPostAuthRecoveryRoute? {
+        if try self.hasCompletedPendingGuestUpgradeRecoveryCheckpoint(apiBaseUrl: apiBaseUrl) {
+            return .pendingGuestUpgradeRecovery
+        }
+        guard self.cloudCredentialRecoveryState != nil else {
+            return nil
+        }
+        if self.cloudCredentialRecoveryState?.reason == .invalidStoredState {
+            try self.throwIfCloudCredentialRecoveryRequired()
+        }
+        guard try self.matchingInFlightPendingGuestUpgradeState(apiBaseUrl: apiBaseUrl) != nil else {
+            return nil
+        }
+        guard try self.loadUsableGuestSessionForCurrentConfiguration() != nil else {
+            try self.markPendingGuestUpgradeGuestSessionMissing(detectedAt: detectedAt)
+            return .guestLocalRecovery
+        }
+
+        return .pendingGuestUpgradeRecovery
     }
 
     func shouldPrepareGuestUpgradeModeForCloudLink(apiBaseUrl: String) throws -> Bool {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudCredentialRecovery.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudCredentialRecovery.swift
@@ -159,6 +159,77 @@ extension FlashcardsStore {
         }
     }
 
+    func linkedCredentialRecoveryWorkspaceBeforeIdentitySideEffects(
+        account: CloudAccountSnapshot,
+        apiBaseUrl: String
+    ) throws -> CloudWorkspaceSummary {
+        guard let recoveryState = self.cloudCredentialRecoveryState else {
+            throw LocalStoreError.uninitialized("Cloud credential recovery state is unavailable")
+        }
+        try self.validateLinkedCredentialRecoveryIdentityBeforeSideEffects(
+            recoveryState: recoveryState,
+            userId: account.userId,
+            email: account.email,
+            apiBaseUrl: apiBaseUrl
+        )
+        guard let expectedWorkspaceId = self.linkedCredentialRecoveryTargetWorkspaceId(
+            recoveryState: recoveryState
+        ) else {
+            self.blockCloudSyncForCredentialRecovery()
+            throw LocalStoreError.validation(localizedCloudCredentialRecoveryWrongLinkedWorkspaceMessage())
+        }
+        guard let expectedWorkspace = account.workspaces.first(where: { workspace in
+            workspace.workspaceId == expectedWorkspaceId
+        }) else {
+            self.blockCloudSyncForCredentialRecovery()
+            throw LocalStoreError.validation(localizedCloudCredentialRecoveryWrongLinkedWorkspaceMessage())
+        }
+
+        return expectedWorkspace
+    }
+
+    func validatePostAuthRecoveryRouteBeforeCloudLinkCompletion(
+        linkContext: CloudWorkspaceLinkContext,
+        selection: CloudWorkspaceLinkSelection
+    ) throws {
+        switch linkContext.postAuthRecoveryRoute {
+        case .none:
+            return
+        case .linkedCredentialRestore:
+            guard self.cloudCredentialRecoveryState != nil else {
+                throw LocalStoreError.uninitialized("Linked credential recovery state is unavailable")
+            }
+            try self.validateCloudCredentialRecoveryUserBeforeIdentitySideEffects(
+                userId: linkContext.userId,
+                email: linkContext.email,
+                apiBaseUrl: linkContext.apiBaseUrl
+            )
+            try self.validateCloudCredentialRecoveryWorkspaceSelectionBeforeIdentitySideEffects(
+                selection: selection,
+                apiBaseUrl: linkContext.apiBaseUrl
+            )
+        case .guestLocalRecovery:
+            try self.throwIfGuestLocalRecoveryRequired()
+        case .pendingGuestUpgradeRecovery:
+            return
+        }
+    }
+
+    func throwIfGuestLocalRecoveryRequired() throws {
+        guard let recoveryState = self.cloudCredentialRecoveryState else {
+            throw LocalStoreError.uninitialized("Guest local recovery state is unavailable")
+        }
+        guard recoveryState.reason == .guestSessionMissing else {
+            try self.throwIfCloudCredentialRecoveryRequired()
+            return
+        }
+
+        self.blockCloudSyncForCredentialRecovery()
+        throw LocalStoreError.validation(
+            localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+        )
+    }
+
     func shouldPreserveLocalDataForCloudCredentialRecovery(
         linkedSession: CloudLinkedSession
     ) throws -> Bool {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudLink.swift
@@ -51,18 +51,73 @@ extension FlashcardsStore {
 
     func prepareCloudLink(verifiedContext: CloudVerifiedAuthContext) async throws -> CloudWorkspaceLinkContext {
         let detectedAt = Date()
+        let postAuthRecoveryRoute = try self.resolvePostAuthRecoveryRouteBeforeIdentitySideEffects(
+            apiBaseUrl: verifiedContext.apiBaseUrl,
+            detectedAt: detectedAt
+        )
+
+        switch postAuthRecoveryRoute {
+        case .linkedCredentialRestore:
+            return try await self.prepareLinkedCredentialRecoveryLink(verifiedContext: verifiedContext)
+        case .guestLocalRecovery:
+            return try await self.prepareGuestLocalRecoveryLink(verifiedContext: verifiedContext)
+        case .pendingGuestUpgradeRecovery:
+            return try await self.prepareStandardCloudLink(
+                verifiedContext: verifiedContext,
+                detectedAt: detectedAt,
+                postAuthRecoveryRoute: .pendingGuestUpgradeRecovery
+            )
+        case .none:
+            return try await self.prepareStandardCloudLink(
+                verifiedContext: verifiedContext,
+                detectedAt: detectedAt,
+                postAuthRecoveryRoute: .none
+            )
+        }
+    }
+
+    private func resolvePostAuthRecoveryRouteBeforeIdentitySideEffects(
+        apiBaseUrl: String,
+        detectedAt: Date
+    ) throws -> CloudPostAuthRecoveryRoute {
+        if self.cloudCredentialRecoveryState?.reason == .invalidStoredState {
+            try self.throwIfCloudCredentialRecoveryRequired()
+        }
+        if let pendingGuestUpgradeRecoveryRoute = try self.pendingGuestUpgradePostAuthRecoveryRoute(
+            apiBaseUrl: apiBaseUrl,
+            detectedAt: detectedAt
+        ) {
+            return pendingGuestUpgradeRecoveryRoute
+        }
+        guard let recoveryState = self.cloudCredentialRecoveryState else {
+            return .none
+        }
+
+        switch recoveryState.reason {
+        case .linkedCredentialsMissing:
+            guard recoveryState.previousCloudState == .linked else {
+                try self.throwIfCloudCredentialRecoveryRequired()
+                return .none
+            }
+            return .linkedCredentialRestore
+        case .guestSessionMissing:
+            return .guestLocalRecovery
+        case .invalidStoredState:
+            try self.throwIfCloudCredentialRecoveryRequired()
+            return .none
+        }
+    }
+
+    private func prepareStandardCloudLink(
+        verifiedContext: CloudVerifiedAuthContext,
+        detectedAt: Date,
+        postAuthRecoveryRoute: CloudPostAuthRecoveryRoute
+    ) async throws -> CloudWorkspaceLinkContext {
         if try self.hasCompletedPendingGuestUpgradeRecoveryCheckpoint(apiBaseUrl: verifiedContext.apiBaseUrl) {
             return try await self.prepareCompletedPendingGuestUpgradeRecoveryLink(
                 verifiedContext: verifiedContext
             )
         }
-        if self.cloudCredentialRecoveryState?.reason == .invalidStoredState {
-            try self.throwIfCloudCredentialRecoveryRequired()
-        }
-        try self.blockPendingGuestUpgradeRecoveryIfMissingGuestSession(
-            apiBaseUrl: verifiedContext.apiBaseUrl,
-            detectedAt: detectedAt
-        )
 
         let prevalidatedAccount: CloudAccountSnapshot?
         if try self.shouldValidatePendingGuestUpgradeAccountBeforePrepare(apiBaseUrl: verifiedContext.apiBaseUrl) {
@@ -103,7 +158,47 @@ extension FlashcardsStore {
             apiBaseUrl: verifiedContext.apiBaseUrl,
             credentials: verifiedContext.credentials,
             workspaces: account.workspaces,
-            guestUpgradeMode: guestUpgradeMode
+            guestUpgradeMode: guestUpgradeMode,
+            postAuthRecoveryRoute: postAuthRecoveryRoute
+        )
+    }
+
+    private func prepareLinkedCredentialRecoveryLink(
+        verifiedContext: CloudVerifiedAuthContext
+    ) async throws -> CloudWorkspaceLinkContext {
+        let account = try await self.cloudRuntime.fetchCloudAccount(verifiedContext: verifiedContext)
+        let expectedWorkspace = try self.linkedCredentialRecoveryWorkspaceBeforeIdentitySideEffects(
+            account: account,
+            apiBaseUrl: verifiedContext.apiBaseUrl
+        )
+        try self.resetLocalStateIfLinkedUserDiffers(nextUserId: account.userId)
+
+        self.globalErrorMessage = ""
+        return CloudWorkspaceLinkContext(
+            userId: account.userId,
+            email: account.email,
+            apiBaseUrl: verifiedContext.apiBaseUrl,
+            credentials: verifiedContext.credentials,
+            workspaces: [expectedWorkspace],
+            guestUpgradeMode: nil,
+            postAuthRecoveryRoute: .linkedCredentialRestore
+        )
+    }
+
+    private func prepareGuestLocalRecoveryLink(
+        verifiedContext: CloudVerifiedAuthContext
+    ) async throws -> CloudWorkspaceLinkContext {
+        let account = try await self.cloudRuntime.fetchCloudAccount(verifiedContext: verifiedContext)
+
+        self.globalErrorMessage = ""
+        return CloudWorkspaceLinkContext(
+            userId: account.userId,
+            email: account.email,
+            apiBaseUrl: verifiedContext.apiBaseUrl,
+            credentials: verifiedContext.credentials,
+            workspaces: account.workspaces,
+            guestUpgradeMode: nil,
+            postAuthRecoveryRoute: .guestLocalRecovery
         )
     }
 
@@ -121,6 +216,10 @@ extension FlashcardsStore {
             }
 
             let trigger = self.manualCloudSyncTrigger(now: Date())
+            try self.validatePostAuthRecoveryRouteBeforeCloudLinkCompletion(
+                linkContext: linkContext,
+                selection: selection
+            )
             try self.validateCloudCredentialRecoveryUserBeforeIdentitySideEffects(
                 userId: linkContext.userId,
                 email: linkContext.email,
@@ -201,7 +300,8 @@ extension FlashcardsStore {
             apiBaseUrl: verifiedContext.apiBaseUrl,
             credentials: verifiedContext.credentials,
             workspaces: account.workspaces,
-            guestUpgradeMode: nil
+            guestUpgradeMode: nil,
+            postAuthRecoveryRoute: .pendingGuestUpgradeRecovery
         )
         try self.validateCloudCredentialRecoveryAccountBeforeIdentityReset(
             account: account,
@@ -223,7 +323,8 @@ extension FlashcardsStore {
             apiBaseUrl: verifiedContext.apiBaseUrl,
             credentials: verifiedContext.credentials,
             workspaces: [completedGuestUpgradeWorkspace],
-            guestUpgradeMode: nil
+            guestUpgradeMode: nil,
+            postAuthRecoveryRoute: .pendingGuestUpgradeRecovery
         )
     }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/Types/CloudTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Types/CloudTypes.swift
@@ -143,10 +143,18 @@ struct CloudWorkspaceLinkContext: Hashable, Identifiable, Sendable {
     let credentials: StoredCloudCredentials
     let workspaces: [CloudWorkspaceSummary]
     let guestUpgradeMode: CloudGuestUpgradeMode?
+    let postAuthRecoveryRoute: CloudPostAuthRecoveryRoute
 
     var id: String {
         userId
     }
+}
+
+enum CloudPostAuthRecoveryRoute: Hashable, Sendable {
+    case none
+    case linkedCredentialRestore
+    case guestLocalRecovery
+    case pendingGuestUpgradeRecovery
 }
 
 struct CloudVerifiedAuthContext: Hashable {

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
@@ -119,6 +119,18 @@ private struct CloudPostAuthSyncState: Identifiable, Hashable {
     }
 }
 
+private struct CloudPostAuthRecoveryNeededState: Identifiable, Hashable {
+    let id: String
+    let title: String
+    let message: String
+
+    init(title: String, message: String) {
+        self.id = UUID().uuidString
+        self.title = title
+        self.message = message
+    }
+}
+
 private struct CloudAuthInlineErrorView: View {
     let presentation: CloudAuthInlineErrorPresentation
 
@@ -167,9 +179,24 @@ func makeCloudPostAuthSyncPresentation() -> CloudPostAuthSyncPresentation {
 enum CloudWorkspacePostAuthRoute: Equatable {
     case autoLink(CloudWorkspaceLinkSelection)
     case chooseWorkspace
+    case guestLocalRecoveryNeeded
 }
 
-func makeCloudWorkspacePostAuthRoute(workspaces: [CloudWorkspaceSummary]) -> CloudWorkspacePostAuthRoute {
+func makeCloudWorkspacePostAuthRoute(linkContext: CloudWorkspaceLinkContext) -> CloudWorkspacePostAuthRoute {
+    switch linkContext.postAuthRecoveryRoute {
+    case .guestLocalRecovery:
+        return .guestLocalRecoveryNeeded
+    case .linkedCredentialRestore:
+        guard linkContext.workspaces.count == 1, let workspace = linkContext.workspaces.first else {
+            return .chooseWorkspace
+        }
+
+        return .autoLink(.existing(workspaceId: workspace.workspaceId))
+    case .none, .pendingGuestUpgradeRecovery:
+        break
+    }
+
+    let workspaces = linkContext.workspaces
     if workspaces.isEmpty {
         return .autoLink(.createNew)
     }
@@ -191,6 +218,7 @@ struct CloudSignInSheet: View {
     @State private var postAuthLoadingState: CloudPostAuthLoadingState?
     @State private var postAuthSyncState: CloudPostAuthSyncState?
     @State private var workspaceLinkContext: CloudWorkspaceLinkContext?
+    @State private var postAuthRecoveryNeededState: CloudPostAuthRecoveryNeededState?
     @State private var postAuthFailureState: CloudPostAuthFailureState?
     @State private var authErrorPresentation: CloudAuthInlineErrorPresentation?
     @State private var isSendingCode: Bool = false
@@ -266,6 +294,7 @@ struct CloudSignInSheet: View {
                         self.postAuthLoadingState = nil
                         self.postAuthSyncState = nil
                         self.workspaceLinkContext = nil
+                        self.postAuthRecoveryNeededState = nil
                         self.postAuthFailureState = nil
                         self.scheduleEmailFieldFocus()
                     }
@@ -298,6 +327,18 @@ struct CloudSignInSheet: View {
                     }
                 )
                 .environment(self.store)
+            }
+            .sheet(item: self.$postAuthRecoveryNeededState) { recoveryState in
+                CloudPostAuthRecoveryNeededSheet(
+                    state: recoveryState,
+                    onClose: {
+                        self.postAuthRecoveryNeededState = nil
+                        self.dismiss()
+                    },
+                    onLogout: {
+                        self.isLogoutConfirmationPresented = true
+                    }
+                )
             }
             .sheet(item: self.$postAuthFailureState) { failureState in
                 CloudPostAuthFailureSheet(
@@ -423,12 +464,20 @@ struct CloudSignInSheet: View {
     private func handlePreparedLinkContext(_ linkContext: CloudWorkspaceLinkContext) {
         self.authErrorPresentation = nil
         self.postAuthLoadingState = nil
+        self.postAuthRecoveryNeededState = nil
+        self.postAuthFailureState = nil
 
-        switch makeCloudWorkspacePostAuthRoute(workspaces: linkContext.workspaces) {
+        switch makeCloudWorkspacePostAuthRoute(linkContext: linkContext) {
         case .autoLink(let selection):
             self.completeLink(linkContext: linkContext, selection: selection)
         case .chooseWorkspace:
             self.workspaceLinkContext = linkContext
+        case .guestLocalRecoveryNeeded:
+            self.postAuthRecoveryNeededState = CloudPostAuthRecoveryNeededState(
+                title: aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
+                message: localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+            )
+            self.workspaceLinkContext = nil
         }
     }
 
@@ -437,6 +486,7 @@ struct CloudSignInSheet: View {
         self.postAuthLoadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
         self.postAuthSyncState = nil
         self.workspaceLinkContext = nil
+        self.postAuthRecoveryNeededState = nil
         self.authErrorPresentation = nil
     }
 
@@ -462,7 +512,7 @@ struct CloudSignInSheet: View {
         }
 
         self.presentPostAuthSync(
-            operation: linkContext.guestUpgradeMode == .mergeRequired
+            operation: linkContext.guestUpgradeMode != nil
                 ? .completeGuestLink(linkContext: linkContext, selection: selection)
                 : .completeLink(linkContext: linkContext, selection: selection)
         )
@@ -490,6 +540,7 @@ struct CloudSignInSheet: View {
         self.postAuthLoadingState = nil
         self.postAuthSyncState = nil
         self.workspaceLinkContext = nil
+        self.postAuthRecoveryNeededState = nil
         self.postAuthFailureState = nil
         self.postAuthSyncState = nextState
     }
@@ -553,6 +604,7 @@ struct CloudSignInSheet: View {
         self.authErrorPresentation = nil
         self.postAuthLoadingState = nil
         self.postAuthSyncState = nil
+        self.postAuthRecoveryNeededState = nil
         self.postAuthFailureState = CloudPostAuthFailureState(
             title: title,
             message: message,
@@ -574,6 +626,7 @@ struct CloudSignInSheet: View {
         self.postAuthSyncState = nil
         self.postAuthFailureState = nil
         self.workspaceLinkContext = nil
+        self.postAuthRecoveryNeededState = nil
         self.otpSheetState = nil
         self.dismiss()
     }
@@ -973,6 +1026,45 @@ private struct CloudWorkspaceSelectionRow: View {
         }
         .contentShape(Rectangle())
         .padding(.vertical, 2)
+    }
+}
+
+private struct CloudPostAuthRecoveryNeededSheet: View {
+    let state: CloudPostAuthRecoveryNeededState
+    let onClose: () -> Void
+    let onLogout: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ReadableContentLayout(
+                maxWidth: flashcardsReadableFormMaxWidth,
+                horizontalPadding: 0
+            ) {
+                Form {
+                    Section(aiSettingsLocalized("settings.account.cloudSignIn.section.cloudAccount", "Cloud account")) {
+                        Text(self.state.title)
+                            .font(.headline)
+                        Text(self.state.message)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureMessage)
+                    }
+
+                    Section {
+                        Button(aiSettingsLocalized("common.close", "Close")) {
+                            self.onClose()
+                        }
+
+                        Button(aiSettingsLocalized("settings.account.status.logOut", "Log out"), role: .destructive) {
+                            self.onLogout()
+                        }
+                    }
+                }
+            }
+            .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureScreen)
+            .navigationTitle(aiSettingsLocalized("settings.account.cloudSignIn.cloudSyncTitle", "Cloud sync"))
+            .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }
 

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudCredentialRecoveryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudCredentialRecoveryTests.swift
@@ -290,6 +290,92 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
     }
 
     @MainActor
+    func testInvalidStoredRecoveryBlocksPrepareCloudLinkBeforeIdentitySideEffects() async throws {
+        let suiteName: String = "recovery-invalid-blocks-prepare-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let corruptPayload: Data = Data(#"{"reason":"linked_credentials_missing","apiBaseUrl":42}"#.utf8)
+        userDefaults.set(corruptPayload, forKey: cloudCredentialRecoveryStateUserDefaultsKey)
+        let database: LocalDatabase = try self.makeDatabase()
+        let credentialStore: CloudCredentialStore = self.makeCredentialStore(
+            suiteName: suiteName,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let guestCredentialStore: GuestCloudCredentialStore = self.makeGuestCredentialStore(
+            suiteName: suiteName,
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        cloudSyncService.fetchCloudAccountHandler = { _, _ in
+            XCTFail("Invalid recovery must block before account fetch.")
+            return CloudAccountSnapshot(userId: "unexpected", email: nil, workspaces: [])
+        }
+        let store: FlashcardsStore = self.makeRecoveryStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            cloudSyncService: cloudSyncService
+        )
+        defer {
+            store.shutdownForTests()
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let configuration: CloudServiceConfiguration = try makeCustomCloudServiceConfiguration(
+            customOrigin: "https://example.test"
+        )
+
+        do {
+            _ = try await store.prepareCloudLink(
+                verifiedContext: CloudVerifiedAuthContext(
+                    apiBaseUrl: configuration.apiBaseUrl,
+                    credentials: StoredCloudCredentials(
+                        refreshToken: "refresh-token",
+                        idToken: "id-token",
+                        idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+                    )
+                )
+            )
+            XCTFail("Expected invalid recovery to block account link preparation.")
+        } catch let error as LocalStoreError {
+            guard case .validation(let message) = error else {
+                XCTFail("Expected validation error, received \(Flashcards.errorMessage(error: error))")
+                return
+            }
+            XCTAssertEqual(localizedCloudCredentialRecoveryBlockedMessage(reason: .invalidStoredState), message)
+        } catch {
+            XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertEqual(0, cloudSyncService.fetchCloudAccountCallCount)
+        XCTAssertNil(try credentialStore.loadCredentials())
+        XCTAssertEqual(
+            corruptPayload,
+            try XCTUnwrap(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+        )
+        XCTAssertBlockedSyncStatus(
+            store.syncStatus,
+            expectedReason: .invalidStoredState,
+            file: #filePath,
+            line: #line
+        )
+    }
+
+    @MainActor
     func testInvalidStoredRecoveryBlocksPendingGuestUpgradeReplayBeforeSideEffects() async throws {
         let suiteName: String = "recovery-invalid-blocks-pending-upgrade-\(UUID().uuidString)"
         let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -346,7 +432,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -609,6 +696,246 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
     }
 
     @MainActor
+    func testLinkedRecoveryRestoresSameAccountAndWorkspace() async throws {
+        let suiteName: String = "linked-recovery-same-account-workspace-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let database: LocalDatabase = try self.makeDatabase()
+        let workspace: Workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard: Card = try self.saveRecoveryTestCard(database: database, workspaceId: workspace.workspaceId)
+        let outboxCountBefore: Int = try self.loadOutboxCount(database: database)
+        let workspaceIdsBefore: [String] = try self.loadWorkspaceIds(database: database)
+        try database.updateCloudSettings(
+            cloudState: .linked,
+            linkedUserId: "linked-user",
+            linkedWorkspaceId: workspace.workspaceId,
+            activeWorkspaceId: workspace.workspaceId,
+            linkedEmail: "user@example.com"
+        )
+        let credentialStore: CloudCredentialStore = self.makeCredentialStore(
+            suiteName: suiteName,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let guestCredentialStore: GuestCloudCredentialStore = self.makeGuestCredentialStore(
+            suiteName: suiteName,
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let configuration: CloudServiceConfiguration = try makeCustomCloudServiceConfiguration(
+            customOrigin: "https://example.test"
+        )
+        let credentials: StoredCloudCredentials = StoredCloudCredentials(
+            refreshToken: "refresh-token",
+            idToken: "id-token",
+            idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+        )
+        let expectedWorkspace: CloudWorkspaceSummary = CloudWorkspaceSummary(
+            workspaceId: workspace.workspaceId,
+            name: workspace.name,
+            createdAt: workspace.createdAt,
+            isSelected: true
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        cloudSyncService.fetchCloudAccountHandler = { apiBaseUrl, bearerToken in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            return CloudAccountSnapshot(
+                userId: "linked-user",
+                email: "user@example.com",
+                workspaces: [expectedWorkspace]
+            )
+        }
+        cloudSyncService.selectWorkspaceHandler = { apiBaseUrl, bearerToken, workspaceId in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            XCTAssertEqual(expectedWorkspace.workspaceId, workspaceId)
+            return expectedWorkspace
+        }
+        let store: FlashcardsStore = self.makeRecoveryStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            cloudSyncService: cloudSyncService
+        )
+        defer {
+            store.shutdownForTests()
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let cloudSettings: CloudSettings = try XCTUnwrap(store.cloudSettings)
+        try store.markCloudCredentialRecoveryRequired(
+            reason: .linkedCredentialsMissing,
+            cloudSettings: cloudSettings,
+            configuration: configuration,
+            detectedAt: Date(timeIntervalSince1970: 1_775_000_000)
+        )
+
+        let linkContext: CloudWorkspaceLinkContext = try await store.prepareCloudLink(
+            verifiedContext: CloudVerifiedAuthContext(
+                apiBaseUrl: configuration.apiBaseUrl,
+                credentials: credentials
+            )
+        )
+        XCTAssertNil(linkContext.guestUpgradeMode)
+        XCTAssertEqual(.linkedCredentialRestore, linkContext.postAuthRecoveryRoute)
+        XCTAssertEqual([expectedWorkspace], linkContext.workspaces)
+        XCTAssertEqual(
+            .autoLink(.existing(workspaceId: expectedWorkspace.workspaceId)),
+            makeCloudWorkspacePostAuthRoute(linkContext: linkContext)
+        )
+
+        try await store.completeCloudLink(
+            linkContext: linkContext,
+            selection: .existing(workspaceId: expectedWorkspace.workspaceId)
+        )
+
+        XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
+        XCTAssertEqual(1, cloudSyncService.selectWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertNil(store.cloudCredentialRecoveryState)
+        XCTAssertNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+        XCTAssertEqual(credentials, try credentialStore.loadCredentials())
+        let cloudSettingsAfterLink: CloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        XCTAssertEqual(.linked, cloudSettingsAfterLink.cloudState)
+        XCTAssertEqual(Optional("linked-user"), cloudSettingsAfterLink.linkedUserId)
+        XCTAssertEqual(Optional(workspace.workspaceId), cloudSettingsAfterLink.linkedWorkspaceId)
+        XCTAssertEqual(Optional(workspace.workspaceId), cloudSettingsAfterLink.activeWorkspaceId)
+        XCTAssertEqual(outboxCountBefore, try self.loadOutboxCount(database: database))
+        XCTAssertEqual(workspaceIdsBefore, try self.loadWorkspaceIds(database: database))
+        XCTAssertTrue(try database.loadActiveCards(workspaceId: workspace.workspaceId).contains { card in
+            card.cardId == savedCard.cardId
+        })
+    }
+
+    @MainActor
+    func testLinkedRecoveryRejectsMissingExpectedWorkspaceBeforeWorkspaceSideEffects() async throws {
+        let suiteName: String = "linked-recovery-missing-workspace-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let database: LocalDatabase = try self.makeDatabase()
+        let workspace: Workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard: Card = try self.saveRecoveryTestCard(database: database, workspaceId: workspace.workspaceId)
+        let outboxCountBefore: Int = try self.loadOutboxCount(database: database)
+        let workspaceIdsBefore: [String] = try self.loadWorkspaceIds(database: database)
+        try database.updateCloudSettings(
+            cloudState: .linked,
+            linkedUserId: "linked-user",
+            linkedWorkspaceId: workspace.workspaceId,
+            activeWorkspaceId: workspace.workspaceId,
+            linkedEmail: "user@example.com"
+        )
+        let credentialStore: CloudCredentialStore = self.makeCredentialStore(
+            suiteName: suiteName,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let guestCredentialStore: GuestCloudCredentialStore = self.makeGuestCredentialStore(
+            suiteName: suiteName,
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let configuration: CloudServiceConfiguration = try makeCustomCloudServiceConfiguration(
+            customOrigin: "https://example.test"
+        )
+        let credentials: StoredCloudCredentials = StoredCloudCredentials(
+            refreshToken: "refresh-token",
+            idToken: "id-token",
+            idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        cloudSyncService.fetchCloudAccountHandler = { apiBaseUrl, bearerToken in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            return CloudAccountSnapshot(
+                userId: "linked-user",
+                email: "user@example.com",
+                workspaces: [
+                    CloudWorkspaceSummary(
+                        workspaceId: "different-workspace",
+                        name: "Other",
+                        createdAt: "2026-04-01T00:00:00.000Z",
+                        isSelected: true
+                    )
+                ]
+            )
+        }
+        let store: FlashcardsStore = self.makeRecoveryStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            cloudSyncService: cloudSyncService
+        )
+        defer {
+            store.shutdownForTests()
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let cloudSettings: CloudSettings = try XCTUnwrap(store.cloudSettings)
+        try store.markCloudCredentialRecoveryRequired(
+            reason: .linkedCredentialsMissing,
+            cloudSettings: cloudSettings,
+            configuration: configuration,
+            detectedAt: Date(timeIntervalSince1970: 1_775_000_000)
+        )
+
+        do {
+            _ = try await store.prepareCloudLink(
+                verifiedContext: CloudVerifiedAuthContext(
+                    apiBaseUrl: configuration.apiBaseUrl,
+                    credentials: credentials
+                )
+            )
+            XCTFail("Expected missing linked workspace to be rejected during recovery.")
+        } catch let error as LocalStoreError {
+            guard case .validation(let message) = error else {
+                XCTFail("Expected validation error, received \(Flashcards.errorMessage(error: error))")
+                return
+            }
+            XCTAssertEqual(localizedCloudCredentialRecoveryWrongLinkedWorkspaceMessage(), message)
+        } catch {
+            XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
+        XCTAssertEqual(0, cloudSyncService.selectWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(outboxCountBefore, try self.loadOutboxCount(database: database))
+        XCTAssertEqual(workspaceIdsBefore, try self.loadWorkspaceIds(database: database))
+        XCTAssertTrue(try database.loadActiveCards(workspaceId: workspace.workspaceId).contains { card in
+            card.cardId == savedCard.cardId
+        })
+        XCTAssertNotNil(store.cloudCredentialRecoveryState)
+        XCTAssertNotNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+    }
+
+    @MainActor
     func testLinkedRecoveryRejectsCreateNewWorkspaceBeforeSelectionSideEffect() async throws {
         let suiteName: String = "linked-recovery-wrong-workspace-\(UUID().uuidString)"
         let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
@@ -687,7 +1014,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                     isSelected: true
                 )
             ],
-            guestUpgradeMode: nil
+            guestUpgradeMode: nil,
+            postAuthRecoveryRoute: .linkedCredentialRestore
         )
 
         do {
@@ -1182,6 +1510,7 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
         let workspace: Workspace = try database.workspaceSettingsStore.loadWorkspace()
         let savedCard: Card = try self.saveRecoveryTestCard(database: database, workspaceId: workspace.workspaceId)
         let outboxCountBefore: Int = try self.loadOutboxCount(database: database)
+        let workspaceIdsBefore: [String] = try self.loadWorkspaceIds(database: database)
         try database.updateCloudSettings(
             cloudState: .guest,
             linkedUserId: "guest-user",
@@ -1219,19 +1548,10 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
             XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
             XCTAssertEqual(credentials.idToken, bearerToken)
             return CloudAccountSnapshot(
-                userId: "linked-user",
-                email: "user@example.com",
+                userId: "unrelated-email-user",
+                email: "other@example.com",
                 workspaces: [linkedWorkspace]
             )
-        }
-        cloudSyncService.selectWorkspaceHandler = { apiBaseUrl, bearerToken, workspaceId in
-            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
-            XCTAssertEqual(credentials.idToken, bearerToken)
-            XCTAssertEqual(linkedWorkspace.workspaceId, workspaceId)
-            return linkedWorkspace
-        }
-        cloudSyncService.isWorkspaceEmptyForBootstrapHandler = { _, _, _, _ in
-            false
         }
         let urlSessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.ephemeral
         urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
@@ -1270,28 +1590,61 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 credentials: credentials
             )
         )
-        try await store.completeCloudLink(
-            linkContext: linkContext,
-            selection: .existing(workspaceId: linkedWorkspace.workspaceId)
-        )
 
         XCTAssertNil(linkContext.guestUpgradeMode)
+        XCTAssertEqual(.guestLocalRecovery, linkContext.postAuthRecoveryRoute)
+        XCTAssertEqual("unrelated-email-user", linkContext.userId)
+        XCTAssertEqual(.guestLocalRecoveryNeeded, makeCloudWorkspacePostAuthRoute(linkContext: linkContext))
         XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
         XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
-        XCTAssertEqual(1, cloudSyncService.selectWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.selectWorkspaceCallCount)
         XCTAssertEqual(0, cloudSyncService.createWorkspaceCallCount)
         XCTAssertEqual(0, cloudSyncService.isWorkspaceEmptyForBootstrapCallCount)
-        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
-        XCTAssertNil(store.cloudCredentialRecoveryState)
-        XCTAssertNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
-        XCTAssertNotNil(try credentialStore.loadCredentials())
+        XCTAssertEqual(0, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertNil(try credentialStore.loadCredentials())
+        XCTAssertNotNil(store.cloudCredentialRecoveryState)
+        XCTAssertNotNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+
+        do {
+            try await store.completeCloudLink(
+                linkContext: linkContext,
+                selection: .existing(workspaceId: linkedWorkspace.workspaceId)
+            )
+            XCTFail("Expected guest local recovery to stop before cloud link completion.")
+        } catch let error as LocalStoreError {
+            guard case .validation(let message) = error else {
+                XCTFail("Expected validation error, received \(Flashcards.errorMessage(error: error))")
+                return
+            }
+            XCTAssertEqual(localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing), message)
+        } catch {
+            XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        do {
+            try await store.completeGuestCloudLink(
+                linkContext: linkContext,
+                selection: .existing(workspaceId: linkedWorkspace.workspaceId)
+            )
+            XCTFail("Expected guest local recovery to stop before guest upgrade completion.")
+        } catch let error as LocalStoreError {
+            guard case .validation(let message) = error else {
+                XCTFail("Expected validation error, received \(Flashcards.errorMessage(error: error))")
+                return
+            }
+            XCTAssertEqual(localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing), message)
+        } catch {
+            XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
+        }
+
         let cloudSettingsAfterLink: CloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
-        XCTAssertEqual(.linked, cloudSettingsAfterLink.cloudState)
-        XCTAssertEqual(Optional("linked-user"), cloudSettingsAfterLink.linkedUserId)
-        XCTAssertEqual(Optional(linkedWorkspace.workspaceId), cloudSettingsAfterLink.linkedWorkspaceId)
-        XCTAssertEqual(Optional(linkedWorkspace.workspaceId), cloudSettingsAfterLink.activeWorkspaceId)
+        XCTAssertEqual(.guest, cloudSettingsAfterLink.cloudState)
+        XCTAssertEqual(Optional("guest-user"), cloudSettingsAfterLink.linkedUserId)
+        XCTAssertEqual(Optional(workspace.workspaceId), cloudSettingsAfterLink.linkedWorkspaceId)
+        XCTAssertEqual(Optional(workspace.workspaceId), cloudSettingsAfterLink.activeWorkspaceId)
         XCTAssertEqual(outboxCountBefore, try self.loadOutboxCount(database: database))
-        XCTAssertTrue(try database.loadActiveCards(workspaceId: linkedWorkspace.workspaceId).contains { card in
+        XCTAssertEqual(workspaceIdsBefore, try self.loadWorkspaceIds(database: database))
+        XCTAssertTrue(try database.loadActiveCards(workspaceId: workspace.workspaceId).contains { card in
             card.cardId == savedCard.cardId
         })
     }
@@ -1350,7 +1703,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -1438,6 +1792,7 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
         XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
         XCTAssertEqual(1, GuestCloudAuthServiceTestURLProtocol.requestCount)
         XCTAssertEqual(.mergeRequired, linkContext.guestUpgradeMode)
+        XCTAssertEqual(.pendingGuestUpgradeRecovery, linkContext.postAuthRecoveryRoute)
         XCTAssertEqual("linked-user", linkContext.userId)
         XCTAssertNotNil(store.cloudCredentialRecoveryState)
     }
@@ -1487,7 +1842,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
             apiBaseUrl: configuration.apiBaseUrl,
             credentials: credentials,
             workspaces: [],
-            guestUpgradeMode: nil
+            guestUpgradeMode: nil,
+            postAuthRecoveryRoute: .none
         )
         let guestSession: StoredGuestCloudSession = StoredGuestCloudSession(
             guestToken: "guest-token",
@@ -1503,7 +1859,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: recoveredLinkContext.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -1624,7 +1981,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -1708,10 +2066,11 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
         XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
         XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
         XCTAssertNil(linkContext.guestUpgradeMode)
+        XCTAssertEqual(.pendingGuestUpgradeRecovery, linkContext.postAuthRecoveryRoute)
         XCTAssertEqual([completedWorkspace], linkContext.workspaces)
         XCTAssertEqual(
             .autoLink(.existing(workspaceId: completedWorkspace.workspaceId)),
-            makeCloudWorkspacePostAuthRoute(workspaces: linkContext.workspaces)
+            makeCloudWorkspacePostAuthRoute(linkContext: linkContext)
         )
     }
 
@@ -1771,7 +2130,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -1927,7 +2287,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -1983,7 +2344,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                     apiBaseUrl: configuration.apiBaseUrl,
                     credentials: credentials,
                     workspaces: [completedWorkspace],
-                    guestUpgradeMode: nil
+                    guestUpgradeMode: nil,
+                    postAuthRecoveryRoute: .pendingGuestUpgradeRecovery
                 ),
                 selection: .existing(workspaceId: completedWorkspace.workspaceId)
             )
@@ -2066,7 +2428,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: StoredGuestCloudSession(
@@ -2087,6 +2450,15 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
         )
         GuestCloudAuthServiceTestURLProtocol.reset()
         let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        cloudSyncService.fetchCloudAccountHandler = { apiBaseUrl, bearerToken in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            return CloudAccountSnapshot(
+                userId: "any-linked-user",
+                email: "any@example.com",
+                workspaces: []
+            )
+        }
         let store: FlashcardsStore = self.makeRecoveryStore(
             userDefaults: userDefaults,
             encoder: encoder,
@@ -2112,26 +2484,18 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
             detectedAt: Date(timeIntervalSince1970: 1_775_000_000)
         )
 
-        do {
-            _ = try await store.prepareCloudLink(
-                verifiedContext: CloudVerifiedAuthContext(
-                    apiBaseUrl: configuration.apiBaseUrl,
-                    credentials: credentials
-                )
+        let linkContext: CloudWorkspaceLinkContext = try await store.prepareCloudLink(
+            verifiedContext: CloudVerifiedAuthContext(
+                apiBaseUrl: configuration.apiBaseUrl,
+                credentials: credentials
             )
-            XCTFail("Expected missing guest token to block account link preparation.")
-        } catch let error as LocalStoreError {
-            guard case .validation(let message) = error else {
-                XCTFail("Expected validation error, received \(Flashcards.errorMessage(error: error))")
-                return
-            }
-            XCTAssertEqual(localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing), message)
-        } catch {
-            XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
-        }
+        )
 
         XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
-        XCTAssertEqual(0, cloudSyncService.fetchCloudAccountCallCount)
+        XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
+        XCTAssertNil(linkContext.guestUpgradeMode)
+        XCTAssertEqual(.guestLocalRecovery, linkContext.postAuthRecoveryRoute)
+        XCTAssertEqual("any-linked-user", linkContext.userId)
         XCTAssertEqual(pendingState, try decoder.decode(
             PendingGuestUpgradeState.self,
             from: try XCTUnwrap(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
@@ -2202,7 +2566,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -2243,7 +2608,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                     apiBaseUrl: configuration.apiBaseUrl,
                     credentials: credentials,
                     workspaces: [],
-                    guestUpgradeMode: .mergeRequired
+                    guestUpgradeMode: .mergeRequired,
+                    postAuthRecoveryRoute: .pendingGuestUpgradeRecovery
                 ),
                 selection: .createNew
             )
@@ -2321,7 +2687,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: guestSession,
@@ -2436,7 +2803,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 apiBaseUrl: configuration.apiBaseUrl,
                 credentials: credentials,
                 workspaces: [],
-                guestUpgradeMode: .mergeRequired
+                guestUpgradeMode: .mergeRequired,
+                postAuthRecoveryRoute: .none
             ),
             configuration: configuration,
             guestSession: StoredGuestCloudSession(
@@ -2566,7 +2934,8 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                             isSelected: true
                         )
                     ],
-                    guestUpgradeMode: .mergeRequired
+                    guestUpgradeMode: .mergeRequired,
+                    postAuthRecoveryRoute: .none
                 ),
                 selection: .createNew
             )

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Guest/GuestCloudUpgradeDrainTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Guest/GuestCloudUpgradeDrainTests.swift
@@ -130,7 +130,8 @@ final class GuestCloudUpgradeDrainTests: XCTestCase {
                 idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
             ),
             workspaces: [],
-            guestUpgradeMode: .mergeRequired
+            guestUpgradeMode: .mergeRequired,
+            postAuthRecoveryRoute: .none
         )
 
         do {
@@ -340,7 +341,8 @@ final class GuestCloudUpgradeDrainTests: XCTestCase {
                 idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
             ),
             workspaces: [],
-            guestUpgradeMode: .mergeRequired
+            guestUpgradeMode: .mergeRequired,
+            postAuthRecoveryRoute: .none
         )
         let upgradeTask: Task<Void, Error> = Task { @MainActor in
             try await store.completeGuestCloudLink(linkContext: linkContext, selection: .createNew)
@@ -617,7 +619,8 @@ final class GuestCloudUpgradeDrainTests: XCTestCase {
                 idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
             ),
             workspaces: [],
-            guestUpgradeMode: .mergeRequired
+            guestUpgradeMode: .mergeRequired,
+            postAuthRecoveryRoute: .none
         )
 
         let upgradeTask = Task { @MainActor in
@@ -838,7 +841,8 @@ final class GuestCloudUpgradeDrainTests: XCTestCase {
                 idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
             ),
             workspaces: [],
-            guestUpgradeMode: .mergeRequired
+            guestUpgradeMode: .mergeRequired,
+            postAuthRecoveryRoute: .none
         )
         let upgradeTask = Task { @MainActor in
             try await store.completeGuestCloudLink(linkContext: linkContext, selection: .createNew)
@@ -1048,7 +1052,8 @@ final class GuestCloudUpgradeDrainTests: XCTestCase {
                 idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
             ),
             workspaces: [],
-            guestUpgradeMode: .mergeRequired
+            guestUpgradeMode: .mergeRequired,
+            postAuthRecoveryRoute: .none
         )
 
         do {


### PR DESCRIPTION
## Summary
- add explicit iOS post-auth recovery routes for linked restore, guest local recovery, and pending guest upgrade recovery
- gate recovery decisions before identity reset, guest upgrade prepare, workspace selection/create, and credential save
- update sign-in routing and focused iOS recovery tests for the decision matrix

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse on the modified Swift source/test files

Simulator-backed iOS tests were not run locally because the repo requires explicit approval for simulator test runs.