### PR TITLE
[codex] Implement Android post-auth recovery matrix

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/CloudPostAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/CloudPostAuthRouteTest.kt
@@ -43,6 +43,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         errorMessage = "",
                         canRetry = false,
                         canLogout = false,
+                        failureActionLabel = "Log out",
                         completionToken = null
                     ),
                     onAutoContinue = {
@@ -50,7 +51,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     },
                     onSelectWorkspace = {},
                     onRetry = {},
-                    onLogout = {},
+                    onFailureAction = {},
                     onBack = {}
                 )
             }
@@ -97,6 +98,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         errorMessage = "",
                         canRetry = false,
                         canLogout = false,
+                        failureActionLabel = "Log out",
                         completionToken = null
                     ),
                     onAutoContinue = {},
@@ -104,7 +106,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         selectedWorkspace = selection
                     },
                     onRetry = {},
-                    onLogout = {},
+                    onFailureAction = {},
                     onBack = {}
                 )
             }
@@ -142,6 +144,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         errorMessage = "Cloud sync could not finish.",
                         canRetry = true,
                         canLogout = true,
+                        failureActionLabel = "Log out",
                         completionToken = null
                     ),
                     onAutoContinue = {},
@@ -149,7 +152,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onRetry = {
                         retryCalls += 1
                     },
-                    onLogout = {
+                    onFailureAction = {
                         logoutCalls += 1
                     },
                     onBack = {}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsAccountAuthNavGraph.kt
@@ -155,9 +155,9 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                         signInViewModel.retryPostAuth()
                     }
                 },
-                onLogout = {
+                onFailureAction = {
                     coroutineScope.launch {
-                        signInViewModel.logoutAfterPostAuthFailure()
+                        signInViewModel.runPostAuthFailureAction()
                         runAuthNavigationOnMainThread {
                             navigateToSettingsAccountStatus(navController = navController)
                         }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/CloudGuestSessionCoordinatorTest.kt
@@ -14,6 +14,7 @@ import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMod
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
 import com.flashcardsopensourceapp.data.local.model.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.makeOfficialCloudServiceConfiguration
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -256,7 +257,8 @@ class CloudGuestSessionCoordinatorTest {
     }
 
     @Test
-    fun corruptCredentialRecoveryStateDoesNotPreventStoreRestartAndThrowsWhenLoaded() = runBlocking {
+    fun corruptCredentialRecoveryStateDoesNotPreventStoreRestartAndLoadsInvalidRecovery() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
         val metadataPreferences = environment.context.getSharedPreferences(
             "flashcards-cloud-metadata",
             Context.MODE_PRIVATE
@@ -271,12 +273,30 @@ class CloudGuestSessionCoordinatorTest {
             remoteGateway = FakeCloudRemoteGateway.standard()
         )
 
-        try {
-            restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState()
-            throw AssertionError("Expected corrupt recovery state to throw when loaded.")
-        } catch (error: IllegalStateException) {
-            assertTrue(error.message?.contains("Cloud credential recovery state is corrupt") == true)
-        }
+        val loadedRecoveryState = requireNotNull(restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        val observedRecoveryState = requireNotNull(
+            restartedRuntime.cloudPreferencesStore.observeCloudCredentialRecoveryState().first()
+        )
+        restartedRuntime.cloudPreferencesStore.saveCredentials(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+        restartedRuntime.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.LINKED,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            activeWorkspaceId = localWorkspaceId
+        )
+
+        restartedRuntime.cloudGuestSessionCoordinator.reconcilePersistedCloudState()
+
+        assertEquals(CloudCredentialRecoveryReason.INVALID_STORED_STATE, loadedRecoveryState.reason)
+        assertEquals(CloudCredentialRecoveryReason.INVALID_STORED_STATE, observedRecoveryState.reason)
+        assertEquals(
+            CloudCredentialRecoveryReason.INVALID_STORED_STATE,
+            restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState()?.reason
+        )
+        assertEquals("{", metadataPreferences.getString("cloud-credential-recovery-state", null))
     }
 
     @Test
@@ -326,12 +346,27 @@ class CloudGuestSessionCoordinatorTest {
                 )
             )
         )
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(
+            recoveryState = CloudCredentialRecoveryState(
+                reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+                previousCloudState = CloudAccountState.GUEST,
+                installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+                linkedUserId = guestSession.userId,
+                linkedWorkspaceId = localWorkspaceId,
+                activeWorkspaceId = localWorkspaceId,
+                linkedEmail = null,
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                detectedAtMillis = 500L
+            )
+        )
         assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
         assertNotNull(environment.database.workspaceDao().loadWorkspaceById(localWorkspaceId))
         assertNull(environment.database.workspaceDao().loadWorkspaceById(linkedWorkspace.workspaceId))
         assertNull(environment.cloudPreferencesStore.loadCredentials())
         assertNotNull(environment.cloudPreferencesStore.loadPendingGuestUpgrade())
+        assertNotNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
 
         val restartedRuntime = environment.createRestartedCloudGuestSessionRuntime(
             remoteGateway = FakeCloudRemoteGateway.forGuestUpgrade(
@@ -359,6 +394,7 @@ class CloudGuestSessionCoordinatorTest {
         assertEquals(linkedWorkspace.workspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
         assertNotNull(restartedRuntime.cloudPreferencesStore.loadCredentials())
         assertNull(restartedRuntime.cloudPreferencesStore.loadPendingGuestUpgrade())
+        assertNull(restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState())
         assertNull(
             restartedRuntime.guestAiSessionStore.loadAnySession(
                 configuration = makeOfficialCloudServiceConfiguration()

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/FakeCloudRemoteGateway.kt
@@ -328,6 +328,8 @@ internal class FakeCloudRemoteGateway private constructor(
     }
 
     var deleteAccountCalls: Int = 0
+    var fetchCloudAccountCalls: Int = 0
+    var verifyCodeCalls: Int = 0
     var prepareGuestUpgradeCalls: Int = 0
     var completeGuestUpgradeCalls: Int = 0
     val completeGuestUpgradeGuestWorkspaceSyncedAndOutboxDrained = mutableListOf<Boolean>()
@@ -358,6 +360,7 @@ internal class FakeCloudRemoteGateway private constructor(
         code: String,
         authBaseUrl: String
     ): StoredCloudCredentials {
+        verifyCodeCalls += 1
         return createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
     }
 
@@ -379,6 +382,7 @@ internal class FakeCloudRemoteGateway private constructor(
         apiBaseUrl: String,
         bearerToken: String
     ): CloudAccountSnapshot {
+        fetchCloudAccountCalls += 1
         onFetchCloudAccountEntered?.complete(Unit)
         blockFetchCloudAccount?.await()
         fetchAccountError?.let { error ->

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositorySignInPreparationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositorySignInPreparationTest.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.data.local.cloudidentity
 
+import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
@@ -8,6 +9,8 @@ import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspacePostAuthRoute
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -77,6 +80,7 @@ class LocalCloudAccountRepositorySignInPreparationTest {
         )
 
         assertEquals(CloudGuestUpgradeMode.BOUND, linkContext.guestUpgradeMode)
+        assertEquals(CloudWorkspacePostAuthRoute.NONE, linkContext.postAuthRoute)
         assertEquals(CloudAccountState.GUEST, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertNull(environment.cloudPreferencesStore.currentCloudSettings().linkedUserId)
         assertNull(environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
@@ -116,6 +120,7 @@ class LocalCloudAccountRepositorySignInPreparationTest {
 
         assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(CloudWorkspacePostAuthRoute.NONE, linkContext.postAuthRoute)
         assertEquals("workspace-2", linkContext.preferredWorkspaceId)
         assertNull(environment.cloudPreferencesStore.loadCredentials())
     }
@@ -163,9 +168,185 @@ class LocalCloudAccountRepositorySignInPreparationTest {
             credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
         )
 
+        assertEquals(CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE, linkContext.postAuthRoute)
         assertEquals(localWorkspaceId, linkContext.preferredWorkspaceId)
         assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
         assertNull(environment.cloudPreferencesStore.loadCredentials())
+    }
+
+    @Test
+    fun linkedCredentialRecoveryRestoresCredentialsForSameAccountAndWorkspace() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = localWorkspaceId,
+                        name = "Recovered",
+                        createdAtMillis = 100L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        val selectedWorkspace = repository.completeCloudLink(
+            linkContext = linkContext,
+            selection = CloudWorkspaceLinkSelection.Existing(workspaceId = localWorkspaceId)
+        )
+
+        assertEquals(CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE, linkContext.postAuthRoute)
+        assertEquals(localWorkspaceId, linkContext.preferredWorkspaceId)
+        assertEquals(localWorkspaceId, selectedWorkspace.workspaceId)
+        assertEquals(1, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertEquals(emptyList<String>(), remoteGateway.bootstrapPullWorkspaceIds)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
+    }
+
+    @Test
+    fun linkedCredentialRecoveryFailsClosedWhenExpectedIdentityIsMissing() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = null,
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = localWorkspaceId,
+                        name = "Recovered",
+                        createdAtMillis = 100L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = localWorkspaceId)
+            )
+            throw AssertionError("Expected linked recovery to fail closed without stored identity.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
+
+        assertEquals(CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE, linkContext.postAuthRoute)
+        assertNull(linkContext.preferredWorkspaceId)
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
+    }
+
+    @Test
+    fun linkedCredentialRecoveryFailsClosedWhenExpectedWorkspaceIsMissing() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = installationId,
+            linkedUserId = "user-1",
+            linkedWorkspaceId = null,
+            activeWorkspaceId = null,
+            linkedEmail = "user@example.com",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forAccountSnapshot(
+            accountSnapshot = createCloudAccountSnapshot(
+                userId = "user-1",
+                email = "user@example.com",
+                workspaces = listOf(
+                    createCloudWorkspaceSummary(
+                        workspaceId = "workspace-remote",
+                        name = "Remote",
+                        createdAtMillis = 100L,
+                        isSelected = true
+                    )
+                )
+            )
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = "workspace-remote")
+            )
+            throw AssertionError("Expected linked recovery to fail closed without a stored workspace.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
+
+        assertEquals(CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE, linkContext.postAuthRoute)
+        assertNull(linkContext.preferredWorkspaceId)
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
     }
 
     @Test
@@ -233,10 +414,10 @@ class LocalCloudAccountRepositorySignInPreparationTest {
     }
 
     @Test
-    fun linkedCredentialRecoveryCanCreateNewWorkspaceWhenRecoveredWorkspaceIsUnavailable() = runBlocking {
+    fun linkedCredentialRecoveryRejectsCreateNewWhenRecoveredWorkspaceIsUnavailable() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
         val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
-        environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
         val recoveryState = CloudCredentialRecoveryState(
             reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
             previousCloudState = CloudAccountState.LINKED,
@@ -269,26 +450,29 @@ class LocalCloudAccountRepositorySignInPreparationTest {
         val linkContext = repository.prepareVerifiedSignIn(
             credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
         )
-        val selectedWorkspace = repository.completeCloudLink(
-            linkContext = linkContext,
-            selection = CloudWorkspaceLinkSelection.CreateNew
-        )
 
-        assertEquals(localWorkspaceId, linkContext.preferredWorkspaceId)
-        assertEquals("workspace-new", selectedWorkspace.workspaceId)
+        assertEquals(CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE, linkContext.postAuthRoute)
+        assertNull(linkContext.preferredWorkspaceId)
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.CreateNew
+            )
+            throw AssertionError("Expected linked credential recovery to reject create-new.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
         assertEquals(0, remoteGateway.selectWorkspaceCalls)
-        assertEquals(1, remoteGateway.createWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
         assertEquals(emptyList<String>(), remoteGateway.bootstrapPullWorkspaceIds)
-        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
-        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
-        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
-        assertEquals("workspace-new", environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
         assertEquals(1, environment.database.workspaceDao().countWorkspaces())
-        assertEquals("workspace-new", environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
-        val migratedCards = environment.database.cardDao().loadCards(workspaceId = "workspace-new")
-        assertEquals(1, migratedCards.count())
-        assertEquals("Question", migratedCards.single().frontText)
-        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = "workspace-new"))
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
     }
 
     @Test
@@ -326,6 +510,7 @@ class LocalCloudAccountRepositorySignInPreparationTest {
             credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
         )
 
+        assertEquals(CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE, linkContext.postAuthRoute)
         assertNull(linkContext.guestUpgradeMode)
         assertEquals(0, remoteGateway.prepareGuestUpgradeCalls)
         assertEquals(
@@ -357,8 +542,8 @@ class LocalCloudAccountRepositorySignInPreparationTest {
                 email = "other@example.com",
                 workspaces = listOf(
                     createCloudWorkspaceSummary(
-                        workspaceId = "workspace-other",
-                        name = "Other",
+                        workspaceId = localWorkspaceId,
+                        name = "Recovered",
                         createdAtMillis = 200L,
                         isSelected = true
                     )
@@ -374,7 +559,7 @@ class LocalCloudAccountRepositorySignInPreparationTest {
         try {
             repository.completeCloudLink(
                 linkContext = linkContext,
-                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = "workspace-other")
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = localWorkspaceId)
             )
             throw AssertionError("Expected completeCloudLink to preserve recovery for another account.")
         } catch (error: CloudCredentialRecoveryRequiredException) {
@@ -459,10 +644,10 @@ class LocalCloudAccountRepositorySignInPreparationTest {
     }
 
     @Test
-    fun completeCloudLinkPreservesGuestRecoveryDataWhenRemoteWorkspaceIsNotEmpty() = runBlocking {
+    fun prepareVerifiedSignInRoutesGuestRecoveryWithoutGuestUpgradePrepare() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
         val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
-        environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
         val remoteWorkspaceId = "workspace-remote"
         val recoveryState = CloudCredentialRecoveryState(
             reason = CloudCredentialRecoveryReason.GUEST_SESSION_MISSING,
@@ -486,26 +671,31 @@ class LocalCloudAccountRepositorySignInPreparationTest {
             credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
         )
 
-        val selectedWorkspace = repository.completeCloudLink(
-            linkContext = linkContext,
-            selection = CloudWorkspaceLinkSelection.Existing(workspaceId = remoteWorkspaceId)
-        )
+        assertEquals(CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY, linkContext.postAuthRoute)
+        assertEquals("user-1", linkContext.userId)
+        assertNull(linkContext.guestUpgradeMode)
+        assertEquals(0, remoteGateway.prepareGuestUpgradeCalls)
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = remoteWorkspaceId)
+            )
+            throw AssertionError("Expected guest local recovery to block normal complete-link.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(recoveryState, error.recoveryState)
+        }
 
-        assertEquals(remoteWorkspaceId, selectedWorkspace.workspaceId)
-        assertEquals(1, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
         assertEquals(0, remoteGateway.createWorkspaceCalls)
         assertEquals(emptyList<String>(), remoteGateway.bootstrapPullWorkspaceIds)
-        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
-        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
-        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
-        assertEquals(remoteWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
-        assertEquals(remoteWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.DISCONNECTED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
         assertEquals(1, environment.database.workspaceDao().countWorkspaces())
-        assertEquals(remoteWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
-        val migratedCards = environment.database.cardDao().loadCards(workspaceId = remoteWorkspaceId)
-        assertEquals(1, migratedCards.count())
-        assertEquals("Question", migratedCards.single().frontText)
-        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = remoteWorkspaceId))
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
     }
 
     @Test
@@ -592,5 +782,98 @@ class LocalCloudAccountRepositorySignInPreparationTest {
             )
         )
         assertEquals(0, remoteGateway.prepareGuestUpgradeCalls)
+    }
+
+    @Test
+    fun invalidStoredRecoveryStateBlocksPostAuthWithoutIdentitySideEffects() = runBlocking {
+        val metadataPreferences = environment.context.getSharedPreferences(
+            "flashcards-cloud-metadata",
+            Context.MODE_PRIVATE
+        )
+        metadataPreferences.edit()
+            .putString("cloud-credential-recovery-state", "{")
+            .commit()
+        val remoteGateway = FakeCloudRemoteGateway.standard()
+        val restartedRuntime = environment.createRestartedCloudAccountRuntime(remoteGateway = remoteGateway)
+
+        val loadedRecoveryState = requireNotNull(restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        val observedRecoveryState = requireNotNull(
+            restartedRuntime.cloudPreferencesStore.observeCloudCredentialRecoveryState().first()
+        )
+        val linkContext = restartedRuntime.repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+        val otpLinkContext = restartedRuntime.repository.verifyCode(
+            challenge = createOtpChallenge(email = "user@example.com"),
+            code = "123456"
+        )
+
+        assertEquals(CloudCredentialRecoveryReason.INVALID_STORED_STATE, loadedRecoveryState.reason)
+        assertEquals(CloudCredentialRecoveryReason.INVALID_STORED_STATE, observedRecoveryState.reason)
+        assertEquals(CloudWorkspacePostAuthRoute.INVALID_STORED_STATE, linkContext.postAuthRoute)
+        assertEquals(CloudWorkspacePostAuthRoute.INVALID_STORED_STATE, otpLinkContext.postAuthRoute)
+        assertEquals(0, remoteGateway.fetchCloudAccountCalls)
+        assertEquals(0, remoteGateway.verifyCodeCalls)
+        try {
+            restartedRuntime.repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.CreateNew
+            )
+            throw AssertionError("Expected invalid stored recovery to block complete-link.")
+        } catch (error: CloudCredentialRecoveryRequiredException) {
+            assertEquals(CloudCredentialRecoveryReason.INVALID_STORED_STATE, error.recoveryState.reason)
+        }
+
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.createWorkspaceCalls)
+        assertNull(restartedRuntime.cloudPreferencesStore.loadCredentials())
+        assertEquals("{", metadataPreferences.getString("cloud-credential-recovery-state", null))
+    }
+
+    @Test
+    fun resetInvalidStoredRecoveryStatePreservesLocalData() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.LINKED,
+            linkedUserId = "user-linked",
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = "user@example.com",
+            activeWorkspaceId = localWorkspaceId
+        )
+        environment.cloudPreferencesStore.saveCredentials(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+        val metadataPreferences = environment.context.getSharedPreferences(
+            "flashcards-cloud-metadata",
+            Context.MODE_PRIVATE
+        )
+        metadataPreferences.edit()
+            .putString("cloud-credential-recovery-state", "{")
+            .commit()
+        val restartedRuntime = environment.createRestartedCloudAccountRuntime(
+            remoteGateway = FakeCloudRemoteGateway.standard()
+        )
+
+        assertEquals(
+            CloudCredentialRecoveryReason.INVALID_STORED_STATE,
+            restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState()?.reason
+        )
+
+        restartedRuntime.repository.resetInvalidCloudCredentialRecoveryState()
+
+        val cloudSettings = restartedRuntime.cloudPreferencesStore.currentCloudSettings()
+        assertNull(restartedRuntime.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertNull(metadataPreferences.getString("cloud-credential-recovery-state", null))
+        assertEquals(CloudAccountState.DISCONNECTED, cloudSettings.cloudState)
+        assertNull(cloudSettings.linkedUserId)
+        assertNull(cloudSettings.linkedWorkspaceId)
+        assertNull(cloudSettings.linkedEmail)
+        assertEquals(localWorkspaceId, cloudSettings.activeWorkspaceId)
+        assertNull(restartedRuntime.cloudPreferencesStore.loadCredentials())
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).count())
+        assertEquals(cardId, environment.database.cardDao().loadCards(workspaceId = localWorkspaceId).single().cardId)
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
@@ -440,11 +440,11 @@ class CloudPreferencesStore(
         return try {
             decodeCloudCredentialRecoveryState(jsonObject = JSONObject(rawValue))
         } catch (error: JSONException) {
-            throw cloudCredentialRecoveryStateCorruptError(cause = error)
+            invalidStoredCloudCredentialRecoveryState()
         } catch (error: IllegalArgumentException) {
-            throw cloudCredentialRecoveryStateCorruptError(cause = error)
+            invalidStoredCloudCredentialRecoveryState()
         } catch (error: IllegalStateException) {
-            throw cloudCredentialRecoveryStateCorruptError(cause = error)
+            invalidStoredCloudCredentialRecoveryState()
         }
     }
 
@@ -766,6 +766,7 @@ private fun encodeCloudCredentialRecoveryState(recoveryState: CloudCredentialRec
 }
 
 private fun decodeCloudCredentialRecoveryState(jsonObject: JSONObject): CloudCredentialRecoveryState {
+    requireCloudCredentialRecoveryStateKnownKeys(jsonObject = jsonObject)
     return CloudCredentialRecoveryState(
         reason = CloudCredentialRecoveryReason.valueOf(jsonObject.getString("reason")),
         previousCloudState = CloudAccountState.valueOf(jsonObject.getString("previousCloudState")),
@@ -780,11 +781,38 @@ private fun decodeCloudCredentialRecoveryState(jsonObject: JSONObject): CloudCre
     )
 }
 
-private fun cloudCredentialRecoveryStateCorruptError(cause: Throwable): IllegalStateException {
-    return IllegalStateException(
-        "Cloud credential recovery state is corrupt and cannot be resumed. " +
-            "Sign in again to resolve cloud credential recovery. Cause='${cause.message}'.",
-        cause
+private fun requireCloudCredentialRecoveryStateKnownKeys(jsonObject: JSONObject) {
+    val expectedKeys = setOf(
+        "reason",
+        "previousCloudState",
+        "installationId",
+        "linkedUserId",
+        "linkedWorkspaceId",
+        "activeWorkspaceId",
+        "linkedEmail",
+        "configurationMode",
+        "apiBaseUrl",
+        "detectedAtMillis"
+    )
+    val actualKeys = jsonObject.keys().asSequence().toSet()
+    val unknownKeys = actualKeys - expectedKeys
+    require(unknownKeys.isEmpty()) {
+        "Cloud credential recovery state contains unknown keys: ${unknownKeys.sorted().joinToString()}."
+    }
+}
+
+private fun invalidStoredCloudCredentialRecoveryState(): CloudCredentialRecoveryState {
+    return CloudCredentialRecoveryState(
+        reason = CloudCredentialRecoveryReason.INVALID_STORED_STATE,
+        previousCloudState = CloudAccountState.DISCONNECTED,
+        installationId = "",
+        linkedUserId = null,
+        linkedWorkspaceId = null,
+        activeWorkspaceId = null,
+        linkedEmail = null,
+        configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+        apiBaseUrl = "",
+        detectedAtMillis = System.currentTimeMillis()
     )
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/FlashcardsModels.kt
@@ -222,11 +222,20 @@ sealed interface CloudWorkspaceLinkSelection {
     data object CreateNew : CloudWorkspaceLinkSelection
 }
 
+enum class CloudWorkspacePostAuthRoute {
+    NONE,
+    LINKED_CREDENTIAL_RESTORE,
+    GUEST_LOCAL_RECOVERY,
+    PENDING_GUEST_UPGRADE_RECOVERY,
+    INVALID_STORED_STATE
+}
+
 data class CloudWorkspaceLinkContext(
     val userId: String,
     val email: String?,
     val credentials: StoredCloudCredentials,
     val workspaces: List<CloudWorkspaceSummary>,
+    val postAuthRoute: CloudWorkspacePostAuthRoute,
     val guestUpgradeMode: CloudGuestUpgradeMode?,
     val preferredWorkspaceId: String?
 )
@@ -243,7 +252,8 @@ data class CloudSettings(
 
 enum class CloudCredentialRecoveryReason {
     LINKED_CREDENTIALS_MISSING,
-    GUEST_SESSION_MISSING
+    GUEST_SESSION_MISSING,
+    INVALID_STORED_STATE
 }
 
 data class CloudCredentialRecoveryState(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -149,6 +149,7 @@ interface CloudAccountRepository {
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary
     suspend fun completeLinkedWorkspaceTransition(selection: CloudWorkspaceLinkSelection): CloudWorkspaceSummary
+    suspend fun resetInvalidCloudCredentialRecoveryState()
     suspend fun logout()
     suspend fun renameCurrentWorkspace(name: String): CloudWorkspaceSummary
     suspend fun loadCurrentWorkspaceDeletePreview(): CloudWorkspaceDeletePreview

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/CloudGuestSessionCoordinator.kt
@@ -87,21 +87,28 @@ class CloudGuestSessionCoordinator(
     }
 
     internal suspend fun reconcilePersistedCloudStateLocked(): CloudIdentityReconciliationResult {
-        val recoveredGuestUpgrade: CloudWorkspaceSummary? = resumePendingGuestUpgradeRecoveryIfNeeded(
-            database = database,
-            preferencesStore = preferencesStore,
-            remoteService = remoteService,
-            syncLocalStore = syncLocalStore,
-            guestSessionStore = guestSessionStore,
-            appVersion = appVersion
-        )
-        if (recoveredGuestUpgrade != null) {
-            return CloudIdentityReconciliationResult(
-                cloudSettings = preferencesStore.currentCloudSettings(),
-                restoredGuestSession = null,
-                guestRestoreRequiresSync = false,
-                didRunSync = false
+        val activeRecoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+        if (activeRecoveryState == null || activeRecoveryState.isPendingGuestUpgradeRecovery()) {
+            val recoveredGuestUpgrade: CloudWorkspaceSummary? = resumePendingGuestUpgradeRecoveryIfNeeded(
+                database = database,
+                preferencesStore = preferencesStore,
+                remoteService = remoteService,
+                syncLocalStore = syncLocalStore,
+                guestSessionStore = guestSessionStore,
+                appVersion = appVersion
             )
+            if (recoveredGuestUpgrade != null) {
+                return CloudIdentityReconciliationResult(
+                    cloudSettings = preferencesStore.currentCloudSettings(),
+                    restoredGuestSession = null,
+                    guestRestoreRequiresSync = false,
+                    didRunSync = false
+                )
+            }
+        }
+
+        activeCredentialRecoveryReconciliationResultOrNull(recoveryState = activeRecoveryState)?.let { result ->
+            return result
         }
 
         var currentCloudSettings = preferencesStore.currentCloudSettings()
@@ -202,6 +209,11 @@ class CloudGuestSessionCoordinator(
         createSessionIfMissing: Boolean
     ): GuestCloudSessionRestoreResult {
         val reconciliation = reconcilePersistedCloudStateLocked()
+        val activeRecoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+        if (activeRecoveryState != null) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = activeRecoveryState)
+        }
+
         if (reconciliation.cloudSettings.cloudState == CloudAccountState.GUEST) {
             val session = requireNotNull(reconciliation.restoredGuestSession) {
                 "Guest cloud state is missing a stored guest session."
@@ -212,10 +224,6 @@ class CloudGuestSessionCoordinator(
             )
         }
 
-        val activeRecoveryState = preferencesStore.loadCloudCredentialRecoveryState()
-        if (activeRecoveryState?.reason == CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
-            throw CloudCredentialRecoveryRequiredException(recoveryState = activeRecoveryState)
-        }
         val configuration = preferencesStore.currentServerConfiguration()
         val existingSession = loadGuestSessionForCurrentConfiguration(
             workspaceId = workspaceId,
@@ -249,6 +257,26 @@ class CloudGuestSessionCoordinator(
             session = resolvedSession,
             shouldSync = shouldSync
         )
+    }
+
+    private fun activeCredentialRecoveryReconciliationResultOrNull(
+        recoveryState: CloudCredentialRecoveryState?
+    ): CloudIdentityReconciliationResult? {
+        if (recoveryState == null) {
+            return null
+        }
+        preferencesStore.loadPendingGuestUpgrade()
+        return CloudIdentityReconciliationResult(
+            cloudSettings = preferencesStore.currentCloudSettings(),
+            restoredGuestSession = null,
+            guestRestoreRequiresSync = false,
+            didRunSync = false
+        )
+    }
+
+    private fun CloudCredentialRecoveryState.isPendingGuestUpgradeRecovery(): Boolean {
+        return reason == CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING &&
+            previousCloudState == CloudAccountState.GUEST
     }
 
     private fun markCloudCredentialRecoveryRequired(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalCloudAccountRepository.kt
@@ -28,12 +28,14 @@ import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceResetProgressP
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkContext
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspacePostAuthRoute
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.makeCustomCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.shouldRefreshCloudIdToken
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
+import java.util.Locale
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import org.json.JSONObject
@@ -102,7 +104,9 @@ class LocalCloudAccountRepository(
 
     override suspend fun prepareVerifiedSignIn(credentials: StoredCloudCredentials): CloudWorkspaceLinkContext {
         return operationCoordinator.runExclusive {
-            resumePendingGuestUpgradeIfNeeded()
+            if (preferencesStore.loadCloudCredentialRecoveryState() == null) {
+                resumePendingGuestUpgradeIfNeeded()
+            }
             val configuration = preferencesStore.currentServerConfiguration()
             buildCloudWorkspaceLinkContext(
                 credentials = credentials,
@@ -113,7 +117,16 @@ class LocalCloudAccountRepository(
 
     override suspend fun verifyCode(challenge: CloudOtpChallenge, code: String): CloudWorkspaceLinkContext {
         return operationCoordinator.runExclusive {
-            resumePendingGuestUpgradeIfNeeded()
+            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+            if (recoveryState?.reason == CloudCredentialRecoveryReason.INVALID_STORED_STATE) {
+                requirePendingGuestUpgradeStateIsDecodable()
+                return@runExclusive invalidStoredRecoveryLinkContext(
+                    credentials = blockedPostAuthRecoveryCredentials()
+                )
+            }
+            if (recoveryState == null) {
+                resumePendingGuestUpgradeIfNeeded()
+            }
             val configuration = preferencesStore.currentServerConfiguration()
             val credentials = remoteService.verifyCode(
                 challenge = challenge,
@@ -143,6 +156,16 @@ class LocalCloudAccountRepository(
         credentials: StoredCloudCredentials,
         configuration: CloudServiceConfiguration
     ): CloudWorkspaceLinkContext {
+        val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+        if (recoveryState != null) {
+            requirePendingGuestUpgradeStateIsDecodable()
+            return buildCloudWorkspaceRecoveryLinkContext(
+                credentials = credentials,
+                configuration = configuration,
+                recoveryState = recoveryState
+            )
+        }
+
         val accountSnapshot = fetchCloudAccount(credentials = credentials, configuration = configuration)
         val guestSession = activeGuestSession(configuration = configuration)
         val guestUpgradeMode = if (guestSession == null) {
@@ -154,19 +177,89 @@ class LocalCloudAccountRepository(
                 guestToken = guestSession.guestToken
             )
         }
-        val preferredWorkspaceId = resolvePostAuthPreferredWorkspaceId(
-            recoveryState = preferencesStore.loadCloudCredentialRecoveryState(),
-            configuration = configuration,
-            accountSnapshot = accountSnapshot
-        )
         return CloudWorkspaceLinkContext(
             userId = accountSnapshot.userId,
             email = accountSnapshot.email,
             credentials = credentials,
             workspaces = accountSnapshot.workspaces,
+            postAuthRoute = CloudWorkspacePostAuthRoute.NONE,
             guestUpgradeMode = guestUpgradeMode,
-            preferredWorkspaceId = preferredWorkspaceId
+            preferredWorkspaceId = resolvePreferredPostAuthWorkspaceId(workspaces = accountSnapshot.workspaces)
         )
+    }
+
+    private suspend fun buildCloudWorkspaceRecoveryLinkContext(
+        credentials: StoredCloudCredentials,
+        configuration: CloudServiceConfiguration,
+        recoveryState: CloudCredentialRecoveryState
+    ): CloudWorkspaceLinkContext {
+        if (recoveryState.reason == CloudCredentialRecoveryReason.INVALID_STORED_STATE) {
+            return invalidStoredRecoveryLinkContext(credentials = credentials)
+        }
+
+        val accountSnapshot = fetchCloudAccount(credentials = credentials, configuration = configuration)
+        return when (recoveryState.reason) {
+            CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING -> {
+                val route = if (recoveryState.previousCloudState == CloudAccountState.GUEST) {
+                    CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY
+                } else {
+                    CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE
+                }
+                CloudWorkspaceLinkContext(
+                    userId = accountSnapshot.userId,
+                    email = accountSnapshot.email,
+                    credentials = credentials,
+                    workspaces = accountSnapshot.workspaces,
+                    postAuthRoute = route,
+                    guestUpgradeMode = null,
+                    preferredWorkspaceId = resolveLinkedCredentialRecoveryPreferredWorkspaceIdOrNull(
+                        recoveryState = recoveryState,
+                        configuration = configuration,
+                        accountSnapshot = accountSnapshot
+                    )
+                )
+            }
+
+            CloudCredentialRecoveryReason.GUEST_SESSION_MISSING -> CloudWorkspaceLinkContext(
+                userId = accountSnapshot.userId,
+                email = accountSnapshot.email,
+                credentials = credentials,
+                workspaces = accountSnapshot.workspaces,
+                postAuthRoute = CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY,
+                guestUpgradeMode = null,
+                preferredWorkspaceId = resolvePreferredPostAuthWorkspaceId(workspaces = accountSnapshot.workspaces)
+            )
+
+            CloudCredentialRecoveryReason.INVALID_STORED_STATE -> error(
+                "Invalid recovery state must be handled before fetching a cloud account."
+            )
+        }
+    }
+
+    private fun invalidStoredRecoveryLinkContext(
+        credentials: StoredCloudCredentials
+    ): CloudWorkspaceLinkContext {
+        return CloudWorkspaceLinkContext(
+            userId = "",
+            email = null,
+            credentials = credentials,
+            workspaces = emptyList(),
+            postAuthRoute = CloudWorkspacePostAuthRoute.INVALID_STORED_STATE,
+            guestUpgradeMode = null,
+            preferredWorkspaceId = null
+        )
+    }
+
+    private fun blockedPostAuthRecoveryCredentials(): StoredCloudCredentials {
+        return StoredCloudCredentials(
+            refreshToken = "",
+            idToken = "",
+            idTokenExpiresAtMillis = 0L
+        )
+    }
+
+    private fun requirePendingGuestUpgradeStateIsDecodable() {
+        preferencesStore.loadPendingGuestUpgrade()
     }
 
     override suspend fun completeCloudLink(
@@ -174,17 +267,26 @@ class LocalCloudAccountRepository(
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary {
         return operationCoordinator.runExclusive {
-            val resumedGuestUpgrade = resumePendingGuestUpgradeIfNeeded()
+            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+            requirePostAuthRouteAllowsCloudLinkCompletion(
+                linkContext = linkContext,
+                recoveryState = recoveryState,
+                selection = selection
+            )
+            val resumedGuestUpgrade = if (recoveryState == null) {
+                resumePendingGuestUpgradeIfNeeded()
+            } else {
+                null
+            }
             if (resumedGuestUpgrade != null) {
                 return@runExclusive resumedGuestUpgrade
             }
-            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
             val authenticatedSession = authenticatedSession(linkContext = linkContext)
-            requireCloudLinkMatchesCredentialRecovery(
+            requireCloudLinkMatchesCredentialRecoveryBeforeSideEffects(
                 recoveryState = recoveryState,
                 authenticatedSession = authenticatedSession
             )
-            requireWorkspaceSelectionMatchesCredentialRecovery(
+            requireWorkspaceSelectionMatchesCredentialRecoveryBeforeSideEffects(
                 recoveryState = recoveryState,
                 selection = selection
             )
@@ -217,6 +319,13 @@ class LocalCloudAccountRepository(
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary {
         return operationCoordinator.runExclusive {
+            require(linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.NONE) {
+                "Guest upgrade cannot run while post-auth recovery is active."
+            }
+            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState()
+            if (recoveryState != null) {
+                throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+            }
             val resumedGuestUpgrade = resumePendingGuestUpgradeIfNeeded()
             if (resumedGuestUpgrade != null) {
                 return@runExclusive resumedGuestUpgrade
@@ -291,6 +400,17 @@ class LocalCloudAccountRepository(
                 selectedWorkspace = selectedWorkspace
             )
             selectedWorkspace
+        }
+    }
+
+    override suspend fun resetInvalidCloudCredentialRecoveryState() {
+        operationCoordinator.runExclusive {
+            val recoveryState = preferencesStore.loadCloudCredentialRecoveryState() ?: return@runExclusive
+            require(recoveryState.reason == CloudCredentialRecoveryReason.INVALID_STORED_STATE) {
+                "Invalid cloud credential recovery reset requires an invalid stored recovery state."
+            }
+            resetCoordinator.disconnectCloudIdentityPreservingLocalState()
+            preferencesStore.clearCloudCredentialRecoveryState()
         }
     }
 
@@ -703,103 +823,162 @@ class LocalCloudAccountRepository(
         }
     }
 
-    private fun requireCloudLinkMatchesCredentialRecovery(
+    private fun requirePostAuthRouteAllowsCloudLinkCompletion(
+        linkContext: CloudWorkspaceLinkContext,
+        recoveryState: CloudCredentialRecoveryState?,
+        selection: CloudWorkspaceLinkSelection
+    ) {
+        when (linkContext.postAuthRoute) {
+            CloudWorkspacePostAuthRoute.NONE -> {
+                if (recoveryState != null) {
+                    throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+                }
+            }
+
+            CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE -> {
+                val linkedRecoveryState = requireActiveCloudCredentialRecoveryState(
+                    recoveryState = recoveryState
+                )
+                if (linkedRecoveryState.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
+                    throw CloudCredentialRecoveryRequiredException(recoveryState = linkedRecoveryState)
+                }
+                requireWorkspaceSelectionMatchesCredentialRecoveryBeforeSideEffects(
+                    recoveryState = linkedRecoveryState,
+                    selection = selection
+                )
+            }
+
+            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY,
+            CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY,
+            CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> {
+                throw CloudCredentialRecoveryRequiredException(
+                    recoveryState = requireActiveCloudCredentialRecoveryState(
+                        recoveryState = recoveryState
+                    )
+                )
+            }
+        }
+    }
+
+    private fun requireActiveCloudCredentialRecoveryState(
+        recoveryState: CloudCredentialRecoveryState?
+    ): CloudCredentialRecoveryState {
+        return requireNotNull(recoveryState) {
+            "Cloud credential recovery state changed during sign-in. Start sign-in again."
+        }
+    }
+
+    private fun requireCloudLinkMatchesCredentialRecoveryBeforeSideEffects(
         recoveryState: CloudCredentialRecoveryState?,
         authenticatedSession: AuthenticatedCloudSession
     ) {
-        if (recoveryState?.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
-            return
-        }
-        if (
-            recoveryState.configurationMode != authenticatedSession.configuration.mode ||
-            recoveryState.apiBaseUrl != authenticatedSession.configuration.apiBaseUrl
-        ) {
-            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
-        }
+        when (recoveryState?.reason) {
+            null -> return
+            CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING -> {
+                if (
+                    linkedCredentialRecoveryConfigurationMatches(
+                        recoveryState = recoveryState,
+                        configuration = authenticatedSession.configuration
+                    ).not() ||
+                    linkedCredentialRecoveryIdentityMatches(
+                        recoveryState = recoveryState,
+                        userId = authenticatedSession.accountSnapshot.userId,
+                        email = authenticatedSession.accountSnapshot.email
+                    ).not()
+                ) {
+                    throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+                }
+            }
 
-        val linkedUserId = recoveryState.linkedUserId
-        if (linkedUserId != null) {
-            if (authenticatedSession.accountSnapshot.userId != linkedUserId) {
+            CloudCredentialRecoveryReason.GUEST_SESSION_MISSING,
+            CloudCredentialRecoveryReason.INVALID_STORED_STATE -> {
                 throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
             }
-            return
-        }
-
-        val linkedEmail = recoveryState.linkedEmail
-        if (
-            linkedEmail != null &&
-            authenticatedSession.accountSnapshot.email.equals(linkedEmail, ignoreCase = true).not()
-        ) {
-            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
         }
     }
 
-    private fun resolvePostAuthPreferredWorkspaceId(
-        recoveryState: CloudCredentialRecoveryState?,
+    private fun resolveLinkedCredentialRecoveryPreferredWorkspaceIdOrNull(
+        recoveryState: CloudCredentialRecoveryState,
         configuration: CloudServiceConfiguration,
         accountSnapshot: CloudAccountSnapshot
     ): String? {
-        val recoveryWorkspaceId = resolveCredentialRecoveryPreferredWorkspaceId(
-            recoveryState = recoveryState,
-            configuration = configuration,
-            accountSnapshot = accountSnapshot
-        )
-        return recoveryWorkspaceId ?: resolvePreferredPostAuthWorkspaceId(
-            workspaces = accountSnapshot.workspaces
-        )
-    }
-
-    private fun resolveCredentialRecoveryPreferredWorkspaceId(
-        recoveryState: CloudCredentialRecoveryState?,
-        configuration: CloudServiceConfiguration,
-        accountSnapshot: CloudAccountSnapshot
-    ): String? {
-        if (recoveryState?.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
-            return null
-        }
         if (
-            recoveryState.configurationMode != configuration.mode ||
-            recoveryState.apiBaseUrl != configuration.apiBaseUrl
+            recoveryState.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING ||
+            recoveryState.previousCloudState != CloudAccountState.LINKED ||
+            linkedCredentialRecoveryConfigurationMatches(
+                recoveryState = recoveryState,
+                configuration = configuration
+            ).not() ||
+            linkedCredentialRecoveryIdentityMatches(
+                recoveryState = recoveryState,
+                userId = accountSnapshot.userId,
+                email = accountSnapshot.email
+            ).not()
         ) {
             return null
         }
-
-        val linkedUserId = recoveryState.linkedUserId
-        if (linkedUserId != null && accountSnapshot.userId != linkedUserId) {
-            return null
+        val expectedWorkspaceId = recoveredWorkspaceId(recoveryState = recoveryState) ?: return null
+        return if (accountSnapshot.workspaces.any { workspace -> workspace.workspaceId == expectedWorkspaceId }) {
+            expectedWorkspaceId
+        } else {
+            null
         }
-
-        val linkedEmail = recoveryState.linkedEmail
-        if (
-            linkedUserId == null &&
-            linkedEmail != null &&
-            accountSnapshot.email.equals(linkedEmail, ignoreCase = true).not()
-        ) {
-            return null
-        }
-
-        return recoveredWorkspaceId(recoveryState = recoveryState)
     }
 
-    private fun requireWorkspaceSelectionMatchesCredentialRecovery(
+    private fun requireWorkspaceSelectionMatchesCredentialRecoveryBeforeSideEffects(
         recoveryState: CloudCredentialRecoveryState?,
         selection: CloudWorkspaceLinkSelection
     ) {
         if (recoveryState?.reason != CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING) {
             return
         }
+        if (recoveryState.previousCloudState != CloudAccountState.LINKED) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+        }
         val recoveredWorkspaceId = recoveredWorkspaceId(recoveryState = recoveryState)
         if (recoveredWorkspaceId == null) {
-            return
+            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
         }
 
         val selectedWorkspaceId = when (selection) {
             is CloudWorkspaceLinkSelection.Existing -> selection.workspaceId
-            CloudWorkspaceLinkSelection.CreateNew -> return
+            CloudWorkspaceLinkSelection.CreateNew -> throw CloudCredentialRecoveryRequiredException(
+                recoveryState = recoveryState
+            )
         }
         if (selectedWorkspaceId != recoveredWorkspaceId) {
             throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
         }
+    }
+
+    private fun linkedCredentialRecoveryConfigurationMatches(
+        recoveryState: CloudCredentialRecoveryState,
+        configuration: CloudServiceConfiguration
+    ): Boolean {
+        return recoveryState.previousCloudState == CloudAccountState.LINKED &&
+            recoveryState.configurationMode == configuration.mode &&
+            recoveryState.apiBaseUrl == configuration.apiBaseUrl
+    }
+
+    private fun linkedCredentialRecoveryIdentityMatches(
+        recoveryState: CloudCredentialRecoveryState,
+        userId: String,
+        email: String?
+    ): Boolean {
+        val linkedUserId = recoveryState.linkedUserId?.takeIf { storedUserId -> storedUserId.isNotBlank() }
+        if (linkedUserId != null) {
+            return userId == linkedUserId
+        }
+
+        val linkedEmail = normalizedCloudCredentialRecoveryEmail(email = recoveryState.linkedEmail)
+            ?: return false
+        return normalizedCloudCredentialRecoveryEmail(email = email) == linkedEmail
+    }
+
+    private fun normalizedCloudCredentialRecoveryEmail(email: String?): String? {
+        return email?.trim()
+            ?.lowercase(Locale.ROOT)
+            ?.takeIf { normalizedEmail -> normalizedEmail.isNotEmpty() }
     }
 
     private fun recoveredWorkspaceId(recoveryState: CloudCredentialRecoveryState): String? {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudAccountUiSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudAccountUiSupport.kt
@@ -95,7 +95,8 @@ internal fun currentWorkspaceSelectionErrorMessage(
 internal fun buildCloudPostAuthWorkspaceItems(
     preferredWorkspaceId: String?,
     workspaces: List<CloudWorkspaceSummary>,
-    strings: SettingsStringResolver
+    strings: SettingsStringResolver,
+    allowCreateNew: Boolean
 ): List<CurrentWorkspaceItemUiState> {
     val selectedWorkspaceId = when (
         val selection = buildAutomaticWorkspaceSelection(
@@ -107,7 +108,7 @@ internal fun buildCloudPostAuthWorkspaceItems(
         CloudWorkspaceLinkSelection.CreateNew,
         null -> null
     }
-    return workspaces.sortedByDescending(CloudWorkspaceSummary::createdAtMillis).map { workspace ->
+    val items = workspaces.sortedByDescending(CloudWorkspaceSummary::createdAtMillis).map { workspace ->
         CurrentWorkspaceItemUiState(
             workspaceId = workspace.workspaceId,
             title = workspace.name,
@@ -118,7 +119,12 @@ internal fun buildCloudPostAuthWorkspaceItems(
             isSelected = workspace.workspaceId == selectedWorkspaceId,
             isCreateNew = false
         )
-    } + CurrentWorkspaceItemUiState(
+    }
+    if (allowCreateNew.not()) {
+        return items
+    }
+
+    return items + CurrentWorkspaceItemUiState(
         workspaceId = "create-new",
         title = strings.get(R.string.settings_current_workspace_create_new_title),
         subtitle = strings.get(R.string.settings_current_workspace_create_new_summary),

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthRoute.kt
@@ -44,7 +44,7 @@ fun CloudPostAuthRoute(
     onAutoContinue: () -> Unit,
     onSelectWorkspace: (CloudWorkspaceLinkSelection) -> Unit,
     onRetry: () -> Unit,
-    onLogout: () -> Unit,
+    onFailureAction: () -> Unit,
     onBack: () -> Unit
 ) {
     LaunchedEffect(uiState.mode, uiState.pendingWorkspaceTitle) {
@@ -219,13 +219,15 @@ fun CloudPostAuthRoute(
                         Text(stringResource(R.string.settings_retry))
                     }
                 }
-                item {
-                    OutlinedButton(
-                        onClick = onLogout,
-                        enabled = uiState.canLogout && uiState.mode == CloudPostAuthMode.FAILED,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(stringResource(R.string.settings_logout))
+                if (uiState.canLogout) {
+                    item {
+                        OutlinedButton(
+                            onClick = onFailureAction,
+                            enabled = uiState.mode == CloudPostAuthMode.FAILED,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(uiState.failureActionLabel)
+                        }
                     }
                 }
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthUiState.kt
@@ -21,5 +21,6 @@ data class CloudPostAuthUiState(
     val errorMessage: String,
     val canRetry: Boolean,
     val canLogout: Boolean,
+    val failureActionLabel: String,
     val completionToken: Long?
 )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
@@ -7,11 +7,15 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
 import com.flashcardsopensourceapp.data.local.model.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.CloudSendCodeResult
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkContext
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspacePostAuthRoute
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import com.flashcardsopensourceapp.feature.settings.R
@@ -46,6 +50,11 @@ private sealed interface CloudPostAuthRetryAction {
     ) : CloudPostAuthRetryAction
 }
 
+private enum class CloudPostAuthFailureAction {
+    RESET_INVALID_RECOVERY,
+    LOGOUT
+}
+
 private data class CloudSignInDraftState(
     val authAttemptId: Long,
     val email: String,
@@ -60,6 +69,8 @@ private data class CloudSignInDraftState(
     val processingTitle: String,
     val processingMessage: String,
     val postAuthErrorMessage: String,
+    val postAuthRecoveryBlocked: Boolean,
+    val postAuthResetAllowed: Boolean,
     val retryAction: CloudPostAuthRetryAction?,
     val completionToken: Long?
 )
@@ -90,6 +101,8 @@ class CloudSignInViewModel(
             processingTitle = "",
             processingMessage = "",
             postAuthErrorMessage = "",
+            postAuthRecoveryBlocked = false,
+            postAuthResetAllowed = false,
             retryAction = null,
             completionToken = null
         )
@@ -139,7 +152,8 @@ class CloudSignInViewModel(
                 workspaces = buildCloudPostAuthWorkspaceItems(
                     preferredWorkspaceId = draft.linkContext?.preferredWorkspaceId,
                     workspaces = draft.linkContext?.workspaces ?: emptyList(),
-                    strings = strings
+                    strings = strings,
+                    allowCreateNew = draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE
                 ),
                 pendingWorkspaceTitle = draft.pendingSelection?.let { selection ->
                     workspaceSelectionTitle(
@@ -151,8 +165,9 @@ class CloudSignInViewModel(
                 processingTitle = draft.processingTitle,
                 processingMessage = draft.processingMessage,
                 errorMessage = draft.postAuthErrorMessage,
-                canRetry = draft.retryAction != null,
-                canLogout = draft.linkContext != null,
+                canRetry = draft.retryAction != null && draft.postAuthRecoveryBlocked.not(),
+                canLogout = canRunPostAuthFailureAction(draft = draft),
+                failureActionLabel = postAuthFailureActionLabel(resetAllowed = draft.postAuthResetAllowed),
                 completionToken = draft.completionToken
             )
         },
@@ -167,6 +182,7 @@ class CloudSignInViewModel(
             errorMessage = "",
             canRetry = false,
             canLogout = false,
+            failureActionLabel = strings.get(R.string.settings_logout),
             completionToken = null
         )
     )
@@ -191,11 +207,92 @@ class CloudSignInViewModel(
         return draftState.value.authAttemptId == authAttemptId
     }
 
+    private fun canRunPostAuthFailureAction(draft: CloudSignInDraftState): Boolean {
+        return resolvePostAuthFailureAction(draft = draft) != null
+    }
+
+    private fun resolvePostAuthFailureAction(draft: CloudSignInDraftState): CloudPostAuthFailureAction? {
+        return when {
+            draft.postAuthResetAllowed -> CloudPostAuthFailureAction.RESET_INVALID_RECOVERY
+            draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE &&
+                draft.postAuthRecoveryBlocked.not() -> CloudPostAuthFailureAction.LOGOUT
+            else -> null
+        }
+    }
+
+    private fun postAuthFailureActionLabel(resetAllowed: Boolean): String {
+        return if (resetAllowed) {
+            strings.get(R.string.settings_post_auth_reset_cloud_identity_button)
+        } else {
+            strings.get(R.string.settings_logout)
+        }
+    }
+
     private fun buildPendingSelection(linkContext: CloudWorkspaceLinkContext): CloudWorkspaceLinkSelection? {
-        return buildAutomaticWorkspaceSelection(
-            preferredWorkspaceId = linkContext.preferredWorkspaceId,
-            workspaces = linkContext.workspaces
-        )
+        return when (linkContext.postAuthRoute) {
+            CloudWorkspacePostAuthRoute.NONE -> buildAutomaticWorkspaceSelection(
+                preferredWorkspaceId = linkContext.preferredWorkspaceId,
+                workspaces = linkContext.workspaces
+            )
+
+            CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE -> {
+                val preferredWorkspaceId = linkContext.preferredWorkspaceId ?: return null
+                if (linkContext.workspaces.any { workspace -> workspace.workspaceId == preferredWorkspaceId }) {
+                    CloudWorkspaceLinkSelection.Existing(workspaceId = preferredWorkspaceId)
+                } else {
+                    null
+                }
+            }
+
+            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY,
+            CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY,
+            CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> null
+        }
+    }
+
+    private fun postAuthRecoveryErrorMessage(
+        linkContext: CloudWorkspaceLinkContext,
+        pendingSelection: CloudWorkspaceLinkSelection?
+    ): String {
+        return when (linkContext.postAuthRoute) {
+            CloudWorkspacePostAuthRoute.NONE -> ""
+            CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE -> {
+                if (pendingSelection == null) {
+                    strings.get(R.string.settings_post_auth_linked_recovery_blocked)
+                } else {
+                    ""
+                }
+            }
+            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> {
+                strings.get(R.string.settings_post_auth_guest_local_recovery_required)
+            }
+            CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY -> {
+                strings.get(R.string.settings_post_auth_pending_guest_upgrade_recovery_required)
+            }
+            CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> {
+                strings.get(R.string.settings_post_auth_invalid_recovery_state)
+            }
+        }
+    }
+
+    private fun postAuthRecoveryExceptionMessage(error: CloudCredentialRecoveryRequiredException): String {
+        return when (error.recoveryState.reason) {
+            CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING -> {
+                if (error.recoveryState.previousCloudState == CloudAccountState.GUEST) {
+                    strings.get(R.string.settings_post_auth_pending_guest_upgrade_recovery_required)
+                } else {
+                    strings.get(R.string.settings_post_auth_linked_recovery_blocked)
+                }
+            }
+
+            CloudCredentialRecoveryReason.GUEST_SESSION_MISSING -> {
+                strings.get(R.string.settings_post_auth_guest_local_recovery_required)
+            }
+
+            CloudCredentialRecoveryReason.INVALID_STORED_STATE -> {
+                strings.get(R.string.settings_post_auth_invalid_recovery_state)
+            }
+        }
     }
 
     private fun publishVerifiedLinkContext(
@@ -208,6 +305,11 @@ class CloudSignInViewModel(
             return false
         }
 
+        val pendingSelection = buildPendingSelection(linkContext)
+        val recoveryErrorMessage = postAuthRecoveryErrorMessage(
+            linkContext = linkContext,
+            pendingSelection = pendingSelection
+        )
         draftState.update { state ->
             if (state.authAttemptId != authAttemptId) {
                 return@update state
@@ -219,10 +321,16 @@ class CloudSignInViewModel(
                 errorTechnicalDetails = null,
                 challenge = null,
                 linkContext = linkContext,
-                pendingSelection = buildPendingSelection(linkContext),
+                pendingSelection = if (recoveryErrorMessage.isEmpty()) {
+                    pendingSelection
+                } else {
+                    null
+                },
                 processingTitle = "",
                 processingMessage = "",
-                postAuthErrorMessage = "",
+                postAuthErrorMessage = recoveryErrorMessage,
+                postAuthRecoveryBlocked = recoveryErrorMessage.isNotEmpty(),
+                postAuthResetAllowed = linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.INVALID_STORED_STATE,
                 retryAction = null,
                 completionToken = null
             )
@@ -246,6 +354,8 @@ class CloudSignInViewModel(
                 processingTitle = "",
                 processingMessage = "",
                 postAuthErrorMessage = "",
+                postAuthRecoveryBlocked = false,
+                postAuthResetAllowed = false,
                 retryAction = null,
                 completionToken = null
             )
@@ -267,6 +377,8 @@ class CloudSignInViewModel(
                             challenge = result.challenge,
                             linkContext = null,
                             pendingSelection = null,
+                            postAuthRecoveryBlocked = false,
+                            postAuthResetAllowed = false,
                             completionToken = null
                         )
                     }
@@ -324,6 +436,8 @@ class CloudSignInViewModel(
                 processingTitle = "",
                 processingMessage = "",
                 postAuthErrorMessage = "",
+                postAuthRecoveryBlocked = false,
+                postAuthResetAllowed = false,
                 retryAction = null,
                 completionToken = null
             )
@@ -418,12 +532,24 @@ class CloudSignInViewModel(
         }
     }
 
-    suspend fun logoutAfterPostAuthFailure() {
-        cloudAccountRepository.logout()
-        clearPostAuthState()
-        messageController.showMessage(
-            message = strings.get(R.string.settings_sign_in_cancelled_message)
-        )
+    suspend fun runPostAuthFailureAction() {
+        when (resolvePostAuthFailureAction(draft = draftState.value) ?: return) {
+            CloudPostAuthFailureAction.RESET_INVALID_RECOVERY -> {
+                cloudAccountRepository.resetInvalidCloudCredentialRecoveryState()
+                clearPostAuthState()
+                messageController.showMessage(
+                    message = strings.get(R.string.settings_post_auth_invalid_recovery_state_cleared_message)
+                )
+            }
+
+            CloudPostAuthFailureAction.LOGOUT -> {
+                cloudAccountRepository.logout()
+                clearPostAuthState()
+                messageController.showMessage(
+                    message = strings.get(R.string.settings_sign_in_cancelled_message)
+                )
+            }
+        }
     }
 
     fun acknowledgePostAuthCompletion() {
@@ -449,7 +575,8 @@ class CloudSignInViewModel(
             return
         }
 
-        val requiresGuestUpgrade = linkContext.guestUpgradeMode == CloudGuestUpgradeMode.MERGE_REQUIRED
+        val requiresGuestUpgrade = linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.NONE &&
+            linkContext.guestUpgradeMode == CloudGuestUpgradeMode.MERGE_REQUIRED
         val isGuestUpgrade = linkContext.guestUpgradeMode != null
         draftState.update { state ->
             if (state.authAttemptId != authAttemptId) {
@@ -468,6 +595,8 @@ class CloudSignInViewModel(
                     strings.get(R.string.settings_post_auth_linking_body)
                 },
                 postAuthErrorMessage = "",
+                postAuthRecoveryBlocked = false,
+                postAuthResetAllowed = false,
                 retryAction = if (requiresGuestUpgrade) {
                     CloudPostAuthRetryAction.CompleteGuestUpgrade(
                         authAttemptId = authAttemptId,
@@ -508,6 +637,7 @@ class CloudSignInViewModel(
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
             }
+            val recoveryError = error as? CloudCredentialRecoveryRequiredException
             draftState.update { state ->
                 if (state.authAttemptId != authAttemptId) {
                     return@update state
@@ -515,10 +645,22 @@ class CloudSignInViewModel(
                 state.copy(
                     processingTitle = "",
                     processingMessage = "",
-                    postAuthErrorMessage = error.message ?: if (requiresGuestUpgrade) {
-                        strings.get(R.string.settings_post_auth_guest_upgrade_failed)
+                    postAuthErrorMessage = if (recoveryError != null) {
+                        postAuthRecoveryExceptionMessage(error = recoveryError)
                     } else {
-                        strings.get(R.string.settings_post_auth_setup_failed)
+                        error.message ?: if (requiresGuestUpgrade) {
+                            strings.get(R.string.settings_post_auth_guest_upgrade_failed)
+                        } else {
+                            strings.get(R.string.settings_post_auth_setup_failed)
+                        }
+                    },
+                    postAuthRecoveryBlocked = recoveryError != null,
+                    postAuthResetAllowed = recoveryError?.recoveryState?.reason ==
+                        CloudCredentialRecoveryReason.INVALID_STORED_STATE,
+                    retryAction = if (recoveryError != null) {
+                        null
+                    } else {
+                        state.retryAction
                     }
                 )
             }
@@ -548,6 +690,8 @@ class CloudSignInViewModel(
                 processingTitle = strings.get(R.string.settings_post_auth_syncing_title),
                 processingMessage = strings.get(R.string.settings_post_auth_syncing_body),
                 postAuthErrorMessage = "",
+                postAuthRecoveryBlocked = false,
+                postAuthResetAllowed = false,
                 retryAction = CloudPostAuthRetryAction.SyncOnly(
                     authAttemptId = authAttemptId,
                     workspaceTitle = workspaceTitle
@@ -577,6 +721,8 @@ class CloudSignInViewModel(
                     processingTitle = "",
                     processingMessage = "",
                     postAuthErrorMessage = "",
+                    postAuthRecoveryBlocked = false,
+                    postAuthResetAllowed = false,
                     retryAction = null,
                     completionToken = System.currentTimeMillis()
                 )
@@ -588,6 +734,7 @@ class CloudSignInViewModel(
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
             }
+            val recoveryError = error as? CloudCredentialRecoveryRequiredException
             draftState.update { state ->
                 if (state.authAttemptId != authAttemptId) {
                     return@update state
@@ -595,7 +742,19 @@ class CloudSignInViewModel(
                 state.copy(
                     processingTitle = "",
                     processingMessage = "",
-                    postAuthErrorMessage = error.message ?: strings.get(R.string.settings_post_auth_sync_failed)
+                    postAuthErrorMessage = if (recoveryError != null) {
+                        postAuthRecoveryExceptionMessage(error = recoveryError)
+                    } else {
+                        error.message ?: strings.get(R.string.settings_post_auth_sync_failed)
+                    },
+                    postAuthRecoveryBlocked = recoveryError != null,
+                    postAuthResetAllowed = recoveryError?.recoveryState?.reason ==
+                        CloudCredentialRecoveryReason.INVALID_STORED_STATE,
+                    retryAction = if (recoveryError != null) {
+                        null
+                    } else {
+                        state.retryAction
+                    }
                 )
             }
         }
@@ -615,6 +774,8 @@ class CloudSignInViewModel(
                 processingTitle = "",
                 processingMessage = "",
                 postAuthErrorMessage = "",
+                postAuthRecoveryBlocked = false,
+                postAuthResetAllowed = false,
                 retryAction = null,
                 completionToken = null,
                 errorMessage = "",

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -411,6 +411,12 @@
     <string name="settings_post_auth_guest_upgrade_failed">Guest account upgrade failed.</string>
     <string name="settings_post_auth_setup_failed">Cloud workspace setup failed.</string>
     <string name="settings_post_auth_sync_failed">Initial sync failed.</string>
+    <string name="settings_post_auth_linked_recovery_blocked">Sign in with the original cloud account and workspace to reconnect preserved local data.</string>
+    <string name="settings_post_auth_guest_local_recovery_required">Guest credentials are missing on this device. Local data is preserved for recovery in a linked workspace.</string>
+    <string name="settings_post_auth_pending_guest_upgrade_recovery_required">Account upgrade recovery is pending. Reopen the app to finish recovery before signing in again.</string>
+    <string name="settings_post_auth_invalid_recovery_state">Cloud recovery data on this device is invalid. Reset cloud identity or sign in again after clearing recovery.</string>
+    <string name="settings_post_auth_reset_cloud_identity_button">Reset cloud identity</string>
+    <string name="settings_post_auth_invalid_recovery_state_cleared_message">Cloud recovery state was reset. Sign in again to continue.</string>
 
     <string name="settings_legal_support_title">Legal &amp; support</string>
     <string name="settings_legal_support_privacy_title">Privacy Policy</string>

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -5,6 +5,8 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryRequiredException
 import com.flashcardsopensourceapp.data.local.model.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.CloudProgressReviewSchedule
@@ -17,6 +19,7 @@ import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceDeletePreview
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceDeleteResult
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkContext
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.CloudWorkspacePostAuthRoute
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceResetProgressPreview
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceResetProgressResult
 import com.flashcardsopensourceapp.data.local.model.CloudWorkspaceSummary
@@ -78,6 +81,7 @@ class CloudSignInViewModelTest {
             email = "first@example.com",
             workspaceId = "workspace-first",
             workspaceName = "Workspace First",
+            postAuthRoute = CloudWorkspacePostAuthRoute.NONE,
             preferredWorkspaceId = "workspace-first"
         )
         val secondLinkContext = makeLinkContext(
@@ -85,6 +89,7 @@ class CloudSignInViewModelTest {
             email = "second@example.com",
             workspaceId = "workspace-second",
             workspaceName = "Workspace Second",
+            postAuthRoute = CloudWorkspacePostAuthRoute.NONE,
             preferredWorkspaceId = "workspace-second"
         )
         val blockedFirstPrepare = CompletableDeferred<CloudWorkspaceLinkContext>()
@@ -145,6 +150,7 @@ class CloudSignInViewModelTest {
                     email = "person@example.com",
                     workspaceId = "workspace-remote",
                     workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.NONE,
                     preferredWorkspaceId = "workspace-recovered"
                 )
             )
@@ -158,6 +164,289 @@ class CloudSignInViewModelTest {
         assertEquals(CloudPostAuthMode.CHOOSE_WORKSPACE, viewModel.postAuthUiState.value.mode)
         assertNull(viewModel.postAuthUiState.value.pendingWorkspaceTitle)
         assertEquals(false, viewModel.postAuthUiState.value.workspaces.first().isSelected)
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun guestLocalRecoveryShowsPostAuthFailureWithoutRetry() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-guest-recovery")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY,
+                    preferredWorkspaceId = "workspace-remote"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        val outcome = viewModel.sendCode()
+        advanceUntilIdle()
+
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, outcome)
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals(
+            "Guest credentials are missing on this device. Local data is preserved for recovery in a linked workspace.",
+            viewModel.postAuthUiState.value.errorMessage
+        )
+        assertEquals(false, viewModel.postAuthUiState.value.canRetry)
+        assertEquals(false, viewModel.postAuthUiState.value.canLogout)
+        assertEquals(false, viewModel.postAuthUiState.value.workspaces.any { workspace -> workspace.isCreateNew })
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun invalidStoredRecoveryShowsResetActionWithoutRetry() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-invalid-recovery")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.INVALID_STORED_STATE,
+                    preferredWorkspaceId = "workspace-remote"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        val outcome = viewModel.sendCode()
+        advanceUntilIdle()
+
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, outcome)
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals(
+            "Cloud recovery data on this device is invalid. Reset cloud identity or sign in again after clearing recovery.",
+            viewModel.postAuthUiState.value.errorMessage
+        )
+        assertEquals(false, viewModel.postAuthUiState.value.canRetry)
+        assertEquals(true, viewModel.postAuthUiState.value.canLogout)
+        assertEquals("Reset cloud identity", viewModel.postAuthUiState.value.failureActionLabel)
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun invalidStoredRecoveryFailureActionResetsRecoveryWithoutLogout() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val messages = mutableListOf<String>()
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { message -> messages.add(message) },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-invalid-recovery-reset")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.INVALID_STORED_STATE,
+                    preferredWorkspaceId = "workspace-remote"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        viewModel.sendCode()
+        advanceUntilIdle()
+        viewModel.runPostAuthFailureAction()
+        advanceUntilIdle()
+        viewModel.runPostAuthFailureAction()
+        advanceUntilIdle()
+
+        assertEquals(1, repository.resetInvalidCloudCredentialRecoveryStateCalls)
+        assertEquals(0, repository.logoutCalls)
+        assertEquals(
+            listOf("Cloud recovery state was reset. Sign in again to continue."),
+            messages
+        )
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun linkedCredentialRestoreTransientCompletionFailureKeepsRetry() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueCompleteCloudLinkError(IllegalStateException("Temporary setup failure."))
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-linked-restore")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-recovered",
+                    workspaceName = "Recovered",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE,
+                    preferredWorkspaceId = "workspace-recovered"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, viewModel.sendCode())
+        advanceUntilIdle()
+        viewModel.completePendingPostAuthIfNeeded()
+        advanceUntilIdle()
+
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals("Temporary setup failure.", viewModel.postAuthUiState.value.errorMessage)
+        assertEquals(true, viewModel.postAuthUiState.value.canRetry)
+        assertEquals(false, viewModel.postAuthUiState.value.canLogout)
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun routeNoneRecoveryCompletionFailureBlocksRetryAndLogout() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueCompleteCloudLinkError(
+            CloudCredentialRecoveryRequiredException(recoveryState = makeRecoveryState())
+        )
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-route-none-recovery")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.NONE,
+                    preferredWorkspaceId = "workspace-remote"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, viewModel.sendCode())
+        advanceUntilIdle()
+        viewModel.completePendingPostAuthIfNeeded()
+        advanceUntilIdle()
+
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals(
+            "Sign in with the original cloud account and workspace to reconnect preserved local data.",
+            viewModel.postAuthUiState.value.errorMessage
+        )
+        assertEquals(false, viewModel.postAuthUiState.value.canRetry)
+        assertEquals(false, viewModel.postAuthUiState.value.canLogout)
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun syncRecoveryFailureBlocksRetryAndLogout() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val syncRepository = FakeSyncRepository()
+        syncRepository.enqueueSyncError(
+            CloudCredentialRecoveryRequiredException(recoveryState = makeRecoveryState())
+        )
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = syncRepository,
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-sync-recovery")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.NONE,
+                    preferredWorkspaceId = "workspace-remote"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, viewModel.sendCode())
+        advanceUntilIdle()
+        viewModel.completePendingPostAuthIfNeeded()
+        advanceUntilIdle()
+
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals(
+            "Sign in with the original cloud account and workspace to reconnect preserved local data.",
+            viewModel.postAuthUiState.value.errorMessage
+        )
+        assertEquals(false, viewModel.postAuthUiState.value.canRetry)
+        assertEquals(false, viewModel.postAuthUiState.value.canLogout)
 
         postAuthCollection.cancel()
     }
@@ -278,6 +567,7 @@ class CloudSignInViewModelTest {
         email: String,
         workspaceId: String,
         workspaceName: String,
+        postAuthRoute: CloudWorkspacePostAuthRoute,
         preferredWorkspaceId: String
     ): CloudWorkspaceLinkContext {
         return CloudWorkspaceLinkContext(
@@ -292,8 +582,24 @@ class CloudSignInViewModelTest {
                     isSelected = true
                 )
             ),
+            postAuthRoute = postAuthRoute,
             guestUpgradeMode = null,
             preferredWorkspaceId = preferredWorkspaceId
+        )
+    }
+
+    private fun makeRecoveryState(): CloudCredentialRecoveryState {
+        return CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+            previousCloudState = CloudAccountState.LINKED,
+            installationId = "installation-1",
+            linkedUserId = "user-1",
+            linkedWorkspaceId = "workspace-local",
+            activeWorkspaceId = "workspace-local",
+            linkedEmail = "person@example.com",
+            configurationMode = makeOfficialCloudServiceConfiguration().mode,
+            apiBaseUrl = makeOfficialCloudServiceConfiguration().apiBaseUrl,
+            detectedAtMillis = 100L
         )
     }
 }
@@ -316,7 +622,12 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
     private val sendCodeResults = ArrayDeque<CloudSendCodeResult>()
     private val sendCodeErrors = ArrayDeque<Exception>()
     private val verifyCodeErrors = ArrayDeque<Exception>()
+    private val completeCloudLinkErrors = ArrayDeque<Exception>()
     private val preparedLinkContexts = mutableMapOf<String, CompletableDeferred<CloudWorkspaceLinkContext>>()
+    var resetInvalidCloudCredentialRecoveryStateCalls: Int = 0
+        private set
+    var logoutCalls: Int = 0
+        private set
 
     fun enqueueSendCodeResult(result: CloudSendCodeResult) {
         sendCodeResults.addLast(result)
@@ -328,6 +639,10 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
 
     fun enqueueVerifyCodeError(error: Exception) {
         verifyCodeErrors.addLast(error)
+    }
+
+    fun enqueueCompleteCloudLinkError(error: Exception) {
+        completeCloudLinkErrors.addLast(error)
     }
 
     fun enqueuePreparedLinkContext(
@@ -389,7 +704,23 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
         linkContext: CloudWorkspaceLinkContext,
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary {
-        throw UnsupportedOperationException()
+        if (completeCloudLinkErrors.isNotEmpty()) {
+            throw completeCloudLinkErrors.removeFirst()
+        }
+        return when (selection) {
+            is CloudWorkspaceLinkSelection.Existing -> requireNotNull(
+                linkContext.workspaces.firstOrNull { workspace -> workspace.workspaceId == selection.workspaceId }
+            ) {
+                "Selected workspace is missing from test link context."
+            }
+
+            CloudWorkspaceLinkSelection.CreateNew -> CloudWorkspaceSummary(
+                workspaceId = "workspace-new",
+                name = "Personal",
+                createdAtMillis = 200L,
+                isSelected = true
+            )
+        }
     }
 
     override suspend fun completeGuestUpgrade(
@@ -403,8 +734,12 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
         throw UnsupportedOperationException()
     }
 
+    override suspend fun resetInvalidCloudCredentialRecoveryState() {
+        resetInvalidCloudCredentialRecoveryStateCalls += 1
+    }
+
     override suspend fun logout() {
-        throw UnsupportedOperationException()
+        logoutCalls += 1
     }
 
     override suspend fun renameCurrentWorkspace(name: String): CloudWorkspaceSummary {
@@ -520,6 +855,28 @@ private class TestSettingsStringResolver : SettingsStringResolver {
 
             R.string.settings_post_auth_signed_in_and_synced -> "Signed in and synced %1\$s."
             R.string.settings_post_auth_sync_failed -> "Initial sync failed."
+            R.string.settings_post_auth_linked_recovery_blocked -> {
+                "Sign in with the original cloud account and workspace to reconnect preserved local data."
+            }
+
+            R.string.settings_post_auth_guest_local_recovery_required -> {
+                "Guest credentials are missing on this device. Local data is preserved for recovery in a linked workspace."
+            }
+
+            R.string.settings_post_auth_pending_guest_upgrade_recovery_required -> {
+                "Account upgrade recovery is pending. Reopen the app to finish recovery before signing in again."
+            }
+
+            R.string.settings_post_auth_invalid_recovery_state -> {
+                "Cloud recovery data on this device is invalid. Reset cloud identity or sign in again after clearing recovery."
+            }
+
+            R.string.settings_post_auth_reset_cloud_identity_button -> "Reset cloud identity"
+
+            R.string.settings_post_auth_invalid_recovery_state_cleared_message -> {
+                "Cloud recovery state was reset. Sign in again to continue."
+            }
+
             else -> error("Unexpected string resource id in CloudSignInViewModelTest: $stringResId")
         }
         return if (formatArgs.isEmpty()) {
@@ -539,6 +896,7 @@ private class TestSettingsStringResolver : SettingsStringResolver {
 }
 
 private class FakeSyncRepository : SyncRepository {
+    private val syncErrors = ArrayDeque<Exception>()
     private val syncStatus = MutableStateFlow(
         SyncStatusSnapshot(
             status = SyncStatus.Idle,
@@ -555,5 +913,12 @@ private class FakeSyncRepository : SyncRepository {
     }
 
     override suspend fun syncNow() {
+        if (syncErrors.isNotEmpty()) {
+            throw syncErrors.removeFirst()
+        }
+    }
+
+    fun enqueueSyncError(error: Exception) {
+        syncErrors.addLast(error)
     }
 }


### PR DESCRIPTION
## Summary
- add explicit Android post-auth recovery routes for linked restore, guest local recovery, pending guest upgrade recovery, and invalid stored state
- make corrupt credential recovery state observable as invalid instead of crashing while preserving corrupt payload until reset
- fail closed before identity side effects for recovery routes and add non-destructive invalid recovery reset handling
- update settings post-auth routing and focused Android tests for the decision matrix

## Validation
- `git diff --check`
- `git diff --check origin/main..HEAD`

Gradle was not run locally because this repository requires explicit approval for local Gradle runs.