### PR TITLE
[codex] Fix Android settings test resolver

### DIFF
--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -829,6 +829,7 @@ private class TestSettingsStringResolver : SettingsStringResolver {
             }
 
             R.string.settings_sign_in_verify_failed -> "Could not verify the code."
+            R.string.settings_logout -> "Log out"
             R.string.settings_current_workspace_create_new_title -> "Create new workspace"
             R.string.settings_current_workspace_create_new_summary -> {
                 "Start a new linked workspace in the cloud"


### PR DESCRIPTION
## Summary
- Add the existing settings_logout resource to the CloudSignInViewModel test string resolver.

## Why
- The ViewModel uses this resource while building post-auth UI state, and the test resolver should mirror the production string keys it exercises.

## Validation
- git --no-pager diff --cached --check