### PR TITLE
[codex] Implement Android guest local recovery

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositorySignInPreparationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloudidentity/LocalCloudAccountRepositorySignInPreparationTest.kt
@@ -644,7 +644,150 @@ class LocalCloudAccountRepositorySignInPreparationTest {
     }
 
     @Test
-    fun prepareVerifiedSignInRoutesGuestRecoveryWithoutGuestUpgradePrepare() = runBlocking {
+    fun completeCloudLinkGuestLocalRecoveryCreatesWorkspaceAndUploadsLocalData() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val syncLocalStore = environment.createSyncLocalStore()
+        val localCard = requireNotNull(environment.database.cardDao().loadCard(cardId = cardId)) {
+            "Seeded card is required for guest local recovery."
+        }
+        syncLocalStore.enqueueCardUpsert(
+            card = localCard,
+            tags = emptyList(),
+            affectsReviewSchedule = true
+        )
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.GUEST_SESSION_MISSING,
+            previousCloudState = CloudAccountState.GUEST,
+            installationId = installationId,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true),
+            bootstrapPushErrors = emptyList()
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        assertEquals(CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY, linkContext.postAuthRoute)
+        assertEquals("user-1", linkContext.userId)
+        assertNull(linkContext.guestUpgradeMode)
+        assertEquals(0, remoteGateway.prepareGuestUpgradeCalls)
+        val selectedWorkspace = repository.completeCloudLink(
+            linkContext = linkContext,
+            selection = CloudWorkspaceLinkSelection.CreateNew
+        )
+
+        val createdWorkspaceId = remoteGateway.createdWorkspaceId
+        assertEquals(createdWorkspaceId, selectedWorkspace.workspaceId)
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(1, remoteGateway.createWorkspaceCalls)
+        assertEquals(0, remoteGateway.completeGuestUpgradeCalls)
+        assertEquals(listOf(createdWorkspaceId), remoteGateway.bootstrapPullWorkspaceIds)
+        assertEquals(true, remoteGateway.bootstrapPushBodies.single().getJSONArray("entries").length() > 0)
+        assertEquals(1, remoteGateway.importReviewHistoryBodies.single().getJSONArray("reviewEvents").length())
+        assertEquals(1, remoteGateway.pushBodies.single().getJSONArray("operations").length())
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(createdWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(createdWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
+        assertEquals(1, environment.database.workspaceDao().countWorkspaces())
+        assertEquals(createdWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        val recoveredCards = environment.database.cardDao().loadCards(workspaceId = createdWorkspaceId)
+        assertEquals(1, recoveredCards.count())
+        assertEquals("Question", recoveredCards.single().frontText)
+        assertEquals("Answer", recoveredCards.single().backText)
+        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = createdWorkspaceId))
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+    }
+
+    @Test
+    fun completeCloudLinkGuestLocalRecoveryRetryUsesCreatedWorkspaceAfterInitialSyncFailure() = runBlocking {
+        val localWorkspaceId = environment.requireLocalWorkspaceId()
+        val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
+        val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
+        val syncLocalStore = environment.createSyncLocalStore()
+        val localCard = requireNotNull(environment.database.cardDao().loadCard(cardId = cardId)) {
+            "Seeded card is required for guest local recovery retry."
+        }
+        syncLocalStore.enqueueCardUpsert(
+            card = localCard,
+            tags = emptyList(),
+            affectsReviewSchedule = true
+        )
+        val recoveryState = CloudCredentialRecoveryState(
+            reason = CloudCredentialRecoveryReason.GUEST_SESSION_MISSING,
+            previousCloudState = CloudAccountState.GUEST,
+            installationId = installationId,
+            linkedUserId = "guest-user",
+            linkedWorkspaceId = localWorkspaceId,
+            activeWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            detectedAtMillis = 500L
+        )
+        val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
+            bootstrapRemoteIsEmptyResponses = listOf(true, true),
+            bootstrapPushErrors = listOf(IllegalStateException("Forced bootstrap failure"))
+        )
+        val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(recoveryState = recoveryState)
+        val linkContext = repository.prepareVerifiedSignIn(
+            credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        )
+
+        try {
+            repository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.CreateNew
+            )
+            throw AssertionError("Expected guest local recovery initial sync to fail.")
+        } catch (error: IllegalStateException) {
+            assertEquals(true, error.message?.contains("Forced bootstrap failure") == true)
+        }
+
+        val createdWorkspaceId = remoteGateway.createdWorkspaceId
+        assertEquals(1, remoteGateway.createWorkspaceCalls)
+        assertNotNull(environment.cloudPreferencesStore.loadCredentials())
+        assertEquals(recoveryState, environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(createdWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(createdWorkspaceId, environment.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId)
+        assertEquals(1, environment.database.cardDao().loadCards(workspaceId = createdWorkspaceId).count())
+        assertEquals(1, environment.database.reviewLogDao().countReviewLogs(workspaceId = createdWorkspaceId))
+        assertEquals(1, environment.database.outboxDao().countOutboxEntriesForWorkspace(workspaceId = createdWorkspaceId))
+
+        val recoveredWorkspace = repository.completeCloudLink(
+            linkContext = linkContext,
+            selection = CloudWorkspaceLinkSelection.CreateNew
+        )
+
+        assertEquals(createdWorkspaceId, recoveredWorkspace.workspaceId)
+        assertEquals(1, remoteGateway.createWorkspaceCalls)
+        assertEquals(0, remoteGateway.selectWorkspaceCalls)
+        assertEquals(0, remoteGateway.completeGuestUpgradeCalls)
+        assertEquals(listOf(createdWorkspaceId, createdWorkspaceId), remoteGateway.bootstrapPullWorkspaceIds)
+        assertEquals(2, remoteGateway.bootstrapPushBodies.size)
+        assertEquals(1, remoteGateway.importReviewHistoryBodies.single().getJSONArray("reviewEvents").length())
+        assertEquals(1, remoteGateway.pushBodies.single().getJSONArray("operations").length())
+        assertNull(environment.cloudPreferencesStore.loadCloudCredentialRecoveryState())
+        assertEquals(0, environment.database.outboxDao().countOutboxEntries())
+    }
+
+    @Test
+    fun completeCloudLinkRejectsExistingWorkspaceForGuestLocalRecoveryBeforeSideEffects() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
         val installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId
         val cardId = environment.seedWorkspaceData(workspaceId = localWorkspaceId)
@@ -662,7 +805,7 @@ class LocalCloudAccountRepositorySignInPreparationTest {
             detectedAtMillis = 500L
         )
         val remoteGateway = FakeCloudRemoteGateway.forBootstrapPushScenario(
-            bootstrapRemoteIsEmptyResponses = listOf(false),
+            bootstrapRemoteIsEmptyResponses = listOf(true),
             bootstrapPushErrors = emptyList()
         )
         val repository = environment.createCloudAccountRepository(remoteGateway = remoteGateway)
@@ -671,16 +814,12 @@ class LocalCloudAccountRepositorySignInPreparationTest {
             credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
         )
 
-        assertEquals(CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY, linkContext.postAuthRoute)
-        assertEquals("user-1", linkContext.userId)
-        assertNull(linkContext.guestUpgradeMode)
-        assertEquals(0, remoteGateway.prepareGuestUpgradeCalls)
         try {
             repository.completeCloudLink(
                 linkContext = linkContext,
                 selection = CloudWorkspaceLinkSelection.Existing(workspaceId = remoteWorkspaceId)
             )
-            throw AssertionError("Expected guest local recovery to block normal complete-link.")
+            throw AssertionError("Expected guest local recovery to reject an existing workspace.")
         } catch (error: CloudCredentialRecoveryRequiredException) {
             assertEquals(recoveryState, error.recoveryState)
         }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/LocalCloudAccountRepository.kt
@@ -273,6 +273,13 @@ class LocalCloudAccountRepository(
                 recoveryState = recoveryState,
                 selection = selection
             )
+            if (linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY) {
+                return@runExclusive completeGuestLocalRecoveryCloudLink(
+                    linkContext = linkContext,
+                    recoveryState = requireActiveCloudCredentialRecoveryState(recoveryState = recoveryState),
+                    selection = selection
+                )
+            }
             val resumedGuestUpgrade = if (recoveryState == null) {
                 resumePendingGuestUpgradeIfNeeded()
             } else {
@@ -848,7 +855,15 @@ class LocalCloudAccountRepository(
                 )
             }
 
-            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY,
+            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> {
+                requireGuestLocalRecoveryAllowsCreateNewCompletion(
+                    recoveryState = requireActiveCloudCredentialRecoveryState(
+                        recoveryState = recoveryState
+                    ),
+                    selection = selection
+                )
+            }
+
             CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY,
             CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> {
                 throw CloudCredentialRecoveryRequiredException(
@@ -865,6 +880,21 @@ class LocalCloudAccountRepository(
     ): CloudCredentialRecoveryState {
         return requireNotNull(recoveryState) {
             "Cloud credential recovery state changed during sign-in. Start sign-in again."
+        }
+    }
+
+    private fun requireGuestLocalRecoveryAllowsCreateNewCompletion(
+        recoveryState: CloudCredentialRecoveryState,
+        selection: CloudWorkspaceLinkSelection
+    ) {
+        if (
+            recoveryState.reason != CloudCredentialRecoveryReason.GUEST_SESSION_MISSING ||
+            recoveryState.previousCloudState != CloudAccountState.GUEST
+        ) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
+        }
+        if (selection != CloudWorkspaceLinkSelection.CreateNew) {
+            throw CloudCredentialRecoveryRequiredException(recoveryState = recoveryState)
         }
     }
 
@@ -1093,6 +1123,102 @@ class LocalCloudAccountRepository(
                 name = "Personal"
             )
         }
+    }
+
+    private suspend fun completeGuestLocalRecoveryCloudLink(
+        linkContext: CloudWorkspaceLinkContext,
+        recoveryState: CloudCredentialRecoveryState,
+        selection: CloudWorkspaceLinkSelection
+    ): CloudWorkspaceSummary {
+        require(linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY) {
+            "Guest local recovery requires the guest recovery post-auth route."
+        }
+        requireGuestLocalRecoveryAllowsCreateNewCompletion(
+            recoveryState = recoveryState,
+            selection = selection
+        )
+        val authenticatedSession = authenticatedSession(linkContext = linkContext)
+        loadResumableGuestLocalRecoveryWorkspaceOrNull(
+            authenticatedSession = authenticatedSession
+        )?.let { resumableWorkspace ->
+            preferencesStore.saveCredentials(authenticatedSession.credentials)
+            requireTransitionInvariant(
+                stage = "before resumed guest local recovery sync",
+                expectedWorkspaceId = resumableWorkspace.workspaceId
+            )
+            runInitialLinkedWorkspaceSync(
+                authenticatedSession = authenticatedSession,
+                workspaceId = resumableWorkspace.workspaceId
+            )
+            requireTransitionInvariant(
+                stage = "after resumed guest local recovery sync",
+                expectedWorkspaceId = resumableWorkspace.workspaceId
+            )
+            clearGuestSessionsIfNeeded()
+            preferencesStore.clearCloudCredentialRecoveryState()
+            return resumableWorkspace
+        }
+
+        val selectedWorkspace = remoteService.createWorkspace(
+            apiBaseUrl = authenticatedSession.configuration.apiBaseUrl,
+            bearerToken = authenticatedSession.credentials.idToken,
+            name = "Personal"
+        )
+        preferencesStore.saveCredentials(authenticatedSession.credentials)
+        applyLinkedWorkspacePreservingLocalData(
+            accountSnapshot = authenticatedSession.accountSnapshot,
+            selectedWorkspace = selectedWorkspace
+        )
+        requireTransitionInvariant(
+            stage = "after guest local recovery prefs update",
+            expectedWorkspaceId = selectedWorkspace.workspaceId
+        )
+        runInitialLinkedWorkspaceSync(
+            authenticatedSession = authenticatedSession,
+            workspaceId = selectedWorkspace.workspaceId
+        )
+        requireTransitionInvariant(
+            stage = "after guest local recovery initial sync",
+            expectedWorkspaceId = selectedWorkspace.workspaceId
+        )
+        clearGuestSessionsIfNeeded()
+        preferencesStore.clearCloudCredentialRecoveryState()
+        return selectedWorkspace
+    }
+
+    private suspend fun loadResumableGuestLocalRecoveryWorkspaceOrNull(
+        authenticatedSession: AuthenticatedCloudSession
+    ): CloudWorkspaceSummary? {
+        val cloudSettings = preferencesStore.currentCloudSettings()
+        if (cloudSettings.cloudState != CloudAccountState.LINKED) {
+            return null
+        }
+        require(cloudSettings.linkedUserId == authenticatedSession.accountSnapshot.userId) {
+            "Guest local recovery retry is signed in as '${authenticatedSession.accountSnapshot.userId}', " +
+                "but the preserved linked workspace belongs to '${cloudSettings.linkedUserId}'. Start sign-in again."
+        }
+        val workspaceId = requireNotNull(cloudSettings.activeWorkspaceId ?: cloudSettings.linkedWorkspaceId) {
+            "Guest local recovery retry requires a preserved linked workspace."
+        }
+        require(cloudSettings.linkedWorkspaceId == workspaceId) {
+            "Guest local recovery retry requires active workspace '$workspaceId' to match linked workspace " +
+                "'${cloudSettings.linkedWorkspaceId}'."
+        }
+        val localWorkspace = requireNotNull(
+            database.workspaceDao().loadWorkspaceById(workspaceId = workspaceId)
+        ) {
+            "Guest local recovery retry requires local workspace '$workspaceId'."
+        }
+        requireTransitionInvariant(
+            stage = "before guest local recovery retry",
+            expectedWorkspaceId = workspaceId
+        )
+        return CloudWorkspaceSummary(
+            workspaceId = localWorkspace.workspaceId,
+            name = localWorkspace.name,
+            createdAtMillis = localWorkspace.createdAtMillis,
+            isSelected = true
+        )
     }
 
     private suspend fun applyLinkedWorkspace(

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
@@ -153,7 +153,8 @@ class CloudSignInViewModel(
                     preferredWorkspaceId = draft.linkContext?.preferredWorkspaceId,
                     workspaces = draft.linkContext?.workspaces ?: emptyList(),
                     strings = strings,
-                    allowCreateNew = draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE
+                    allowCreateNew = draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE ||
+                        draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY
                 ),
                 pendingWorkspaceTitle = draft.pendingSelection?.let { selection ->
                     workspaceSelectionTitle(
@@ -244,7 +245,8 @@ class CloudSignInViewModel(
                 }
             }
 
-            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY,
+            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> CloudWorkspaceLinkSelection.CreateNew
+
             CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY,
             CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> null
         }
@@ -264,7 +266,7 @@ class CloudSignInViewModel(
                 }
             }
             CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> {
-                strings.get(R.string.settings_post_auth_guest_local_recovery_required)
+                ""
             }
             CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY -> {
                 strings.get(R.string.settings_post_auth_pending_guest_upgrade_recovery_required)
@@ -629,10 +631,17 @@ class CloudSignInViewModel(
                     selection = selection
                 )
             }
-            runPostAuthSyncOnly(
-                authAttemptId = authAttemptId,
-                workspaceTitle = workspace.name
-            )
+            if (linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY) {
+                finishPostAuthSuccess(
+                    authAttemptId = authAttemptId,
+                    workspaceTitle = workspace.name
+                )
+            } else {
+                runPostAuthSyncOnly(
+                    authAttemptId = authAttemptId,
+                    workspaceTitle = workspace.name
+                )
+            }
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
@@ -708,27 +717,9 @@ class CloudSignInViewModel(
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
             }
-            draftState.update { state ->
-                if (state.authAttemptId != authAttemptId) {
-                    return@update state
-                }
-                state.copy(
-                    email = "",
-                    code = "",
-                    challenge = null,
-                    linkContext = null,
-                    pendingSelection = null,
-                    processingTitle = "",
-                    processingMessage = "",
-                    postAuthErrorMessage = "",
-                    postAuthRecoveryBlocked = false,
-                    postAuthResetAllowed = false,
-                    retryAction = null,
-                    completionToken = System.currentTimeMillis()
-                )
-            }
-            messageController.showMessage(
-                message = strings.get(R.string.settings_post_auth_signed_in_and_synced, workspaceTitle)
+            finishPostAuthSuccess(
+                authAttemptId = authAttemptId,
+                workspaceTitle = workspaceTitle
             )
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
@@ -758,6 +749,37 @@ class CloudSignInViewModel(
                 )
             }
         }
+    }
+
+    private fun finishPostAuthSuccess(
+        authAttemptId: Long,
+        workspaceTitle: String
+    ) {
+        if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
+            return
+        }
+        draftState.update { state ->
+            if (state.authAttemptId != authAttemptId) {
+                return@update state
+            }
+            state.copy(
+                email = "",
+                code = "",
+                challenge = null,
+                linkContext = null,
+                pendingSelection = null,
+                processingTitle = "",
+                processingMessage = "",
+                postAuthErrorMessage = "",
+                postAuthRecoveryBlocked = false,
+                postAuthResetAllowed = false,
+                retryAction = null,
+                completionToken = System.currentTimeMillis()
+            )
+        }
+        messageController.showMessage(
+            message = strings.get(R.string.settings_post_auth_signed_in_and_synced, workspaceTitle)
+        )
     }
 
     private fun clearPostAuthState() {

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -169,13 +170,15 @@ class CloudSignInViewModelTest {
     }
 
     @Test
-    fun guestLocalRecoveryShowsPostAuthFailureWithoutRetry() = runTest(dispatcher) {
+    fun guestLocalRecoveryAutoCreatesNewWorkspaceWithoutSeparatePostAuthSync() = runTest(dispatcher) {
         Dispatchers.setMain(dispatcher)
         val repository = FakeCloudAccountRepository()
+        val syncRepository = FakeSyncRepository()
+        val messages = mutableListOf<String>()
         val viewModel = CloudSignInViewModel(
             cloudAccountRepository = repository,
-            syncRepository = FakeSyncRepository(),
-            messageController = TransientMessageController { },
+            syncRepository = syncRepository,
+            messageController = TransientMessageController { message -> messages += message },
             strings = strings
         )
         val postAuthCollection = backgroundScope.async {
@@ -202,14 +205,19 @@ class CloudSignInViewModelTest {
         advanceUntilIdle()
 
         assertEquals(CloudSendCodeNavigationOutcome.Verified, outcome)
-        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
-        assertEquals(
-            "Guest credentials are missing on this device. Local data is preserved for recovery in a linked workspace.",
-            viewModel.postAuthUiState.value.errorMessage
-        )
+        assertEquals(CloudPostAuthMode.READY_TO_AUTO_LINK, viewModel.postAuthUiState.value.mode)
+        assertEquals("New workspace", viewModel.postAuthUiState.value.pendingWorkspaceTitle)
+        assertEquals(true, viewModel.postAuthUiState.value.workspaces.any { workspace -> workspace.isCreateNew })
         assertEquals(false, viewModel.postAuthUiState.value.canRetry)
-        assertEquals(false, viewModel.postAuthUiState.value.canLogout)
-        assertEquals(false, viewModel.postAuthUiState.value.workspaces.any { workspace -> workspace.isCreateNew })
+
+        viewModel.completePendingPostAuthIfNeeded()
+        advanceUntilIdle()
+
+        assertEquals(listOf(CloudWorkspaceLinkSelection.CreateNew), repository.completeCloudLinkSelections)
+        assertEquals(0, syncRepository.syncNowCalls)
+        assertEquals(CloudPostAuthMode.IDLE, viewModel.postAuthUiState.value.mode)
+        assertNotNull(viewModel.postAuthUiState.value.completionToken)
+        assertEquals("Signed in and synced Personal.", messages.single())
 
         postAuthCollection.cancel()
     }
@@ -624,6 +632,7 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
     private val verifyCodeErrors = ArrayDeque<Exception>()
     private val completeCloudLinkErrors = ArrayDeque<Exception>()
     private val preparedLinkContexts = mutableMapOf<String, CompletableDeferred<CloudWorkspaceLinkContext>>()
+    val completeCloudLinkSelections = mutableListOf<CloudWorkspaceLinkSelection>()
     var resetInvalidCloudCredentialRecoveryStateCalls: Int = 0
         private set
     var logoutCalls: Int = 0
@@ -704,6 +713,7 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
         linkContext: CloudWorkspaceLinkContext,
         selection: CloudWorkspaceLinkSelection
     ): CloudWorkspaceSummary {
+        completeCloudLinkSelections += selection
         if (completeCloudLinkErrors.isNotEmpty()) {
             throw completeCloudLinkErrors.removeFirst()
         }
@@ -829,6 +839,7 @@ private class TestSettingsStringResolver : SettingsStringResolver {
             }
 
             R.string.settings_sign_in_verify_failed -> "Could not verify the code."
+            R.string.settings_current_workspace_new_title -> "New workspace"
             R.string.settings_current_workspace_create_new_title -> "Create new workspace"
             R.string.settings_current_workspace_create_new_summary -> {
                 "Start a new linked workspace in the cloud"
@@ -904,6 +915,8 @@ private class FakeSyncRepository : SyncRepository {
             lastErrorMessage = ""
         )
     )
+    var syncNowCalls: Int = 0
+        private set
 
     override fun observeSyncStatus(): Flow<SyncStatusSnapshot> {
         return syncStatus
@@ -913,6 +926,7 @@ private class FakeSyncRepository : SyncRepository {
     }
 
     override suspend fun syncNow() {
+        syncNowCalls += 1
         if (syncErrors.isNotEmpty()) {
             throw syncErrors.removeFirst()
         }


### PR DESCRIPTION
## Summary
- Complete Android `GUEST_LOCAL_RECOVERY` by creating a new linked workspace and preserving local SQLite data into it.
- Save email credentials, run the initial linked sync/bootstrap, and clear recovery state only after successful recovery.
- Update the Android post-auth flow to auto-create a workspace for guest local recovery without a duplicate sync step.

## Validation
- `git diff --check`
- Gradle not run locally per repository instructions requiring explicit approval for Android Gradle runs.