### PR TITLE
[codex] Fix Android guest recovery post-auth UI

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/CloudPostAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/CloudPostAuthRouteTest.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -36,6 +37,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         mode = CloudPostAuthMode.READY_TO_AUTO_LINK,
                         verifiedEmail = "user@example.com",
                         isGuestUpgrade = false,
+                        isGuestLocalRecovery = false,
                         workspaces = emptyList(),
                         pendingWorkspaceTitle = "Personal",
                         processingTitle = "",
@@ -76,6 +78,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         mode = CloudPostAuthMode.CHOOSE_WORKSPACE,
                         verifiedEmail = "user@example.com",
                         isGuestUpgrade = false,
+                        isGuestLocalRecovery = false,
                         workspaces = listOf(
                             CurrentWorkspaceItemUiState(
                                 workspaceId = "workspace-1",
@@ -137,6 +140,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         mode = CloudPostAuthMode.FAILED,
                         verifiedEmail = "user@example.com",
                         isGuestUpgrade = false,
+                        isGuestLocalRecovery = false,
                         workspaces = emptyList(),
                         pendingWorkspaceTitle = null,
                         processingTitle = "",
@@ -168,5 +172,95 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         }
         assertEquals(1, retryCalls)
         assertEquals(1, logoutCalls)
+    }
+
+    @Test
+    fun guestLocalRecoveryReadyStateShowsRecoveryCopyAndAutoContinues() {
+        var autoContinueCalls = 0
+
+        composeRule.setContent {
+            FlashcardsTheme {
+                CloudPostAuthRoute(
+                    uiState = CloudPostAuthUiState(
+                        mode = CloudPostAuthMode.READY_TO_AUTO_LINK,
+                        verifiedEmail = "user@example.com",
+                        isGuestUpgrade = false,
+                        isGuestLocalRecovery = true,
+                        workspaces = emptyList(),
+                        pendingWorkspaceTitle = null,
+                        processingTitle = "",
+                        processingMessage = "",
+                        errorMessage = "",
+                        canRetry = false,
+                        canLogout = false,
+                        failureActionLabel = "Log out",
+                        completionToken = null
+                    ),
+                    onAutoContinue = {
+                        autoContinueCalls += 1
+                    },
+                    onSelectWorkspace = {},
+                    onRetry = {},
+                    onFailureAction = {},
+                    onBack = {}
+                )
+            }
+        }
+
+        composeRule.waitUntil(timeoutMillis = 5_000L) {
+            autoContinueCalls == 1
+        }
+        composeRule.onNodeWithText("Preparing recovered workspace...").assertIsDisplayed()
+        composeRule.onNodeWithText("Create new workspace").assertDoesNotExist()
+        composeRule.onNodeWithContentDescription("Back").assertIsNotEnabled()
+        assertEquals(1, autoContinueCalls)
+    }
+
+    @Test
+    fun guestLocalRecoveryFailureShowsRetryWithoutLogoutAction() {
+        var retryCalls = 0
+        var failureActionCalls = 0
+
+        composeRule.setContent {
+            FlashcardsTheme {
+                CloudPostAuthRoute(
+                    uiState = CloudPostAuthUiState(
+                        mode = CloudPostAuthMode.FAILED,
+                        verifiedEmail = "user@example.com",
+                        isGuestUpgrade = false,
+                        isGuestLocalRecovery = true,
+                        workspaces = emptyList(),
+                        pendingWorkspaceTitle = null,
+                        processingTitle = "",
+                        processingMessage = "",
+                        errorMessage = "Local data recovery failed. Try again; local data stays on this device.",
+                        canRetry = true,
+                        canLogout = false,
+                        failureActionLabel = "Log out",
+                        completionToken = null
+                    ),
+                    onAutoContinue = {},
+                    onSelectWorkspace = {},
+                    onRetry = {
+                        retryCalls += 1
+                    },
+                    onFailureAction = {
+                        failureActionCalls += 1
+                    },
+                    onBack = {}
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(
+            "Local data recovery failed. Try again; local data stays on this device."
+        ).assertIsDisplayed()
+        composeRule.onNodeWithText("Retry").performClick()
+        composeRule.onNodeWithText("Log out").assertDoesNotExist()
+        composeRule.waitUntil(timeoutMillis = 5_000L) {
+            retryCalls == 1
+        }
+        assertEquals(1, retryCalls)
+        assertEquals(0, failureActionCalls)
     }
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthRoute.kt
@@ -89,7 +89,11 @@ fun CloudPostAuthRoute(
                         when (uiState.mode) {
                             CloudPostAuthMode.READY_TO_AUTO_LINK -> {
                                 Text(
-                                    if (uiState.isGuestUpgrade) {
+                                    if (uiState.isGuestLocalRecovery) {
+                                        stringResource(
+                                            R.string.settings_post_auth_prepare_guest_local_recovery_title
+                                        )
+                                    } else if (uiState.isGuestUpgrade) {
                                         stringResource(
                                             R.string.settings_post_auth_prepare_guest_title,
                                             uiState.pendingWorkspaceTitle

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPostAuthUiState.kt
@@ -14,6 +14,7 @@ data class CloudPostAuthUiState(
     val mode: CloudPostAuthMode,
     val verifiedEmail: String?,
     val isGuestUpgrade: Boolean,
+    val isGuestLocalRecovery: Boolean,
     val workspaces: List<CurrentWorkspaceItemUiState>,
     val pendingWorkspaceTitle: String?,
     val processingTitle: String,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
@@ -44,6 +44,11 @@ private sealed interface CloudPostAuthRetryAction {
         val selection: CloudWorkspaceLinkSelection
     ) : CloudPostAuthRetryAction
 
+    data class CompleteGuestLocalRecovery(
+        val authAttemptId: Long,
+        val linkContext: CloudWorkspaceLinkContext
+    ) : CloudPostAuthRetryAction
+
     data class SyncOnly(
         val authAttemptId: Long,
         val workspaceTitle: String
@@ -139,6 +144,8 @@ class CloudSignInViewModel(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
         transform = { draft ->
+            val isGuestLocalRecovery = draft.linkContext?.postAuthRoute ==
+                CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY
             CloudPostAuthUiState(
                 mode = when {
                     draft.postAuthErrorMessage.isNotEmpty() -> CloudPostAuthMode.FAILED
@@ -149,19 +156,27 @@ class CloudSignInViewModel(
                 },
                 verifiedEmail = draft.linkContext?.email,
                 isGuestUpgrade = draft.linkContext?.guestUpgradeMode != null,
-                workspaces = buildCloudPostAuthWorkspaceItems(
-                    preferredWorkspaceId = draft.linkContext?.preferredWorkspaceId,
-                    workspaces = draft.linkContext?.workspaces ?: emptyList(),
-                    strings = strings,
-                    allowCreateNew = draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE ||
-                        draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY
-                ),
-                pendingWorkspaceTitle = draft.pendingSelection?.let { selection ->
-                    workspaceSelectionTitle(
-                        selection = selection,
+                isGuestLocalRecovery = isGuestLocalRecovery,
+                workspaces = if (isGuestLocalRecovery) {
+                    emptyList()
+                } else {
+                    buildCloudPostAuthWorkspaceItems(
+                        preferredWorkspaceId = draft.linkContext?.preferredWorkspaceId,
                         workspaces = draft.linkContext?.workspaces ?: emptyList(),
-                        strings = strings
+                        strings = strings,
+                        allowCreateNew = draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE
                     )
+                },
+                pendingWorkspaceTitle = if (isGuestLocalRecovery) {
+                    null
+                } else {
+                    draft.pendingSelection?.let { selection ->
+                        workspaceSelectionTitle(
+                            selection = selection,
+                            workspaces = draft.linkContext?.workspaces ?: emptyList(),
+                            strings = strings
+                        )
+                    }
                 },
                 processingTitle = draft.processingTitle,
                 processingMessage = draft.processingMessage,
@@ -176,6 +191,7 @@ class CloudSignInViewModel(
             mode = CloudPostAuthMode.IDLE,
             verifiedEmail = null,
             isGuestUpgrade = false,
+            isGuestLocalRecovery = false,
             workspaces = emptyList(),
             pendingWorkspaceTitle = null,
             processingTitle = "",
@@ -522,6 +538,15 @@ class CloudSignInViewModel(
                     selection = retryAction.selection
                 )
             }
+            is CloudPostAuthRetryAction.CompleteGuestLocalRecovery -> {
+                if (retryAction.authAttemptId != currentAttemptId) {
+                    return
+                }
+                completeGuestLocalRecovery(
+                    authAttemptId = retryAction.authAttemptId,
+                    linkContext = retryAction.linkContext
+                )
+            }
             is CloudPostAuthRetryAction.SyncOnly -> {
                 if (retryAction.authAttemptId != currentAttemptId) {
                     return
@@ -574,6 +599,17 @@ class CloudSignInViewModel(
         }
 
         if (isPostAuthProcessing(state = draftState.value)) {
+            return
+        }
+
+        if (linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY) {
+            require(selection == CloudWorkspaceLinkSelection.CreateNew) {
+                "Guest local recovery must create the recovered linked workspace."
+            }
+            completeGuestLocalRecovery(
+                authAttemptId = authAttemptId,
+                linkContext = linkContext
+            )
             return
         }
 
@@ -631,17 +667,10 @@ class CloudSignInViewModel(
                     selection = selection
                 )
             }
-            if (linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY) {
-                finishPostAuthSuccess(
-                    authAttemptId = authAttemptId,
-                    workspaceTitle = workspace.name
-                )
-            } else {
-                runPostAuthSyncOnly(
-                    authAttemptId = authAttemptId,
-                    workspaceTitle = workspace.name
-                )
-            }
+            runPostAuthSyncOnly(
+                authAttemptId = authAttemptId,
+                workspaceTitle = workspace.name
+            )
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
@@ -662,6 +691,85 @@ class CloudSignInViewModel(
                         } else {
                             strings.get(R.string.settings_post_auth_setup_failed)
                         }
+                    },
+                    postAuthRecoveryBlocked = recoveryError != null,
+                    postAuthResetAllowed = recoveryError?.recoveryState?.reason ==
+                        CloudCredentialRecoveryReason.INVALID_STORED_STATE,
+                    retryAction = if (recoveryError != null) {
+                        null
+                    } else {
+                        state.retryAction
+                    }
+                )
+            }
+        }
+    }
+
+    private suspend fun completeGuestLocalRecovery(
+        authAttemptId: Long,
+        linkContext: CloudWorkspaceLinkContext
+    ) {
+        if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
+            return
+        }
+
+        if (isPostAuthProcessing(state = draftState.value)) {
+            return
+        }
+
+        draftState.update { state ->
+            if (state.authAttemptId != authAttemptId) {
+                return@update state
+            }
+            state.copy(
+                pendingSelection = null,
+                processingTitle = strings.get(
+                    R.string.settings_post_auth_recovering_local_data_title
+                ),
+                processingMessage = strings.get(
+                    R.string.settings_post_auth_recovering_local_data_body
+                ),
+                postAuthErrorMessage = "",
+                postAuthRecoveryBlocked = false,
+                postAuthResetAllowed = false,
+                retryAction = CloudPostAuthRetryAction.CompleteGuestLocalRecovery(
+                    authAttemptId = authAttemptId,
+                    linkContext = linkContext
+                )
+            )
+        }
+
+        if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
+            return
+        }
+
+        try {
+            val workspace = cloudAccountRepository.completeCloudLink(
+                linkContext = linkContext,
+                selection = CloudWorkspaceLinkSelection.CreateNew
+            )
+            finishPostAuthSuccess(
+                authAttemptId = authAttemptId,
+                workspaceTitle = workspace.name
+            )
+        } catch (error: Exception) {
+            if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
+                return
+            }
+            val recoveryError = error as? CloudCredentialRecoveryRequiredException
+            draftState.update { state ->
+                if (state.authAttemptId != authAttemptId) {
+                    return@update state
+                }
+                state.copy(
+                    processingTitle = "",
+                    processingMessage = "",
+                    postAuthErrorMessage = if (recoveryError != null) {
+                        postAuthRecoveryExceptionMessage(error = recoveryError)
+                    } else {
+                        error.message ?: strings.get(
+                            R.string.settings_post_auth_guest_local_recovery_failed
+                        )
                     },
                     postAuthRecoveryBlocked = recoveryError != null,
                     postAuthResetAllowed = recoveryError?.recoveryState?.reason ==

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -395,6 +395,7 @@
     <string name="settings_post_auth_title">Cloud sync</string>
     <string name="settings_post_auth_prepare_title">Preparing %1$s...</string>
     <string name="settings_post_auth_prepare_guest_title">Preparing to upgrade Guest AI into %1$s...</string>
+    <string name="settings_post_auth_prepare_guest_local_recovery_title">Preparing recovered workspace...</string>
     <string name="settings_post_auth_choose_workspace_body">Choose a linked workspace to open on this Android device, or create a new one.</string>
     <string name="settings_post_auth_choose_guest_workspace_body">Choose the linked workspace that should receive this Guest AI session, or create a new one.</string>
     <string name="settings_post_auth_current_workspace_suffix">%1$s (Current)</string>
@@ -403,11 +404,14 @@
     <string name="settings_post_auth_idle">Cloud account setup is idle.</string>
     <string name="settings_post_auth_upgrading_title">Upgrading guest account</string>
     <string name="settings_post_auth_linking_title">Linking workspace</string>
+    <string name="settings_post_auth_recovering_local_data_title">Recovering local data</string>
     <string name="settings_post_auth_upgrading_body">Preparing your Guest AI session for a linked Android cloud account.</string>
     <string name="settings_post_auth_linking_body">Preparing your cloud workspace on this Android device.</string>
+    <string name="settings_post_auth_recovering_local_data_body">Keep this screen open while Android reconnects preserved local data to your recovered workspace.</string>
     <string name="settings_post_auth_syncing_title">Syncing workspace</string>
     <string name="settings_post_auth_syncing_body">Keep this screen open while Android finishes the initial cloud sync.</string>
     <string name="settings_post_auth_signed_in_and_synced">Signed in and synced %1$s.</string>
+    <string name="settings_post_auth_guest_local_recovery_failed">Local data recovery failed. Try again; local data stays on this device.</string>
     <string name="settings_post_auth_guest_upgrade_failed">Guest account upgrade failed.</string>
     <string name="settings_post_auth_setup_failed">Cloud workspace setup failed.</string>
     <string name="settings_post_auth_sync_failed">Initial sync failed.</string>

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -170,7 +170,7 @@ class CloudSignInViewModelTest {
     }
 
     @Test
-    fun guestLocalRecoveryAutoCreatesNewWorkspaceWithoutSeparatePostAuthSync() = runTest(dispatcher) {
+    fun guestLocalRecoveryAutoCreatesNewWorkspaceAndCompletes() = runTest(dispatcher) {
         Dispatchers.setMain(dispatcher)
         val repository = FakeCloudAccountRepository()
         val syncRepository = FakeSyncRepository()
@@ -185,6 +185,8 @@ class CloudSignInViewModelTest {
             viewModel.postAuthUiState.collect()
         }
         val credentials = makeCredentials(idToken = "id-token-guest-recovery")
+        val recoveryWorkspace = CompletableDeferred<CloudWorkspaceSummary>()
+        repository.enqueueCompleteCloudLinkResult(result = recoveryWorkspace)
         repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
         repository.enqueuePreparedLinkContext(
             idToken = credentials.idToken,
@@ -206,17 +208,102 @@ class CloudSignInViewModelTest {
 
         assertEquals(CloudSendCodeNavigationOutcome.Verified, outcome)
         assertEquals(CloudPostAuthMode.READY_TO_AUTO_LINK, viewModel.postAuthUiState.value.mode)
-        assertEquals("New workspace", viewModel.postAuthUiState.value.pendingWorkspaceTitle)
-        assertEquals(true, viewModel.postAuthUiState.value.workspaces.any { workspace -> workspace.isCreateNew })
+        assertEquals(true, viewModel.postAuthUiState.value.isGuestLocalRecovery)
+        assertNull(viewModel.postAuthUiState.value.pendingWorkspaceTitle)
+        assertEquals(0, viewModel.postAuthUiState.value.workspaces.size)
         assertEquals(false, viewModel.postAuthUiState.value.canRetry)
+        assertEquals(false, viewModel.postAuthUiState.value.canLogout)
 
-        viewModel.completePendingPostAuthIfNeeded()
+        val completionJob = backgroundScope.async {
+            viewModel.completePendingPostAuthIfNeeded()
+        }
         advanceUntilIdle()
 
+        assertEquals(CloudPostAuthMode.PROCESSING, viewModel.postAuthUiState.value.mode)
+        assertEquals("Recovering local data", viewModel.postAuthUiState.value.processingTitle)
+        assertEquals(
+            "Keep this screen open while Android reconnects preserved local data to your recovered workspace.",
+            viewModel.postAuthUiState.value.processingMessage
+        )
+        assertEquals(listOf(CloudWorkspaceLinkSelection.CreateNew), repository.completeCloudLinkSelections)
+        assertEquals(0, syncRepository.syncNowCalls)
+
+        recoveryWorkspace.complete(
+            CloudWorkspaceSummary(
+                workspaceId = "workspace-new",
+                name = "Personal",
+                createdAtMillis = 200L,
+                isSelected = true
+            )
+        )
+        advanceUntilIdle()
+
+        completionJob.await()
         assertEquals(listOf(CloudWorkspaceLinkSelection.CreateNew), repository.completeCloudLinkSelections)
         assertEquals(0, syncRepository.syncNowCalls)
         assertEquals(CloudPostAuthMode.IDLE, viewModel.postAuthUiState.value.mode)
         assertNotNull(viewModel.postAuthUiState.value.completionToken)
+        assertEquals("Signed in and synced Personal.", messages.single())
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun guestLocalRecoveryTransientFailureRetriesWithoutLogoutOrReset() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueCompleteCloudLinkError(IllegalStateException("Temporary recovery failure."))
+        val syncRepository = FakeSyncRepository()
+        val messages = mutableListOf<String>()
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = syncRepository,
+            messageController = TransientMessageController { message -> messages += message },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-guest-recovery-retry")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY,
+                    preferredWorkspaceId = "workspace-remote"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, viewModel.sendCode())
+        advanceUntilIdle()
+        viewModel.completePendingPostAuthIfNeeded()
+        advanceUntilIdle()
+
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals("Temporary recovery failure.", viewModel.postAuthUiState.value.errorMessage)
+        assertEquals(true, viewModel.postAuthUiState.value.isGuestLocalRecovery)
+        assertEquals(true, viewModel.postAuthUiState.value.canRetry)
+        assertEquals(false, viewModel.postAuthUiState.value.canLogout)
+        assertEquals(listOf(CloudWorkspaceLinkSelection.CreateNew), repository.completeCloudLinkSelections)
+
+        viewModel.retryPostAuth()
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(CloudWorkspaceLinkSelection.CreateNew, CloudWorkspaceLinkSelection.CreateNew),
+            repository.completeCloudLinkSelections
+        )
+        assertEquals(0, syncRepository.syncNowCalls)
+        assertEquals(0, repository.logoutCalls)
+        assertEquals(0, repository.resetInvalidCloudCredentialRecoveryStateCalls)
+        assertEquals(CloudPostAuthMode.IDLE, viewModel.postAuthUiState.value.mode)
         assertEquals("Signed in and synced Personal.", messages.single())
 
         postAuthCollection.cancel()
@@ -631,6 +718,7 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
     private val sendCodeErrors = ArrayDeque<Exception>()
     private val verifyCodeErrors = ArrayDeque<Exception>()
     private val completeCloudLinkErrors = ArrayDeque<Exception>()
+    private val completeCloudLinkResults = ArrayDeque<CompletableDeferred<CloudWorkspaceSummary>>()
     private val preparedLinkContexts = mutableMapOf<String, CompletableDeferred<CloudWorkspaceLinkContext>>()
     val completeCloudLinkSelections = mutableListOf<CloudWorkspaceLinkSelection>()
     var resetInvalidCloudCredentialRecoveryStateCalls: Int = 0
@@ -652,6 +740,10 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
 
     fun enqueueCompleteCloudLinkError(error: Exception) {
         completeCloudLinkErrors.addLast(error)
+    }
+
+    fun enqueueCompleteCloudLinkResult(result: CompletableDeferred<CloudWorkspaceSummary>) {
+        completeCloudLinkResults.addLast(result)
     }
 
     fun enqueuePreparedLinkContext(
@@ -716,6 +808,9 @@ private class FakeCloudAccountRepository : CloudAccountRepository {
         completeCloudLinkSelections += selection
         if (completeCloudLinkErrors.isNotEmpty()) {
             throw completeCloudLinkErrors.removeFirst()
+        }
+        if (completeCloudLinkResults.isNotEmpty()) {
+            return completeCloudLinkResults.removeFirst().await()
         }
         return when (selection) {
             is CloudWorkspaceLinkSelection.Existing -> requireNotNull(
@@ -850,12 +945,17 @@ private class TestSettingsStringResolver : SettingsStringResolver {
             R.string.settings_never -> "Never"
             R.string.settings_post_auth_upgrading_title -> "Upgrading guest account"
             R.string.settings_post_auth_linking_title -> "Linking workspace"
+            R.string.settings_post_auth_recovering_local_data_title -> "Recovering local data"
             R.string.settings_post_auth_upgrading_body -> {
                 "Preparing your Guest AI session for a linked Android cloud account."
             }
 
             R.string.settings_post_auth_linking_body -> {
                 "Preparing your cloud workspace on this Android device."
+            }
+
+            R.string.settings_post_auth_recovering_local_data_body -> {
+                "Keep this screen open while Android reconnects preserved local data to your recovered workspace."
             }
 
             R.string.settings_post_auth_guest_upgrade_failed -> "Guest account upgrade failed."
@@ -866,6 +966,10 @@ private class TestSettingsStringResolver : SettingsStringResolver {
             }
 
             R.string.settings_post_auth_signed_in_and_synced -> "Signed in and synced %1\$s."
+            R.string.settings_post_auth_guest_local_recovery_failed -> {
+                "Local data recovery failed. Try again; local data stays on this device."
+            }
+
             R.string.settings_post_auth_sync_failed -> "Initial sync failed."
             R.string.settings_post_auth_linked_recovery_blocked -> {
                 "Sign in with the original cloud account and workspace to reconnect preserved local data."


### PR DESCRIPTION
## Summary
- route Android GUEST_LOCAL_RECOVERY through a recovery completion UI path
- hide the workspace picker and primary logout/reset action for valid guest recovery
- add recovery-specific progress and retry coverage

## Validation
- git --no-pager diff --check
- xmllint --noout apps/android/feature/settings/src/main/res/values/strings.xml

Gradle was not run locally because repository instructions require explicit approval for local Gradle runs.