### PR TITLE
[codex] Fix Android guest recovery test synchronization

### DIFF
--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -214,7 +214,7 @@ class CloudSignInViewModelTest {
         assertEquals(false, viewModel.postAuthUiState.value.canRetry)
         assertEquals(false, viewModel.postAuthUiState.value.canLogout)
 
-        val completionJob = backgroundScope.async {
+        val completionJob = async {
             viewModel.completePendingPostAuthIfNeeded()
         }
         advanceUntilIdle()
@@ -239,6 +239,7 @@ class CloudSignInViewModelTest {
         advanceUntilIdle()
 
         completionJob.await()
+        advanceUntilIdle()
         assertEquals(listOf(CloudWorkspaceLinkSelection.CreateNew), repository.completeCloudLinkSelections)
         assertEquals(0, syncRepository.syncNowCalls)
         assertEquals(CloudPostAuthMode.IDLE, viewModel.postAuthUiState.value.mode)


### PR DESCRIPTION
## Summary
- make the guest local recovery ViewModel test run post-auth completion in the test scope instead of the background scope
- flush the test scheduler after the completion job finishes so the final StateFlow state is observed deterministically

## Root Cause
The new test asserted intermediate and final post-auth states around a suspended recovery completion. Running that operation from `backgroundScope` made the scheduler timing less deterministic in CI, so the test could observe stale state.

## Validation
- `git --no-pager diff --check`

Gradle was not run locally because repository instructions require explicit approval for local Gradle runs.