### PR TITLE
Implement iOS guest local recovery

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -18,7 +18,8 @@ extension FlashcardsStore {
                 throw LocalStoreError.uninitialized("Flashcards store is unavailable")
             }
 
-            if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
+            if linkContext.postAuthRecoveryRoute == .guestLocalRecovery
+                || linkContext.postAuthRecoveryRoute == .pendingGuestUpgradeMissingGuestSessionRecovery {
                 try self.throwIfGuestLocalRecoveryRequired()
             }
             guard let guestUpgradeMode = linkContext.guestUpgradeMode else {
@@ -153,10 +154,27 @@ extension FlashcardsStore {
         }
         guard try self.loadUsableGuestSessionForCurrentConfiguration() != nil else {
             try self.markPendingGuestUpgradeGuestSessionMissing(detectedAt: detectedAt)
-            return .guestLocalRecovery
+            return .pendingGuestUpgradeMissingGuestSessionRecovery
         }
 
         return .pendingGuestUpgradeRecovery
+    }
+
+    func validateNoPendingGuestUpgradeStateForGuestLocalRecovery(apiBaseUrl: String) throws {
+        guard let pendingGuestUpgradeState = try self.loadPendingGuestUpgradeState() else {
+            return
+        }
+
+        let configuration = try self.currentCloudServiceConfiguration()
+        guard pendingGuestUpgradeState.common.apiBaseUrl == apiBaseUrl
+            && pendingGuestUpgradeState.common.configurationMode == configuration.mode else {
+            return
+        }
+
+        self.blockCloudSyncForCredentialRecoveryIfNeeded()
+        throw LocalStoreError.validation(
+            localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+        )
     }
 
     func shouldPrepareGuestUpgradeModeForCloudLink(apiBaseUrl: String) throws -> Bool {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -345,6 +345,13 @@ final class CloudSessionRuntime {
         }
     }
 
+    func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        let cloudSyncService = try requireCloudSyncService(cloudSyncService: self.cloudSyncService)
+        return try await self.runCloudSyncTask {
+            try await cloudSyncService.runGuestLocalRecoveryLinkedSync(linkedSession: linkedSession)
+        }
+    }
+
     func runFreshLinkedSyncAfterActiveSyncSettles(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
         let cloudSyncService = try requireCloudSyncService(cloudSyncService: self.cloudSyncService)
         await self.waitForActiveCloudSyncToSettle()

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudCredentialRecovery.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudCredentialRecovery.swift
@@ -209,10 +209,48 @@ extension FlashcardsStore {
                 apiBaseUrl: linkContext.apiBaseUrl
             )
         case .guestLocalRecovery:
+            try self.validateGuestLocalRecoveryBeforeCloudLinkCompletion(
+                linkContext: linkContext,
+                selection: selection
+            )
+        case .pendingGuestUpgradeMissingGuestSessionRecovery:
             try self.throwIfGuestLocalRecoveryRequired()
         case .pendingGuestUpgradeRecovery:
             return
         }
+    }
+
+    @discardableResult
+    func validateGuestLocalRecoveryBeforeCloudLinkCompletion(
+        linkContext: CloudWorkspaceLinkContext,
+        selection: CloudWorkspaceLinkSelection
+    ) throws -> CloudCredentialRecoveryState {
+        guard let recoveryState = self.cloudCredentialRecoveryState else {
+            throw LocalStoreError.uninitialized("Guest local recovery state is unavailable")
+        }
+
+        try self.validateGuestLocalRecoveryState(
+            recoveryState: recoveryState,
+            apiBaseUrl: linkContext.apiBaseUrl
+        )
+        guard linkContext.guestUpgradeMode == nil else {
+            self.blockCloudSyncForCredentialRecovery()
+            throw LocalStoreError.validation(
+                localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+            )
+        }
+        switch selection {
+        case .createNew:
+            break
+        case .existing:
+            self.blockCloudSyncForCredentialRecovery()
+            throw LocalStoreError.validation(
+                localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+            )
+        }
+
+        try self.validateNoPendingGuestUpgradeStateForGuestLocalRecovery(apiBaseUrl: linkContext.apiBaseUrl)
+        return recoveryState
     }
 
     func throwIfGuestLocalRecoveryRequired() throws {
@@ -239,6 +277,10 @@ extension FlashcardsStore {
 
         switch recoveryState.reason {
         case .guestSessionMissing:
+            try self.validateGuestLocalRecoveryState(
+                recoveryState: recoveryState,
+                apiBaseUrl: linkedSession.apiBaseUrl
+            )
             return true
         case .linkedCredentialsMissing:
             try self.validateLinkedCredentialRecoveryConfiguration(
@@ -466,6 +508,29 @@ extension FlashcardsStore {
         }
 
         return nil
+    }
+
+    func validateGuestLocalRecoveryState(
+        recoveryState: CloudCredentialRecoveryState,
+        apiBaseUrl: String
+    ) throws {
+        guard recoveryState.reason == .guestSessionMissing,
+            recoveryState.previousCloudState == .guest,
+            recoveryState.apiBaseUrl == apiBaseUrl else {
+            self.blockCloudSyncForCredentialRecovery()
+            throw LocalStoreError.validation(
+                localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+            )
+        }
+
+        let configuration = try self.currentCloudServiceConfiguration()
+        guard recoveryState.configurationMode == configuration.mode,
+            recoveryState.apiBaseUrl == configuration.apiBaseUrl else {
+            self.blockCloudSyncForCredentialRecovery()
+            throw LocalStoreError.validation(
+                localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+            )
+        }
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudLink.swift
@@ -60,7 +60,15 @@ extension FlashcardsStore {
         case .linkedCredentialRestore:
             return try await self.prepareLinkedCredentialRecoveryLink(verifiedContext: verifiedContext)
         case .guestLocalRecovery:
-            return try await self.prepareGuestLocalRecoveryLink(verifiedContext: verifiedContext)
+            return try await self.prepareGuestLocalRecoveryLink(
+                verifiedContext: verifiedContext,
+                postAuthRecoveryRoute: .guestLocalRecovery
+            )
+        case .pendingGuestUpgradeMissingGuestSessionRecovery:
+            return try await self.prepareGuestLocalRecoveryLink(
+                verifiedContext: verifiedContext,
+                postAuthRecoveryRoute: .pendingGuestUpgradeMissingGuestSessionRecovery
+            )
         case .pendingGuestUpgradeRecovery:
             return try await self.prepareStandardCloudLink(
                 verifiedContext: verifiedContext,
@@ -186,7 +194,8 @@ extension FlashcardsStore {
     }
 
     private func prepareGuestLocalRecoveryLink(
-        verifiedContext: CloudVerifiedAuthContext
+        verifiedContext: CloudVerifiedAuthContext,
+        postAuthRecoveryRoute: CloudPostAuthRecoveryRoute
     ) async throws -> CloudWorkspaceLinkContext {
         let account = try await self.cloudRuntime.fetchCloudAccount(verifiedContext: verifiedContext)
 
@@ -198,7 +207,7 @@ extension FlashcardsStore {
             credentials: verifiedContext.credentials,
             workspaces: account.workspaces,
             guestUpgradeMode: nil,
-            postAuthRecoveryRoute: .guestLocalRecovery
+            postAuthRecoveryRoute: postAuthRecoveryRoute
         )
     }
 
@@ -206,6 +215,14 @@ extension FlashcardsStore {
         linkContext: CloudWorkspaceLinkContext,
         selection: CloudWorkspaceLinkSelection
     ) async throws {
+        if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
+            try await self.completeGuestLocalRecoveryCloudLink(
+                linkContext: linkContext,
+                selection: selection
+            )
+            return
+        }
+
         _ = try await self.cloudRuntime.runWorkspaceCompletion { [weak self] in
             guard let self else {
                 throw LocalStoreError.uninitialized("Flashcards store is unavailable")
@@ -288,6 +305,281 @@ extension FlashcardsStore {
             self.globalErrorMessage = ""
             return linkedWorkspace
         }
+    }
+
+    private func completeGuestLocalRecoveryCloudLink(
+        linkContext: CloudWorkspaceLinkContext,
+        selection: CloudWorkspaceLinkSelection
+    ) async throws {
+        _ = try await self.cloudRuntime.runWorkspaceCompletion { [weak self] in
+            guard let self else {
+                throw LocalStoreError.uninitialized("Flashcards store is unavailable")
+            }
+
+            guard let workspace = self.workspace else {
+                throw LocalStoreError.uninitialized("Workspace is unavailable")
+            }
+
+            let trigger = self.manualCloudSyncTrigger(now: Date())
+            let recoveryState = try self.validateGuestLocalRecoveryBeforeCloudLinkCompletion(
+                linkContext: linkContext,
+                selection: selection
+            )
+            let configuration = try self.currentCloudServiceConfiguration()
+
+            let linkedWorkspace: CloudWorkspaceSummary
+            var credentials: StoredCloudCredentials
+            if let retryWorkspace = try self.guestLocalRecoveryRetryWorkspace(linkContext: linkContext) {
+                linkedWorkspace = retryWorkspace
+                credentials = try await self.guestLocalRecoveryCredentials(
+                    linkContextCredentials: linkContext.credentials,
+                    configuration: configuration,
+                    forceRefresh: false
+                )
+            } else if let checkpointWorkspace = try self.guestLocalRecoveryCheckpointWorkspace(
+                linkContext: linkContext,
+                recoveryState: recoveryState
+            ) {
+                linkedWorkspace = checkpointWorkspace
+                credentials = try await self.guestLocalRecoveryCredentials(
+                    linkContextCredentials: linkContext.credentials,
+                    configuration: configuration,
+                    forceRefresh: false
+                )
+            } else {
+                credentials = try await self.guestLocalRecoveryCredentials(
+                    linkContextCredentials: linkContext.credentials,
+                    configuration: configuration,
+                    forceRefresh: false
+                )
+                let workspaceCreation = try await self.createGuestLocalRecoveryWorkspace(
+                    linkContext: linkContext,
+                    configuration: configuration,
+                    localWorkspaceName: workspace.name,
+                    credentials: credentials
+                )
+                linkedWorkspace = workspaceCreation.workspace
+                credentials = workspaceCreation.credentials
+                try self.saveGuestLocalRecoveryWorkspaceCheckpoint(
+                    linkContext: linkContext,
+                    recoveryState: recoveryState,
+                    workspace: linkedWorkspace
+                )
+            }
+
+            _ = try await self.finishGuestLocalRecoveryCloudLink(
+                linkContext: linkContext,
+                linkedWorkspace: linkedWorkspace,
+                configuration: configuration,
+                credentials: credentials,
+                trigger: trigger
+            )
+            self.clearPendingGuestUpgradeStateAndUnblockMutations()
+            try self.clearGuestSessionIfNeeded()
+            self.clearCloudCredentialRecoveryState()
+            self.globalErrorMessage = ""
+            return linkedWorkspace
+        }
+    }
+
+    private func guestLocalRecoveryCredentials(
+        linkContextCredentials: StoredCloudCredentials,
+        configuration: CloudServiceConfiguration,
+        forceRefresh: Bool
+    ) async throws -> StoredCloudCredentials {
+        let storedCredentials = try self.cloudRuntime.loadCredentials()
+        if let storedCredentials {
+            if storedCredentials.refreshToken != linkContextCredentials.refreshToken {
+                try self.cloudRuntime.saveCredentials(credentials: linkContextCredentials)
+            }
+        } else {
+            try self.cloudRuntime.saveCredentials(credentials: linkContextCredentials)
+        }
+
+        return try await self.cloudRuntime.refreshCloudCredentials(
+            forceRefresh: forceRefresh,
+            configuration: configuration,
+            now: Date()
+        )
+    }
+
+    private func createGuestLocalRecoveryWorkspace(
+        linkContext: CloudWorkspaceLinkContext,
+        configuration: CloudServiceConfiguration,
+        localWorkspaceName: String,
+        credentials: StoredCloudCredentials
+    ) async throws -> (workspace: CloudWorkspaceSummary, credentials: StoredCloudCredentials) {
+        do {
+            let workspace = try await self.cloudRuntime.selectOrCreateWorkspace(
+                linkContext: self.guestLocalRecoveryLinkContext(
+                    linkContext: linkContext,
+                    credentials: credentials
+                ),
+                selection: .createNew,
+                localWorkspaceName: localWorkspaceName
+            )
+            return (workspace, credentials)
+        } catch {
+            guard self.isCloudAuthorizationError(error) else {
+                throw error
+            }
+        }
+
+        let refreshedCredentials = try await self.guestLocalRecoveryCredentials(
+            linkContextCredentials: linkContext.credentials,
+            configuration: configuration,
+            forceRefresh: true
+        )
+        let workspace = try await self.cloudRuntime.selectOrCreateWorkspace(
+            linkContext: self.guestLocalRecoveryLinkContext(
+                linkContext: linkContext,
+                credentials: refreshedCredentials
+            ),
+            selection: .createNew,
+            localWorkspaceName: localWorkspaceName
+        )
+        return (workspace, refreshedCredentials)
+    }
+
+    private func finishGuestLocalRecoveryCloudLink(
+        linkContext: CloudWorkspaceLinkContext,
+        linkedWorkspace: CloudWorkspaceSummary,
+        configuration: CloudServiceConfiguration,
+        credentials: StoredCloudCredentials,
+        trigger: CloudSyncTrigger
+    ) async throws -> CloudLinkedSession {
+        let linkedSession = self.guestLocalRecoveryLinkedSession(
+            linkContext: linkContext,
+            linkedWorkspace: linkedWorkspace,
+            configuration: configuration,
+            credentials: credentials
+        )
+
+        do {
+            try await self.finishCloudLink(linkedSession: linkedSession, trigger: trigger)
+            return linkedSession
+        } catch {
+            guard self.isCloudAuthorizationError(error) else {
+                throw error
+            }
+        }
+
+        let refreshedCredentials = try await self.guestLocalRecoveryCredentials(
+            linkContextCredentials: linkContext.credentials,
+            configuration: configuration,
+            forceRefresh: true
+        )
+        let refreshedSession = self.guestLocalRecoveryLinkedSession(
+            linkContext: linkContext,
+            linkedWorkspace: linkedWorkspace,
+            configuration: configuration,
+            credentials: refreshedCredentials
+        )
+        try await self.finishCloudLink(linkedSession: refreshedSession, trigger: trigger)
+        return refreshedSession
+    }
+
+    private func guestLocalRecoveryLinkContext(
+        linkContext: CloudWorkspaceLinkContext,
+        credentials: StoredCloudCredentials
+    ) -> CloudWorkspaceLinkContext {
+        CloudWorkspaceLinkContext(
+            userId: linkContext.userId,
+            email: linkContext.email,
+            apiBaseUrl: linkContext.apiBaseUrl,
+            credentials: credentials,
+            workspaces: linkContext.workspaces,
+            guestUpgradeMode: linkContext.guestUpgradeMode,
+            postAuthRecoveryRoute: linkContext.postAuthRecoveryRoute
+        )
+    }
+
+    private func guestLocalRecoveryLinkedSession(
+        linkContext: CloudWorkspaceLinkContext,
+        linkedWorkspace: CloudWorkspaceSummary,
+        configuration: CloudServiceConfiguration,
+        credentials: StoredCloudCredentials
+    ) -> CloudLinkedSession {
+        CloudLinkedSession(
+            userId: linkContext.userId,
+            workspaceId: linkedWorkspace.workspaceId,
+            email: linkContext.email,
+            configurationMode: configuration.mode,
+            apiBaseUrl: linkContext.apiBaseUrl,
+            authorization: .bearer(credentials.idToken)
+        )
+    }
+
+    private func guestLocalRecoveryRetryWorkspace(
+        linkContext: CloudWorkspaceLinkContext
+    ) throws -> CloudWorkspaceSummary? {
+        guard let cloudSettings = self.cloudSettings,
+            cloudSettings.cloudState == .linked,
+            cloudSettings.linkedUserId == linkContext.userId else {
+            return nil
+        }
+
+        let targetWorkspaceId = cloudSettings.activeWorkspaceId ?? cloudSettings.linkedWorkspaceId
+        guard let workspace = self.workspace,
+            targetWorkspaceId == workspace.workspaceId else {
+            return nil
+        }
+
+        let configuration = try self.currentCloudServiceConfiguration()
+        guard configuration.apiBaseUrl == linkContext.apiBaseUrl else {
+            return nil
+        }
+
+        return CloudWorkspaceSummary(
+            workspaceId: workspace.workspaceId,
+            name: workspace.name,
+            createdAt: workspace.createdAt,
+            isSelected: true
+        )
+    }
+
+    private func guestLocalRecoveryCheckpointWorkspace(
+        linkContext: CloudWorkspaceLinkContext,
+        recoveryState: CloudCredentialRecoveryState
+    ) throws -> CloudWorkspaceSummary? {
+        guard let checkpoint = try loadGuestLocalRecoveryWorkspaceCheckpoint(
+            userDefaults: self.userDefaults,
+            decoder: self.decoder
+        ) else {
+            return nil
+        }
+
+        let configuration = try self.currentCloudServiceConfiguration()
+        guard checkpoint.userId == linkContext.userId,
+            checkpoint.apiBaseUrl == linkContext.apiBaseUrl,
+            checkpoint.configurationMode == configuration.mode,
+            checkpoint.recoveryDetectedAt == recoveryState.detectedAt else {
+            self.blockCloudSyncForCredentialRecovery()
+            throw LocalStoreError.validation(
+                localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing)
+            )
+        }
+
+        return checkpoint.workspace
+    }
+
+    private func saveGuestLocalRecoveryWorkspaceCheckpoint(
+        linkContext: CloudWorkspaceLinkContext,
+        recoveryState: CloudCredentialRecoveryState,
+        workspace: CloudWorkspaceSummary
+    ) throws {
+        let configuration = try self.currentCloudServiceConfiguration()
+        try Flashcards.saveGuestLocalRecoveryWorkspaceCheckpoint(
+            checkpoint: GuestLocalRecoveryWorkspaceCheckpoint(
+                userId: linkContext.userId,
+                apiBaseUrl: linkContext.apiBaseUrl,
+                configurationMode: configuration.mode,
+                recoveryDetectedAt: recoveryState.detectedAt,
+                workspace: workspace
+            ),
+            userDefaults: self.userDefaults,
+            encoder: self.encoder
+        )
     }
 
     private func prepareCompletedPendingGuestUpgradeRecoveryLink(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudSync.swift
@@ -506,6 +506,10 @@ extension FlashcardsStore {
     func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
         try self.enforceCloudCredentialRecoveryGateOutsideIdentityResolution(detectedAt: Date())
         do {
+            if try self.shouldRunGuestLocalRecoveryLinkedSync(linkedSession: linkedSession) {
+                return try await self.cloudRuntime.runGuestLocalRecoveryLinkedSync(linkedSession: linkedSession)
+            }
+
             return try await self.cloudRuntime.runLinkedSync(linkedSession: linkedSession)
         } catch {
             throw try self.failureErrorAfterApplyingLocalIdRepairSideEffectsIfNeeded(
@@ -513,6 +517,19 @@ extension FlashcardsStore {
                 now: Date()
             )
         }
+    }
+
+    private func shouldRunGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) throws -> Bool {
+        guard let recoveryState = self.cloudCredentialRecoveryState,
+            recoveryState.reason == .guestSessionMissing else {
+            return false
+        }
+
+        try self.validateGuestLocalRecoveryState(
+            recoveryState: recoveryState,
+            apiBaseUrl: linkedSession.apiBaseUrl
+        )
+        return linkedSession.authorization.isGuest == false
     }
 
     func runFreshLinkedSyncAfterActiveSyncSettles(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
@@ -38,6 +38,7 @@ enum AppConfigurationError: LocalizedError, Equatable {
 let customCloudServerOverrideUserDefaultsKey: String = "custom-cloud-server-override"
 let pendingCloudServerBootstrapUserDefaultsKey: String = "pending-cloud-server-bootstrap"
 let cloudCredentialRecoveryStateUserDefaultsKey: String = "cloud-credential-recovery-state"
+let guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey: String = "guest-local-recovery-workspace-checkpoint"
 let flashcardsRepositoryUrl: String = "https://github.com/kirill-markin/flashcards-open-source-app"
 
 var flashcardsPrivacyPolicyUrl: String {
@@ -192,6 +193,43 @@ func saveCloudCredentialRecoveryState(
 
 func clearCloudCredentialRecoveryState(userDefaults: UserDefaults) {
     userDefaults.removeObject(forKey: cloudCredentialRecoveryStateUserDefaultsKey)
+    clearGuestLocalRecoveryWorkspaceCheckpoint(userDefaults: userDefaults)
+}
+
+func loadGuestLocalRecoveryWorkspaceCheckpoint(
+    userDefaults: UserDefaults,
+    decoder: JSONDecoder
+) throws -> GuestLocalRecoveryWorkspaceCheckpoint? {
+    guard let storedData = userDefaults.data(forKey: guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey) else {
+        return nil
+    }
+
+    do {
+        return try decoder.decode(GuestLocalRecoveryWorkspaceCheckpoint.self, from: storedData)
+    } catch {
+        throw LocalStoreError.validation(
+            "Guest local recovery workspace checkpoint is invalid: \(Flashcards.errorMessage(error: error))"
+        )
+    }
+}
+
+func saveGuestLocalRecoveryWorkspaceCheckpoint(
+    checkpoint: GuestLocalRecoveryWorkspaceCheckpoint,
+    userDefaults: UserDefaults,
+    encoder: JSONEncoder
+) throws {
+    do {
+        let storedData = try encoder.encode(checkpoint)
+        userDefaults.set(storedData, forKey: guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey)
+    } catch {
+        throw LocalStoreError.validation(
+            "Guest local recovery workspace checkpoint could not be saved: \(Flashcards.errorMessage(error: error))"
+        )
+    }
+}
+
+func clearGuestLocalRecoveryWorkspaceCheckpoint(userDefaults: UserDefaults) {
+    userDefaults.removeObject(forKey: guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey)
 }
 
 func makeCustomCloudServiceConfiguration(customOrigin: String) throws -> CloudServiceConfiguration {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
@@ -55,6 +55,23 @@ struct CloudSyncRunner {
     }
 
     func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        try await self.runLinkedSync(
+            linkedSession: linkedSession,
+            importsLocalReviewHistoryBeforeReviewPull: false
+        )
+    }
+
+    func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        try await self.runLinkedSync(
+            linkedSession: linkedSession,
+            importsLocalReviewHistoryBeforeReviewPull: true
+        )
+    }
+
+    private func runLinkedSync(
+        linkedSession: CloudLinkedSession,
+        importsLocalReviewHistoryBeforeReviewPull: Bool
+    ) async throws -> CloudSyncResult {
         let cloudSettings = try self.database.loadBootstrapSnapshot().cloudSettings
         let workspaceId = linkedSession.workspaceId
         let syncBasePath = "/workspaces/\(workspaceId)/sync"
@@ -67,7 +84,8 @@ struct CloudSyncRunner {
                     linkedSession: linkedSession,
                     workspaceId: workspaceId,
                     installationId: cloudSettings.installationId,
-                    syncBasePath: syncBasePath
+                    syncBasePath: syncBasePath,
+                    importsLocalReviewHistoryBeforeReviewPull: importsLocalReviewHistoryBeforeReviewPull
                 )
 
                 guard publicWorkspaceForkRepairEntityTypes.isEmpty == false else {
@@ -108,7 +126,8 @@ struct CloudSyncRunner {
         linkedSession: CloudLinkedSession,
         workspaceId: String,
         installationId: String,
-        syncBasePath: String
+        syncBasePath: String,
+        importsLocalReviewHistoryBeforeReviewPull: Bool
     ) async throws -> CloudSyncResult {
         var syncResult = try self.cleanupStaleReviewEventOutboxEntries(
             workspaceId: workspaceId,
@@ -154,6 +173,20 @@ struct CloudSyncRunner {
             )
         }
         syncResult = syncResult.merging(hotPullResult)
+        if importsLocalReviewHistoryBeforeReviewPull,
+            try self.database.hasHydratedReviewHistory(workspaceId: workspaceId) == false {
+            // Guest local recovery creates a new workspace. If review history is
+            // still unhydrated here, an earlier attempt may have pushed hot state
+            // before review-history import completed.
+            syncResult = syncResult.merging(
+                try await self.importLocalReviewHistory(
+                    linkedSession: linkedSession,
+                    workspaceId: workspaceId,
+                    installationId: installationId,
+                    syncBasePath: syncBasePath
+                )
+            )
+        }
         syncResult = syncResult.merging(
             try await self.pullReviewHistory(
                 linkedSession: linkedSession,
@@ -547,31 +580,13 @@ struct CloudSyncRunner {
             bootstrapHotChangeId = responseHotChangeId
         }
 
-        var nextReviewSequenceId: Int64 = 0
-        if reviewEvents.isEmpty == false {
-            var startIndex = 0
-            while startIndex < reviewEvents.count {
-                let endIndex = min(startIndex + 200, reviewEvents.count)
-                let response: RemoteReviewHistoryImportResponseEnvelope = try await self.transport.request(
-                    apiBaseUrl: linkedSession.apiBaseUrl,
-                    authorizationHeader: linkedSession.authorization.headerValue,
-                    path: "\(syncBasePath)/review-history/import",
-                    method: "POST",
-                    body: ReviewHistoryImportRequest(
-                        installationId: installationId,
-                        platform: "ios",
-                        appVersion: self.transport.appVersion(),
-                        reviewEvents: Array(reviewEvents[startIndex..<endIndex])
-                    )
-                )
-                guard let responseReviewSequenceId = response.nextReviewSequenceId else {
-                    throw LocalStoreError.validation("Review history import response is missing nextReviewSequenceId")
-                }
-
-                nextReviewSequenceId = responseReviewSequenceId
-                startIndex = endIndex
-            }
-        }
+        let nextReviewSequenceId = try await self.importReviewEventsToRemote(
+            linkedSession: linkedSession,
+            installationId: installationId,
+            syncBasePath: syncBasePath,
+            initialReviewSequenceId: 0,
+            reviewEvents: reviewEvents
+        )
 
         try self.database.deleteAllOutboxEntries(workspaceId: workspaceId)
         try self.database.setLastAppliedHotChangeId(
@@ -608,6 +623,83 @@ struct CloudSyncRunner {
             cleanedUpReviewEventOperationCount: pendingReviewEventOutboxCount,
             cleanedUpReviewScheduleImpactingOperationCount: pendingReviewScheduleImpactingOutboxCount
         )
+    }
+
+    private func importLocalReviewHistory(
+        linkedSession: CloudLinkedSession,
+        workspaceId: String,
+        installationId: String,
+        syncBasePath: String
+    ) async throws -> CloudSyncResult {
+        let reviewEvents = try self.database.loadReviewEvents(workspaceId: workspaceId)
+        let currentReviewSequenceId = try self.database.loadLastAppliedReviewSequenceId(workspaceId: workspaceId)
+        let nextReviewSequenceId = try await self.importReviewEventsToRemote(
+            linkedSession: linkedSession,
+            installationId: installationId,
+            syncBasePath: syncBasePath,
+            initialReviewSequenceId: currentReviewSequenceId,
+            reviewEvents: reviewEvents
+        )
+
+        try self.database.setLastAppliedReviewSequenceId(
+            workspaceId: workspaceId,
+            reviewSequenceId: nextReviewSequenceId
+        )
+        try self.database.setHasHydratedReviewHistory(
+            workspaceId: workspaceId,
+            hasHydratedReviewHistory: true
+        )
+
+        guard reviewEvents.isEmpty == false else {
+            return .noChanges
+        }
+
+        return CloudSyncResult(
+            appliedPullChangeCount: 0,
+            reviewScheduleImpactingPullChangeCount: 0,
+            changedEntityTypes: [.reviewEvent],
+            localIdRepairEntityTypes: [],
+            acknowledgedOperationCount: 0,
+            acknowledgedReviewEventOperationCount: 0,
+            acknowledgedReviewScheduleImpactingOperationCount: 0,
+            cleanedUpOperationCount: 0,
+            cleanedUpReviewEventOperationCount: 0,
+            cleanedUpReviewScheduleImpactingOperationCount: 0
+        )
+    }
+
+    private func importReviewEventsToRemote(
+        linkedSession: CloudLinkedSession,
+        installationId: String,
+        syncBasePath: String,
+        initialReviewSequenceId: Int64,
+        reviewEvents: [ReviewEvent]
+    ) async throws -> Int64 {
+        var nextReviewSequenceId = initialReviewSequenceId
+        var startIndex = 0
+        while startIndex < reviewEvents.count {
+            let endIndex = min(startIndex + 200, reviewEvents.count)
+            let response: RemoteReviewHistoryImportResponseEnvelope = try await self.transport.request(
+                apiBaseUrl: linkedSession.apiBaseUrl,
+                authorizationHeader: linkedSession.authorization.headerValue,
+                path: "\(syncBasePath)/review-history/import",
+                method: "POST",
+                body: ReviewHistoryImportRequest(
+                    installationId: installationId,
+                    platform: "ios",
+                    appVersion: self.transport.appVersion(),
+                    reviewEvents: Array(reviewEvents[startIndex..<endIndex])
+                )
+            )
+            guard let responseReviewSequenceId = response.nextReviewSequenceId else {
+                throw LocalStoreError.validation("Review history import response is missing nextReviewSequenceId")
+            }
+
+            nextReviewSequenceId = responseReviewSequenceId
+            startIndex = endIndex
+        }
+
+        return nextReviewSequenceId
     }
 
     private func pushOutboxBatches(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
@@ -324,4 +324,10 @@ final class CloudSyncService: @unchecked Sendable {
             linkedSession: linkedSession
         )
     }
+
+    func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        try await CloudSyncRunner(database: self.database, transport: self.transport).runGuestLocalRecoveryLinkedSync(
+            linkedSession: linkedSession
+        )
+    }
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Types/CloudTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Types/CloudTypes.swift
@@ -154,7 +154,16 @@ enum CloudPostAuthRecoveryRoute: Hashable, Sendable {
     case none
     case linkedCredentialRestore
     case guestLocalRecovery
+    case pendingGuestUpgradeMissingGuestSessionRecovery
     case pendingGuestUpgradeRecovery
+}
+
+struct GuestLocalRecoveryWorkspaceCheckpoint: Codable, Hashable, Sendable {
+    let userId: String
+    let apiBaseUrl: String
+    let configurationMode: CloudServiceConfigurationMode
+    let recoveryDetectedAt: String
+    let workspace: CloudWorkspaceSummary
 }
 
 struct CloudVerifiedAuthContext: Hashable {

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStoreSupport.swift
@@ -83,6 +83,7 @@ protocol CloudSyncServing {
     ) async throws -> Bool
     func deleteAccount(apiBaseUrl: String, bearerToken: String, confirmationText: String) async throws
     func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult
+    func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult
 }
 
 protocol CredentialStoring {

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
@@ -61,6 +61,15 @@ func makeCloudPostAuthFailurePresentation(
 ) -> CloudPostAuthFailurePresentation {
     switch operation {
     case .completeLink(let linkContext, let selection):
+        if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
+            return CloudPostAuthFailurePresentation(
+                title: cloudState == .linked
+                    ? aiSettingsLocalized("settings.account.cloudSignIn.failure.initialSyncFailed", "Signed in, but initial sync failed.")
+                    : aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
+                retryAction: .completeLink(linkContext: linkContext, selection: selection)
+            )
+        }
+
         if cloudState == .linked {
             return CloudPostAuthFailurePresentation(
                 title: aiSettingsLocalized("settings.account.cloudSignIn.failure.initialSyncFailed", "Signed in, but initial sync failed."),
@@ -185,6 +194,8 @@ enum CloudWorkspacePostAuthRoute: Equatable {
 func makeCloudWorkspacePostAuthRoute(linkContext: CloudWorkspaceLinkContext) -> CloudWorkspacePostAuthRoute {
     switch linkContext.postAuthRecoveryRoute {
     case .guestLocalRecovery:
+        return .autoLink(.createNew)
+    case .pendingGuestUpgradeMissingGuestSessionRecovery:
         return .guestLocalRecoveryNeeded
     case .linkedCredentialRestore:
         guard linkContext.workspaces.count == 1, let workspace = linkContext.workspaces.first else {

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
@@ -627,6 +627,10 @@ enum AIChatStoreTestSupport {
                 cleanedUpReviewScheduleImpactingOperationCount: 0
             )
         }
+
+        func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+            try await self.runLinkedSync(linkedSession: linkedSession)
+        }
     }
 
     @MainActor

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudCredentialRecoveryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudCredentialRecoveryTests.swift
@@ -1511,6 +1511,17 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
         let savedCard: Card = try self.saveRecoveryTestCard(database: database, workspaceId: workspace.workspaceId)
         let outboxCountBefore: Int = try self.loadOutboxCount(database: database)
         let workspaceIdsBefore: [String] = try self.loadWorkspaceIds(database: database)
+        let recoveredWorkspace = CloudWorkspaceSummary(
+            workspaceId: "linked-recovery-workspace",
+            name: workspace.name,
+            createdAt: "2026-04-01T00:00:00.000Z",
+            isSelected: true
+        )
+        let expectedRecoveredCardId: String = forkedCardIdForWorkspace(
+            sourceWorkspaceId: workspace.workspaceId,
+            destinationWorkspaceId: recoveredWorkspace.workspaceId,
+            sourceCardId: savedCard.cardId
+        )
         try database.updateCloudSettings(
             cloudState: .guest,
             linkedUserId: "guest-user",
@@ -1553,6 +1564,21 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
                 workspaces: [linkedWorkspace]
             )
         }
+        cloudSyncService.createWorkspaceHandler = { apiBaseUrl, bearerToken, name in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            XCTAssertEqual(workspace.name, name)
+            return recoveredWorkspace
+        }
+        cloudSyncService.runLinkedSyncHandler = { linkedSession in
+            XCTAssertEqual("unrelated-email-user", linkedSession.userId)
+            XCTAssertEqual("other@example.com", linkedSession.email)
+            XCTAssertEqual(recoveredWorkspace.workspaceId, linkedSession.workspaceId)
+            XCTAssertEqual(configuration.apiBaseUrl, linkedSession.apiBaseUrl)
+            XCTAssertEqual(.bearer(credentials.idToken), linkedSession.authorization)
+            try database.deleteAllOutboxEntries(workspaceId: linkedSession.workspaceId)
+            return .noChanges
+        }
         let urlSessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.ephemeral
         urlSessionConfiguration.protocolClasses = [GuestCloudAuthServiceTestURLProtocol.self]
         let guestCloudAuthService: GuestCloudAuthService = GuestCloudAuthService(
@@ -1594,7 +1620,7 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
         XCTAssertNil(linkContext.guestUpgradeMode)
         XCTAssertEqual(.guestLocalRecovery, linkContext.postAuthRecoveryRoute)
         XCTAssertEqual("unrelated-email-user", linkContext.userId)
-        XCTAssertEqual(.guestLocalRecoveryNeeded, makeCloudWorkspacePostAuthRoute(linkContext: linkContext))
+        XCTAssertEqual(.autoLink(.createNew), makeCloudWorkspacePostAuthRoute(linkContext: linkContext))
         XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
         XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
         XCTAssertEqual(0, cloudSyncService.selectWorkspaceCallCount)
@@ -1621,6 +1647,15 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
             XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
         }
 
+        XCTAssertEqual(0, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(0, cloudSyncService.runGuestLocalRecoveryLinkedSyncCallCount)
+        XCTAssertNil(try credentialStore.loadCredentials())
+        XCTAssertNotNil(store.cloudCredentialRecoveryState)
+        XCTAssertNotNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+        XCTAssertEqual(outboxCountBefore, try self.loadOutboxCount(database: database))
+        XCTAssertEqual(workspaceIdsBefore, try self.loadWorkspaceIds(database: database))
+
         do {
             try await store.completeGuestCloudLink(
                 linkContext: linkContext,
@@ -1637,15 +1672,327 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
             XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
         }
 
+        try await store.completeCloudLink(
+            linkContext: linkContext,
+            selection: .createNew
+        )
+
+        XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
+        XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
+        XCTAssertEqual(0, cloudSyncService.selectWorkspaceCallCount)
+        XCTAssertEqual(1, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.isWorkspaceEmptyForBootstrapCallCount)
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(1, cloudSyncService.runGuestLocalRecoveryLinkedSyncCallCount)
+        XCTAssertEqual(credentials, try credentialStore.loadCredentials())
+        XCTAssertNil(store.cloudCredentialRecoveryState)
+        XCTAssertNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+        XCTAssertNil(userDefaults.data(forKey: guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey))
         let cloudSettingsAfterLink: CloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
-        XCTAssertEqual(.guest, cloudSettingsAfterLink.cloudState)
-        XCTAssertEqual(Optional("guest-user"), cloudSettingsAfterLink.linkedUserId)
-        XCTAssertEqual(Optional(workspace.workspaceId), cloudSettingsAfterLink.linkedWorkspaceId)
-        XCTAssertEqual(Optional(workspace.workspaceId), cloudSettingsAfterLink.activeWorkspaceId)
-        XCTAssertEqual(outboxCountBefore, try self.loadOutboxCount(database: database))
-        XCTAssertEqual(workspaceIdsBefore, try self.loadWorkspaceIds(database: database))
-        XCTAssertTrue(try database.loadActiveCards(workspaceId: workspace.workspaceId).contains { card in
-            card.cardId == savedCard.cardId
+        XCTAssertEqual(.linked, cloudSettingsAfterLink.cloudState)
+        XCTAssertEqual(Optional("unrelated-email-user"), cloudSettingsAfterLink.linkedUserId)
+        XCTAssertEqual(Optional(recoveredWorkspace.workspaceId), cloudSettingsAfterLink.linkedWorkspaceId)
+        XCTAssertEqual(Optional(recoveredWorkspace.workspaceId), cloudSettingsAfterLink.activeWorkspaceId)
+        XCTAssertEqual(Optional("other@example.com"), cloudSettingsAfterLink.linkedEmail)
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+        XCTAssertEqual([recoveredWorkspace.workspaceId], try self.loadWorkspaceIds(database: database))
+        XCTAssertTrue(try database.loadActiveCards(workspaceId: recoveredWorkspace.workspaceId).contains { card in
+            card.cardId == expectedRecoveredCardId
+        })
+    }
+
+    @MainActor
+    func testGuestRecoveryRetryReusesMigratedLinkedWorkspaceAfterInitialSyncFailure() async throws {
+        let suiteName: String = "guest-recovery-sync-retry-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let database: LocalDatabase = try self.makeDatabase()
+        let workspace: Workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard: Card = try self.saveRecoveryTestCard(database: database, workspaceId: workspace.workspaceId)
+        let recoveredWorkspace = CloudWorkspaceSummary(
+            workspaceId: "linked-recovery-retry-workspace",
+            name: workspace.name,
+            createdAt: "2026-04-01T00:00:00.000Z",
+            isSelected: true
+        )
+        let expectedRecoveredCardId: String = forkedCardIdForWorkspace(
+            sourceWorkspaceId: workspace.workspaceId,
+            destinationWorkspaceId: recoveredWorkspace.workspaceId,
+            sourceCardId: savedCard.cardId
+        )
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: "guest-user",
+            linkedWorkspaceId: workspace.workspaceId,
+            activeWorkspaceId: workspace.workspaceId,
+            linkedEmail: nil
+        )
+        let credentialStore: CloudCredentialStore = self.makeCredentialStore(
+            suiteName: suiteName,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let guestCredentialStore: GuestCloudCredentialStore = self.makeGuestCredentialStore(
+            suiteName: suiteName,
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let configuration: CloudServiceConfiguration = try makeCustomCloudServiceConfiguration(
+            customOrigin: "https://example.test"
+        )
+        let credentials: StoredCloudCredentials = StoredCloudCredentials(
+            refreshToken: "refresh-token",
+            idToken: "id-token",
+            idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        cloudSyncService.fetchCloudAccountHandler = { apiBaseUrl, bearerToken in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            return CloudAccountSnapshot(
+                userId: "retry-email-user",
+                email: "retry@example.com",
+                workspaces: []
+            )
+        }
+        cloudSyncService.createWorkspaceHandler = { apiBaseUrl, bearerToken, name in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            XCTAssertEqual(workspace.name, name)
+            return recoveredWorkspace
+        }
+        cloudSyncService.runLinkedSyncHandler = { linkedSession in
+            XCTAssertEqual("retry-email-user", linkedSession.userId)
+            XCTAssertEqual(recoveredWorkspace.workspaceId, linkedSession.workspaceId)
+            XCTAssertEqual(.bearer(credentials.idToken), linkedSession.authorization)
+            if cloudSyncService.runLinkedSyncCallCount == 1 {
+                throw LocalStoreError.database("Forced guest local recovery sync failure")
+            }
+
+            try database.deleteAllOutboxEntries(workspaceId: linkedSession.workspaceId)
+            return .noChanges
+        }
+        let store: FlashcardsStore = self.makeRecoveryStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            cloudSyncService: cloudSyncService
+        )
+        defer {
+            store.shutdownForTests()
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let cloudSettings: CloudSettings = try XCTUnwrap(store.cloudSettings)
+        try store.markCloudCredentialRecoveryRequired(
+            reason: .guestSessionMissing,
+            cloudSettings: cloudSettings,
+            configuration: configuration,
+            detectedAt: Date(timeIntervalSince1970: 1_775_000_000)
+        )
+        let linkContext: CloudWorkspaceLinkContext = try await store.prepareCloudLink(
+            verifiedContext: CloudVerifiedAuthContext(
+                apiBaseUrl: configuration.apiBaseUrl,
+                credentials: credentials
+            )
+        )
+
+        do {
+            try await store.completeCloudLink(
+                linkContext: linkContext,
+                selection: .createNew
+            )
+            XCTFail("Expected initial guest local recovery sync to fail.")
+        } catch let error as LocalStoreError {
+            guard case .database(let message) = error else {
+                XCTFail("Expected database error, received \(Flashcards.errorMessage(error: error))")
+                return
+            }
+            XCTAssertEqual("Forced guest local recovery sync failure", message)
+        } catch {
+            XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertEqual(1, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(1, cloudSyncService.runGuestLocalRecoveryLinkedSyncCallCount)
+        XCTAssertEqual(credentials, try credentialStore.loadCredentials())
+        XCTAssertNotNil(store.cloudCredentialRecoveryState)
+        XCTAssertNotNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+        XCTAssertNotNil(userDefaults.data(forKey: guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey))
+        let failedCloudSettings: CloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        XCTAssertEqual(.linked, failedCloudSettings.cloudState)
+        XCTAssertEqual(Optional("retry-email-user"), failedCloudSettings.linkedUserId)
+        XCTAssertEqual(Optional(recoveredWorkspace.workspaceId), failedCloudSettings.activeWorkspaceId)
+        XCTAssertEqual([recoveredWorkspace.workspaceId], try self.loadWorkspaceIds(database: database))
+        XCTAssertGreaterThan(try self.loadOutboxCount(database: database), 0)
+        XCTAssertTrue(try database.loadActiveCards(workspaceId: recoveredWorkspace.workspaceId).contains { card in
+            card.cardId == expectedRecoveredCardId
+        })
+        let failurePresentation = makeCloudPostAuthFailurePresentation(
+            operation: .completeLink(linkContext: linkContext, selection: .createNew),
+            cloudState: store.cloudSettings?.cloudState
+        )
+        XCTAssertEqual(
+            .completeLink(linkContext: linkContext, selection: .createNew),
+            failurePresentation.retryAction
+        )
+
+        try await store.completeCloudLink(
+            linkContext: linkContext,
+            selection: .createNew
+        )
+
+        XCTAssertEqual(1, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(2, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(2, cloudSyncService.runGuestLocalRecoveryLinkedSyncCallCount)
+        XCTAssertNil(store.cloudCredentialRecoveryState)
+        XCTAssertNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+        XCTAssertNil(userDefaults.data(forKey: guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey))
+        XCTAssertEqual(0, try self.loadOutboxCount(database: database))
+        XCTAssertEqual(.idle, store.syncStatus)
+    }
+
+    @MainActor
+    func testGuestRecoveryRetryReusesCreatedWorkspaceCheckpointBeforeLocalMigration() async throws {
+        let suiteName: String = "guest-recovery-created-workspace-checkpoint-\(UUID().uuidString)"
+        let userDefaults: UserDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let encoder: JSONEncoder = JSONEncoder()
+        let decoder: JSONDecoder = JSONDecoder()
+        try saveCloudServerOverride(
+            override: CloudServerOverride(customOrigin: "https://example.test"),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+        let database: LocalDatabase = try self.makeDatabase()
+        let workspace: Workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard: Card = try self.saveRecoveryTestCard(database: database, workspaceId: workspace.workspaceId)
+        let recoveredWorkspace = CloudWorkspaceSummary(
+            workspaceId: "linked-recovery-checkpoint-workspace",
+            name: workspace.name,
+            createdAt: "2026-04-01T00:00:00.000Z",
+            isSelected: true
+        )
+        let expectedRecoveredCardId: String = forkedCardIdForWorkspace(
+            sourceWorkspaceId: workspace.workspaceId,
+            destinationWorkspaceId: recoveredWorkspace.workspaceId,
+            sourceCardId: savedCard.cardId
+        )
+        try database.updateCloudSettings(
+            cloudState: .guest,
+            linkedUserId: "guest-user",
+            linkedWorkspaceId: workspace.workspaceId,
+            activeWorkspaceId: workspace.workspaceId,
+            linkedEmail: nil
+        )
+        let credentialStore: CloudCredentialStore = self.makeCredentialStore(
+            suiteName: suiteName,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let guestCredentialStore: GuestCloudCredentialStore = self.makeGuestCredentialStore(
+            suiteName: suiteName,
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder
+        )
+        let configuration: CloudServiceConfiguration = try makeCustomCloudServiceConfiguration(
+            customOrigin: "https://example.test"
+        )
+        let credentials: StoredCloudCredentials = StoredCloudCredentials(
+            refreshToken: "refresh-token",
+            idToken: "id-token",
+            idTokenExpiresAt: "2099-01-01T00:00:00.000Z"
+        )
+        let cloudSyncService: GuestUpgradeDrainCloudSyncService = GuestUpgradeDrainCloudSyncService()
+        cloudSyncService.fetchCloudAccountHandler = { apiBaseUrl, bearerToken in
+            XCTAssertEqual(configuration.apiBaseUrl, apiBaseUrl)
+            XCTAssertEqual(credentials.idToken, bearerToken)
+            return CloudAccountSnapshot(
+                userId: "checkpoint-email-user",
+                email: "checkpoint@example.com",
+                workspaces: []
+            )
+        }
+        cloudSyncService.createWorkspaceHandler = { _, _, _ in
+            XCTFail("Guest local recovery retry should reuse the created workspace checkpoint.")
+            return recoveredWorkspace
+        }
+        cloudSyncService.runLinkedSyncHandler = { linkedSession in
+            XCTAssertEqual("checkpoint-email-user", linkedSession.userId)
+            XCTAssertEqual(recoveredWorkspace.workspaceId, linkedSession.workspaceId)
+            XCTAssertEqual(.bearer(credentials.idToken), linkedSession.authorization)
+            try database.deleteAllOutboxEntries(workspaceId: linkedSession.workspaceId)
+            return .noChanges
+        }
+        let store: FlashcardsStore = self.makeRecoveryStore(
+            userDefaults: userDefaults,
+            encoder: encoder,
+            decoder: decoder,
+            database: database,
+            credentialStore: credentialStore,
+            guestCredentialStore: guestCredentialStore,
+            guestCloudAuthService: GuestCloudAuthService(),
+            cloudSyncService: cloudSyncService
+        )
+        defer {
+            store.shutdownForTests()
+            try? credentialStore.clearCredentials()
+            try? guestCredentialStore.clearGuestSession()
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        let cloudSettings: CloudSettings = try XCTUnwrap(store.cloudSettings)
+        try store.markCloudCredentialRecoveryRequired(
+            reason: .guestSessionMissing,
+            cloudSettings: cloudSettings,
+            configuration: configuration,
+            detectedAt: Date(timeIntervalSince1970: 1_775_000_000)
+        )
+        let linkContext: CloudWorkspaceLinkContext = try await store.prepareCloudLink(
+            verifiedContext: CloudVerifiedAuthContext(
+                apiBaseUrl: configuration.apiBaseUrl,
+                credentials: credentials
+            )
+        )
+        let recoveryState: CloudCredentialRecoveryState = try XCTUnwrap(store.cloudCredentialRecoveryState)
+        try saveGuestLocalRecoveryWorkspaceCheckpoint(
+            checkpoint: GuestLocalRecoveryWorkspaceCheckpoint(
+                userId: linkContext.userId,
+                apiBaseUrl: linkContext.apiBaseUrl,
+                configurationMode: configuration.mode,
+                recoveryDetectedAt: recoveryState.detectedAt,
+                workspace: recoveredWorkspace
+            ),
+            userDefaults: userDefaults,
+            encoder: encoder
+        )
+
+        try await store.completeCloudLink(
+            linkContext: linkContext,
+            selection: .createNew
+        )
+
+        XCTAssertEqual(0, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(1, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(1, cloudSyncService.runGuestLocalRecoveryLinkedSyncCallCount)
+        XCTAssertNil(store.cloudCredentialRecoveryState)
+        XCTAssertNil(userDefaults.data(forKey: cloudCredentialRecoveryStateUserDefaultsKey))
+        XCTAssertNil(userDefaults.data(forKey: guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey))
+        XCTAssertEqual([recoveredWorkspace.workspaceId], try self.loadWorkspaceIds(database: database))
+        XCTAssertTrue(try database.loadActiveCards(workspaceId: recoveredWorkspace.workspaceId).contains { card in
+            card.cardId == expectedRecoveredCardId
         })
     }
 
@@ -2493,8 +2840,12 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
 
         XCTAssertEqual(0, GuestCloudAuthServiceTestURLProtocol.requestCount)
         XCTAssertEqual(1, cloudSyncService.fetchCloudAccountCallCount)
+        XCTAssertEqual(0, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(0, cloudSyncService.runGuestLocalRecoveryLinkedSyncCallCount)
         XCTAssertNil(linkContext.guestUpgradeMode)
-        XCTAssertEqual(.guestLocalRecovery, linkContext.postAuthRecoveryRoute)
+        XCTAssertEqual(.pendingGuestUpgradeMissingGuestSessionRecovery, linkContext.postAuthRecoveryRoute)
+        XCTAssertEqual(.guestLocalRecoveryNeeded, makeCloudWorkspacePostAuthRoute(linkContext: linkContext))
         XCTAssertEqual("any-linked-user", linkContext.userId)
         XCTAssertEqual(pendingState, try decoder.decode(
             PendingGuestUpgradeState.self,
@@ -2510,6 +2861,32 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
             file: #filePath,
             line: #line
         )
+
+        do {
+            try await store.completeCloudLink(
+                linkContext: linkContext,
+                selection: .createNew
+            )
+            XCTFail("Expected pending guest-upgrade missing-token recovery to stay blocked.")
+        } catch let error as LocalStoreError {
+            guard case .validation(let message) = error else {
+                XCTFail("Expected validation error, received \(Flashcards.errorMessage(error: error))")
+                return
+            }
+            XCTAssertEqual(localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing), message)
+        } catch {
+            XCTFail("Unexpected error: \(Flashcards.errorMessage(error: error))")
+        }
+
+        XCTAssertEqual(0, cloudSyncService.createWorkspaceCallCount)
+        XCTAssertEqual(0, cloudSyncService.runLinkedSyncCallCount)
+        XCTAssertEqual(0, cloudSyncService.runGuestLocalRecoveryLinkedSyncCallCount)
+        XCTAssertNil(try credentialStore.loadCredentials())
+        XCTAssertNotNil(store.cloudCredentialRecoveryState)
+        XCTAssertEqual(pendingState, try decoder.decode(
+            PendingGuestUpgradeState.self,
+            from: try XCTUnwrap(userDefaults.data(forKey: pendingGuestUpgradeUserDefaultsKey))
+        ))
     }
 
     @MainActor

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/GuestCloudUpgradeTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/GuestCloudUpgradeTestSupport.swift
@@ -87,6 +87,7 @@ final class GuestUpgradeDrainCloudSyncService: CloudSyncServing {
     private(set) var createWorkspaceCallCount: Int = 0
     private(set) var isWorkspaceEmptyForBootstrapCallCount: Int = 0
     private(set) var runLinkedSyncCallCount: Int = 0
+    private(set) var runGuestLocalRecoveryLinkedSyncCallCount: Int = 0
     private(set) var runLinkedSyncAuthorizations: [CloudAuthorization] = []
     var fetchCloudAccountHandler: ((String, String) async throws -> CloudAccountSnapshot)?
     var selectWorkspaceHandler: ((String, String, String) async throws -> CloudWorkspaceSummary)?
@@ -299,6 +300,11 @@ final class GuestUpgradeDrainCloudSyncService: CloudSyncServing {
             return try await runLinkedSyncHandler(linkedSession)
         }
         return .noChanges
+    }
+
+    func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        self.runGuestLocalRecoveryLinkedSyncCallCount += 1
+        return try await self.runLinkedSync(linkedSession: linkedSession)
     }
 }
 

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
@@ -671,6 +671,66 @@ enum LinkedSyncRunnerTestTransportSupport {
         throw URLError(.badURL)
     }
 
+    static func handleGuestLocalRecoveryReviewHistoryImportRetryRequest(
+        request: URLRequest,
+        reviewEventId: String
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/pull") {
+            return try Self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [],
+                  "nextHotChangeId": 20,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/import") {
+            let body = try Self.jsonObjectBody(request: request)
+            let reviewEvents = try XCTUnwrap(body["reviewEvents"] as? [[String: Any]])
+            let importedReviewEvent = try XCTUnwrap(reviewEvents.first)
+            XCTAssertEqual(1, reviewEvents.count)
+            XCTAssertEqual(reviewEventId, importedReviewEvent["reviewEventId"] as? String)
+            CloudSyncRunnerTestURLProtocol.reviewHistoryImportEventCounts.append(reviewEvents.count)
+            return try Self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "importedCount": 1,
+                  "duplicateCount": 0,
+                  "nextReviewSequenceId": 5
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            let body = try Self.jsonObjectBody(request: request)
+            let afterReviewSequenceId = try XCTUnwrap(body["afterReviewSequenceId"] as? NSNumber).int64Value
+            CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds.append(afterReviewSequenceId)
+            return try Self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [],
+                  "nextReviewSequenceId": 5,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
     private static func workspaceForkRequiredJsonResponse(
         request: URLRequest,
         requestId: String,
@@ -756,6 +816,8 @@ final class CloudSyncRunnerTestURLProtocol: URLProtocol, @unchecked Sendable {
     nonisolated(unsafe) static var pushEntityIds: [String] = []
     nonisolated(unsafe) static var pushEntitySnapshots: [[String: String]] = []
     nonisolated(unsafe) static var pullAfterHotChangeIds: [Int64] = []
+    nonisolated(unsafe) static var reviewHistoryImportEventCounts: [Int] = []
+    nonisolated(unsafe) static var reviewHistoryPullAfterSequenceIds: [Int64] = []
 
     override class func canInit(with request: URLRequest) -> Bool {
         _ = request
@@ -792,5 +854,7 @@ final class CloudSyncRunnerTestURLProtocol: URLProtocol, @unchecked Sendable {
         self.pushEntityIds = []
         self.pushEntitySnapshots = []
         self.pullAfterHotChangeIds = []
+        self.reviewHistoryImportEventCounts = []
+        self.reviewHistoryPullAfterSequenceIds = []
     }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
@@ -411,6 +411,60 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
         XCTAssertEqual(20, syncState.lastAppliedHotChangeId)
         XCTAssertTrue(syncState.hasHydratedHotState)
     }
+
+    func testGuestLocalRecoveryLinkedSyncImportsReviewHistoryWhenHotStateAlreadyHydrated() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: savedCard.cardId,
+                rating: .good,
+                reviewedAtClient: "2026-04-01T00:00:00.000Z"
+            )
+        )
+        let reviewEvent = try XCTUnwrap(try database.loadReviewEvents(workspaceId: workspace.workspaceId).first)
+        try database.deleteAllOutboxEntries(workspaceId: workspace.workspaceId)
+        try database.setLastAppliedHotChangeId(workspaceId: workspace.workspaceId, changeId: 20)
+        try database.setLastAppliedReviewSequenceId(workspaceId: workspace.workspaceId, reviewSequenceId: 0)
+        try database.setHasHydratedHotState(workspaceId: workspace.workspaceId, hasHydratedHotState: true)
+        try database.setHasHydratedReviewHistory(workspaceId: workspace.workspaceId, hasHydratedReviewHistory: false)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try LinkedSyncRunnerTestTransportSupport.handleGuestLocalRecoveryReviewHistoryImportRetryRequest(
+                request: request,
+                reviewEventId: reviewEvent.reviewEventId
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runGuestLocalRecoveryLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
+        XCTAssertEqual([1], CloudSyncRunnerTestURLProtocol.reviewHistoryImportEventCounts)
+        XCTAssertEqual([5], CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds)
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.reviewEvent))
+        XCTAssertEqual(5, syncState.lastAppliedReviewSequenceId)
+        XCTAssertTrue(syncState.hasHydratedHotState)
+        XCTAssertTrue(syncState.hasHydratedReviewHistory)
+    }
 }
 
 private struct CloudSyncDecodeFailureProbeResponse: Decodable {

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressCloudSyncService.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressCloudSyncService.swift
@@ -278,6 +278,11 @@ final class ProgressCloudSyncService: CloudSyncServing {
         _ = linkedSession
         fatalError("Progress refresh should not trigger sync in progress tests.")
     }
+
+    func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
+        _ = linkedSession
+        fatalError("Progress refresh should not trigger guest local recovery sync in progress tests.")
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- add a dedicated iOS guest local recovery completion path after email sign-in
- create or reuse a recovered linked workspace and preserve local SQLite data into it
- run recovery-aware linked sync/bootstrap and keep pending guest-upgrade missing-token recovery blocked

## Validation
- git diff --check
- xcrun swiftc -parse on changed Swift files
- no simulator-backed iOS tests run per repository instructions