### PR TITLE
[codex] Improve iOS guest local recovery UI

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift
@@ -50,9 +50,20 @@ enum CloudPostAuthSyncOperation: Hashable {
     case syncOnly
 }
 
+enum CloudPostAuthFailureKind: Hashable {
+    case standard
+    case guestLocalRecovery
+}
+
 struct CloudPostAuthFailurePresentation: Equatable {
     let title: String
+    let message: String?
     let retryAction: CloudPostAuthRetryAction
+    let kind: CloudPostAuthFailureKind
+
+    var allowsAccountExitActions: Bool {
+        self.kind == .standard
+    }
 }
 
 func makeCloudPostAuthFailurePresentation(
@@ -62,10 +73,7 @@ func makeCloudPostAuthFailurePresentation(
     switch operation {
     case .completeLink(let linkContext, let selection):
         if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
-            return CloudPostAuthFailurePresentation(
-                title: cloudState == .linked
-                    ? aiSettingsLocalized("settings.account.cloudSignIn.failure.initialSyncFailed", "Signed in, but initial sync failed.")
-                    : aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
+            return makeGuestLocalRecoveryPostAuthFailurePresentation(
                 retryAction: .completeLink(linkContext: linkContext, selection: selection)
             )
         }
@@ -73,38 +81,77 @@ func makeCloudPostAuthFailurePresentation(
         if cloudState == .linked {
             return CloudPostAuthFailurePresentation(
                 title: aiSettingsLocalized("settings.account.cloudSignIn.failure.initialSyncFailed", "Signed in, but initial sync failed."),
-                retryAction: .syncOnly
+                message: nil,
+                retryAction: .syncOnly,
+                kind: .standard
             )
         }
 
         return CloudPostAuthFailurePresentation(
             title: aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
-            retryAction: .completeLink(linkContext: linkContext, selection: selection)
+            message: nil,
+            retryAction: .completeLink(linkContext: linkContext, selection: selection),
+            kind: .standard
         )
     case .completeGuestLink(let linkContext, let selection):
         return CloudPostAuthFailurePresentation(
             title: aiSettingsLocalized("settings.account.cloudSignIn.failure.accountUpgradeFailed", "Signed in, but account upgrade failed."),
-            retryAction: .completeGuestLink(linkContext: linkContext, selection: selection)
+            message: nil,
+            retryAction: .completeGuestLink(linkContext: linkContext, selection: selection),
+            kind: .standard
         )
     case .syncOnly:
         return CloudPostAuthFailurePresentation(
             title: aiSettingsLocalized("settings.account.cloudSignIn.failure.initialSyncFailed", "Signed in, but initial sync failed."),
-            retryAction: .syncOnly
+            message: nil,
+            retryAction: .syncOnly,
+            kind: .standard
         )
     }
+}
+
+func makeGuestLocalRecoveryPostAuthFailurePresentation(
+    retryAction: CloudPostAuthRetryAction
+) -> CloudPostAuthFailurePresentation {
+    CloudPostAuthFailurePresentation(
+        title: aiSettingsLocalized(
+            "settings.account.cloudSignIn.guestLocalRecovery.failure.title",
+            "Local data recovery failed."
+        ),
+        message: aiSettingsLocalized(
+            "settings.account.cloudSignIn.guestLocalRecovery.failure.message",
+            "Try again; local data stays on this device."
+        ),
+        retryAction: retryAction,
+        kind: .guestLocalRecovery
+    )
 }
 
 private struct CloudPostAuthFailureState: Identifiable, Hashable {
     let id: String
     let title: String
     let message: String
+    let technicalDetails: String?
     let retryAction: CloudPostAuthRetryAction
+    let kind: CloudPostAuthFailureKind
 
-    init(title: String, message: String, retryAction: CloudPostAuthRetryAction) {
+    init(
+        title: String,
+        message: String,
+        technicalDetails: String?,
+        retryAction: CloudPostAuthRetryAction,
+        kind: CloudPostAuthFailureKind
+    ) {
         self.id = UUID().uuidString
         self.title = title
         self.message = message
+        self.technicalDetails = technicalDetails
         self.retryAction = retryAction
+        self.kind = kind
+    }
+
+    var allowsAccountExitActions: Bool {
+        self.kind == .standard
     }
 }
 
@@ -125,6 +172,18 @@ private struct CloudPostAuthSyncState: Identifiable, Hashable {
     init(operation: CloudPostAuthSyncOperation) {
         self.id = UUID().uuidString
         self.operation = operation
+    }
+}
+
+private struct CloudPostAuthGuestLocalRecoveryPreparationState: Identifiable, Hashable {
+    let id: String
+    let linkContext: CloudWorkspaceLinkContext
+    let selection: CloudWorkspaceLinkSelection
+
+    init(linkContext: CloudWorkspaceLinkContext, selection: CloudWorkspaceLinkSelection) {
+        self.id = UUID().uuidString
+        self.linkContext = linkContext
+        self.selection = selection
     }
 }
 
@@ -185,6 +244,32 @@ func makeCloudPostAuthSyncPresentation() -> CloudPostAuthSyncPresentation {
     )
 }
 
+func makeCloudPostAuthSyncPresentation(operation: CloudPostAuthSyncOperation) -> CloudPostAuthSyncPresentation {
+    if isGuestLocalRecoverySyncOperation(operation) {
+        return CloudPostAuthSyncPresentation(
+            title: aiSettingsLocalized(
+                "settings.account.cloudSignIn.guestLocalRecovery.recovering.title",
+                "Recovering local data"
+            ),
+            message: aiSettingsLocalized(
+                "settings.account.cloudSignIn.guestLocalRecovery.recovering.message",
+                "Keep this screen open while iOS reconnects local data on this device to your recovered workspace."
+            )
+        )
+    }
+
+    return makeCloudPostAuthSyncPresentation()
+}
+
+func isGuestLocalRecoverySyncOperation(_ operation: CloudPostAuthSyncOperation) -> Bool {
+    switch operation {
+    case .completeLink(let linkContext, _):
+        return linkContext.postAuthRecoveryRoute == .guestLocalRecovery
+    case .completeGuestLink, .syncOnly:
+        return false
+    }
+}
+
 enum CloudWorkspacePostAuthRoute: Equatable {
     case autoLink(CloudWorkspaceLinkSelection)
     case chooseWorkspace
@@ -227,6 +312,7 @@ struct CloudSignInSheet: View {
     @State private var email: String = ""
     @State private var otpSheetState: CloudOtpSheetState?
     @State private var postAuthLoadingState: CloudPostAuthLoadingState?
+    @State private var postAuthGuestLocalRecoveryPreparationState: CloudPostAuthGuestLocalRecoveryPreparationState?
     @State private var postAuthSyncState: CloudPostAuthSyncState?
     @State private var workspaceLinkContext: CloudWorkspaceLinkContext?
     @State private var postAuthRecoveryNeededState: CloudPostAuthRecoveryNeededState?
@@ -303,6 +389,7 @@ struct CloudSignInSheet: View {
                     onReturnToEmail: {
                         self.otpSheetState = nil
                         self.postAuthLoadingState = nil
+                        self.postAuthGuestLocalRecoveryPreparationState = nil
                         self.postAuthSyncState = nil
                         self.workspaceLinkContext = nil
                         self.postAuthRecoveryNeededState = nil
@@ -319,8 +406,15 @@ struct CloudSignInSheet: View {
                         await self.prepareCloudLink(verifiedContext: loadingState.verifiedContext)
                     }
             }
+            .sheet(item: self.$postAuthGuestLocalRecoveryPreparationState) { recoveryState in
+                CloudPostAuthGuestLocalRecoveryPreparationSheet()
+                    .interactiveDismissDisabled(true)
+                    .task(id: recoveryState.id) {
+                        await self.runGuestLocalRecoveryPreparation(recoveryState)
+                    }
+            }
             .sheet(item: self.$postAuthSyncState) { syncState in
-                CloudPostAuthSyncSheet()
+                CloudPostAuthSyncSheet(operation: syncState.operation)
                     .interactiveDismissDisabled(true)
                     .task(id: syncState.id) {
                         await self.runPostAuthSync(syncState)
@@ -366,6 +460,7 @@ struct CloudSignInSheet: View {
                         self.isLogoutConfirmationPresented = true
                     }
                 )
+                .interactiveDismissDisabled(failureState.kind == .guestLocalRecovery)
                 .environment(self.store)
             }
             .alert(aiSettingsLocalized("settings.account.status.logoutAlertTitle", "Log out and clear this device?"), isPresented: self.$isLogoutConfirmationPresented) {
@@ -388,7 +483,9 @@ struct CloudSignInSheet: View {
     }
 
     private var isPostAuthActionInFlight: Bool {
-        self.postAuthLoadingState != nil || self.postAuthSyncState != nil
+        self.postAuthLoadingState != nil
+            || self.postAuthGuestLocalRecoveryPreparationState != nil
+            || self.postAuthSyncState != nil
     }
 
     private func scheduleEmailFieldFocus() {
@@ -475,12 +572,20 @@ struct CloudSignInSheet: View {
     private func handlePreparedLinkContext(_ linkContext: CloudWorkspaceLinkContext) {
         self.authErrorPresentation = nil
         self.postAuthLoadingState = nil
+        self.postAuthGuestLocalRecoveryPreparationState = nil
         self.postAuthRecoveryNeededState = nil
         self.postAuthFailureState = nil
 
         switch makeCloudWorkspacePostAuthRoute(linkContext: linkContext) {
         case .autoLink(let selection):
-            self.completeLink(linkContext: linkContext, selection: selection)
+            if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
+                self.postAuthGuestLocalRecoveryPreparationState = CloudPostAuthGuestLocalRecoveryPreparationState(
+                    linkContext: linkContext,
+                    selection: selection
+                )
+            } else {
+                self.completeLink(linkContext: linkContext, selection: selection)
+            }
         case .chooseWorkspace:
             self.workspaceLinkContext = linkContext
         case .guestLocalRecoveryNeeded:
@@ -495,6 +600,7 @@ struct CloudSignInSheet: View {
     private func handleVerifiedAuthContext(_ verifiedContext: CloudVerifiedAuthContext) {
         self.otpSheetState = nil
         self.postAuthLoadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
+        self.postAuthGuestLocalRecoveryPreparationState = nil
         self.postAuthSyncState = nil
         self.workspaceLinkContext = nil
         self.postAuthRecoveryNeededState = nil
@@ -508,12 +614,28 @@ struct CloudSignInSheet: View {
             self.handlePreparedLinkContext(linkContext)
         } catch {
             self.postAuthLoadingState = nil
+            self.postAuthGuestLocalRecoveryPreparationState = nil
             self.postAuthSyncState = nil
-            self.presentPostAuthFailure(
-                title: aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
-                message: Flashcards.errorMessage(error: error),
-                retryAction: .prepareLink(verifiedContext: verifiedContext)
-            )
+            if self.store.cloudCredentialRecoveryState?.reason == .guestSessionMissing {
+                let failurePresentation = makeGuestLocalRecoveryPostAuthFailurePresentation(
+                    retryAction: .prepareLink(verifiedContext: verifiedContext)
+                )
+                self.presentPostAuthFailure(
+                    title: failurePresentation.title,
+                    message: failurePresentation.message ?? Flashcards.errorMessage(error: error),
+                    technicalDetails: Flashcards.errorMessage(error: error),
+                    retryAction: failurePresentation.retryAction,
+                    kind: failurePresentation.kind
+                )
+            } else {
+                self.presentPostAuthFailure(
+                    title: aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
+                    message: Flashcards.errorMessage(error: error),
+                    technicalDetails: nil,
+                    retryAction: .prepareLink(verifiedContext: verifiedContext),
+                    kind: .standard
+                )
+            }
         }
     }
 
@@ -526,6 +648,20 @@ struct CloudSignInSheet: View {
             operation: linkContext.guestUpgradeMode != nil
                 ? .completeGuestLink(linkContext: linkContext, selection: selection)
                 : .completeLink(linkContext: linkContext, selection: selection)
+        )
+    }
+
+    private func runGuestLocalRecoveryPreparation(_ recoveryState: CloudPostAuthGuestLocalRecoveryPreparationState) async {
+        guard self.postAuthGuestLocalRecoveryPreparationState?.id == recoveryState.id else {
+            return
+        }
+
+        self.postAuthGuestLocalRecoveryPreparationState = nil
+        self.presentPostAuthSync(
+            operation: .completeLink(
+                linkContext: recoveryState.linkContext,
+                selection: recoveryState.selection
+            )
         )
     }
 
@@ -549,6 +685,7 @@ struct CloudSignInSheet: View {
 
         self.authErrorPresentation = nil
         self.postAuthLoadingState = nil
+        self.postAuthGuestLocalRecoveryPreparationState = nil
         self.postAuthSyncState = nil
         self.workspaceLinkContext = nil
         self.postAuthRecoveryNeededState = nil
@@ -601,8 +738,12 @@ struct CloudSignInSheet: View {
             self.postAuthSyncState = nil
             self.presentPostAuthFailure(
                 title: failurePresentation.title,
-                message: Flashcards.errorMessage(error: error),
-                retryAction: failurePresentation.retryAction
+                message: failurePresentation.message ?? Flashcards.errorMessage(error: error),
+                technicalDetails: failurePresentation.kind == .guestLocalRecovery
+                    ? Flashcards.errorMessage(error: error)
+                    : nil,
+                retryAction: failurePresentation.retryAction,
+                kind: failurePresentation.kind
             )
         }
     }
@@ -610,16 +751,21 @@ struct CloudSignInSheet: View {
     private func presentPostAuthFailure(
         title: String,
         message: String,
-        retryAction: CloudPostAuthRetryAction
+        technicalDetails: String?,
+        retryAction: CloudPostAuthRetryAction,
+        kind: CloudPostAuthFailureKind
     ) {
         self.authErrorPresentation = nil
         self.postAuthLoadingState = nil
+        self.postAuthGuestLocalRecoveryPreparationState = nil
         self.postAuthSyncState = nil
         self.postAuthRecoveryNeededState = nil
         self.postAuthFailureState = CloudPostAuthFailureState(
             title: title,
             message: message,
-            retryAction: retryAction
+            technicalDetails: technicalDetails,
+            retryAction: retryAction,
+            kind: kind
         )
     }
 
@@ -634,6 +780,7 @@ struct CloudSignInSheet: View {
         }
 
         self.postAuthLoadingState = nil
+        self.postAuthGuestLocalRecoveryPreparationState = nil
         self.postAuthSyncState = nil
         self.postAuthFailureState = nil
         self.workspaceLinkContext = nil
@@ -1088,6 +1235,18 @@ private struct CloudPostAuthFailureSheet: View {
     let onClose: () -> Void
     let onLogout: () -> Void
 
+    private var isRetryButtonDisabled: Bool {
+        if self.isRetryDisabled {
+            return true
+        }
+
+        guard self.state.kind == .standard else {
+            return false
+        }
+
+        return isCloudSignInSyncInFlight(status: self.store.syncStatus)
+    }
+
     var body: some View {
         NavigationStack {
             ReadableContentLayout(
@@ -1095,40 +1254,115 @@ private struct CloudPostAuthFailureSheet: View {
                 horizontalPadding: 0
             ) {
                 Form {
-                    Section {
-                        CopyableErrorMessageView(message: self.state.message)
-                            .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureMessage)
+                    if self.state.kind == .standard {
+                        Section {
+                            CopyableErrorMessageView(message: self.state.message)
+                                .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureMessage)
+                        }
                     }
 
                     Section(aiSettingsLocalized("settings.account.cloudSignIn.section.cloudAccount", "Cloud account")) {
                         Text(self.state.title)
                             .font(.headline)
-                        Text(
-                            aiSettingsLocalized(
-                                "settings.account.cloudSignIn.failureDescription",
-                                "Your sign-in succeeded, but the cloud workspace setup or initial sync did not finish."
-                            )
-                        )
-                            .foregroundStyle(.secondary)
+                        if self.state.kind == .guestLocalRecovery {
+                            Text(self.failureDescription)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                                .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureMessage)
+                        } else {
+                            Text(self.failureDescription)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if let technicalDetails = self.state.technicalDetails {
+                        Section {
+                            DisclosureGroup(aiSettingsLocalized("settings.account.cloudSignIn.technicalDetails", "Technical details")) {
+                                Text(technicalDetails)
+                                    .font(.caption.monospaced())
+                                    .foregroundStyle(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .textSelection(.enabled)
+                                    .padding(.top, 4)
+                                    .contextMenu {
+                                        Button(aiSettingsLocalized("settings.account.cloudSignIn.copyTechnicalDetails", "Copy technical details")) {
+                                            UIPasteboard.general.string = technicalDetails
+                                        }
+                                    }
+                            }
+                            .tint(.secondary)
+                        }
                     }
 
                     Section {
                         Button(aiSettingsLocalized("common.retry", "Retry")) {
                             self.onRetry()
                         }
-                        .disabled(self.isRetryDisabled || isCloudSignInSyncInFlight(status: self.store.syncStatus))
+                        .disabled(self.isRetryButtonDisabled)
 
-                        Button(aiSettingsLocalized("common.close", "Close")) {
-                            self.onClose()
-                        }
+                        if self.state.allowsAccountExitActions {
+                            Button(aiSettingsLocalized("common.close", "Close")) {
+                                self.onClose()
+                            }
 
-                        Button(aiSettingsLocalized("settings.account.status.logOut", "Log out"), role: .destructive) {
-                            self.onLogout()
+                            Button(aiSettingsLocalized("settings.account.status.logOut", "Log out"), role: .destructive) {
+                                self.onLogout()
+                            }
                         }
                     }
                 }
             }
             .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureScreen)
+            .navigationTitle(aiSettingsLocalized("settings.account.cloudSignIn.cloudSyncTitle", "Cloud sync"))
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private var failureDescription: String {
+        switch self.state.kind {
+        case .standard:
+            return aiSettingsLocalized(
+                "settings.account.cloudSignIn.failureDescription",
+                "Your sign-in succeeded, but the cloud workspace setup or initial sync did not finish."
+            )
+        case .guestLocalRecovery:
+            return self.state.message
+        }
+    }
+}
+
+private struct CloudPostAuthGuestLocalRecoveryPreparationSheet: View {
+    var body: some View {
+        NavigationStack {
+            ReadableContentLayout(
+                maxWidth: flashcardsReadableFormMaxWidth,
+                horizontalPadding: 24
+            ) {
+                VStack(spacing: 16) {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+
+                    Text(
+                        aiSettingsLocalized(
+                            "settings.account.cloudSignIn.guestLocalRecovery.prepare.title",
+                            "Preparing recovered workspace..."
+                        )
+                    )
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+
+                    Text(
+                        aiSettingsLocalized(
+                            "settings.account.cloudSignIn.guestLocalRecovery.prepare.message",
+                            "Local data is still on this device. Keep this screen open while iOS prepares a recovered workspace."
+                        )
+                    )
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthSyncScreen)
             .navigationTitle(aiSettingsLocalized("settings.account.cloudSignIn.cloudSyncTitle", "Cloud sync"))
             .navigationBarTitleDisplayMode(.inline)
         }
@@ -1173,7 +1407,11 @@ private struct CloudPostAuthLoadingSheet: View {
 }
 
 private struct CloudPostAuthSyncSheet: View {
-    private let presentation: CloudPostAuthSyncPresentation = makeCloudPostAuthSyncPresentation()
+    private let presentation: CloudPostAuthSyncPresentation
+
+    init(operation: CloudPostAuthSyncOperation) {
+        self.presentation = makeCloudPostAuthSyncPresentation(operation: operation)
+    }
 
     var body: some View {
         NavigationStack {

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "المزامنة السحابية";
 "settings.account.cloudSignIn.loadingWorkspaces" = "جارٍ تحميل مساحات العمل...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "اكتمل تسجيل الدخول. يقوم التطبيق الآن بتحميل خطوة مساحة العمل السحابية.";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "جارٍ تحضير مساحة العمل المستردة...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "لا تزال البيانات المحلية على هذا الجهاز. اترك هذه الشاشة مفتوحة بينما يجهز iOS مساحة عمل مستردة.";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "استرداد البيانات المحلية";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "اترك هذه الشاشة مفتوحة بينما يعيد iOS ربط البيانات المحلية على هذا الجهاز بمساحة العمل المستردة.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "فشل استرداد البيانات المحلية.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "حاول مرة أخرى؛ تظل البيانات المحلية على هذا الجهاز.";
 "settings.account.cloudSignIn.technicalDetails" = "التفاصيل الفنية";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "نسخ التفاصيل الفنية";
 

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "Cloud-Synchronisierung";
 "settings.account.cloudSignIn.loadingWorkspaces" = "Arbeitsbereiche werden geladen...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "Die Anmeldung ist abgeschlossen. Die App lädt jetzt den Cloud-Workspace-Schritt.";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "Geretteter Arbeitsbereich wird vorbereitet...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "Lokale Daten sind weiterhin auf diesem Gerät. Lassen Sie diesen Bildschirm geöffnet, während iOS einen wiederhergestellten Arbeitsbereich vorbereitet.";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "Lokale Daten werden wiederhergestellt";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "Lassen Sie diesen Bildschirm geöffnet, während iOS lokale Daten auf diesem Gerät wieder mit dem wiederhergestellten Arbeitsbereich verbindet.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "Lokale Datenwiederherstellung fehlgeschlagen.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "Versuchen Sie es erneut; lokale Daten bleiben auf diesem Gerät.";
 "settings.account.cloudSignIn.technicalDetails" = "Technische Details";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "Technische Details kopieren";
 

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "Sincronizacion en la nube";
 "settings.account.cloudSignIn.loadingWorkspaces" = "Cargando espacios de trabajo...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "El inicio de sesion se completo. La app esta cargando ahora el paso del espacio de trabajo en la nube.";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "Preparando espacio de trabajo recuperado...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "Los datos locales siguen en este dispositivo. Manten esta pantalla abierta mientras iOS prepara un espacio de trabajo recuperado.";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "Recuperando datos locales";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "Manten esta pantalla abierta mientras iOS vuelve a conectar los datos locales de este dispositivo con tu espacio de trabajo recuperado.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "Fallo la recuperacion de datos locales.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "Intentalo de nuevo; los datos locales permanecen en este dispositivo.";
 "settings.account.cloudSignIn.technicalDetails" = "Detalles tecnicos";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "Copiar detalles tecnicos";
 

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "Sincronizacion en la nube";
 "settings.account.cloudSignIn.loadingWorkspaces" = "Cargando espacios de trabajo...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "El inicio de sesion se completo. La app esta cargando ahora el paso del espacio de trabajo en la nube.";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "Preparando espacio de trabajo recuperado...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "Los datos locales siguen en este dispositivo. Manten esta pantalla abierta mientras iOS prepara un espacio de trabajo recuperado.";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "Recuperando datos locales";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "Manten esta pantalla abierta mientras iOS vuelve a conectar los datos locales de este dispositivo con tu espacio de trabajo recuperado.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "Fallo la recuperacion de datos locales.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "Intentalo de nuevo; los datos locales permanecen en este dispositivo.";
 "settings.account.cloudSignIn.technicalDetails" = "Detalles tecnicos";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "Copiar detalles tecnicos";
 

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "क्लाउड सिंक";
 "settings.account.cloudSignIn.loadingWorkspaces" = "कार्यस्थान लोड हो रहा है...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "लॉगिन पूरा हो गया है. ऐप अब क्लाउड वर्कस्पेस चरण लोड कर रहा है।";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "रिकवर किया गया कार्यक्षेत्र तैयार हो रहा है...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "स्थानीय डेटा अभी भी इस डिवाइस पर है. iOS के रिकवर किए गए कार्यक्षेत्र को तैयार करने तक यह स्क्रीन खुली रखें।";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "स्थानीय डेटा रिकवर किया जा रहा है";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "iOS जब इस डिवाइस के स्थानीय डेटा को आपके रिकवर किए गए कार्यक्षेत्र से फिर से जोड़ता है, तब यह स्क्रीन खुली रखें।";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "स्थानीय डेटा रिकवरी विफल रही।";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "फिर से कोशिश करें; स्थानीय डेटा इस डिवाइस पर ही रहता है।";
 "settings.account.cloudSignIn.technicalDetails" = "तकनीकी विवरण";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "तकनीकी विवरण कॉपी करें";
 

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "クラウド同期";
 "settings.account.cloudSignIn.loadingWorkspaces" = "ワークスペースを読み込み中...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "ログインが完了しました。アプリは現在、クラウド ワークスペース ステップを読み込み中です。";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "復元したワークスペースを準備中...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "ローカルデータはまだこのデバイスにあります。iOS が復元したワークスペースを準備する間、この画面を開いたままにしてください。";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "ローカルデータを復元中";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "iOS がこのデバイスのローカルデータを復元したワークスペースに再接続する間、この画面を開いたままにしてください。";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "ローカルデータの復元に失敗しました。";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "もう一度試してください。ローカルデータはこのデバイスに残っています。";
 "settings.account.cloudSignIn.technicalDetails" = "技術的な詳細";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "技術的な詳細をコピー";
 

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "Облачная синхронизация";
 "settings.account.cloudSignIn.loadingWorkspaces" = "Загрузка рабочих пространств...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "Вход завершен. Приложение сейчас загружает этап облачной рабочей области.";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "Подготовка восстановленного рабочего пространства...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "Локальные данные все еще на этом устройстве. Оставьте этот экран открытым, пока iOS подготавливает восстановленное рабочее пространство.";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "Восстановление локальных данных";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "Оставьте этот экран открытым, пока iOS повторно подключает локальные данные на этом устройстве к восстановленному рабочему пространству.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "Не удалось восстановить локальные данные.";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "Попробуйте еще раз; локальные данные остаются на этом устройстве.";
 "settings.account.cloudSignIn.technicalDetails" = "Технические подробности";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "Копировать технические подробности";
 

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -304,6 +304,12 @@
 "settings.account.cloudSignIn.cloudSyncTitle" = "云同步";
 "settings.account.cloudSignIn.loadingWorkspaces" = "正在加载工作区...";
 "settings.account.cloudSignIn.loadingWorkspacesDescription" = "登录完成。应用程序现在正在加载云工作区步骤。";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.title" = "正在准备已恢复的工作空间...";
+"settings.account.cloudSignIn.guestLocalRecovery.prepare.message" = "本地数据仍在此设备上。请保持此屏幕打开，iOS 正在准备已恢复的工作空间。";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.title" = "正在恢复本地数据";
+"settings.account.cloudSignIn.guestLocalRecovery.recovering.message" = "请保持此屏幕打开，iOS 正在将此设备上的本地数据重新连接到已恢复的工作空间。";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.title" = "本地数据恢复失败。";
+"settings.account.cloudSignIn.guestLocalRecovery.failure.message" = "请重试；本地数据仍保留在此设备上。";
 "settings.account.cloudSignIn.technicalDetails" = "技术细节";
 "settings.account.cloudSignIn.copyTechnicalDetails" = "复制技术细节";
 

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudCredentialRecoveryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudCredentialRecoveryTests.swift
@@ -1846,8 +1846,41 @@ final class CloudCredentialRecoveryTests: LocalWorkspaceSyncTestCase {
             cloudState: store.cloudSettings?.cloudState
         )
         XCTAssertEqual(
+            aiSettingsLocalized(
+                "settings.account.cloudSignIn.guestLocalRecovery.failure.title",
+                "Local data recovery failed."
+            ),
+            failurePresentation.title
+        )
+        XCTAssertEqual(
+            Optional(aiSettingsLocalized(
+                "settings.account.cloudSignIn.guestLocalRecovery.failure.message",
+                "Try again; local data stays on this device."
+            )),
+            failurePresentation.message
+        )
+        XCTAssertEqual(.guestLocalRecovery, failurePresentation.kind)
+        XCTAssertFalse(failurePresentation.allowsAccountExitActions)
+        XCTAssertEqual(
             .completeLink(linkContext: linkContext, selection: .createNew),
             failurePresentation.retryAction
+        )
+        let syncPresentation = makeCloudPostAuthSyncPresentation(
+            operation: .completeLink(linkContext: linkContext, selection: .createNew)
+        )
+        XCTAssertEqual(
+            aiSettingsLocalized(
+                "settings.account.cloudSignIn.guestLocalRecovery.recovering.title",
+                "Recovering local data"
+            ),
+            syncPresentation.title
+        )
+        XCTAssertEqual(
+            aiSettingsLocalized(
+                "settings.account.cloudSignIn.guestLocalRecovery.recovering.message",
+                "Keep this screen open while iOS reconnects local data on this device to your recovered workspace."
+            ),
+            syncPresentation.message
         )
 
         try await store.completeCloudLink(


### PR DESCRIPTION
## Summary
- Replace the blocked iOS guest local recovery post-auth failure path with preparation and recovery progress states.
- Keep guest local recovery on automatic recovered workspace creation with retry-only failure handling.
- Add localized recovery copy and update recovery coverage for the presentation helpers.

## Validation
- `swiftc -parse apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignInSheet.swift apps/ios/Flashcards/FlashcardsTests/Cloud/CloudCredentialRecoveryTests.swift`
- `git --no-pager diff --check`
- `plutil -lint apps/ios/Flashcards/Flashcards/*.lproj/AISettings.strings`