### PR TITLE
[codex] Fix Android settings coroutine launch import

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudSignInViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 private sealed interface CloudPostAuthRetryAction {
     data class CompleteCloudLink(


### PR DESCRIPTION
## Summary

Adds the missing `kotlinx.coroutines.launch` import in `CloudSignInViewModel` so the newly added `viewModelScope.launch` calls compile.

## Root cause

PR #228 added `viewModelScope.launch { ... }` wrappers, but the file did not import the `launch` coroutine extension. The Android release gate failed in `:feature:settings:compileDebugKotlin` with unresolved `launch` references and cascading suspend-call errors.

## Validation

- `ANDROID_VERSION_CODE=12419082 ./gradlew --no-daemon :feature:settings:compileDebugKotlin`