### PR TITLE
[codex] Align web review reaction fallback duration

### DIFF
--- a/apps/web/src/screens/review/ReviewScreen.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.tsx
@@ -16,6 +16,7 @@ export function ReviewScreen(): ReactElement {
     headerProps,
     paneProps,
     queuePanelProps,
+    reviewReactionFallbackHandler,
     reviewReactionEvents,
   } = useReviewScreenController();
 
@@ -29,7 +30,10 @@ export function ReviewScreen(): ReactElement {
           <ReviewQueuePanel {...queuePanelProps} />
         </div>
 
-        <ReviewRatingReactionLayer events={reviewReactionEvents} />
+        <ReviewRatingReactionLayer
+          events={reviewReactionEvents}
+          onReactionEventFallback={reviewReactionFallbackHandler}
+        />
       </section>
 
       <ReviewEditorModal {...editorModalProps} />

--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+import { act, useEffect, type ReactElement } from "react";
+import ReactDOM from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  reducedReviewReactionMotionMediaQuery,
+  type ReviewReactionVariant,
+} from "./reviewReaction";
+import { ReviewRatingReactionLayer } from "./ReviewRatingReactionLayer";
+import {
+  loadReviewReactionLottieAssets,
+  reviewReactionLottieFallbackVariant,
+} from "./reviewReactionLottie";
+import {
+  useReviewRatingReactions,
+  type UseReviewRatingReactionsResult,
+} from "./useReviewRatingReactions";
+
+const { loadAnimationMock } = vi.hoisted(() => ({
+  loadAnimationMock: vi.fn(),
+}));
+
+vi.mock("lottie-web/build/player/lottie_light", () => ({
+  default: {
+    loadAnimation: loadAnimationMock,
+  },
+}));
+
+type ReviewReactionLayerHarnessProps = Readonly<{
+  onResult: (result: UseReviewRatingReactionsResult) => void;
+}>;
+
+type LottieFailureExpectation = Readonly<{
+  randomValue: number;
+  variant: ReviewReactionVariant;
+}>;
+
+const lottieFailureExpectations: ReadonlyArray<LottieFailureExpectation> = [
+  {
+    randomValue: 0.5,
+    variant: "easyRainbowStreak",
+  },
+  {
+    randomValue: 0.95,
+    variant: "easyUnicornFlyby",
+  },
+];
+
+function ReviewReactionLayerHarness(props: ReviewReactionLayerHarnessProps): ReactElement {
+  const { onResult } = props;
+  const result = useReviewRatingReactions();
+
+  useEffect(() => {
+    onResult(result);
+  }, [onResult, result]);
+
+  return (
+    <ReviewRatingReactionLayer
+      events={result.events}
+      onReactionEventFallback={result.handleReactionEventFallback}
+    />
+  );
+}
+
+function installReviewReactionMotionPreference(matches: boolean): void {
+  const mediaQueryList = {
+    matches,
+    media: reducedReviewReactionMotionMediaQuery,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+  } satisfies Partial<MediaQueryList>;
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn(() => mediaQueryList as MediaQueryList),
+  });
+}
+
+async function flushReactionPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("ReviewRatingReactionLayer Lottie fallback", () => {
+  let container: HTMLDivElement | null = null;
+  let root: ReactDOM.Root | null = null;
+  let latestResult: UseReviewRatingReactionsResult | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    loadAnimationMock.mockReset();
+    loadAnimationMock.mockImplementation(() => {
+      throw new Error("Lottie render failed.");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000101");
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = ReactDOM.createRoot(container);
+    latestResult = null;
+  });
+
+  afterEach(() => {
+    const currentRoot = root;
+    if (currentRoot !== null) {
+      act(() => currentRoot.unmount());
+    }
+
+    container?.remove();
+    container = null;
+    root = null;
+    latestResult = null;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  async function renderHarness(): Promise<void> {
+    const currentRoot = root;
+    if (currentRoot === null) {
+      throw new Error("Review reaction test root is not ready.");
+    }
+
+    await loadReviewReactionLottieAssets();
+
+    await act(async () => {
+      currentRoot.render(
+        <ReviewReactionLayerHarness
+          onResult={(result) => {
+            latestResult = result;
+          }}
+        />,
+      );
+    });
+  }
+
+  function requireLatestResult(): UseReviewRatingReactionsResult {
+    if (latestResult === null) {
+      throw new Error("Review reaction hook result was not rendered.");
+    }
+
+    return latestResult;
+  }
+
+  function requireReactionEventElement(): HTMLElement {
+    const currentContainer = container;
+    if (currentContainer === null) {
+      throw new Error("Review reaction test container is not ready.");
+    }
+
+    const eventElement = currentContainer.querySelector<HTMLElement>("[data-testid='review-rating-reaction-event']");
+    if (eventElement === null) {
+      throw new Error("Review reaction event was not rendered.");
+    }
+
+    return eventElement;
+  }
+
+  async function emitEasyReactionAfterLottieRenderFailure(randomValue: number): Promise<void> {
+    vi.spyOn(Math, "random").mockReturnValue(randomValue);
+    await act(async () => {
+      requireLatestResult().emitReaction(3);
+      await flushReactionPromises();
+    });
+  }
+
+  for (const expectation of lottieFailureExpectations) {
+    it(`converts ${expectation.variant} render failures to the crown fallback duration`, async () => {
+      installReviewReactionMotionPreference(false);
+      await renderHarness();
+
+      await emitEasyReactionAfterLottieRenderFailure(expectation.randomValue);
+
+      expect(loadAnimationMock).toHaveBeenCalledTimes(1);
+      expect(requireLatestResult().events).toEqual([
+        {
+          id: "00000000-0000-4000-8000-000000000101",
+          rating: "easy",
+          variant: reviewReactionLottieFallbackVariant,
+        },
+      ]);
+      expect(requireReactionEventElement().dataset.reviewReactionVariant).toBe(reviewReactionLottieFallbackVariant);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1729);
+      });
+
+      expect(requireLatestResult().events).toHaveLength(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+      });
+
+      expect(requireLatestResult().events).toHaveLength(0);
+    });
+  }
+
+  it("keeps reduced-motion cleanup at 400ms after Lottie render fallback", async () => {
+    installReviewReactionMotionPreference(true);
+    await renderHarness();
+
+    await emitEasyReactionAfterLottieRenderFailure(0.5);
+
+    expect(requireReactionEventElement().dataset.reviewReactionVariant).toBe(reviewReactionLottieFallbackVariant);
+
+    await act(async () => {
+      vi.advanceTimersByTime(399);
+    });
+
+    expect(requireLatestResult().events).toHaveLength(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(requireLatestResult().events).toHaveLength(0);
+  });
+});

--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactElement } from "react";
+import { useEffect, useRef, type CSSProperties, type ReactElement } from "react";
 import type { AnimationItem } from "lottie-web";
 import {
   matchesReducedReviewReactionMotion,
@@ -17,6 +17,7 @@ import {
 
 type ReviewRatingReactionLayerProps = Readonly<{
   events: ReadonlyArray<ReviewReactionEvent>;
+  onReactionEventFallback: (eventId: string) => void;
 }>;
 
 type ReviewReactionStyle = CSSProperties & Readonly<{
@@ -284,19 +285,16 @@ function ReviewReactionCrownFallbackArt(): ReactElement {
 }
 
 type ReviewReactionLottieAnimationProps = Readonly<{
+  eventId: string;
+  onReactionEventFallback: (eventId: string) => void;
   variant: ReviewReactionLottieVariant;
 }>;
 
 function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps): ReactElement {
-  const { variant } = props;
+  const { eventId, onReactionEventFallback, variant } = props;
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [shouldUseFallback, setShouldUseFallback] = useState<boolean>(false);
 
   useEffect(() => {
-    if (shouldUseFallback) {
-      return;
-    }
-
     const mountedContainer = containerRef.current;
     if (mountedContainer === null) {
       reportReviewReactionLottieFailure(
@@ -304,7 +302,7 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
         "render",
         variant,
       );
-      setShouldUseFallback(true);
+      onReactionEventFallback(eventId);
       return;
     }
     const container: HTMLDivElement = mountedContainer;
@@ -351,7 +349,7 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
       }
 
       reportReviewReactionLottieFailure(error, "render", variant);
-      setShouldUseFallback(true);
+      onReactionEventFallback(eventId);
     });
 
     return () => {
@@ -359,11 +357,7 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
       removeDomLoadedListener?.();
       animationItem?.destroy();
     };
-  }, [shouldUseFallback, variant]);
-
-  if (shouldUseFallback) {
-    return <ReviewReactionCrownFallbackArt />;
-  }
+  }, [eventId, onReactionEventFallback, variant]);
 
   return (
     <div ref={containerRef} className={reviewReactionLottieContainerClassByVariant[variant]} />
@@ -407,7 +401,12 @@ function renderReviewReactionVariant(variant: ReviewReactionVariant): ReactEleme
   }
 }
 
-function renderReviewReactionArt(variant: ReviewReactionVariant): ReactElement {
+function renderReviewReactionArt(
+  event: ReviewReactionEvent,
+  onReactionEventFallback: (eventId: string) => void,
+): ReactElement {
+  const { variant } = event;
+
   if (isReviewReactionLottieVariant(variant)) {
     if (!isReviewReactionLottieAssetsReady()) {
       return <ReviewReactionCrownFallbackArt />;
@@ -415,7 +414,11 @@ function renderReviewReactionArt(variant: ReviewReactionVariant): ReactElement {
 
     return (
       <div className="review-rating-reaction-art review-rating-reaction-lottie-art">
-        <ReviewReactionLottieAnimation variant={variant} />
+        <ReviewReactionLottieAnimation
+          eventId={event.id}
+          onReactionEventFallback={onReactionEventFallback}
+          variant={variant}
+        />
       </div>
     );
   }
@@ -428,7 +431,7 @@ function renderReviewReactionArt(variant: ReviewReactionVariant): ReactElement {
 }
 
 export function ReviewRatingReactionLayer(props: ReviewRatingReactionLayerProps): ReactElement {
-  const { events } = props;
+  const { events, onReactionEventFallback } = props;
 
   useEffect(() => {
     let isMounted = true;
@@ -456,7 +459,7 @@ export function ReviewRatingReactionLayer(props: ReviewRatingReactionLayerProps)
           data-testid="review-rating-reaction-event"
           style={makeReviewReactionStyle(event)}
         >
-          {renderReviewReactionArt(event.variant)}
+          {renderReviewReactionArt(event, onReactionEventFallback)}
         </div>
       ))}
     </div>

--- a/apps/web/src/screens/review/reactions/useReviewRatingReactions.ts
+++ b/apps/web/src/screens/review/reactions/useReviewRatingReactions.ts
@@ -9,12 +9,18 @@ import {
   selectReviewReactionVariant,
   type ReviewReactionEvent,
   type ReviewReactionMotionMode,
+  type ReviewReactionVariant,
 } from "./reviewReaction";
-import { reviewReactionVariantWithReadyLottieFallback } from "./reviewReactionLottie";
+import {
+  isReviewReactionLottieVariant,
+  reviewReactionLottieFallbackVariant,
+  reviewReactionVariantWithReadyLottieFallback,
+} from "./reviewReactionLottie";
 
 export type UseReviewRatingReactionsResult = Readonly<{
   emitReaction: (rating: 0 | 1 | 2 | 3) => void;
   events: ReadonlyArray<ReviewReactionEvent>;
+  handleReactionEventFallback: (eventId: string) => void;
 }>;
 
 function clearReviewReactionTimer(
@@ -47,6 +53,7 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
   const [motionMode, setMotionMode] = useState<ReviewReactionMotionMode>(
     matchesReducedReviewReactionMotion() ? "reduced" : "standard",
   );
+  const eventsRef = useRef<ReadonlyArray<ReviewReactionEvent>>([]);
   const cleanupTimersRef = useRef<Map<string, number>>(new Map<string, number>());
 
   useEffect(() => {
@@ -77,6 +84,25 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
     clearTrimmedReviewReactionTimers(cleanupTimersRef.current, events);
   }, [events]);
 
+  const removeReactionEvent = useCallback((eventId: string): void => {
+    clearReviewReactionTimer(cleanupTimersRef.current, eventId);
+    setEvents((currentEvents) => {
+      const nextEvents = currentEvents.filter((activeEvent) => activeEvent.id !== eventId);
+      eventsRef.current = nextEvents;
+      return nextEvents;
+    });
+  }, []);
+
+  const scheduleReactionEventCleanup = useCallback((
+    eventId: string,
+    variant: ReviewReactionVariant,
+  ): void => {
+    const cleanupTimerId = window.setTimeout(() => {
+      removeReactionEvent(eventId);
+    }, reviewReactionCleanupDelayMillis(variant, motionMode));
+    cleanupTimersRef.current.set(eventId, cleanupTimerId);
+  }, [motionMode, removeReactionEvent]);
+
   const emitReaction = useCallback((rating: 0 | 1 | 2 | 3): void => {
     const reactionRating = makeReviewReactionRating(rating);
     const event: ReviewReactionEvent = {
@@ -89,23 +115,46 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
         ),
       ),
     };
-    const cleanupTimerId = window.setTimeout(() => {
-      clearReviewReactionTimer(cleanupTimersRef.current, event.id);
-      setEvents((currentEvents) => currentEvents.filter((activeEvent) => activeEvent.id !== event.id));
-    }, reviewReactionCleanupDelayMillis(event.variant, motionMode));
-    cleanupTimersRef.current.set(event.id, cleanupTimerId);
+    scheduleReactionEventCleanup(event.id, event.variant);
 
     setEvents((currentEvents) => {
-      return appendReviewReactionEvent(
+      const nextEvents = appendReviewReactionEvent(
         currentEvents,
         event,
         reviewReactionMaximumActiveEvents,
       );
+      eventsRef.current = nextEvents;
+      return nextEvents;
     });
-  }, [motionMode]);
+  }, [scheduleReactionEventCleanup]);
+
+  const handleReactionEventFallback = useCallback((eventId: string): void => {
+    const event = eventsRef.current.find((activeEvent) => activeEvent.id === eventId);
+    if (event === undefined || !isReviewReactionLottieVariant(event.variant)) {
+      return;
+    }
+
+    clearReviewReactionTimer(cleanupTimersRef.current, eventId);
+    scheduleReactionEventCleanup(eventId, reviewReactionLottieFallbackVariant);
+    setEvents((currentEvents) => {
+      const nextEvents = currentEvents.map((activeEvent) => {
+        if (activeEvent.id !== eventId || !isReviewReactionLottieVariant(activeEvent.variant)) {
+          return activeEvent;
+        }
+
+        return {
+          ...activeEvent,
+          variant: reviewReactionLottieFallbackVariant,
+        };
+      });
+      eventsRef.current = nextEvents;
+      return nextEvents;
+    });
+  }, [scheduleReactionEventCleanup]);
 
   return {
     emitReaction,
     events,
+    handleReactionEventFallback,
   };
 }

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -35,6 +35,7 @@ export type UseReviewScreenControllerResult = Readonly<{
   headerProps: ReviewScreenHeaderProps;
   paneProps: ReviewPaneProps;
   queuePanelProps: ReviewQueuePanelProps;
+  reviewReactionFallbackHandler: UseReviewRatingReactionsResult["handleReactionEventFallback"];
   reviewReactionEvents: UseReviewRatingReactionsResult["events"];
 }>;
 
@@ -69,6 +70,7 @@ export function useReviewScreenController(): UseReviewScreenControllerResult {
   const {
     emitReaction: emitReviewReaction,
     events: reviewReactionEvents,
+    handleReactionEventFallback: handleReviewReactionEventFallback,
   } = useReviewRatingReactions();
   const {
     activeReviewQueue,
@@ -398,6 +400,7 @@ export function useReviewScreenController(): UseReviewScreenControllerResult {
       selectedCardId: selectedCard?.cardId ?? null,
       visibleQueueCardsCount,
     },
+    reviewReactionFallbackHandler: handleReviewReactionEventFallback,
     reviewReactionEvents,
   };
 }

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import { settingsTestAnimationsRoute } from "../../routes";
 import {
@@ -12,10 +12,15 @@ import {
   type ReviewReactionEvent,
   type ReviewReactionMotionMode,
   type ReviewReactionRating,
+  type ReviewReactionVariant,
   type ReviewReactionVariantDistributionEntry,
 } from "../review/reactions/reviewReaction";
 import { ReviewRatingReactionLayer } from "../review/reactions/ReviewRatingReactionLayer";
-import { reviewReactionVariantWithReadyLottieFallback } from "../review/reactions/reviewReactionLottie";
+import {
+  isReviewReactionLottieVariant,
+  reviewReactionLottieFallbackVariant,
+  reviewReactionVariantWithReadyLottieFallback,
+} from "../review/reactions/reviewReactionLottie";
 import { SettingsGroup, SettingsNavigationCard, SettingsShell } from "./SettingsShared";
 
 type Translate = (key: TranslationKey, values?: TranslationValues) => string;
@@ -117,6 +122,7 @@ export function TestAnimationsScreen(): ReactElement {
   const [motionMode, setMotionMode] = useState<ReviewReactionMotionMode>(
     matchesReducedReviewReactionMotion() ? "reduced" : "standard",
   );
+  const activeReviewReactionEventsRef = useRef<ReadonlyArray<ReviewReactionEvent>>([]);
   const cleanupTimersRef = useRef<Map<string, number>>(new Map<string, number>());
 
   useEffect(() => {
@@ -149,25 +155,66 @@ export function TestAnimationsScreen(): ReactElement {
     clearTrimmedReviewReactionTimers(cleanupTimersRef.current, activeReviewReactionEvents);
   }, [activeReviewReactionEvents]);
 
+  const removeReviewReactionEvent = useCallback((eventId: string): void => {
+    clearReviewReactionTimer(cleanupTimersRef.current, eventId);
+    setActiveReviewReactionEvents((currentEvents) => {
+      const nextEvents = currentEvents.filter((activeEvent) => activeEvent.id !== eventId);
+      activeReviewReactionEventsRef.current = nextEvents;
+      return nextEvents;
+    });
+  }, []);
+
+  const scheduleReviewReactionEventCleanup = useCallback((
+    eventId: string,
+    variant: ReviewReactionVariant,
+  ): void => {
+    const cleanupTimerId = window.setTimeout(() => {
+      removeReviewReactionEvent(eventId);
+    }, reviewReactionCleanupDelayMillis(variant, motionMode));
+    cleanupTimersRef.current.set(eventId, cleanupTimerId);
+  }, [motionMode, removeReviewReactionEvent]);
+
+  const handleReviewReactionEventFallback = useCallback((eventId: string): void => {
+    const event = activeReviewReactionEventsRef.current.find((activeEvent) => activeEvent.id === eventId);
+    if (event === undefined || !isReviewReactionLottieVariant(event.variant)) {
+      return;
+    }
+
+    clearReviewReactionTimer(cleanupTimersRef.current, eventId);
+    scheduleReviewReactionEventCleanup(eventId, reviewReactionLottieFallbackVariant);
+    setActiveReviewReactionEvents((currentEvents) => {
+      const nextEvents = currentEvents.map((activeEvent) => {
+        if (activeEvent.id !== eventId || !isReviewReactionLottieVariant(activeEvent.variant)) {
+          return activeEvent;
+        }
+
+        return {
+          ...activeEvent,
+          variant: reviewReactionLottieFallbackVariant,
+        };
+      });
+      activeReviewReactionEventsRef.current = nextEvents;
+      return nextEvents;
+    });
+  }, [scheduleReviewReactionEventCleanup]);
+
   function playAnimation(entry: ReviewReactionVariantDistributionEntry): void {
     const event: ReviewReactionEvent = {
       id: crypto.randomUUID(),
       rating: entry.rating,
       variant: reviewReactionVariantWithReadyLottieFallback(entry.variant),
     };
-    const cleanupTimerId = window.setTimeout(() => {
-      clearReviewReactionTimer(cleanupTimersRef.current, event.id);
-      setActiveReviewReactionEvents((currentEvents) => (
-        currentEvents.filter((activeEvent) => activeEvent.id !== event.id)
-      ));
-    }, reviewReactionCleanupDelayMillis(event.variant, motionMode));
-    cleanupTimersRef.current.set(event.id, cleanupTimerId);
+    scheduleReviewReactionEventCleanup(event.id, event.variant);
 
-    setActiveReviewReactionEvents((currentEvents) => appendReviewReactionEvent(
-      currentEvents,
-      event,
-      reviewReactionMaximumActiveEvents,
-    ));
+    setActiveReviewReactionEvents((currentEvents) => {
+      const nextEvents = appendReviewReactionEvent(
+        currentEvents,
+        event,
+        reviewReactionMaximumActiveEvents,
+      );
+      activeReviewReactionEventsRef.current = nextEvents;
+      return nextEvents;
+    });
   }
 
   return (
@@ -202,7 +249,10 @@ export function TestAnimationsScreen(): ReactElement {
           </SettingsGroup>
         ))}
       </div>
-      <ReviewRatingReactionLayer events={activeReviewReactionEvents} />
+      <ReviewRatingReactionLayer
+        events={activeReviewReactionEvents}
+        onReactionEventFallback={handleReviewReactionEventFallback}
+      />
     </SettingsShell>
   );
 }


### PR DESCRIPTION
## Summary
- convert failed web Lottie review reactions to the crown fallback at the event owner level
- reschedule cleanup timers using the fallback duration in review and test animation surfaces
- add focused Vitest coverage for standard and reduced-motion fallback cleanup

## Validation
- npx vitest run src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx src/screens/review/reactions/useReviewRatingReactions.test.tsx src/screens/review/reactions/reviewReaction.test.ts
- npm run test
- npx tsc -b --pretty false
- git --no-pager diff --check