### PR TITLE
[codex] Fix iOS review reaction cleanup timing

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
@@ -136,6 +136,28 @@ private func reviewReactionLottieConfiguration(
     }
 }
 
+@MainActor
+private func finishReviewReactionEventAfterDelay(
+    event: ReviewReactionEvent,
+    motionMode: ReviewReactionMotionMode,
+    onEventFinished: (UUID) -> Void
+) async {
+    do {
+        try await Task.sleep(
+            nanoseconds: reviewReactionCleanupDelayNanoseconds(
+                variant: event.variant,
+                motionMode: motionMode
+            )
+        )
+    } catch is CancellationError {
+        return
+    } catch {
+        preconditionFailure("Unexpected review reaction visual cleanup sleep error: \(error).")
+    }
+
+    onEventFinished(event.id)
+}
+
 struct ReviewReactionLayer: View {
     @Environment(\.accessibilityReduceMotion) private var isReduceMotionEnabled
     @State private var hasStartedReviewReactionLottiePreload: Bool = false
@@ -146,6 +168,7 @@ struct ReviewReactionLayer: View {
         )
 
     let events: [ReviewReactionEvent]
+    let onEventFinished: (UUID) -> Void
 
     var body: some View {
         GeometryReader { proxy in
@@ -154,7 +177,8 @@ struct ReviewReactionLayer: View {
                     ReviewReactionEventView(
                         event: event,
                         animationStore: self.reviewReactionLottieAnimationStore,
-                        isReduceMotionEnabled: self.isReduceMotionEnabled
+                        isReduceMotionEnabled: self.isReduceMotionEnabled,
+                        onEventFinished: self.onEventFinished
                     )
                     .id(event.id)
                 }
@@ -165,6 +189,9 @@ struct ReviewReactionLayer: View {
         .accessibilityHidden(true)
         .onAppear {
             self.preloadReviewReactionLottieAnimations()
+        }
+        .onDisappear {
+            self.finishActiveEvents()
         }
     }
 
@@ -181,23 +208,32 @@ struct ReviewReactionLayer: View {
             }
         }
     }
+
+    private func finishActiveEvents() {
+        for event in self.events {
+            self.onEventFinished(event.id)
+        }
+    }
 }
 
 private struct ReviewReactionEventView: View {
     let event: ReviewReactionEvent
     let animationStore: ReviewReactionLottieAnimationStore
     let isReduceMotionEnabled: Bool
+    let onEventFinished: (UUID) -> Void
 
     @State private var shouldUseCrownFallback: Bool
 
     init(
         event: ReviewReactionEvent,
         animationStore: ReviewReactionLottieAnimationStore,
-        isReduceMotionEnabled: Bool
+        isReduceMotionEnabled: Bool,
+        onEventFinished: @escaping (UUID) -> Void
     ) {
         self.event = event
         self.animationStore = animationStore
         self.isReduceMotionEnabled = isReduceMotionEnabled
+        self.onEventFinished = onEventFinished
         self._shouldUseCrownFallback = State(
             initialValue: isReviewReactionLottieVariant(variant: event.variant)
                 && reviewReactionLottieConfiguration(
@@ -217,12 +253,14 @@ private struct ReviewReactionEventView: View {
             ReviewReactionLottieView(
                 event: self.event,
                 isReduceMotionEnabled: self.isReduceMotionEnabled,
-                configuration: lottieConfiguration
+                configuration: lottieConfiguration,
+                onEventFinished: self.onEventFinished
             )
         } else {
             ReviewReactionCanvas(
                 event: self.canvasEvent,
-                isReduceMotionEnabled: self.isReduceMotionEnabled
+                isReduceMotionEnabled: self.isReduceMotionEnabled,
+                onEventFinished: self.onEventFinished
             )
         }
     }
@@ -240,6 +278,7 @@ private struct ReviewReactionLottieView: View {
     let event: ReviewReactionEvent
     let isReduceMotionEnabled: Bool
     let configuration: ReviewReactionLottieConfiguration
+    let onEventFinished: (UUID) -> Void
 
     @State private var startedAt: Date = Date()
 
@@ -262,6 +301,13 @@ private struct ReviewReactionLottieView: View {
                     )
                     .opacity(ReviewReactionRenderer.reviewReactionOpacity(progress: progress))
             }
+        }
+        .task(id: self.event.id) {
+            await finishReviewReactionEventAfterDelay(
+                event: self.event,
+                motionMode: self.motionMode,
+                onEventFinished: self.onEventFinished
+            )
         }
     }
 
@@ -295,6 +341,7 @@ private struct ReviewReactionLottieView: View {
 private struct ReviewReactionCanvas: View {
     let event: ReviewReactionEvent
     let isReduceMotionEnabled: Bool
+    let onEventFinished: (UUID) -> Void
 
     @State private var startedAt: Date = Date()
 
@@ -311,6 +358,13 @@ private struct ReviewReactionCanvas: View {
                     motionMode: self.motionMode
                 )
             }
+        }
+        .task(id: self.event.id) {
+            await finishReviewReactionEventAfterDelay(
+                event: self.event,
+                motionMode: self.motionMode,
+                onEventFinished: self.onEventFinished
+            )
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
@@ -1,10 +1,7 @@
 import SwiftUI
 
 extension ReviewView {
-    func emitReviewReaction(
-        rating: ReviewRating,
-        motionMode: ReviewReactionMotionMode
-    ) {
+    func emitReviewReaction(rating: ReviewRating) {
         let reactionRating = makeReviewReactionRating(rating: rating)
         let event = ReviewReactionEvent(
             id: UUID(),
@@ -19,24 +16,11 @@ extension ReviewView {
             event: event,
             maximumActiveEvents: reviewReactionMaximumActiveEvents
         )
+    }
 
-        Task { @MainActor in
-            do {
-                try await Task.sleep(
-                    nanoseconds: reviewReactionCleanupDelayNanoseconds(
-                        variant: event.variant,
-                        motionMode: motionMode
-                    )
-                )
-            } catch is CancellationError {
-                return
-            } catch {
-                preconditionFailure("Unexpected review reaction cleanup sleep error: \(error).")
-            }
-
-            self.activeReviewReactionEvents = self.activeReviewReactionEvents.filter { activeEvent in
-                activeEvent.id != event.id
-            }
+    func removeFinishedReviewReactionEvent(eventId: UUID) {
+        self.activeReviewReactionEvents = self.activeReviewReactionEvents.filter { activeEvent in
+            activeEvent.id != eventId
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -14,7 +14,6 @@ let emptyBackTextPlaceholder: String = String(localized: "No back text", table: 
 private let reviewQueuePreviewPageSize: Int = 50
 
 struct ReviewView: View {
-    @Environment(\.accessibilityReduceMotion) private var isReduceMotionEnabled
     @Environment(FlashcardsStore.self) var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
 
@@ -123,10 +122,6 @@ struct ReviewView: View {
         return store.isReviewQueueChunkLoading
     }
 
-    private var reviewReactionMotionMode: ReviewReactionMotionMode {
-        self.isReduceMotionEnabled ? .reduced : .standard
-    }
-
     var body: some View {
         ZStack {
             Group {
@@ -139,7 +134,10 @@ struct ReviewView: View {
                 }
             }
 
-            ReviewReactionLayer(events: self.activeReviewReactionEvents)
+            ReviewReactionLayer(
+                events: self.activeReviewReactionEvents,
+                onEventFinished: self.removeFinishedReviewReactionEvent(eventId:)
+            )
         }
         .accessibilityIdentifier(UITestIdentifier.reviewScreen)
         .navigationTitle(String(localized: "Review", table: reviewCardsStringsTableName))
@@ -666,10 +664,7 @@ struct ReviewView: View {
 
     private func reviewAnswerButton(cardId: String, option: ReviewAnswerOption) -> some View {
         Button {
-            self.emitReviewReaction(
-                rating: option.rating,
-                motionMode: self.reviewReactionMotionMode
-            )
+            self.emitReviewReaction(rating: option.rating)
             self.submitReview(cardId: cardId, rating: option.rating)
         } label: {
             VStack(alignment: .center, spacing: 4) {

--- a/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
@@ -21,12 +21,7 @@ struct TestSettingsView: View {
 }
 
 struct TestAnimationsView: View {
-    @Environment(\.accessibilityReduceMotion) private var isReduceMotionEnabled
     @State private var activeReviewReactionEvents: [ReviewReactionEvent] = []
-
-    private var reviewReactionMotionMode: ReviewReactionMotionMode {
-        self.isReduceMotionEnabled ? .reduced : .standard
-    }
 
     var body: some View {
         ZStack {
@@ -57,7 +52,10 @@ struct TestAnimationsView: View {
             .listStyle(.insetGrouped)
             .accessibilityIdentifier(UITestIdentifier.testAnimationsScreen)
 
-            ReviewReactionLayer(events: self.activeReviewReactionEvents)
+            ReviewReactionLayer(
+                events: self.activeReviewReactionEvents,
+                onEventFinished: self.removeFinishedReviewReactionEvent(eventId:)
+            )
         }
         .navigationTitle(aiSettingsLocalized("settings.test.animations.title", "Animations"))
     }
@@ -68,40 +66,16 @@ struct TestAnimationsView: View {
             rating: entry.rating,
             variant: entry.variant
         )
-        let motionMode: ReviewReactionMotionMode = self.reviewReactionMotionMode
         self.activeReviewReactionEvents = appendReviewReactionEvent(
             events: self.activeReviewReactionEvents,
             event: event,
             maximumActiveEvents: reviewReactionMaximumActiveEvents
         )
-
-        Task { @MainActor in
-            await self.removeAnimationEventAfterDelay(
-                event: event,
-                motionMode: motionMode
-            )
-        }
     }
 
-    private func removeAnimationEventAfterDelay(
-        event: ReviewReactionEvent,
-        motionMode: ReviewReactionMotionMode
-    ) async {
-        do {
-            try await Task.sleep(
-                nanoseconds: reviewReactionCleanupDelayNanoseconds(
-                    variant: event.variant,
-                    motionMode: motionMode
-                )
-            )
-        } catch is CancellationError {
-            return
-        } catch {
-            preconditionFailure("Unexpected test animation cleanup sleep error: \(error).")
-        }
-
+    private func removeFinishedReviewReactionEvent(eventId: UUID) {
         self.activeReviewReactionEvents = self.activeReviewReactionEvents.filter { activeEvent in
-            activeEvent.id != event.id
+            activeEvent.id != eventId
         }
     }
 }


### PR DESCRIPTION
## Summary
- move iOS review reaction cleanup ownership into the visual layer
- make Lottie fallback cleanup follow the rendered `.easyCrownBounce` event timing
- keep review and hidden animation test screens aligned through the layer completion callback

## Impact
This prevents Lottie-unavailable reactions from staying on screen for the original Lottie duration when the UI is actually rendering the crown fallback. Active reaction events are also cleared when the layer disappears so stale animations do not replay later.

## Validation
- `git diff --check`
- static search confirmed parent timer cleanup was removed from ReviewView and TestAnimationsView
- static search confirmed reaction cleanup delay is owned by the visual layer

Local iOS build was attempted but did not reach compilation because the installed Xcode environment has no matching iOS destination/platform and reports iOS 26.5 is not installed.