### PR TITLE
[codex] Fix web Lottie fallback isolation

### DIFF
--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
@@ -139,6 +139,18 @@ async function flushReactionPromises(): Promise<void> {
   await Promise.resolve();
 }
 
+function makeReviewReactionLottieResponse(): Response {
+  return new Response(JSON.stringify({
+    layers: [],
+    v: "test",
+  }), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status: 200,
+  });
+}
+
 describe("ReviewRatingReactionLayer Lottie fallback", () => {
   let container: HTMLDivElement | null = null;
   let root: ReactDOM.Root | null = null;
@@ -150,6 +162,9 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
     loadAnimationMock.mockImplementation(() => {
       throw new Error("Lottie render failed.");
     });
+    vi.stubGlobal("fetch", vi.fn((_input: RequestInfo | URL): Promise<Response> => (
+      Promise.resolve(makeReviewReactionLottieResponse())
+    )));
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000101");
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -170,6 +185,7 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
     container = null;
     root = null;
     latestResult = null;
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
     vi.useRealTimers();
   });

--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
@@ -7,8 +7,9 @@ import {
   type ReviewReactionRenderableVariant,
 } from "./reviewReaction";
 import {
-  isReviewReactionLottieAssetsReady,
+  isReviewReactionLottieAssetReady,
   isReviewReactionLottieVariant,
+  loadReviewReactionLottieAsset,
   loadReviewReactionLottieAssets,
   reviewReactionLottieFallbackVariant,
   reviewReactionVariantWithReadyLottieFallback,
@@ -177,19 +178,19 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
     let isCancelled = false;
 
     async function loadReviewReactionLottieAnimation(): Promise<void> {
-      const assets = await loadReviewReactionLottieAssets();
+      const asset = await loadReviewReactionLottieAsset(variant);
 
       if (isCancelled) {
         return;
       }
 
       const isReducedMotionEnabled = matchesReducedReviewReactionMotion();
-      const nextAnimationItem = assets.player.loadAnimation({
+      const nextAnimationItem = asset.player.loadAnimation({
         container,
         renderer: "svg",
         loop: false,
         autoplay: !isReducedMotionEnabled,
-        animationData: assets.animationDataByVariant[variant],
+        animationData: asset.animationData,
       });
 
       animationItem = nextAnimationItem;
@@ -270,7 +271,7 @@ function renderReviewReactionArt(
   const { variant } = event;
 
   if (isReviewReactionLottieVariant(variant)) {
-    if (!isReviewReactionLottieAssetsReady()) {
+    if (!isReviewReactionLottieAssetReady(variant)) {
       return <ReviewReactionCrownFallbackArt />;
     }
 
@@ -297,13 +298,23 @@ export function ReviewRatingReactionLayer(props: ReviewRatingReactionLayerProps)
 
   useEffect(() => {
     let isMounted = true;
-    void loadReviewReactionLottieAssets().catch((error: unknown) => {
-      if (!isMounted) {
-        return;
-      }
+    void loadReviewReactionLottieAssets()
+      .then((preloadResult) => {
+        if (!isMounted) {
+          return;
+        }
 
-      reportReviewReactionLottieFailure(error, "preload", null);
-    });
+        for (const failure of preloadResult.failures) {
+          reportReviewReactionLottieFailure(failure.error, "preload", failure.variant);
+        }
+      })
+      .catch((error: unknown) => {
+        if (!isMounted) {
+          return;
+        }
+
+        reportReviewReactionLottieFailure(error, "preload", null);
+      });
 
     return () => {
       isMounted = false;

--- a/apps/web/src/screens/review/reactions/reviewReactionLottie.test.ts
+++ b/apps/web/src/screens/review/reactions/reviewReactionLottie.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReviewReactionLottieVariant } from "./reviewReactionLottie";
+
+const { lottiePlayerMock } = vi.hoisted(() => ({
+  lottiePlayerMock: {
+    loadAnimation: vi.fn(),
+  },
+}));
+
+vi.mock("lottie-web/build/player/lottie_light", () => ({
+  default: lottiePlayerMock,
+}));
+
+type ReviewReactionLottieModule = typeof import("./reviewReactionLottie");
+
+const failedVariant: ReviewReactionLottieVariant = "againWormWiggle";
+const readyVariant: ReviewReactionLottieVariant = "againTornado";
+
+async function importReviewReactionLottieModule(): Promise<ReviewReactionLottieModule> {
+  return import("./reviewReactionLottie");
+}
+
+function makeReviewReactionLottieResponse(animationData: object): Response {
+  return new Response(JSON.stringify(animationData), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status: 200,
+  });
+}
+
+describe("reviewReactionLottie", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("isolates preload failures to the broken animation variant", async () => {
+    const failedFetchError = new Error("Review reaction worm animation failed to fetch.");
+    const retriedAnimationData = {
+      layers: [],
+      v: "retry",
+    };
+    let failedVariantFetchCount = 0;
+
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL): Promise<Response> => {
+      const url = input.toString();
+      if (url.includes("review_again_worm")) {
+        failedVariantFetchCount += 1;
+        if (failedVariantFetchCount === 1) {
+          return Promise.reject(failedFetchError);
+        }
+
+        return Promise.resolve(makeReviewReactionLottieResponse(retriedAnimationData));
+      }
+
+      return Promise.resolve(makeReviewReactionLottieResponse({
+        layers: [],
+        v: url,
+      }));
+    }));
+
+    const reviewReactionLottie = await importReviewReactionLottieModule();
+
+    const preloadResult = await reviewReactionLottie.loadReviewReactionLottieAssets();
+
+    expect(preloadResult.failures).toHaveLength(1);
+    expect(preloadResult.failures[0]?.variant).toBe(failedVariant);
+    expect(preloadResult.failures[0]?.error).toBeInstanceOf(Error);
+    expect(reviewReactionLottie.isReviewReactionLottieAssetReady(failedVariant)).toBe(false);
+    expect(reviewReactionLottie.reviewReactionVariantWithReadyLottieFallback(failedVariant))
+      .toBe(reviewReactionLottie.reviewReactionLottieFallbackVariant);
+    expect(reviewReactionLottie.isReviewReactionLottieAssetReady(readyVariant)).toBe(true);
+    expect(reviewReactionLottie.reviewReactionVariantWithReadyLottieFallback(readyVariant)).toBe(readyVariant);
+
+    const retriedAsset = await reviewReactionLottie.loadReviewReactionLottieAsset(failedVariant);
+
+    expect(failedVariantFetchCount).toBe(2);
+    expect(retriedAsset.animationData).toEqual(retriedAnimationData);
+    expect(reviewReactionLottie.isReviewReactionLottieAssetReady(failedVariant)).toBe(true);
+  });
+});

--- a/apps/web/src/screens/review/reactions/reviewReactionLottie.ts
+++ b/apps/web/src/screens/review/reactions/reviewReactionLottie.ts
@@ -1,162 +1,306 @@
 import type { LottiePlayer } from "lottie-web";
+import againSnailCrawlAnimationUrl from "../../../assets/review_again_snail.json?url";
+import againTornadoAnimationUrl from "../../../assets/review_again_tornado.json?url";
+import againWiltedFlowerAnimationUrl from "../../../assets/review_again_wilted_flower.json?url";
+import againWormWiggleAnimationUrl from "../../../assets/review_again_worm.json?url";
+import easyPhoenixRiseAnimationUrl from "../../../assets/review_easy_phoenix.json?url";
+import easyRainbowStreakAnimationUrl from "../../../assets/review_easy_rainbow.json?url";
+import easyRoseBloomAnimationUrl from "../../../assets/review_easy_rose.json?url";
+import easyUnicornFlybyAnimationUrl from "../../../assets/review_easy_unicorn.json?url";
+import goodOwlAnimationUrl from "../../../assets/review_good_owl.json?url";
+import goodPeacockAnimationUrl from "../../../assets/review_good_peacock.json?url";
+import goodPoodleAnimationUrl from "../../../assets/review_good_poodle.json?url";
+import goodWhaleAnimationUrl from "../../../assets/review_good_whale.json?url";
+import hardOxChargeAnimationUrl from "../../../assets/review_hard_ox.json?url";
+import hardPawPrintsAnimationUrl from "../../../assets/review_hard_paw_prints.json?url";
+import hardRacehorseGallopAnimationUrl from "../../../assets/review_hard_racehorse.json?url";
+import hardVolcanoEruptionAnimationUrl from "../../../assets/review_hard_volcano.json?url";
 import type { ReviewReactionFallbackVariant, ReviewReactionRenderableVariant } from "./reviewReaction";
 
 type ReviewReactionLottiePlayerModule = Readonly<{
   default: LottiePlayer;
 }>;
 
-type ReviewReactionLottieAnimationModule = Readonly<{
-  default: object;
-}>;
+type ReviewReactionLottieAnimationLoader = () => Promise<object>;
+type ReviewReactionLottieAnimationDataByVariant = Record<ReviewReactionLottieVariant, object | null>;
+type ReviewReactionLottieAnimationPromiseByVariant = Record<ReviewReactionLottieVariant, Promise<object> | null>;
 
-export type ReviewReactionLottieVariant =
-  | "againWormWiggle"
-  | "againTornado"
-  | "againSnailCrawl"
-  | "againWiltedFlower"
-  | "goodOwl"
-  | "goodPoodle"
-  | "goodWhale"
-  | "goodPeacock"
-  | "hardOxCharge"
-  | "hardPawPrints"
-  | "hardRacehorseGallop"
-  | "hardVolcanoEruption"
-  | "easyRoseBloom"
-  | "easyRainbowStreak"
-  | "easyPhoenixRise"
-  | "easyUnicornFlyby";
+export const reviewReactionLottieVariants = [
+  "againWormWiggle",
+  "againTornado",
+  "againSnailCrawl",
+  "againWiltedFlower",
+  "goodOwl",
+  "goodPoodle",
+  "goodWhale",
+  "goodPeacock",
+  "hardOxCharge",
+  "hardPawPrints",
+  "hardRacehorseGallop",
+  "hardVolcanoEruption",
+  "easyRoseBloom",
+  "easyRainbowStreak",
+  "easyPhoenixRise",
+  "easyUnicornFlyby",
+] as const;
 
-export type ReviewReactionLottieAssets = Readonly<{
-  animationDataByVariant: Readonly<Record<ReviewReactionLottieVariant, object>>;
+export type ReviewReactionLottieVariant = (typeof reviewReactionLottieVariants)[number];
+
+export type ReviewReactionLottieAsset = Readonly<{
+  animationData: object;
   player: LottiePlayer;
 }>;
 
-let reviewReactionLottieAssetsPromise: Promise<ReviewReactionLottieAssets> | null = null;
-let reviewReactionLottieAssetsReady = false;
+export type ReviewReactionLottieAssetFailure = Readonly<{
+  error: unknown;
+  variant: ReviewReactionLottieVariant;
+}>;
+
+export type ReviewReactionLottiePreloadResult = Readonly<{
+  failures: ReadonlyArray<ReviewReactionLottieAssetFailure>;
+}>;
+
+const reviewReactionLottieVariantSet: ReadonlySet<ReviewReactionRenderableVariant> = new Set(
+  reviewReactionLottieVariants,
+);
+
+const reviewReactionLottieAnimationUrlByVariant: Readonly<Record<ReviewReactionLottieVariant, string>> = {
+  againWormWiggle: againWormWiggleAnimationUrl,
+  againTornado: againTornadoAnimationUrl,
+  againSnailCrawl: againSnailCrawlAnimationUrl,
+  againWiltedFlower: againWiltedFlowerAnimationUrl,
+  goodOwl: goodOwlAnimationUrl,
+  goodPoodle: goodPoodleAnimationUrl,
+  goodWhale: goodWhaleAnimationUrl,
+  goodPeacock: goodPeacockAnimationUrl,
+  hardOxCharge: hardOxChargeAnimationUrl,
+  hardPawPrints: hardPawPrintsAnimationUrl,
+  hardRacehorseGallop: hardRacehorseGallopAnimationUrl,
+  hardVolcanoEruption: hardVolcanoEruptionAnimationUrl,
+  easyRoseBloom: easyRoseBloomAnimationUrl,
+  easyRainbowStreak: easyRainbowStreakAnimationUrl,
+  easyPhoenixRise: easyPhoenixRiseAnimationUrl,
+  easyUnicornFlyby: easyUnicornFlybyAnimationUrl,
+};
+
+const reviewReactionLottieAnimationLoaderByVariant: Readonly<Record<ReviewReactionLottieVariant, ReviewReactionLottieAnimationLoader>> = {
+  againWormWiggle: () => fetchReviewReactionLottieAnimationData("againWormWiggle"),
+  againTornado: () => fetchReviewReactionLottieAnimationData("againTornado"),
+  againSnailCrawl: () => fetchReviewReactionLottieAnimationData("againSnailCrawl"),
+  againWiltedFlower: () => fetchReviewReactionLottieAnimationData("againWiltedFlower"),
+  goodOwl: () => fetchReviewReactionLottieAnimationData("goodOwl"),
+  goodPoodle: () => fetchReviewReactionLottieAnimationData("goodPoodle"),
+  goodWhale: () => fetchReviewReactionLottieAnimationData("goodWhale"),
+  goodPeacock: () => fetchReviewReactionLottieAnimationData("goodPeacock"),
+  hardOxCharge: () => fetchReviewReactionLottieAnimationData("hardOxCharge"),
+  hardPawPrints: () => fetchReviewReactionLottieAnimationData("hardPawPrints"),
+  hardRacehorseGallop: () => fetchReviewReactionLottieAnimationData("hardRacehorseGallop"),
+  hardVolcanoEruption: () => fetchReviewReactionLottieAnimationData("hardVolcanoEruption"),
+  easyRoseBloom: () => fetchReviewReactionLottieAnimationData("easyRoseBloom"),
+  easyRainbowStreak: () => fetchReviewReactionLottieAnimationData("easyRainbowStreak"),
+  easyPhoenixRise: () => fetchReviewReactionLottieAnimationData("easyPhoenixRise"),
+  easyUnicornFlyby: () => fetchReviewReactionLottieAnimationData("easyUnicornFlyby"),
+};
+
+let reviewReactionLottiePlayerPromise: Promise<LottiePlayer> | null = null;
+let reviewReactionLottiePlayerReady = false;
+let reviewReactionLottieAnimationDataByVariant: ReviewReactionLottieAnimationDataByVariant = {
+  againWormWiggle: null,
+  againTornado: null,
+  againSnailCrawl: null,
+  againWiltedFlower: null,
+  goodOwl: null,
+  goodPoodle: null,
+  goodWhale: null,
+  goodPeacock: null,
+  hardOxCharge: null,
+  hardPawPrints: null,
+  hardRacehorseGallop: null,
+  hardVolcanoEruption: null,
+  easyRoseBloom: null,
+  easyRainbowStreak: null,
+  easyPhoenixRise: null,
+  easyUnicornFlyby: null,
+};
+let reviewReactionLottieAnimationPromiseByVariant: ReviewReactionLottieAnimationPromiseByVariant = {
+  againWormWiggle: null,
+  againTornado: null,
+  againSnailCrawl: null,
+  againWiltedFlower: null,
+  goodOwl: null,
+  goodPoodle: null,
+  goodWhale: null,
+  goodPeacock: null,
+  hardOxCharge: null,
+  hardPawPrints: null,
+  hardRacehorseGallop: null,
+  hardVolcanoEruption: null,
+  easyRoseBloom: null,
+  easyRainbowStreak: null,
+  easyPhoenixRise: null,
+  easyUnicornFlyby: null,
+};
 
 export const reviewReactionLottieFallbackVariant: ReviewReactionFallbackVariant = "fallbackCrownBounce";
 
 export function isReviewReactionLottieVariant(
   variant: ReviewReactionRenderableVariant,
 ): variant is ReviewReactionLottieVariant {
-  return variant === "againWormWiggle"
-    || variant === "againTornado"
-    || variant === "againSnailCrawl"
-    || variant === "againWiltedFlower"
-    || variant === "goodOwl"
-    || variant === "goodPoodle"
-    || variant === "goodWhale"
-    || variant === "goodPeacock"
-    || variant === "hardOxCharge"
-    || variant === "hardPawPrints"
-    || variant === "hardRacehorseGallop"
-    || variant === "hardVolcanoEruption"
-    || variant === "easyRoseBloom"
-    || variant === "easyRainbowStreak"
-    || variant === "easyPhoenixRise"
-    || variant === "easyUnicornFlyby";
+  return reviewReactionLottieVariantSet.has(variant);
 }
 
-export function isReviewReactionLottieAssetsReady(): boolean {
-  return reviewReactionLottieAssetsReady;
+export function isReviewReactionLottieAssetReady(variant: ReviewReactionLottieVariant): boolean {
+  return reviewReactionLottiePlayerReady && reviewReactionLottieAnimationDataByVariant[variant] !== null;
 }
 
 export function reviewReactionVariantWithReadyLottieFallback(
   variant: ReviewReactionRenderableVariant,
 ): ReviewReactionRenderableVariant {
-  if (isReviewReactionLottieVariant(variant) && !isReviewReactionLottieAssetsReady()) {
+  if (isReviewReactionLottieVariant(variant) && !isReviewReactionLottieAssetReady(variant)) {
     return reviewReactionLottieFallbackVariant;
   }
 
   return variant;
 }
 
-export function loadReviewReactionLottieAssets(): Promise<ReviewReactionLottieAssets> {
-  if (reviewReactionLottieAssetsPromise !== null) {
-    return reviewReactionLottieAssetsPromise;
+function loadReviewReactionLottiePlayer(): Promise<LottiePlayer> {
+  if (reviewReactionLottiePlayerPromise !== null) {
+    return reviewReactionLottiePlayerPromise;
   }
 
-  reviewReactionLottieAssetsPromise = Promise.all([
-    import("lottie-web/build/player/lottie_light"),
-    import("../../../assets/review_again_worm.json"),
-    import("../../../assets/review_again_tornado.json"),
-    import("../../../assets/review_again_snail.json"),
-    import("../../../assets/review_again_wilted_flower.json"),
-    import("../../../assets/review_good_owl.json"),
-    import("../../../assets/review_good_poodle.json"),
-    import("../../../assets/review_good_whale.json"),
-    import("../../../assets/review_good_peacock.json"),
-    import("../../../assets/review_hard_ox.json"),
-    import("../../../assets/review_hard_paw_prints.json"),
-    import("../../../assets/review_hard_racehorse.json"),
-    import("../../../assets/review_hard_volcano.json"),
-    import("../../../assets/review_easy_rose.json"),
-    import("../../../assets/review_easy_rainbow.json"),
-    import("../../../assets/review_easy_phoenix.json"),
-    import("../../../assets/review_easy_unicorn.json"),
-  ]).then((
-    [
-      lottieModule,
-      wormAnimationModule,
-      tornadoAnimationModule,
-      snailAnimationModule,
-      wiltedFlowerAnimationModule,
-      owlAnimationModule,
-      poodleAnimationModule,
-      whaleAnimationModule,
-      peacockAnimationModule,
-      oxAnimationModule,
-      pawPrintsAnimationModule,
-      racehorseAnimationModule,
-      volcanoAnimationModule,
-      roseAnimationModule,
-      rainbowAnimationModule,
-      phoenixAnimationModule,
-      unicornAnimationModule,
-    ]: [
-      ReviewReactionLottiePlayerModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-      ReviewReactionLottieAnimationModule,
-    ],
-  ): ReviewReactionLottieAssets => {
-    reviewReactionLottieAssetsReady = true;
-    return {
-      animationDataByVariant: {
-        againWormWiggle: wormAnimationModule.default,
-        againTornado: tornadoAnimationModule.default,
-        againSnailCrawl: snailAnimationModule.default,
-        againWiltedFlower: wiltedFlowerAnimationModule.default,
-        goodOwl: owlAnimationModule.default,
-        goodPoodle: poodleAnimationModule.default,
-        goodWhale: whaleAnimationModule.default,
-        goodPeacock: peacockAnimationModule.default,
-        hardOxCharge: oxAnimationModule.default,
-        hardPawPrints: pawPrintsAnimationModule.default,
-        hardRacehorseGallop: racehorseAnimationModule.default,
-        hardVolcanoEruption: volcanoAnimationModule.default,
-        easyRoseBloom: roseAnimationModule.default,
-        easyRainbowStreak: rainbowAnimationModule.default,
-        easyPhoenixRise: phoenixAnimationModule.default,
-        easyUnicornFlyby: unicornAnimationModule.default,
-      },
-      player: lottieModule.default,
-    };
-  });
+  reviewReactionLottiePlayerPromise = import("lottie-web/build/player/lottie_light")
+    .then((lottieModule: ReviewReactionLottiePlayerModule): LottiePlayer => {
+      reviewReactionLottiePlayerReady = true;
+      return lottieModule.default;
+    })
+    .catch((error: unknown): never => {
+      reviewReactionLottiePlayerReady = false;
+      reviewReactionLottiePlayerPromise = null;
+      throw error;
+    });
 
-  return reviewReactionLottieAssetsPromise;
+  return reviewReactionLottiePlayerPromise;
+}
+
+function isReviewReactionLottieAnimationData(animationData: unknown): animationData is object {
+  return typeof animationData === "object" && animationData !== null && !Array.isArray(animationData);
+}
+
+async function fetchReviewReactionLottieAnimationData(
+  variant: ReviewReactionLottieVariant,
+): Promise<object> {
+  const url = reviewReactionLottieAnimationUrlByVariant[variant];
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to fetch review reaction Lottie animation JSON for variant ${variant} from ${url}.`,
+      { cause: error },
+    );
+  }
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(
+      `Failed to fetch review reaction Lottie animation JSON for variant ${variant} from ${url}. `
+        + `Received status ${response.status} ${response.statusText}. Response body: ${responseBody}`,
+    );
+  }
+
+  let animationData: unknown;
+  try {
+    animationData = await response.json();
+  } catch (error: unknown) {
+    throw new Error(
+      `Failed to parse review reaction Lottie animation JSON for variant ${variant} from ${url}.`,
+      { cause: error },
+    );
+  }
+
+  if (!isReviewReactionLottieAnimationData(animationData)) {
+    throw new TypeError(
+      `Review reaction Lottie animation JSON for variant ${variant} from ${url} must parse to an object.`,
+    );
+  }
+
+  return animationData;
+}
+
+function loadReviewReactionLottieAnimationData(variant: ReviewReactionLottieVariant): Promise<object> {
+  const cachedAnimationData = reviewReactionLottieAnimationDataByVariant[variant];
+  if (cachedAnimationData !== null) {
+    return Promise.resolve(cachedAnimationData);
+  }
+
+  const cachedAnimationPromise = reviewReactionLottieAnimationPromiseByVariant[variant];
+  if (cachedAnimationPromise !== null) {
+    return cachedAnimationPromise;
+  }
+
+  const animationDataPromise = reviewReactionLottieAnimationLoaderByVariant[variant]()
+    .then((animationData: object): object => {
+      reviewReactionLottieAnimationDataByVariant = {
+        ...reviewReactionLottieAnimationDataByVariant,
+        [variant]: animationData,
+      };
+      reviewReactionLottieAnimationPromiseByVariant = {
+        ...reviewReactionLottieAnimationPromiseByVariant,
+        [variant]: null,
+      };
+      return animationData;
+    })
+    .catch((error: unknown): never => {
+      reviewReactionLottieAnimationDataByVariant = {
+        ...reviewReactionLottieAnimationDataByVariant,
+        [variant]: null,
+      };
+      reviewReactionLottieAnimationPromiseByVariant = {
+        ...reviewReactionLottieAnimationPromiseByVariant,
+        [variant]: null,
+      };
+      throw error;
+    });
+
+  reviewReactionLottieAnimationPromiseByVariant = {
+    ...reviewReactionLottieAnimationPromiseByVariant,
+    [variant]: animationDataPromise,
+  };
+
+  return animationDataPromise;
+}
+
+export async function loadReviewReactionLottieAsset(
+  variant: ReviewReactionLottieVariant,
+): Promise<ReviewReactionLottieAsset> {
+  const [player, animationData] = await Promise.all([
+    loadReviewReactionLottiePlayer(),
+    loadReviewReactionLottieAnimationData(variant),
+  ]);
+
+  return {
+    animationData,
+    player,
+  };
+}
+
+export async function loadReviewReactionLottieAssets(): Promise<ReviewReactionLottiePreloadResult> {
+  await loadReviewReactionLottiePlayer();
+
+  const settledAnimationData = await Promise.allSettled(
+    reviewReactionLottieVariants.map((variant) => loadReviewReactionLottieAnimationData(variant)),
+  );
+  const failures: Array<ReviewReactionLottieAssetFailure> = [];
+
+  for (const [index, settledAsset] of settledAnimationData.entries()) {
+    if (settledAsset.status === "rejected") {
+      const error: unknown = settledAsset.reason;
+      failures.push({
+        error,
+        variant: reviewReactionLottieVariants[index],
+      });
+    }
+  }
+
+  return { failures };
 }


### PR DESCRIPTION
## Summary
- isolate web review reaction Lottie readiness per variant
- keep the Lottie runtime shared while loading animation JSON per asset URL
- preserve fallback behavior for events that started as fallback and allow later variant-specific retries

## Validation
- npm --prefix apps/web exec vitest run -- src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx src/screens/review/reactions/reviewReactionLottie.test.ts
- npm --prefix apps/web run build
- git --no-pager diff --check