### PR TITLE
[codex] Use weighted review reaction selection

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionState.kt
@@ -66,98 +66,95 @@ internal val ReviewReactionVariant.debugIdentifier: String
 internal data class ReviewReactionVariantDistributionEntry(
     val rating: ReviewRating,
     val variant: ReviewReactionVariant,
-    val rollRange: IntRange
+    val weight: Int
 ) {
     val id: String
         get() = "${rating.reviewReactionDebugIdentifier}.${variant.debugIdentifier}"
 
-    val rollCount: Int
-        get() = rollRange.last - rollRange.first + 1
-
-    val probabilityPercent: Int
-        get() = rollCount / 10
+    val probabilityPercent: Double
+        get() = weight.toDouble() / reviewReactionVariantTotalWeight(rating = rating).toDouble() * 100.0
 }
 
 internal val allReviewReactionVariantDistributionEntries: List<ReviewReactionVariantDistributionEntry> = listOf(
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.AGAIN,
         variant = ReviewReactionVariant.AGAIN_WORM_WIGGLE,
-        rollRange = 0..399
+        weight = 40
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.AGAIN,
         variant = ReviewReactionVariant.AGAIN_TORNADO,
-        rollRange = 400..699
+        weight = 30
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.AGAIN,
         variant = ReviewReactionVariant.AGAIN_SNAIL_CRAWL,
-        rollRange = 700..919
+        weight = 22
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.AGAIN,
         variant = ReviewReactionVariant.AGAIN_WILTED_FLOWER,
-        rollRange = 920..999
+        weight = 8
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.HARD,
         variant = ReviewReactionVariant.HARD_OX_CHARGE,
-        rollRange = 0..399
+        weight = 40
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.HARD,
         variant = ReviewReactionVariant.HARD_PAW_PRINTS,
-        rollRange = 400..699
+        weight = 30
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.HARD,
         variant = ReviewReactionVariant.HARD_RACEHORSE_GALLOP,
-        rollRange = 700..919
+        weight = 22
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.HARD,
         variant = ReviewReactionVariant.HARD_VOLCANO_ERUPTION,
-        rollRange = 920..999
+        weight = 8
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.GOOD,
         variant = ReviewReactionVariant.GOOD_OWL,
-        rollRange = 0..399
+        weight = 40
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.GOOD,
         variant = ReviewReactionVariant.GOOD_POODLE,
-        rollRange = 400..699
+        weight = 30
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.GOOD,
         variant = ReviewReactionVariant.GOOD_WHALE,
-        rollRange = 700..919
+        weight = 22
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.GOOD,
         variant = ReviewReactionVariant.GOOD_PEACOCK,
-        rollRange = 920..999
+        weight = 8
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.EASY,
         variant = ReviewReactionVariant.EASY_ROSE_BLOOM,
-        rollRange = 0..399
+        weight = 40
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.EASY,
         variant = ReviewReactionVariant.EASY_RAINBOW_STREAK,
-        rollRange = 400..699
+        weight = 30
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.EASY,
         variant = ReviewReactionVariant.EASY_PHOENIX_RISE,
-        rollRange = 700..919
+        weight = 22
     ),
     ReviewReactionVariantDistributionEntry(
         rating = ReviewRating.EASY,
         variant = ReviewReactionVariant.EASY_UNICORN_FLYBY,
-        rollRange = 920..999
+        weight = 8
     )
 )
 
@@ -167,6 +164,23 @@ internal fun reviewReactionVariantDistributionEntries(
     return allReviewReactionVariantDistributionEntries.filter { entry: ReviewReactionVariantDistributionEntry ->
         entry.rating == rating
     }
+}
+
+internal fun reviewReactionVariantTotalWeight(rating: ReviewRating): Int {
+    val entries: List<ReviewReactionVariantDistributionEntry> = reviewReactionVariantDistributionEntries(rating = rating)
+    require(entries.isNotEmpty()) {
+        "Review reaction distribution is missing a rating. rating=${rating.reviewReactionDebugIdentifier}"
+    }
+
+    var totalWeight = 0
+    entries.forEach { entry: ReviewReactionVariantDistributionEntry ->
+        require(entry.weight > 0) {
+            "Review reaction weight must be positive. entryId=${entry.id} weight=${entry.weight}"
+        }
+        totalWeight += entry.weight
+    }
+
+    return totalWeight
 }
 
 internal data class ReviewReactionEvent(
@@ -179,19 +193,24 @@ internal fun selectReviewReactionVariant(
     rating: ReviewRating,
     roll: Int
 ): ReviewReactionVariant {
-    require(roll in 0..999) {
-        "Review reaction roll must be in 0..999, received $roll."
+    val entries: List<ReviewReactionVariantDistributionEntry> = reviewReactionVariantDistributionEntries(rating = rating)
+    val totalWeight: Int = reviewReactionVariantTotalWeight(rating = rating)
+    require(roll in 0 until totalWeight) {
+        "Review reaction roll must be in 0 until $totalWeight, received $roll."
     }
 
-    val matchingEntry: ReviewReactionVariantDistributionEntry =
-        reviewReactionVariantDistributionEntries(rating = rating).firstOrNull { entry: ReviewReactionVariantDistributionEntry ->
-            roll in entry.rollRange
-        } ?: error(
-            "Review reaction distribution is missing a variant. " +
-                "rating=${rating.reviewReactionDebugIdentifier} roll=$roll"
-        )
+    var cumulativeWeight = 0
+    for (entry in entries) {
+        cumulativeWeight += entry.weight
+        if (roll < cumulativeWeight) {
+            return entry.variant
+        }
+    }
 
-    return matchingEntry.variant
+    error(
+        "Review reaction distribution is missing a variant. " +
+            "rating=${rating.reviewReactionDebugIdentifier} roll=$roll"
+    )
 }
 
 internal fun appendReviewReactionEvent(
@@ -220,7 +239,8 @@ internal fun reviewReactionMotionModeFromAnimatorSettings(): ReviewReactionMotio
 }
 
 internal fun makeRandomReviewReactionEvent(rating: ReviewRating): ReviewReactionEvent {
-    val roll: Int = Random.nextInt(from = 0, until = 1_000)
+    val totalWeight: Int = reviewReactionVariantTotalWeight(rating = rating)
+    val roll: Int = Random.nextInt(from = 0, until = totalWeight)
     return ReviewReactionEvent(
         id = UUID.randomUUID().toString(),
         rating = rating,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/TestAnimationsRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/TestAnimationsRoute.kt
@@ -33,6 +33,7 @@ import com.flashcardsopensourceapp.core.ui.components.SectionTitle
 import com.flashcardsopensourceapp.data.local.model.ReviewRating
 import com.flashcardsopensourceapp.feature.review.R
 import java.util.UUID
+import kotlin.math.roundToInt
 
 internal const val testAnimationsScreenTag: String = "test_animations_screen"
 
@@ -175,7 +176,7 @@ private fun reviewReactionRatingTitle(rating: ReviewRating): String {
 private fun testAnimationProbabilityText(entry: ReviewReactionVariantDistributionEntry): String {
     return stringResource(
         R.string.review_test_animations_probability,
-        entry.probabilityPercent
+        entry.probabilityPercent.roundToInt()
     )
 }
 

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionVariantSelectionTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionVariantSelectionTest.kt
@@ -8,49 +8,67 @@ class ReviewReactionVariantSelectionTest {
     @Test
     fun againSelectionUsesConfiguredBoundaries() {
         assertSelectedVariant(ReviewRating.AGAIN, 0, ReviewReactionVariant.AGAIN_WORM_WIGGLE)
-        assertSelectedVariant(ReviewRating.AGAIN, 399, ReviewReactionVariant.AGAIN_WORM_WIGGLE)
-        assertSelectedVariant(ReviewRating.AGAIN, 400, ReviewReactionVariant.AGAIN_TORNADO)
-        assertSelectedVariant(ReviewRating.AGAIN, 699, ReviewReactionVariant.AGAIN_TORNADO)
-        assertSelectedVariant(ReviewRating.AGAIN, 700, ReviewReactionVariant.AGAIN_SNAIL_CRAWL)
-        assertSelectedVariant(ReviewRating.AGAIN, 919, ReviewReactionVariant.AGAIN_SNAIL_CRAWL)
-        assertSelectedVariant(ReviewRating.AGAIN, 920, ReviewReactionVariant.AGAIN_WILTED_FLOWER)
-        assertSelectedVariant(ReviewRating.AGAIN, 999, ReviewReactionVariant.AGAIN_WILTED_FLOWER)
+        assertSelectedVariant(ReviewRating.AGAIN, 39, ReviewReactionVariant.AGAIN_WORM_WIGGLE)
+        assertSelectedVariant(ReviewRating.AGAIN, 40, ReviewReactionVariant.AGAIN_TORNADO)
+        assertSelectedVariant(ReviewRating.AGAIN, 69, ReviewReactionVariant.AGAIN_TORNADO)
+        assertSelectedVariant(ReviewRating.AGAIN, 70, ReviewReactionVariant.AGAIN_SNAIL_CRAWL)
+        assertSelectedVariant(ReviewRating.AGAIN, 91, ReviewReactionVariant.AGAIN_SNAIL_CRAWL)
+        assertSelectedVariant(ReviewRating.AGAIN, 92, ReviewReactionVariant.AGAIN_WILTED_FLOWER)
+        assertSelectedVariant(ReviewRating.AGAIN, 99, ReviewReactionVariant.AGAIN_WILTED_FLOWER)
     }
 
     @Test
     fun hardSelectionUsesConfiguredBoundaries() {
         assertSelectedVariant(ReviewRating.HARD, 0, ReviewReactionVariant.HARD_OX_CHARGE)
-        assertSelectedVariant(ReviewRating.HARD, 399, ReviewReactionVariant.HARD_OX_CHARGE)
-        assertSelectedVariant(ReviewRating.HARD, 400, ReviewReactionVariant.HARD_PAW_PRINTS)
-        assertSelectedVariant(ReviewRating.HARD, 699, ReviewReactionVariant.HARD_PAW_PRINTS)
-        assertSelectedVariant(ReviewRating.HARD, 700, ReviewReactionVariant.HARD_RACEHORSE_GALLOP)
-        assertSelectedVariant(ReviewRating.HARD, 919, ReviewReactionVariant.HARD_RACEHORSE_GALLOP)
-        assertSelectedVariant(ReviewRating.HARD, 920, ReviewReactionVariant.HARD_VOLCANO_ERUPTION)
-        assertSelectedVariant(ReviewRating.HARD, 999, ReviewReactionVariant.HARD_VOLCANO_ERUPTION)
+        assertSelectedVariant(ReviewRating.HARD, 39, ReviewReactionVariant.HARD_OX_CHARGE)
+        assertSelectedVariant(ReviewRating.HARD, 40, ReviewReactionVariant.HARD_PAW_PRINTS)
+        assertSelectedVariant(ReviewRating.HARD, 69, ReviewReactionVariant.HARD_PAW_PRINTS)
+        assertSelectedVariant(ReviewRating.HARD, 70, ReviewReactionVariant.HARD_RACEHORSE_GALLOP)
+        assertSelectedVariant(ReviewRating.HARD, 91, ReviewReactionVariant.HARD_RACEHORSE_GALLOP)
+        assertSelectedVariant(ReviewRating.HARD, 92, ReviewReactionVariant.HARD_VOLCANO_ERUPTION)
+        assertSelectedVariant(ReviewRating.HARD, 99, ReviewReactionVariant.HARD_VOLCANO_ERUPTION)
     }
 
     @Test
     fun goodSelectionUsesConfiguredBoundaries() {
         assertSelectedVariant(ReviewRating.GOOD, 0, ReviewReactionVariant.GOOD_OWL)
-        assertSelectedVariant(ReviewRating.GOOD, 399, ReviewReactionVariant.GOOD_OWL)
-        assertSelectedVariant(ReviewRating.GOOD, 400, ReviewReactionVariant.GOOD_POODLE)
-        assertSelectedVariant(ReviewRating.GOOD, 699, ReviewReactionVariant.GOOD_POODLE)
-        assertSelectedVariant(ReviewRating.GOOD, 700, ReviewReactionVariant.GOOD_WHALE)
-        assertSelectedVariant(ReviewRating.GOOD, 919, ReviewReactionVariant.GOOD_WHALE)
-        assertSelectedVariant(ReviewRating.GOOD, 920, ReviewReactionVariant.GOOD_PEACOCK)
-        assertSelectedVariant(ReviewRating.GOOD, 999, ReviewReactionVariant.GOOD_PEACOCK)
+        assertSelectedVariant(ReviewRating.GOOD, 39, ReviewReactionVariant.GOOD_OWL)
+        assertSelectedVariant(ReviewRating.GOOD, 40, ReviewReactionVariant.GOOD_POODLE)
+        assertSelectedVariant(ReviewRating.GOOD, 69, ReviewReactionVariant.GOOD_POODLE)
+        assertSelectedVariant(ReviewRating.GOOD, 70, ReviewReactionVariant.GOOD_WHALE)
+        assertSelectedVariant(ReviewRating.GOOD, 91, ReviewReactionVariant.GOOD_WHALE)
+        assertSelectedVariant(ReviewRating.GOOD, 92, ReviewReactionVariant.GOOD_PEACOCK)
+        assertSelectedVariant(ReviewRating.GOOD, 99, ReviewReactionVariant.GOOD_PEACOCK)
     }
 
     @Test
     fun easySelectionUsesConfiguredBoundaries() {
         assertSelectedVariant(ReviewRating.EASY, 0, ReviewReactionVariant.EASY_ROSE_BLOOM)
-        assertSelectedVariant(ReviewRating.EASY, 399, ReviewReactionVariant.EASY_ROSE_BLOOM)
-        assertSelectedVariant(ReviewRating.EASY, 400, ReviewReactionVariant.EASY_RAINBOW_STREAK)
-        assertSelectedVariant(ReviewRating.EASY, 699, ReviewReactionVariant.EASY_RAINBOW_STREAK)
-        assertSelectedVariant(ReviewRating.EASY, 700, ReviewReactionVariant.EASY_PHOENIX_RISE)
-        assertSelectedVariant(ReviewRating.EASY, 919, ReviewReactionVariant.EASY_PHOENIX_RISE)
-        assertSelectedVariant(ReviewRating.EASY, 920, ReviewReactionVariant.EASY_UNICORN_FLYBY)
-        assertSelectedVariant(ReviewRating.EASY, 999, ReviewReactionVariant.EASY_UNICORN_FLYBY)
+        assertSelectedVariant(ReviewRating.EASY, 39, ReviewReactionVariant.EASY_ROSE_BLOOM)
+        assertSelectedVariant(ReviewRating.EASY, 40, ReviewReactionVariant.EASY_RAINBOW_STREAK)
+        assertSelectedVariant(ReviewRating.EASY, 69, ReviewReactionVariant.EASY_RAINBOW_STREAK)
+        assertSelectedVariant(ReviewRating.EASY, 70, ReviewReactionVariant.EASY_PHOENIX_RISE)
+        assertSelectedVariant(ReviewRating.EASY, 91, ReviewReactionVariant.EASY_PHOENIX_RISE)
+        assertSelectedVariant(ReviewRating.EASY, 92, ReviewReactionVariant.EASY_UNICORN_FLYBY)
+        assertSelectedVariant(ReviewRating.EASY, 99, ReviewReactionVariant.EASY_UNICORN_FLYBY)
+    }
+
+    @Test
+    fun probabilityPercentagesUseWeights() {
+        val expectedPercentages: List<Double> = listOf(40.0, 30.0, 22.0, 8.0)
+
+        listOf(
+            ReviewRating.AGAIN,
+            ReviewRating.HARD,
+            ReviewRating.GOOD,
+            ReviewRating.EASY
+        ).forEach { rating: ReviewRating ->
+            assertEquals(
+                expectedPercentages,
+                reviewReactionVariantDistributionEntries(rating = rating)
+                    .map { entry: ReviewReactionVariantDistributionEntry -> entry.probabilityPercent }
+            )
+        }
     }
 
     @Test

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionState.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionState.swift
@@ -87,38 +87,34 @@ enum ReviewReactionVariant: CaseIterable, Hashable, Sendable {
 struct ReviewReactionVariantDistributionEntry: Identifiable, Hashable, Sendable {
     let rating: ReviewReactionRating
     let variant: ReviewReactionVariant
-    let rollRange: ClosedRange<Int>
+    let weight: Int
 
     var id: String {
         "\(self.rating.debugIdentifier).\(self.variant.debugIdentifier)"
     }
 
-    var rollCount: Int {
-        self.rollRange.upperBound - self.rollRange.lowerBound + 1
-    }
-
     var probabilityPercent: Double {
-        Double(self.rollCount) / 10
+        Double(self.weight) / Double(reviewReactionVariantTotalWeight(rating: self.rating)) * 100
     }
 }
 
 let allReviewReactionVariantDistributionEntries: [ReviewReactionVariantDistributionEntry] = [
-    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againWormWiggle, rollRange: 0...399),
-    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againTornado, rollRange: 400...699),
-    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againSnailCrawl, rollRange: 700...919),
-    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againWiltedFlower, rollRange: 920...999),
-    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardOxCharge, rollRange: 0...399),
-    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardPawPrints, rollRange: 400...699),
-    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardRacehorseGallop, rollRange: 700...919),
-    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardVolcanoEruption, rollRange: 920...999),
-    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodOwl, rollRange: 0...399),
-    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodPoodle, rollRange: 400...699),
-    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodWhale, rollRange: 700...919),
-    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodPeacock, rollRange: 920...999),
-    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyRoseBloom, rollRange: 0...399),
-    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyRainbowStreak, rollRange: 400...699),
-    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyPhoenixRise, rollRange: 700...919),
-    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyUnicornFlyby, rollRange: 920...999)
+    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againWormWiggle, weight: 40),
+    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againTornado, weight: 30),
+    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againSnailCrawl, weight: 22),
+    ReviewReactionVariantDistributionEntry(rating: .again, variant: .againWiltedFlower, weight: 8),
+    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardOxCharge, weight: 40),
+    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardPawPrints, weight: 30),
+    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardRacehorseGallop, weight: 22),
+    ReviewReactionVariantDistributionEntry(rating: .hard, variant: .hardVolcanoEruption, weight: 8),
+    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodOwl, weight: 40),
+    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodPoodle, weight: 30),
+    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodWhale, weight: 22),
+    ReviewReactionVariantDistributionEntry(rating: .good, variant: .goodPeacock, weight: 8),
+    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyRoseBloom, weight: 40),
+    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyRainbowStreak, weight: 30),
+    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyPhoenixRise, weight: 22),
+    ReviewReactionVariantDistributionEntry(rating: .easy, variant: .easyUnicornFlyby, weight: 8)
 ]
 
 func reviewReactionVariantDistributionEntries(
@@ -127,6 +123,21 @@ func reviewReactionVariantDistributionEntries(
     allReviewReactionVariantDistributionEntries.filter { entry in
         entry.rating == rating
     }
+}
+
+func reviewReactionVariantTotalWeight(
+    rating: ReviewReactionRating
+) -> Int {
+    let entries = reviewReactionVariantDistributionEntries(rating: rating)
+    precondition(!entries.isEmpty, "Review reaction distribution is missing rating \(rating.debugIdentifier).")
+
+    var totalWeight = 0
+    for entry in entries {
+        precondition(entry.weight > 0, "Invalid review reaction weight for \(entry.id): \(entry.weight).")
+        totalWeight += entry.weight
+    }
+
+    return totalWeight
 }
 
 func reviewReactionCleanupDelayNanoseconds(
@@ -151,15 +162,19 @@ func selectReviewReactionVariant(
     rating: ReviewReactionRating,
     roll: Int
 ) -> ReviewReactionVariant {
-    precondition((0...999).contains(roll), "Review reaction roll must be in 0...999, received \(roll).")
+    let entries = reviewReactionVariantDistributionEntries(rating: rating)
+    let totalWeight = reviewReactionVariantTotalWeight(rating: rating)
+    precondition((0..<totalWeight).contains(roll), "Review reaction roll must be in 0..<\(totalWeight), received \(roll).")
 
-    guard let entry = reviewReactionVariantDistributionEntries(rating: rating).first(where: { entry in
-        entry.rollRange.contains(roll)
-    }) else {
-        preconditionFailure("Review reaction distribution is missing rating \(rating.debugIdentifier) roll \(roll).")
+    var cumulativeWeight = 0
+    for entry in entries {
+        cumulativeWeight += entry.weight
+        if roll < cumulativeWeight {
+            return entry.variant
+        }
     }
 
-    return entry.variant
+    preconditionFailure("Review reaction distribution is missing rating \(rating.debugIdentifier) roll \(roll).")
 }
 
 func makeReviewReactionRating(rating: ReviewRating) -> ReviewReactionRating {

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
@@ -3,12 +3,13 @@ import SwiftUI
 extension ReviewView {
     func emitReviewReaction(rating: ReviewRating) {
         let reactionRating = makeReviewReactionRating(rating: rating)
+        let totalWeight = reviewReactionVariantTotalWeight(rating: reactionRating)
         let event = ReviewReactionEvent(
             id: UUID(),
             rating: reactionRating,
             variant: selectReviewReactionVariant(
                 rating: reactionRating,
-                roll: Int.random(in: 0...999)
+                roll: Int.random(in: 0..<totalWeight)
             )
         )
         self.activeReviewReactionEvents = appendReviewReactionEvent(

--- a/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
@@ -94,7 +94,7 @@ private func localizedReviewReactionRatingTitle(rating: ReviewReactionRating) ->
 }
 
 private func testAnimationProbabilityText(entry: ReviewReactionVariantDistributionEntry) -> String {
-    let percentText: String = "\(Int(entry.probabilityPercent))%"
+    let percentText: String = "\(Int(entry.probabilityPercent.rounded()))%"
     return aiSettingsLocalizedFormat(
         "settings.test.animations.probability",
         "%@ probability",

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Reaction/ReviewReactionVariantSelectionTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Reaction/ReviewReactionVariantSelectionTests.swift
@@ -4,45 +4,57 @@ import XCTest
 final class ReviewReactionVariantSelectionTests: XCTestCase {
     func testAgainVariantBoundaries() {
         XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 0), .againWormWiggle)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 399), .againWormWiggle)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 400), .againTornado)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 699), .againTornado)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 700), .againSnailCrawl)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 919), .againSnailCrawl)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 920), .againWiltedFlower)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 999), .againWiltedFlower)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 39), .againWormWiggle)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 40), .againTornado)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 69), .againTornado)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 70), .againSnailCrawl)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 91), .againSnailCrawl)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 92), .againWiltedFlower)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .again, roll: 99), .againWiltedFlower)
     }
 
     func testHardVariantBoundaries() {
         XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 0), .hardOxCharge)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 399), .hardOxCharge)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 400), .hardPawPrints)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 699), .hardPawPrints)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 700), .hardRacehorseGallop)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 919), .hardRacehorseGallop)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 920), .hardVolcanoEruption)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 999), .hardVolcanoEruption)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 39), .hardOxCharge)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 40), .hardPawPrints)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 69), .hardPawPrints)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 70), .hardRacehorseGallop)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 91), .hardRacehorseGallop)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 92), .hardVolcanoEruption)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .hard, roll: 99), .hardVolcanoEruption)
     }
 
     func testGoodVariantBoundaries() {
         XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 0), .goodOwl)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 399), .goodOwl)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 400), .goodPoodle)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 699), .goodPoodle)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 700), .goodWhale)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 919), .goodWhale)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 920), .goodPeacock)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 999), .goodPeacock)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 39), .goodOwl)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 40), .goodPoodle)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 69), .goodPoodle)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 70), .goodWhale)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 91), .goodWhale)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 92), .goodPeacock)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .good, roll: 99), .goodPeacock)
     }
 
     func testEasyVariantBoundaries() {
         XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 0), .easyRoseBloom)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 399), .easyRoseBloom)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 400), .easyRainbowStreak)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 699), .easyRainbowStreak)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 700), .easyPhoenixRise)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 919), .easyPhoenixRise)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 920), .easyUnicornFlyby)
-        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 999), .easyUnicornFlyby)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 39), .easyRoseBloom)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 40), .easyRainbowStreak)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 69), .easyRainbowStreak)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 70), .easyPhoenixRise)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 91), .easyPhoenixRise)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 92), .easyUnicornFlyby)
+        XCTAssertEqual(selectReviewReactionVariant(rating: .easy, roll: 99), .easyUnicornFlyby)
+    }
+
+    func testProbabilityPercentagesUseWeights() {
+        let expectedPercentages = [40.0, 30.0, 22.0, 8.0]
+
+        for rating in ReviewReactionRating.allCases {
+            let actualPercentages = reviewReactionVariantDistributionEntries(rating: rating).map(\.probabilityPercent)
+            XCTAssertEqual(actualPercentages.count, expectedPercentages.count)
+            for index in expectedPercentages.indices {
+                XCTAssertEqual(actualPercentages[index], expectedPercentages[index], accuracy: 0.0001)
+            }
+        }
     }
 }

--- a/apps/web/src/screens/review/reactions/reviewReaction.test.ts
+++ b/apps/web/src/screens/review/reactions/reviewReaction.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  reviewReactionVariantDistributionEntries,
+  reviewReactionVariantProbabilityPercent,
   selectReviewReactionVariant,
   type ReviewReactionRating,
   type ReviewReactionVariant,
@@ -10,7 +12,8 @@ type ReviewReactionBoundaryExpectation = Readonly<{
   variants: ReadonlyArray<ReviewReactionVariant>;
 }>;
 
-const boundaryRolls: ReadonlyArray<number> = [0, 399, 400, 699, 700, 919, 920, 999];
+const boundaryRolls: ReadonlyArray<number> = [0, 39, 40, 69, 70, 91, 92, 99];
+const expectedProbabilityPercents: ReadonlyArray<number> = [40, 30, 22, 8];
 
 const boundaryExpectations: ReadonlyArray<ReviewReactionBoundaryExpectation> = [
   {
@@ -73,6 +76,15 @@ describe("selectReviewReactionVariant", () => {
       for (const [index, roll] of boundaryRolls.entries()) {
         expect(selectReviewReactionVariant(expectation.rating, roll)).toBe(expectation.variants[index]);
       }
+    }
+  });
+
+  it("computes review reaction probability percentages from weights", () => {
+    for (const expectation of boundaryExpectations) {
+      expect(
+        reviewReactionVariantDistributionEntries(expectation.rating)
+          .map((entry) => reviewReactionVariantProbabilityPercent(entry)),
+      ).toEqual(expectedProbabilityPercents);
     }
   });
 });

--- a/apps/web/src/screens/review/reactions/reviewReaction.ts
+++ b/apps/web/src/screens/review/reactions/reviewReaction.ts
@@ -48,62 +48,43 @@ export type ReviewReactionVariantDistributionEntry = Readonly<{
   id: string;
   rating: ReviewReactionRating;
   variant: ReviewReactionVariant;
-  rollRange: Readonly<{
-    lowerBound: number;
-    upperBound: number;
-  }>;
-  rollCount: number;
-  probabilityPercent: number;
+  weight: number;
 }>;
 
 function makeReviewReactionVariantDistributionEntry(
   rating: ReviewReactionRating,
   variant: ReviewReactionVariant,
-  lowerBound: number,
-  upperBound: number,
+  weight: number,
 ): ReviewReactionVariantDistributionEntry {
-  if (
-    !Number.isInteger(lowerBound)
-    || !Number.isInteger(upperBound)
-    || lowerBound < 0
-    || upperBound > 999
-    || upperBound < lowerBound
-  ) {
-    throw new RangeError(`Invalid review reaction roll range for ${rating}.${variant}: ${lowerBound}...${upperBound}`);
+  if (!Number.isInteger(weight) || weight <= 0) {
+    throw new RangeError(`Invalid review reaction weight for ${rating}.${variant}: ${weight}`);
   }
-
-  const rollCount = upperBound - lowerBound + 1;
 
   return {
     id: `${rating}.${variant}`,
     rating,
     variant,
-    rollRange: {
-      lowerBound,
-      upperBound,
-    },
-    rollCount,
-    probabilityPercent: rollCount / 10,
+    weight,
   };
 }
 
 export const allReviewReactionVariantDistributionEntries: ReadonlyArray<ReviewReactionVariantDistributionEntry> = [
-  makeReviewReactionVariantDistributionEntry("again", "againWormWiggle", 0, 399),
-  makeReviewReactionVariantDistributionEntry("again", "againTornado", 400, 699),
-  makeReviewReactionVariantDistributionEntry("again", "againSnailCrawl", 700, 919),
-  makeReviewReactionVariantDistributionEntry("again", "againWiltedFlower", 920, 999),
-  makeReviewReactionVariantDistributionEntry("hard", "hardOxCharge", 0, 399),
-  makeReviewReactionVariantDistributionEntry("hard", "hardPawPrints", 400, 699),
-  makeReviewReactionVariantDistributionEntry("hard", "hardRacehorseGallop", 700, 919),
-  makeReviewReactionVariantDistributionEntry("hard", "hardVolcanoEruption", 920, 999),
-  makeReviewReactionVariantDistributionEntry("good", "goodOwl", 0, 399),
-  makeReviewReactionVariantDistributionEntry("good", "goodPoodle", 400, 699),
-  makeReviewReactionVariantDistributionEntry("good", "goodWhale", 700, 919),
-  makeReviewReactionVariantDistributionEntry("good", "goodPeacock", 920, 999),
-  makeReviewReactionVariantDistributionEntry("easy", "easyRoseBloom", 0, 399),
-  makeReviewReactionVariantDistributionEntry("easy", "easyRainbowStreak", 400, 699),
-  makeReviewReactionVariantDistributionEntry("easy", "easyPhoenixRise", 700, 919),
-  makeReviewReactionVariantDistributionEntry("easy", "easyUnicornFlyby", 920, 999),
+  makeReviewReactionVariantDistributionEntry("again", "againWormWiggle", 40),
+  makeReviewReactionVariantDistributionEntry("again", "againTornado", 30),
+  makeReviewReactionVariantDistributionEntry("again", "againSnailCrawl", 22),
+  makeReviewReactionVariantDistributionEntry("again", "againWiltedFlower", 8),
+  makeReviewReactionVariantDistributionEntry("hard", "hardOxCharge", 40),
+  makeReviewReactionVariantDistributionEntry("hard", "hardPawPrints", 30),
+  makeReviewReactionVariantDistributionEntry("hard", "hardRacehorseGallop", 22),
+  makeReviewReactionVariantDistributionEntry("hard", "hardVolcanoEruption", 8),
+  makeReviewReactionVariantDistributionEntry("good", "goodOwl", 40),
+  makeReviewReactionVariantDistributionEntry("good", "goodPoodle", 30),
+  makeReviewReactionVariantDistributionEntry("good", "goodWhale", 22),
+  makeReviewReactionVariantDistributionEntry("good", "goodPeacock", 8),
+  makeReviewReactionVariantDistributionEntry("easy", "easyRoseBloom", 40),
+  makeReviewReactionVariantDistributionEntry("easy", "easyRainbowStreak", 30),
+  makeReviewReactionVariantDistributionEntry("easy", "easyPhoenixRise", 22),
+  makeReviewReactionVariantDistributionEntry("easy", "easyUnicornFlyby", 8),
 ];
 
 export function reviewReactionVariantDistributionEntries(
@@ -112,29 +93,58 @@ export function reviewReactionVariantDistributionEntries(
   return allReviewReactionVariantDistributionEntries.filter((entry) => entry.rating === rating);
 }
 
-function isRollInReviewReactionDistributionEntry(
+function reviewReactionVariantTotalWeightFromEntries(
+  rating: ReviewReactionRating,
+  entries: ReadonlyArray<ReviewReactionVariantDistributionEntry>,
+): number {
+  if (entries.length === 0) {
+    throw new Error(`Review reaction distribution is missing rating ${rating}.`);
+  }
+
+  let totalWeight = 0;
+  for (const entry of entries) {
+    if (!Number.isInteger(entry.weight) || entry.weight <= 0) {
+      throw new RangeError(`Invalid review reaction weight for ${entry.id}: ${entry.weight}`);
+    }
+    totalWeight += entry.weight;
+  }
+
+  return totalWeight;
+}
+
+export function reviewReactionVariantTotalWeight(rating: ReviewReactionRating): number {
+  return reviewReactionVariantTotalWeightFromEntries(
+    rating,
+    reviewReactionVariantDistributionEntries(rating),
+  );
+}
+
+export function reviewReactionVariantProbabilityPercent(
   entry: ReviewReactionVariantDistributionEntry,
-  roll: number,
-): boolean {
-  return roll >= entry.rollRange.lowerBound && roll <= entry.rollRange.upperBound;
+): number {
+  return (entry.weight / reviewReactionVariantTotalWeight(entry.rating)) * 100;
 }
 
 export function selectReviewReactionVariant(
   rating: ReviewReactionRating,
   roll: number,
 ): ReviewReactionVariant {
-  if (!Number.isInteger(roll) || roll < 0 || roll > 999) {
-    throw new RangeError(`Review reaction roll must be an integer in 0...999, received ${roll}.`);
+  const entries = reviewReactionVariantDistributionEntries(rating);
+  const totalWeight = reviewReactionVariantTotalWeightFromEntries(rating, entries);
+
+  if (!Number.isInteger(roll) || roll < 0 || roll >= totalWeight) {
+    throw new RangeError(`Review reaction roll must be an integer in 0...${totalWeight - 1}, received ${roll}.`);
   }
 
-  const entry = reviewReactionVariantDistributionEntries(rating).find((candidate) => (
-    isRollInReviewReactionDistributionEntry(candidate, roll)
-  ));
-  if (entry === undefined) {
-    throw new Error(`Review reaction distribution is missing rating ${rating} roll ${roll}.`);
+  let cumulativeWeight = 0;
+  for (const entry of entries) {
+    cumulativeWeight += entry.weight;
+    if (roll < cumulativeWeight) {
+      return entry.variant;
+    }
   }
 
-  return entry.variant;
+  throw new Error(`Review reaction distribution is missing rating ${rating} roll ${roll}.`);
 }
 
 export function makeReviewReactionRating(rating: 0 | 1 | 2 | 3): ReviewReactionRating {

--- a/apps/web/src/screens/review/reactions/useReviewRatingReactions.ts
+++ b/apps/web/src/screens/review/reactions/useReviewRatingReactions.ts
@@ -5,6 +5,7 @@ import {
   matchesReducedReviewReactionMotion,
   reviewReactionCleanupDelayMillis,
   reviewReactionMaximumActiveEvents,
+  reviewReactionVariantTotalWeight,
   reducedReviewReactionMotionMediaQuery,
   selectReviewReactionVariant,
   type ReviewReactionEvent,
@@ -105,13 +106,14 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
 
   const emitReaction = useCallback((rating: 0 | 1 | 2 | 3): void => {
     const reactionRating = makeReviewReactionRating(rating);
+    const totalWeight = reviewReactionVariantTotalWeight(reactionRating);
     const event: ReviewReactionEvent = {
       id: crypto.randomUUID(),
       rating: reactionRating,
       variant: reviewReactionVariantWithReadyLottieFallback(
         selectReviewReactionVariant(
           reactionRating,
-          Math.floor(Math.random() * 1000),
+          Math.floor(Math.random() * totalWeight),
         ),
       ),
     };

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -7,6 +7,7 @@ import {
   reviewReactionCleanupDelayMillis,
   reviewReactionMaximumActiveEvents,
   reviewReactionRatings,
+  reviewReactionVariantProbabilityPercent,
   reviewReactionVariantDistributionEntries,
   reducedReviewReactionMotionMediaQuery,
   type ReviewReactionEvent,
@@ -74,7 +75,7 @@ function testAnimationProbabilityText(
   formatNumber: FormatNumber,
   t: Translate,
 ): string {
-  const percentText = `${formatNumber(entry.probabilityPercent, probabilityFormatOptions)}%`;
+  const percentText = `${formatNumber(reviewReactionVariantProbabilityPercent(entry), probabilityFormatOptions)}%`;
   return t("settingsTest.animations.probability", {
     percent: percentText,
   });


### PR DESCRIPTION
## Summary
- Replace manual review reaction roll ranges with integer weights on web, iOS, and Android.
- Keep the current effective 40/30/22/8 probabilities for each rating.
- Update selection tests and probability display to use weighted totals.

## Validation
- `npx vitest run src/screens/review/reactions/reviewReaction.test.ts src/screens/review/reactions/useReviewRatingReactions.test.tsx src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx`
- `npx tsc --noEmit`

Android Gradle and iOS simulator-backed tests were not run locally per repository constraints.