### PR TITLE
[codex] Stabilize Android reset progress smoke

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeScenarioHelpers.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeScenarioHelpers.kt
@@ -24,8 +24,11 @@ import com.flashcardsopensourceapp.data.local.model.AiChatContentPart
 import com.flashcardsopensourceapp.data.local.model.AiChatPersistedState
 import com.flashcardsopensourceapp.data.local.model.AiChatRole
 import com.flashcardsopensourceapp.data.local.model.AiChatToolCallStatus
+import com.flashcardsopensourceapp.data.local.model.CardFilter
+import com.flashcardsopensourceapp.data.local.model.CardSummary
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
+import com.flashcardsopensourceapp.data.local.model.SyncStatus
 import com.flashcardsopensourceapp.feature.ai.aiAssistantMessageBubbleTag
 import com.flashcardsopensourceapp.feature.ai.aiAssistantTextPartTag
 import com.flashcardsopensourceapp.feature.ai.aiComposerMessageFieldTag
@@ -80,6 +83,60 @@ internal fun LiveSmokeContext.withLinkedWorkspaceSession(
                 }
             }
         }
+    }
+}
+
+internal fun LiveSmokeContext.deleteCurrentWorkspaceCards() {
+    val deletedCards: List<CardSummary> = runBlocking {
+        val appGraph = appGraph()
+        val currentCards: List<CardSummary> = appGraph.cardsRepository.observeCards(
+            searchQuery = "",
+            filter = CardFilter(
+                tags = emptyList(),
+                effort = emptyList()
+            )
+        ).first()
+        if (currentCards.isEmpty()) {
+            return@runBlocking emptyList<CardSummary>()
+        }
+
+        currentCards.forEach { card ->
+            appGraph.cardsRepository.deleteCard(cardId = card.cardId)
+        }
+        appGraph.syncRepository.syncNow()
+
+        val syncStatus = appGraph.syncRepository.observeSyncStatus().first()
+        if (syncStatus.status != SyncStatus.Idle || syncStatus.lastErrorMessage.isNotEmpty()) {
+            throw AssertionError(
+                "Workspace card cleanup sync did not finish cleanly. " +
+                    "Status=${syncStatus.status} " +
+                    "LastError=${syncStatus.lastErrorMessage} " +
+                    "CloudSettings=${currentCloudSettingsSummary()} " +
+                    "CurrentWorkspace=${currentWorkspaceSummaryOrNull()}"
+            )
+        }
+
+        val remainingCards: List<CardSummary> = appGraph.cardsRepository.observeCards(
+            searchQuery = "",
+            filter = CardFilter(
+                tags = emptyList(),
+                effort = emptyList()
+            )
+        ).first()
+        if (remainingCards.isNotEmpty()) {
+            throw AssertionError(
+                "Workspace card cleanup left active cards behind. " +
+                    "RemainingCards=${remainingCards.map { card -> card.cardId }} " +
+                    "CloudSettings=${currentCloudSettingsSummary()} " +
+                    "CurrentWorkspace=${currentWorkspaceSummaryOrNull()}"
+            )
+        }
+
+        currentCards
+    }
+
+    if (deletedCards.isNotEmpty()) {
+        composeRule.waitForIdle()
     }
 }
 

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt
@@ -110,6 +110,10 @@ class LiveSmokeTest : FirebaseAppInstrumentationTimeoutTest() {
             reviewEmail = reviewEmail,
             workspaceName = workspaceName
         ) {
+            liveSmokeContext.step("clear inherited cards from the linked workspace") {
+                liveSmokeContext.deleteCurrentWorkspaceCards()
+            }
+
             liveSmokeContext.step("create one manual card in the linked workspace") {
                 liveSmokeContext.createManualCard(
                     frontText = manualFrontText,


### PR DESCRIPTION
## Summary
- clear inherited cards from the linked Android live-smoke workspace before the reset-progress scenario creates its fixture card
- verify cleanup sync finishes cleanly before continuing the smoke flow

## Validation
- git --no-pager diff --check

Android Gradle/instrumentation was not run locally because the repository instructions require explicit permission for local Gradle or device-backed Android runs.