### PR TITLE
Revert regional German Android locale

### DIFF
--- a/apps/android/app/src/main/res/xml/locales_config.xml
+++ b/apps/android/app/src/main/res/xml/locales_config.xml
@@ -8,7 +8,7 @@
     <locale android:name="ca" />
     <locale android:name="cs" />
     <locale android:name="da" />
-    <locale android:name="de-DE" />
+    <locale android:name="de" />
     <locale android:name="el" />
     <locale android:name="es" />
     <locale android:name="et" />


### PR DESCRIPTION
## Summary
- Revert the Android supported locale declaration from `de-DE` back to `de`.
- Keep the Play Console translation experiment out of the release language config because Play still stores German as `de` and API uploads continue to fail while automatic translations are enabled.

## Validation
- Ran `git diff --cached --check` before commit.
- Did not run Gradle locally; repository instructions require explicit approval for local Gradle runs, and this is a one-line XML rollback.