### PR TITLE
[codex] Harden web API transport retries

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -9,6 +9,7 @@ export type {
 } from "./api/authUrls";
 export {
   ApiError,
+  ApiNetworkError,
   AuthRedirectError,
 } from "./api/errors";
 export type {

--- a/apps/web/src/api/chat.ts
+++ b/apps/web/src/api/chat.ts
@@ -19,7 +19,11 @@ import type {
   StopChatRunResponse,
 } from "../types";
 import { parseContractResponse } from "./response";
-import { allowAuthRecovery, requestJson } from "./transport";
+import {
+  allowAuthRecovery,
+  allowAuthRecoveryWithTransientNetworkRetry,
+  requestJson,
+} from "./transport";
 
 type ChatResumeRequestDiagnostics = Readonly<{
   resumeAttemptId: number;
@@ -36,7 +40,7 @@ function buildChatSnapshotPath(sessionId: string, workspaceId: string): string {
 export async function getChatSnapshot(sessionId: string, workspaceId: string): Promise<ChatSessionSnapshot> {
   return parseContractResponse(await requestJson(buildChatSnapshotPath(sessionId, workspaceId), {
     method: "GET",
-  }, allowAuthRecovery), "GET /chat", parseChatSessionSnapshotResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), "GET /chat", parseChatSessionSnapshotResponse);
 }
 
 export async function getChatSnapshotWithResumeDiagnostics(
@@ -51,14 +55,14 @@ export async function getChatSnapshotWithResumeDiagnostics(
       "X-Client-Platform": "web",
       "X-Client-Version": webAppVersion,
     },
-  }, allowAuthRecovery), "GET /chat", parseChatSessionSnapshotResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), "GET /chat", parseChatSessionSnapshotResponse);
 }
 
 export async function startChatRun(body: StartChatRunRequestBody): Promise<StartChatRunResponse> {
   return parseContractResponse(await requestJson("/chat", {
     method: "POST",
     body: JSON.stringify(body),
-  }, allowAuthRecovery), "POST /chat", parseStartChatRunResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), "POST /chat", parseStartChatRunResponse);
 }
 
 export async function createNewChatSession(
@@ -75,7 +79,7 @@ export async function createNewChatSession(
   return parseContractResponse(await requestJson("/chat/new", {
     method: "POST",
     body: JSON.stringify(requestBody),
-  }, allowAuthRecovery), "POST /chat/new", parseNewChatSessionResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), "POST /chat/new", parseNewChatSessionResponse);
 }
 
 export async function stopChatRun(

--- a/apps/web/src/api/errors.ts
+++ b/apps/web/src/api/errors.ts
@@ -1,4 +1,5 @@
 export type ApiResponseBodyKind = "empty" | "json" | "text" | "invalid_json";
+export const apiNetworkErrorCode: string = "API_NETWORK_ERROR";
 
 type ApiErrorParams = Readonly<{
   statusCode: number;
@@ -23,6 +24,34 @@ export class ApiError extends Error {
     this.requestId = params.requestId;
     this.endpoint = params.endpoint;
     this.responseBodyKind = params.responseBodyKind;
+  }
+}
+
+type ApiNetworkErrorParams = Readonly<{
+  endpoint: string;
+  originalErrorName: string;
+  originalErrorMessage: string;
+  attemptCount: number;
+}>;
+
+export class ApiNetworkError extends ApiError {
+  readonly originalErrorName: string;
+  readonly originalErrorMessage: string;
+  readonly attemptCount: number;
+
+  constructor(params: ApiNetworkErrorParams) {
+    super({
+      statusCode: 0,
+      message: `The API is unavailable. Try again. (${params.endpoint}; ${params.originalErrorName}: ${params.originalErrorMessage})`,
+      code: apiNetworkErrorCode,
+      requestId: null,
+      endpoint: params.endpoint,
+      responseBodyKind: "empty",
+    });
+    this.name = "ApiNetworkError";
+    this.originalErrorName = params.originalErrorName;
+    this.originalErrorMessage = params.originalErrorMessage;
+    this.attemptCount = params.attemptCount;
   }
 }
 

--- a/apps/web/src/api/progress.ts
+++ b/apps/web/src/api/progress.ts
@@ -13,7 +13,7 @@ import type {
   ProgressSummaryPayload,
 } from "../types";
 import { parseContractResponse } from "./response";
-import { allowAuthRecovery, requestJson } from "./transport";
+import { allowAuthRecoveryWithTransientNetworkRetry, requestJson } from "./transport";
 
 export async function loadProgressSummary(input: ProgressSummaryInput): Promise<ProgressSummaryPayload> {
   const searchParams = new URLSearchParams({
@@ -23,7 +23,7 @@ export async function loadProgressSummary(input: ProgressSummaryInput): Promise<
   return parseContractResponse(
     await requestJson(`/me/progress/summary?${searchParams.toString()}`, {
       method: "GET",
-    }, allowAuthRecovery),
+    }, allowAuthRecoveryWithTransientNetworkRetry),
     "GET /me/progress/summary",
     parseProgressSummaryResponse,
   );
@@ -39,7 +39,7 @@ export async function loadProgressSeries(input: ProgressSeriesInput): Promise<Pr
   return parseContractResponse(
     await requestJson(`/me/progress/series?${searchParams.toString()}`, {
       method: "GET",
-    }, allowAuthRecovery),
+    }, allowAuthRecoveryWithTransientNetworkRetry),
     "GET /me/progress/series",
     parseProgressSeriesResponse,
   );
@@ -55,7 +55,7 @@ export async function loadProgressReviewSchedule(
   return parseContractResponse(
     await requestJson(`/me/progress/review-schedule?${searchParams.toString()}`, {
       method: "GET",
-    }, allowAuthRecovery),
+    }, allowAuthRecoveryWithTransientNetworkRetry),
     endpoint,
     (value: unknown, parseEndpoint: string): ProgressReviewSchedule => {
       const schedule = parseProgressReviewScheduleResponse(value, parseEndpoint);

--- a/apps/web/src/api/sync.ts
+++ b/apps/web/src/api/sync.ts
@@ -18,7 +18,11 @@ import type {
   SyncReviewHistoryPullResult,
 } from "../types";
 import { parseContractResponse } from "./response";
-import { allowAuthRecovery, requestJson } from "./transport";
+import {
+  allowAuthRecovery,
+  allowAuthRecoveryWithTransientNetworkRetry,
+  requestJson,
+} from "./transport";
 
 export async function pushSyncOperations(
   workspaceId: string,
@@ -35,7 +39,7 @@ export async function pushSyncOperations(
       appVersion,
       operations,
     }),
-  }, allowAuthRecovery), `POST /workspaces/${workspaceId}/sync/push`, parseSyncPushResultResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/push`, parseSyncPushResultResponse);
 }
 
 export async function pullSyncChanges(
@@ -55,7 +59,7 @@ export async function pullSyncChanges(
       afterHotChangeId,
       limit,
     }),
-  }, allowAuthRecovery), `POST /workspaces/${workspaceId}/sync/pull`, parseSyncPullResultResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/pull`, parseSyncPullResultResponse);
 }
 
 export async function bootstrapPullSyncState(
@@ -76,7 +80,7 @@ export async function bootstrapPullSyncState(
       cursor,
       limit,
     }),
-  }, allowAuthRecovery), `POST /workspaces/${workspaceId}/sync/bootstrap`, parseSyncBootstrapPullResultResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/bootstrap`, parseSyncBootstrapPullResultResponse);
 }
 
 export async function bootstrapPushSyncState(
@@ -115,7 +119,7 @@ export async function pullReviewHistorySync(
       afterReviewSequenceId,
       limit,
     }),
-  }, allowAuthRecovery), `POST /workspaces/${workspaceId}/sync/review-history/pull`, parseSyncReviewHistoryPullResultResponse);
+  }, allowAuthRecoveryWithTransientNetworkRetry), `POST /workspaces/${workspaceId}/sync/review-history/pull`, parseSyncReviewHistoryPullResultResponse);
 }
 
 export async function importReviewHistorySync(

--- a/apps/web/src/api/transport.test.ts
+++ b/apps/web/src/api/transport.test.ts
@@ -6,8 +6,10 @@ import { ApiContractError } from "../apiContracts/core";
 import { persistLocalePreference } from "../i18n/runtime";
 import type { NewChatSessionResponse } from "../types";
 import {
+  createChatSnapshotResponse,
   createNewChatSessionResponse,
   createSessionResponse,
+  createStartChatRunResponse,
   createStorageMock,
   expectLocalBrowserStatePreserved,
   expectLocalBrowserStatePreservedForReauth,
@@ -15,16 +17,65 @@ import {
   seedLocalBrowserState,
   setNavigatorLanguages,
 } from "./ApiTestSupport";
-import { createNewChatSession } from "./chat";
-import { ApiError, AuthRedirectError } from "./errors";
+import {
+  createNewChatSession,
+  getChatSnapshot,
+  startChatRun,
+  stopChatRun,
+} from "./chat";
+import { ApiError, ApiNetworkError, AuthRedirectError } from "./errors";
+import { pullSyncChanges } from "./sync";
 import {
   getSession,
+  primeSessionCsrfToken,
   resetApiClientStateForTests,
   setNavigationHandlerForTests,
 } from "./transport";
 
 async function createTransportBackedChatSession(sessionId: string): Promise<NewChatSessionResponse> {
   return createNewChatSession(sessionId, "workspace-1", "en");
+}
+
+type DeferredResponsePromise = Readonly<{
+  promise: Promise<Response>;
+  reject: (error: Error) => void;
+  resolve: (value: Response) => void;
+}>;
+
+function createDeferredResponsePromise(): DeferredResponsePromise {
+  let rejectPromise: ((error: Error) => void) | null = null;
+  let resolvePromise: ((value: Response) => void) | null = null;
+  const promise = new Promise<Response>((resolve, reject) => {
+    rejectPromise = reject;
+    resolvePromise = resolve;
+  });
+
+  if (rejectPromise === null || resolvePromise === null) {
+    throw new Error("Deferred response promise callbacks were not initialized");
+  }
+
+  return {
+    promise,
+    reject: rejectPromise,
+    resolve: resolvePromise,
+  };
+}
+
+async function waitForFetchCallCount(
+  fetchMock: ReturnType<typeof vi.fn<(...args: Array<unknown>) => Promise<Response>>>,
+  expectedCallCount: number,
+): Promise<void> {
+  for (let attemptCount = 0; attemptCount < 20; attemptCount += 1) {
+    if (fetchMock.mock.calls.length >= expectedCallCount) {
+      return;
+    }
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+  }
+
+  throw new Error(`Expected fetch to be called ${expectedCallCount} times`);
 }
 
 beforeEach(() => {
@@ -409,5 +460,341 @@ describe("unsafe request session transport", () => {
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("API transport network retry", () => {
+  it("retries a transient network failure for chat snapshot reads", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createChatSnapshotResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getChatSnapshot("session-1", "workspace-1")).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "GET /chat",
+      attemptCount: 1,
+      maximumAttemptCount: 3,
+      nextAttemptCount: 2,
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Failed to fetch",
+    }));
+  });
+
+  it("retries a transient network failure for sync pull requests", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const workspaceId = "99782554-9362-416c-93c7-0eb1d8079948";
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        changes: [],
+        nextHotChangeId: 42,
+        hasMore: false,
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(pullSyncChanges(
+      workspaceId,
+      "installation-1",
+      "web",
+      "1.4.0",
+      0,
+      200,
+    )).resolves.toEqual({
+      changes: [],
+      nextHotChangeId: 42,
+      hasMore: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "POST /workspaces/{uuid}/sync/pull",
+      attemptCount: 1,
+    }));
+  });
+
+  it("retries session readiness for retry-enabled unsafe sync requests", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const workspaceId = "99782554-9362-416c-93c7-0eb1d8079948";
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createSessionResponse(null))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        changes: [],
+        nextHotChangeId: 42,
+        hasMore: false,
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(pullSyncChanges(
+      workspaceId,
+      "installation-1",
+      "web",
+      "1.4.0",
+      0,
+      200,
+    )).resolves.toEqual({
+      changes: [],
+      nextHotChangeId: 42,
+      hasMore: false,
+    });
+
+    const syncRequestInit = fetchMock.mock.calls[2]?.[1] as RequestInit | undefined;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(`http://localhost:8080/v1/workspaces/${workspaceId}/sync/pull`);
+    expect(new Headers(syncRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-1");
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "GET /me",
+      attemptCount: 1,
+    }));
+  });
+
+  it("retries session reload after auth recovery for retry-enabled requests", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createSessionResponse(null))
+      .mockResolvedValueOnce(createChatSnapshotResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getChatSnapshot("session-1", "workspace-1")).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/chat?sessionId=session-1&workspaceId=workspace-1");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8081/api/refresh-session");
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[4]?.[0]).toBe("http://localhost:8080/v1/chat?sessionId=session-1&workspaceId=workspace-1");
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "GET /me",
+      attemptCount: 1,
+    }));
+  });
+
+  it("retries a transient network failure for idempotent chat run starts", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createStartChatRunResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(startChatRun({
+      sessionId: "session-1",
+      workspaceId: "workspace-1",
+      clientRequestId: "client-request-1",
+      content: [{ type: "text", text: "hello" }],
+      timezone: "UTC",
+      uiLocale: "en",
+    })).resolves.toMatchObject({
+      accepted: true,
+      sessionId: "session-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "POST /chat",
+      attemptCount: 1,
+    }));
+  });
+
+  it("retries a transient network failure for explicit chat session creation", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createNewChatSessionResponse("session-1"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createTransportBackedChatSession("session-1")).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "POST /chat/new",
+      attemptCount: 1,
+    }));
+  });
+
+  it("upgrades auth recovery retry mode for concurrent retry-enabled requests", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    primeSessionCsrfToken("csrf-token-1");
+    const refreshResponse = createDeferredResponsePromise();
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockImplementationOnce(() => refreshResponse.promise)
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createSessionResponse(null))
+      .mockResolvedValueOnce(createChatSnapshotResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const nonRetryErrorPromise = stopChatRun("session-1", "workspace-1", null)
+      .catch((error: unknown): unknown => error);
+    await waitForFetchCallCount(fetchMock, 2);
+
+    const retryPromise = getChatSnapshot("session-1", "workspace-1");
+    await waitForFetchCallCount(fetchMock, 3);
+    refreshResponse.resolve(new Response(null, { status: 200 }));
+
+    await expect(retryPromise).resolves.toMatchObject({
+      sessionId: "session-1",
+    });
+    await expect(nonRetryErrorPromise).resolves.toMatchObject({
+      endpoint: "GET /me",
+      attemptCount: 1,
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/chat/stop");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8081/api/refresh-session");
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("http://localhost:8080/v1/chat?sessionId=session-1&workspaceId=workspace-1");
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[4]?.[0]).toBe("http://localhost:8081/api/refresh-session");
+    expect(fetchMock.mock.calls[5]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[6]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[7]?.[0]).toBe("http://localhost:8080/v1/chat?sessionId=session-1&workspaceId=workspace-1");
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "GET /me",
+      attemptCount: 1,
+    }));
+  });
+
+  it("upgrades active auth recovery retry mode before retry-enabled unsafe requests", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const workspaceId = "99782554-9362-416c-93c7-0eb1d8079948";
+    const refreshResponse = createDeferredResponsePromise();
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockImplementationOnce(() => refreshResponse.promise)
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(createSessionResponse(null))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        changes: [],
+        nextHotChangeId: 42,
+        hasMore: false,
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const nonRetryErrorPromise = getSession()
+      .catch((error: unknown): unknown => error);
+    await waitForFetchCallCount(fetchMock, 2);
+
+    const retryPromise = pullSyncChanges(
+      workspaceId,
+      "installation-1",
+      "web",
+      "1.4.0",
+      0,
+      200,
+    );
+    refreshResponse.resolve(new Response(null, { status: 200 }));
+
+    await expect(retryPromise).resolves.toEqual({
+      changes: [],
+      nextHotChangeId: 42,
+      hasMore: false,
+    });
+    await expect(nonRetryErrorPromise).resolves.toMatchObject({
+      endpoint: "GET /me",
+      attemptCount: 1,
+    } satisfies Partial<ApiNetworkError>);
+
+    const syncRequestInit = fetchMock.mock.calls[6]?.[1] as RequestInit | undefined;
+    expect(fetchMock).toHaveBeenCalledTimes(7);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("http://localhost:8081/api/refresh-session");
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[3]?.[0]).toBe("http://localhost:8081/api/refresh-session");
+    expect(fetchMock.mock.calls[4]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[5]?.[0]).toBe("http://localhost:8080/v1/me");
+    expect(fetchMock.mock.calls[6]?.[0]).toBe(`http://localhost:8080/v1/workspaces/${workspaceId}/sync/pull`);
+    expect(new Headers(syncRequestInit?.headers).get("X-CSRF-Token")).toBe("csrf-token-1");
+    expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
+      endpoint: "GET /me",
+      attemptCount: 1,
+    }));
+  });
+
+  it("raises a structured API network error after transient retry attempts are exhausted", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+    const snapshotPromise = getChatSnapshot("session-1", "workspace-1");
+
+    await expect(snapshotPromise).rejects.toBeInstanceOf(ApiNetworkError);
+    await expect(snapshotPromise).rejects.toMatchObject({
+      statusCode: 0,
+      code: "API_NETWORK_ERROR",
+      requestId: null,
+      endpoint: "GET /chat",
+      responseBodyKind: "empty",
+      originalErrorName: "TypeError",
+      originalErrorMessage: "Failed to fetch",
+      attemptCount: 3,
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry mutating chat stop requests when network retry is not enabled", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation((): void => {});
+    primeSessionCsrfToken("csrf-token-1");
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(stopChatRun("session-1", "workspace-1", null)).rejects.toMatchObject({
+      statusCode: 0,
+      code: "API_NETWORK_ERROR",
+      endpoint: "POST /chat/stop",
+      attemptCount: 1,
+    } satisfies Partial<ApiNetworkError>);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/api/transport.ts
+++ b/apps/web/src/api/transport.ts
@@ -3,7 +3,7 @@ import { markBrowserReauthRequired } from "../accountDeletion";
 import { getAppConfig } from "../config";
 import type { SessionInfo } from "../types";
 import { buildLoginUrl, getPreferredAuthUiLocale } from "./authUrls";
-import { ApiError, AuthRedirectError } from "./errors";
+import { ApiError, ApiNetworkError, AuthRedirectError } from "./errors";
 import {
   getJsonErrorMessage,
   isRecoverableSessionCsrfResponse,
@@ -15,10 +15,12 @@ import {
 
 type SessionCsrfState = "unknown" | "session" | "non-session";
 export type AuthRecoveryMode = "allow" | "skip";
+export type NetworkRetryMode = "none" | "transient";
 type NavigateToUrl = (url: string) => void;
 type PrepareForAuthRedirect = () => void;
 export type RequestOptions = Readonly<{
   authRecoveryMode: AuthRecoveryMode;
+  networkRetryMode: NetworkRetryMode;
   prepareForAuthRedirect: PrepareForAuthRedirect | null;
 }>;
 
@@ -26,6 +28,10 @@ const refreshSessionEndpoint = "POST /api/refresh-session";
 const refreshSessionMaximumAttemptCount = 3;
 const refreshSessionBaseRetryDelayMs = 100;
 const refreshSessionMaximumRetryDelayMs = 500;
+const apiNetworkRetryMaximumAttemptCount = 3;
+const apiNetworkRetryBaseDelayMs = 100;
+const apiNetworkRetryMaximumDelayMs = 500;
+const uuidPathSegmentPattern = /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=\/|$)/giu;
 const transientRefreshSessionStatusCodes: ReadonlySet<number> = new Set([
   408,
   429,
@@ -38,8 +44,11 @@ const transientRefreshSessionStatusCodes: ReadonlySet<number> = new Set([
 let sessionCsrfToken: string | null = null;
 let sessionCsrfState: SessionCsrfState = "unknown";
 let sessionRecoveryPromise: Promise<void> | null = null;
+let sessionRecoveryNetworkRetryMode: NetworkRetryMode | null = null;
 let sessionCsrfRecoveryPromise: Promise<void> | null = null;
+let sessionCsrfRecoveryNetworkRetryMode: NetworkRetryMode | null = null;
 let sessionTransportReadyPromise: Promise<void> | null = null;
+let sessionTransportReadyNetworkRetryMode: NetworkRetryMode | null = null;
 let redirectInFlight = false;
 let navigationHandler: NavigateToUrl | null = null;
 
@@ -53,8 +62,23 @@ function prepareForAuthRedirect(): void {
 
 export const allowAuthRecovery: RequestOptions = {
   authRecoveryMode: "allow",
+  networkRetryMode: "none",
   prepareForAuthRedirect,
 };
+
+export const allowAuthRecoveryWithTransientNetworkRetry: RequestOptions = {
+  authRecoveryMode: "allow",
+  networkRetryMode: "transient",
+  prepareForAuthRedirect,
+};
+
+function createSkipAuthRecoveryOptions(networkRetryMode: NetworkRetryMode): RequestOptions {
+  return {
+    authRecoveryMode: "skip",
+    networkRetryMode,
+    prepareForAuthRedirect: null,
+  };
+}
 
 /**
  * Returns `true` when the web API client has already started the auth redirect
@@ -80,8 +104,11 @@ export function resetApiClientStateForTests(): void {
   sessionCsrfToken = null;
   sessionCsrfState = "unknown";
   sessionRecoveryPromise = null;
+  sessionRecoveryNetworkRetryMode = null;
   sessionCsrfRecoveryPromise = null;
+  sessionCsrfRecoveryNetworkRetryMode = null;
   sessionTransportReadyPromise = null;
+  sessionTransportReadyNetworkRetryMode = null;
   redirectInFlight = false;
   navigationHandler = null;
 }
@@ -122,6 +149,15 @@ function buildRequestEndpoint(pathname: string, init: RequestInit): string {
   return `${getMethod(init)} ${pathOnly}`;
 }
 
+function sanitizeRequestPath(pathname: string): string {
+  const pathOnly = pathname.split("?", 1)[0] ?? pathname;
+  return pathOnly.replace(uuidPathSegmentPattern, "/{uuid}");
+}
+
+function buildSanitizedRequestEndpoint(pathname: string, init: RequestInit): string {
+  return `${getMethod(init)} ${sanitizeRequestPath(pathname)}`;
+}
+
 function createHeaders(init: RequestInit): Headers {
   const headers = new Headers(init.headers);
 
@@ -147,7 +183,73 @@ function createHeaders(init: RequestInit): Headers {
   return headers;
 }
 
-async function performFetch(pathname: string, init: RequestInit): Promise<Response> {
+function readOriginalErrorName(error: unknown): string {
+  if (error instanceof Error && error.name.trim() !== "") {
+    return error.name;
+  }
+
+  return typeof error;
+}
+
+function readOriginalErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim() !== "") {
+    return error.message;
+  }
+
+  const errorMessage = String(error);
+  return errorMessage.trim() === "" ? "Unknown fetch failure" : errorMessage;
+}
+
+function createApiNetworkError(
+  pathname: string,
+  init: RequestInit,
+  error: unknown,
+  attemptCount: number,
+): ApiNetworkError {
+  return new ApiNetworkError({
+    endpoint: buildSanitizedRequestEndpoint(pathname, init),
+    originalErrorName: readOriginalErrorName(error),
+    originalErrorMessage: readOriginalErrorMessage(error),
+    attemptCount,
+  });
+}
+
+function hasRemainingNetworkRetryAttempt(attemptCount: number): boolean {
+  return attemptCount < apiNetworkRetryMaximumAttemptCount;
+}
+
+function canReuseNetworkRetryPromise(
+  activeNetworkRetryMode: NetworkRetryMode | null,
+  requestedNetworkRetryMode: NetworkRetryMode,
+): boolean {
+  return requestedNetworkRetryMode === "none" || activeNetworkRetryMode === "transient";
+}
+
+function createApiNetworkRetryDelayMs(attemptCount: number): number {
+  const exponentialDelayMs = apiNetworkRetryBaseDelayMs * (2 ** (attemptCount - 1));
+  const cappedDelayMs = Math.min(exponentialDelayMs, apiNetworkRetryMaximumDelayMs);
+  return Math.floor(Math.random() * cappedDelayMs);
+}
+
+function waitForApiNetworkRetry(attemptCount: number): Promise<void> {
+  const delayMs = createApiNetworkRetryDelayMs(attemptCount);
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, delayMs);
+  });
+}
+
+function warnApiTransportRetry(error: ApiNetworkError): void {
+  console.warn("API transport retry", {
+    endpoint: error.endpoint,
+    attemptCount: error.attemptCount,
+    maximumAttemptCount: apiNetworkRetryMaximumAttemptCount,
+    nextAttemptCount: error.attemptCount + 1,
+    originalErrorName: error.originalErrorName,
+    originalErrorMessage: error.originalErrorMessage,
+  });
+}
+
+async function performFetch(pathname: string, init: RequestInit, attemptCount: number): Promise<Response> {
   const config = getAppConfig();
   const headers = createHeaders(init);
 
@@ -158,10 +260,33 @@ async function performFetch(pathname: string, init: RequestInit): Promise<Respon
       headers,
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `The API is unavailable or not deployed yet. Try again. (${pathname}; ${message})`,
-    );
+    throw createApiNetworkError(pathname, init, error, attemptCount);
+  }
+}
+
+async function performFetchWithNetworkRetry(
+  pathname: string,
+  init: RequestInit,
+  options: RequestOptions,
+): Promise<Response> {
+  let attemptCount = 1;
+
+  while (true) {
+    try {
+      return await performFetch(pathname, init, attemptCount);
+    } catch (error) {
+      if (
+        error instanceof ApiNetworkError === false
+        || options.networkRetryMode === "none"
+        || hasRemainingNetworkRetryAttempt(attemptCount) === false
+      ) {
+        throw error;
+      }
+
+      warnApiTransportRetry(error);
+      await waitForApiNetworkRetry(attemptCount);
+      attemptCount += 1;
+    }
   }
 }
 
@@ -203,10 +328,9 @@ async function redirectToLogin(prepareForAuthRedirectCallback: PrepareForAuthRed
  * Loads `/me` without attempting another refresh cycle. This function is used
  * only inside auth recovery to ensure a failed refresh cannot recurse forever.
  */
-async function loadSessionInfoWithoutRecovery(): Promise<SessionInfo> {
-  const response = await performFetch("/me", { method: "GET" });
+async function loadSessionInfoWithoutRecovery(networkRetryMode: NetworkRetryMode): Promise<SessionInfo> {
   const session = parseContractResponse(
-    await parseJsonPayload(response, "GET /me"),
+    await requestJson("/me", { method: "GET" }, createSkipAuthRecoveryOptions(networkRetryMode)),
     "GET /me",
     parseSessionInfoResponse,
   );
@@ -315,83 +439,127 @@ async function refreshBrowserSession(): Promise<boolean> {
  * Performs a single shared auth recovery operation for all concurrent browser
  * requests that observe the same expired session token.
  */
-async function recoverSession(prepareForAuthRedirectCallback: PrepareForAuthRedirect | null): Promise<void> {
-  const activeRecovery = sessionRecoveryPromise;
-  if (activeRecovery !== null) {
-    return activeRecovery;
-  }
+function shouldRetryAfterWeakerSessionRecovery(error: unknown, options: RequestOptions): boolean {
+  return options.networkRetryMode === "transient" && error instanceof ApiNetworkError;
+}
 
+function startSessionRecovery(options: RequestOptions): Promise<void> {
   const recoveryTask = (async (): Promise<void> => {
     const refreshed = await refreshBrowserSession();
     if (refreshed === false) {
-      await redirectToLogin(prepareForAuthRedirectCallback);
+      await redirectToLogin(options.prepareForAuthRedirect);
     }
 
     try {
-      await loadSessionInfoWithoutRecovery();
+      await loadSessionInfoWithoutRecovery(options.networkRetryMode);
     } catch (error) {
       if (error instanceof ApiError && error.statusCode === 401) {
-        await redirectToLogin(prepareForAuthRedirectCallback);
+        await redirectToLogin(options.prepareForAuthRedirect);
       }
 
       throw error;
     }
   })();
 
-  sessionRecoveryPromise = recoveryTask.finally(() => {
-    sessionRecoveryPromise = null;
+  const trackedRecoveryTask = recoveryTask.finally(() => {
+    if (sessionRecoveryPromise === trackedRecoveryTask) {
+      sessionRecoveryPromise = null;
+      sessionRecoveryNetworkRetryMode = null;
+    }
   });
+  sessionRecoveryPromise = trackedRecoveryTask;
+  sessionRecoveryNetworkRetryMode = options.networkRetryMode;
 
   return sessionRecoveryPromise;
+}
+
+async function recoverSession(options: RequestOptions): Promise<void> {
+  while (true) {
+    const activeRecovery = sessionRecoveryPromise;
+    if (
+      activeRecovery !== null
+      && canReuseNetworkRetryPromise(sessionRecoveryNetworkRetryMode, options.networkRetryMode)
+    ) {
+      return activeRecovery;
+    }
+
+    if (activeRecovery !== null) {
+      try {
+        await activeRecovery;
+        return;
+      } catch (error) {
+        if (shouldRetryAfterWeakerSessionRecovery(error, options) === false) {
+          throw error;
+        }
+
+        continue;
+      }
+    }
+
+    return startSessionRecovery(options);
+  }
 }
 
 /**
  * Reloads the current session-bound CSRF token after another same-site app has
  * rotated the shared session cookie.
  */
-async function recoverSessionCsrf(): Promise<void> {
+async function recoverSessionCsrf(options: RequestOptions): Promise<void> {
   const activeRecovery = sessionCsrfRecoveryPromise;
-  if (activeRecovery !== null) {
+  if (
+    activeRecovery !== null
+    && canReuseNetworkRetryPromise(sessionCsrfRecoveryNetworkRetryMode, options.networkRetryMode)
+  ) {
     return activeRecovery;
   }
 
   const recoveryTask = (async (): Promise<void> => {
-    await loadSessionInfoWithRecovery();
+    await loadSessionInfoWithRecovery(options);
   })();
 
-  sessionCsrfRecoveryPromise = recoveryTask.finally(() => {
-    sessionCsrfRecoveryPromise = null;
+  const trackedRecoveryTask = recoveryTask.finally(() => {
+    if (sessionCsrfRecoveryPromise === trackedRecoveryTask) {
+      sessionCsrfRecoveryPromise = null;
+      sessionCsrfRecoveryNetworkRetryMode = null;
+    }
   });
+  sessionCsrfRecoveryPromise = trackedRecoveryTask;
+  sessionCsrfRecoveryNetworkRetryMode = options.networkRetryMode;
 
   return sessionCsrfRecoveryPromise;
 }
 
-async function ensureSessionTransportReadyForUnsafeRequest(): Promise<void> {
+async function ensureSessionTransportReadyForUnsafeRequest(options: RequestOptions): Promise<void> {
   if (sessionCsrfState !== "unknown") {
     return;
   }
 
   if (sessionRecoveryPromise !== null) {
-    await sessionRecoveryPromise;
+    await recoverSession(options);
     return;
   }
 
   const activeBootstrap = sessionTransportReadyPromise;
-  if (activeBootstrap !== null) {
+  if (
+    activeBootstrap !== null
+    && canReuseNetworkRetryPromise(sessionTransportReadyNetworkRetryMode, options.networkRetryMode)
+  ) {
     await activeBootstrap;
     return;
   }
 
   const readinessTask = (async (): Promise<void> => {
-    await loadSessionInfoWithRecovery();
+    await loadSessionInfoWithRecovery(options);
   })();
 
   const trackedReadinessTask = readinessTask.finally(() => {
     if (sessionTransportReadyPromise === trackedReadinessTask) {
       sessionTransportReadyPromise = null;
+      sessionTransportReadyNetworkRetryMode = null;
     }
   });
   sessionTransportReadyPromise = trackedReadinessTask;
+  sessionTransportReadyNetworkRetryMode = options.networkRetryMode;
   await trackedReadinessTask;
 }
 
@@ -406,10 +574,10 @@ async function requestResponse(
   options: RequestOptions,
 ): Promise<Response> {
   if (isUnsafeMethod(getMethod(init))) {
-    await ensureSessionTransportReadyForUnsafeRequest();
+    await ensureSessionTransportReadyForUnsafeRequest(options);
   }
 
-  let response: Response = await performFetch(pathname, init);
+  let response: Response = await performFetchWithNetworkRetry(pathname, init, options);
   if (options.authRecoveryMode === "skip") {
     return response;
   }
@@ -423,8 +591,8 @@ async function requestResponse(
       }
 
       didRecoverSession = true;
-      await recoverSession(options.prepareForAuthRedirect);
-      response = await performFetch(pathname, init);
+      await recoverSession(options);
+      response = await performFetchWithNetworkRetry(pathname, init, options);
       continue;
     }
 
@@ -434,8 +602,8 @@ async function requestResponse(
       && await isRecoverableSessionCsrfResponse(response)
     ) {
       didRecoverSessionCsrf = true;
-      await recoverSessionCsrf();
-      response = await performFetch(pathname, init);
+      await recoverSessionCsrf(options);
+      response = await performFetchWithNetworkRetry(pathname, init, options);
       continue;
     }
 
@@ -457,7 +625,7 @@ export async function requestJson(
  * CSRF token when the backend authenticates the request via shared cookies.
  */
 export async function getSession(): Promise<SessionInfo> {
-  return loadSessionInfoWithRecovery();
+  return loadSessionInfoWithRecovery(allowAuthRecovery);
 }
 
 /**
@@ -465,17 +633,17 @@ export async function getSession(): Promise<SessionInfo> {
  * UI state. Callers should use this on tab resume before background sync.
  */
 export async function revalidateSession(): Promise<SessionInfo> {
-  return loadSessionInfoWithRecovery();
+  return loadSessionInfoWithRecovery(allowAuthRecovery);
 }
 
 /**
  * Loads `/me` through the normal request pipeline so the API layer can recover
  * from one expired session token without forcing a full page reload.
  */
-async function loadSessionInfoWithRecovery(): Promise<SessionInfo> {
+async function loadSessionInfoWithRecovery(options: RequestOptions): Promise<SessionInfo> {
   const session = parseContractResponse(await requestJson("/me", {
     method: "GET",
-  }, allowAuthRecovery), "GET /me", parseSessionInfoResponse);
+  }, options), "GET /me", parseSessionInfoResponse);
   setSessionCsrfToken(session.csrfToken, session.authTransport);
   redirectInFlight = false;
   return session;

--- a/apps/web/src/appData/progress/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/progressSourceTestSupport.tsx
@@ -70,6 +70,7 @@ vi.mock("../../api", async (importOriginal) => {
 
   return {
     ApiContractError: actual.ApiContractError,
+    ApiNetworkError: actual.ApiNetworkError,
     loadProgressSummary: progressSourceMocks.loadProgressSummaryMock,
     loadProgressSeries: progressSourceMocks.loadProgressSeriesMock,
     loadProgressReviewSchedule: progressSourceMocks.loadProgressReviewScheduleMock,

--- a/apps/web/src/appData/progress/useProgressSource.ts
+++ b/apps/web/src/appData/progress/useProgressSource.ts
@@ -6,8 +6,18 @@ import {
   useRef,
   useState,
 } from "react";
-import { loadProgressReviewSchedule, loadProgressSeries, loadProgressSummary } from "../../api";
+import {
+  ApiNetworkError,
+  loadProgressReviewSchedule,
+  loadProgressSeries,
+  loadProgressSummary,
+} from "../../api";
 import { captureApiContractError } from "../../observability/apiContractObservation";
+import {
+  captureWebException,
+  type ProgressServerLoadFailureDetails,
+  type WebObservationScope,
+} from "../../observability/webObservability";
 import {
   hasPendingProgressReviewEvents,
   loadLocalProgressDailyReviews,
@@ -90,8 +100,68 @@ type ProgressReviewScheduleRefreshRequest = Readonly<{
   progressScheduleLocalVersion: number;
 }>;
 
+type ProgressServerLoadOperation = ProgressServerLoadFailureDetails["operation"];
+
+type ProgressServerLoadObservationContext = Readonly<{
+  operation: ProgressServerLoadOperation;
+  workspaceId: string | null;
+  installationId: string | null;
+}>;
+
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildProgressNetworkErrorScope(
+  error: ApiNetworkError,
+  context: ProgressServerLoadObservationContext,
+): WebObservationScope {
+  return {
+    app: "web",
+    feature: "progress",
+    userId: null,
+    workspaceId: context.workspaceId,
+    installationId: context.installationId,
+    route: getCurrentRoute(),
+    requestId: error.requestId,
+    statusCode: error.statusCode,
+    code: error.code,
+  };
+}
+
+function captureProgressNetworkError(error: unknown, context: ProgressServerLoadObservationContext): void {
+  if (error instanceof ApiNetworkError === false) {
+    return;
+  }
+
+  captureWebException({
+    action: "progress_server_load_failed",
+    error,
+    scope: buildProgressNetworkErrorScope(error, context),
+    details: {
+      operation: context.operation,
+      workspaceId: context.workspaceId,
+    },
+  });
+}
+
+function captureProgressServerLoadError(error: unknown, context: ProgressServerLoadObservationContext): void {
+  captureApiContractError(error, {
+    feature: "progress",
+    sourceAction: context.operation,
+    userId: null,
+    workspaceId: context.workspaceId,
+    installationId: context.installationId,
+  });
+  captureProgressNetworkError(error, context);
 }
 
 export function useProgressSource(params: UseProgressSourceParams): UseProgressSourceResult {
@@ -448,10 +518,8 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
                 errorMessage: getErrorMessage(error),
                 canRenderServerBase: canLoadServerBaseRef.current,
               });
-              captureApiContractError(error, {
-                feature: "progress",
-                sourceAction: "progress_summary_server_load",
-                userId: null,
+              captureProgressServerLoadError(error, {
+                operation: "progress_summary_server_load",
                 workspaceId: activeWorkspaceId,
                 installationId: cloudSettings?.installationId ?? null,
               });
@@ -531,10 +599,8 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
                 errorMessage: getErrorMessage(error),
                 canRenderServerBase: canLoadServerBaseRef.current,
               });
-              captureApiContractError(error, {
-                feature: "progress",
-                sourceAction: "progress_series_server_load",
-                userId: null,
+              captureProgressServerLoadError(error, {
+                operation: "progress_series_server_load",
                 workspaceId: activeWorkspaceId,
                 installationId: cloudSettings?.installationId ?? null,
               });
@@ -620,10 +686,8 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
                 progressScheduleLocalVersion: requestedRefresh.progressScheduleLocalVersion,
                 canRenderServerBase: canLoadServerBaseRef.current,
               });
-              captureApiContractError(error, {
-                feature: "progress",
-                sourceAction: "progress_review_schedule_server_load",
-                userId: null,
+              captureProgressServerLoadError(error, {
+                operation: "progress_review_schedule_server_load",
                 workspaceId: activeWorkspaceId,
                 installationId: cloudSettings?.installationId ?? null,
               });

--- a/apps/web/src/observability/instrument.test.ts
+++ b/apps/web/src/observability/instrument.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
+import { ApiNetworkError } from "../api/errors";
 import { sanitizeSentryBreadcrumbForPrivacy, sanitizeSentryEventForPrivacy } from "./instrument";
+import {
+  buildWebExceptionFingerprint,
+  type WebExceptionEvent,
+  type WebObservationScope,
+} from "./webObservability";
 
 type SentryPrivacyEvent = Parameters<typeof sanitizeSentryEventForPrivacy>[0];
 type SentryPrivacyBreadcrumb = Parameters<typeof sanitizeSentryBreadcrumbForPrivacy>[0];
@@ -184,5 +190,37 @@ describe("Sentry privacy sanitizer", () => {
     expect(sanitizedEvent.extra?.messageCount).toBe(3);
     expect(serializeEvent(sanitizedEvent)).not.toContain(sensitiveCardText);
     expect(serializeEvent(sanitizedEvent)).not.toContain(sensitiveAiText);
+  });
+
+  it("groups API network errors by transport endpoint", () => {
+    const scope: WebObservationScope = {
+      app: "web",
+      feature: "chat",
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      installationId: "installation-1",
+      route: "/review",
+      requestId: null,
+      statusCode: 0,
+      code: "API_NETWORK_ERROR",
+    };
+    const event: WebExceptionEvent = {
+      action: "chat_snapshot_failed",
+      error: new ApiNetworkError({
+        endpoint: "GET /chat",
+        originalErrorName: "TypeError",
+        originalErrorMessage: "Failed to fetch",
+        attemptCount: 3,
+      }),
+      scope,
+      details: {
+        sessionId: "session-1",
+        workspaceId: "workspace-1",
+        trigger: "initial_hydration",
+        resumeAttemptId: null,
+      },
+    };
+
+    expect(buildWebExceptionFingerprint(event)).toEqual(["{{ default }}", "api_network_failed", "GET /chat"]);
   });
 });

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react";
 import type { Scope } from "@sentry/react";
+import { ApiNetworkError } from "../api/errors";
 import { isWebSentryEnabled } from "./instrument";
 
 export type WebObservationFeature =
@@ -172,6 +173,14 @@ export type SyncFailureDetails = Readonly<{
   workspaceId: string;
 }>;
 
+export type ProgressServerLoadFailureDetails = Readonly<{
+  operation:
+    | "progress_summary_server_load"
+    | "progress_series_server_load"
+    | "progress_review_schedule_server_load";
+  workspaceId: string | null;
+}>;
+
 export type AuthResetCleanupFailureDetails = Readonly<{
   operation: "auth_reset_cleanup_failed";
 }>;
@@ -268,6 +277,12 @@ export type WebExceptionEvent =
     details: SyncFailureDetails;
   }>
   | Readonly<{
+    action: "progress_server_load_failed";
+    error: Error;
+    scope: WebObservationScope;
+    details: ProgressServerLoadFailureDetails;
+  }>
+  | Readonly<{
     action: "auth_reset_cleanup_failed";
     error: Error;
     scope: WebObservationScope;
@@ -324,6 +339,8 @@ type ErrorMetadata = Readonly<{
   statusCode: number | null;
   code: string | null;
   bodyKind: string | null;
+  networkAttemptCount: number | null;
+  networkErrorName: string | null;
 }>;
 
 type ErrorMetadataValue = string | number | null;
@@ -388,14 +405,18 @@ export function captureWebException(event: WebExceptionEvent): void {
 
   Sentry.withScope((scope: Scope): void => {
     applyObservationScope(scope, event.scope, event.action);
-    scope.setFingerprint(buildExceptionFingerprint(event));
+    scope.setFingerprint(buildWebExceptionFingerprint(event));
     scope.setContext("web.exception", detailsToContext(event.details));
     scope.setContext("web.error", errorMetadataToContext(readErrorMetadata(event.error)));
     Sentry.captureException(toSafeCapturedError(event.action, event.error));
   });
 }
 
-function buildExceptionFingerprint(event: WebExceptionEvent): Array<string> {
+export function buildWebExceptionFingerprint(event: WebExceptionEvent): Array<string> {
+  if (event.error instanceof ApiNetworkError) {
+    return ["{{ default }}", "api_network_failed", event.error.endpoint];
+  }
+
   if (event.action === "app_operation_failed") {
     return ["{{ default }}", event.action, event.details.operation];
   }
@@ -428,6 +449,8 @@ function readErrorMetadata(error: Error): ErrorMetadata {
       statusCode: null,
       code: null,
       bodyKind: null,
+      networkAttemptCount: null,
+      networkErrorName: null,
     };
   }
 
@@ -438,6 +461,8 @@ function readErrorMetadata(error: Error): ErrorMetadata {
     statusCode: readNumberMetadata(error, "statusCode"),
     code: readStringMetadata(error, "code"),
     bodyKind: readStringMetadata(error, "responseBodyKind"),
+    networkAttemptCount: readNumberMetadata(error, "attemptCount"),
+    networkErrorName: readStringMetadata(error, "originalErrorName"),
   };
 }
 
@@ -449,6 +474,8 @@ function errorMetadataToContext(metadata: ErrorMetadata): SentryContext {
     statusCode: metadata.statusCode,
     code: metadata.code,
     bodyKind: metadata.bodyKind,
+    networkAttemptCount: metadata.networkAttemptCount,
+    networkErrorName: metadata.networkErrorName,
   };
 }
 


### PR DESCRIPTION
## Summary
- classify browser fetch failures as structured API network errors
- add transient network retry for selected safe/idempotent web API calls
- group network failures in Sentry by sanitized transport endpoint
- capture progress server network failures with web observability context

## Validation
- `npx vitest run src/api/transport.test.ts src/api/endpoints.test.ts src/observability/instrument.test.ts`
- `npm run build`
- `git --no-pager diff --check`