### PR TITLE
[codex] Fix Android AI handoff noise

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AiNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AiNavGraph.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.data.local.ai.AiChatDiagnosticsLogger
+import com.flashcardsopensourceapp.feature.ai.AiCardHandoffResult
 import com.flashcardsopensourceapp.feature.ai.AiRoute
 import com.flashcardsopensourceapp.feature.ai.createAiViewModelFactory
 
@@ -88,7 +89,7 @@ internal fun NavGraphBuilder.registerAiNavGraph(
                 )
                 return@LaunchedEffect
             }
-            val didApplyRequest = aiViewModel.handoffCardToChat(
+            val handoffResult = aiViewModel.handoffCardToChat(
                 cardId = request.cardId,
                 frontText = request.frontText,
                 backText = request.backText,
@@ -100,11 +101,16 @@ internal fun NavGraphBuilder.registerAiNavGraph(
                 fields = listOf(
                     "requestId" to request.requestId.toString(),
                     "cardId" to request.cardId,
-                    "didApplyRequest" to didApplyRequest.toString()
+                    "handoffResult" to handoffResult.name
                 )
             )
-            if (didApplyRequest) {
-                appGraph.appHandoffCoordinator.consumeAiCardHandoff(requestId = request.requestId)
+            when (handoffResult) {
+                AiCardHandoffResult.APPLIED,
+                AiCardHandoffResult.REQUIRES_FRESH_CHAT -> {
+                    appGraph.appHandoffCoordinator.consumeAiCardHandoff(requestId = request.requestId)
+                }
+
+                AiCardHandoffResult.DEFERRED -> Unit
             }
         }
 

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
@@ -56,7 +56,6 @@ enum class AndroidAiObservationName(
     RUNTIME_HANDOFF_REJECTED_NOT_READY(tagValue = "ai_runtime_handoff_rejected_not_ready"),
     RUNTIME_HANDOFF_REJECTED_LOCKED_PHASE(tagValue = "ai_runtime_handoff_rejected_locked_phase"),
     RUNTIME_HANDOFF_REJECTED_ACCESS_PREPARING(tagValue = "ai_runtime_handoff_rejected_access_preparing"),
-    RUNTIME_HANDOFF_REJECTED_DIRTY_STATE(tagValue = "ai_runtime_handoff_rejected_dirty_state"),
     RUNTIME_HANDOFF_APPLIED_TO_RUNNING_DRAFT(tagValue = "ai_runtime_handoff_applied_to_running_draft"),
     RUNTIME_HANDOFF_START_FRESH_CONVERSATION(tagValue = "ai_runtime_handoff_start_fresh_conversation"),
     RUNTIME_HANDOFF_APPLIED_TO_EXISTING_SESSION(tagValue = "ai_runtime_handoff_applied_to_existing_session")

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiCardHandoffResult.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiCardHandoffResult.kt
@@ -1,0 +1,7 @@
+package com.flashcardsopensourceapp.feature.ai
+
+enum class AiCardHandoffResult {
+    APPLIED,
+    DEFERRED,
+    REQUIRES_FRESH_CHAT
+}

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiViewModel.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiViewModel.kt
@@ -218,7 +218,7 @@ class AiViewModel(
         backText: String,
         tags: List<String>,
         effortLevel: EffortLevel
-    ): Boolean {
+    ): AiCardHandoffResult {
         return chatRuntime.handoffCardToChat(
             cardId = cardId,
             frontText = frontText,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatObservability.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatObservability.kt
@@ -168,16 +168,6 @@ internal sealed interface AiChatWarning {
         val cloudState: String,
         val conversationBootstrapState: String
     ) : AiChatWarning
-
-    data class RuntimeHandoffRejectedDirtyState(
-        val workspaceId: String?,
-        val cardId: String,
-        val composerPhase: String,
-        val pendingAttachmentCount: Int,
-        val draftLength: Int,
-        val messageCount: Int,
-        val hasActiveRun: Boolean
-    ) : AiChatWarning
 }
 
 internal sealed interface AiChatExceptionEvent {
@@ -617,16 +607,6 @@ private fun AiChatWarning.toAndroidEvent(): AndroidWarningIssueEvent {
             cardId = cardId,
             cloudState = cloudState,
             bootstrapState = conversationBootstrapState
-        )
-        is AiChatWarning.RuntimeHandoffRejectedDirtyState -> aiWarning(
-            name = AndroidAiObservationName.RUNTIME_HANDOFF_REJECTED_DIRTY_STATE,
-            workspaceId = workspaceId,
-            cardId = cardId,
-            composerPhase = composerPhase,
-            message = hasActiveRun.toString(),
-            messageCount = messageCount,
-            pendingAttachmentCount = pendingAttachmentCount,
-            draftLength = draftLength
         )
     }
 }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.data.local.model.effectiveAiChatServerConfig
 import com.flashcardsopensourceapp.data.local.model.makeAiChatCardAttachment
 import com.flashcardsopensourceapp.data.local.repository.AiChatRepository
 import com.flashcardsopensourceapp.data.local.repository.AutoSyncEventRepository
+import com.flashcardsopensourceapp.feature.ai.AiCardHandoffResult
 import com.flashcardsopensourceapp.feature.ai.AiEntryPrefill
 import com.flashcardsopensourceapp.feature.ai.aiEntryPrefillPrompt
 import com.flashcardsopensourceapp.feature.ai.strings.AiTextProvider
@@ -279,7 +280,7 @@ internal class AiChatRuntime(
         backText: String,
         tags: List<String>,
         effortLevel: EffortLevel
-    ): Boolean {
+    ): AiCardHandoffResult {
         val currentState = runtimeStateMutable.value
         context.observability.recordAiChatBreadcrumb(
             breadcrumb = AiChatBreadcrumb.RuntimeHandoffRequested(
@@ -307,7 +308,7 @@ internal class AiChatRuntime(
                     dictationState = currentState.dictationState.name
                 )
             )
-            return false
+            return AiCardHandoffResult.DEFERRED
         }
         if (canPrepareAiDraftInComposerPhase(composerPhase = currentState.composerPhase).not()) {
             context.observability.recordAiChatWarning(
@@ -317,7 +318,7 @@ internal class AiChatRuntime(
                     composerPhase = currentState.composerPhase.name
                 )
             )
-            return false
+            return AiCardHandoffResult.DEFERRED
         }
         if (
             shouldPrepareGuestAccess(
@@ -333,7 +334,7 @@ internal class AiChatRuntime(
                     conversationBootstrapState = currentState.conversationBootstrapState.name
                 )
             )
-            return false
+            return AiCardHandoffResult.DEFERRED
         }
         val pendingCardAttachment = makeAiChatCardAttachment(
             cardId = cardId,
@@ -361,7 +362,7 @@ internal class AiChatRuntime(
                     pendingAttachmentCount = currentState.pendingAttachments.size + 1
                 )
             )
-            return true
+            return AiCardHandoffResult.APPLIED
         }
 
         if (
@@ -369,17 +370,6 @@ internal class AiChatRuntime(
                 state = currentState
             )
         ) {
-            context.observability.recordAiChatWarning(
-                warning = AiChatWarning.RuntimeHandoffRejectedDirtyState(
-                    workspaceId = currentState.workspaceId,
-                    cardId = cardId,
-                    composerPhase = currentState.composerPhase.name,
-                    pendingAttachmentCount = currentState.pendingAttachments.size,
-                    draftLength = currentState.draftMessage.length,
-                    messageCount = currentState.persistedState.messages.size,
-                    hasActiveRun = currentState.activeRun != null
-                )
-            )
             runtimeStateMutable.update { state ->
                 state.copy(
                     activeAlert = context.textProvider.generalError(
@@ -388,7 +378,7 @@ internal class AiChatRuntime(
                     errorMessage = ""
                 )
             }
-            return false
+            return AiCardHandoffResult.REQUIRES_FRESH_CHAT
         }
 
         if (currentState.persistedState.chatSessionId.isBlank()) {
@@ -404,7 +394,7 @@ internal class AiChatRuntime(
                 pendingAttachments = listOf(pendingCardAttachment),
                 shouldFocusComposer = true
             )
-            return true
+            return AiCardHandoffResult.APPLIED
         }
 
         runtimeStateMutable.update { state ->
@@ -425,7 +415,7 @@ internal class AiChatRuntime(
                 pendingAttachmentCount = 1
             )
         )
-        return true
+        return AiCardHandoffResult.APPLIED
     }
 
     fun showAlert(alert: AiAlertState) {

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeCardHandoffTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeCardHandoffTest.kt
@@ -6,12 +6,12 @@ import com.flashcardsopensourceapp.data.local.model.AiChatDraftState
 import com.flashcardsopensourceapp.data.local.model.AiChatLiveEvent
 import com.flashcardsopensourceapp.data.local.model.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.makeDefaultAiChatPersistedState
+import com.flashcardsopensourceapp.feature.ai.AiCardHandoffResult
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -46,7 +46,7 @@ class AiChatRuntimeCardHandoffTest {
         runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
         advanceUntilIdle()
 
-        val didHandoff = runtime.handoffCardToChat(
+        val handoffResult = runtime.handoffCardToChat(
             cardId = "card-1",
             frontText = "Front",
             backText = "Back",
@@ -55,7 +55,7 @@ class AiChatRuntimeCardHandoffTest {
         )
         advanceUntilIdle()
 
-        assertFalse(didHandoff)
+        assertEquals(AiCardHandoffResult.REQUIRES_FRESH_CHAT, handoffResult)
         assertTrue(repository.createNewSessionRequests.isEmpty())
         assertEquals(oldSessionId, runtime.state.value.persistedState.chatSessionId)
         assertTrue(runtime.state.value.pendingAttachments.isEmpty())
@@ -83,7 +83,7 @@ class AiChatRuntimeCardHandoffTest {
         runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
         advanceUntilIdle()
 
-        val didHandoff = runtime.handoffCardToChat(
+        val handoffResult = runtime.handoffCardToChat(
             cardId = "card-1",
             frontText = "Front",
             backText = "Back",
@@ -92,7 +92,7 @@ class AiChatRuntimeCardHandoffTest {
         )
         advanceUntilIdle()
 
-        assertTrue(didHandoff)
+        assertEquals(AiCardHandoffResult.APPLIED, handoffResult)
         assertTrue(repository.createNewSessionRequests.isEmpty())
         assertEquals("session-1", runtime.state.value.persistedState.chatSessionId)
         assertEquals(1, runtime.state.value.pendingAttachments.size)
@@ -140,7 +140,7 @@ class AiChatRuntimeCardHandoffTest {
         runtime.updateDraftMessage(draftMessage = "Next draft")
         runtime.addPendingAttachment(attachment = existingAttachment)
 
-        val didHandoff = runtime.handoffCardToChat(
+        val handoffResult = runtime.handoffCardToChat(
             cardId = "card-1",
             frontText = "Front",
             backText = "Back",
@@ -149,7 +149,7 @@ class AiChatRuntimeCardHandoffTest {
         )
         advanceUntilIdle()
 
-        assertTrue(didHandoff)
+        assertEquals(AiCardHandoffResult.APPLIED, handoffResult)
         assertTrue(repository.createNewSessionRequests.isEmpty())
         assertEquals("run-1", runtime.state.value.activeRun?.runId)
         assertEquals(AiComposerPhase.RUNNING, runtime.state.value.composerPhase)
@@ -189,7 +189,7 @@ class AiChatRuntimeCardHandoffTest {
         runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
         advanceUntilIdle()
 
-        val didHandoff = runtime.handoffCardToChat(
+        val handoffResult = runtime.handoffCardToChat(
             cardId = "card-1",
             frontText = "Front",
             backText = "Back",
@@ -198,7 +198,7 @@ class AiChatRuntimeCardHandoffTest {
         )
         advanceUntilIdle()
 
-        assertFalse(didHandoff)
+        assertEquals(AiCardHandoffResult.REQUIRES_FRESH_CHAT, handoffResult)
         assertTrue(repository.createNewSessionRequests.isEmpty())
         assertEquals("session-1", runtime.state.value.persistedState.chatSessionId)
         assertEquals("Unsaved note", runtime.state.value.draftMessage)
@@ -224,7 +224,7 @@ class AiChatRuntimeCardHandoffTest {
 
         assertEquals(listOf("session-from-server"), repository.createNewSessionRequests)
         assertEquals(listOf("session-from-server"), repository.loadBootstrapSessionIds)
-        val didHandoff = runtime.handoffCardToChat(
+        val handoffResult = runtime.handoffCardToChat(
             cardId = "card-1",
             frontText = "Front",
             backText = "Back",
@@ -233,7 +233,7 @@ class AiChatRuntimeCardHandoffTest {
         )
         advanceUntilIdle()
 
-        assertTrue(didHandoff)
+        assertEquals(AiCardHandoffResult.APPLIED, handoffResult)
         assertEquals(listOf("session-from-server"), repository.createNewSessionRequests)
         assertEquals("session-from-server", runtime.state.value.persistedState.chatSessionId)
         assertEquals(1, runtime.state.value.pendingAttachments.size)


### PR DESCRIPTION
## Summary
- return typed Android AI card handoff results instead of a boolean
- consume expected dirty-state handoff requests without capturing Sentry warnings
- update existing handoff tests to assert applied vs fresh-chat-required outcomes

## Validation
- git --no-pager diff --check
- git --no-pager diff --cached --check
- Gradle not run: repository instructions require explicit approval for ./gradlew