### PR TITLE
Fix stale Android progress refresh warnings

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
@@ -80,6 +80,7 @@ class SentryAppObservability : AppObservability {
         Log.w(sentryObservabilityLogTag, renderLogLine(prefix = "warning", event = event))
         Sentry.captureMessage(renderWarningIssueMessage(event = event), SentryLevel.WARNING) { scope ->
             applyTags(scope = scope, event = event)
+            scope.setFingerprint(warningIssueFingerprint(event = event))
             scope.setContexts("android_observability", warningContext(event = event))
         }
     }
@@ -712,6 +713,20 @@ private fun renderWarningIssueMessage(event: AndroidWarningIssueEvent): String {
         parts.add("status_$statusCode")
     }
     return parts.joinToString(separator = ":")
+}
+
+internal fun warningIssueFingerprint(event: AndroidWarningIssueEvent): List<String> {
+    val groupKey: String = warningIssueGroupKey(event = event) ?: "no_group"
+    val code: String = sanitizeSentryTagValue(fieldName = "code", value = event.tags.code) ?: "no_code"
+    val statusCode: String = event.tags.statusCode?.toString() ?: "no_status"
+    return listOf(
+        "android",
+        event.feature.tagValue,
+        event.action.tagValue,
+        groupKey,
+        code,
+        statusCode
+    )
 }
 
 private fun warningIssueGroupKey(event: AndroidWarningIssueEvent): String? {

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
@@ -1,0 +1,61 @@
+package com.flashcardsopensourceapp.app.observability
+
+import com.flashcardsopensourceapp.core.observability.AndroidObservationFeature
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SentryAppObservabilityTest {
+    @Test
+    fun warningIssueFingerprintUsesStableWarningDimensions(): Unit {
+        val progressWarning: AndroidWarningIssueEvent.ProgressRefreshWarning =
+            AndroidWarningIssueEvent.ProgressRefreshWarning(
+                workspaceId = "workspace-1",
+                refreshAction = "progress_review_schedule_remote_load_failed",
+                scopeId = "linked:user-1",
+                source = "review_schedule_remote_load",
+                appVersion = testAppVersion,
+                clientVersion = testAppVersion,
+                versionCode = testVersionCode
+            )
+        val httpWarning: AndroidWarningIssueEvent.HttpUnexpectedClientError =
+            AndroidWarningIssueEvent.HttpUnexpectedClientError(
+                feature = AndroidObservationFeature.BACKEND,
+                endpointName = "/v1/chat",
+                method = "POST",
+                requestId = "request-1",
+                statusCode = 413,
+                code = null,
+                stage = null,
+                appVersion = testAppVersion,
+                clientVersion = testAppVersion,
+                versionCode = testVersionCode
+            )
+
+        assertEquals(
+            listOf(
+                "android",
+                "progress",
+                "progress_refresh_warning",
+                "progress_review_schedule_remote_load_failed",
+                "progress_review_schedule_remote_load_failed",
+                "no_status"
+            ),
+            warningIssueFingerprint(event = progressWarning)
+        )
+        assertEquals(
+            listOf(
+                "android",
+                "backend",
+                "http_unexpected_client_error",
+                "/v1/chat",
+                "no_code",
+                "413"
+            ),
+            warningIssueFingerprint(event = httpWarning)
+        )
+    }
+}
+
+private const val testAppVersion: String = "1.4.0"
+private const val testVersionCode: Int = 1

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryRuntime.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryRuntime.kt
@@ -115,6 +115,54 @@ internal fun supportsServerRefresh(
     return cloudState == CloudAccountState.GUEST || cloudState == CloudAccountState.LINKED
 }
 
+internal fun shouldSuppressProgressSummaryRemoteLoadWarning(
+    latestStoreState: ProgressSummaryStoreState?,
+    refreshStoreState: ProgressSummaryStoreState
+): Boolean {
+    if (latestStoreState == null) {
+        return true
+    }
+    if (latestStoreState.scopeKey != refreshStoreState.scopeKey) {
+        return true
+    }
+    if (supportsServerRefresh(cloudState = latestStoreState.cloudState).not()) {
+        return true
+    }
+
+    return latestStoreState.isLocalCacheReady.not()
+}
+
+internal fun shouldSuppressProgressSeriesRemoteLoadWarning(
+    latestStoreState: ProgressSeriesStoreState?,
+    refreshStoreState: ProgressSeriesStoreState
+): Boolean {
+    if (latestStoreState == null) {
+        return true
+    }
+    if (latestStoreState.scopeKey != refreshStoreState.scopeKey) {
+        return true
+    }
+    if (supportsServerRefresh(cloudState = latestStoreState.cloudState).not()) {
+        return true
+    }
+
+    return latestStoreState.isLocalCacheReady.not()
+}
+
+internal fun shouldSuppressProgressReviewScheduleRemoteLoadWarning(
+    latestStoreState: ProgressReviewScheduleStoreState?,
+    refreshStoreState: ProgressReviewScheduleStoreState
+): Boolean {
+    if (latestStoreState == null) {
+        return true
+    }
+    if (latestStoreState.scopeKey != refreshStoreState.scopeKey) {
+        return true
+    }
+
+    return supportsServerRefresh(cloudState = latestStoreState.cloudState).not()
+}
+
 private fun extractProgressWorkspaceId(
     fields: List<Pair<String, String?>>,
     scopeId: String?

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressReviewScheduleOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressReviewScheduleOrchestration.kt
@@ -234,6 +234,14 @@ internal class ProgressReviewScheduleOrchestration(
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
+            if (
+                shouldSuppressProgressReviewScheduleRemoteLoadWarning(
+                    latestStoreState = currentStoreState(),
+                    refreshStoreState = resolvedRefreshStoreState
+                )
+            ) {
+                return
+            }
             logProgressRefreshWarning(
                 observability = observability,
                 observationVersions = observationVersions,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressSeriesOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressSeriesOrchestration.kt
@@ -253,6 +253,14 @@ internal class ProgressSeriesOrchestration(
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
+            if (
+                shouldSuppressProgressSeriesRemoteLoadWarning(
+                    latestStoreState = currentStoreState(),
+                    refreshStoreState = resolvedRefreshStoreState
+                )
+            ) {
+                return
+            }
             logProgressRefreshWarning(
                 observability = observability,
                 observationVersions = observationVersions,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressSummaryOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressSummaryOrchestration.kt
@@ -249,6 +249,14 @@ internal class ProgressSummaryOrchestration(
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
+            if (
+                shouldSuppressProgressSummaryRemoteLoadWarning(
+                    latestStoreState = currentStoreState(),
+                    refreshStoreState = resolvedRefreshStoreState
+                )
+            ) {
+                return
+            }
             logProgressRefreshWarning(
                 observability = observability,
                 observationVersions = observationVersions,

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
@@ -1,0 +1,298 @@
+package com.flashcardsopensourceapp.data.local.repository.progress
+
+import com.flashcardsopensourceapp.data.local.model.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.CloudProgressReviewSchedule
+import com.flashcardsopensourceapp.data.local.model.ProgressReviewScheduleScopeKey
+import com.flashcardsopensourceapp.data.local.model.ProgressReviewScheduleSnapshot
+import com.flashcardsopensourceapp.data.local.model.ProgressSeriesScopeKey
+import com.flashcardsopensourceapp.data.local.model.ProgressSnapshotSource
+import com.flashcardsopensourceapp.data.local.model.ProgressSummaryScopeKey
+import com.flashcardsopensourceapp.data.local.model.SyncStatus
+import com.flashcardsopensourceapp.data.local.model.SyncStatusSnapshot
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProgressRemoteLoadWarningSuppressionTest {
+    @Test
+    fun summaryRemoteLoadWarningIsSuppressedOnlyForStaleState(): Unit {
+        val refreshStoreState: ProgressSummaryStoreState = createSummaryStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = true
+        )
+        val validLatestStoreState: ProgressSummaryStoreState = createSummaryStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = true
+        )
+        val changedScopeStoreState: ProgressSummaryStoreState = createSummaryStoreState(
+            scopeId = "linked:user-2",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = true
+        )
+        val disconnectedStoreState: ProgressSummaryStoreState = createSummaryStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.DISCONNECTED,
+            isLocalCacheReady = true
+        )
+        val linkingStoreState: ProgressSummaryStoreState = createSummaryStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKING_READY,
+            isLocalCacheReady = true
+        )
+        val unreadyCacheStoreState: ProgressSummaryStoreState = createSummaryStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = false
+        )
+
+        assertFalse(
+            shouldSuppressProgressSummaryRemoteLoadWarning(
+                latestStoreState = validLatestStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSummaryRemoteLoadWarning(
+                latestStoreState = null,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSummaryRemoteLoadWarning(
+                latestStoreState = changedScopeStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSummaryRemoteLoadWarning(
+                latestStoreState = disconnectedStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSummaryRemoteLoadWarning(
+                latestStoreState = linkingStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSummaryRemoteLoadWarning(
+                latestStoreState = unreadyCacheStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+    }
+
+    @Test
+    fun seriesRemoteLoadWarningIsSuppressedOnlyForStaleState(): Unit {
+        val refreshStoreState: ProgressSeriesStoreState = createSeriesStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = true
+        )
+        val validLatestStoreState: ProgressSeriesStoreState = createSeriesStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = true
+        )
+        val changedScopeStoreState: ProgressSeriesStoreState = createSeriesStoreState(
+            scopeId = "linked:user-2",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = true
+        )
+        val disconnectedStoreState: ProgressSeriesStoreState = createSeriesStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.DISCONNECTED,
+            isLocalCacheReady = true
+        )
+        val linkingStoreState: ProgressSeriesStoreState = createSeriesStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKING_READY,
+            isLocalCacheReady = true
+        )
+        val unreadyCacheStoreState: ProgressSeriesStoreState = createSeriesStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED,
+            isLocalCacheReady = false
+        )
+
+        assertFalse(
+            shouldSuppressProgressSeriesRemoteLoadWarning(
+                latestStoreState = validLatestStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSeriesRemoteLoadWarning(
+                latestStoreState = null,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSeriesRemoteLoadWarning(
+                latestStoreState = changedScopeStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSeriesRemoteLoadWarning(
+                latestStoreState = disconnectedStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSeriesRemoteLoadWarning(
+                latestStoreState = linkingStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressSeriesRemoteLoadWarning(
+                latestStoreState = unreadyCacheStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+    }
+
+    @Test
+    fun reviewScheduleRemoteLoadWarningIsSuppressedOnlyForStaleState(): Unit {
+        val refreshStoreState: ProgressReviewScheduleStoreState = createReviewScheduleStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED
+        )
+        val validLatestStoreState: ProgressReviewScheduleStoreState = createReviewScheduleStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKED
+        )
+        val changedScopeStoreState: ProgressReviewScheduleStoreState = createReviewScheduleStoreState(
+            scopeId = "linked:user-2",
+            cloudState = CloudAccountState.LINKED
+        )
+        val disconnectedStoreState: ProgressReviewScheduleStoreState = createReviewScheduleStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.DISCONNECTED
+        )
+        val linkingStoreState: ProgressReviewScheduleStoreState = createReviewScheduleStoreState(
+            scopeId = "linked:user-1",
+            cloudState = CloudAccountState.LINKING_READY
+        )
+
+        assertFalse(
+            shouldSuppressProgressReviewScheduleRemoteLoadWarning(
+                latestStoreState = validLatestStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressReviewScheduleRemoteLoadWarning(
+                latestStoreState = null,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressReviewScheduleRemoteLoadWarning(
+                latestStoreState = changedScopeStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressReviewScheduleRemoteLoadWarning(
+                latestStoreState = linkingStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+        assertTrue(
+            shouldSuppressProgressReviewScheduleRemoteLoadWarning(
+                latestStoreState = disconnectedStoreState,
+                refreshStoreState = refreshStoreState
+            )
+        )
+    }
+}
+
+private fun createSummaryStoreState(
+    scopeId: String,
+    cloudState: CloudAccountState,
+    isLocalCacheReady: Boolean
+): ProgressSummaryStoreState {
+    return ProgressSummaryStoreState(
+        scopeKey = ProgressSummaryScopeKey(
+            scopeId = scopeId,
+            timeZone = testTimeZone,
+            referenceLocalDate = testDate
+        ),
+        cloudState = cloudState,
+        snapshot = null,
+        isLocalCacheReady = isLocalCacheReady,
+        reviewHistoryFingerprint = testFingerprint,
+        syncStatus = createTestSyncStatus()
+    )
+}
+
+private fun createSeriesStoreState(
+    scopeId: String,
+    cloudState: CloudAccountState,
+    isLocalCacheReady: Boolean
+): ProgressSeriesStoreState {
+    return ProgressSeriesStoreState(
+        scopeKey = ProgressSeriesScopeKey(
+            scopeId = scopeId,
+            timeZone = testTimeZone,
+            from = "2026-05-19",
+            to = testDate
+        ),
+        cloudState = cloudState,
+        snapshot = null,
+        isLocalCacheReady = isLocalCacheReady,
+        reviewHistoryFingerprint = testFingerprint,
+        syncStatus = createTestSyncStatus()
+    )
+}
+
+private fun createReviewScheduleStoreState(
+    scopeId: String,
+    cloudState: CloudAccountState
+): ProgressReviewScheduleStoreState {
+    val scopeKey: ProgressReviewScheduleScopeKey = ProgressReviewScheduleScopeKey(
+        scopeId = scopeId,
+        timeZone = testTimeZone,
+        workspaceMembershipKey = "workspace-1",
+        referenceLocalDate = testDate
+    )
+    val localSchedule: CloudProgressReviewSchedule = createReviewSchedule(
+        timeZone = testTimeZone,
+        newCount = 0,
+        todayCount = 0
+    )
+    val snapshot: ProgressReviewScheduleSnapshot = ProgressReviewScheduleSnapshot(
+        scopeKey = scopeKey,
+        renderedSchedule = localSchedule,
+        localFallback = localSchedule,
+        serverBase = null,
+        source = ProgressSnapshotSource.LOCAL_ONLY,
+        isApproximate = true
+    )
+
+    return ProgressReviewScheduleStoreState(
+        scopeKey = scopeKey,
+        cloudState = cloudState,
+        snapshot = snapshot,
+        hasPendingScheduleImpactingCardChanges = false,
+        reviewScheduleFingerprint = testFingerprint,
+        syncStatus = createTestSyncStatus()
+    )
+}
+
+private fun createTestSyncStatus(): SyncStatusSnapshot {
+    return SyncStatusSnapshot(
+        status = SyncStatus.Idle,
+        lastSuccessfulSyncAtMillis = null,
+        lastErrorMessage = ""
+    )
+}
+
+private const val testTimeZone: String = "Europe/Madrid"
+private const val testDate: String = "2026-05-26"
+private const val testFingerprint: String = "fingerprint"


### PR DESCRIPTION
## Summary
- suppress stale Android progress remote-load warnings after scope or cloud identity changes
- keep current-scope remote-load failures visible
- add explicit Sentry warning fingerprints by platform, feature, action, group, code, and status
- add focused JVM tests for warning suppression and fingerprint dimensions

## Validation
- git --no-pager diff --check
- git --no-pager diff --cached --check
- ./gradlew not run because repository policy requires explicit permission for Gradle runs