### PR TITLE
[codex] Handle missing web card form records

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -601,6 +601,7 @@ const arCatalog: TranslationCatalog = {
     deleteConfirmation: "هل تريد حذف هذه البطاقة؟",
     errors: {
       cardIdRequired: "معرّف البطاقة مطلوب",
+      cardNotFound: "لم يتم العثور على البطاقة",
     },
     fields: {
       back: "الخلف",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -601,6 +601,7 @@ const deCatalog: TranslationCatalog = {
     deleteConfirmation: "Diese Karte löschen?",
     errors: {
       cardIdRequired: "Karten-ID ist erforderlich",
+      cardNotFound: "Karte nicht gefunden",
     },
     fields: {
       back: "Rückseite",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -599,6 +599,7 @@ const enCatalog = {
     deleteConfirmation: "Delete this card?",
     errors: {
       cardIdRequired: "Card ID is required",
+      cardNotFound: "Card not found",
     },
     fields: {
       back: "Back",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -601,6 +601,7 @@ const esEsCatalog: TranslationCatalog = {
     deleteConfirmation: "¿Eliminar esta tarjeta?",
     errors: {
       cardIdRequired: "El ID de la tarjeta es obligatorio",
+      cardNotFound: "Tarjeta no encontrada",
     },
     fields: {
       back: "Reverso",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -601,6 +601,7 @@ const esMxCatalog: TranslationCatalog = {
     deleteConfirmation: "¿Eliminar esta tarjeta?",
     errors: {
       cardIdRequired: "El ID de la tarjeta es obligatorio",
+      cardNotFound: "Tarjeta no encontrada",
     },
     fields: {
       back: "Reverso",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -601,6 +601,7 @@ const hiCatalog: TranslationCatalog = {
     deleteConfirmation: "क्या यह कार्ड हटाएँ?",
     errors: {
       cardIdRequired: "कार्ड ID आवश्यक है",
+      cardNotFound: "कार्ड नहीं मिला",
     },
     fields: {
       back: "पीछे",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -601,6 +601,7 @@ export const jaCatalog = {
     deleteConfirmation: "このカードを削除しますか？",
     errors: {
       cardIdRequired: "カード ID は必須です",
+      cardNotFound: "カードが見つかりません",
     },
     fields: {
       back: "裏面",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -601,6 +601,7 @@ export const ruCatalog = {
     deleteConfirmation: "Удалить эту карточку?",
     errors: {
       cardIdRequired: "Требуется ID карточки",
+      cardNotFound: "Карточка не найдена",
     },
     fields: {
       back: "Обратная сторона",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -601,6 +601,7 @@ export const zhHansCatalog = {
     deleteConfirmation: "删除这张卡片？",
     errors: {
       cardIdRequired: "卡片 ID 为必填项",
+      cardNotFound: "未找到卡片",
     },
     fields: {
       back: "背面",

--- a/apps/web/src/screens/cards/CardFormScreen.tsx
+++ b/apps/web/src/screens/cards/CardFormScreen.tsx
@@ -5,6 +5,7 @@ import { useAiCardHandoff } from "../../chat/handoff/useAiCardHandoff";
 import { useI18n } from "../../i18n";
 import { CardFormFields, isCardFormStateDirty, toCardFormState, type CardFormState } from "./CardForm";
 import type { Card, CreateCardInput, TagSuggestion, UpdateCardInput } from "../../types";
+import { loadCardById } from "../../localDb/cards";
 import { loadWorkspaceTagsSummary } from "../../localDb/workspace";
 import { captureAppOperationError } from "../../observability/appOperationObservation";
 import { cardsRoute } from "../../routes";
@@ -24,7 +25,6 @@ export function CardFormScreen(): ReactElement {
   const {
     activeWorkspace,
     cloudSettings,
-    getCardById,
     createCardItem,
     updateCardItem,
     deleteCardItem,
@@ -47,6 +47,7 @@ export function CardFormScreen(): ReactElement {
     userId: null,
     installationId: null,
   });
+  const loadRequestSequenceRef = useRef<number>(0);
   const isCreateMode = cardId === undefined;
   const handoffCardToAi = useAiCardHandoff();
   observationIdentityRef.current = {
@@ -55,6 +56,12 @@ export function CardFormScreen(): ReactElement {
   };
 
   const loadScreenData = useCallback(async function loadScreenData(): Promise<void> {
+    const requestSequence = loadRequestSequenceRef.current + 1;
+    loadRequestSequenceRef.current = requestSequence;
+    const isCurrentLoadRequest = function isCurrentLoadRequest(): boolean {
+      return loadRequestSequenceRef.current === requestSequence;
+    };
+
     setLoadErrorMessage("");
     setActionErrorMessage("");
     setIsLoading(true);
@@ -64,16 +71,29 @@ export function CardFormScreen(): ReactElement {
         throw new Error("Workspace is unavailable");
       }
 
+      const workspaceId = activeWorkspace.workspaceId;
       const [tagsSummary, loadedCard] = await Promise.all([
-        loadWorkspaceTagsSummary(activeWorkspace.workspaceId),
-        isCreateMode || cardId === undefined ? Promise.resolve(null) : getCardById(cardId),
+        loadWorkspaceTagsSummary(workspaceId),
+        isCreateMode || cardId === undefined ? Promise.resolve(null) : loadCardById(workspaceId, cardId),
       ]);
+      if (isCurrentLoadRequest() === false) {
+        return;
+      }
+
       setTagSuggestions(toTagSuggestions(tagsSummary.tags));
       setCurrentCard(loadedCard);
       if (loadedCard !== null) {
         setFormState(toCardFormState(loadedCard));
       }
+      if (isCreateMode === false && loadedCard === null) {
+        setFormState(toCardFormState(null));
+        setLoadErrorMessage(t("cardForm.errors.cardNotFound"));
+      }
     } catch (error) {
+      if (isCurrentLoadRequest() === false) {
+        return;
+      }
+
       if (activeWorkspace !== null) {
         const observationIdentity = observationIdentityRef.current;
         captureAppOperationError(error, {
@@ -87,12 +107,17 @@ export function CardFormScreen(): ReactElement {
       }
       setLoadErrorMessage(error instanceof Error ? error.message : String(error));
     } finally {
-      setIsLoading(false);
+      if (isCurrentLoadRequest()) {
+        setIsLoading(false);
+      }
     }
-  }, [activeWorkspace, cardId, getCardById, isCreateMode]);
+  }, [activeWorkspace, cardId, isCreateMode, t]);
 
   useEffect(() => {
     void loadScreenData();
+    return () => {
+      loadRequestSequenceRef.current += 1;
+    };
   }, [loadScreenData, localReadVersion]);
 
   function buildUpdatePayload(): UpdateCardInput {


### PR DESCRIPTION
## Summary

- Treat missing local cards on the web card form as a handled not-found state instead of an app operation failure.
- Ignore stale card-form load tasks after route changes or refreshes.
- Add localized card form not-found copy across supported web locales.

## Validation

- `npm run build` in `apps/web`