### PR TITLE
Replace copyright symbol with ASCII text

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -6,7 +6,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Rain Cloud Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-rain-cloud-animation_12152618
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -16,7 +16,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Tornado Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-tornado-animation_12152595
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -26,7 +26,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Wind Face Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-wind-face-animation_12152602
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -36,7 +36,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Snowflake Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-snowflake-animation_12152628
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -46,7 +46,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Snail Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-snail-animation_12152626
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -56,7 +56,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Turtle Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-turtle-animation_12152597
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -66,7 +66,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Wilted Flower Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-wilted-flower-animation_12152601
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -76,7 +76,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Spider Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-spider-animation_12152629
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -86,7 +86,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Rat Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-rat-animation_12152619
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -96,7 +96,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Worm Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-worm-animation_12152603
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -106,7 +106,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Tiger Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-tiger-animation_12152594
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -116,7 +116,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free T Rex Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-t-rex-animation_12152596
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -126,7 +126,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Shark Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-shark-animation_12152625
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -136,7 +136,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Ox Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-ox-animation_12152607
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -146,7 +146,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Racehorse Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-racehorse-animation_12152616
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -156,7 +156,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Snake Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-snake-animation_12152627
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -166,7 +166,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Volcano Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-volcano-animation_12152599
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -176,7 +176,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Scorpion Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-scorpion-animation_12152622
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -186,7 +186,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Paw Prints Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-paw-prints-animation_12152608
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -196,7 +196,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Rooster Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-rooster-animation_12152620
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -206,7 +206,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Otter Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-otter-animation_12152605
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -216,7 +216,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Owl Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-owl-animation_12152606
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -226,7 +226,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Rabbit Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-rabbit-animation_12152615
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -236,7 +236,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Seal Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-seal-animation_12152623
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -246,7 +246,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Service Dog Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-service-dog-animation_12152624
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -256,7 +256,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Poodle Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-poodle-animation_12152614
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -266,7 +266,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Chimpanzee Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-chimpanzee-animation_12152604
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -276,7 +276,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Whale Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-whale-animation_12152600
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -286,7 +286,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Peacock Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-peacock-animation_12152610
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -296,7 +296,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Pig Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-pig-animation_12152612
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -306,7 +306,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Sunrise Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-sunrise-animation_12152630
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -316,7 +316,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Sunrise Over Mountains Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-sunrise-over-mountains-animation_12152631
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -326,7 +326,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Rose Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-rose-animation_12152621
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -336,7 +336,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Peace Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-peace-animation_12152609
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -346,7 +346,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Plant Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-plant-animation_12152613
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -356,7 +356,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Rainbow Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-rainbow-animation_12152617
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -366,7 +366,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Phoenix Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-phoenix-animation_12152611
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/
@@ -376,7 +376,7 @@ This file lists third-party assets and runtime libraries bundled for the review 
 
 - Asset: Free Unicorn Animation
 - Author: Google Inc.
-- Copyright: Copyright © 2026 Google Inc.
+- Copyright: Copyright (c) 2026 Google Inc.
 - Source: https://iconscout.com/free-lottie-animation/free-unicorn-animation_12152598
 - License: Creative Commons Attribution 4.0 International
 - License URL: https://creativecommons.org/licenses/by/4.0/

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -485,81 +485,81 @@
     <string name="settings_open_source_repository_title">GitHub repository</string>
     <string name="settings_open_source_repository_summary">Browse the public source code and issues.</string>
     <string name="settings_open_source_third_party_rain_cloud_source_title" translatable="false">Review rain cloud animation</string>
-    <string name="settings_open_source_third_party_rain_cloud_source_summary" translatable="false">Free Rain Cloud Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_rain_cloud_source_summary" translatable="false">Free Rain Cloud Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_wind_face_source_title" translatable="false">Review wind face animation</string>
-    <string name="settings_open_source_third_party_wind_face_source_summary" translatable="false">Free Wind Face Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_wind_face_source_summary" translatable="false">Free Wind Face Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_snowflake_source_title" translatable="false">Review snowflake animation</string>
-    <string name="settings_open_source_third_party_snowflake_source_summary" translatable="false">Free Snowflake Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_snowflake_source_summary" translatable="false">Free Snowflake Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_turtle_source_title" translatable="false">Review turtle animation</string>
-    <string name="settings_open_source_third_party_turtle_source_summary" translatable="false">Free Turtle Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_turtle_source_summary" translatable="false">Free Turtle Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_spider_source_title" translatable="false">Review spider animation</string>
-    <string name="settings_open_source_third_party_spider_source_summary" translatable="false">Free Spider Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_spider_source_summary" translatable="false">Free Spider Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_rat_source_title" translatable="false">Review rat animation</string>
-    <string name="settings_open_source_third_party_rat_source_summary" translatable="false">Free Rat Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_rat_source_summary" translatable="false">Free Rat Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_tiger_source_title" translatable="false">Review tiger animation</string>
-    <string name="settings_open_source_third_party_tiger_source_summary" translatable="false">Free Tiger Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_tiger_source_summary" translatable="false">Free Tiger Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_t_rex_source_title" translatable="false">Review T Rex animation</string>
-    <string name="settings_open_source_third_party_t_rex_source_summary" translatable="false">Free T Rex Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_t_rex_source_summary" translatable="false">Free T Rex Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_shark_source_title" translatable="false">Review shark animation</string>
-    <string name="settings_open_source_third_party_shark_source_summary" translatable="false">Free Shark Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_shark_source_summary" translatable="false">Free Shark Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_snake_source_title" translatable="false">Review snake animation</string>
-    <string name="settings_open_source_third_party_snake_source_summary" translatable="false">Free Snake Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_snake_source_summary" translatable="false">Free Snake Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_scorpion_source_title" translatable="false">Review scorpion animation</string>
-    <string name="settings_open_source_third_party_scorpion_source_summary" translatable="false">Free Scorpion Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_scorpion_source_summary" translatable="false">Free Scorpion Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_rooster_source_title" translatable="false">Review rooster animation</string>
-    <string name="settings_open_source_third_party_rooster_source_summary" translatable="false">Free Rooster Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_rooster_source_summary" translatable="false">Free Rooster Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_otter_source_title" translatable="false">Review otter animation</string>
-    <string name="settings_open_source_third_party_otter_source_summary" translatable="false">Free Otter Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_otter_source_summary" translatable="false">Free Otter Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_rabbit_source_title" translatable="false">Review rabbit animation</string>
-    <string name="settings_open_source_third_party_rabbit_source_summary" translatable="false">Free Rabbit Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_rabbit_source_summary" translatable="false">Free Rabbit Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_seal_source_title" translatable="false">Review seal animation</string>
-    <string name="settings_open_source_third_party_seal_source_summary" translatable="false">Free Seal Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_seal_source_summary" translatable="false">Free Seal Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_service_dog_source_title" translatable="false">Review service dog animation</string>
-    <string name="settings_open_source_third_party_service_dog_source_summary" translatable="false">Free Service Dog Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_service_dog_source_summary" translatable="false">Free Service Dog Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_chimpanzee_source_title" translatable="false">Review chimpanzee animation</string>
-    <string name="settings_open_source_third_party_chimpanzee_source_summary" translatable="false">Free Chimpanzee Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_chimpanzee_source_summary" translatable="false">Free Chimpanzee Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_pig_source_title" translatable="false">Review pig animation</string>
-    <string name="settings_open_source_third_party_pig_source_summary" translatable="false">Free Pig Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_pig_source_summary" translatable="false">Free Pig Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_sunrise_source_title" translatable="false">Review sunrise animation</string>
-    <string name="settings_open_source_third_party_sunrise_source_summary" translatable="false">Free Sunrise Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_sunrise_source_summary" translatable="false">Free Sunrise Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_sunrise_over_mountains_source_title" translatable="false">Review sunrise over mountains animation</string>
-    <string name="settings_open_source_third_party_sunrise_over_mountains_source_summary" translatable="false">Free Sunrise Over Mountains Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_sunrise_over_mountains_source_summary" translatable="false">Free Sunrise Over Mountains Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_peace_source_title" translatable="false">Review peace animation</string>
-    <string name="settings_open_source_third_party_peace_source_summary" translatable="false">Free Peace Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_peace_source_summary" translatable="false">Free Peace Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_plant_source_title" translatable="false">Review plant animation</string>
-    <string name="settings_open_source_third_party_plant_source_summary" translatable="false">Free Plant Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_plant_source_summary" translatable="false">Free Plant Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_owl_source_title" translatable="false">Review owl animation</string>
-    <string name="settings_open_source_third_party_owl_source_summary" translatable="false">Free Owl Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_owl_source_summary" translatable="false">Free Owl Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_poodle_source_title" translatable="false">Review poodle animation</string>
-    <string name="settings_open_source_third_party_poodle_source_summary" translatable="false">Free Poodle Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_poodle_source_summary" translatable="false">Free Poodle Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_whale_source_title" translatable="false">Review whale animation</string>
-    <string name="settings_open_source_third_party_whale_source_summary" translatable="false">Free Whale Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_whale_source_summary" translatable="false">Free Whale Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_peacock_source_title" translatable="false">Review peacock animation</string>
-    <string name="settings_open_source_third_party_peacock_source_summary" translatable="false">Free Peacock Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_peacock_source_summary" translatable="false">Free Peacock Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_ox_source_title" translatable="false">Review ox animation</string>
-    <string name="settings_open_source_third_party_ox_source_summary" translatable="false">Free Ox Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_ox_source_summary" translatable="false">Free Ox Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_paw_prints_source_title" translatable="false">Review paw prints animation</string>
-    <string name="settings_open_source_third_party_paw_prints_source_summary" translatable="false">Free Paw Prints Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_paw_prints_source_summary" translatable="false">Free Paw Prints Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_racehorse_source_title" translatable="false">Review racehorse animation</string>
-    <string name="settings_open_source_third_party_racehorse_source_summary" translatable="false">Free Racehorse Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_racehorse_source_summary" translatable="false">Free Racehorse Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_volcano_source_title" translatable="false">Review volcano animation</string>
-    <string name="settings_open_source_third_party_volcano_source_summary" translatable="false">Free Volcano Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_volcano_source_summary" translatable="false">Free Volcano Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_unicorn_source_title" translatable="false">Review unicorn animation</string>
-    <string name="settings_open_source_third_party_unicorn_source_summary" translatable="false">Free Unicorn Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_unicorn_source_summary" translatable="false">Free Unicorn Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_snail_source_title" translatable="false">Review snail animation</string>
-    <string name="settings_open_source_third_party_snail_source_summary" translatable="false">Free Snail Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_snail_source_summary" translatable="false">Free Snail Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_rose_source_title" translatable="false">Review rose animation</string>
-    <string name="settings_open_source_third_party_rose_source_summary" translatable="false">Free Rose Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_rose_source_summary" translatable="false">Free Rose Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_rainbow_source_title" translatable="false">Review rainbow animation</string>
-    <string name="settings_open_source_third_party_rainbow_source_summary" translatable="false">Free Rainbow Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_rainbow_source_summary" translatable="false">Free Rainbow Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_phoenix_source_title" translatable="false">Review phoenix animation</string>
-    <string name="settings_open_source_third_party_phoenix_source_summary" translatable="false">Free Phoenix Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_phoenix_source_summary" translatable="false">Free Phoenix Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_worm_source_title" translatable="false">Review worm animation</string>
-    <string name="settings_open_source_third_party_worm_source_summary" translatable="false">Free Worm Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_worm_source_summary" translatable="false">Free Worm Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_tornado_source_title" translatable="false">Review tornado animation</string>
-    <string name="settings_open_source_third_party_tornado_source_summary" translatable="false">Free Tornado Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
+    <string name="settings_open_source_third_party_tornado_source_summary" translatable="false">Free Tornado Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0.</string>
     <string name="settings_open_source_third_party_wilted_flower_source_title" translatable="false">Review wilted flower animation</string>
-    <string name="settings_open_source_third_party_wilted_flower_source_summary" translatable="false">Free Wilted Flower Animation by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0. Lottie runtimes use MIT and Apache 2.0 licenses.</string>
+    <string name="settings_open_source_third_party_wilted_flower_source_summary" translatable="false">Free Wilted Flower Animation by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0. Lottie runtimes use MIT and Apache 2.0 licenses.</string>
     <string name="settings_open_source_third_party_notices_title" translatable="false">Full third-party notices</string>
     <string name="settings_open_source_third_party_notices_summary" translatable="false">Open complete third-party notices and bundled license text.</string>
     <string name="settings_open_source_third_party_license_title" translatable="false">Creative Commons Attribution 4.0</string>

--- a/apps/android/gradlew
+++ b/apps/android/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015 the original authors.
+# Copyright (c) 2015 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/AccountOpenSourceView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/AccountOpenSourceView.swift
@@ -246,7 +246,7 @@ struct AccountOpenSourceView: View {
                 Text(
                     aiSettingsLocalized(
                         "settings.account.openSource.thirdPartyNotice",
-                        "Review Lottie animations: 38 animal and nature animations by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0. Lottie runtimes use MIT and Apache 2.0 licenses."
+                        "Review Lottie animations: 38 animal and nature animations by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0. Lottie runtimes use MIT and Apache 2.0 licenses."
                     )
                 )
                     .foregroundStyle(.secondary)

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "مستودع GitHub (ترخيص MIT)";
 "settings.account.openSource.selfHosting" = "إذا كنت بحاجة إلى الواجهة الخلفية الخاصة بك، فيمكنك نشر نفس المكدس مفتوح المصدر وتوجيه تطبيق iOS إلى المجال الخاص بك من Advanced > Server.";
 "settings.account.openSource.section.thirdPartyNotices" = "إشعارات الجهات الخارجية";
-"settings.account.openSource.thirdPartyNotice" = "رسوم Lottie لمراجعة البطاقات: 38 رسمًا متحركًا للحيوانات والطبيعة من Google Inc.، حقوق النشر © 2026 Google Inc.، مستخدمة بموجب Creative Commons Attribution 4.0. تستخدم مشغلات Lottie تراخيص MIT وApache 2.0.";
+"settings.account.openSource.thirdPartyNotice" = "رسوم Lottie لمراجعة البطاقات: 38 رسمًا متحركًا للحيوانات والطبيعة من Google Inc.، حقوق النشر (c) 2026 Google Inc.، مستخدمة بموجب Creative Commons Attribution 4.0. تستخدم مشغلات Lottie تراخيص MIT وApache 2.0.";
 "settings.account.openSource.thirdPartyNoticeFull" = "إشعارات الجهات الخارجية الكاملة";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "مصدر أصل سحابة المطر";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "مصدر أصل وجه الرياح";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "GitHub-Repository (MIT-Lizenz)";
 "settings.account.openSource.selfHosting" = "Wenn Sie Ihr eigenes Backend benötigen, können Sie denselben Open-Source-Stack bereitstellen und die iOS-App über Erweitert > Server auf Ihre Domäne verweisen.";
 "settings.account.openSource.section.thirdPartyNotices" = "Drittanbieterhinweise";
-"settings.account.openSource.thirdPartyNotice" = "Review-Lottie-Animationen: 38 Tier- und Naturanimationen von Google Inc., Copyright © 2026 Google Inc., verwendet unter Creative Commons Attribution 4.0. Lottie-Runtimes verwenden MIT- und Apache-2.0-Lizenzen.";
+"settings.account.openSource.thirdPartyNotice" = "Review-Lottie-Animationen: 38 Tier- und Naturanimationen von Google Inc., Copyright (c) 2026 Google Inc., verwendet unter Creative Commons Attribution 4.0. Lottie-Runtimes verwenden MIT- und Apache-2.0-Lizenzen.";
 "settings.account.openSource.thirdPartyNoticeFull" = "Vollständige Drittanbieterhinweise";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "Quelle des Regenwolken-Assets";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "Quelle des Windgesicht-Assets";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "Repositorio de GitHub (Licencia MIT)";
 "settings.account.openSource.selfHosting" = "Si necesitas tu propio backend, puedes desplegar la misma pila de codigo abierto y apuntar la app de iOS a tu dominio desde Avanzado > Servidor.";
 "settings.account.openSource.section.thirdPartyNotices" = "Avisos de terceros";
-"settings.account.openSource.thirdPartyNotice" = "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright © 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.";
+"settings.account.openSource.thirdPartyNotice" = "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright (c) 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.";
 "settings.account.openSource.thirdPartyNoticeFull" = "Avisos completos de terceros";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "Fuente del recurso de nube de lluvia";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "Fuente del recurso de cara de viento";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "Repositorio de GitHub (Licencia MIT)";
 "settings.account.openSource.selfHosting" = "Si necesitas tu propio backend, puedes desplegar la misma pila de codigo abierto y apuntar la app de iOS a tu dominio desde Avanzado > Servidor.";
 "settings.account.openSource.section.thirdPartyNotices" = "Avisos de terceros";
-"settings.account.openSource.thirdPartyNotice" = "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright © 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.";
+"settings.account.openSource.thirdPartyNotice" = "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright (c) 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.";
 "settings.account.openSource.thirdPartyNoticeFull" = "Avisos completos de terceros";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "Fuente del recurso de nube de lluvia";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "Fuente del recurso de cara de viento";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "GitHub रिपॉजिटरी (MIT लाइसेंस)";
 "settings.account.openSource.selfHosting" = "यदि आपको अपने स्वयं के बैकएंड की आवश्यकता है, तो आप उसी ओपन सोर्स स्टैक को तैनात कर सकते हैं और उन्नत> सर्वर से iOS ऐप को अपने डोमेन पर इंगित कर सकते हैं।";
 "settings.account.openSource.section.thirdPartyNotices" = "तृतीय-पक्ष नोटिस";
-"settings.account.openSource.thirdPartyNotice" = "Review Lottie ऐनिमेशन: Google Inc. के 38 animal और nature ऐनिमेशन, Copyright © 2026 Google Inc., Creative Commons Attribution 4.0 के तहत इस्तेमाल किए गए। Lottie runtimes MIT और Apache 2.0 licenses का उपयोग करते हैं।";
+"settings.account.openSource.thirdPartyNotice" = "Review Lottie ऐनिमेशन: Google Inc. के 38 animal और nature ऐनिमेशन, Copyright (c) 2026 Google Inc., Creative Commons Attribution 4.0 के तहत इस्तेमाल किए गए। Lottie runtimes MIT और Apache 2.0 licenses का उपयोग करते हैं।";
 "settings.account.openSource.thirdPartyNoticeFull" = "पूरे तृतीय-पक्ष नोटिस";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "वर्षा बादल एसेट स्रोत";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "हवा चेहरे का एसेट स्रोत";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "GitHub リポジトリ (MIT ライセンス)";
 "settings.account.openSource.selfHosting" = "独自のバックエンドが必要な場合は、同じオープン ソース スタックをデプロイし、[詳細] > [サーバー] から iOS アプリをドメインに指定できます。";
 "settings.account.openSource.section.thirdPartyNotices" = "サードパーティ通知";
-"settings.account.openSource.thirdPartyNotice" = "復習用Lottieアニメーション: Google Inc. による動物と自然のアニメーション38件。Copyright © 2026 Google Inc. Creative Commons Attribution 4.0 の下で使用。Lottieランタイムは MIT および Apache 2.0 ライセンスです。";
+"settings.account.openSource.thirdPartyNotice" = "復習用Lottieアニメーション: Google Inc. による動物と自然のアニメーション38件。Copyright (c) 2026 Google Inc. Creative Commons Attribution 4.0 の下で使用。Lottieランタイムは MIT および Apache 2.0 ライセンスです。";
 "settings.account.openSource.thirdPartyNoticeFull" = "完全なサードパーティ通知";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "雨雲アセットのソース";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "風の顔アセットのソース";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "Репозиторий GitHub (лицензия MIT)";
 "settings.account.openSource.selfHosting" = "Если вам нужен собственный бэкэнд, вы можете развернуть тот же стек с открытым исходным кодом и указать приложение iOS в своем домене, выбрав «Дополнительно» > «Сервер».";
 "settings.account.openSource.section.thirdPartyNotices" = "Сторонние материалы";
-"settings.account.openSource.thirdPartyNotice" = "Lottie-анимации повторения: 38 анимаций животных и природы от Google Inc., Copyright © 2026 Google Inc., используются по лицензии Creative Commons Attribution 4.0. Среды выполнения Lottie используют лицензии MIT и Apache 2.0.";
+"settings.account.openSource.thirdPartyNotice" = "Lottie-анимации повторения: 38 анимаций животных и природы от Google Inc., Copyright (c) 2026 Google Inc., используются по лицензии Creative Commons Attribution 4.0. Среды выполнения Lottie используют лицензии MIT и Apache 2.0.";
 "settings.account.openSource.thirdPartyNoticeFull" = "Полные сведения о сторонних материалах";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "Источник ассета дождевого облака";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "Источник ассета лица ветра";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -264,7 +264,7 @@
 "settings.account.openSource.repository" = "GitHub 存储库（MIT 许可证）";
 "settings.account.openSource.selfHosting" = "如果您需要自己的后端，则可以部署相同的开源堆栈并将 iOS 应用程序从“高级”>“服务器”指向您的域。";
 "settings.account.openSource.section.thirdPartyNotices" = "第三方声明";
-"settings.account.openSource.thirdPartyNotice" = "复习 Lottie 动画：Google Inc. 提供的 38 个动物和自然动画，Copyright © 2026 Google Inc.，根据 Creative Commons Attribution 4.0 使用。Lottie 运行时使用 MIT 和 Apache 2.0 许可证。";
+"settings.account.openSource.thirdPartyNotice" = "复习 Lottie 动画：Google Inc. 提供的 38 个动物和自然动画，Copyright (c) 2026 Google Inc.，根据 Creative Commons Attribution 4.0 使用。Lottie 运行时使用 MIT 和 Apache 2.0 许可证。";
 "settings.account.openSource.thirdPartyNoticeFull" = "完整第三方声明";
 "settings.account.openSource.thirdPartyNoticeRainCloudSource" = "雨云资源来源";
 "settings.account.openSource.thirdPartyNoticeWindFaceSource" = "风脸资源来源";

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -874,7 +874,7 @@ const arCatalog: TranslationCatalog = {
     stackDescription: "تطبيق iOS والخادم الخلفي مفتوحا المصدر بالكامل. يمكنك فحص الكود واستخدام ترخيص MIT وتشغيل الحزمة نفسها على خوادمك الخاصة.",
     repositoryAction: "فتح المستودع",
     selfHostingDescription: "إذا كنت بحاجة إلى خادم خلفي خاص بك، فانشر الحزمة مفتوحة المصدر نفسها على بنيتك التحتية واستخدم عملاء الويب وiOS الخاصين بك مع ذلك النشر.",
-    thirdPartyNoticeDescription: "رسوم Lottie لمراجعة البطاقات: 38 رسمًا متحركًا للحيوانات والطبيعة من Google Inc.، حقوق النشر © 2026 Google Inc.، مستخدمة بموجب Creative Commons Attribution 4.0. تستخدم مشغلات Lottie تراخيص MIT وApache 2.0.",
+    thirdPartyNoticeDescription: "رسوم Lottie لمراجعة البطاقات: 38 رسمًا متحركًا للحيوانات والطبيعة من Google Inc.، حقوق النشر (c) 2026 Google Inc.، مستخدمة بموجب Creative Commons Attribution 4.0. تستخدم مشغلات Lottie تراخيص MIT وApache 2.0.",
     thirdPartyNoticeFullAction: "فتح الإشعارات الكاملة",
     thirdPartyNoticeRainCloudSourceAction: "فتح مصدر سحابة المطر",
     thirdPartyNoticeWindFaceSourceAction: "فتح مصدر وجه الرياح",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -874,7 +874,7 @@ const deCatalog: TranslationCatalog = {
     stackDescription: "Die iOS-App und das Backend sind vollständig Open Source. Du kannst den Code prüfen, die MIT-Lizenz nutzen und denselben Stack auf deinen eigenen Servern ausführen.",
     repositoryAction: "Repository öffnen",
     selfHostingDescription: "Wenn du dein eigenes Backend benötigst, stelle denselben Open-Source-Stack auf deiner Infrastruktur bereit und nutze deine eigenen Web- und iOS-Clients mit dieser Bereitstellung.",
-    thirdPartyNoticeDescription: "Review-Lottie-Animationen: 38 Tier- und Naturanimationen von Google Inc., Copyright © 2026 Google Inc., verwendet unter Creative Commons Attribution 4.0. Lottie-Runtimes verwenden MIT- und Apache-2.0-Lizenzen.",
+    thirdPartyNoticeDescription: "Review-Lottie-Animationen: 38 Tier- und Naturanimationen von Google Inc., Copyright (c) 2026 Google Inc., verwendet unter Creative Commons Attribution 4.0. Lottie-Runtimes verwenden MIT- und Apache-2.0-Lizenzen.",
     thirdPartyNoticeFullAction: "Vollständige Hinweise öffnen",
     thirdPartyNoticeRainCloudSourceAction: "Regenwolken-Quelle öffnen",
     thirdPartyNoticeWindFaceSourceAction: "Windgesicht-Quelle öffnen",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -872,7 +872,7 @@ const enCatalog = {
     stackDescription: "The iOS app and the backend are fully open source. You can inspect the code, use the MIT license, and run the same stack on your own servers.",
     repositoryAction: "Open repository",
     selfHostingDescription: "If you need your own backend, deploy the same open-source stack on your infrastructure and use your own web and iOS clients with that deployment.",
-    thirdPartyNoticeDescription: "Review Lottie animations: 38 animal and nature animations by Google Inc., Copyright © 2026 Google Inc., used under Creative Commons Attribution 4.0. Lottie runtimes use MIT and Apache 2.0 licenses.",
+    thirdPartyNoticeDescription: "Review Lottie animations: 38 animal and nature animations by Google Inc., Copyright (c) 2026 Google Inc., used under Creative Commons Attribution 4.0. Lottie runtimes use MIT and Apache 2.0 licenses.",
     thirdPartyNoticeFullAction: "Open full notices",
     thirdPartyNoticeRainCloudSourceAction: "Open rain cloud source",
     thirdPartyNoticeWindFaceSourceAction: "Open wind face source",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -874,7 +874,7 @@ const esEsCatalog: TranslationCatalog = {
     stackDescription: "La app de iOS y el backend son completamente de código abierto. Puedes inspeccionar el código, usar la licencia MIT y ejecutar la misma pila en tus propios servidores.",
     repositoryAction: "Abrir repositorio",
     selfHostingDescription: "Si necesitas tu propio backend, despliega la misma pila de código abierto en tu infraestructura y usa tus propios clientes web e iOS con ese despliegue.",
-    thirdPartyNoticeDescription: "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright © 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.",
+    thirdPartyNoticeDescription: "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright (c) 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.",
     thirdPartyNoticeFullAction: "Abrir avisos completos",
     thirdPartyNoticeRainCloudSourceAction: "Abrir fuente de nube de lluvia",
     thirdPartyNoticeWindFaceSourceAction: "Abrir fuente de cara de viento",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -874,7 +874,7 @@ const esMxCatalog: TranslationCatalog = {
     stackDescription: "La app de iOS y el backend son completamente de código abierto. Puedes inspeccionar el código, usar la licencia MIT y ejecutar la misma pila en tus propios servidores.",
     repositoryAction: "Abrir repositorio",
     selfHostingDescription: "Si necesitas tu propio backend, despliega la misma pila de código abierto en tu infraestructura y usa tus propios clientes web e iOS con ese despliegue.",
-    thirdPartyNoticeDescription: "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright © 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.",
+    thirdPartyNoticeDescription: "Animaciones Lottie de repaso: 38 animaciones de animales y naturaleza de Google Inc., Copyright (c) 2026 Google Inc., usadas bajo Creative Commons Attribution 4.0. Los runtimes de Lottie usan licencias MIT y Apache 2.0.",
     thirdPartyNoticeFullAction: "Abrir avisos completos",
     thirdPartyNoticeRainCloudSourceAction: "Abrir fuente de nube de lluvia",
     thirdPartyNoticeWindFaceSourceAction: "Abrir fuente de cara de viento",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -874,7 +874,7 @@ const hiCatalog: TranslationCatalog = {
     stackDescription: "iOS ऐप और बैकएंड पूरी तरह ओपन सोर्स हैं। आप कोड देख सकते हैं, MIT लाइसेंस का उपयोग कर सकते हैं और वही स्टैक अपने सर्वर पर चला सकते हैं।",
     repositoryAction: "रिपॉज़िटरी खोलें",
     selfHostingDescription: "अगर आपको अपना बैकएंड चाहिए, तो वही ओपन सोर्स स्टैक अपने इंफ्रास्ट्रक्चर पर डिप्लॉय करें और उसी डिप्लॉयमेंट के साथ अपने वेब और iOS क्लाइंट इस्तेमाल करें।",
-    thirdPartyNoticeDescription: "Review Lottie ऐनिमेशन: Google Inc. के 38 animal और nature ऐनिमेशन, Copyright © 2026 Google Inc., Creative Commons Attribution 4.0 के तहत इस्तेमाल किए गए। Lottie runtimes MIT और Apache 2.0 licenses का उपयोग करते हैं।",
+    thirdPartyNoticeDescription: "Review Lottie ऐनिमेशन: Google Inc. के 38 animal और nature ऐनिमेशन, Copyright (c) 2026 Google Inc., Creative Commons Attribution 4.0 के तहत इस्तेमाल किए गए। Lottie runtimes MIT और Apache 2.0 licenses का उपयोग करते हैं।",
     thirdPartyNoticeFullAction: "पूरे नोटिस खोलें",
     thirdPartyNoticeRainCloudSourceAction: "वर्षा बादल स्रोत खोलें",
     thirdPartyNoticeWindFaceSourceAction: "हवा चेहरे का स्रोत खोलें",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -874,7 +874,7 @@ export const jaCatalog = {
     stackDescription: "iOS アプリとバックエンドは完全にオープンソースです。コードを確認し、MIT ライセンスを利用し、自分のサーバーで同じスタックを実行できます。",
     repositoryAction: "リポジトリを開く",
     selfHostingDescription: "独自のバックエンドが必要な場合は、同じオープンソーススタックを自分のインフラにデプロイし、その環境に接続する独自の Web クライアントと iOS クライアントを使用できます。",
-    thirdPartyNoticeDescription: "復習用Lottieアニメーション: Google Inc. による動物と自然のアニメーション38件。Copyright © 2026 Google Inc. Creative Commons Attribution 4.0 の下で使用。Lottieランタイムは MIT および Apache 2.0 ライセンスです。",
+    thirdPartyNoticeDescription: "復習用Lottieアニメーション: Google Inc. による動物と自然のアニメーション38件。Copyright (c) 2026 Google Inc. Creative Commons Attribution 4.0 の下で使用。Lottieランタイムは MIT および Apache 2.0 ライセンスです。",
     thirdPartyNoticeFullAction: "完全な通知を開く",
     thirdPartyNoticeRainCloudSourceAction: "雨雲のソースを開く",
     thirdPartyNoticeWindFaceSourceAction: "風の顔のソースを開く",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -874,7 +874,7 @@ export const ruCatalog = {
     stackDescription: "Приложение для iOS и бэкенд полностью открыты. Вы можете изучить код, использовать лицензию MIT и запускать тот же стек на своих серверах.",
     repositoryAction: "Открыть репозиторий",
     selfHostingDescription: "Если вам нужен собственный бэкенд, разверните тот же open-source стек в своей инфраструктуре и используйте с ним собственные веб- и iOS-клиенты.",
-    thirdPartyNoticeDescription: "Lottie-анимации повторения: 38 анимаций животных и природы от Google Inc., Copyright © 2026 Google Inc., используются по лицензии Creative Commons Attribution 4.0. Среды выполнения Lottie используют лицензии MIT и Apache 2.0.",
+    thirdPartyNoticeDescription: "Lottie-анимации повторения: 38 анимаций животных и природы от Google Inc., Copyright (c) 2026 Google Inc., используются по лицензии Creative Commons Attribution 4.0. Среды выполнения Lottie используют лицензии MIT и Apache 2.0.",
     thirdPartyNoticeFullAction: "Открыть полный список",
     thirdPartyNoticeRainCloudSourceAction: "Открыть источник дождевого облака",
     thirdPartyNoticeWindFaceSourceAction: "Открыть источник лица ветра",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -874,7 +874,7 @@ export const zhHansCatalog = {
     stackDescription: "iOS 应用和后端都是完全开源的。您可以查看代码、使用 MIT 许可证，并在自己的服务器上运行相同的技术栈。",
     repositoryAction: "打开仓库",
     selfHostingDescription: "如果您需要自己的后端，可以在自己的基础设施上部署同样的开源技术栈，并让自己的 Web 和 iOS 客户端连接到该部署。",
-    thirdPartyNoticeDescription: "复习 Lottie 动画：Google Inc. 提供的 38 个动物和自然动画，Copyright © 2026 Google Inc.，根据 Creative Commons Attribution 4.0 使用。Lottie 运行时使用 MIT 和 Apache 2.0 许可证。",
+    thirdPartyNoticeDescription: "复习 Lottie 动画：Google Inc. 提供的 38 个动物和自然动画，Copyright (c) 2026 Google Inc.，根据 Creative Commons Attribution 4.0 使用。Lottie 运行时使用 MIT 和 Apache 2.0 许可证。",
     thirdPartyNoticeFullAction: "打开完整声明",
     thirdPartyNoticeRainCloudSourceAction: "打开雨云来源",
     thirdPartyNoticeWindFaceSourceAction: "打开风脸来源",


### PR DESCRIPTION
## Summary
- Replace literal copyright symbols in text resources and notices with ASCII `(c)`
- Keep Android, iOS, web, and repo-level third-party notice copy aligned

## Validation
- `git grep -I -n "©" -- .`
- `xmllint --noout apps/android/feature/settings/src/main/res/values/strings.xml`
- `plutil -lint apps/ios/Flashcards/Flashcards/{ar,de,es-ES,es-MX,hi,ja,ru,zh-Hans}.lproj/AISettings.strings`
- `git --no-pager diff --check`