### PR TITLE
[codex] Prewarm Android review reaction Lottie

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/ReviewRouteTest.kt
@@ -21,6 +21,7 @@ import com.flashcardsopensourceapp.feature.review.ReviewRoute
 import com.flashcardsopensourceapp.feature.review.ReviewUiState
 import com.flashcardsopensourceapp.feature.review.reviewProgressBadgeTag
 import com.flashcardsopensourceapp.feature.review.reviewQueueButtonTag
+import com.flashcardsopensourceapp.feature.review.reaction.rememberReviewReactionLottieConfigurationStore
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -52,6 +53,8 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
 
         composeRule.setContent {
             FlashcardsTheme {
+                val reviewReactionLottieConfigurationStore =
+                    rememberReviewReactionLottieConfigurationStore()
                 ReviewRoute(
                     uiState = ReviewUiState(
                         isLoading = false,
@@ -81,6 +84,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isNotificationPermissionPromptVisible = false,
                         isHardAnswerReminderVisible = false
                     ),
+                    reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                     onSelectFilter = {},
                     onOpenPreview = {
                         openPreviewCalls += 1

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -76,6 +76,7 @@ import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersRecon
 import com.flashcardsopensourceapp.data.local.repository.AutoSyncSource
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
+import com.flashcardsopensourceapp.feature.review.reaction.rememberReviewReactionLottieConfigurationStore
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -111,6 +112,7 @@ fun FlashcardsApp(
         }
 
         val snackbarHostState = remember { SnackbarHostState() }
+        val reviewReactionLottieConfigurationStore = rememberReviewReactionLottieConfigurationStore()
         LaunchedEffect(appGraph.appMessageBus, snackbarHostState) {
             appGraph.appMessageBus.messages.collect { message ->
                 snackbarHostState.showSnackbar(message = message)
@@ -443,6 +445,7 @@ fun FlashcardsApp(
                 AppNavHost(
                     appGraph = appGraph,
                     navController = navController,
+                    reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
                     appNotificationTapRequest = appNotificationTapRequest,
                     consumeAppNotificationTap = consumeAppNotificationTap
                 )

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
@@ -1,4 +1,5 @@
 package com.flashcardsopensourceapp.app.navigation
+
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -10,11 +11,13 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.notifications.AppNotificationTapType
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 
 @Composable
 fun AppNavHost(
     appGraph: AppGraph,
     navController: NavHostController,
+    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
     appNotificationTapRequest: AppNotificationTapHandoffRequest?,
     consumeAppNotificationTap: (Long) -> Unit
 ) {
@@ -67,7 +70,8 @@ fun AppNavHost(
     ) {
         registerReviewNavGraph(
             appGraph = appGraph,
-            navController = navController
+            navController = navController,
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore
         )
         registerCardsNavGraph(
             appGraph = appGraph,
@@ -85,7 +89,8 @@ fun AppNavHost(
             appGraph = appGraph,
             navController = navController,
             packageInfo = packageInfo,
-            coroutineScope = coroutineScope
+            coroutineScope = coroutineScope,
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore
         )
     }
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ReviewNavGraph.kt
@@ -21,10 +21,12 @@ import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersRecon
 import com.flashcardsopensourceapp.feature.review.ReviewPreviewRoute
 import com.flashcardsopensourceapp.feature.review.ReviewRoute
 import com.flashcardsopensourceapp.feature.review.createReviewViewModelFactory
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 
 internal fun NavGraphBuilder.registerReviewNavGraph(
     appGraph: AppGraph,
-    navController: NavHostController
+    navController: NavHostController,
+    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore
 ) {
     fun handleNotificationPermissionGranted() {
         appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
@@ -80,6 +82,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
 
         ReviewRoute(
             uiState = uiState,
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
             onSelectFilter = reviewViewModel::selectFilter,
             onOpenPreview = {
                 navController.navigate(route = ReviewPreviewDestination.route)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsNavGraph.kt
@@ -4,13 +4,15 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.navigation
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 import kotlinx.coroutines.CoroutineScope
 
 internal fun NavGraphBuilder.registerSettingsNavGraph(
     appGraph: AppGraph,
     navController: NavHostController,
     packageInfo: AppPackageInfo,
-    coroutineScope: CoroutineScope
+    coroutineScope: CoroutineScope,
+    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore
 ) {
     navigation(
         startDestination = SettingsDestination.route,
@@ -20,7 +22,8 @@ internal fun NavGraphBuilder.registerSettingsNavGraph(
             appGraph = appGraph,
             navController = navController,
             packageInfo = packageInfo,
-            coroutineScope = coroutineScope
+            coroutineScope = coroutineScope,
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore
         )
         registerSettingsWorkspaceNavGraph(
             appGraph = appGraph,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/SettingsRootNavGraph.kt
@@ -13,6 +13,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.feature.review.reaction.TestAnimationsRoute
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 import com.flashcardsopensourceapp.feature.settings.SettingsRoute
 import com.flashcardsopensourceapp.feature.settings.TestSettingsRoute
 import com.flashcardsopensourceapp.feature.settings.createSettingsViewModelFactory
@@ -26,7 +27,8 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
     appGraph: AppGraph,
     navController: NavHostController,
     packageInfo: AppPackageInfo,
-    coroutineScope: CoroutineScope
+    coroutineScope: CoroutineScope,
+    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore
 ) {
     composable(route = SettingsDestination.route) { backStackEntry ->
         val context = LocalContext.current
@@ -160,6 +162,7 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
 
     composable(route = SettingsTestAnimationsDestination.route) {
         TestAnimationsRoute(
+            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
             onBack = {
                 navController.popBackStack()
             }

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -2,7 +2,6 @@ package com.flashcardsopensourceapp.feature.review
 
 import androidx.compose.material3.AlertDialog
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -28,9 +27,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.flashcardsopensourceapp.data.local.model.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.ReviewRating
 import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionEvent
+import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionOverlay
 import com.flashcardsopensourceapp.feature.review.reaction.appendReviewReactionEvent
-import com.flashcardsopensourceapp.feature.review.reaction.makeRandomReviewReactionEvent
+import com.flashcardsopensourceapp.feature.review.reaction.makeRandomReadyReviewReactionEvent
 import com.flashcardsopensourceapp.feature.review.reaction.reviewReactionMaximumActiveEvents
 import com.flashcardsopensourceapp.feature.review.reaction.reviewReactionMotionModeFromAnimatorSettings
 import java.util.Locale
@@ -39,6 +39,7 @@ import java.util.Locale
 @Composable
 fun ReviewRoute(
     uiState: ReviewUiState,
+    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
     onSelectFilter: (ReviewFilter) -> Unit,
     onOpenPreview: () -> Unit,
     onOpenCurrentCard: (String) -> Unit,
@@ -85,9 +86,14 @@ fun ReviewRoute(
         )
     }
     fun emitReviewReaction(rating: ReviewRating): Unit {
+        val event: ReviewReactionEvent = makeRandomReadyReviewReactionEvent(
+            rating = rating,
+            configurationStore = reviewReactionLottieConfigurationStore
+        ) ?: return
+
         activeReviewReactionEvents = appendReviewReactionEvent(
             events = activeReviewReactionEvents,
-            event = makeRandomReviewReactionEvent(rating = rating),
+            event = event,
             maximumActiveEvents = reviewReactionMaximumActiveEvents
         )
     }
@@ -240,6 +246,7 @@ fun ReviewRoute(
                 modifier = Modifier.matchParentSize(),
                 events = activeReviewReactionEvents,
                 motionMode = reviewReactionMotionMode,
+                configurationStore = reviewReactionLottieConfigurationStore,
                 onEventFinished = { eventId ->
                     activeReviewReactionEvents = activeReviewReactionEvents.filter { event ->
                         event.id != eventId

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionLottieState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionLottieState.kt
@@ -1,0 +1,480 @@
+package com.flashcardsopensourceapp.feature.review.reaction
+
+import android.util.Log
+import androidx.annotation.RawRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.airbnb.lottie.LottieComposition
+import com.airbnb.lottie.compose.LottieCompositionResult
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.rememberLottieComposition
+import com.flashcardsopensourceapp.data.local.model.ReviewRating
+import com.flashcardsopensourceapp.feature.review.R
+
+private const val reviewReactionLogTag: String = "ReviewReaction"
+
+internal val reviewReactionLottieFallbackVariant: ReviewReactionVariant =
+    ReviewReactionVariant.FALLBACK_CROWN_BOUNCE
+
+class ReviewReactionLottieConfigurationStore internal constructor(
+    internal val configurations: Map<ReviewReactionVariant, ReviewReactionLottieConfiguration>
+) {
+    internal fun updateReadiness(
+        variant: ReviewReactionVariant,
+        readiness: ReviewReactionLottieReadiness
+    ) {
+        val configuration: ReviewReactionLottieConfiguration = configurations[variant]
+            ?: error("Review reaction Lottie configuration is missing. variant=${variant.debugIdentifier}")
+
+        configuration.readiness = readiness
+    }
+}
+
+internal sealed interface ReviewReactionLottieReadiness {
+    data class Ready(
+        val composition: LottieComposition
+    ) : ReviewReactionLottieReadiness
+
+    data object Pending : ReviewReactionLottieReadiness
+
+    data class Failed(
+        val error: Throwable
+    ) : ReviewReactionLottieReadiness
+}
+
+internal class ReviewReactionLottieConfiguration(
+    initialReadiness: ReviewReactionLottieReadiness,
+    val frameScale: Float,
+    val centerX: Float,
+    val centerY: Float
+) {
+    var readiness: ReviewReactionLottieReadiness by mutableStateOf(value = initialReadiness)
+        internal set
+}
+
+private data class ReviewReactionLottieAssetConfiguration(
+    val variant: ReviewReactionVariant,
+    @RawRes val rawResourceId: Int,
+    val assetName: String,
+    val frameScale: Float,
+    val centerX: Float,
+    val centerY: Float
+)
+
+private val reviewReactionLottieAssetConfigurations: List<ReviewReactionLottieAssetConfiguration> = listOf(
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_RAIN_CLOUD,
+        rawResourceId = R.raw.review_again_rain_cloud,
+        assetName = "review_again_rain_cloud",
+        frameScale = 0.62f,
+        centerX = 0.50f,
+        centerY = 0.44f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_TORNADO,
+        rawResourceId = R.raw.review_again_tornado,
+        assetName = "review_again_tornado",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.45f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_WIND_FACE,
+        rawResourceId = R.raw.review_again_wind_face,
+        assetName = "review_again_wind_face",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.45f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_SNOWFLAKE,
+        rawResourceId = R.raw.review_again_snowflake,
+        assetName = "review_again_snowflake",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.45f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_SNAIL_CRAWL,
+        rawResourceId = R.raw.review_again_snail,
+        assetName = "review_again_snail",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.48f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_TURTLE,
+        rawResourceId = R.raw.review_again_turtle,
+        assetName = "review_again_turtle",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_WILTED_FLOWER,
+        rawResourceId = R.raw.review_again_wilted_flower,
+        assetName = "review_again_wilted_flower",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_SPIDER,
+        rawResourceId = R.raw.review_again_spider,
+        assetName = "review_again_spider",
+        frameScale = 0.54f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_RAT,
+        rawResourceId = R.raw.review_again_rat,
+        assetName = "review_again_rat",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.AGAIN_WORM_WIGGLE,
+        rawResourceId = R.raw.review_again_worm,
+        assetName = "review_again_worm",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.52f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_TIGER,
+        rawResourceId = R.raw.review_hard_tiger,
+        assetName = "review_hard_tiger",
+        frameScale = 0.62f,
+        centerX = 0.50f,
+        centerY = 0.48f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_T_REX,
+        rawResourceId = R.raw.review_hard_t_rex,
+        assetName = "review_hard_t_rex",
+        frameScale = 0.62f,
+        centerX = 0.50f,
+        centerY = 0.48f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_SHARK,
+        rawResourceId = R.raw.review_hard_shark,
+        assetName = "review_hard_shark",
+        frameScale = 0.62f,
+        centerX = 0.50f,
+        centerY = 0.47f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_OX_CHARGE,
+        rawResourceId = R.raw.review_hard_ox,
+        assetName = "review_hard_ox",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_RACEHORSE_GALLOP,
+        rawResourceId = R.raw.review_hard_racehorse,
+        assetName = "review_hard_racehorse",
+        frameScale = 0.62f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_SNAKE,
+        rawResourceId = R.raw.review_hard_snake,
+        assetName = "review_hard_snake",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_VOLCANO_ERUPTION,
+        rawResourceId = R.raw.review_hard_volcano,
+        assetName = "review_hard_volcano",
+        frameScale = 0.64f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_SCORPION,
+        rawResourceId = R.raw.review_hard_scorpion,
+        assetName = "review_hard_scorpion",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_PAW_PRINTS,
+        rawResourceId = R.raw.review_hard_paw_prints,
+        assetName = "review_hard_paw_prints",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.HARD_ROOSTER,
+        rawResourceId = R.raw.review_hard_rooster,
+        assetName = "review_hard_rooster",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.48f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_OTTER,
+        rawResourceId = R.raw.review_good_otter,
+        assetName = "review_good_otter",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.48f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_OWL,
+        rawResourceId = R.raw.review_good_owl,
+        assetName = "review_good_owl",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.42f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_RABBIT,
+        rawResourceId = R.raw.review_good_rabbit,
+        assetName = "review_good_rabbit",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.47f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_SEAL,
+        rawResourceId = R.raw.review_good_seal,
+        assetName = "review_good_seal",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.47f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_SERVICE_DOG,
+        rawResourceId = R.raw.review_good_service_dog,
+        assetName = "review_good_service_dog",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.47f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_POODLE,
+        rawResourceId = R.raw.review_good_poodle,
+        assetName = "review_good_poodle",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.43f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_CHIMPANZEE,
+        rawResourceId = R.raw.review_good_chimpanzee,
+        assetName = "review_good_chimpanzee",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.46f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_WHALE,
+        rawResourceId = R.raw.review_good_whale,
+        assetName = "review_good_whale",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.42f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_PEACOCK,
+        rawResourceId = R.raw.review_good_peacock,
+        assetName = "review_good_peacock",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.42f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.GOOD_PIG,
+        rawResourceId = R.raw.review_good_pig,
+        assetName = "review_good_pig",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_SUNRISE,
+        rawResourceId = R.raw.review_easy_sunrise,
+        assetName = "review_easy_sunrise",
+        frameScale = 0.64f,
+        centerX = 0.50f,
+        centerY = 0.42f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_SUNRISE_OVER_MOUNTAINS,
+        rawResourceId = R.raw.review_easy_sunrise_over_mountains,
+        assetName = "review_easy_sunrise_over_mountains",
+        frameScale = 0.64f,
+        centerX = 0.50f,
+        centerY = 0.44f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_ROSE_BLOOM,
+        rawResourceId = R.raw.review_easy_rose,
+        assetName = "review_easy_rose",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_PEACE,
+        rawResourceId = R.raw.review_easy_peace,
+        assetName = "review_easy_peace",
+        frameScale = 0.56f,
+        centerX = 0.50f,
+        centerY = 0.48f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_PLANT,
+        rawResourceId = R.raw.review_easy_plant,
+        assetName = "review_easy_plant",
+        frameScale = 0.58f,
+        centerX = 0.50f,
+        centerY = 0.50f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_RAINBOW_STREAK,
+        rawResourceId = R.raw.review_easy_rainbow,
+        assetName = "review_easy_rainbow",
+        frameScale = 0.64f,
+        centerX = 0.50f,
+        centerY = 0.42f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_PHOENIX_RISE,
+        rawResourceId = R.raw.review_easy_phoenix,
+        assetName = "review_easy_phoenix",
+        frameScale = 0.64f,
+        centerX = 0.50f,
+        centerY = 0.42f
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant = ReviewReactionVariant.EASY_UNICORN_FLYBY,
+        rawResourceId = R.raw.review_easy_unicorn,
+        assetName = "review_easy_unicorn",
+        frameScale = 0.52f,
+        centerX = 0.56f,
+        centerY = 0.30f
+    )
+)
+
+@Composable
+fun rememberReviewReactionLottieConfigurationStore(): ReviewReactionLottieConfigurationStore {
+    val configurationStore: ReviewReactionLottieConfigurationStore =
+        remember { createReviewReactionLottieConfigurationStore() }
+
+    reviewReactionLottieAssetConfigurations.forEach { assetConfiguration: ReviewReactionLottieAssetConfiguration ->
+        val readiness: ReviewReactionLottieReadiness = rememberReviewReactionLottieReadiness(
+            assetConfiguration = assetConfiguration
+        )
+        SideEffect {
+            configurationStore.updateReadiness(
+                variant = assetConfiguration.variant,
+                readiness = readiness
+            )
+        }
+    }
+
+    return configurationStore
+}
+
+private fun createReviewReactionLottieConfigurationStore(): ReviewReactionLottieConfigurationStore {
+    val configurations: Map<ReviewReactionVariant, ReviewReactionLottieConfiguration> =
+        reviewReactionLottieAssetConfigurations.associate { assetConfiguration: ReviewReactionLottieAssetConfiguration ->
+            assetConfiguration.variant to ReviewReactionLottieConfiguration(
+                initialReadiness = ReviewReactionLottieReadiness.Pending,
+                frameScale = assetConfiguration.frameScale,
+                centerX = assetConfiguration.centerX,
+                centerY = assetConfiguration.centerY
+            )
+        }
+
+    return ReviewReactionLottieConfigurationStore(configurations = configurations)
+}
+
+@Composable
+private fun rememberReviewReactionLottieReadiness(
+    assetConfiguration: ReviewReactionLottieAssetConfiguration
+): ReviewReactionLottieReadiness {
+    val compositionResult: LottieCompositionResult = rememberLottieComposition(
+        spec = LottieCompositionSpec.RawRes(assetConfiguration.rawResourceId)
+    )
+    val composition: LottieComposition? = compositionResult.value
+    if (composition != null) {
+        return ReviewReactionLottieReadiness.Ready(composition = composition)
+    }
+
+    val compositionFailure: Throwable? = compositionResult.error
+    if (compositionFailure != null) {
+        LaunchedEffect(assetConfiguration.assetName, compositionFailure) {
+            logReviewReactionLottieWarning(
+                assetConfiguration = assetConfiguration,
+                error = compositionFailure
+            )
+        }
+        return ReviewReactionLottieReadiness.Failed(error = compositionFailure)
+    }
+
+    return ReviewReactionLottieReadiness.Pending
+}
+
+private fun logReviewReactionLottieWarning(
+    assetConfiguration: ReviewReactionLottieAssetConfiguration,
+    error: Throwable
+) {
+    Log.w(
+        reviewReactionLogTag,
+        "Review reaction Lottie asset failed to load. " +
+            "assetName=${assetConfiguration.assetName} rawResourceId=${assetConfiguration.rawResourceId}",
+        error
+    )
+}
+
+internal fun reviewReactionLottieConfiguration(
+    variant: ReviewReactionVariant,
+    configurationStore: ReviewReactionLottieConfigurationStore
+): ReviewReactionLottieConfiguration? {
+    return configurationStore.configurations[variant]
+}
+
+internal fun reviewReactionReadyVariants(
+    rating: ReviewRating,
+    configurationStore: ReviewReactionLottieConfigurationStore
+): Set<ReviewReactionVariant> {
+    return reviewReactionVariantDistributionEntries(rating = rating)
+        .mapNotNull { entry: ReviewReactionVariantDistributionEntry ->
+            val readiness: ReviewReactionLottieReadiness? =
+                configurationStore.configurations[entry.variant]?.readiness
+            if (readiness is ReviewReactionLottieReadiness.Ready) {
+                entry.variant
+            } else {
+                null
+            }
+        }
+        .toSet()
+}
+
+internal fun reviewReactionFallbackVariantForReadiness(
+    readiness: ReviewReactionLottieReadiness
+): ReviewReactionVariant? {
+    return when (readiness) {
+        is ReviewReactionLottieReadiness.Ready,
+        ReviewReactionLottieReadiness.Pending -> null
+        is ReviewReactionLottieReadiness.Failed -> reviewReactionLottieFallbackVariant
+    }
+}

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionOverlay.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionOverlay.kt
@@ -1,7 +1,5 @@
 package com.flashcardsopensourceapp.feature.review.reaction
 
-import android.util.Log
-import androidx.annotation.RawRes
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.LinearEasing
@@ -23,414 +21,21 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.Dp
 import com.airbnb.lottie.LottieComposition
 import com.airbnb.lottie.compose.LottieAnimation
-import com.airbnb.lottie.compose.LottieCompositionResult
-import com.airbnb.lottie.compose.LottieCompositionSpec
-import com.airbnb.lottie.compose.rememberLottieComposition
-import com.flashcardsopensourceapp.feature.review.R
 import kotlinx.coroutines.delay
 
 private const val reviewReactionAnimationMinimumProgress: Float = 0f
 private const val reviewReactionAnimationMaximumProgress: Float = 1f
 private const val reviewReactionCleanupExtraMillis: Long = 80L
-private const val reviewReactionLogTag: String = "ReviewReaction"
 private const val reviewReactionReducedMotionDrawingProgress: Float = 0.55f
-private val reviewReactionLottieFallbackVariant: ReviewReactionVariant =
-    ReviewReactionVariant.FALLBACK_CROWN_BOUNCE
-
-private data class ReviewReactionLottieAssetConfiguration(
-    val variant: ReviewReactionVariant,
-    @RawRes val rawResourceId: Int,
-    val assetName: String,
-    val frameScale: Float,
-    val centerX: Float,
-    val centerY: Float
-)
-
-private data class ReviewReactionLottieConfiguration(
-    val composition: LottieComposition?,
-    val frameScale: Float,
-    val centerX: Float,
-    val centerY: Float
-)
-
-private typealias ReviewReactionLottieCompositionStore = Map<ReviewReactionVariant, LottieComposition?>
-
-private val reviewReactionLottieAssetConfigurations: List<ReviewReactionLottieAssetConfiguration> = listOf(
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_RAIN_CLOUD,
-        rawResourceId = R.raw.review_again_rain_cloud,
-        assetName = "review_again_rain_cloud",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.44f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_TORNADO,
-        rawResourceId = R.raw.review_again_tornado,
-        assetName = "review_again_tornado",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.45f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_WIND_FACE,
-        rawResourceId = R.raw.review_again_wind_face,
-        assetName = "review_again_wind_face",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.45f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_SNOWFLAKE,
-        rawResourceId = R.raw.review_again_snowflake,
-        assetName = "review_again_snowflake",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.45f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_SNAIL_CRAWL,
-        rawResourceId = R.raw.review_again_snail,
-        assetName = "review_again_snail",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.48f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_TURTLE,
-        rawResourceId = R.raw.review_again_turtle,
-        assetName = "review_again_turtle",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_WILTED_FLOWER,
-        rawResourceId = R.raw.review_again_wilted_flower,
-        assetName = "review_again_wilted_flower",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_SPIDER,
-        rawResourceId = R.raw.review_again_spider,
-        assetName = "review_again_spider",
-        frameScale = 0.54f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_RAT,
-        rawResourceId = R.raw.review_again_rat,
-        assetName = "review_again_rat",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.AGAIN_WORM_WIGGLE,
-        rawResourceId = R.raw.review_again_worm,
-        assetName = "review_again_worm",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.52f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_TIGER,
-        rawResourceId = R.raw.review_hard_tiger,
-        assetName = "review_hard_tiger",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.48f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_T_REX,
-        rawResourceId = R.raw.review_hard_t_rex,
-        assetName = "review_hard_t_rex",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.48f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_SHARK,
-        rawResourceId = R.raw.review_hard_shark,
-        assetName = "review_hard_shark",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.47f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_OX_CHARGE,
-        rawResourceId = R.raw.review_hard_ox,
-        assetName = "review_hard_ox",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_RACEHORSE_GALLOP,
-        rawResourceId = R.raw.review_hard_racehorse,
-        assetName = "review_hard_racehorse",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_SNAKE,
-        rawResourceId = R.raw.review_hard_snake,
-        assetName = "review_hard_snake",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_VOLCANO_ERUPTION,
-        rawResourceId = R.raw.review_hard_volcano,
-        assetName = "review_hard_volcano",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_SCORPION,
-        rawResourceId = R.raw.review_hard_scorpion,
-        assetName = "review_hard_scorpion",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_PAW_PRINTS,
-        rawResourceId = R.raw.review_hard_paw_prints,
-        assetName = "review_hard_paw_prints",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.HARD_ROOSTER,
-        rawResourceId = R.raw.review_hard_rooster,
-        assetName = "review_hard_rooster",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.48f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_OTTER,
-        rawResourceId = R.raw.review_good_otter,
-        assetName = "review_good_otter",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.48f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_OWL,
-        rawResourceId = R.raw.review_good_owl,
-        assetName = "review_good_owl",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.42f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_RABBIT,
-        rawResourceId = R.raw.review_good_rabbit,
-        assetName = "review_good_rabbit",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.47f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_SEAL,
-        rawResourceId = R.raw.review_good_seal,
-        assetName = "review_good_seal",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.47f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_SERVICE_DOG,
-        rawResourceId = R.raw.review_good_service_dog,
-        assetName = "review_good_service_dog",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.47f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_POODLE,
-        rawResourceId = R.raw.review_good_poodle,
-        assetName = "review_good_poodle",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.43f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_CHIMPANZEE,
-        rawResourceId = R.raw.review_good_chimpanzee,
-        assetName = "review_good_chimpanzee",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.46f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_WHALE,
-        rawResourceId = R.raw.review_good_whale,
-        assetName = "review_good_whale",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.42f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_PEACOCK,
-        rawResourceId = R.raw.review_good_peacock,
-        assetName = "review_good_peacock",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.42f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.GOOD_PIG,
-        rawResourceId = R.raw.review_good_pig,
-        assetName = "review_good_pig",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_SUNRISE,
-        rawResourceId = R.raw.review_easy_sunrise,
-        assetName = "review_easy_sunrise",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.42f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_SUNRISE_OVER_MOUNTAINS,
-        rawResourceId = R.raw.review_easy_sunrise_over_mountains,
-        assetName = "review_easy_sunrise_over_mountains",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.44f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_ROSE_BLOOM,
-        rawResourceId = R.raw.review_easy_rose,
-        assetName = "review_easy_rose",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_PEACE,
-        rawResourceId = R.raw.review_easy_peace,
-        assetName = "review_easy_peace",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.48f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_PLANT,
-        rawResourceId = R.raw.review_easy_plant,
-        assetName = "review_easy_plant",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_RAINBOW_STREAK,
-        rawResourceId = R.raw.review_easy_rainbow,
-        assetName = "review_easy_rainbow",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.42f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_PHOENIX_RISE,
-        rawResourceId = R.raw.review_easy_phoenix,
-        assetName = "review_easy_phoenix",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.42f
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant = ReviewReactionVariant.EASY_UNICORN_FLYBY,
-        rawResourceId = R.raw.review_easy_unicorn,
-        assetName = "review_easy_unicorn",
-        frameScale = 0.52f,
-        centerX = 0.56f,
-        centerY = 0.30f
-    )
-)
-
-private fun logReviewReactionLottieWarning(
-    assetName: String,
-    error: Throwable
-) {
-    Log.w(
-        reviewReactionLogTag,
-        "Review reaction Lottie asset failed to load. assetName=$assetName",
-        error
-    )
-}
-
-@Composable
-private fun rememberReviewReactionLottieComposition(
-    @RawRes rawResourceId: Int,
-    assetName: String
-): LottieComposition? {
-    val compositionResult: LottieCompositionResult = rememberLottieComposition(
-        spec = LottieCompositionSpec.RawRes(rawResourceId)
-    )
-    val compositionFailure: Throwable? = compositionResult.error
-    if (compositionFailure != null) {
-        LaunchedEffect(compositionFailure) {
-            logReviewReactionLottieWarning(
-                assetName = assetName,
-                error = compositionFailure
-            )
-        }
-    }
-
-    return if (compositionFailure == null) {
-        compositionResult.value
-    } else {
-        null
-    }
-}
-
-private fun reviewReactionLottieConfiguration(
-    variant: ReviewReactionVariant,
-    compositionStore: ReviewReactionLottieCompositionStore
-): ReviewReactionLottieConfiguration? {
-    val assetConfiguration: ReviewReactionLottieAssetConfiguration = reviewReactionLottieAssetConfigurations
-        .firstOrNull { configuration: ReviewReactionLottieAssetConfiguration ->
-            configuration.variant == variant
-        }
-        ?: return null
-
-    return ReviewReactionLottieConfiguration(
-        composition = compositionStore[variant],
-        frameScale = assetConfiguration.frameScale,
-        centerX = assetConfiguration.centerX,
-        centerY = assetConfiguration.centerY
-    )
-}
 
 @Composable
 internal fun ReviewReactionOverlay(
     modifier: Modifier,
     events: List<ReviewReactionEvent>,
     motionMode: ReviewReactionMotionMode,
+    configurationStore: ReviewReactionLottieConfigurationStore,
     onEventFinished: (String) -> Unit
 ) {
-    val compositionStore: ReviewReactionLottieCompositionStore = reviewReactionLottieAssetConfigurations.associate {
-        assetConfiguration: ReviewReactionLottieAssetConfiguration ->
-        assetConfiguration.variant to rememberReviewReactionLottieComposition(
-            rawResourceId = assetConfiguration.rawResourceId,
-            assetName = assetConfiguration.assetName
-        )
-    }
-
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -441,7 +46,7 @@ internal fun ReviewReactionOverlay(
                 ReviewReactionCanvas(
                     event = event,
                     motionMode = motionMode,
-                    compositionStore = compositionStore,
+                    configurationStore = configurationStore,
                     onEventFinished = onEventFinished
                 )
             }
@@ -453,38 +58,72 @@ internal fun ReviewReactionOverlay(
 private fun ReviewReactionCanvas(
     event: ReviewReactionEvent,
     motionMode: ReviewReactionMotionMode,
-    compositionStore: ReviewReactionLottieCompositionStore,
+    configurationStore: ReviewReactionLottieConfigurationStore,
     onEventFinished: (String) -> Unit
 ) {
-    val initialLottieConfiguration: ReviewReactionLottieConfiguration? = remember(event.id, event.variant) {
-        reviewReactionLottieConfiguration(
-            variant = event.variant,
-            compositionStore = compositionStore
-        )
-    }
-    if (initialLottieConfiguration != null) {
-        val composition: LottieComposition? = initialLottieConfiguration.composition
-        if (composition != null) {
-            ReviewReactionLottieAnimation(
-                event = event,
-                motionMode = motionMode,
-                composition = composition,
-                frameScale = initialLottieConfiguration.frameScale,
-                centerX = initialLottieConfiguration.centerX,
-                centerY = initialLottieConfiguration.centerY,
-                onEventFinished = onEventFinished
-            )
-            return
+    val lottieConfiguration: ReviewReactionLottieConfiguration? = reviewReactionLottieConfiguration(
+        variant = event.variant,
+        configurationStore = configurationStore
+    )
+    if (lottieConfiguration != null) {
+        when (val readiness: ReviewReactionLottieReadiness = lottieConfiguration.readiness) {
+            is ReviewReactionLottieReadiness.Ready -> {
+                ReviewReactionLottieAnimation(
+                    event = event,
+                    motionMode = motionMode,
+                    composition = readiness.composition,
+                    frameScale = lottieConfiguration.frameScale,
+                    centerX = lottieConfiguration.centerX,
+                    centerY = lottieConfiguration.centerY,
+                    onEventFinished = onEventFinished
+                )
+                return
+            }
+
+            ReviewReactionLottieReadiness.Pending -> {
+                ReviewReactionSkippedEvent(
+                    event = event,
+                    onEventFinished = onEventFinished
+                )
+                return
+            }
+
+            is ReviewReactionLottieReadiness.Failed -> {
+                ReviewReactionDrawnAnimation(
+                    event = event.copy(variant = reviewReactionLottieFallbackVariant),
+                    motionMode = motionMode,
+                    onEventFinished = onEventFinished
+                )
+                return
+            }
         }
     }
 
-    val drawingEvent: ReviewReactionEvent = if (initialLottieConfiguration != null) {
-        event.copy(variant = reviewReactionLottieFallbackVariant)
-    } else {
-        event
+    ReviewReactionDrawnAnimation(
+        event = event,
+        motionMode = motionMode,
+        onEventFinished = onEventFinished
+    )
+}
+
+@Composable
+private fun ReviewReactionSkippedEvent(
+    event: ReviewReactionEvent,
+    onEventFinished: (String) -> Unit
+) {
+    LaunchedEffect(event.id) {
+        onEventFinished(event.id)
     }
+}
+
+@Composable
+private fun ReviewReactionDrawnAnimation(
+    event: ReviewReactionEvent,
+    motionMode: ReviewReactionMotionMode,
+    onEventFinished: (String) -> Unit
+) {
     val durationMillis: Int = reviewReactionAnimationDurationMillis(
-        variant = drawingEvent.variant,
+        variant = event.variant,
         motionMode = motionMode
     )
 
@@ -502,7 +141,7 @@ private fun ReviewReactionCanvas(
                 }
         ) {
             drawReviewReaction(
-                event = drawingEvent,
+                event = event,
                 progress = reviewReactionReducedMotionDrawingProgress,
                 motionMode = motionMode
             )
@@ -539,7 +178,7 @@ private fun ReviewReactionCanvas(
             }
     ) {
         drawReviewReaction(
-            event = drawingEvent,
+            event = event,
             progress = drawingProgress,
             motionMode = motionMode
         )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionState.kt
@@ -215,6 +215,80 @@ internal fun selectReviewReactionVariant(
     )
 }
 
+internal fun selectReadyReviewReactionVariant(
+    rating: ReviewRating,
+    preferredVariant: ReviewReactionVariant,
+    readyVariants: Set<ReviewReactionVariant>,
+    replacementRoll: Int
+): ReviewReactionVariant? {
+    val readyEntries: List<ReviewReactionVariantDistributionEntry> =
+        reviewReactionReadyDistributionEntries(
+            rating = rating,
+            readyVariants = readyVariants
+        )
+    val hasReadyPreferredVariant: Boolean = readyEntries.any { entry: ReviewReactionVariantDistributionEntry ->
+        entry.variant == preferredVariant
+    }
+    if (hasReadyPreferredVariant) {
+        return preferredVariant
+    }
+
+    if (readyEntries.isEmpty()) {
+        return null
+    }
+
+    val totalReadyWeight: Int = readyEntries.sumOf { entry: ReviewReactionVariantDistributionEntry ->
+        entry.weight
+    }
+    require(replacementRoll in 0 until totalReadyWeight) {
+        "Review reaction replacement roll must be in 0 until $totalReadyWeight, received $replacementRoll."
+    }
+
+    var cumulativeWeight = 0
+    for (entry in readyEntries) {
+        cumulativeWeight += entry.weight
+        if (replacementRoll < cumulativeWeight) {
+            return entry.variant
+        }
+    }
+
+    error(
+        "Ready review reaction distribution is missing a variant. " +
+            "rating=${rating.reviewReactionDebugIdentifier} replacementRoll=$replacementRoll"
+    )
+}
+
+private fun reviewReactionReadyDistributionEntries(
+    rating: ReviewRating,
+    readyVariants: Set<ReviewReactionVariant>
+): List<ReviewReactionVariantDistributionEntry> {
+    return reviewReactionVariantDistributionEntries(rating = rating)
+        .filter { entry: ReviewReactionVariantDistributionEntry ->
+            entry.variant in readyVariants
+        }
+}
+
+internal fun makeReviewReactionEventForReadyVariants(
+    id: String,
+    rating: ReviewRating,
+    preferredVariant: ReviewReactionVariant,
+    readyVariants: Set<ReviewReactionVariant>,
+    replacementRoll: Int
+): ReviewReactionEvent? {
+    val variant: ReviewReactionVariant = selectReadyReviewReactionVariant(
+        rating = rating,
+        preferredVariant = preferredVariant,
+        readyVariants = readyVariants,
+        replacementRoll = replacementRoll
+    ) ?: return null
+
+    return ReviewReactionEvent(
+        id = id,
+        rating = rating,
+        variant = variant
+    )
+}
+
 internal fun appendReviewReactionEvent(
     events: List<ReviewReactionEvent>,
     event: ReviewReactionEvent,
@@ -240,13 +314,47 @@ internal fun reviewReactionMotionModeFromAnimatorSettings(): ReviewReactionMotio
     }
 }
 
-internal fun makeRandomReviewReactionEvent(rating: ReviewRating): ReviewReactionEvent {
+internal fun makeRandomReadyReviewReactionEvent(
+    rating: ReviewRating,
+    configurationStore: ReviewReactionLottieConfigurationStore
+): ReviewReactionEvent? {
     val totalWeight: Int = reviewReactionVariantTotalWeight(rating = rating)
-    val roll: Int = Random.nextInt(from = 0, until = totalWeight)
-    return ReviewReactionEvent(
+    val preferredRoll: Int = Random.nextInt(from = 0, until = totalWeight)
+    val preferredVariant: ReviewReactionVariant = selectReviewReactionVariant(
+        rating = rating,
+        roll = preferredRoll
+    )
+    val readyVariants: Set<ReviewReactionVariant> = reviewReactionReadyVariants(
+        rating = rating,
+        configurationStore = configurationStore
+    )
+    val readyEntries: List<ReviewReactionVariantDistributionEntry> =
+        reviewReactionReadyDistributionEntries(
+            rating = rating,
+            readyVariants = readyVariants
+        )
+    if (readyEntries.isEmpty()) {
+        return null
+    }
+
+    val isPreferredVariantReady: Boolean = readyEntries.any { entry: ReviewReactionVariantDistributionEntry ->
+        entry.variant == preferredVariant
+    }
+    val replacementRoll: Int = if (isPreferredVariantReady) {
+        0
+    } else {
+        val totalReadyWeight: Int = readyEntries.sumOf { entry: ReviewReactionVariantDistributionEntry ->
+            entry.weight
+        }
+        Random.nextInt(from = 0, until = totalReadyWeight)
+    }
+
+    return makeReviewReactionEventForReadyVariants(
         id = UUID.randomUUID().toString(),
         rating = rating,
-        variant = selectReviewReactionVariant(rating = rating, roll = roll)
+        preferredVariant = preferredVariant,
+        readyVariants = readyVariants,
+        replacementRoll = replacementRoll
     )
 }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/TestAnimationsRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/TestAnimationsRoute.kt
@@ -47,6 +47,7 @@ private val testAnimationRatingOrder: List<ReviewRating> = listOf(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TestAnimationsRoute(
+    reviewReactionLottieConfigurationStore: ReviewReactionLottieConfigurationStore,
     onBack: () -> Unit
 ) {
     var activeReviewReactionEvents by remember {
@@ -117,6 +118,7 @@ fun TestAnimationsRoute(
                 modifier = Modifier.fillMaxSize(),
                 events = activeReviewReactionEvents,
                 motionMode = reviewReactionMotionMode,
+                configurationStore = reviewReactionLottieConfigurationStore,
                 onEventFinished = { eventId: String ->
                     activeReviewReactionEvents = activeReviewReactionEvents.filter { event: ReviewReactionEvent ->
                         event.id != eventId

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionVariantSelectionTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionVariantSelectionTest.kt
@@ -2,6 +2,7 @@ package com.flashcardsopensourceapp.feature.review.reaction
 
 import com.flashcardsopensourceapp.data.local.model.ReviewRating
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 private data class ExpectedReviewReactionDistribution(
@@ -137,6 +138,63 @@ class ReviewReactionVariantSelectionTest {
         )
 
         assertEquals(listOf(secondEvent, thirdEvent, fourthEvent), result)
+    }
+
+    @Test
+    fun pendingCompositionDoesNotUseCrownFallback() {
+        assertNull(
+            reviewReactionFallbackVariantForReadiness(
+                readiness = ReviewReactionLottieReadiness.Pending
+            )
+        )
+    }
+
+    @Test
+    fun failedCompositionUsesCrownFallback() {
+        assertEquals(
+            ReviewReactionVariant.FALLBACK_CROWN_BOUNCE,
+            reviewReactionFallbackVariantForReadiness(
+                readiness = ReviewReactionLottieReadiness.Failed(
+                    error = IllegalStateException("Missing test composition.")
+                )
+            )
+        )
+    }
+
+    @Test
+    fun readySelectionSkipsEventWhenRatingHasNoReadyVariants() {
+        assertNull(
+            makeReviewReactionEventForReadyVariants(
+                id = "reaction-1",
+                rating = ReviewRating.GOOD,
+                preferredVariant = ReviewReactionVariant.GOOD_OWL,
+                readyVariants = emptySet(),
+                replacementRoll = 0
+            )
+        )
+    }
+
+    @Test
+    fun readySelectionReplacesUnavailablePreferredVariantWithReadyVariant() {
+        val result: ReviewReactionEvent? = makeReviewReactionEventForReadyVariants(
+            id = "reaction-1",
+            rating = ReviewRating.AGAIN,
+            preferredVariant = ReviewReactionVariant.AGAIN_RAIN_CLOUD,
+            readyVariants = setOf(
+                ReviewReactionVariant.AGAIN_TURTLE,
+                ReviewReactionVariant.AGAIN_WORM_WIGGLE
+            ),
+            replacementRoll = 16
+        )
+
+        assertEquals(
+            makeTestReactionEvent(
+                id = "reaction-1",
+                rating = ReviewRating.AGAIN,
+                variant = ReviewReactionVariant.AGAIN_WORM_WIGGLE
+            ),
+            result
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Prewarm Android review reaction Lottie compositions after app startup reaches Ready.
- Pass the prewarmed readiness store through app navigation into review and animation test routes.
- Create decorative reaction events only for ready variants and keep crown fallback limited to failed composition loads.

## Validation
- git --no-pager diff --check
- git --no-pager diff --no-index --check /dev/null apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionLottieState.kt

Gradle was not run locally because this repository treats local Gradle runs as heavy and requires separate permission.