### PR TITLE
[codex] Implement web review Lottie prewarm

### DIFF
--- a/apps/web/src/screens/review/ReviewScreen.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.tsx
@@ -1,10 +1,11 @@
-import type { ReactElement } from "react";
+import { useEffect, type ReactElement } from "react";
 import { ReviewEditorModal } from "./components/ReviewEditorModal";
 import { ReviewPane } from "./components/ReviewPane";
 import { ReviewQueuePanel } from "./components/ReviewQueuePanel";
 import { ReviewScreenHeader } from "./components/ReviewScreenHeader";
 import { ReviewHardReminderDialog } from "./hardReminder/ReviewHardReminderDialog";
 import { ReviewRatingReactionLayer } from "./reactions/ReviewRatingReactionLayer";
+import { startReviewReactionLottiePrewarm } from "./reactions/reviewReactionLottie";
 import { useReviewScreenController } from "./useReviewScreenController";
 
 export { normalizeReviewMarkdownForWeb } from "./components/ReviewCardSide";
@@ -19,6 +20,10 @@ export function ReviewScreen(): ReactElement {
     reviewReactionFallbackHandler,
     reviewReactionEvents,
   } = useReviewScreenController();
+
+  useEffect(() => {
+    startReviewReactionLottiePrewarm();
+  }, []);
 
   return (
     <main className="container" data-testid="review-screen">

--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "./reviewReaction";
 import { ReviewRatingReactionLayer } from "./ReviewRatingReactionLayer";
 import {
+  loadReviewReactionLottieAsset,
   loadReviewReactionLottieAssets,
   reviewReactionLottieFallbackVariant,
   resetReviewReactionLottieStateForTests,
@@ -134,6 +135,58 @@ function makeDeferredReviewReactionLottieResponse(): DeferredReviewReactionLotti
   };
 }
 
+function makeLoadedReviewReactionLottieAnimationItem(): object {
+  return {
+    addEventListener: vi.fn((_eventName: string, _listener: () => void): (() => void) => vi.fn()),
+    destroy: vi.fn(),
+    goToAndStop: vi.fn(),
+    isLoaded: true,
+    play: vi.fn(),
+    setSpeed: vi.fn(),
+    totalFrames: 100,
+  };
+}
+
+function makeFailingPlaybackReviewReactionLottieAnimationItem(): object {
+  const listenersByEventName = new Map<string, Array<() => void>>();
+  let isDestroyed = false;
+  const emitEvent = (eventName: string): void => {
+    for (const listener of listenersByEventName.get(eventName) ?? []) {
+      listener();
+    }
+  };
+
+  return {
+    addEventListener: vi.fn((eventName: string, listener: () => void): (() => void) => {
+      const listeners = listenersByEventName.get(eventName) ?? [];
+      listeners.push(listener);
+      listenersByEventName.set(eventName, listeners);
+      return () => {
+        if (isDestroyed) {
+          throw new Error("Lottie listener was removed after destroy.");
+        }
+
+        listenersByEventName.set(
+          eventName,
+          listeners.filter((existingListener) => existingListener !== listener),
+        );
+      };
+    }),
+    destroy: vi.fn(() => {
+      isDestroyed = true;
+    }),
+    goToAndStop: vi.fn(() => {
+      emitEvent("error");
+    }),
+    isLoaded: true,
+    play: vi.fn(() => {
+      emitEvent("error");
+    }),
+    setSpeed: vi.fn(),
+    totalFrames: 100,
+  };
+}
+
 describe("ReviewRatingReactionLayer Lottie fallback", () => {
   let container: HTMLDivElement | null = null;
   let root: ReactDOM.Root | null = null;
@@ -143,14 +196,15 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
     vi.useFakeTimers();
     resetReviewReactionLottieStateForTests();
     loadAnimationMock.mockReset();
-    loadAnimationMock.mockImplementation(() => {
-      throw new Error("Lottie render failed.");
-    });
+    loadAnimationMock.mockImplementation(() => makeLoadedReviewReactionLottieAnimationItem());
     vi.stubGlobal("fetch", vi.fn((_input: RequestInfo | URL): Promise<Response> => (
       Promise.resolve(makeReviewReactionLottieResponse())
     )));
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000101");
+    vi.spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000101")
+      .mockReturnValueOnce("00000000-0000-4000-8000-000000000102")
+      .mockReturnValue("00000000-0000-4000-8000-000000000103");
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
     container = document.createElement("div");
@@ -217,6 +271,15 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
     return eventElement;
   }
 
+  function queryReactionEventElement(): HTMLElement | null {
+    const currentContainer = container;
+    if (currentContainer === null) {
+      throw new Error("Review reaction test container is not ready.");
+    }
+
+    return currentContainer.querySelector<HTMLElement>("[data-testid='review-rating-reaction-event']");
+  }
+
   function queryCrownFallbackArtElement(): SVGSVGElement | null {
     const currentContainer = container;
     if (currentContainer === null) {
@@ -235,7 +298,7 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
     return fallbackArtElement;
   }
 
-  async function emitReactionAfterLottieRenderFailure(
+  async function emitReactionAfterLottiePlaybackFailure(
     rating: 0 | 1 | 2 | 3,
     randomValue: number,
   ): Promise<void> {
@@ -246,25 +309,11 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
     });
   }
 
-  it("shows the crown fallback while a cold Lottie asset is still loading", async () => {
+  it("does not show the crown fallback while a cold Lottie asset is still loading", async () => {
     installReviewReactionMotionPreference(false);
     const deferredResponse = makeDeferredReviewReactionLottieResponse();
-    let emitDomLoaded: (() => void) | null = null;
-
     vi.mocked(fetch).mockImplementation((_input: RequestInfo | URL): Promise<Response> => deferredResponse.promise);
-    loadAnimationMock.mockImplementation(() => ({
-      addEventListener: vi.fn((_eventName: string, listener: () => void): (() => void) => {
-        emitDomLoaded = listener;
-        return () => {
-          emitDomLoaded = null;
-        };
-      }),
-      destroy: vi.fn(),
-      goToAndStop: vi.fn(),
-      isLoaded: false,
-      setSpeed: vi.fn(),
-      totalFrames: 100,
-    }));
+    const loadingAssetPromise = loadReviewReactionLottieAsset("easySunrise");
 
     await renderHarness({ shouldPreloadLottieAssets: false });
 
@@ -274,47 +323,35 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
       await flushReactionPromises();
     });
 
-    expect(requireReactionEventElement().dataset.reviewReactionVariant).toBe("easySunrise");
-    expect(requireCrownFallbackArtElement()).toBeInstanceOf(SVGSVGElement);
+    expect(requireLatestResult().events).toHaveLength(0);
+    expect(queryReactionEventElement()).toBeNull();
+    expect(queryCrownFallbackArtElement()).toBeNull();
     expect(loadAnimationMock).not.toHaveBeenCalled();
 
     deferredResponse.resolve(makeReviewReactionLottieResponse());
     await act(async () => {
+      await loadingAssetPromise;
       await flushReactionPromises();
     });
-
-    expect(loadAnimationMock).toHaveBeenCalledTimes(1);
-    expect(requireCrownFallbackArtElement()).toBeInstanceOf(SVGSVGElement);
-
-    const currentEmitDomLoaded = emitDomLoaded;
-    if (currentEmitDomLoaded === null) {
-      throw new Error("Review reaction Lottie DOMLoaded listener was not registered.");
-    }
-
-    await act(async () => {
-      currentEmitDomLoaded();
-      await flushReactionPromises();
-    });
-
-    expect(queryCrownFallbackArtElement()).toBeNull();
   });
 
   for (const expectation of lottieFailureExpectations) {
-    it(`converts ${expectation.variant} render failures to the crown fallback duration`, async () => {
+    it(`converts ${expectation.variant} playback error events to the crown fallback duration`, async () => {
       installReviewReactionMotionPreference(false);
+      loadAnimationMock.mockImplementation(() => makeFailingPlaybackReviewReactionLottieAnimationItem());
       await renderHarness({ shouldPreloadLottieAssets: true });
 
-      await emitReactionAfterLottieRenderFailure(expectation.rating, expectation.randomValue);
+      await emitReactionAfterLottiePlaybackFailure(expectation.rating, expectation.randomValue);
 
-      expect(loadAnimationMock).toHaveBeenCalledTimes(1);
       expect(requireLatestResult().events).toEqual([
         {
-          id: "00000000-0000-4000-8000-000000000101",
+          id: "00000000-0000-4000-8000-000000000102",
           rating: makeReviewReactionRating(expectation.rating),
           variant: reviewReactionLottieFallbackVariant,
         },
       ]);
       expect(requireReactionEventElement().dataset.reviewReactionVariant).toBe(reviewReactionLottieFallbackVariant);
+      expect(requireCrownFallbackArtElement()).toBeInstanceOf(SVGSVGElement);
 
       await act(async () => {
         vi.advanceTimersByTime(1729);
@@ -330,11 +367,12 @@ describe("ReviewRatingReactionLayer Lottie fallback", () => {
     });
   }
 
-  it("keeps reduced-motion cleanup at 400ms after Lottie render fallback", async () => {
+  it("keeps reduced-motion cleanup at 400ms after Lottie playback error fallback", async () => {
     installReviewReactionMotionPreference(true);
+    loadAnimationMock.mockImplementation(() => makeFailingPlaybackReviewReactionLottieAnimationItem());
     await renderHarness({ shouldPreloadLottieAssets: true });
 
-    await emitReactionAfterLottieRenderFailure(3, 0.5);
+    await emitReactionAfterLottiePlaybackFailure(3, 0.5);
 
     expect(requireReactionEventElement().dataset.reviewReactionVariant).toBe(reviewReactionLottieFallbackVariant);
 

--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactElement } from "react";
+import { useEffect, useRef, type CSSProperties, type ReactElement } from "react";
 import type { AnimationItem } from "lottie-web";
 import {
   matchesReducedReviewReactionMotion,
@@ -8,8 +8,9 @@ import {
 } from "./reviewReaction";
 import {
   isReviewReactionLottieVariant,
-  loadReviewReactionLottieAsset,
+  mountReservedReviewReactionLottieRender,
   reviewReactionLottieFallbackVariant,
+  unmountReservedReviewReactionLottieRender,
   type ReviewReactionLottieVariant,
 } from "./reviewReactionLottie";
 
@@ -24,7 +25,7 @@ type ReviewReactionStyle = CSSProperties & Readonly<{
 
 const reviewReactionLottieReducedMotionProgress: number = 0.55;
 
-type ReviewReactionLottieFailurePhase = "render";
+type ReviewReactionLottieFailurePhase = "render" | "playback";
 type ReviewReactionLottieContainerClassMap = Readonly<Record<ReviewReactionLottieVariant, string>>;
 
 const reviewReactionLottieContainerClassByVariant: ReviewReactionLottieContainerClassMap = {
@@ -169,20 +170,12 @@ function EasyCrownBounceReaction(): ReactElement {
   );
 }
 
-function ReviewReactionCrownFallbackArt(): ReactElement {
-  return (
-    <svg className="review-rating-reaction-art review-rating-reaction-crown-fallback-art" viewBox="0 0 100 100" focusable="false">
-      {renderReviewReactionVariant(reviewReactionLottieFallbackVariant)}
-    </svg>
-  );
-}
-
 function reportReviewReactionLottieFailure(
   error: unknown,
   phase: ReviewReactionLottieFailurePhase,
   variant: ReviewReactionLottieVariant | null,
 ): void {
-  console.warn("Review reaction Lottie asset failed to load.", {
+  console.warn("Review reaction Lottie render failed.", {
     error,
     phase,
     variant,
@@ -198,11 +191,8 @@ type ReviewReactionLottieAnimationProps = Readonly<{
 function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps): ReactElement {
   const { eventId, onReactionEventFallback, variant } = props;
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [isAnimationReady, setIsAnimationReady] = useState<boolean>(false);
 
   useEffect(() => {
-    setIsAnimationReady(false);
-
     const mountedContainer = containerRef.current;
     if (mountedContainer === null) {
       reportReviewReactionLottieFailure(
@@ -213,75 +203,59 @@ function ReviewReactionLottieAnimation(props: ReviewReactionLottieAnimationProps
       onReactionEventFallback(eventId);
       return;
     }
-    const container: HTMLDivElement = mountedContainer;
 
-    let animationItem: AnimationItem | null = null;
-    let removeDomLoadedListener: (() => void) | null = null;
-    let isCancelled = false;
-    let hasMarkedAnimationReady = false;
-
-    async function loadReviewReactionLottieAnimation(): Promise<void> {
-      const asset = await loadReviewReactionLottieAsset(variant);
-
-      if (isCancelled) {
-        return;
-      }
-
-      const isReducedMotionEnabled = matchesReducedReviewReactionMotion();
-      const nextAnimationItem = asset.player.loadAnimation({
-        container,
-        renderer: "svg",
-        loop: false,
-        autoplay: !isReducedMotionEnabled,
-        animationData: asset.animationData,
-      });
-
-      animationItem = nextAnimationItem;
-      nextAnimationItem.setSpeed(reviewReactionLottiePlaybackSpeed(variant));
-
-      const markAnimationReady = (): void => {
-        if (isCancelled || hasMarkedAnimationReady) {
-          return;
-        }
-
-        hasMarkedAnimationReady = true;
-        if (isReducedMotionEnabled) {
-          nextAnimationItem.goToAndStop(
-            nextAnimationItem.totalFrames * reviewReactionLottieReducedMotionProgress,
-            true,
-          );
-        }
-
-        setIsAnimationReady(true);
-      };
-
-      removeDomLoadedListener = nextAnimationItem.addEventListener("DOMLoaded", markAnimationReady);
-      if (nextAnimationItem.isLoaded) {
-        markAnimationReady();
-      }
-    }
-
-    void loadReviewReactionLottieAnimation().catch((error: unknown) => {
-      if (isCancelled) {
-        return;
-      }
-
+    let animationItem: AnimationItem;
+    try {
+      animationItem = mountReservedReviewReactionLottieRender(eventId, variant, mountedContainer).animationItem;
+    } catch (error: unknown) {
       reportReviewReactionLottieFailure(error, "render", variant);
       onReactionEventFallback(eventId);
+      return;
+    }
+
+    let hasReportedFailure = false;
+    const handlePlaybackFailure = (error: unknown): void => {
+      if (hasReportedFailure) {
+        return;
+      }
+
+      hasReportedFailure = true;
+      reportReviewReactionLottieFailure(error, "playback", variant);
+      onReactionEventFallback(eventId);
+    };
+    const removeErrorListener = animationItem.addEventListener("error", () => {
+      handlePlaybackFailure(new Error(`Review reaction Lottie playback emitted error for variant ${variant}.`));
+    });
+    const removeDataFailedListener = animationItem.addEventListener("data_failed", () => {
+      handlePlaybackFailure(new Error(`Review reaction Lottie playback emitted data_failed for variant ${variant}.`));
     });
 
+    try {
+      animationItem.setSpeed(reviewReactionLottiePlaybackSpeed(variant));
+      if (matchesReducedReviewReactionMotion()) {
+        animationItem.goToAndStop(
+          animationItem.totalFrames * reviewReactionLottieReducedMotionProgress,
+          true,
+        );
+      } else {
+        animationItem.goToAndStop(0, true);
+        if (!hasReportedFailure) {
+          animationItem.play();
+        }
+      }
+    } catch (error: unknown) {
+      handlePlaybackFailure(error);
+    }
+
     return () => {
-      isCancelled = true;
-      removeDomLoadedListener?.();
-      animationItem?.destroy();
+      removeErrorListener();
+      removeDataFailedListener();
+      unmountReservedReviewReactionLottieRender(eventId);
     };
   }, [eventId, onReactionEventFallback, variant]);
 
   return (
-    <>
-      {isAnimationReady ? null : <ReviewReactionCrownFallbackArt />}
-      <div ref={containerRef} className={reviewReactionLottieContainerClassByVariant[variant]} />
-    </>
+    <div ref={containerRef} className={reviewReactionLottieContainerClassByVariant[variant]} />
   );
 }
 
@@ -349,8 +323,12 @@ function renderReviewReactionArt(
     );
   }
 
+  const artClassName = variant === reviewReactionLottieFallbackVariant
+    ? "review-rating-reaction-art review-rating-reaction-crown-fallback-art"
+    : "review-rating-reaction-art";
+
   return (
-    <svg className="review-rating-reaction-art" viewBox="0 0 100 100" focusable="false">
+    <svg className={artClassName} viewBox="0 0 100 100" focusable="false">
       {renderReviewReactionVariant(variant)}
     </svg>
   );

--- a/apps/web/src/screens/review/reactions/reviewReactionLottie.test.ts
+++ b/apps/web/src/screens/review/reactions/reviewReactionLottie.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReviewReactionLottieVariant } from "./reviewReactionLottie";
 
 const { lottiePlayerMock } = vi.hoisted(() => ({
@@ -12,9 +13,14 @@ vi.mock("lottie-web/build/player/lottie_light", () => ({
 }));
 
 type ReviewReactionLottieModule = typeof import("./reviewReactionLottie");
+type DeferredReviewReactionLottieSignal = Readonly<{
+  promise: Promise<void>;
+  resolve: () => void;
+}>;
 
 const failedVariant: ReviewReactionLottieVariant = "againWormWiggle";
 const readyVariant: ReviewReactionLottieVariant = "againTornado";
+const domLoadedVariant: ReviewReactionLottieVariant = "easySunrise";
 
 async function importReviewReactionLottieModule(): Promise<ReviewReactionLottieModule> {
   return import("./reviewReactionLottie");
@@ -29,8 +35,43 @@ function makeReviewReactionLottieResponse(animationData: object): Response {
   });
 }
 
+function makeDeferredReviewReactionLottieSignal(): DeferredReviewReactionLottieSignal {
+  let resolveSignal: (() => void) | null = null;
+  const promise = new Promise<void>((resolve) => {
+    resolveSignal = resolve;
+  });
+
+  if (resolveSignal === null) {
+    throw new Error("Review reaction Lottie test signal resolver was not initialized.");
+  }
+
+  return {
+    promise,
+    resolve: resolveSignal,
+  };
+}
+
+function makeLoadedReviewReactionLottieAnimationItem(): object {
+  return {
+    addEventListener: vi.fn((_eventName: string, _listener: () => void): (() => void) => vi.fn()),
+    destroy: vi.fn(),
+    goToAndStop: vi.fn(),
+    isLoaded: true,
+    play: vi.fn(),
+    setSpeed: vi.fn(),
+    totalFrames: 100,
+  };
+}
+
 describe("reviewReactionLottie", () => {
-  afterEach(() => {
+  beforeEach(() => {
+    lottiePlayerMock.loadAnimation.mockReset();
+    lottiePlayerMock.loadAnimation.mockImplementation(() => makeLoadedReviewReactionLottieAnimationItem());
+  });
+
+  afterEach(async () => {
+    const reviewReactionLottie = await importReviewReactionLottieModule();
+    reviewReactionLottie.resetReviewReactionLottieStateForTests();
     vi.unstubAllGlobals();
     vi.resetModules();
   });
@@ -68,6 +109,7 @@ describe("reviewReactionLottie", () => {
     expect(preloadResult.failures[0]?.variant).toBe(failedVariant);
     expect(preloadResult.failures[0]?.error).toBeInstanceOf(Error);
     expect(reviewReactionLottie.isReviewReactionLottieAssetReady(failedVariant)).toBe(false);
+    expect(reviewReactionLottie.reviewReactionLottieAssetFailure(failedVariant)).toBeInstanceOf(Error);
     expect(reviewReactionLottie.isReviewReactionLottieAssetReady(readyVariant)).toBe(true);
 
     const retriedAsset = await reviewReactionLottie.loadReviewReactionLottieAsset(failedVariant);
@@ -75,5 +117,123 @@ describe("reviewReactionLottie", () => {
     expect(failedVariantFetchCount).toBe(2);
     expect(retriedAsset.animationData).toEqual(retriedAnimationData);
     expect(reviewReactionLottie.isReviewReactionLottieAssetReady(failedVariant)).toBe(true);
+    expect(reviewReactionLottie.reviewReactionLottieAssetFailure(failedVariant)).toBeNull();
+  });
+
+  it("reuses in-flight prewarm work for repeated prewarm calls", async () => {
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL): Promise<Response> => (
+      Promise.resolve(makeReviewReactionLottieResponse({
+        layers: [],
+        v: input.toString(),
+      }))
+    )));
+
+    const reviewReactionLottie = await importReviewReactionLottieModule();
+    const [firstPreloadResult, secondPreloadResult] = await Promise.all([
+      reviewReactionLottie.prewarmReviewReactionLottieAssets(),
+      reviewReactionLottie.prewarmReviewReactionLottieAssets(),
+    ]);
+
+    expect(firstPreloadResult.failures).toHaveLength(0);
+    expect(secondPreloadResult.failures).toHaveLength(0);
+    expect(fetch).toHaveBeenCalledTimes(reviewReactionLottie.reviewReactionLottieVariants.length);
+    expect(lottiePlayerMock.loadAnimation).toHaveBeenCalledTimes(
+      reviewReactionLottie.reviewReactionLottieVariants.length,
+    );
+  });
+
+  it("marks a variant ready only after the offscreen Lottie render is prepared", async () => {
+    const domLoadedListenerRegistered = makeDeferredReviewReactionLottieSignal();
+    let emitDomLoaded: (() => void) | null = null;
+    lottiePlayerMock.loadAnimation.mockImplementation(() => ({
+      addEventListener: vi.fn((eventName: string, listener: () => void): (() => void) => {
+        if (eventName === "DOMLoaded") {
+          emitDomLoaded = listener;
+          domLoadedListenerRegistered.resolve();
+        }
+
+        return () => {
+          if (eventName === "DOMLoaded") {
+            emitDomLoaded = null;
+          }
+        };
+      }),
+      destroy: vi.fn(),
+      goToAndStop: vi.fn(),
+      isLoaded: false,
+      play: vi.fn(),
+      setSpeed: vi.fn(),
+      totalFrames: 100,
+    }));
+    vi.stubGlobal("fetch", vi.fn((_input: RequestInfo | URL): Promise<Response> => (
+      Promise.resolve(makeReviewReactionLottieResponse({
+        layers: [],
+        v: "dom-loaded",
+      }))
+    )));
+
+    const reviewReactionLottie = await importReviewReactionLottieModule();
+    const assetPromise = reviewReactionLottie.loadReviewReactionLottieAsset(domLoadedVariant);
+    await domLoadedListenerRegistered.promise;
+
+    expect(reviewReactionLottie.isReviewReactionLottieAssetReady(domLoadedVariant)).toBe(false);
+
+    const currentEmitDomLoaded = emitDomLoaded;
+    if (currentEmitDomLoaded === null) {
+      throw new Error("Review reaction Lottie DOMLoaded listener was not registered.");
+    }
+
+    currentEmitDomLoaded();
+    await assetPromise;
+
+    expect(reviewReactionLottie.isReviewReactionLottieAssetReady(domLoadedVariant)).toBe(true);
+  });
+
+  it("marks a variant failed when the offscreen Lottie render emits data_failed", async () => {
+    const dataFailedListenerRegistered = makeDeferredReviewReactionLottieSignal();
+    let emitDataFailed: (() => void) | null = null;
+    lottiePlayerMock.loadAnimation.mockImplementation(() => ({
+      addEventListener: vi.fn((eventName: string, listener: () => void): (() => void) => {
+        if (eventName === "data_failed") {
+          emitDataFailed = listener;
+          dataFailedListenerRegistered.resolve();
+        }
+
+        return () => {
+          if (eventName === "data_failed") {
+            emitDataFailed = null;
+          }
+        };
+      }),
+      destroy: vi.fn(),
+      goToAndStop: vi.fn(),
+      isLoaded: false,
+      play: vi.fn(),
+      setSpeed: vi.fn(),
+      totalFrames: 100,
+    }));
+    vi.stubGlobal("fetch", vi.fn((_input: RequestInfo | URL): Promise<Response> => (
+      Promise.resolve(makeReviewReactionLottieResponse({
+        layers: [],
+        v: "data-failed",
+      }))
+    )));
+
+    const reviewReactionLottie = await importReviewReactionLottieModule();
+    const assetPromise = reviewReactionLottie.loadReviewReactionLottieAsset(domLoadedVariant);
+    await dataFailedListenerRegistered.promise;
+
+    expect(reviewReactionLottie.isReviewReactionLottieAssetReady(domLoadedVariant)).toBe(false);
+
+    const currentEmitDataFailed = emitDataFailed;
+    if (currentEmitDataFailed === null) {
+      throw new Error("Review reaction Lottie data_failed listener was not registered.");
+    }
+
+    currentEmitDataFailed();
+
+    await expect(assetPromise).rejects.toThrow("Failed to prepare review reaction Lottie render instance");
+    expect(reviewReactionLottie.isReviewReactionLottieAssetReady(domLoadedVariant)).toBe(false);
+    expect(reviewReactionLottie.reviewReactionLottieAssetFailure(domLoadedVariant)).toBeInstanceOf(Error);
   });
 });

--- a/apps/web/src/screens/review/reactions/reviewReactionLottie.ts
+++ b/apps/web/src/screens/review/reactions/reviewReactionLottie.ts
@@ -1,4 +1,4 @@
-import type { LottiePlayer } from "lottie-web";
+import type { AnimationItem, LottiePlayer } from "lottie-web";
 import againRainCloudAnimationUrl from "../../../assets/review_again_rain_cloud.json?url";
 import againSnailCrawlAnimationUrl from "../../../assets/review_again_snail.json?url";
 import againSnowflakeAnimationUrl from "../../../assets/review_again_snowflake.json?url";
@@ -46,6 +46,9 @@ type ReviewReactionLottiePlayerModule = Readonly<{
 type ReviewReactionLottieAnimationLoader = () => Promise<object>;
 type ReviewReactionLottieAnimationDataByVariant = Record<ReviewReactionLottieVariant, object | null>;
 type ReviewReactionLottieAnimationPromiseByVariant = Record<ReviewReactionLottieVariant, Promise<object> | null>;
+type ReviewReactionLottiePreparedRenderByVariant = Record<ReviewReactionLottieVariant, ReviewReactionLottiePreparedRender | null>;
+type ReviewReactionLottiePreparedRenderPromiseByVariant = Record<ReviewReactionLottieVariant, Promise<ReviewReactionLottiePreparedRender> | null>;
+type ReviewReactionLottieFailureByVariant = Record<ReviewReactionLottieVariant, unknown | null>;
 
 export const reviewReactionLottieVariants = [
   "againRainCloud",
@@ -102,6 +105,18 @@ export type ReviewReactionLottieAssetFailure = Readonly<{
 
 export type ReviewReactionLottiePreloadResult = Readonly<{
   failures: ReadonlyArray<ReviewReactionLottieAssetFailure>;
+}>;
+
+export type ReviewReactionLottieMountedRender = Readonly<{
+  animationItem: AnimationItem;
+}>;
+
+type ReviewReactionLottiePreparedRender = Readonly<{
+  animationData: object;
+  animationItem: AnimationItem;
+  container: HTMLDivElement;
+  player: LottiePlayer;
+  variant: ReviewReactionLottieVariant;
 }>;
 
 const reviewReactionLottieVariantSet: ReadonlySet<ReviewReactionRenderableVariant> = new Set(
@@ -276,6 +291,135 @@ function makeEmptyReviewReactionLottieAnimationPromiseByVariant(): ReviewReactio
   };
 }
 
+function makeEmptyReviewReactionLottiePreparedRenderByVariant(): ReviewReactionLottiePreparedRenderByVariant {
+  return {
+    againRainCloud: null,
+    againTornado: null,
+    againWindFace: null,
+    againSnowflake: null,
+    againSnailCrawl: null,
+    againTurtle: null,
+    againWiltedFlower: null,
+    againSpider: null,
+    againRat: null,
+    againWormWiggle: null,
+    hardTiger: null,
+    hardTRex: null,
+    hardShark: null,
+    hardOxCharge: null,
+    hardRacehorseGallop: null,
+    hardSnake: null,
+    hardVolcanoEruption: null,
+    hardScorpion: null,
+    hardPawPrints: null,
+    hardRooster: null,
+    goodOtter: null,
+    goodOwl: null,
+    goodRabbit: null,
+    goodSeal: null,
+    goodServiceDog: null,
+    goodPoodle: null,
+    goodChimpanzee: null,
+    goodWhale: null,
+    goodPeacock: null,
+    goodPig: null,
+    easySunrise: null,
+    easySunriseOverMountains: null,
+    easyRoseBloom: null,
+    easyPeace: null,
+    easyPlant: null,
+    easyRainbowStreak: null,
+    easyPhoenixRise: null,
+    easyUnicornFlyby: null,
+  };
+}
+
+function makeEmptyReviewReactionLottiePreparedRenderPromiseByVariant(): ReviewReactionLottiePreparedRenderPromiseByVariant {
+  return {
+    againRainCloud: null,
+    againTornado: null,
+    againWindFace: null,
+    againSnowflake: null,
+    againSnailCrawl: null,
+    againTurtle: null,
+    againWiltedFlower: null,
+    againSpider: null,
+    againRat: null,
+    againWormWiggle: null,
+    hardTiger: null,
+    hardTRex: null,
+    hardShark: null,
+    hardOxCharge: null,
+    hardRacehorseGallop: null,
+    hardSnake: null,
+    hardVolcanoEruption: null,
+    hardScorpion: null,
+    hardPawPrints: null,
+    hardRooster: null,
+    goodOtter: null,
+    goodOwl: null,
+    goodRabbit: null,
+    goodSeal: null,
+    goodServiceDog: null,
+    goodPoodle: null,
+    goodChimpanzee: null,
+    goodWhale: null,
+    goodPeacock: null,
+    goodPig: null,
+    easySunrise: null,
+    easySunriseOverMountains: null,
+    easyRoseBloom: null,
+    easyPeace: null,
+    easyPlant: null,
+    easyRainbowStreak: null,
+    easyPhoenixRise: null,
+    easyUnicornFlyby: null,
+  };
+}
+
+function makeEmptyReviewReactionLottieFailureByVariant(): ReviewReactionLottieFailureByVariant {
+  return {
+    againRainCloud: null,
+    againTornado: null,
+    againWindFace: null,
+    againSnowflake: null,
+    againSnailCrawl: null,
+    againTurtle: null,
+    againWiltedFlower: null,
+    againSpider: null,
+    againRat: null,
+    againWormWiggle: null,
+    hardTiger: null,
+    hardTRex: null,
+    hardShark: null,
+    hardOxCharge: null,
+    hardRacehorseGallop: null,
+    hardSnake: null,
+    hardVolcanoEruption: null,
+    hardScorpion: null,
+    hardPawPrints: null,
+    hardRooster: null,
+    goodOtter: null,
+    goodOwl: null,
+    goodRabbit: null,
+    goodSeal: null,
+    goodServiceDog: null,
+    goodPoodle: null,
+    goodChimpanzee: null,
+    goodWhale: null,
+    goodPeacock: null,
+    goodPig: null,
+    easySunrise: null,
+    easySunriseOverMountains: null,
+    easyRoseBloom: null,
+    easyPeace: null,
+    easyPlant: null,
+    easyRainbowStreak: null,
+    easyPhoenixRise: null,
+    easyUnicornFlyby: null,
+  };
+}
+
 let reviewReactionLottiePlayerPromise: Promise<LottiePlayer> | null = null;
 let reviewReactionLottiePlayerReady = false;
 let reviewReactionLottieAnimationDataByVariant: ReviewReactionLottieAnimationDataByVariant = (
@@ -284,6 +428,22 @@ let reviewReactionLottieAnimationDataByVariant: ReviewReactionLottieAnimationDat
 let reviewReactionLottieAnimationPromiseByVariant: ReviewReactionLottieAnimationPromiseByVariant = (
   makeEmptyReviewReactionLottieAnimationPromiseByVariant()
 );
+let reviewReactionLottiePreparedRenderByVariant: ReviewReactionLottiePreparedRenderByVariant = (
+  makeEmptyReviewReactionLottiePreparedRenderByVariant()
+);
+let reviewReactionLottiePreparedRenderPromiseByVariant: ReviewReactionLottiePreparedRenderPromiseByVariant = (
+  makeEmptyReviewReactionLottiePreparedRenderPromiseByVariant()
+);
+let reviewReactionLottieFailureByVariant: ReviewReactionLottieFailureByVariant = (
+  makeEmptyReviewReactionLottieFailureByVariant()
+);
+let reviewReactionLottieReservedRenderByEventId: Map<string, ReviewReactionLottiePreparedRender> = (
+  new Map<string, ReviewReactionLottiePreparedRender>()
+);
+let reviewReactionLottieMountedRenderEventIds: Set<string> = new Set<string>();
+let reviewReactionLottieReleaseRequestedEventIds: Set<string> = new Set<string>();
+let reviewReactionLottieOffscreenRoot: HTMLDivElement | null = null;
+let reviewReactionLottieStateGeneration = 0;
 
 export const reviewReactionLottieFallbackVariant: ReviewReactionFallbackVariant = "fallbackCrownBounce";
 
@@ -294,14 +454,47 @@ export function isReviewReactionLottieVariant(
 }
 
 export function isReviewReactionLottieAssetReady(variant: ReviewReactionLottieVariant): boolean {
-  return reviewReactionLottiePlayerReady && reviewReactionLottieAnimationDataByVariant[variant] !== null;
+  return reviewReactionLottiePlayerReady && reviewReactionLottiePreparedRenderByVariant[variant] !== null;
+}
+
+export function reviewReactionLottieAssetFailure(variant: ReviewReactionLottieVariant): unknown | null {
+  return reviewReactionLottieFailureByVariant[variant];
 }
 
 export function resetReviewReactionLottieStateForTests(): void {
+  reviewReactionLottieStateGeneration += 1;
+  destroyReviewReactionLottiePreparedRenders(reviewReactionLottiePreparedRenderByVariant);
+  for (const preparedRender of reviewReactionLottieReservedRenderByEventId.values()) {
+    destroyReviewReactionLottiePreparedRender(preparedRender);
+  }
+  reviewReactionLottieOffscreenRoot?.remove();
+
   reviewReactionLottiePlayerPromise = null;
   reviewReactionLottiePlayerReady = false;
   reviewReactionLottieAnimationDataByVariant = makeEmptyReviewReactionLottieAnimationDataByVariant();
   reviewReactionLottieAnimationPromiseByVariant = makeEmptyReviewReactionLottieAnimationPromiseByVariant();
+  reviewReactionLottiePreparedRenderByVariant = makeEmptyReviewReactionLottiePreparedRenderByVariant();
+  reviewReactionLottiePreparedRenderPromiseByVariant = makeEmptyReviewReactionLottiePreparedRenderPromiseByVariant();
+  reviewReactionLottieFailureByVariant = makeEmptyReviewReactionLottieFailureByVariant();
+  reviewReactionLottieReservedRenderByEventId = new Map<string, ReviewReactionLottiePreparedRender>();
+  reviewReactionLottieMountedRenderEventIds = new Set<string>();
+  reviewReactionLottieReleaseRequestedEventIds = new Set<string>();
+  reviewReactionLottieOffscreenRoot = null;
+}
+
+function destroyReviewReactionLottiePreparedRenders(
+  preparedRenderByVariant: ReviewReactionLottiePreparedRenderByVariant,
+): void {
+  for (const preparedRender of Object.values(preparedRenderByVariant)) {
+    if (preparedRender !== null) {
+      destroyReviewReactionLottiePreparedRender(preparedRender);
+    }
+  }
+}
+
+function destroyReviewReactionLottiePreparedRender(preparedRender: ReviewReactionLottiePreparedRender): void {
+  preparedRender.animationItem.destroy();
+  preparedRender.container.remove();
 }
 
 function loadReviewReactionLottiePlayer(): Promise<LottiePlayer> {
@@ -309,14 +502,19 @@ function loadReviewReactionLottiePlayer(): Promise<LottiePlayer> {
     return reviewReactionLottiePlayerPromise;
   }
 
+  const generation = reviewReactionLottieStateGeneration;
   reviewReactionLottiePlayerPromise = import("lottie-web/build/player/lottie_light")
     .then((lottieModule: ReviewReactionLottiePlayerModule): LottiePlayer => {
-      reviewReactionLottiePlayerReady = true;
+      if (generation === reviewReactionLottieStateGeneration) {
+        reviewReactionLottiePlayerReady = true;
+      }
       return lottieModule.default;
     })
     .catch((error: unknown): never => {
-      reviewReactionLottiePlayerReady = false;
-      reviewReactionLottiePlayerPromise = null;
+      if (generation === reviewReactionLottieStateGeneration) {
+        reviewReactionLottiePlayerReady = false;
+        reviewReactionLottiePlayerPromise = null;
+      }
       throw error;
     });
 
@@ -411,31 +609,257 @@ function loadReviewReactionLottieAnimationData(variant: ReviewReactionLottieVari
   return animationDataPromise;
 }
 
-export async function loadReviewReactionLottieAsset(
+function requireReviewReactionLottieDocumentBody(): HTMLElement {
+  if (typeof document === "undefined" || document.body === null) {
+    throw new Error("Review reaction Lottie prewarm requires a mounted document body.");
+  }
+
+  return document.body;
+}
+
+function makeReviewReactionLottieOffscreenRoot(): HTMLDivElement {
+  const existingRoot = reviewReactionLottieOffscreenRoot;
+  if (existingRoot !== null && existingRoot.isConnected) {
+    return existingRoot;
+  }
+
+  const body = requireReviewReactionLottieDocumentBody();
+  const root = document.createElement("div");
+  root.setAttribute("aria-hidden", "true");
+  root.setAttribute("data-review-reaction-lottie-prewarm-root", "true");
+  root.style.position = "absolute";
+  root.style.width = "1px";
+  root.style.height = "1px";
+  root.style.overflow = "hidden";
+  root.style.left = "-10000px";
+  root.style.top = "-10000px";
+  root.style.opacity = "0";
+  root.style.pointerEvents = "none";
+  body.appendChild(root);
+  reviewReactionLottieOffscreenRoot = root;
+  return root;
+}
+
+function makeReviewReactionLottieOffscreenContainer(): HTMLDivElement {
+  const root = makeReviewReactionLottieOffscreenRoot();
+  const container = document.createElement("div");
+  root.appendChild(container);
+  return container;
+}
+
+function moveReviewReactionLottieRenderToOffscreenRoot(
+  preparedRender: ReviewReactionLottiePreparedRender,
+): void {
+  makeReviewReactionLottieOffscreenRoot().appendChild(preparedRender.container);
+}
+
+function makeReviewReactionLottieRenderEventError(
+  eventName: "data_failed" | "error",
   variant: ReviewReactionLottieVariant,
-): Promise<ReviewReactionLottieAsset> {
+): Error {
+  return new Error(
+    `Review reaction Lottie render instance for variant ${variant} emitted ${eventName}.`,
+  );
+}
+
+function waitForReviewReactionLottiePreparedRender(
+  animationItem: AnimationItem,
+  variant: ReviewReactionLottieVariant,
+): Promise<void> {
+  if (animationItem.isLoaded) {
+    return Promise.resolve();
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    let removeDomLoadedListener: (() => void) | null = null;
+    let removeDataFailedListener: (() => void) | null = null;
+    let removeErrorListener: (() => void) | null = null;
+    let hasSettled = false;
+
+    const removeListeners = (): void => {
+      removeDomLoadedListener?.();
+      removeDataFailedListener?.();
+      removeErrorListener?.();
+      removeDomLoadedListener = null;
+      removeDataFailedListener = null;
+      removeErrorListener = null;
+    };
+
+    const markRenderReady = (): void => {
+      if (hasSettled) {
+        return;
+      }
+
+      hasSettled = true;
+      removeListeners();
+      resolve();
+    };
+
+    const markRenderFailed = (eventName: "data_failed" | "error"): void => {
+      if (hasSettled) {
+        return;
+      }
+
+      hasSettled = true;
+      removeListeners();
+      reject(makeReviewReactionLottieRenderEventError(eventName, variant));
+    };
+
+    removeDomLoadedListener = animationItem.addEventListener("DOMLoaded", markRenderReady);
+    removeDataFailedListener = animationItem.addEventListener("data_failed", () => {
+      markRenderFailed("data_failed");
+    });
+    removeErrorListener = animationItem.addEventListener("error", () => {
+      markRenderFailed("error");
+    });
+    if (animationItem.isLoaded) {
+      markRenderReady();
+    }
+  });
+}
+
+async function makeReviewReactionLottiePreparedRender(
+  variant: ReviewReactionLottieVariant,
+): Promise<ReviewReactionLottiePreparedRender> {
   const [player, animationData] = await Promise.all([
     loadReviewReactionLottiePlayer(),
     loadReviewReactionLottieAnimationData(variant),
   ]);
+  const container = makeReviewReactionLottieOffscreenContainer();
+  let animationItem: AnimationItem;
+
+  try {
+    animationItem = player.loadAnimation({
+      container,
+      renderer: "svg",
+      loop: false,
+      autoplay: false,
+      animationData,
+    });
+  } catch (error: unknown) {
+    container.remove();
+    throw new Error(
+      `Failed to create review reaction Lottie render instance for variant ${variant}.`,
+      { cause: error },
+    );
+  }
+
+  try {
+    await waitForReviewReactionLottiePreparedRender(animationItem, variant);
+  } catch (error: unknown) {
+    animationItem.destroy();
+    container.remove();
+    throw new Error(
+      `Failed to prepare review reaction Lottie render instance for variant ${variant}.`,
+      { cause: error },
+    );
+  }
 
   return {
     animationData,
+    animationItem,
+    container,
     player,
+    variant,
   };
 }
 
-export async function loadReviewReactionLottieAssets(): Promise<ReviewReactionLottiePreloadResult> {
-  await loadReviewReactionLottiePlayer();
+function prewarmReviewReactionLottieVariant(
+  variant: ReviewReactionLottieVariant,
+): Promise<ReviewReactionLottiePreparedRender> {
+  const preparedRender = reviewReactionLottiePreparedRenderByVariant[variant];
+  if (preparedRender !== null) {
+    return Promise.resolve(preparedRender);
+  }
 
-  const settledAnimationData = await Promise.allSettled(
-    reviewReactionLottieVariants.map((variant) => loadReviewReactionLottieAnimationData(variant)),
+  const preparedRenderPromise = reviewReactionLottiePreparedRenderPromiseByVariant[variant];
+  if (preparedRenderPromise !== null) {
+    return preparedRenderPromise;
+  }
+
+  const generation = reviewReactionLottieStateGeneration;
+  const nextPreparedRenderPromise = makeReviewReactionLottiePreparedRender(variant)
+    .then((nextPreparedRender: ReviewReactionLottiePreparedRender): ReviewReactionLottiePreparedRender => {
+      if (generation !== reviewReactionLottieStateGeneration) {
+        destroyReviewReactionLottiePreparedRender(nextPreparedRender);
+        return nextPreparedRender;
+      }
+
+      reviewReactionLottiePreparedRenderByVariant = {
+        ...reviewReactionLottiePreparedRenderByVariant,
+        [variant]: nextPreparedRender,
+      };
+      reviewReactionLottiePreparedRenderPromiseByVariant = {
+        ...reviewReactionLottiePreparedRenderPromiseByVariant,
+        [variant]: null,
+      };
+      reviewReactionLottieFailureByVariant = {
+        ...reviewReactionLottieFailureByVariant,
+        [variant]: null,
+      };
+      return nextPreparedRender;
+    })
+    .catch((error: unknown): never => {
+      if (generation === reviewReactionLottieStateGeneration) {
+        reviewReactionLottiePreparedRenderByVariant = {
+          ...reviewReactionLottiePreparedRenderByVariant,
+          [variant]: null,
+        };
+        reviewReactionLottiePreparedRenderPromiseByVariant = {
+          ...reviewReactionLottiePreparedRenderPromiseByVariant,
+          [variant]: null,
+        };
+        reviewReactionLottieFailureByVariant = {
+          ...reviewReactionLottieFailureByVariant,
+          [variant]: error,
+        };
+      }
+      throw error;
+    });
+
+  reviewReactionLottiePreparedRenderPromiseByVariant = {
+    ...reviewReactionLottiePreparedRenderPromiseByVariant,
+    [variant]: nextPreparedRenderPromise,
+  };
+
+  return nextPreparedRenderPromise;
+}
+
+function reportReviewReactionLottiePrewarmFailure(
+  error: unknown,
+  variant: ReviewReactionLottieVariant | null,
+): void {
+  console.warn("Review reaction Lottie prewarm failed.", {
+    error,
+    variant,
+  });
+}
+
+function startReviewReactionLottieVariantPrewarm(variant: ReviewReactionLottieVariant): void {
+  void prewarmReviewReactionLottieVariant(variant).catch((error: unknown) => {
+    reportReviewReactionLottiePrewarmFailure(error, variant);
+  });
+}
+
+export async function loadReviewReactionLottieAsset(
+  variant: ReviewReactionLottieVariant,
+): Promise<ReviewReactionLottieAsset> {
+  const preparedRender = await prewarmReviewReactionLottieVariant(variant);
+  return {
+    animationData: preparedRender.animationData,
+    player: preparedRender.player,
+  };
+}
+
+export async function prewarmReviewReactionLottieAssets(): Promise<ReviewReactionLottiePreloadResult> {
+  const settledPreparedRenders = await Promise.allSettled(
+    reviewReactionLottieVariants.map((variant) => prewarmReviewReactionLottieVariant(variant)),
   );
   const failures: Array<ReviewReactionLottieAssetFailure> = [];
 
-  for (const [index, settledAsset] of settledAnimationData.entries()) {
-    if (settledAsset.status === "rejected") {
-      const error: unknown = settledAsset.reason;
+  for (const [index, settledPreparedRender] of settledPreparedRenders.entries()) {
+    if (settledPreparedRender.status === "rejected") {
+      const error: unknown = settledPreparedRender.reason;
       failures.push({
         error,
         variant: reviewReactionLottieVariants[index],
@@ -444,4 +868,100 @@ export async function loadReviewReactionLottieAssets(): Promise<ReviewReactionLo
   }
 
   return { failures };
+}
+
+export async function loadReviewReactionLottieAssets(): Promise<ReviewReactionLottiePreloadResult> {
+  return prewarmReviewReactionLottieAssets();
+}
+
+export function startReviewReactionLottiePrewarm(): void {
+  void prewarmReviewReactionLottieAssets()
+    .then((result: ReviewReactionLottiePreloadResult): void => {
+      for (const failure of result.failures) {
+        reportReviewReactionLottiePrewarmFailure(failure.error, failure.variant);
+      }
+    })
+    .catch((error: unknown): void => {
+      reportReviewReactionLottiePrewarmFailure(error, null);
+    });
+}
+
+export function reserveReviewReactionLottieRender(
+  eventId: string,
+  variant: ReviewReactionLottieVariant,
+): boolean {
+  if (reviewReactionLottieReservedRenderByEventId.has(eventId)) {
+    throw new Error(`Review reaction Lottie render reservation already exists for event ${eventId}.`);
+  }
+
+  const preparedRender = reviewReactionLottiePreparedRenderByVariant[variant];
+  if (preparedRender === null) {
+    return false;
+  }
+
+  reviewReactionLottiePreparedRenderByVariant = {
+    ...reviewReactionLottiePreparedRenderByVariant,
+    [variant]: null,
+  };
+  reviewReactionLottieReservedRenderByEventId.set(eventId, preparedRender);
+  startReviewReactionLottieVariantPrewarm(variant);
+  return true;
+}
+
+export function mountReservedReviewReactionLottieRender(
+  eventId: string,
+  variant: ReviewReactionLottieVariant,
+  container: HTMLDivElement,
+): ReviewReactionLottieMountedRender {
+  const preparedRender = reviewReactionLottieReservedRenderByEventId.get(eventId);
+  if (preparedRender === undefined) {
+    throw new Error(`Review reaction Lottie render reservation is missing for event ${eventId} variant ${variant}.`);
+  }
+  if (preparedRender.variant !== variant) {
+    throw new Error(
+      `Review reaction Lottie render reservation for event ${eventId} expected variant ${variant}, `
+        + `received ${preparedRender.variant}.`,
+    );
+  }
+
+  container.appendChild(preparedRender.container);
+  reviewReactionLottieMountedRenderEventIds.add(eventId);
+  return {
+    animationItem: preparedRender.animationItem,
+  };
+}
+
+export function unmountReservedReviewReactionLottieRender(eventId: string): void {
+  const preparedRender = reviewReactionLottieReservedRenderByEventId.get(eventId);
+  if (preparedRender === undefined) {
+    return;
+  }
+
+  reviewReactionLottieMountedRenderEventIds.delete(eventId);
+  if (reviewReactionLottieReleaseRequestedEventIds.has(eventId)) {
+    reviewReactionLottieReleaseRequestedEventIds.delete(eventId);
+    reviewReactionLottieReservedRenderByEventId.delete(eventId);
+    destroyReviewReactionLottiePreparedRender(preparedRender);
+    return;
+  }
+
+  moveReviewReactionLottieRenderToOffscreenRoot(preparedRender);
+}
+
+export function releaseReviewReactionLottieRender(eventId: string): void {
+  const preparedRender = reviewReactionLottieReservedRenderByEventId.get(eventId);
+  if (preparedRender === undefined) {
+    reviewReactionLottieMountedRenderEventIds.delete(eventId);
+    reviewReactionLottieReleaseRequestedEventIds.delete(eventId);
+    return;
+  }
+
+  if (reviewReactionLottieMountedRenderEventIds.has(eventId)) {
+    reviewReactionLottieReleaseRequestedEventIds.add(eventId);
+    return;
+  }
+
+  reviewReactionLottieReservedRenderByEventId.delete(eventId);
+  reviewReactionLottieReleaseRequestedEventIds.delete(eventId);
+  destroyReviewReactionLottiePreparedRender(preparedRender);
 }

--- a/apps/web/src/screens/review/reactions/useReviewRatingReactions.test.tsx
+++ b/apps/web/src/screens/review/reactions/useReviewRatingReactions.test.tsx
@@ -2,6 +2,25 @@
 import { act, useEffect, type ReactElement } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  readyLottieVariants,
+  releaseReviewReactionLottieRenderMock,
+  reserveReviewReactionLottieRenderMock,
+} = vi.hoisted(() => ({
+  readyLottieVariants: new Set<string>(),
+  releaseReviewReactionLottieRenderMock: vi.fn(),
+  reserveReviewReactionLottieRenderMock: vi.fn(),
+}));
+
+vi.mock("./reviewReactionLottie", () => ({
+  isReviewReactionLottieAssetReady: (variant: string): boolean => readyLottieVariants.has(variant),
+  isReviewReactionLottieVariant: (variant: string): boolean => variant !== "fallbackCrownBounce",
+  releaseReviewReactionLottieRender: releaseReviewReactionLottieRenderMock,
+  reserveReviewReactionLottieRender: reserveReviewReactionLottieRenderMock,
+  reviewReactionLottieFallbackVariant: "fallbackCrownBounce",
+}));
+
 import {
   useReviewRatingReactions,
   type UseReviewRatingReactionsResult,
@@ -22,7 +41,12 @@ function ReviewRatingReactionHarness(props: ReviewRatingReactionHarnessProps): R
   return (
     <div>
       {result.events.map((event) => (
-        <span key={event.id} data-testid="review-reaction-event" data-event-id={event.id} />
+        <span
+          key={event.id}
+          data-testid="review-reaction-event"
+          data-event-id={event.id}
+          data-event-variant={event.variant}
+        />
       ))}
     </div>
   );
@@ -35,6 +59,26 @@ describe("useReviewRatingReactions", () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    readyLottieVariants.clear();
+    for (const variant of [
+      "goodOtter",
+      "goodOwl",
+      "goodRabbit",
+      "goodSeal",
+      "goodServiceDog",
+      "goodPoodle",
+      "goodChimpanzee",
+      "goodWhale",
+      "goodPeacock",
+      "goodPig",
+    ]) {
+      readyLottieVariants.add(variant);
+    }
+    releaseReviewReactionLottieRenderMock.mockReset();
+    reserveReviewReactionLottieRenderMock.mockReset();
+    reserveReviewReactionLottieRenderMock.mockImplementation((_eventId: string, variant: string): boolean => (
+      readyLottieVariants.has(variant)
+    ));
     vi.spyOn(Math, "random").mockReturnValue(0.72);
     vi.spyOn(crypto, "randomUUID")
       .mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
@@ -116,5 +160,42 @@ describe("useReviewRatingReactions", () => {
     });
 
     expect(requireLatestResult().events).toHaveLength(0);
+  });
+
+  it("uses a ready same-rating variant when the selected variant is not prewarmed", async () => {
+    readyLottieVariants.clear();
+    readyLottieVariants.add("goodRabbit");
+    vi.mocked(Math.random)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0);
+    await renderHarness();
+
+    await act(async () => {
+      requireLatestResult().emitReaction(2);
+    });
+
+    expect(requireLatestResult().events).toEqual([
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        rating: "good",
+        variant: "goodRabbit",
+      },
+    ]);
+    expect(reserveReviewReactionLottieRenderMock).toHaveBeenCalledWith(
+      "00000000-0000-4000-8000-000000000001",
+      "goodRabbit",
+    );
+  });
+
+  it("does not emit a decorative event when the rating group has no ready variants", async () => {
+    readyLottieVariants.clear();
+    await renderHarness();
+
+    await act(async () => {
+      requireLatestResult().emitReaction(2);
+    });
+
+    expect(requireLatestResult().events).toHaveLength(0);
+    expect(reserveReviewReactionLottieRenderMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/screens/review/reactions/useReviewRatingReactions.ts
+++ b/apps/web/src/screens/review/reactions/useReviewRatingReactions.ts
@@ -1,19 +1,26 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   appendReviewReactionEvent,
   makeReviewReactionRating,
   matchesReducedReviewReactionMotion,
   reviewReactionCleanupDelayMillis,
   reviewReactionMaximumActiveEvents,
+  reviewReactionVariantDistributionEntries,
   reviewReactionVariantTotalWeight,
   reducedReviewReactionMotionMediaQuery,
   selectReviewReactionVariant,
   type ReviewReactionEvent,
   type ReviewReactionMotionMode,
+  type ReviewReactionRating,
   type ReviewReactionRenderableVariant,
+  type ReviewReactionVariant,
+  type ReviewReactionVariantDistributionEntry,
 } from "./reviewReaction";
 import {
+  isReviewReactionLottieAssetReady,
   isReviewReactionLottieVariant,
+  releaseReviewReactionLottieRender,
+  reserveReviewReactionLottieRender,
   reviewReactionLottieFallbackVariant,
 } from "./reviewReactionLottie";
 
@@ -44,8 +51,91 @@ function clearTrimmedReviewReactionTimers(
   for (const eventId of cleanupTimers.keys()) {
     if (!retainedEventIds.has(eventId)) {
       clearReviewReactionTimer(cleanupTimers, eventId);
+      releaseReviewReactionLottieRender(eventId);
     }
   }
+}
+
+function reviewReactionDistributionEntryTotalWeight(
+  rating: ReviewReactionRating,
+  entries: ReadonlyArray<ReviewReactionVariantDistributionEntry>,
+): number {
+  if (entries.length === 0) {
+    throw new Error(`Review reaction ready distribution is missing rating ${rating}.`);
+  }
+
+  let totalWeight = 0;
+  for (const entry of entries) {
+    if (!Number.isInteger(entry.weight) || entry.weight <= 0) {
+      throw new RangeError(`Invalid review reaction ready weight for ${entry.id}: ${entry.weight}`);
+    }
+    totalWeight += entry.weight;
+  }
+
+  return totalWeight;
+}
+
+function selectReviewReactionVariantFromEntries(
+  rating: ReviewReactionRating,
+  entries: ReadonlyArray<ReviewReactionVariantDistributionEntry>,
+  roll: number,
+): ReviewReactionVariant {
+  const totalWeight = reviewReactionDistributionEntryTotalWeight(rating, entries);
+  if (!Number.isInteger(roll) || roll < 0 || roll >= totalWeight) {
+    throw new RangeError(`Review reaction ready roll must be an integer in 0...${totalWeight - 1}, received ${roll}.`);
+  }
+
+  let cumulativeWeight = 0;
+  for (const entry of entries) {
+    cumulativeWeight += entry.weight;
+    if (roll < cumulativeWeight) {
+      return entry.variant;
+    }
+  }
+
+  throw new Error(`Review reaction ready distribution is missing rating ${rating} roll ${roll}.`);
+}
+
+function readyReviewReactionVariantDistributionEntries(
+  rating: ReviewReactionRating,
+): ReadonlyArray<ReviewReactionVariantDistributionEntry> {
+  return reviewReactionVariantDistributionEntries(rating).filter((entry) => (
+    isReviewReactionLottieVariant(entry.variant) && isReviewReactionLottieAssetReady(entry.variant)
+  ));
+}
+
+function reserveReviewReactionEventVariant(
+  eventId: string,
+  rating: ReviewReactionRating,
+  selectedVariant: ReviewReactionVariant,
+): ReviewReactionVariant | null {
+  if (
+    isReviewReactionLottieVariant(selectedVariant)
+    && isReviewReactionLottieAssetReady(selectedVariant)
+    && reserveReviewReactionLottieRender(eventId, selectedVariant)
+  ) {
+    return selectedVariant;
+  }
+
+  const readyEntries = readyReviewReactionVariantDistributionEntries(rating);
+  if (readyEntries.length === 0) {
+    return null;
+  }
+
+  const totalWeight = reviewReactionDistributionEntryTotalWeight(rating, readyEntries);
+  const readyVariant = selectReviewReactionVariantFromEntries(
+    rating,
+    readyEntries,
+    Math.floor(Math.random() * totalWeight),
+  );
+  if (!isReviewReactionLottieVariant(readyVariant)) {
+    throw new Error(`Review reaction ready variant ${readyVariant} is not a Lottie variant.`);
+  }
+  if (!reserveReviewReactionLottieRender(eventId, readyVariant)) {
+    return null;
+  }
+
+  return readyVariant;
 }
 
 export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
@@ -77,15 +167,20 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
         window.clearTimeout(timerId);
       }
       cleanupTimersRef.current.clear();
+      for (const event of eventsRef.current) {
+        releaseReviewReactionLottieRender(event.id);
+      }
+      eventsRef.current = [];
     };
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     clearTrimmedReviewReactionTimers(cleanupTimersRef.current, events);
   }, [events]);
 
   const removeReactionEvent = useCallback((eventId: string): void => {
     clearReviewReactionTimer(cleanupTimersRef.current, eventId);
+    releaseReviewReactionLottieRender(eventId);
     setEvents((currentEvents) => {
       const nextEvents = currentEvents.filter((activeEvent) => activeEvent.id !== eventId);
       eventsRef.current = nextEvents;
@@ -106,13 +201,24 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
   const emitReaction = useCallback((rating: 0 | 1 | 2 | 3): void => {
     const reactionRating = makeReviewReactionRating(rating);
     const totalWeight = reviewReactionVariantTotalWeight(reactionRating);
+    const eventId = crypto.randomUUID();
+    const selectedVariant = selectReviewReactionVariant(
+      reactionRating,
+      Math.floor(Math.random() * totalWeight),
+    );
+    const reservedVariant = reserveReviewReactionEventVariant(
+      eventId,
+      reactionRating,
+      selectedVariant,
+    );
+    if (reservedVariant === null) {
+      return;
+    }
+
     const event: ReviewReactionEvent = {
-      id: crypto.randomUUID(),
+      id: eventId,
       rating: reactionRating,
-      variant: selectReviewReactionVariant(
-        reactionRating,
-        Math.floor(Math.random() * totalWeight),
-      ),
+      variant: reservedVariant,
     };
     scheduleReactionEventCleanup(event.id, event.variant);
 
@@ -134,7 +240,9 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
     }
 
     clearReviewReactionTimer(cleanupTimersRef.current, eventId);
-    scheduleReactionEventCleanup(eventId, reviewReactionLottieFallbackVariant);
+    releaseReviewReactionLottieRender(eventId);
+    const fallbackEventId = crypto.randomUUID();
+    scheduleReactionEventCleanup(fallbackEventId, reviewReactionLottieFallbackVariant);
     setEvents((currentEvents) => {
       const nextEvents = currentEvents.map((activeEvent) => {
         if (activeEvent.id !== eventId || !isReviewReactionLottieVariant(activeEvent.variant)) {
@@ -143,6 +251,7 @@ export function useReviewRatingReactions(): UseReviewRatingReactionsResult {
 
         return {
           ...activeEvent,
+          id: fallbackEventId,
           variant: reviewReactionLottieFallbackVariant,
         };
       });

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -23,6 +23,7 @@ const {
   loadReviewQueueSnapshotMock,
   loadReviewTimelinePageMock,
   loadWorkspaceTagsSummaryMock,
+  reviewReactionLottieLoadAnimationMock,
   useAppDataMock,
   useReviewProgressBadgeMock,
 } = vi.hoisted(() => ({
@@ -31,6 +32,7 @@ const {
   loadReviewQueueSnapshotMock: vi.fn(),
   loadReviewTimelinePageMock: vi.fn(),
   loadWorkspaceTagsSummaryMock: vi.fn(),
+  reviewReactionLottieLoadAnimationMock: vi.fn(),
   useAppDataMock: vi.fn(),
   useReviewProgressBadgeMock: vi.fn(),
 }));
@@ -56,13 +58,7 @@ vi.mock("../../../localDb/workspace", () => ({
 
 vi.mock("lottie-web/build/player/lottie_light", () => ({
   default: {
-    loadAnimation: vi.fn(() => ({
-      addEventListener: vi.fn(() => vi.fn()),
-      destroy: vi.fn(),
-      goToAndStop: vi.fn(),
-      isLoaded: true,
-      play: vi.fn(),
-    })),
+    loadAnimation: reviewReactionLottieLoadAnimationMock,
   },
 }));
 
@@ -71,10 +67,13 @@ import {
   useReviewScreenData,
   type UseReviewScreenDataResult,
 } from "../data/useReviewScreenData";
+import { resetReviewReactionLottieStateForTests } from "../reactions/reviewReactionLottie";
 
 type Mutable<Type> = {
   -readonly [Key in keyof Type]: Type[Key];
 };
+
+export { reviewReactionLottieLoadAnimationMock };
 
 type ReviewScreenAppData = Mutable<AppDataContextValue>;
 
@@ -408,6 +407,53 @@ function clearWindowLocalStorage(): void {
   }
 }
 
+function makeReviewReactionLottieAnimationItemForTest(): object {
+  return {
+    addEventListener: vi.fn(() => vi.fn()),
+    destroy: vi.fn(),
+    goToAndStop: vi.fn(),
+    isLoaded: true,
+    play: vi.fn(),
+    setSpeed: vi.fn(),
+    totalFrames: 100,
+  };
+}
+
+function makeReviewReactionLottieResponse(): Response {
+  return new Response(JSON.stringify({
+    layers: [],
+    v: "test",
+  }), {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    status: 200,
+  });
+}
+
+function reviewReactionLottieFetchUrl(input: RequestInfo | URL): string {
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return input.url;
+  }
+
+  return input.toString();
+}
+
+function isReviewReactionLottieAssetRequest(input: RequestInfo | URL): boolean {
+  const requestUrl = reviewReactionLottieFetchUrl(input);
+  return /(?:^|\/)review_(again|hard|good|easy)_[A-Za-z0-9_-]+\.json(?:[?#].*)?$/.test(requestUrl);
+}
+
+function fetchReviewReactionLottieAssetForTest(input: RequestInfo | URL): Promise<Response> {
+  if (!isReviewReactionLottieAssetRequest(input)) {
+    return Promise.reject(
+      new Error(`Unexpected fetch in review screen test harness: ${reviewReactionLottieFetchUrl(input)}`),
+    );
+  }
+
+  return Promise.resolve(makeReviewReactionLottieResponse());
+}
+
 function readStylesheetWithImports(stylesheetPath: string): string {
   const stylesheet = readFileSync(stylesheetPath, "utf8");
   const stylesheetDir = dirname(stylesheetPath);
@@ -432,6 +478,10 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     vi.setSystemTime(new Date("2026-03-10T12:00:00.000Z"));
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     clearWindowLocalStorage();
+    resetReviewReactionLottieStateForTests();
+    reviewReactionLottieLoadAnimationMock.mockReset();
+    reviewReactionLottieLoadAnimationMock.mockImplementation(() => makeReviewReactionLottieAnimationItemForTest());
+    vi.stubGlobal("fetch", vi.fn(fetchReviewReactionLottieAssetForTest));
 
     state = createDefaultReviewScreenTestState();
     container = document.createElement("div");
@@ -467,6 +517,7 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     container?.remove();
     container = null;
     root = null;
+    vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -7,10 +7,15 @@ import {
   createCard,
   createDecks,
   loadReviewQueueSnapshotMock,
+  reviewReactionLottieLoadAnimationMock,
   reviewStylesContain,
   setTextFieldValueAsync,
   setupReviewScreenTest,
 } from "../testSupport/ReviewScreenTestSupport";
+import {
+  isReviewReactionLottieAssetReady,
+  reviewReactionLottieVariants,
+} from "../reactions/reviewReactionLottie";
 
 const {
   dispatchDocumentKeydown,
@@ -21,7 +26,14 @@ const {
   revealAnswer,
 } = setupReviewScreenTest();
 
-async function flushReviewScreenMicrotasks(): Promise<void> {
+async function waitForReviewReactionLottieTestPrewarm(): Promise<void> {
+  await vi.waitFor(() => {
+    expect(reviewReactionLottieVariants.every((variant) => isReviewReactionLottieAssetReady(variant))).toBe(true);
+  });
+  expect(reviewReactionLottieLoadAnimationMock).toHaveBeenCalled();
+}
+
+async function flushReviewScreenPromises(): Promise<void> {
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
@@ -124,6 +136,7 @@ describe("ReviewScreen controls", () => {
     });
 
     await renderReviewScreen();
+    await waitForReviewReactionLottieTestPrewarm();
     await revealAnswer();
 
     const goodButton = getContainer().querySelector("[data-testid='review-rate-good']");
@@ -132,7 +145,7 @@ describe("ReviewScreen controls", () => {
     }
 
     await clickElementAsync(goodButton);
-    await flushReviewScreenMicrotasks();
+    await flushReviewScreenPromises();
 
     const reactionLayer = getContainer().querySelector("[data-testid='review-rating-reaction-layer']");
     if (!(reactionLayer instanceof HTMLElement)) {
@@ -145,6 +158,7 @@ describe("ReviewScreen controls", () => {
 
     expect(reactionLayer.getAttribute("aria-hidden")).toBe("true");
     expect(getContainer().querySelectorAll("[data-testid='review-rating-reaction-event']")).toHaveLength(1);
+    expect(getContainer().querySelector(".review-rating-reaction-crown-fallback-art")).toBeNull();
     expect(state.appData.submitReviewItem).toHaveBeenCalledWith("card-reaction-first", 2);
     expect(reviewPane.getAttribute("data-review-current-card-id")).toBe("card-reaction-second");
     expect(getContainer().textContent).toContain("Second reaction question");
@@ -170,6 +184,7 @@ describe("ReviewScreen controls", () => {
     });
 
     await renderReviewScreen();
+    await waitForReviewReactionLottieTestPrewarm();
 
     for (let index = 0; index < 4; index += 1) {
       await revealAnswer();
@@ -179,7 +194,7 @@ describe("ReviewScreen controls", () => {
       }
 
       await clickElementAsync(goodButton);
-      await flushReviewScreenMicrotasks();
+      await flushReviewScreenPromises();
     }
 
     expect(getContainer().querySelectorAll("[data-testid='review-rating-reaction-event']")).toHaveLength(3);

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactElement } from "react";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import { settingsTestAnimationsRoute } from "../../routes";
 import {
@@ -19,7 +19,11 @@ import {
 import { ReviewRatingReactionLayer } from "../review/reactions/ReviewRatingReactionLayer";
 import {
   isReviewReactionLottieVariant,
+  loadReviewReactionLottieAsset,
+  releaseReviewReactionLottieRender,
+  reserveReviewReactionLottieRender,
   reviewReactionLottieFallbackVariant,
+  startReviewReactionLottiePrewarm,
 } from "../review/reactions/reviewReactionLottie";
 import { SettingsGroup, SettingsNavigationCard, SettingsShell } from "./SettingsShared";
 
@@ -112,6 +116,7 @@ function clearTrimmedReviewReactionTimers(
   for (const eventId of cleanupTimers.keys()) {
     if (!retainedEventIds.has(eventId)) {
       clearReviewReactionTimer(cleanupTimers, eventId);
+      releaseReviewReactionLottieRender(eventId);
     }
   }
 }
@@ -124,6 +129,22 @@ export function TestAnimationsScreen(): ReactElement {
   );
   const activeReviewReactionEventsRef = useRef<ReadonlyArray<ReviewReactionEvent>>([]);
   const cleanupTimersRef = useRef<Map<string, number>>(new Map<string, number>());
+  const isMountedRef = useRef<boolean>(false);
+
+  function reportTestAnimationPlaybackFailure(
+    error: unknown,
+    entry: ReviewReactionVariantDistributionEntry,
+  ): void {
+    console.warn("Review reaction test animation failed.", {
+      error,
+      rating: entry.rating,
+      variant: entry.variant,
+    });
+  }
+
+  useEffect(() => {
+    startReviewReactionLottiePrewarm();
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -143,20 +164,28 @@ export function TestAnimationsScreen(): ReactElement {
   }, []);
 
   useEffect(() => {
+    isMountedRef.current = true;
+
     return (): void => {
+      isMountedRef.current = false;
       for (const timerId of cleanupTimersRef.current.values()) {
         window.clearTimeout(timerId);
       }
       cleanupTimersRef.current.clear();
+      for (const event of activeReviewReactionEventsRef.current) {
+        releaseReviewReactionLottieRender(event.id);
+      }
+      activeReviewReactionEventsRef.current = [];
     };
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     clearTrimmedReviewReactionTimers(cleanupTimersRef.current, activeReviewReactionEvents);
   }, [activeReviewReactionEvents]);
 
   const removeReviewReactionEvent = useCallback((eventId: string): void => {
     clearReviewReactionTimer(cleanupTimersRef.current, eventId);
+    releaseReviewReactionLottieRender(eventId);
     setActiveReviewReactionEvents((currentEvents) => {
       const nextEvents = currentEvents.filter((activeEvent) => activeEvent.id !== eventId);
       activeReviewReactionEventsRef.current = nextEvents;
@@ -181,7 +210,9 @@ export function TestAnimationsScreen(): ReactElement {
     }
 
     clearReviewReactionTimer(cleanupTimersRef.current, eventId);
-    scheduleReviewReactionEventCleanup(eventId, reviewReactionLottieFallbackVariant);
+    releaseReviewReactionLottieRender(eventId);
+    const fallbackEventId = crypto.randomUUID();
+    scheduleReviewReactionEventCleanup(fallbackEventId, reviewReactionLottieFallbackVariant);
     setActiveReviewReactionEvents((currentEvents) => {
       const nextEvents = currentEvents.map((activeEvent) => {
         if (activeEvent.id !== eventId || !isReviewReactionLottieVariant(activeEvent.variant)) {
@@ -190,6 +221,7 @@ export function TestAnimationsScreen(): ReactElement {
 
         return {
           ...activeEvent,
+          id: fallbackEventId,
           variant: reviewReactionLottieFallbackVariant,
         };
       });
@@ -198,9 +230,39 @@ export function TestAnimationsScreen(): ReactElement {
     });
   }, [scheduleReviewReactionEventCleanup]);
 
-  function playAnimation(entry: ReviewReactionVariantDistributionEntry): void {
+  async function reserveTestAnimationRender(
+    eventId: string,
+    variant: ReviewReactionVariantDistributionEntry["variant"],
+  ): Promise<void> {
+    if (!isReviewReactionLottieVariant(variant)) {
+      throw new Error(`Test animation variant ${variant} is not a Lottie variant.`);
+    }
+    if (reserveReviewReactionLottieRender(eventId, variant)) {
+      return;
+    }
+
+    await loadReviewReactionLottieAsset(variant);
+    if (reserveReviewReactionLottieRender(eventId, variant)) {
+      return;
+    }
+
+    throw new Error(`Test animation variant ${variant} was not available after prewarm.`);
+  }
+
+  async function playAnimation(entry: ReviewReactionVariantDistributionEntry): Promise<void> {
+    if (!isReviewReactionLottieVariant(entry.variant)) {
+      throw new Error(`Test animation entry ${entry.id} is not a Lottie variant.`);
+    }
+
+    const eventId = crypto.randomUUID();
+    await reserveTestAnimationRender(eventId, entry.variant);
+    if (!isMountedRef.current) {
+      releaseReviewReactionLottieRender(eventId);
+      return;
+    }
+
     const event: ReviewReactionEvent = {
-      id: crypto.randomUUID(),
+      id: eventId,
       rating: entry.rating,
       variant: entry.variant,
     };
@@ -237,7 +299,11 @@ export function TestAnimationsScreen(): ReactElement {
                   data-review-reaction-rating={entry.rating}
                   data-review-reaction-variant={entry.variant}
                   data-testid="test-animation-row"
-                  onClick={() => playAnimation(entry)}
+                  onClick={() => {
+                    void playAnimation(entry).catch((error: unknown) => {
+                      reportTestAnimationPlaybackFailure(error, entry);
+                    });
+                  }}
                 >
                   <span className="settings-test-animation-name">{entry.variant}</span>
                   <span className="badge">


### PR DESCRIPTION
## Summary
- add an idempotent Web Lottie prewarm manager for review rating reactions
- reserve and mount only prepared Lottie render instances on rating taps
- remove the crown from loading/pending states and keep it only for explicit Lottie playback/render failures
- update focused review reaction coverage for prewarm readiness, fallback behavior, and ready-only selection

## Validation
- git --no-pager diff --check
- npm exec vitest -- run src/screens/review
- npm run build
