### PR TITLE
[codex] Prewarm iOS review reaction Lotties

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
@@ -1,25 +1,9 @@
 import Foundation
 import Lottie
-import OSLog
 import SwiftUI
-import UIKit
 
 private let reviewReactionAnimationMinimumIntervalSeconds: Double = 1.0 / 60.0
 private let reviewReactionLottieReducedMotionProgress: AnimationProgressTime = 0.55
-private let reviewReactionLottieFallbackVariant: ReviewReactionVariant = .fallbackCrownBounce
-private let reviewReactionLogger: Logger = Logger(
-    subsystem: appBundleIdentifier(),
-    category: "review_reactions"
-)
-
-private struct ReviewReactionLottieAssetConfiguration {
-    let variant: ReviewReactionVariant
-    let assetName: String
-    let assetDescription: String
-    let frameScale: CGFloat
-    let centerX: CGFloat
-    let centerY: CGFloat
-}
 
 private struct ReviewReactionLottieConfiguration {
     let animation: LottieAnimation
@@ -27,348 +11,6 @@ private struct ReviewReactionLottieConfiguration {
     let centerX: CGFloat
     let centerY: CGFloat
     let reducedMotionProgress: AnimationProgressTime
-}
-
-private typealias ReviewReactionLottieAnimationStore = [ReviewReactionVariant: LottieAnimation]
-
-private let reviewReactionLottieAssetConfigurations: [ReviewReactionLottieAssetConfiguration] = [
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againRainCloud,
-        assetName: "ReviewAgainRainCloud",
-        assetDescription: "rain cloud",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.44
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againTornado,
-        assetName: "ReviewAgainTornado",
-        assetDescription: "tornado",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.45
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againWindFace,
-        assetName: "ReviewAgainWindFace",
-        assetDescription: "wind face",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.45
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againSnowflake,
-        assetName: "ReviewAgainSnowflake",
-        assetDescription: "snowflake",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.45
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againSnailCrawl,
-        assetName: "ReviewAgainSnail",
-        assetDescription: "snail",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.48
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againTurtle,
-        assetName: "ReviewAgainTurtle",
-        assetDescription: "turtle",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againWiltedFlower,
-        assetName: "ReviewAgainWiltedFlower",
-        assetDescription: "wilted flower",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againSpider,
-        assetName: "ReviewAgainSpider",
-        assetDescription: "spider",
-        frameScale: 0.54,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againRat,
-        assetName: "ReviewAgainRat",
-        assetDescription: "rat",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .againWormWiggle,
-        assetName: "ReviewAgainWorm",
-        assetDescription: "worm",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.52
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardTiger,
-        assetName: "ReviewHardTiger",
-        assetDescription: "tiger",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.48
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardTRex,
-        assetName: "ReviewHardTRex",
-        assetDescription: "t rex",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.48
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardShark,
-        assetName: "ReviewHardShark",
-        assetDescription: "shark",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.47
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardOxCharge,
-        assetName: "ReviewHardOx",
-        assetDescription: "ox",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardRacehorseGallop,
-        assetName: "ReviewHardRacehorse",
-        assetDescription: "racehorse",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardSnake,
-        assetName: "ReviewHardSnake",
-        assetDescription: "snake",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardVolcanoEruption,
-        assetName: "ReviewHardVolcano",
-        assetDescription: "volcano",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardScorpion,
-        assetName: "ReviewHardScorpion",
-        assetDescription: "scorpion",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardPawPrints,
-        assetName: "ReviewHardPawPrints",
-        assetDescription: "paw prints",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .hardRooster,
-        assetName: "ReviewHardRooster",
-        assetDescription: "rooster",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.48
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodOtter,
-        assetName: "ReviewGoodOtter",
-        assetDescription: "otter",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.48
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodOwl,
-        assetName: "ReviewGoodOwl",
-        assetDescription: "owl",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.42
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodRabbit,
-        assetName: "ReviewGoodRabbit",
-        assetDescription: "rabbit",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.47
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodSeal,
-        assetName: "ReviewGoodSeal",
-        assetDescription: "seal",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.47
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodServiceDog,
-        assetName: "ReviewGoodServiceDog",
-        assetDescription: "service dog",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.47
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodPoodle,
-        assetName: "ReviewGoodPoodle",
-        assetDescription: "poodle",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.43
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodChimpanzee,
-        assetName: "ReviewGoodChimpanzee",
-        assetDescription: "chimpanzee",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.46
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodWhale,
-        assetName: "ReviewGoodWhale",
-        assetDescription: "whale",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.42
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodPeacock,
-        assetName: "ReviewGoodPeacock",
-        assetDescription: "peacock",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.42
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .goodPig,
-        assetName: "ReviewGoodPig",
-        assetDescription: "pig",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easySunrise,
-        assetName: "ReviewEasySunrise",
-        assetDescription: "sunrise",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.42
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easySunriseOverMountains,
-        assetName: "ReviewEasySunriseOverMountains",
-        assetDescription: "sunrise over mountains",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.44
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easyRoseBloom,
-        assetName: "ReviewEasyRose",
-        assetDescription: "rose",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easyPeace,
-        assetName: "ReviewEasyPeace",
-        assetDescription: "peace",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.48
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easyPlant,
-        assetName: "ReviewEasyPlant",
-        assetDescription: "plant",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easyRainbowStreak,
-        assetName: "ReviewEasyRainbow",
-        assetDescription: "rainbow",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.42
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easyPhoenixRise,
-        assetName: "ReviewEasyPhoenix",
-        assetDescription: "phoenix",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.42
-    ),
-    ReviewReactionLottieAssetConfiguration(
-        variant: .easyUnicornFlyby,
-        assetName: "ReviewEasyUnicorn",
-        assetDescription: "unicorn",
-        frameScale: 0.52,
-        centerX: 0.56,
-        centerY: 0.30
-    )
-]
-
-private func makeReviewReactionLottieAnimation(assetName: String, assetDescription: String) -> LottieAnimation? {
-    guard let dataAsset: NSDataAsset = NSDataAsset(name: assetName) else {
-        reviewReactionLogger.error(
-            "Review Lottie data asset is missing. assetName=\(assetName, privacy: .public) assetDescription=\(assetDescription, privacy: .public)"
-        )
-        return nil
-    }
-
-    do {
-        return try LottieAnimation.from(data: dataAsset.data)
-    } catch {
-        let errorMessage: String = String(describing: error)
-        reviewReactionLogger.error(
-            "Review Lottie asset failed to decode. assetName=\(assetName, privacy: .public) assetDescription=\(assetDescription, privacy: .public) error=\(errorMessage, privacy: .public)"
-        )
-        return nil
-    }
-}
-
-private func makeReviewReactionLottieAnimationStore() -> ReviewReactionLottieAnimationStore {
-    var animationStore: ReviewReactionLottieAnimationStore = [:]
-    for assetConfiguration in reviewReactionLottieAssetConfigurations {
-        if let animation = makeReviewReactionLottieAnimation(
-            assetName: assetConfiguration.assetName,
-            assetDescription: assetConfiguration.assetDescription
-        ) {
-            animationStore[assetConfiguration.variant] = animation
-        }
-    }
-
-    return animationStore
 }
 
 private func reviewReactionFallbackEvent(event: ReviewReactionEvent) -> ReviewReactionEvent {
@@ -379,22 +21,14 @@ private func reviewReactionFallbackEvent(event: ReviewReactionEvent) -> ReviewRe
     )
 }
 
-private func isReviewReactionLottieVariant(variant: ReviewReactionVariant) -> Bool {
-    reviewReactionLottieAssetConfigurations.contains { assetConfiguration in
-        assetConfiguration.variant == variant
-    }
-}
-
 private func reviewReactionLottieConfiguration(
     variant: ReviewReactionVariant,
-    animationStore: ReviewReactionLottieAnimationStore
+    assetStore: ReviewReactionLottieAssetStore
 ) -> ReviewReactionLottieConfiguration? {
-    guard let assetConfiguration = reviewReactionLottieAssetConfigurations.first(where: { configuration in
-        configuration.variant == variant
-    }) else {
+    guard let assetConfiguration = reviewReactionLottieAssetConfiguration(variant: variant) else {
         return nil
     }
-    guard let animation = animationStore[variant] else {
+    guard let animation = assetStore.readyAnimations[variant] else {
         return nil
     }
 
@@ -431,10 +65,9 @@ private func finishReviewReactionEventAfterDelay(
 
 struct ReviewReactionLayer: View {
     @Environment(\.accessibilityReduceMotion) private var isReduceMotionEnabled
-    @State private var hasStartedReviewReactionLottiePreload: Bool = false
-    @State private var reviewReactionLottieAnimationStore: ReviewReactionLottieAnimationStore = [:]
 
     let events: [ReviewReactionEvent]
+    let lottieAssetStore: ReviewReactionLottieAssetStore
     let onEventFinished: (UUID) -> Void
 
     var body: some View {
@@ -443,7 +76,7 @@ struct ReviewReactionLayer: View {
                 ForEach(self.events) { event in
                     ReviewReactionEventView(
                         event: event,
-                        animationStore: self.reviewReactionLottieAnimationStore,
+                        lottieAssetStore: self.lottieAssetStore,
                         isReduceMotionEnabled: self.isReduceMotionEnabled,
                         onEventFinished: self.onEventFinished
                     )
@@ -454,25 +87,8 @@ struct ReviewReactionLayer: View {
         }
         .allowsHitTesting(false)
         .accessibilityHidden(true)
-        .onAppear {
-            self.preloadReviewReactionLottieAnimations()
-        }
         .onDisappear {
             self.finishActiveEvents()
-        }
-    }
-
-    private func preloadReviewReactionLottieAnimations() {
-        if self.hasStartedReviewReactionLottiePreload {
-            return
-        }
-
-        self.hasStartedReviewReactionLottiePreload = true
-        DispatchQueue.global(qos: .utility).async {
-            let animationStore: ReviewReactionLottieAnimationStore = makeReviewReactionLottieAnimationStore()
-            DispatchQueue.main.async {
-                self.reviewReactionLottieAnimationStore = animationStore
-            }
         }
     }
 
@@ -485,59 +101,65 @@ struct ReviewReactionLayer: View {
 
 private struct ReviewReactionEventView: View {
     let event: ReviewReactionEvent
-    let animationStore: ReviewReactionLottieAnimationStore
+    let lottieAssetStore: ReviewReactionLottieAssetStore
     let isReduceMotionEnabled: Bool
     let onEventFinished: (UUID) -> Void
 
-    @State private var shouldUseCrownFallback: Bool
-
-    init(
-        event: ReviewReactionEvent,
-        animationStore: ReviewReactionLottieAnimationStore,
-        isReduceMotionEnabled: Bool,
-        onEventFinished: @escaping (UUID) -> Void
-    ) {
-        self.event = event
-        self.animationStore = animationStore
-        self.isReduceMotionEnabled = isReduceMotionEnabled
-        self.onEventFinished = onEventFinished
-        self._shouldUseCrownFallback = State(
-            initialValue: isReviewReactionLottieVariant(variant: event.variant)
-                && reviewReactionLottieConfiguration(
-                    variant: event.variant,
-                    animationStore: animationStore
-                ) == nil
-        )
-    }
-
     var body: some View {
-        if isReviewReactionLottieVariant(variant: self.event.variant),
-           !self.shouldUseCrownFallback,
-           let lottieConfiguration: ReviewReactionLottieConfiguration = reviewReactionLottieConfiguration(
-                variant: self.event.variant,
-                animationStore: self.animationStore
-           ) {
+        switch reviewReactionLottieAssetStatus(
+            variant: self.event.variant,
+            readiness: self.lottieAssetStore.readiness
+        ) {
+        case .ready:
             ReviewReactionLottieView(
                 event: self.event,
                 isReduceMotionEnabled: self.isReduceMotionEnabled,
-                configuration: lottieConfiguration,
+                configuration: self.requiredLottieConfiguration,
                 onEventFinished: self.onEventFinished
             )
-        } else {
+        case .failed:
             ReviewReactionCanvas(
-                event: self.canvasEvent,
+                event: reviewReactionFallbackEvent(event: self.event),
+                isReduceMotionEnabled: self.isReduceMotionEnabled,
+                onEventFinished: self.onEventFinished
+            )
+        case .pending:
+            ReviewReactionPendingEventView(
+                event: self.event,
+                onEventFinished: self.onEventFinished
+            )
+        case .notLottie:
+            ReviewReactionCanvas(
+                event: self.event,
                 isReduceMotionEnabled: self.isReduceMotionEnabled,
                 onEventFinished: self.onEventFinished
             )
         }
     }
 
-    private var canvasEvent: ReviewReactionEvent {
-        if isReviewReactionLottieVariant(variant: self.event.variant) {
-            return reviewReactionFallbackEvent(event: self.event)
+    private var requiredLottieConfiguration: ReviewReactionLottieConfiguration {
+        guard let configuration: ReviewReactionLottieConfiguration = reviewReactionLottieConfiguration(
+            variant: self.event.variant,
+            assetStore: self.lottieAssetStore
+        ) else {
+            preconditionFailure("Ready Review Lottie asset is missing decoded animation for \(self.event.variant.debugIdentifier).")
         }
 
-        return self.event
+        return configuration
+    }
+}
+
+private struct ReviewReactionPendingEventView: View {
+    let event: ReviewReactionEvent
+    let onEventFinished: (UUID) -> Void
+
+    var body: some View {
+        Color.clear
+            .task(id: self.event.id) {
+                await MainActor.run {
+                    self.onEventFinished(self.event.id)
+                }
+            }
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLottieAssetStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLottieAssetStore.swift
@@ -1,0 +1,553 @@
+import Foundation
+import Lottie
+import OSLog
+import UIKit
+
+let reviewReactionLottieFallbackVariant: ReviewReactionVariant = .fallbackCrownBounce
+
+private let reviewReactionLottieAssetLogger: Logger = Logger(
+    subsystem: appBundleIdentifier(),
+    category: "review_reactions"
+)
+
+struct ReviewReactionLottieAssetConfiguration: Hashable, Sendable {
+    let variant: ReviewReactionVariant
+    let assetName: String
+    let assetDescription: String
+    let frameScale: CGFloat
+    let centerX: CGFloat
+    let centerY: CGFloat
+}
+
+struct ReviewReactionLottieAssetFailure: Hashable, Sendable {
+    let variant: ReviewReactionVariant
+    let assetName: String
+    let assetDescription: String
+    let failureReason: String
+    let message: String
+}
+
+struct ReviewReactionLottieAssetReadiness: Hashable, Sendable {
+    let readyVariants: Set<ReviewReactionVariant>
+    let pendingVariants: Set<ReviewReactionVariant>
+    let failedVariants: Set<ReviewReactionVariant>
+}
+
+enum ReviewReactionLottieAssetStatus: Hashable, Sendable {
+    case ready
+    case pending
+    case failed
+    case notLottie
+}
+
+enum ReviewReactionLottieAssetLoadResult: @unchecked Sendable {
+    case ready(variant: ReviewReactionVariant, animation: LottieAnimation)
+    case failed(failure: ReviewReactionLottieAssetFailure)
+}
+
+typealias ReviewReactionLottieAssetLoadHandler = @MainActor @Sendable (ReviewReactionLottieAssetLoadResult) -> Void
+
+struct ReviewReactionLottieAssetStore {
+    let readyAnimations: [ReviewReactionVariant: LottieAnimation]
+    let failedAssets: [ReviewReactionVariant: ReviewReactionLottieAssetFailure]
+    let pendingVariants: Set<ReviewReactionVariant>
+
+    var readyVariants: Set<ReviewReactionVariant> {
+        Set(self.readyAnimations.keys)
+    }
+
+    var failedVariants: Set<ReviewReactionVariant> {
+        Set(self.failedAssets.keys)
+    }
+
+    var availableVariants: Set<ReviewReactionVariant> {
+        self.readyVariants.union(self.failedVariants)
+    }
+
+    var readiness: ReviewReactionLottieAssetReadiness {
+        ReviewReactionLottieAssetReadiness(
+            readyVariants: self.readyVariants,
+            pendingVariants: self.pendingVariants,
+            failedVariants: self.failedVariants
+        )
+    }
+
+    func recordingLoadResult(loadResult: ReviewReactionLottieAssetLoadResult) -> ReviewReactionLottieAssetStore {
+        switch loadResult {
+        case .ready(let variant, let animation):
+            return self.recordingReadyAsset(variant: variant, animation: animation)
+        case .failed(let failure):
+            return self.recordingFailedAsset(failure: failure)
+        }
+    }
+
+    private func recordingReadyAsset(
+        variant: ReviewReactionVariant,
+        animation: LottieAnimation
+    ) -> ReviewReactionLottieAssetStore {
+        var nextReadyAnimations: [ReviewReactionVariant: LottieAnimation] = self.readyAnimations
+        var nextFailedAssets: [ReviewReactionVariant: ReviewReactionLottieAssetFailure] = self.failedAssets
+        var nextPendingVariants: Set<ReviewReactionVariant> = self.pendingVariants
+
+        nextReadyAnimations[variant] = animation
+        nextFailedAssets.removeValue(forKey: variant)
+        nextPendingVariants.remove(variant)
+
+        return ReviewReactionLottieAssetStore(
+            readyAnimations: nextReadyAnimations,
+            failedAssets: nextFailedAssets,
+            pendingVariants: nextPendingVariants
+        )
+    }
+
+    private func recordingFailedAsset(
+        failure: ReviewReactionLottieAssetFailure
+    ) -> ReviewReactionLottieAssetStore {
+        var nextReadyAnimations: [ReviewReactionVariant: LottieAnimation] = self.readyAnimations
+        var nextFailedAssets: [ReviewReactionVariant: ReviewReactionLottieAssetFailure] = self.failedAssets
+        var nextPendingVariants: Set<ReviewReactionVariant> = self.pendingVariants
+
+        nextReadyAnimations.removeValue(forKey: failure.variant)
+        nextFailedAssets[failure.variant] = failure
+        nextPendingVariants.remove(failure.variant)
+
+        return ReviewReactionLottieAssetStore(
+            readyAnimations: nextReadyAnimations,
+            failedAssets: nextFailedAssets,
+            pendingVariants: nextPendingVariants
+        )
+    }
+}
+
+let reviewReactionLottieAssetConfigurations: [ReviewReactionLottieAssetConfiguration] = [
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againRainCloud,
+        assetName: "ReviewAgainRainCloud",
+        assetDescription: "rain cloud",
+        frameScale: 0.62,
+        centerX: 0.50,
+        centerY: 0.44
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againTornado,
+        assetName: "ReviewAgainTornado",
+        assetDescription: "tornado",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.45
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againWindFace,
+        assetName: "ReviewAgainWindFace",
+        assetDescription: "wind face",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.45
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againSnowflake,
+        assetName: "ReviewAgainSnowflake",
+        assetDescription: "snowflake",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.45
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againSnailCrawl,
+        assetName: "ReviewAgainSnail",
+        assetDescription: "snail",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.48
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againTurtle,
+        assetName: "ReviewAgainTurtle",
+        assetDescription: "turtle",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againWiltedFlower,
+        assetName: "ReviewAgainWiltedFlower",
+        assetDescription: "wilted flower",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againSpider,
+        assetName: "ReviewAgainSpider",
+        assetDescription: "spider",
+        frameScale: 0.54,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againRat,
+        assetName: "ReviewAgainRat",
+        assetDescription: "rat",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .againWormWiggle,
+        assetName: "ReviewAgainWorm",
+        assetDescription: "worm",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.52
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardTiger,
+        assetName: "ReviewHardTiger",
+        assetDescription: "tiger",
+        frameScale: 0.62,
+        centerX: 0.50,
+        centerY: 0.48
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardTRex,
+        assetName: "ReviewHardTRex",
+        assetDescription: "t rex",
+        frameScale: 0.62,
+        centerX: 0.50,
+        centerY: 0.48
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardShark,
+        assetName: "ReviewHardShark",
+        assetDescription: "shark",
+        frameScale: 0.62,
+        centerX: 0.50,
+        centerY: 0.47
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardOxCharge,
+        assetName: "ReviewHardOx",
+        assetDescription: "ox",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardRacehorseGallop,
+        assetName: "ReviewHardRacehorse",
+        assetDescription: "racehorse",
+        frameScale: 0.62,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardSnake,
+        assetName: "ReviewHardSnake",
+        assetDescription: "snake",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardVolcanoEruption,
+        assetName: "ReviewHardVolcano",
+        assetDescription: "volcano",
+        frameScale: 0.64,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardScorpion,
+        assetName: "ReviewHardScorpion",
+        assetDescription: "scorpion",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardPawPrints,
+        assetName: "ReviewHardPawPrints",
+        assetDescription: "paw prints",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .hardRooster,
+        assetName: "ReviewHardRooster",
+        assetDescription: "rooster",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.48
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodOtter,
+        assetName: "ReviewGoodOtter",
+        assetDescription: "otter",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.48
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodOwl,
+        assetName: "ReviewGoodOwl",
+        assetDescription: "owl",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.42
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodRabbit,
+        assetName: "ReviewGoodRabbit",
+        assetDescription: "rabbit",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.47
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodSeal,
+        assetName: "ReviewGoodSeal",
+        assetDescription: "seal",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.47
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodServiceDog,
+        assetName: "ReviewGoodServiceDog",
+        assetDescription: "service dog",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.47
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodPoodle,
+        assetName: "ReviewGoodPoodle",
+        assetDescription: "poodle",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.43
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodChimpanzee,
+        assetName: "ReviewGoodChimpanzee",
+        assetDescription: "chimpanzee",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.46
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodWhale,
+        assetName: "ReviewGoodWhale",
+        assetDescription: "whale",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.42
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodPeacock,
+        assetName: "ReviewGoodPeacock",
+        assetDescription: "peacock",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.42
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .goodPig,
+        assetName: "ReviewGoodPig",
+        assetDescription: "pig",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easySunrise,
+        assetName: "ReviewEasySunrise",
+        assetDescription: "sunrise",
+        frameScale: 0.64,
+        centerX: 0.50,
+        centerY: 0.42
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easySunriseOverMountains,
+        assetName: "ReviewEasySunriseOverMountains",
+        assetDescription: "sunrise over mountains",
+        frameScale: 0.64,
+        centerX: 0.50,
+        centerY: 0.44
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easyRoseBloom,
+        assetName: "ReviewEasyRose",
+        assetDescription: "rose",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easyPeace,
+        assetName: "ReviewEasyPeace",
+        assetDescription: "peace",
+        frameScale: 0.56,
+        centerX: 0.50,
+        centerY: 0.48
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easyPlant,
+        assetName: "ReviewEasyPlant",
+        assetDescription: "plant",
+        frameScale: 0.58,
+        centerX: 0.50,
+        centerY: 0.50
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easyRainbowStreak,
+        assetName: "ReviewEasyRainbow",
+        assetDescription: "rainbow",
+        frameScale: 0.64,
+        centerX: 0.50,
+        centerY: 0.42
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easyPhoenixRise,
+        assetName: "ReviewEasyPhoenix",
+        assetDescription: "phoenix",
+        frameScale: 0.64,
+        centerX: 0.50,
+        centerY: 0.42
+    ),
+    ReviewReactionLottieAssetConfiguration(
+        variant: .easyUnicornFlyby,
+        assetName: "ReviewEasyUnicorn",
+        assetDescription: "unicorn",
+        frameScale: 0.52,
+        centerX: 0.56,
+        centerY: 0.30
+    )
+]
+
+func makePendingReviewReactionLottieAssetStore() -> ReviewReactionLottieAssetStore {
+    ReviewReactionLottieAssetStore(
+        readyAnimations: [:],
+        failedAssets: [:],
+        pendingVariants: Set(reviewReactionLottieAssetConfigurations.map(\.variant))
+    )
+}
+
+func loadReviewReactionLottieAsset(
+    assetConfiguration: ReviewReactionLottieAssetConfiguration
+) -> ReviewReactionLottieAssetLoadResult {
+    guard let dataAsset: NSDataAsset = NSDataAsset(name: assetConfiguration.assetName) else {
+        let failure: ReviewReactionLottieAssetFailure = ReviewReactionLottieAssetFailure(
+            variant: assetConfiguration.variant,
+            assetName: assetConfiguration.assetName,
+            assetDescription: assetConfiguration.assetDescription,
+            failureReason: "missing_data_asset",
+            message: "Review Lottie data asset is missing."
+        )
+        logReviewReactionLottieAssetFailure(failure: failure)
+        return .failed(failure: failure)
+    }
+
+    do {
+        let animation: LottieAnimation = try LottieAnimation.from(data: dataAsset.data)
+        return .ready(variant: assetConfiguration.variant, animation: animation)
+    } catch {
+        let failure: ReviewReactionLottieAssetFailure = ReviewReactionLottieAssetFailure(
+            variant: assetConfiguration.variant,
+            assetName: assetConfiguration.assetName,
+            assetDescription: assetConfiguration.assetDescription,
+            failureReason: "decode_failed",
+            message: String(describing: error)
+        )
+        logReviewReactionLottieAssetFailure(failure: failure)
+        return .failed(failure: failure)
+    }
+}
+
+func reviewReactionLottiePrewarmAssetConfigurations() -> [ReviewReactionLottieAssetConfiguration] {
+    let configurationsByVariant: [ReviewReactionVariant: ReviewReactionLottieAssetConfiguration] = Dictionary(
+        uniqueKeysWithValues: reviewReactionLottieAssetConfigurations.map { assetConfiguration in
+            (assetConfiguration.variant, assetConfiguration)
+        }
+    )
+    let ratingEntries: [[ReviewReactionVariantDistributionEntry]] = ReviewReactionRating.allCases.map { rating in
+        reviewReactionVariantDistributionEntries(rating: rating)
+    }
+    let maximumVariantCount: Int = ratingEntries.map(\.count).max() ?? 0
+
+    var orderedConfigurations: [ReviewReactionLottieAssetConfiguration] = []
+    for index in 0..<maximumVariantCount {
+        for entries in ratingEntries where index < entries.count {
+            let variant: ReviewReactionVariant = entries[index].variant
+            guard let assetConfiguration: ReviewReactionLottieAssetConfiguration = configurationsByVariant[variant] else {
+                preconditionFailure("Review Lottie asset configuration is missing variant \(variant.debugIdentifier).")
+            }
+            orderedConfigurations.append(assetConfiguration)
+        }
+    }
+
+    return orderedConfigurations
+}
+
+func startReviewReactionLottieAssetPrewarm(
+    onLoadResult: @escaping ReviewReactionLottieAssetLoadHandler
+) {
+    Task.detached(priority: .utility) {
+        for assetConfiguration in reviewReactionLottiePrewarmAssetConfigurations() {
+            let loadResult: ReviewReactionLottieAssetLoadResult = loadReviewReactionLottieAsset(
+                assetConfiguration: assetConfiguration
+            )
+            await MainActor.run {
+                onLoadResult(loadResult)
+            }
+        }
+    }
+}
+
+func isReviewReactionLottieVariant(variant: ReviewReactionVariant) -> Bool {
+    reviewReactionLottieAssetConfigurations.contains { assetConfiguration in
+        assetConfiguration.variant == variant
+    }
+}
+
+func reviewReactionLottieAssetConfiguration(
+    variant: ReviewReactionVariant
+) -> ReviewReactionLottieAssetConfiguration? {
+    reviewReactionLottieAssetConfigurations.first { assetConfiguration in
+        assetConfiguration.variant == variant
+    }
+}
+
+func reviewReactionLottieAssetStatus(
+    variant: ReviewReactionVariant,
+    readiness: ReviewReactionLottieAssetReadiness
+) -> ReviewReactionLottieAssetStatus {
+    guard isReviewReactionLottieVariant(variant: variant) else {
+        return .notLottie
+    }
+    if readiness.readyVariants.contains(variant) {
+        return .ready
+    }
+    if readiness.failedVariants.contains(variant) {
+        return .failed
+    }
+    if readiness.pendingVariants.contains(variant) {
+        return .pending
+    }
+
+    preconditionFailure("Review Lottie readiness is missing state for \(variant.debugIdentifier).")
+}
+
+func shouldUseReviewReactionCrownFallback(
+    variant: ReviewReactionVariant,
+    readiness: ReviewReactionLottieAssetReadiness
+) -> Bool {
+    reviewReactionLottieAssetStatus(variant: variant, readiness: readiness) == .failed
+}
+
+private func logReviewReactionLottieAssetFailure(failure: ReviewReactionLottieAssetFailure) {
+    reviewReactionLottieAssetLogger.error(
+        "Review Lottie asset failed. variant=\(failure.variant.debugIdentifier, privacy: .public) assetName=\(failure.assetName, privacy: .public) assetDescription=\(failure.assetDescription, privacy: .public) failureReason=\(failure.failureReason, privacy: .public) message=\(failure.message, privacy: .public)"
+    )
+}

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionState.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionState.swift
@@ -218,6 +218,60 @@ func reviewReactionVariantTotalWeight(
     return totalWeight
 }
 
+func reviewReactionReadyVariantDistributionEntries(
+    rating: ReviewReactionRating,
+    readyVariants: Set<ReviewReactionVariant>
+) -> [ReviewReactionVariantDistributionEntry] {
+    reviewReactionVariantDistributionEntries(rating: rating).filter { entry in
+        readyVariants.contains(entry.variant)
+    }
+}
+
+func reviewReactionReadyVariantTotalWeight(
+    rating: ReviewReactionRating,
+    readyVariants: Set<ReviewReactionVariant>
+) -> Int {
+    let entries: [ReviewReactionVariantDistributionEntry] = reviewReactionReadyVariantDistributionEntries(
+        rating: rating,
+        readyVariants: readyVariants
+    )
+
+    var totalWeight: Int = 0
+    for entry in entries {
+        precondition(entry.weight > 0, "Invalid review reaction weight for \(entry.id): \(entry.weight).")
+        totalWeight += entry.weight
+    }
+
+    return totalWeight
+}
+
+func reviewReactionAvailableVariantDistributionEntries(
+    rating: ReviewReactionRating,
+    availableVariants: Set<ReviewReactionVariant>
+) -> [ReviewReactionVariantDistributionEntry] {
+    reviewReactionVariantDistributionEntries(rating: rating).filter { entry in
+        availableVariants.contains(entry.variant)
+    }
+}
+
+func reviewReactionAvailableVariantTotalWeight(
+    rating: ReviewReactionRating,
+    availableVariants: Set<ReviewReactionVariant>
+) -> Int {
+    let entries: [ReviewReactionVariantDistributionEntry] = reviewReactionAvailableVariantDistributionEntries(
+        rating: rating,
+        availableVariants: availableVariants
+    )
+
+    var totalWeight: Int = 0
+    for entry in entries {
+        precondition(entry.weight > 0, "Invalid review reaction weight for \(entry.id): \(entry.weight).")
+        totalWeight += entry.weight
+    }
+
+    return totalWeight
+}
+
 func reviewReactionCleanupDelayNanoseconds(
     variant: ReviewReactionVariant,
     motionMode: ReviewReactionMotionMode
@@ -253,6 +307,66 @@ func selectReviewReactionVariant(
     }
 
     preconditionFailure("Review reaction distribution is missing rating \(rating.debugIdentifier) roll \(roll).")
+}
+
+func selectReadyReviewReactionVariant(
+    rating: ReviewReactionRating,
+    readyVariants: Set<ReviewReactionVariant>,
+    roll: Int
+) -> ReviewReactionVariant? {
+    let entries: [ReviewReactionVariantDistributionEntry] = reviewReactionReadyVariantDistributionEntries(
+        rating: rating,
+        readyVariants: readyVariants
+    )
+    guard entries.isEmpty == false else {
+        return nil
+    }
+
+    let totalWeight: Int = reviewReactionReadyVariantTotalWeight(
+        rating: rating,
+        readyVariants: readyVariants
+    )
+    precondition((0..<totalWeight).contains(roll), "Ready review reaction roll must be in 0..<\(totalWeight), received \(roll).")
+
+    var cumulativeWeight: Int = 0
+    for entry in entries {
+        cumulativeWeight += entry.weight
+        if roll < cumulativeWeight {
+            return entry.variant
+        }
+    }
+
+    preconditionFailure("Ready review reaction distribution is missing rating \(rating.debugIdentifier) roll \(roll).")
+}
+
+func selectAvailableReviewReactionVariant(
+    rating: ReviewReactionRating,
+    availableVariants: Set<ReviewReactionVariant>,
+    roll: Int
+) -> ReviewReactionVariant? {
+    let entries: [ReviewReactionVariantDistributionEntry] = reviewReactionAvailableVariantDistributionEntries(
+        rating: rating,
+        availableVariants: availableVariants
+    )
+    guard entries.isEmpty == false else {
+        return nil
+    }
+
+    let totalWeight: Int = reviewReactionAvailableVariantTotalWeight(
+        rating: rating,
+        availableVariants: availableVariants
+    )
+    precondition((0..<totalWeight).contains(roll), "Available review reaction roll must be in 0..<\(totalWeight), received \(roll).")
+
+    var cumulativeWeight: Int = 0
+    for entry in entries {
+        cumulativeWeight += entry.weight
+        if roll < cumulativeWeight {
+            return entry.variant
+        }
+    }
+
+    preconditionFailure("Available review reaction distribution is missing rating \(rating.debugIdentifier) roll \(roll).")
 }
 
 func makeReviewReactionRating(rating: ReviewRating) -> ReviewReactionRating {

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
@@ -1,16 +1,41 @@
 import SwiftUI
 
 extension ReviewView {
+    func prewarmReviewReactionLottieAssets() {
+        if self.hasStartedReviewReactionLottiePrewarm {
+            return
+        }
+
+        self.hasStartedReviewReactionLottiePrewarm = true
+        startReviewReactionLottieAssetPrewarm { loadResult in
+            self.reviewReactionLottieAssetStore = self.reviewReactionLottieAssetStore.recordingLoadResult(
+                loadResult: loadResult
+            )
+        }
+    }
+
     func emitReviewReaction(rating: ReviewRating) {
         let reactionRating = makeReviewReactionRating(rating: rating)
-        let totalWeight = reviewReactionVariantTotalWeight(rating: reactionRating)
+        let availableVariants: Set<ReviewReactionVariant> = self.reviewReactionLottieAssetStore.availableVariants
+        let totalWeight: Int = reviewReactionAvailableVariantTotalWeight(
+            rating: reactionRating,
+            availableVariants: availableVariants
+        )
+        guard totalWeight > 0 else {
+            return
+        }
+        guard let variant: ReviewReactionVariant = selectAvailableReviewReactionVariant(
+            rating: reactionRating,
+            availableVariants: availableVariants,
+            roll: Int.random(in: 0..<totalWeight)
+        ) else {
+            return
+        }
+
         let event = ReviewReactionEvent(
             id: UUID(),
             rating: reactionRating,
-            variant: selectReviewReactionVariant(
-                rating: reactionRating,
-                roll: Int.random(in: 0..<totalWeight)
-            )
+            variant: variant
         )
         self.activeReviewReactionEvents = appendReviewReactionEvent(
             events: self.activeReviewReactionEvents,

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -22,6 +22,8 @@ struct ReviewView: View {
     @State var preparedRevealState: PreparedReviewRevealState? = nil
     // Keep the next review card warm so the next front can appear immediately after rating.
     @State var preparedNextRevealState: PreparedReviewRevealState? = nil
+    @State var hasStartedReviewReactionLottiePrewarm: Bool = false
+    @State var reviewReactionLottieAssetStore: ReviewReactionLottieAssetStore = makePendingReviewReactionLottieAssetStore()
     @State var activeReviewReactionEvents: [ReviewReactionEvent] = []
     @State var isQueuePreviewPresented: Bool = false
     @State var isEditorPresented: Bool = false
@@ -136,11 +138,15 @@ struct ReviewView: View {
 
             ReviewReactionLayer(
                 events: self.activeReviewReactionEvents,
+                lottieAssetStore: self.reviewReactionLottieAssetStore,
                 onEventFinished: self.removeFinishedReviewReactionEvent(eventId:)
             )
         }
         .accessibilityIdentifier(UITestIdentifier.reviewScreen)
         .navigationTitle(String(localized: "Review", table: reviewCardsStringsTableName))
+        .onAppear {
+            self.prewarmReviewReactionLottieAssets()
+        }
         .onChange(of: currentCard?.cardId) { _, _ in
             isAnswerVisible = false
             self.reviewSpeechController.stopSpeech()

--- a/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
@@ -21,6 +21,8 @@ struct TestSettingsView: View {
 }
 
 struct TestAnimationsView: View {
+    @State private var hasStartedReviewReactionLottiePrewarm: Bool = false
+    @State private var reviewReactionLottieAssetStore: ReviewReactionLottieAssetStore = makePendingReviewReactionLottieAssetStore()
     @State private var activeReviewReactionEvents: [ReviewReactionEvent] = []
 
     var body: some View {
@@ -29,6 +31,7 @@ struct TestAnimationsView: View {
                 ForEach(ReviewReactionRating.allCases, id: \.self) { rating in
                     Section(localizedReviewReactionRatingTitle(rating: rating)) {
                         ForEach(reviewReactionVariantDistributionEntries(rating: rating)) { entry in
+                            let assetStatus: ReviewReactionLottieAssetStatus = self.assetStatus(entry: entry)
                             Button {
                                 self.playAnimation(entry: entry)
                             } label: {
@@ -39,12 +42,13 @@ struct TestAnimationsView: View {
 
                                     Spacer(minLength: 0)
 
-                                    Text(testAnimationProbabilityText(entry: entry))
+                                    Text(testAnimationDetailText(entry: entry, assetStatus: assetStatus))
                                         .font(.subheadline.monospacedDigit())
                                         .foregroundStyle(.secondary)
                                 }
                             }
-                            .accessibilityLabel(testAnimationAccessibilityLabel(entry: entry))
+                            .disabled(assetStatus == .pending)
+                            .accessibilityLabel(testAnimationAccessibilityLabel(entry: entry, assetStatus: assetStatus))
                         }
                     }
                 }
@@ -54,13 +58,34 @@ struct TestAnimationsView: View {
 
             ReviewReactionLayer(
                 events: self.activeReviewReactionEvents,
+                lottieAssetStore: self.reviewReactionLottieAssetStore,
                 onEventFinished: self.removeFinishedReviewReactionEvent(eventId:)
             )
         }
         .navigationTitle(aiSettingsLocalized("settings.test.animations.title", "Animations"))
+        .onAppear {
+            self.prewarmReviewReactionLottieAssets()
+        }
+    }
+
+    private func prewarmReviewReactionLottieAssets() {
+        if self.hasStartedReviewReactionLottiePrewarm {
+            return
+        }
+
+        self.hasStartedReviewReactionLottiePrewarm = true
+        startReviewReactionLottieAssetPrewarm { loadResult in
+            self.reviewReactionLottieAssetStore = self.reviewReactionLottieAssetStore.recordingLoadResult(
+                loadResult: loadResult
+            )
+        }
     }
 
     private func playAnimation(entry: ReviewReactionVariantDistributionEntry) {
+        guard self.assetStatus(entry: entry) != .pending else {
+            return
+        }
+
         let event = ReviewReactionEvent(
             id: UUID(),
             rating: entry.rating,
@@ -77,6 +102,13 @@ struct TestAnimationsView: View {
         self.activeReviewReactionEvents = self.activeReviewReactionEvents.filter { activeEvent in
             activeEvent.id != eventId
         }
+    }
+
+    private func assetStatus(entry: ReviewReactionVariantDistributionEntry) -> ReviewReactionLottieAssetStatus {
+        reviewReactionLottieAssetStatus(
+            variant: entry.variant,
+            readiness: self.reviewReactionLottieAssetStore.readiness
+        )
     }
 }
 
@@ -102,12 +134,27 @@ private func testAnimationProbabilityText(entry: ReviewReactionVariantDistributi
     )
 }
 
-private func testAnimationAccessibilityLabel(entry: ReviewReactionVariantDistributionEntry) -> String {
+private func testAnimationDetailText(
+    entry: ReviewReactionVariantDistributionEntry,
+    assetStatus: ReviewReactionLottieAssetStatus
+) -> String {
+    switch assetStatus {
+    case .pending:
+        return aiSettingsLocalized("common.loading", "Loading...")
+    case .ready, .failed, .notLottie:
+        return testAnimationProbabilityText(entry: entry)
+    }
+}
+
+private func testAnimationAccessibilityLabel(
+    entry: ReviewReactionVariantDistributionEntry,
+    assetStatus: ReviewReactionLottieAssetStatus
+) -> String {
     aiSettingsLocalizedFormat(
         "settings.test.animations.playAccessibility",
         "Play %@ animation, %@",
         entry.variant.debugIdentifier,
-        testAnimationProbabilityText(entry: entry)
+        testAnimationDetailText(entry: entry, assetStatus: assetStatus)
     )
 }
 

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Reaction/ReviewReactionVariantSelectionTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Reaction/ReviewReactionVariantSelectionTests.swift
@@ -85,6 +85,252 @@ final class ReviewReactionVariantSelectionTests: XCTestCase {
         }
     }
 
+    func testLottieAssetConfigurationsMatchDistributedVariants() {
+        let distributedVariants: Set<ReviewReactionVariant> = Set(
+            allReviewReactionVariantDistributionEntries.map(\.variant)
+        )
+        let configuredVariants: Set<ReviewReactionVariant> = Set(
+            reviewReactionLottieAssetConfigurations.map(\.variant)
+        )
+
+        XCTAssertEqual(configuredVariants, distributedVariants)
+    }
+
+    func testLottieAssetConfigurationNamesAreUnique() {
+        let assetNames: [String] = reviewReactionLottieAssetConfigurations.map(\.assetName)
+
+        XCTAssertEqual(Set(assetNames).count, assetNames.count)
+    }
+
+    func testLottieAssetConfigurationVariantsAreUnique() {
+        let variants: [ReviewReactionVariant] = reviewReactionLottieAssetConfigurations.map(\.variant)
+
+        XCTAssertEqual(Set(variants).count, variants.count)
+    }
+
+    func testReviewReactionLottiePrewarmAssetConfigurationsInterleaveRatingGroups() {
+        let prewarmVariants: [ReviewReactionVariant] = reviewReactionLottiePrewarmAssetConfigurations().map(\.variant)
+        let configuredVariants: [ReviewReactionVariant] = reviewReactionLottieAssetConfigurations.map(\.variant)
+
+        XCTAssertEqual(prewarmVariants.count, configuredVariants.count)
+        XCTAssertEqual(Set(prewarmVariants), Set(configuredVariants))
+        XCTAssertEqual(
+            Array(prewarmVariants.prefix(4)),
+            [.againRainCloud, .hardTiger, .goodOtter, .easySunrise]
+        )
+        XCTAssertEqual(
+            Array(prewarmVariants.dropFirst(4).prefix(4)),
+            [.againTornado, .hardTRex, .goodOwl, .easySunriseOverMountains]
+        )
+    }
+
+    func testConfiguredLottieAssetsLoad() {
+        var failedAssetMessages: [String] = []
+
+        for assetConfiguration in reviewReactionLottieAssetConfigurations {
+            let loadResult: ReviewReactionLottieAssetLoadResult = loadReviewReactionLottieAsset(
+                assetConfiguration: assetConfiguration
+            )
+            switch loadResult {
+            case .ready(let variant, _):
+                XCTAssertEqual(variant, assetConfiguration.variant)
+            case .failed(let failure):
+                failedAssetMessages.append(
+                    "\(failure.assetName): \(failure.failureReason) \(failure.message)"
+                )
+            }
+        }
+
+        XCTAssertTrue(failedAssetMessages.isEmpty, failedAssetMessages.joined(separator: "\n"))
+    }
+
+    func testReadyVariantSelectionPreservesBoundariesWhenAllRatingVariantsAreReady() {
+        for distribution in expectedReviewReactionDistributions {
+            let readyVariants: Set<ReviewReactionVariant> = Set(distribution.entries.map(\.variant))
+            var startRoll: Int = 0
+            for entry in distribution.entries {
+                let endRoll: Int = startRoll + entry.weight - 1
+                XCTAssertEqual(
+                    selectReadyReviewReactionVariant(
+                        rating: distribution.rating,
+                        readyVariants: readyVariants,
+                        roll: startRoll
+                    ),
+                    entry.variant
+                )
+                XCTAssertEqual(
+                    selectReadyReviewReactionVariant(
+                        rating: distribution.rating,
+                        readyVariants: readyVariants,
+                        roll: endRoll
+                    ),
+                    entry.variant
+                )
+                startRoll += entry.weight
+            }
+        }
+    }
+
+    func testReadyVariantSelectionReturnsNilWhenRatingHasNoReadyVariants() {
+        let readyVariants: Set<ReviewReactionVariant> = [.hardTiger, .goodOwl, .easySunrise]
+
+        XCTAssertEqual(
+            reviewReactionReadyVariantTotalWeight(
+                rating: .again,
+                readyVariants: readyVariants
+            ),
+            0
+        )
+        XCTAssertNil(
+            selectReadyReviewReactionVariant(
+                rating: .again,
+                readyVariants: readyVariants,
+                roll: 0
+            )
+        )
+    }
+
+    func testReadyVariantSelectionUsesReadySameRatingVariantWhenHigherWeightVariantIsPending() {
+        let readyVariants: Set<ReviewReactionVariant> = [.goodOwl]
+
+        XCTAssertEqual(
+            reviewReactionReadyVariantTotalWeight(
+                rating: .good,
+                readyVariants: readyVariants
+            ),
+            28
+        )
+        XCTAssertEqual(
+            selectReadyReviewReactionVariant(
+                rating: .good,
+                readyVariants: readyVariants,
+                roll: 0
+            ),
+            .goodOwl
+        )
+        XCTAssertEqual(
+            selectReadyReviewReactionVariant(
+                rating: .good,
+                readyVariants: readyVariants,
+                roll: 27
+            ),
+            .goodOwl
+        )
+    }
+
+    func testAvailableVariantSelectionPreservesBoundariesWhenAllRatingVariantsAreAvailable() {
+        for distribution in expectedReviewReactionDistributions {
+            let availableVariants: Set<ReviewReactionVariant> = Set(distribution.entries.map(\.variant))
+            var startRoll: Int = 0
+            for entry in distribution.entries {
+                let endRoll: Int = startRoll + entry.weight - 1
+                XCTAssertEqual(
+                    selectAvailableReviewReactionVariant(
+                        rating: distribution.rating,
+                        availableVariants: availableVariants,
+                        roll: startRoll
+                    ),
+                    entry.variant
+                )
+                XCTAssertEqual(
+                    selectAvailableReviewReactionVariant(
+                        rating: distribution.rating,
+                        availableVariants: availableVariants,
+                        roll: endRoll
+                    ),
+                    entry.variant
+                )
+                startRoll += entry.weight
+            }
+        }
+    }
+
+    func testAvailableVariantSelectionReturnsNilWhenRatingHasNoAvailableVariants() {
+        let availableVariants: Set<ReviewReactionVariant> = [.hardTiger, .goodOwl, .easySunrise]
+
+        XCTAssertEqual(
+            reviewReactionAvailableVariantTotalWeight(
+                rating: .again,
+                availableVariants: availableVariants
+            ),
+            0
+        )
+        XCTAssertNil(
+            selectAvailableReviewReactionVariant(
+                rating: .again,
+                availableVariants: availableVariants,
+                roll: 0
+            )
+        )
+    }
+
+    func testAvailableVariantSelectionCanChooseFailedAssetFallbackCandidate() {
+        let availableVariants: Set<ReviewReactionVariant> = [.goodOtter]
+
+        XCTAssertEqual(
+            reviewReactionAvailableVariantTotalWeight(
+                rating: .good,
+                availableVariants: availableVariants
+            ),
+            32
+        )
+        XCTAssertEqual(
+            selectAvailableReviewReactionVariant(
+                rating: .good,
+                availableVariants: availableVariants,
+                roll: 0
+            ),
+            .goodOtter
+        )
+        XCTAssertEqual(
+            selectAvailableReviewReactionVariant(
+                rating: .good,
+                availableVariants: availableVariants,
+                roll: 31
+            ),
+            .goodOtter
+        )
+    }
+
+    func testLottieAssetStoreAvailableVariantsExcludePendingVariants() {
+        let failedAsset: ReviewReactionLottieAssetFailure = ReviewReactionLottieAssetFailure(
+            variant: .goodOtter,
+            assetName: "ReviewGoodOtter",
+            assetDescription: "test asset",
+            failureReason: "decode_failed",
+            message: "test failure"
+        )
+        let store: ReviewReactionLottieAssetStore = ReviewReactionLottieAssetStore(
+            readyAnimations: [:],
+            failedAssets: [.goodOtter: failedAsset],
+            pendingVariants: [.goodOwl]
+        )
+
+        XCTAssertEqual(store.availableVariants, [.goodOtter])
+    }
+
+    func testPendingLottieAssetDoesNotUseCrownFallback() {
+        let readiness: ReviewReactionLottieAssetReadiness = ReviewReactionLottieAssetReadiness(
+            readyVariants: [],
+            pendingVariants: [.goodOtter],
+            failedVariants: []
+        )
+
+        XCTAssertEqual(reviewReactionLottieAssetStatus(variant: .goodOtter, readiness: readiness), .pending)
+        XCTAssertFalse(shouldUseReviewReactionCrownFallback(variant: .goodOtter, readiness: readiness))
+    }
+
+    func testFailedLottieAssetUsesCrownFallback() {
+        let readiness: ReviewReactionLottieAssetReadiness = ReviewReactionLottieAssetReadiness(
+            readyVariants: [],
+            pendingVariants: [],
+            failedVariants: [.goodOtter]
+        )
+
+        XCTAssertEqual(reviewReactionLottieAssetStatus(variant: .goodOtter, readiness: readiness), .failed)
+        XCTAssertTrue(shouldUseReviewReactionCrownFallback(variant: .goodOtter, readiness: readiness))
+    }
+
     func testProbabilityPercentagesUseWeights() {
         for distribution in expectedReviewReactionDistributions {
             let totalWeight = distribution.entries.reduce(0) { result, entry in


### PR DESCRIPTION
## Summary

- Moves iOS review reaction Lottie readiness into a shared prewarm/cache store owned from the review root.
- Starts prewarming before the first rating tap and keeps pending assets from rendering as crown fallback.
- Keeps crown fallback for real bundled asset failures and updates the settings animation test screen to use the same readiness path.
- Adds contract coverage for ready/pending/failed status and ready/available weighted selection.

## Validation

- `git --no-pager diff --check`
- `find apps/ios/Flashcards/Flashcards/Assets.xcassets -name 'review_*.json' -print0 | xargs -0 jq empty`

Simulator-backed XCTest/smoke was not run per repository guidance without explicit simulator-run permission. Local `xcodebuild build` was attempted earlier but could not reach compilation because this machine lacks an eligible iOS 26.5 destination/platform setup.