### PR TITLE
Fix Android AI test JSON dependency

### DIFF
--- a/apps/android/feature/ai/build.gradle.kts
+++ b/apps/android/feature/ai/build.gradle.kts
@@ -45,5 +45,6 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
 
     testImplementation(libs.junit4)
+    testImplementation(libs.org.json)
     testImplementation(libs.org.jetbrains.kotlinx.coroutines.test)
 }


### PR DESCRIPTION
## Summary
- Add the JVM org.json test dependency to the Android AI feature module.

## Root cause
- The AI runtime send path now calls JSON request-size encoding from data:local during feature:ai JVM tests. Without org.json on the feature test runtime classpath, those tests hit Android JSON stubs and fail with RuntimeException.

## Validation
- git diff --check HEAD~1..HEAD
- Gradle was not run locally because repository instructions require explicit approval for local Gradle runs.