### PR TITLE
[codex] Fix iOS Xcode Cloud build errors

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -35,6 +35,84 @@ struct RootTabView: View {
         )
     }
 
+    private var guestSignInAfterReviewPromptPresentation: Binding<Bool> {
+        Binding<Bool>(
+            get: {
+                store.isGuestSignInAfterReviewPromptPresented
+            },
+            set: { isPresented in
+                if isPresented == false {
+                    store.dismissGuestSignInAfterReviewPrompt()
+                }
+            }
+        )
+    }
+
+    private var accountDeletionSuccessPresentation: Binding<Bool> {
+        Binding<Bool>(
+            get: {
+                store.accountDeletionSuccessMessage != nil
+            },
+            set: { isPresented in
+                if isPresented == false {
+                    store.dismissAccountDeletionSuccessMessage()
+                }
+            }
+        )
+    }
+
+    private var guestSignInAfterReviewPromptTitle: String {
+        String(
+            localized: "root_tab.guest_sign_in_after_review_prompt.title",
+            defaultValue: "Save your progress",
+            table: "Foundation",
+            comment: "Guest sign-in prompt title after reviewing enough cards"
+        )
+    }
+
+    private var guestSignInAfterReviewPromptMessage: String {
+        String(
+            localized: "root_tab.guest_sign_in_after_review_prompt.message",
+            defaultValue: "Sign in with email so these cards and review progress are not lost.",
+            table: "Foundation",
+            comment: "Guest sign-in prompt body after reviewing enough cards"
+        )
+    }
+
+    private var guestSignInAfterReviewPromptLaterTitle: String {
+        String(
+            localized: "root_tab.guest_sign_in_after_review_prompt.later",
+            defaultValue: "Later",
+            table: "Foundation",
+            comment: "Guest sign-in prompt secondary button"
+        )
+    }
+
+    private var guestSignInAfterReviewPromptSignInTitle: String {
+        String(
+            localized: "root_tab.guest_sign_in_after_review_prompt.sign_in",
+            defaultValue: "Sign in",
+            table: "Foundation",
+            comment: "Guest sign-in prompt primary button"
+        )
+    }
+
+    private var accountDeletedTitle: String {
+        String(
+            localized: "root_tab.account_deleted.title",
+            table: "Foundation",
+            comment: "Account deletion success alert title"
+        )
+    }
+
+    private var confirmationButtonTitle: String {
+        String(
+            localized: "shared.ok",
+            table: "Foundation",
+            comment: "Confirmation button title"
+        )
+    }
+
     @MainActor
     private func reconcileGuestSignInAfterReviewPrompt() {
         self.store.reconcileGuestSignInAfterReviewPrompt(
@@ -353,30 +431,11 @@ struct RootTabView: View {
                 .environment(store)
         }
         .alert(
-            String(
-                localized: "root_tab.guest_sign_in_after_review_prompt.title",
-                defaultValue: "Save your progress",
-                table: "Foundation",
-                comment: "Guest sign-in prompt title after reviewing enough cards"
-            ),
-            isPresented: Binding(
-                get: {
-                    store.isGuestSignInAfterReviewPromptPresented
-                },
-                set: { isPresented in
-                    if isPresented == false {
-                        store.dismissGuestSignInAfterReviewPrompt()
-                    }
-                }
-            )
+            self.guestSignInAfterReviewPromptTitle,
+            isPresented: self.guestSignInAfterReviewPromptPresentation
         ) {
             Button(
-                String(
-                    localized: "root_tab.guest_sign_in_after_review_prompt.later",
-                    defaultValue: "Later",
-                    table: "Foundation",
-                    comment: "Guest sign-in prompt secondary button"
-                ),
+                self.guestSignInAfterReviewPromptLaterTitle,
                 role: .cancel
             ) {
                 store.snoozeGuestSignInAfterReviewPrompt(
@@ -385,49 +444,20 @@ struct RootTabView: View {
                 )
             }
             Button(
-                String(
-                    localized: "root_tab.guest_sign_in_after_review_prompt.sign_in",
-                    defaultValue: "Sign in",
-                    table: "Foundation",
-                    comment: "Guest sign-in prompt primary button"
-                )
+                self.guestSignInAfterReviewPromptSignInTitle
             ) {
                 store.acceptGuestSignInAfterReviewPrompt(now: Date())
                 self.isGuestSignInCloudSignInPresented = true
             }
         } message: {
-            Text(
-                String(
-                    localized: "root_tab.guest_sign_in_after_review_prompt.message",
-                    defaultValue: "Sign in with email so these cards and review progress are not lost.",
-                    table: "Foundation",
-                    comment: "Guest sign-in prompt body after reviewing enough cards"
-                )
-            )
+            Text(self.guestSignInAfterReviewPromptMessage)
         }
         .alert(
-            String(
-                localized: "root_tab.account_deleted.title",
-                table: "Foundation",
-                comment: "Account deletion success alert title"
-            ),
-            isPresented: Binding(
-                get: {
-                    store.accountDeletionSuccessMessage != nil
-                },
-                set: { isPresented in
-                    if isPresented == false {
-                        store.dismissAccountDeletionSuccessMessage()
-                    }
-                }
-            )
+            self.accountDeletedTitle,
+            isPresented: self.accountDeletionSuccessPresentation
         ) {
             Button(
-                String(
-                    localized: "shared.ok",
-                    table: "Foundation",
-                    comment: "Confirmation button title"
-                ),
+                self.confirmationButtonTitle,
                 role: .cancel
             ) {
                 store.dismissAccountDeletionSuccessMessage()

--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -233,12 +233,6 @@ extension FlashcardsStore {
         return pendingState.common.userId
     }
 
-    func shouldFinalizeCompletedPendingGuestUpgradeForRecoveredLink(
-        linkContext: CloudWorkspaceLinkContext
-    ) throws -> Bool {
-        try self.completedPendingGuestUpgradeStateForRecoveredLink(linkContext: linkContext) != nil
-    }
-
     func validateCompletedPendingGuestUpgradeRecoverySelection(
         selection: CloudWorkspaceLinkSelection,
         workspace: CloudWorkspaceSummary

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudCredentialRecovery.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudCredentialRecovery.swift
@@ -432,7 +432,7 @@ extension FlashcardsStore {
         )
     }
 
-    private func blockCloudSyncForCredentialRecovery() {
+    func blockCloudSyncForCredentialRecovery() {
         guard let recoveryState = self.cloudCredentialRecoveryState else {
             return
         }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudLink.swift
@@ -242,21 +242,22 @@ extension FlashcardsStore {
                 email: linkContext.email,
                 apiBaseUrl: linkContext.apiBaseUrl
             )
-            if linkContext.guestUpgradeMode == nil
-                && (try self.shouldFinalizeCompletedPendingGuestUpgradeForRecoveredLink(linkContext: linkContext)),
-                let completedGuestUpgradeWorkspace = try self.completedPendingGuestUpgradeWorkspaceForRecoveredLink(
+            if linkContext.guestUpgradeMode == nil {
+                let completedGuestUpgradeWorkspace: CloudWorkspaceSummary? = try self.completedPendingGuestUpgradeWorkspaceForRecoveredLink(
                     linkContext: linkContext
-                ) {
-                try self.validateCompletedPendingGuestUpgradeRecoverySelection(
-                    selection: selection,
-                    workspace: completedGuestUpgradeWorkspace
                 )
-                if let completedGuestUpgradeWorkspace = try await self.finalizeCompletedPendingGuestUpgradeForRecoveredLinkIfNeeded(
-                    linkContext: linkContext,
-                    trigger: trigger
-                ) {
-                    self.globalErrorMessage = ""
-                    return completedGuestUpgradeWorkspace
+                if let completedGuestUpgradeWorkspace {
+                    try self.validateCompletedPendingGuestUpgradeRecoverySelection(
+                        selection: selection,
+                        workspace: completedGuestUpgradeWorkspace
+                    )
+                    if let completedGuestUpgradeWorkspace = try await self.finalizeCompletedPendingGuestUpgradeForRecoveredLinkIfNeeded(
+                        linkContext: linkContext,
+                        trigger: trigger
+                    ) {
+                        self.globalErrorMessage = ""
+                        return completedGuestUpgradeWorkspace
+                    }
                 }
             }
             try self.validateCloudCredentialRecoveryWorkspaceSelectionBeforeIdentitySideEffects(


### PR DESCRIPTION
## Summary

Fixes the current iOS Xcode Cloud compiler failures by keeping the guest-upgrade recovery lookup explicit, allowing the credential-recovery sync blocker to be reused across the relevant store extensions, and reducing the SwiftUI alert expression complexity in `RootTabView`.

## Validation

- `git --no-pager diff --cached --check`
- Review-only validation of the current diff

Local iOS builds, simulator tests, and smoke flows were not run because they are resource-heavy for this machine.