### PR TITLE
[codex] Fix iOS test target guest upgrade helper

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -212,6 +212,12 @@ extension FlashcardsStore {
         try self.completedPendingGuestUpgradeStateForRecoveredLink(linkContext: linkContext)?.workspace
     }
 
+    func shouldFinalizeCompletedPendingGuestUpgradeForRecoveredLink(
+        linkContext: CloudWorkspaceLinkContext
+    ) throws -> Bool {
+        try self.completedPendingGuestUpgradeStateForRecoveredLink(linkContext: linkContext) != nil
+    }
+
     func completedPendingGuestUpgradeRecoveryUserId(apiBaseUrl: String) throws -> String? {
         try self.completedPendingGuestUpgradeRecoveryCheckpoint(apiBaseUrl: apiBaseUrl)?.common.userId
     }


### PR DESCRIPTION
## Summary

Restores the guest-upgrade recovery helper used by the iOS test target so Xcode Cloud `build-for-testing` can compile the existing credential recovery tests.

## Validation

- `git --no-pager diff --check`

Local iOS builds, simulator tests, and smoke flows were not run because they are resource-heavy for this machine.