### PR TITLE
Fix chat attachment validation

### DIFF
--- a/apps/backend/src/chat/attachmentPolicy.ts
+++ b/apps/backend/src/chat/attachmentPolicy.ts
@@ -1,3 +1,5 @@
+import { Buffer } from "node:buffer";
+import { TextDecoder } from "node:util";
 import { HttpError } from "../shared/errors";
 
 export const chatAttachmentUnsupportedTypeCode = "CHAT_ATTACHMENT_UNSUPPORTED_TYPE";
@@ -51,6 +53,35 @@ const canonicalImageMediaTypeByAlias: Readonly<Record<string, string>> = {
   "image/png": "image/png",
   "image/webp": "image/webp",
 };
+
+const strictStandardBase64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const pdfEndMarker = Buffer.from("%%EOF", "ascii");
+const zipLocalFileHeaderSignature = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+const zipEndOfCentralDirectorySignature = Buffer.from([0x50, 0x4b, 0x05, 0x06]);
+const minimumOleCompoundFileByteLength = 512;
+const textLikeFileMediaTypes: ReadonlySet<string> = new Set([
+  "application/json",
+  "application/typescript",
+  "application/x-yaml",
+  "text/csv",
+  "text/html",
+  "text/javascript",
+  "text/markdown",
+  "text/plain",
+  "text/x-python",
+  "text/xml",
+]);
+const utf8TextDecoder = new TextDecoder("utf-8", { fatal: true });
+
+type DecodedAttachmentData = Readonly<{
+  base64Data: string;
+  decodedData: Buffer;
+}>;
+
+export type ValidatedChatAttachmentContent = Readonly<{
+  mediaType: string;
+  base64Data: string;
+}>;
 
 function throwUnsupportedChatAttachmentType(): never {
   throw new HttpError(
@@ -109,4 +140,348 @@ export function normalizeChatImageAttachmentMediaType(mediaType: string): string
   }
 
   throwUnsupportedChatAttachmentType();
+}
+
+function isDataUrlBase64Payload(base64Data: string): boolean {
+  const lowerCaseValue = base64Data.toLowerCase();
+  return lowerCaseValue.startsWith("data:") || lowerCaseValue.includes(";base64,");
+}
+
+function decodeStrictStandardBase64(base64Data: string): DecodedAttachmentData {
+  const trimmedBase64Data = base64Data.trim();
+  if (
+    trimmedBase64Data === ""
+    || isDataUrlBase64Payload(trimmedBase64Data)
+    || !strictStandardBase64Pattern.test(trimmedBase64Data)
+  ) {
+    throwUnsupportedChatAttachmentType();
+  }
+
+  const decodedData = Buffer.from(trimmedBase64Data, "base64");
+  if (decodedData.length === 0 || decodedData.toString("base64") !== trimmedBase64Data) {
+    throwUnsupportedChatAttachmentType();
+  }
+
+  return {
+    base64Data: trimmedBase64Data,
+    decodedData,
+  };
+}
+
+function startsWithBytes(data: Buffer, expectedBytes: ReadonlyArray<number>): boolean {
+  if (data.length < expectedBytes.length) {
+    return false;
+  }
+
+  return expectedBytes.every((expectedByte, index) => data[index] === expectedByte);
+}
+
+function endsWithBytes(data: Buffer, expectedBytes: ReadonlyArray<number>): boolean {
+  if (data.length < expectedBytes.length) {
+    return false;
+  }
+
+  const startIndex = data.length - expectedBytes.length;
+  return expectedBytes.every((expectedByte, index) => data[startIndex + index] === expectedByte);
+}
+
+function hasPngSignature(data: Buffer): boolean {
+  return startsWithBytes(data, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+function hasJpegSignature(data: Buffer): boolean {
+  return startsWithBytes(data, [0xff, 0xd8, 0xff]);
+}
+
+function hasGifSignature(data: Buffer): boolean {
+  return startsWithBytes(data, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61])
+    || startsWithBytes(data, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+}
+
+function hasWebpSignature(data: Buffer): boolean {
+  return data.length >= 12
+    && startsWithBytes(data, [0x52, 0x49, 0x46, 0x46])
+    && startsWithBytes(data.subarray(8), [0x57, 0x45, 0x42, 0x50]);
+}
+
+function hasPdfSignature(data: Buffer): boolean {
+  return startsWithBytes(data, [0x25, 0x50, 0x44, 0x46, 0x2d]);
+}
+
+function hasZipSignature(data: Buffer): boolean {
+  return startsWithBytes(data, [0x50, 0x4b, 0x03, 0x04])
+    || startsWithBytes(data, [0x50, 0x4b, 0x05, 0x06])
+    || startsWithBytes(data, [0x50, 0x4b, 0x07, 0x08]);
+}
+
+function hasOleCompoundFileSignature(data: Buffer): boolean {
+  return startsWithBytes(data, [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+}
+
+function hasPdfStructure(data: Buffer): boolean {
+  const pdfTailSearchStart = Math.max(0, data.length - 2048);
+  return data.length >= 20
+    && hasPdfSignature(data)
+    && data.subarray(pdfTailSearchStart).indexOf(pdfEndMarker) >= 0;
+}
+
+function hasPngStructure(data: Buffer): boolean {
+  if (!hasPngSignature(data)) {
+    return false;
+  }
+
+  let offset = 8;
+  let hasImageHeader = false;
+  while (offset + 12 <= data.length) {
+    const chunkLength = data.readUInt32BE(offset);
+    const chunkTypeStart = offset + 4;
+    const chunkDataStart = offset + 8;
+    const nextOffset = chunkDataStart + chunkLength + 4;
+    if (nextOffset > data.length || nextOffset <= offset) {
+      return false;
+    }
+
+    const chunkType = data.toString("ascii", chunkTypeStart, chunkTypeStart + 4);
+    if (!hasImageHeader) {
+      if (chunkType !== "IHDR" || chunkLength !== 13) {
+        return false;
+      }
+      hasImageHeader = true;
+    }
+
+    if (chunkType === "IEND") {
+      return hasImageHeader && chunkLength === 0 && nextOffset === data.length;
+    }
+
+    offset = nextOffset;
+  }
+
+  return false;
+}
+
+function hasJpegStructure(data: Buffer): boolean {
+  return data.length >= 4
+    && hasJpegSignature(data)
+    && endsWithBytes(data, [0xff, 0xd9]);
+}
+
+function hasGifStructure(data: Buffer): boolean {
+  return data.length >= 14
+    && hasGifSignature(data)
+    && endsWithBytes(data, [0x3b]);
+}
+
+function hasWebpStructure(data: Buffer): boolean {
+  if (!hasWebpSignature(data) || data.length < 20) {
+    return false;
+  }
+
+  const riffPayloadLength = data.readUInt32LE(4);
+  if (riffPayloadLength + 8 !== data.length) {
+    return false;
+  }
+
+  const firstChunkType = data.toString("ascii", 12, 16);
+  if (firstChunkType !== "VP8 " && firstChunkType !== "VP8L" && firstChunkType !== "VP8X") {
+    return false;
+  }
+
+  const firstChunkPayloadLength = data.readUInt32LE(16);
+  const firstChunkEnd = 20 + firstChunkPayloadLength + (firstChunkPayloadLength % 2);
+  return firstChunkEnd <= data.length;
+}
+
+function hasZipEndOfCentralDirectory(data: Buffer): boolean {
+  const maximumEndRecordSearchLength = 65_557;
+  const searchStart = Math.max(0, data.length - maximumEndRecordSearchLength);
+  return data.subarray(searchStart).indexOf(zipEndOfCentralDirectorySignature) >= 0;
+}
+
+function readZipLocalFileNames(data: Buffer): ReadonlySet<string> {
+  const fileNames = new Set<string>();
+  let searchOffset = 0;
+
+  while (searchOffset < data.length) {
+    const headerOffset = data.indexOf(zipLocalFileHeaderSignature, searchOffset);
+    if (headerOffset < 0) {
+      return fileNames;
+    }
+
+    if (headerOffset + 30 > data.length) {
+      return fileNames;
+    }
+
+    const generalPurposeBitFlag = data.readUInt16LE(headerOffset + 6);
+    const compressedSize = data.readUInt32LE(headerOffset + 18);
+    const fileNameLength = data.readUInt16LE(headerOffset + 26);
+    const extraFieldLength = data.readUInt16LE(headerOffset + 28);
+    const fileNameStart = headerOffset + 30;
+    const fileNameEnd = fileNameStart + fileNameLength;
+    const entryDataStart = fileNameEnd + extraFieldLength;
+    const hasDataDescriptor = (generalPurposeBitFlag & 0x08) !== 0;
+    const nextOffset = hasDataDescriptor ? entryDataStart : entryDataStart + compressedSize;
+    if (
+      fileNameLength === 0
+      || fileNameEnd > data.length
+      || entryDataStart > data.length
+      || nextOffset > data.length
+      || nextOffset <= headerOffset
+    ) {
+      return fileNames;
+    }
+
+    fileNames.add(data.toString("utf8", fileNameStart, fileNameEnd));
+    searchOffset = nextOffset;
+  }
+
+  return fileNames;
+}
+
+function hasOpenXmlPackageStructure(data: Buffer, requiredEntryName: string): boolean {
+  if (!hasZipSignature(data) || !hasZipEndOfCentralDirectory(data)) {
+    return false;
+  }
+
+  const fileNames = readZipLocalFileNames(data);
+  return fileNames.has("[Content_Types].xml") && fileNames.has(requiredEntryName);
+}
+
+function hasOleCompoundFileStructure(data: Buffer): boolean {
+  return data.length >= minimumOleCompoundFileByteLength && hasOleCompoundFileSignature(data);
+}
+
+function hasUtf16ByteOrderMark(data: Buffer): boolean {
+  return data.length >= 4
+    && data.length % 2 === 0
+    && (
+      startsWithBytes(data, [0xff, 0xfe])
+      || startsWithBytes(data, [0xfe, 0xff])
+    );
+}
+
+function hasOnlyTextControlBytes(data: Buffer): boolean {
+  return data.every((byte) => byte >= 0x20
+    || byte === 0x09
+    || byte === 0x0a
+    || byte === 0x0c
+    || byte === 0x0d);
+}
+
+function isUtf8TextData(data: Buffer): boolean {
+  if (!hasOnlyTextControlBytes(data)) {
+    return false;
+  }
+
+  try {
+    utf8TextDecoder.decode(data);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSingleByteTextData(data: Buffer): boolean {
+  return hasOnlyTextControlBytes(data);
+}
+
+function assertTextLikeAttachmentData(data: Buffer): void {
+  if (isUtf8TextData(data) || hasUtf16ByteOrderMark(data) || isSingleByteTextData(data)) {
+    return;
+  }
+
+  throwUnsupportedChatAttachmentType();
+}
+
+function assertChatImageAttachmentData(mediaType: string, decodedData: Buffer): void {
+  if (mediaType === "image/png" && hasPngStructure(decodedData)) {
+    return;
+  }
+
+  if (mediaType === "image/jpeg" && hasJpegStructure(decodedData)) {
+    return;
+  }
+
+  if (mediaType === "image/gif" && hasGifStructure(decodedData)) {
+    return;
+  }
+
+  if (mediaType === "image/webp" && hasWebpStructure(decodedData)) {
+    return;
+  }
+
+  throwUnsupportedChatAttachmentType();
+}
+
+function assertChatFileAttachmentData(mediaType: string, decodedData: Buffer): void {
+  if (mediaType === "application/pdf") {
+    if (hasPdfStructure(decodedData)) {
+      return;
+    }
+
+    throwUnsupportedChatAttachmentType();
+  }
+
+  if (mediaType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
+    if (hasOpenXmlPackageStructure(decodedData, "word/document.xml")) {
+      return;
+    }
+
+    throwUnsupportedChatAttachmentType();
+  }
+
+  if (mediaType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") {
+    if (hasOpenXmlPackageStructure(decodedData, "xl/workbook.xml")) {
+      return;
+    }
+
+    throwUnsupportedChatAttachmentType();
+  }
+
+  if (mediaType === "application/vnd.ms-excel") {
+    if (hasOleCompoundFileStructure(decodedData)) {
+      return;
+    }
+
+    throwUnsupportedChatAttachmentType();
+  }
+
+  if (textLikeFileMediaTypes.has(mediaType)) {
+    assertTextLikeAttachmentData(decodedData);
+    return;
+  }
+
+  throwUnsupportedChatAttachmentType();
+}
+
+export function validateChatImageAttachmentContent(
+  mediaType: string,
+  base64Data: string,
+): ValidatedChatAttachmentContent {
+  const canonicalMediaType = normalizeChatImageAttachmentMediaType(mediaType);
+  const decodedAttachment = decodeStrictStandardBase64(base64Data);
+  assertChatImageAttachmentData(canonicalMediaType, decodedAttachment.decodedData);
+
+  return {
+    mediaType: canonicalMediaType,
+    base64Data: decodedAttachment.base64Data,
+  };
+}
+
+export function validateChatFileAttachmentContent(
+  fileName: string,
+  mediaType: string,
+  base64Data: string,
+): ValidatedChatAttachmentContent {
+  const canonicalMediaType = normalizeChatFileAttachmentMediaType(fileName, mediaType);
+  const decodedAttachment = decodeStrictStandardBase64(base64Data);
+  assertChatFileAttachmentData(canonicalMediaType, decodedAttachment.decodedData);
+
+  return {
+    mediaType: canonicalMediaType,
+    base64Data: decodedAttachment.base64Data,
+  };
+}
+
+export function isChatAttachmentUnsupportedTypeError(error: unknown): boolean {
+  return error instanceof HttpError && error.code === chatAttachmentUnsupportedTypeCode;
 }

--- a/apps/backend/src/chat/http/contract.ts
+++ b/apps/backend/src/chat/http/contract.ts
@@ -4,8 +4,8 @@ import {
 } from "../composerSuggestions";
 import { HttpError } from "../../shared/errors";
 import {
-  normalizeChatFileAttachmentMediaType,
-  normalizeChatImageAttachmentMediaType,
+  validateChatFileAttachmentContent,
+  validateChatImageAttachmentContent,
 } from "../attachmentPolicy";
 import {
   expectNonEmptyString,
@@ -189,20 +189,29 @@ function parseChatContentPart(value: unknown, context: string): ChatContentPart 
 
   if (type === "image") {
     const mediaType = expectString(body.mediaType, `${context}.mediaType`);
+    const attachment = validateChatImageAttachmentContent(
+      mediaType,
+      expectNonEmptyString(body.base64Data, `${context}.base64Data`),
+    );
     return {
       type: "image",
-      mediaType: normalizeChatImageAttachmentMediaType(mediaType),
-      base64Data: expectNonEmptyString(body.base64Data, `${context}.base64Data`),
+      mediaType: attachment.mediaType,
+      base64Data: attachment.base64Data,
     };
   }
 
   if (type === "file") {
     const mediaType = expectString(body.mediaType, `${context}.mediaType`);
     const fileName = expectNonEmptyString(body.fileName, `${context}.fileName`);
+    const attachment = validateChatFileAttachmentContent(
+      fileName,
+      mediaType,
+      expectNonEmptyString(body.base64Data, `${context}.base64Data`),
+    );
     return {
       type: "file",
-      mediaType: normalizeChatFileAttachmentMediaType(fileName, mediaType),
-      base64Data: expectNonEmptyString(body.base64Data, `${context}.base64Data`),
+      mediaType: attachment.mediaType,
+      base64Data: attachment.base64Data,
       fileName,
     };
   }

--- a/apps/backend/src/chat/openai/input.test.ts
+++ b/apps/backend/src/chat/openai/input.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { HttpError } from "../../shared/errors";
+import {
+  chatAttachmentUnsupportedTypeCode,
+  chatAttachmentUnsupportedTypeMessage,
+} from "../attachmentPolicy";
 import { buildChatCompletionInput } from "./input";
 
 test("buildChatCompletionInput serializes card parts into deterministic XML before user text", async () => {
@@ -123,4 +128,31 @@ test("buildChatCompletionInput normalizes persisted history attachment aliases b
       file_data: "data:text/csv;base64,ZnJvbnQsYmFjaw==",
     },
   ]);
+});
+
+test("buildChatCompletionInput rejects invalid persisted history attachments with the attachment error", async () => {
+  await assert.rejects(
+    () => buildChatCompletionInput([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            fileName: "notes.pdf",
+            mediaType: "application/pdf",
+            base64Data: "cGxhaW4gdGV4dA==",
+          },
+        ],
+      },
+    ], [
+      {
+        type: "text",
+        text: "Continue.",
+      },
+    ], "Europe/Madrid"),
+    (error: unknown) => error instanceof HttpError
+      && error.statusCode === 400
+      && error.code === chatAttachmentUnsupportedTypeCode
+      && error.message === chatAttachmentUnsupportedTypeMessage,
+  );
 });

--- a/apps/backend/src/chat/openai/input.ts
+++ b/apps/backend/src/chat/openai/input.ts
@@ -7,8 +7,8 @@ import type { ContentPart, FileContentPart, ImageContentPart } from "../types";
 import { buildSystemInstructions } from "../shared";
 import { buildCardContextXml } from "../cardContext";
 import {
-  normalizeChatFileAttachmentMediaType,
-  normalizeChatImageAttachmentMediaType,
+  validateChatFileAttachmentContent,
+  validateChatImageAttachmentContent,
 } from "../attachmentPolicy";
 import {
   normalizeStoredOpenAIReplayItems,
@@ -20,13 +20,13 @@ type OpenAIInputItem = OpenAI.Responses.ResponseInputItem;
 type OpenAIInputContent = OpenAI.Responses.ResponseInputMessageContentList[number];
 
 function buildImageDataUrl(part: ImageContentPart): string {
-  const mediaType = normalizeChatImageAttachmentMediaType(part.mediaType);
-  return `data:${mediaType};base64,${part.base64Data}`;
+  const attachment = validateChatImageAttachmentContent(part.mediaType, part.base64Data);
+  return `data:${attachment.mediaType};base64,${attachment.base64Data}`;
 }
 
 function buildFileDataUrl(part: FileContentPart): string {
-  const mediaType = normalizeChatFileAttachmentMediaType(part.fileName, part.mediaType);
-  return `data:${mediaType};base64,${part.base64Data}`;
+  const attachment = validateChatFileAttachmentContent(part.fileName, part.mediaType, part.base64Data);
+  return `data:${attachment.mediaType};base64,${attachment.base64Data}`;
 }
 
 async function mapAttachmentPart(

--- a/apps/backend/src/chat/runtime.ts
+++ b/apps/backend/src/chat/runtime.ts
@@ -9,6 +9,10 @@ import {
   type ChatComposerSuggestionsLocale,
   type ChatComposerSuggestion,
 } from "./composerSuggestions";
+import {
+  chatAttachmentUnsupportedTypeMessage,
+  isChatAttachmentUnsupportedTypeError,
+} from "./attachmentPolicy";
 import { isChatStorageEntityNotFoundError } from "./errors";
 import { getAIProviderFailureMetadata } from "./providerFailure";
 import { getErrorLogContext } from "../server/logging";
@@ -245,6 +249,11 @@ function createSafeProviderErrorDetails(error: unknown | null): SafeProviderErro
 function createPublicTerminalErrorMessage(error: unknown): string {
   const providerMetadata = getAIProviderFailureMetadata(error);
   const category = classifyProviderErrorCategory(error, providerMetadata.upstreamStatus);
+  const providerErrorCode = readErrorRecordStringField(error, "code");
+
+  if (isChatAttachmentUnsupportedTypeError(error) || providerErrorCode === "invalid_file") {
+    return chatAttachmentUnsupportedTypeMessage;
+  }
 
   if (category === "provider_auth") {
     return PROVIDER_AUTH_ERROR_MESSAGE;
@@ -270,6 +279,10 @@ function createPublicTerminalErrorMessage(error: unknown): string {
 }
 
 function isHandledProviderFailure(error: unknown): boolean {
+  if (isChatAttachmentUnsupportedTypeError(error)) {
+    return true;
+  }
+
   const providerMetadata = getAIProviderFailureMetadata(error);
   const category = classifyProviderErrorCategory(error, providerMetadata.upstreamStatus);
   return category !== null && category !== "runtime_error";

--- a/apps/backend/src/chat/tests/chat-route-contract.test.ts
+++ b/apps/backend/src/chat/tests/chat-route-contract.test.ts
@@ -19,6 +19,14 @@ import {
 import type { ChatSessionSnapshot, PersistedChatMessageItem } from "../store";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
+const PLAIN_TEXT_BASE64 = "cGxhaW4gdGV4dA==";
+const VALID_PDF_BASE64 = "JVBERi0xLjEKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCAxIDFdID4+CmVuZG9iagp4cmVmCjAgNAowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAwIG4gCnRyYWlsZXIKPDwgL1Jvb3QgMSAwIFIgL1NpemUgNCA+PgpzdGFydHhyZWYKMTgyCiUlRU9GCg==";
+const TRUNCATED_PDF_BASE64 = "JVBERi0xLjcK";
+const VALID_PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+const TRUNCATED_PNG_BASE64 = "iVBORw0KGgo=";
+const WINDOWS_1252_CSV_BASE64 = "ZnJvbnQsYmFjawpjYWbpLGNvZmZlZQo=";
+const UTF16_LE_CSV_BASE64 = "//5mAHIAbwBuAHQALABiAGEAYwBrAAoAYwBhAGYA6QAsAGMAbwBmAGYAZQBlAAoA";
+const BINARY_TEXT_FILE_BASE64 = "AAECAwQFBgc=";
 
 type ConsoleMethod = "log" | "warn" | "error";
 type StructuredLogRecord = Readonly<Record<string, unknown> & {
@@ -201,6 +209,80 @@ test("parseChatRequestBody normalizes supported attachment media type aliases", 
     assert.ok(part !== undefined);
     if (part.type !== "file") {
       throw new Error("Expected a file content part.");
+    }
+    assert.equal(part.mediaType, testCase.expectedMediaType);
+  }
+});
+
+test("parseChatRequestBody accepts valid attachment payload signatures", () => {
+  const cases = [
+    {
+      content: [{
+        type: "file",
+        fileName: "deck.csv",
+        mediaType: "text/comma-separated-values",
+        base64Data: "ZnJvbnQsYmFjaw==",
+      }],
+      expectedMediaType: "text/csv",
+    },
+    {
+      content: [{
+        type: "file",
+        fileName: "cards.xml",
+        mediaType: "application/xml",
+        base64Data: "PGNhcmRzIC8+",
+      }],
+      expectedMediaType: "text/xml",
+    },
+    {
+      content: [{
+        type: "file",
+        fileName: "deck.csv",
+        mediaType: "text/csv",
+        base64Data: WINDOWS_1252_CSV_BASE64,
+      }],
+      expectedMediaType: "text/csv",
+    },
+    {
+      content: [{
+        type: "file",
+        fileName: "deck.csv",
+        mediaType: "text/csv",
+        base64Data: UTF16_LE_CSV_BASE64,
+      }],
+      expectedMediaType: "text/csv",
+    },
+    {
+      content: [{
+        type: "file",
+        fileName: "notes.pdf",
+        mediaType: "application/pdf",
+        base64Data: VALID_PDF_BASE64,
+      }],
+      expectedMediaType: "application/pdf",
+    },
+    {
+      content: [{
+        type: "image",
+        mediaType: "image/png",
+        base64Data: VALID_PNG_BASE64,
+      }],
+      expectedMediaType: "image/png",
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    const body = parseChatRequestBody({
+      sessionId: SESSION_ONE,
+      clientRequestId: "client-request-1",
+      content: testCase.content,
+      timezone: "Europe/Madrid",
+    });
+
+    const part = body.content[0];
+    assert.ok(part !== undefined);
+    if (part.type !== "file" && part.type !== "image") {
+      throw new Error("Expected an attachment content part.");
     }
     assert.equal(part.mediaType, testCase.expectedMediaType);
   }
@@ -477,6 +559,95 @@ test("POST /chat rejects unsupported attachments before preparing a run", async 
     requestId: null,
     code: chatAttachmentUnsupportedTypeCode,
   });
+});
+
+test("POST /chat rejects invalid attachment payloads before preparing a run", async () => {
+  let prepareChatRunCount = 0;
+  const routes = createChatRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    prepareChatRunFn: async () => {
+      prepareChatRunCount += 1;
+      throw new Error("prepareChatRunFn should not be called");
+    },
+  });
+  const app = createRoutesWithHttpErrorJson();
+  app.route("/", routes);
+  const cases = [
+    {
+      content: [{
+        type: "file",
+        fileName: "notes.txt",
+        mediaType: "text/plain",
+        base64Data: "not-base64!",
+      }],
+    },
+    {
+      content: [{
+        type: "image",
+        mediaType: "image/png",
+        base64Data: `data:image/png;base64,${VALID_PNG_BASE64}`,
+      }],
+    },
+    {
+      content: [{
+        type: "file",
+        fileName: "notes.pdf",
+        mediaType: "application/pdf",
+        base64Data: PLAIN_TEXT_BASE64,
+      }],
+    },
+    {
+      content: [{
+        type: "file",
+        fileName: "notes.pdf",
+        mediaType: "application/pdf",
+        base64Data: TRUNCATED_PDF_BASE64,
+      }],
+    },
+    {
+      content: [{
+        type: "image",
+        mediaType: "image/png",
+        base64Data: TRUNCATED_PNG_BASE64,
+      }],
+    },
+    {
+      content: [{
+        type: "file",
+        fileName: "notes.txt",
+        mediaType: "text/plain",
+        base64Data: BINARY_TEXT_FILE_BASE64,
+      }],
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    const response = await app.request("http://localhost/chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        sessionId: SESSION_ONE,
+        clientRequestId: "client-request-1",
+        content: testCase.content,
+        timezone: "Europe/Madrid",
+      }),
+    });
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      error: chatAttachmentUnsupportedTypeMessage,
+      requestId: null,
+      code: chatAttachmentUnsupportedTypeCode,
+    });
+  }
+
+  assert.equal(prepareChatRunCount, 0);
 });
 
 test("POST /chat fails with a stable contract code when a running response cannot create a live stream", async () => {

--- a/apps/backend/src/chat/tests/chat-runtime.test.ts
+++ b/apps/backend/src/chat/tests/chat-runtime.test.ts
@@ -1,9 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import {
+  chatAttachmentUnsupportedTypeCode,
+  chatAttachmentUnsupportedTypeMessage,
+} from "../attachmentPolicy";
 import { ChatRunRowNotFoundError } from "../errors";
 import type { ChatRuntimeDependencies, StartPersistedChatRunParams } from "../runtime";
 import { runPersistedChatSessionWithDeps } from "../runtime";
 import type { OpenAILoopCompletion, OpenAILoopEventSink, StartOpenAILoopParams } from "../openai/loop";
+import { HttpError } from "../../shared/errors";
 
 type ConsoleMethod = "log" | "warn" | "error";
 type StructuredLogRecord = Readonly<Record<string, unknown> & {
@@ -48,6 +53,20 @@ function createProviderApiError(rawMessage: string): Error & Readonly<{
     status: 429,
     code: "rate_limit_exceeded",
     requestID: "req_provider_123",
+  });
+}
+
+function createProviderInvalidFileError(rawMessage: string): Error & Readonly<{
+  status: number;
+  code: string;
+  requestID: string;
+}> {
+  const error = new Error(rawMessage);
+  error.name = "BadRequestError";
+  return Object.assign(error, {
+    status: 400,
+    code: "invalid_file",
+    requestID: "req_invalid_file_123",
   });
 }
 
@@ -931,6 +950,87 @@ test("runPersistedChatSessionWithDeps persists a failed run for real provider er
   assert.equal(terminalLog?.errorClass, undefined);
   assert.equal(terminalLog?.errorMessage, undefined);
   assert.equal(JSON.stringify(terminalLog).includes(rawProviderMessage), false);
+});
+
+test("runPersistedChatSessionWithDeps maps provider invalid_file failures to attachment guidance", async () => {
+  let terminalPersistParams: PersistAssistantTerminalErrorParams | null = null;
+  const rawProviderMessage = "provider invalid_file response included attachment details";
+
+  const logs = await withCapturedLogs(async () => {
+    const result = await runPersistedChatSessionWithDeps(
+      createParams(),
+      createDependencies({
+        startOpenAILoop: async (): Promise<OpenAILoopCompletion> => {
+          throw createProviderInvalidFileError(rawProviderMessage);
+        },
+        persistAssistantTerminalError: async (_userId, _workspaceId, params) => {
+          terminalPersistParams = params;
+        },
+      }),
+    );
+
+    assert.deepEqual(result, {
+      outcome: "failed",
+      abortReason: null,
+      runStatus: "failed",
+      sessionState: "idle",
+    });
+  });
+
+  assert.equal(
+    requireTerminalPersistParams(terminalPersistParams).errorMessage,
+    chatAttachmentUnsupportedTypeMessage,
+  );
+  const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
+  assert.equal(terminalLog?.consoleMethod, "warn");
+  assert.equal(terminalLog?.providerErrorClass, "BadRequestError");
+  assert.equal(terminalLog?.providerErrorMessage, null);
+  assert.equal(terminalLog?.providerErrorStatus, 400);
+  assert.equal(terminalLog?.providerErrorCode, "invalid_file");
+  assert.equal(terminalLog?.providerErrorCategory, "provider_error");
+  assert.equal(terminalLog?.providerRequestId, "req_invalid_file_123");
+  assert.equal(terminalLog?.errorClass, undefined);
+  assert.equal(terminalLog?.errorMessage, undefined);
+  assert.equal(JSON.stringify(terminalLog).includes(rawProviderMessage), false);
+});
+
+test("runPersistedChatSessionWithDeps maps local attachment validation failures to attachment guidance", async () => {
+  let terminalPersistParams: PersistAssistantTerminalErrorParams | null = null;
+
+  const logs = await withCapturedLogs(async () => {
+    const result = await runPersistedChatSessionWithDeps(
+      createParams(),
+      createDependencies({
+        startOpenAILoop: async (): Promise<OpenAILoopCompletion> => {
+          throw new HttpError(
+            400,
+            chatAttachmentUnsupportedTypeMessage,
+            chatAttachmentUnsupportedTypeCode,
+          );
+        },
+        persistAssistantTerminalError: async (_userId, _workspaceId, params) => {
+          terminalPersistParams = params;
+        },
+      }),
+    );
+
+    assert.deepEqual(result, {
+      outcome: "failed",
+      abortReason: null,
+      runStatus: "failed",
+      sessionState: "idle",
+    });
+  });
+
+  assert.equal(
+    requireTerminalPersistParams(terminalPersistParams).errorMessage,
+    chatAttachmentUnsupportedTypeMessage,
+  );
+  const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
+  assert.equal(terminalLog?.consoleMethod, "warn");
+  assert.equal(terminalLog?.providerErrorMessage, null);
+  assert.equal(terminalLog?.errorClass, undefined);
+  assert.equal(terminalLog?.errorMessage, undefined);
 });
 
 test("runPersistedChatSessionWithDeps captures unexpected runtime failures as backend exceptions", async () => {


### PR DESCRIPTION
## Summary
- Validate chat attachment base64 and decoded content before queued runs and OpenAI input construction
- Map invalid_file/provider attachment failures to existing attachment guidance
- Cover request parsing, persisted history, and runtime error mapping with backend tests

## Validation
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend
- git --no-pager diff --check