### PR TITLE
[codex] Fix iOS AI handoff smoke

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
@@ -33,10 +33,10 @@ extension AIChatStore {
             pendingAttachments: self.pendingAttachments
         )
         if self.chatSessionId.isEmpty && self.messages.isEmpty && draft.isEmpty && self.activeRunId == nil {
-            self.applyComposerDraft(inputText: "", pendingAttachments: [attachment])
-            self.schedulePersistCurrentDraftState()
-            self.activeAlert = nil
-            self.repairStatus = nil
+            self.startFreshLocalSession(
+                inputText: "",
+                pendingAttachments: [attachment]
+            )
             return true
         }
         if self.shouldAutoStartFreshLocalSession(persistedState: self.currentPersistedState()) {

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -512,6 +512,9 @@ struct AIChatView: View {
             return
         }
         self.captureAIChatPresentationRequest(request: resolvedRequest)
+        guard self.chatStore.hasExternalProviderConsent else {
+            return
+        }
         guard self.chatStore.isChatInteractive else {
             return
         }
@@ -608,10 +611,12 @@ struct AIChatView: View {
         }
 
         self.syncChatSurface(refreshConsent: true)
+        self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
     }
 
     func handleSurfaceInputsChange() {
         self.syncChatSurface(refreshConsent: false)
+        self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
     }
 
     func handleSelectedTabChange(nextTab: AppTab) {
@@ -622,6 +627,7 @@ struct AIChatView: View {
         }
 
         self.syncChatSurface(refreshConsent: false)
+        self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
         self.scheduleDeferredBottomSyncIfNeeded()
     }
 


### PR DESCRIPTION
Fixes the remaining Xcode Cloud UI smoke failure in LiveSmokeCardsTests/testLiveSmokeCardsEditorAiHandoffFlow.\n\nWhat changed:\n- Replays deferred AI presentation requests after AI surface/tab state changes.\n- Keeps card handoff gated until consent is accepted.\n- Creates an explicit local AI session for card handoff drafts when there is no current AI session, so the attachment survives surface reload/refresh.\n\nValidation:\n- git diff --check\n- git diff --cached --check\n- Inspected Xcode Cloud build 407 xcresult/logs.\n\nLocal iOS simulator tests were intentionally not run because simulator-backed runs are heavy in this repository and should run in Xcode Cloud.