### PR TITLE
[codex] Dismiss review reactions on touch down

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
@@ -44,6 +44,14 @@ extension ReviewView {
         )
     }
 
+    func dismissActiveReviewReactions() {
+        if self.activeReviewReactionEvents.isEmpty {
+            return
+        }
+
+        self.activeReviewReactionEvents = []
+    }
+
     func removeFinishedReviewReactionEvent(eventId: UUID) {
         self.activeReviewReactionEvents = self.activeReviewReactionEvents.filter { activeEvent in
             activeEvent.id != eventId

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -163,6 +163,12 @@ struct ReviewView: View {
         .safeAreaBar(edge: .bottom, spacing: 0) {
             reviewBottomAccessory
         }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    self.dismissActiveReviewReactions()
+                }
+        )
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 reviewFilterMenu


### PR DESCRIPTION
## Summary
- clear active review reaction events on review-screen touch down
- attach the gesture after the bottom safe-area review controls so button taps also dismiss old reactions

## Validation
- `git --no-pager diff --check`
- iOS simulator-backed tests were not run because this repository requires explicit permission for simulator runs.