### PR TITLE
[codex] Fix iOS AI handoff draft

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
@@ -33,14 +33,14 @@ extension AIChatStore {
             pendingAttachments: self.pendingAttachments
         )
         if self.chatSessionId.isEmpty && self.messages.isEmpty && draft.isEmpty && self.activeRunId == nil {
-            self.startFreshLocalSession(
+            self.startFreshLocalDraftSession(
                 inputText: "",
                 pendingAttachments: [attachment]
             )
             return true
         }
         if self.shouldAutoStartFreshLocalSession(persistedState: self.currentPersistedState()) {
-            self.startFreshLocalSession(
+            self.startFreshLocalDraftSession(
                 inputText: "",
                 pendingAttachments: [attachment]
             )
@@ -53,7 +53,7 @@ extension AIChatStore {
             activeRunId: self.activeRunId,
             currentSessionId: self.chatSessionId
         ) == false {
-            self.startFreshLocalSession(
+            self.startFreshLocalDraftSession(
                 inputText: "",
                 pendingAttachments: [attachment]
             )
@@ -65,6 +65,19 @@ extension AIChatStore {
         self.activeAlert = nil
         self.repairStatus = nil
         return true
+    }
+
+    func startFreshLocalDraftSession(
+        inputText: String,
+        pendingAttachments: [AIChatAttachment]
+    ) {
+        self.bootstrapPhase = .ready
+        self.invalidatePendingNewSessionRequest()
+        self.resetConversationForNewSession(
+            sessionId: makeAIChatSessionId(),
+            inputText: inputText,
+            pendingAttachments: pendingAttachments
+        )
     }
 
     func startFreshLocalSession(

--- a/apps/ios/Flashcards/Flashcards/Cards/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/CardsScreen.swift
@@ -189,9 +189,15 @@ struct CardsScreen: View {
                             guard let cardReference else {
                                 return
                             }
+                            let didPrepareAIHandoff = self.store.aiChatStore.prepareCardHandoff(card: cardReference)
                             self.editorPresentation = nil
                             Task { @MainActor in
-                                self.navigation.openAICardHandoff(card: cardReference)
+                                if didPrepareAIHandoff {
+                                    self.navigation.clearAIChatPresentationRequest()
+                                    self.navigation.selectTab(.ai)
+                                } else {
+                                    self.navigation.openAICardHandoff(card: cardReference)
+                                }
                             }
                         }
                     },


### PR DESCRIPTION
Fixes the remaining Xcode Cloud UI smoke failure in LiveSmokeCardsTests/testLiveSmokeCardsEditorAiHandoffFlow.\n\nWhat changed:\n- Prepares the AI card handoff draft directly from CardsScreen before switching to the AI tab.\n- Keeps the navigation presentation request as a fallback when the store cannot prepare the handoff immediately.\n- Creates a local draft-only AI session for card handoff without kicking off remote session provisioning, so the attachment remains visible through consent and AI surface refreshes.\n\nValidation:\n- git diff --check\n- git diff --cached --check\n- Inspected Xcode Cloud build 408 xcresult/logs.\n\nLocal iOS simulator tests were intentionally not run because simulator-backed runs are heavy in this repository and should run in Xcode Cloud.