### PR TITLE
[codex] Persist iOS AI handoff draft state

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
@@ -78,6 +78,7 @@ extension AIChatStore {
             inputText: inputText,
             pendingAttachments: pendingAttachments
         )
+        self.persistStateSynchronously(state: self.currentPersistedState())
     }
 
     func startFreshLocalSession(


### PR DESCRIPTION
Fixes the remaining Xcode Cloud UI smoke failure in LiveSmokeCardsTests/testLiveSmokeCardsEditorAiHandoffFlow.\n\nWhat changed:\n- Persists the local AI handoff session state synchronously after creating the draft-only AI session.\n\nWhy:\n- The card attachment draft was saved under the new session, but the session id itself could still be queued for async state persistence. When the AI surface restored immediately after the tab switch, it could load the previous session state and miss the pending attachment.\n\nValidation:\n- git diff --check\n- git diff --cached --check\n- Inspected Xcode Cloud build 411 xcresult/logs.\n\nLocal iOS simulator tests were intentionally not run because simulator-backed runs are heavy in this repository and should run in Xcode Cloud.