### PR TITLE
[codex] Fix iOS AI handoff request retry

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
@@ -21,8 +21,20 @@ extension AIChatStore {
             id: UUID().uuidString.lowercased(),
             payload: .card(card)
         )
+        if aiChatPendingAttachmentsContainMatchingCard(
+            pendingAttachments: self.pendingAttachments,
+            card: card
+        ) {
+            self.activeAlert = nil
+            self.repairStatus = nil
+            return true
+        }
         if self.composerPhase == .running {
-            self.pendingAttachments.append(attachment)
+            self.pendingAttachments = aiChatPendingAttachmentsReplacingCard(
+                pendingAttachments: self.pendingAttachments,
+                attachment: attachment,
+                cardId: card.cardId
+            )
             self.activeAlert = nil
             self.repairStatus = nil
             return true
@@ -676,6 +688,43 @@ extension AIChatStore {
             }
         }
     }
+}
+
+private func aiChatPendingAttachmentsContainMatchingCard(
+    pendingAttachments: [AIChatAttachment],
+    card: AIChatCardReference
+) -> Bool {
+    pendingAttachments.contains { attachment in
+        guard case .card(let existingCard) = attachment.payload else {
+            return false
+        }
+
+        return existingCard == card
+    }
+}
+
+private func aiChatPendingAttachmentsReplacingCard(
+    pendingAttachments: [AIChatAttachment],
+    attachment: AIChatAttachment,
+    cardId: String
+) -> [AIChatAttachment] {
+    var didReplaceCard = false
+    var updatedAttachments: [AIChatAttachment] = pendingAttachments.map { pendingAttachment in
+        guard case .card(let existingCard) = pendingAttachment.payload,
+              existingCard.cardId == cardId
+        else {
+            return pendingAttachment
+        }
+
+        didReplaceCard = true
+        return attachment
+    }
+
+    if didReplaceCard == false {
+        updatedAttachments.append(attachment)
+    }
+
+    return updatedAttachments
 }
 
 private func aiChatNewSessionRetryLogMetadata(

--- a/apps/ios/Flashcards/Flashcards/Cards/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/CardsScreen.swift
@@ -189,15 +189,10 @@ struct CardsScreen: View {
                             guard let cardReference else {
                                 return
                             }
-                            let didPrepareAIHandoff = self.store.aiChatStore.prepareCardHandoff(card: cardReference)
+                            _ = self.store.aiChatStore.prepareCardHandoff(card: cardReference)
                             self.editorPresentation = nil
                             Task { @MainActor in
-                                if didPrepareAIHandoff {
-                                    self.navigation.clearAIChatPresentationRequest()
-                                    self.navigation.selectTab(.ai)
-                                } else {
-                                    self.navigation.openAICardHandoff(card: cardReference)
-                                }
+                                self.navigation.openAICardHandoff(card: cardReference)
                             }
                         }
                     },


### PR DESCRIPTION
## Summary

- keep the card editor to AI handoff request available until the AI surface applies it
- make card attachment handoff idempotent so repeated request handling does not duplicate card context
- replace stale same-card draft attachments by `cardId` during an active AI run

## Validation

- `git diff --check`

Local iOS simulator tests were not run because simulator-backed iOS runs are intentionally avoided in this workspace unless explicitly allowed.