### PR TITLE
[codex] Fix review cold sync restore

### DIFF
--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -104,6 +104,14 @@ export type SyncBootstrapDetails = Readonly<{
   platform: string;
   appVersion: string | null;
   mode: string;
+  cursorPresent: boolean | null;
+  limit: number | null;
+  entriesCount: number | null;
+  appliedEntriesCount: number | null;
+  hasMore: boolean | null;
+  nextCursorPresent: boolean | null;
+  bootstrapHotChangeId: number | null;
+  remoteIsEmpty: boolean | null;
 }>;
 
 export type SyncReviewHistoryPullDetails = Readonly<{

--- a/apps/backend/src/routes/sync.ts
+++ b/apps/backend/src/routes/sync.ts
@@ -11,6 +11,9 @@ import {
   processSyncPush,
   processSyncReviewHistoryImport,
   processSyncReviewHistoryPull,
+  type SyncBootstrapInput,
+  type SyncBootstrapPullResult,
+  type SyncBootstrapPushResult,
   type SyncPullInput,
   type SyncPullResult,
   type SyncReviewHistoryPullInput,
@@ -35,6 +38,7 @@ import {
   normalizeCaughtError,
   type BackendObservationScope,
   type BackendSyncConflictDetails,
+  type SyncBootstrapDetails,
   type SyncPullDetails,
   type SyncReviewHistoryPullDetails,
 } from "../observability/sentry";
@@ -105,6 +109,82 @@ function getSyncReviewHistoryPullInputDetails(
     platform: input.platform,
     appVersion: input.appVersion ?? null,
     afterReviewSequenceId: input.afterReviewSequenceId,
+  };
+}
+
+function buildSyncBootstrapPullDetails(
+  input: Extract<SyncBootstrapInput, Readonly<{ mode: "pull" }>>,
+  result: SyncBootstrapPullResult,
+): SyncBootstrapDetails {
+  return {
+    statusCode: 200,
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    mode: input.mode,
+    cursorPresent: input.cursor !== null,
+    limit: input.limit,
+    entriesCount: result.entries.length,
+    appliedEntriesCount: null,
+    hasMore: result.hasMore,
+    nextCursorPresent: result.nextCursor !== null,
+    bootstrapHotChangeId: result.bootstrapHotChangeId,
+    remoteIsEmpty: result.remoteIsEmpty,
+  };
+}
+
+function buildSyncBootstrapPushDetails(
+  input: Extract<SyncBootstrapInput, Readonly<{ mode: "push" }>>,
+  result: SyncBootstrapPushResult,
+): SyncBootstrapDetails {
+  return {
+    statusCode: 200,
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    mode: input.mode,
+    cursorPresent: null,
+    limit: null,
+    entriesCount: input.entries.length,
+    appliedEntriesCount: result.appliedEntriesCount,
+    hasMore: null,
+    nextCursorPresent: null,
+    bootstrapHotChangeId: result.bootstrapHotChangeId,
+    remoteIsEmpty: null,
+  };
+}
+
+function buildSyncBootstrapDetails(
+  input: SyncBootstrapInput,
+  result: SyncBootstrapPullResult | SyncBootstrapPushResult,
+): SyncBootstrapDetails {
+  if (input.mode === "pull" && result.mode === "pull") {
+    return buildSyncBootstrapPullDetails(input, result);
+  }
+
+  if (input.mode === "push" && result.mode === "push") {
+    return buildSyncBootstrapPushDetails(input, result);
+  }
+
+  throw new Error(`Sync bootstrap result mode mismatch: input=${input.mode} result=${result.mode}`);
+}
+
+function getSyncBootstrapFailureInputDetails(
+  input: SyncBootstrapInput,
+): Omit<SyncBootstrapDetails, "statusCode"> {
+  return {
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    mode: input.mode,
+    cursorPresent: input.mode === "pull" ? input.cursor !== null : null,
+    limit: input.mode === "pull" ? input.limit : null,
+    entriesCount: input.mode === "push" ? input.entries.length : null,
+    appliedEntriesCount: null,
+    hasMore: null,
+    nextCursorPresent: null,
+    bootstrapHotChangeId: null,
+    remoteIsEmpty: null,
   };
 }
 
@@ -314,22 +394,13 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
       addBackendBreadcrumb({
         action: "sync_bootstrap",
         scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),
-        details: {
-          statusCode: 200,
-          installationId: input.installationId,
-          platform: input.platform,
-          appVersion: input.appVersion ?? null,
-          mode: input.mode,
-        },
+        details: buildSyncBootstrapDetails(input, result),
       });
       return context.json(result);
     } catch (error) {
       const scope = createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId);
       const details = {
-        installationId: input.installationId,
-        platform: input.platform,
-        appVersion: input.appVersion ?? null,
-        mode: input.mode,
+        ...getSyncBootstrapFailureInputDetails(input),
         ...createBackendFailureDetails(error),
         ...getSyncConflictLogContext(error),
       };

--- a/apps/web/src/appData/sync/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/syncLifecycleObservation.ts
@@ -1,0 +1,64 @@
+import {
+  captureWebWarning,
+  type WebObservationScope,
+} from "../../observability/webObservability";
+
+export type HotBootstrapSlowObservationInput = Readonly<{
+  userId: string;
+  workspaceId: string;
+  installationId: string;
+  durationMs: number;
+  pageCount: number;
+  entriesCount: number;
+  localCardCountBefore: number;
+  localCardCountAfter: number;
+  lastAppliedHotChangeIdBefore: number | null;
+  nextHotChangeId: number | null;
+  remoteIsEmpty: boolean | null;
+}>;
+
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildSyncObservationScope(
+  userId: string,
+  workspaceId: string,
+  installationId: string,
+): WebObservationScope {
+  return {
+    app: "web",
+    feature: "sync",
+    userId,
+    workspaceId,
+    installationId,
+    route: getCurrentRoute(),
+    requestId: null,
+    statusCode: null,
+    code: null,
+  };
+}
+
+export function observeSlowHotBootstrap(input: HotBootstrapSlowObservationInput): void {
+  captureWebWarning({
+    action: "sync_restore_slow",
+    scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
+    details: {
+      eventName: "sync_hot_bootstrap_slow",
+      workspaceId: input.workspaceId,
+      installationId: input.installationId,
+      durationMs: input.durationMs,
+      pageCount: input.pageCount,
+      entriesCount: input.entriesCount,
+      localCardCountBefore: input.localCardCountBefore,
+      localCardCountAfter: input.localCardCountAfter,
+      lastAppliedHotChangeIdBefore: input.lastAppliedHotChangeIdBefore,
+      nextHotChangeId: input.nextHotChangeId,
+      remoteIsEmpty: input.remoteIsEmpty,
+    },
+  });
+}

--- a/apps/web/src/appData/sync/syncRemote.ts
+++ b/apps/web/src/appData/sync/syncRemote.ts
@@ -5,7 +5,7 @@ import {
   pushSyncOperations,
 } from "../../api";
 import { webAppVersion } from "../../clientIdentity";
-import { loadCardsByIds } from "../../localDb/cards";
+import { loadActiveCardCount, loadCardsByIds } from "../../localDb/cards";
 import {
   deleteOutboxRecord,
   isScheduleRelevantCardOutboxRecord,
@@ -16,10 +16,10 @@ import {
 import {
   applyHotSyncPage,
   applyReviewHistorySyncPage,
-  hasHydratedHotState,
   hasHydratedReviewHistory,
   loadLastAppliedHotChangeId,
   loadLastAppliedReviewSequenceId,
+  loadWorkspaceSyncState,
 } from "../../localDb/workspace";
 import type {
   SyncBootstrapEntry,
@@ -31,8 +31,10 @@ import {
   doesCardMutationAffectReviewSchedule,
   getErrorMessage,
 } from "../domain";
+import { observeSlowHotBootstrap } from "./syncLifecycleObservation";
 
 const syncPageSize = 200;
+const slowHotBootstrapWarningThresholdMs = 2000;
 
 type HotSyncEntry = SyncBootstrapEntry | SyncChange;
 type CardHotSyncEntry = Extract<HotSyncEntry, Readonly<{ entityType: "card" }>>;
@@ -43,6 +45,7 @@ export type RemoteSyncFlags = Readonly<{
 }>;
 
 export type WorkspaceRemoteSyncInput = Readonly<{
+  userId: string;
   workspaceId: string;
   installationId: string;
   requireWorkspaceSyncNotDiscarded: (workspaceId: string) => void;
@@ -102,6 +105,10 @@ function isCardHotSyncEntry(entry: HotSyncEntry): entry is CardHotSyncEntry {
   return entry.entityType === "card";
 }
 
+function shouldObserveHotBootstrap(durationMs: number, pageCount: number): boolean {
+  return durationMs >= slowHotBootstrapWarningThresholdMs || pageCount > 1;
+}
+
 async function doHotSyncEntriesAffectReviewSchedule(
   workspaceId: string,
   entries: ReadonlyArray<HotSyncEntry>,
@@ -123,14 +130,21 @@ async function doHotSyncEntriesAffectReviewSchedule(
 }
 
 async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
-  const hotStateHydrated = await hasHydratedHotState(input.workspaceId);
+  const syncStateBefore = await loadWorkspaceSyncState(input.workspaceId);
+  const hotStateHydrated = syncStateBefore?.hasHydratedHotState ?? false;
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   if (hotStateHydrated) {
     return createEmptyRemoteSyncFlags();
   }
 
+  const startedAtMs = Date.now();
+  const localCardCountBefore = await loadActiveCardCount(input.workspaceId);
   let didChangeReviewSchedule = false;
   let bootstrapCursor: string | null = null;
+  let pageCount = 0;
+  let entriesCount = 0;
+  let nextHotChangeId: number | null = null;
+  let remoteIsEmpty: boolean | null = null;
 
   while (true) {
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
@@ -143,6 +157,10 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
       syncPageSize,
     );
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+    pageCount += 1;
+    entriesCount += bootstrapResult.entries.length;
+    nextHotChangeId = bootstrapResult.bootstrapHotChangeId;
+    remoteIsEmpty = bootstrapResult.remoteIsEmpty;
 
     if (await doHotSyncEntriesAffectReviewSchedule(input.workspaceId, bootstrapResult.entries)) {
       didChangeReviewSchedule = true;
@@ -171,6 +189,24 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   await input.refreshWorkspaceView(input.workspaceId);
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
+  const durationMs = Date.now() - startedAtMs;
+  const localCardCountAfter = await loadActiveCardCount(input.workspaceId);
+  if (shouldObserveHotBootstrap(durationMs, pageCount)) {
+    observeSlowHotBootstrap({
+      userId: input.userId,
+      workspaceId: input.workspaceId,
+      installationId: input.installationId,
+      durationMs,
+      pageCount,
+      entriesCount,
+      localCardCountBefore,
+      localCardCountAfter,
+      lastAppliedHotChangeIdBefore: syncStateBefore?.lastAppliedHotChangeId ?? null,
+      nextHotChangeId,
+      remoteIsEmpty,
+    });
+  }
+
   return {
     didChangeProgressHistory: false,
     didChangeReviewSchedule,

--- a/apps/web/src/appData/sync/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/useSyncEngine.ts
@@ -327,6 +327,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
         const installationId = requireCloudInstallationId(cloudSettings);
         syncInstallationId = installationId;
         const syncFlags = await runWorkspaceRemoteSync({
+          userId: session.userId,
           workspaceId,
           installationId,
           requireWorkspaceSyncNotDiscarded: requireCurrentWorkspaceSync,

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -308,6 +308,20 @@ export type WorkspaceStateWarningDetails = Readonly<{
   activeWorkspaceId: string | null;
 }>;
 
+export type SyncRestoreWarningDetails = Readonly<{
+  eventName: "sync_hot_bootstrap_slow";
+  workspaceId: string;
+  installationId: string;
+  durationMs: number;
+  pageCount: number;
+  entriesCount: number;
+  localCardCountBefore: number;
+  localCardCountAfter: number;
+  lastAppliedHotChangeIdBefore: number | null;
+  nextHotChangeId: number | null;
+  remoteIsEmpty: boolean | null;
+}>;
+
 export type WebWarningEvent =
   | Readonly<{
     action: "api_contract_warning";
@@ -318,6 +332,11 @@ export type WebWarningEvent =
     action: "workspace_state_inconsistency";
     scope: WebObservationScope;
     details: WorkspaceStateWarningDetails;
+  }>
+  | Readonly<{
+    action: "sync_restore_slow";
+    scope: WebObservationScope;
+    details: SyncRestoreWarningDetails;
   }>;
 
 type SentryContextValue =

--- a/apps/web/src/screens/review/data/useReviewScreenData.ts
+++ b/apps/web/src/screens/review/data/useReviewScreenData.ts
@@ -10,7 +10,7 @@ import {
   loadReviewQueueSnapshot,
   loadReviewTimelinePage,
 } from "../../../localDb/reviews";
-import { loadWorkspaceTagsSummary } from "../../../localDb/workspace";
+import { hasHydratedHotState, loadWorkspaceTagsSummary } from "../../../localDb/workspace";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
 import type {
   Card,
@@ -59,14 +59,18 @@ import {
 
 type UseReviewScreenDataParams = Readonly<{
   activeWorkspaceId: string | null;
+  appErrorMessage: string;
   getCardById: (cardId: string) => Promise<Card>;
   installationId: string | null;
+  isSyncing: boolean;
   localReadVersion: number;
   selectedReviewFilter: ReviewFilter;
   setErrorMessage: (message: string) => void;
   submitReviewItem: (cardId: string, rating: 0 | 1 | 2 | 3) => Promise<Card>;
   userId: string | null;
 }>;
+
+type LocalHotStateStatus = "loading" | "hydrated" | "unhydrated";
 
 export type ReviewSubmissionOutcome = "saved" | "failed" | "stale";
 
@@ -77,6 +81,7 @@ export type UseReviewScreenDataResult = Readonly<{
   hasLoadedReviewData: boolean;
   isInitialReviewLoad: boolean;
   isReviewLoading: boolean;
+  localWorkspaceCardCount: number;
   queueCards: ReadonlyArray<Card>;
   resolvedReviewFilter: ReviewFilter;
   reviewCounts: ReviewCounts;
@@ -90,8 +95,10 @@ export type UseReviewScreenDataResult = Readonly<{
 export function useReviewScreenData(params: UseReviewScreenDataParams): UseReviewScreenDataResult {
   const {
     activeWorkspaceId,
+    appErrorMessage,
     getCardById,
     installationId,
+    isSyncing,
     localReadVersion,
     selectedReviewFilter,
     setErrorMessage,
@@ -109,10 +116,13 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const [resolvedReviewFilter, setResolvedReviewFilter] = useState<ReviewFilter>(ALL_CARDS_REVIEW_FILTER);
   const [selectedReviewFilterTitle, setSelectedReviewFilterTitle] = useState<string>(t("filters.allCards"));
   const [isReviewLoading, setIsReviewLoading] = useState<boolean>(true);
+  const [localHotStateStatus, setLocalHotStateStatus] = useState<LocalHotStateStatus>("loading");
+  const [localWorkspaceCardCount, setLocalWorkspaceCardCount] = useState<number>(0);
   const [reviewLoadErrorMessage, setReviewLoadErrorMessage] = useState<string>("");
   const [hasLoadedReviewData, setHasLoadedReviewData] = useState<boolean>(false);
   const [presentedCard, setPresentedCard] = useState<Card | null>(null);
   const activeWorkspaceIdRef = useRef<string | null>(activeWorkspaceId);
+  const loadedWorkspaceIdRef = useRef<string | null>(null);
   const previousReviewFilterRef = useRef<ReviewFilter | null>(null);
   const canonicalReviewQueueRef = useRef<ReadonlyArray<Card>>([]);
   const deckSummariesRef = useRef<ReadonlyArray<DeckSummary>>([]);
@@ -135,7 +145,16 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
   const reviewLoadingSnapshot = activeWorkspaceId === null
     ? null
     : readReviewLoadingSnapshot(activeWorkspaceId, selectedReviewFilter);
-  const isInitialReviewLoad = isReviewLoading && hasLoadedReviewData === false;
+  const hasColdEmptyLocalHotState = localHotStateStatus !== "hydrated" && localWorkspaceCardCount === 0;
+  const hasColdEmptyRestoreFailure = hasColdEmptyLocalHotState && isSyncing === false && appErrorMessage !== "";
+  const visibleHasLoadedReviewData = hasColdEmptyRestoreFailure ? false : hasLoadedReviewData;
+  const visibleReviewLoadErrorMessage = reviewLoadErrorMessage !== ""
+    ? reviewLoadErrorMessage
+    : hasColdEmptyRestoreFailure
+      ? appErrorMessage
+      : "";
+  const isLocalEmptyHotStateRestoring = hasColdEmptyLocalHotState && hasColdEmptyRestoreFailure === false;
+  const isInitialReviewLoad = (isReviewLoading && visibleHasLoadedReviewData === false) || isLocalEmptyHotStateRestoring;
   const activeReviewQueue = buildDisplayedReviewQueue(canonicalReviewQueue, presentedCard);
   observationIdentityRef.current = {
     userId,
@@ -216,6 +235,10 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
       if (shouldShowBlockingLoader) {
         setIsReviewLoading(true);
       }
+      if (loadedWorkspaceIdRef.current !== activeWorkspaceId) {
+        setLocalHotStateStatus("loading");
+        setLocalWorkspaceCardCount(0);
+      }
       setReviewLoadErrorMessage("");
 
       try {
@@ -228,11 +251,13 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
           reviewTimelinePage,
           tagsSummary,
           decksSnapshot,
+          isHotStateHydrated,
         ] = await Promise.all([
           loadReviewQueueSnapshot(activeWorkspaceId, selectedReviewFilter, 8),
           loadReviewTimelinePage(activeWorkspaceId, selectedReviewFilter, 200, 0),
           loadWorkspaceTagsSummary(activeWorkspaceId),
           loadDecksListSnapshot(activeWorkspaceId),
+          hasHydratedHotState(activeWorkspaceId),
         ]);
         if (isCancelled) {
           return;
@@ -301,6 +326,9 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
         setReviewQueueCursorState(reviewQueueSnapshot.nextCursor);
         setQueueCardsState(nextQueueCards);
         setReviewTagSummaries(tagsSummary.tags);
+        setLocalWorkspaceCardCount(tagsSummary.totalCards);
+        setLocalHotStateStatus(isHotStateHydrated ? "hydrated" : "unhydrated");
+        loadedWorkspaceIdRef.current = activeWorkspaceId;
         setTagSuggestions(toTagSuggestions(tagsSummary.tags));
         setDeckSummariesState(decksSnapshot.deckSummaries);
         writeReviewLoadingSnapshot({
@@ -596,13 +624,14 @@ export function useReviewScreenData(params: UseReviewScreenDataParams): UseRevie
     activeReviewQueue,
     deckSummaries,
     handleReview,
-    hasLoadedReviewData,
+    hasLoadedReviewData: visibleHasLoadedReviewData,
     isInitialReviewLoad,
     isReviewLoading,
+    localWorkspaceCardCount,
     queueCards,
     resolvedReviewFilter,
     reviewCounts,
-    reviewLoadErrorMessage,
+    reviewLoadErrorMessage: visibleReviewLoadErrorMessage,
     reviewLoadingSnapshot,
     reviewTagSummaries,
     selectedReviewFilterTitle,

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../../../types";
 
 const {
+  hasHydratedHotStateMock,
   loadDecksListSnapshotMock,
   loadReviewQueueChunkMock,
   loadReviewQueueSnapshotMock,
@@ -27,6 +28,7 @@ const {
   useAppDataMock,
   useReviewProgressBadgeMock,
 } = vi.hoisted(() => ({
+  hasHydratedHotStateMock: vi.fn(),
   loadDecksListSnapshotMock: vi.fn(),
   loadReviewQueueChunkMock: vi.fn(),
   loadReviewQueueSnapshotMock: vi.fn(),
@@ -53,6 +55,7 @@ vi.mock("../../../localDb/reviews", () => ({
 }));
 
 vi.mock("../../../localDb/workspace", () => ({
+  hasHydratedHotState: hasHydratedHotStateMock,
   loadWorkspaceTagsSummary: loadWorkspaceTagsSummaryMock,
 }));
 
@@ -138,11 +141,15 @@ export function ReviewScreenDataHarness(props: ReviewScreenDataHarnessProps): Re
   } = props;
   const result = useReviewScreenData({
     activeWorkspaceId: state.appData.activeWorkspace?.workspaceId ?? null,
+    appErrorMessage: state.appData.errorMessage,
     getCardById: state.appData.getCardById,
+    installationId: state.appData.cloudSettings?.installationId ?? null,
+    isSyncing: state.appData.isSyncing,
     localReadVersion: state.appData.localReadVersion,
     selectedReviewFilter: state.appData.selectedReviewFilter,
     setErrorMessage: state.appData.setErrorMessage,
     submitReviewItem: state.appData.submitReviewItem,
+    userId: state.appData.session?.userId ?? null,
   });
 
   useEffect(() => {
@@ -489,6 +496,7 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     root = ReactDOM.createRoot(container);
 
     useAppDataMock.mockReset();
+    hasHydratedHotStateMock.mockReset();
     loadDecksListSnapshotMock.mockReset();
     loadReviewQueueChunkMock.mockReset();
     loadReviewQueueSnapshotMock.mockReset();
@@ -498,6 +506,7 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
 
     useAppDataMock.mockImplementation(() => state.appData);
     useReviewProgressBadgeMock.mockImplementation(() => state.reviewProgressBadge);
+    hasHydratedHotStateMock.mockResolvedValue(true);
     loadDecksListSnapshotMock.mockImplementation(async (): Promise<DecksListSnapshot> => createDecksSnapshot(state));
     loadReviewQueueChunkMock.mockResolvedValue({
       cards: [],
@@ -587,6 +596,7 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
 
 export {
   loadDecksListSnapshotMock,
+  hasHydratedHotStateMock,
   loadReviewQueueChunkMock,
   loadReviewQueueSnapshotMock,
   loadReviewTimelinePageMock,

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -7,6 +7,7 @@ import {
   clickElementAsync,
   createCard,
   createDecks,
+  hasHydratedHotStateMock,
   loadReviewQueueSnapshotMock,
   reviewReactionLottieLoadAnimationMock,
   reviewStylesContain,
@@ -106,6 +107,46 @@ const reviewRatingShortcutDismissCases: ReadonlyArray<ReviewRatingShortcutDismis
 ];
 
 describe("ReviewScreen controls", () => {
+  it("keeps a cold empty local workspace in loading state until sync hydrates it", async () => {
+    hasHydratedHotStateMock.mockResolvedValue(false);
+
+    await renderReviewScreen();
+    await flushReviewScreenPromises();
+
+    const reviewPane = getContainer().querySelector("[data-testid='review-pane']");
+    if (!(reviewPane instanceof HTMLElement)) {
+      throw new Error("Review pane was not found");
+    }
+
+    expect(reviewPane.dataset.reviewPaneState).toBe("loading");
+    expect(reviewPane.dataset.reviewPaneEmptyReason).toBe("none");
+    expect(getContainer().textContent).not.toContain("No Cards Yet");
+  });
+
+  it("shows a retry path instead of staying in cold empty loading after sync fails", async () => {
+    const state = getState();
+    state.appData.errorMessage = "Cloud sync failed";
+    state.appData.isSyncing = false;
+    hasHydratedHotStateMock.mockResolvedValue(false);
+
+    await renderReviewScreen();
+    await flushReviewScreenPromises();
+
+    const reviewPane = getContainer().querySelector("[data-testid='review-pane']");
+    if (!(reviewPane instanceof HTMLElement)) {
+      throw new Error("Review pane was not found");
+    }
+
+    const retryButton = getContainer().querySelector(".review-loading-retry-btn");
+    if (!(retryButton instanceof HTMLButtonElement)) {
+      throw new Error("Review retry button was not found");
+    }
+
+    expect(reviewPane.dataset.reviewPaneState).toBe("empty");
+    expect(reviewPane.dataset.reviewPaneEmptyReason).toBe("no-cards");
+    expect(getContainer().textContent).toContain("Cloud sync failed");
+  });
+
   it("renders compact review header controls with scope before streak", async () => {
     const state = getState();
     const card = createCard({

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -44,10 +44,11 @@ export function useReviewScreenController(): UseReviewScreenControllerResult {
   const {
     activeWorkspace,
     cloudSettings,
+    errorMessage,
     selectedReviewFilter,
     workspaceSettings,
+    isSyncing,
     localReadVersion,
-    localCardCount,
     getCardById,
     refreshLocalData,
     selectReviewFilter,
@@ -80,6 +81,7 @@ export function useReviewScreenController(): UseReviewScreenControllerResult {
     handleReview: handleReviewData,
     hasLoadedReviewData,
     isInitialReviewLoad,
+    localWorkspaceCardCount,
     queueCards,
     resolvedReviewFilter,
     reviewLoadErrorMessage,
@@ -89,8 +91,10 @@ export function useReviewScreenController(): UseReviewScreenControllerResult {
     tagSuggestions,
   } = useReviewScreenData({
     activeWorkspaceId: activeWorkspace?.workspaceId ?? null,
+    appErrorMessage: errorMessage,
     getCardById,
     installationId: cloudSettings?.installationId ?? null,
+    isSyncing,
     localReadVersion,
     selectedReviewFilter,
     setErrorMessage,
@@ -156,7 +160,7 @@ export function useReviewScreenController(): UseReviewScreenControllerResult {
   const nowTimestamp = Date.now();
   const selectedFrontSpeakableText = selectedCard === null ? "" : makeReviewSpeakableText(selectedCard.frontText);
   const selectedBackSpeakableText = selectedCard === null ? "" : makeReviewSpeakableText(selectedCard.backText);
-  const hasCards = localCardCount > 0;
+  const hasCards = localWorkspaceCardCount > 0;
   const shouldShowSwitchToAllCardsAction = resolvedReviewFilter.kind !== "allCards";
   const loadingReviewCurrentCard = reviewLoadingSnapshot?.currentCard ?? reviewLoadingSnapshot?.queuePreview[0] ?? null;
   const visibleSelectedReviewFilterTitle = isInitialReviewLoad && reviewLoadingSnapshot !== null


### PR DESCRIPTION
## Summary
- keep the Review screen in a restoring state for cold empty local data until hot sync hydrates or reports an error
- surface the existing retry path instead of staying in loading after cold sync failure
- add client/server bootstrap diagnostics for slow hot-state restore

## Validation
- npm exec -- vitest run src/screens/review/**/*.test.ts src/screens/review/**/*.test.tsx
- npm run build (apps/web; existing chunk-size warning only)
- npm run lint (apps/backend)
- git --no-pager diff --check
