### PR TITLE
[codex] Fix iOS AI handoff tab lifecycle

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -512,6 +512,9 @@ struct AIChatView: View {
             return
         }
         self.captureAIChatPresentationRequest(request: resolvedRequest)
+        guard self.navigation.selectedTab == .ai else {
+            return
+        }
         guard self.chatStore.hasExternalProviderConsent else {
             return
         }
@@ -626,7 +629,7 @@ struct AIChatView: View {
             return
         }
 
-        self.syncChatSurface(refreshConsent: false)
+        self.syncChatSurface(refreshConsent: true)
         self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
         self.scheduleDeferredBottomSyncIfNeeded()
     }


### PR DESCRIPTION
## Summary
- keep AI presentation requests deferred until the AI tab is actually selected
- refresh AI consent state when entering the AI tab before applying a deferred request

## Validation
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift

## Notes
- No simulator-backed iOS test was run locally.