### PR TITLE
Fix AI stop during workspace switch

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+RunCancellation.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+RunCancellation.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+struct AIChatStopTarget: Sendable {
+    let session: CloudLinkedSession
+    let sessionId: String
+    let runId: String?
+    let cloudState: CloudAccountState?
+}
+
+struct AIChatStopRequestContext: Sendable {
+    let sessionId: String
+    let runId: String?
+    let workspaceId: String?
+    let cloudState: CloudAccountState?
+}
+
 func shouldAttemptRemoteAIChatStop(
     initialComposerPhase: AIChatComposerPhase,
     hadActiveSendTask: Bool,
@@ -80,6 +94,53 @@ func makeAIChatStopFailureMetadata(
 
 extension AIChatStore {
     func cancelStreaming() {
+        guard let stopContext = self.prepareStreamingCancellationForRemoteStop() else {
+            return
+        }
+
+        if let stopTarget = try? self.makeCurrentAIChatStopTarget(context: stopContext) {
+            Task {
+                await self.performRemoteAIChatStop(
+                    target: stopTarget,
+                    shouldReloadBootstrapWhenStopRejected: true
+                )
+            }
+            return
+        }
+
+        Task {
+            do {
+                let stopTarget = try await self.makeResolvedAIChatStopTarget(context: stopContext)
+                await self.performRemoteAIChatStop(
+                    target: stopTarget,
+                    shouldReloadBootstrapWhenStopRejected: true
+                )
+            } catch {
+                self.finishFailedAIChatStopPreparation(error: error, context: stopContext)
+            }
+        }
+    }
+
+    func stopStreamingForWorkspaceChange() async {
+        guard let stopContext = self.prepareStreamingCancellationForRemoteStop() else {
+            return
+        }
+
+        let stopTarget: AIChatStopTarget
+        do {
+            stopTarget = try self.makeCurrentAIChatStopTarget(context: stopContext)
+        } catch {
+            self.finishFailedAIChatStopPreparation(error: error, context: stopContext)
+            return
+        }
+
+        await self.performRemoteAIChatStop(
+            target: stopTarget,
+            shouldReloadBootstrapWhenStopRejected: false
+        )
+    }
+
+    private func prepareStreamingCancellationForRemoteStop() -> AIChatStopRequestContext? {
         let stopRunId: String? = aiChatNonEmptyRunId(runId: self.activeRunId)
         let initialComposerPhase = self.composerPhase
         let hadActiveSendTask = self.activeSendTask != nil
@@ -108,62 +169,143 @@ extension AIChatStore {
         self.chatSessionId = sessionId
         self.conversationScopeId = sessionId
         guard shouldAttemptRemoteStop else {
-            return
+            return nil
         }
         guard sessionId.isEmpty == false else {
             self.transitionToIdle()
             self.schedulePersistCurrentState()
+            return nil
+        }
+
+        return AIChatStopRequestContext(
+            sessionId: sessionId,
+            runId: stopRunId,
+            workspaceId: self.currentAIChatStopWorkspaceId(),
+            cloudState: self.flashcardsStore.cloudSettings?.cloudState
+        )
+    }
+
+    private func currentAIChatStopWorkspaceId() -> String? {
+        self.flashcardsStore.workspace?.workspaceId
+            ?? self.flashcardsStore.cloudSettings?.activeWorkspaceId
+            ?? self.flashcardsStore.cloudSettings?.linkedWorkspaceId
+    }
+
+    private func makeCurrentAIChatStopTarget(context: AIChatStopRequestContext) throws -> AIChatStopTarget {
+        let session = try self.flashcardsStore.currentActiveCloudSessionForAI()
+        try self.validateAIChatStopWorkspace(session: session, context: context)
+        return AIChatStopTarget(
+            session: session,
+            sessionId: context.sessionId,
+            runId: context.runId,
+            cloudState: context.cloudState
+        )
+    }
+
+    private func makeResolvedAIChatStopTarget(context: AIChatStopRequestContext) async throws -> AIChatStopTarget {
+        let session = try await self.flashcardsStore.cloudSessionForAI()
+        try self.validateAIChatStopWorkspace(session: session, context: context)
+        return AIChatStopTarget(
+            session: session,
+            sessionId: context.sessionId,
+            runId: context.runId,
+            cloudState: context.cloudState
+        )
+    }
+
+    private func validateAIChatStopWorkspace(
+        session: CloudLinkedSession,
+        context: AIChatStopRequestContext
+    ) throws {
+        guard let workspaceId = context.workspaceId,
+              workspaceId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        else {
             return
         }
 
-        Task {
-            var stopSession: CloudLinkedSession?
-            defer {
-                if self.composerPhase == .stopping {
-                    self.transitionToIdle()
-                }
-                self.schedulePersistCurrentState()
+        guard session.workspaceId == workspaceId else {
+            throw LocalStoreError.validation(
+                """
+                AI chat stop workspace changed before the stop request could be prepared. \
+                expectedWorkspaceId=\(workspaceId) \
+                actualWorkspaceId=\(session.workspaceId)
+                """
+            )
+        }
+    }
+
+    private func finishFailedAIChatStopPreparation(error: Error, context: AIChatStopRequestContext) {
+        if self.composerPhase == .stopping {
+            self.transitionToIdle()
+        }
+        self.schedulePersistCurrentState()
+        logAIChatStoreEvent(
+            action: "ai_stop_failed",
+            metadata: makeAIChatStopFailureMetadata(
+                error: error,
+                sessionId: context.sessionId,
+                runId: context.runId,
+                workspaceId: context.workspaceId,
+                cloudState: context.cloudState,
+                configurationMode: nil
+            )
+        )
+    }
+
+    private func performRemoteAIChatStop(
+        target: AIChatStopTarget,
+        shouldReloadBootstrapWhenStopRejected: Bool
+    ) async {
+        defer {
+            if self.composerPhase == .stopping {
+                self.transitionToIdle()
             }
-            do {
-                let session = try await self.flashcardsStore.cloudSessionForAI()
-                stopSession = session
-                let stopResponse = try await self.chatService.stopRun(
-                    session: session,
-                    sessionId: sessionId,
-                    runId: stopRunId
+            self.schedulePersistCurrentState()
+        }
+
+        do {
+            let stopResponse = try await self.flashcardsStore.withCloudSessionPreservingStableContext(
+                linkedSession: target.session
+            ) { refreshedSession in
+                try await self.chatService.stopRun(
+                    session: refreshedSession,
+                    sessionId: target.sessionId,
+                    runId: target.runId
                 )
-                // The cancel-cleanup branches below mutate state for the run we
-                // were stopping. If composerPhase moved off .stopping (e.g. a
-                // new run started or transitionToIdle already ran) the
-                // response is stale and must not clobber the new state.
-                guard self.composerPhase == .stopping else {
-                    return
-                }
-                if stopResponse.stopped == false {
-                    self.transitionToIdle()
+            }
+            // The cancel-cleanup branches below mutate state for the run we
+            // were stopping. If composerPhase moved off .stopping (e.g. a
+            // new run started or transitionToIdle already ran) the
+            // response is stale and must not clobber the new state.
+            guard self.composerPhase == .stopping else {
+                return
+            }
+            if stopResponse.stopped == false {
+                self.transitionToIdle()
+                if shouldReloadBootstrapWhenStopRejected {
                     self.startLinkedBootstrap(forceReloadState: true, resumeAttemptDiagnostics: nil)
-                    return
                 }
-                if stopResponse.stopped, stopResponse.stillRunning == false {
-                    self.finalizeStoppedAssistantMessageIfNeeded()
-                    self.activeStreamingMessageId = nil
-                    self.activeStreamingItemId = nil
-                    self.transitionToIdle()
-                    self.repairStatus = nil
-                }
-            } catch {
-                logAIChatStoreEvent(
-                    action: "ai_stop_failed",
-                    metadata: makeAIChatStopFailureMetadata(
-                        error: error,
-                        sessionId: sessionId,
-                        runId: stopRunId,
-                        workspaceId: stopSession?.workspaceId ?? self.flashcardsStore.workspace?.workspaceId,
-                        cloudState: self.flashcardsStore.cloudSettings?.cloudState,
-                        configurationMode: stopSession?.configurationMode
-                    )
-                )
+                return
             }
+            if stopResponse.stopped, stopResponse.stillRunning == false {
+                self.finalizeStoppedAssistantMessageIfNeeded()
+                self.activeStreamingMessageId = nil
+                self.activeStreamingItemId = nil
+                self.transitionToIdle()
+                self.repairStatus = nil
+            }
+        } catch {
+            logAIChatStoreEvent(
+                action: "ai_stop_failed",
+                metadata: makeAIChatStopFailureMetadata(
+                    error: error,
+                    sessionId: target.sessionId,
+                    runId: target.runId,
+                    workspaceId: target.session.workspaceId,
+                    cloudState: target.cloudState,
+                    configurationMode: target.session.configurationMode
+                )
+            )
         }
     }
 }

--- a/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/AIChatStore+Surface.swift
@@ -119,10 +119,11 @@ extension AIChatStore {
         self.schedulePersistState(state: clearedState)
     }
 
-    func prepareForWorkspaceChange() {
+    func prepareForWorkspaceChange() async {
         self.invalidatePendingNewSessionRequest()
-        self.invalidatePendingRemoteSessionProvisionRequest()
-        self.resetLocalHistoryState()
+        self.prepareLocalHistoryStateReset()
+        await self.stopStreamingForWorkspaceChange()
+        self.resetLocalHistoryStateAfterStreamingStopped()
         self.bootstrapPhase = .loading
     }
 
@@ -444,11 +445,19 @@ extension AIChatStore {
     }
 
     func resetLocalHistoryState() {
+        self.prepareLocalHistoryStateReset()
+        self.cancelStreaming()
+        self.resetLocalHistoryStateAfterStreamingStopped()
+    }
+
+    private func prepareLocalHistoryStateReset() {
         self.invalidateActiveBootstrapTask()
         self.activeWarmUpTask?.cancel()
         self.activeWarmUpTask = nil
         self.invalidatePendingRemoteSessionProvisionRequest()
-        self.cancelStreaming()
+    }
+
+    private func resetLocalHistoryStateAfterStreamingStopped() {
         self.cancelDictation()
         let resolvedSessionId = aiChatResolvedSessionId(
             workspaceId: self.historyWorkspaceId(),

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudAccount.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudAccount.swift
@@ -327,16 +327,13 @@ extension FlashcardsStore {
         }
     }
 
-    func runLinkedSyncPreservingSessionContext(
-        linkedSession: CloudLinkedSession
-    ) async throws -> CloudSyncResult {
-        if case .blocked(let message) = self.syncStatus {
-            throw LocalStoreError.validation(message)
-        }
-
+    func withCloudSessionPreservingStableContext<Result>(
+        linkedSession: CloudLinkedSession,
+        operation: (CloudLinkedSession) async throws -> Result
+    ) async throws -> Result {
         switch linkedSession.authorization {
         case .guest:
-            return try await self.runLinkedSync(linkedSession: linkedSession)
+            return try await operation(linkedSession)
         case .bearer:
             do {
                 return try await self.withStoredAuthenticatedCredentials { credentials, _ in
@@ -348,7 +345,7 @@ extension FlashcardsStore {
                         apiBaseUrl: linkedSession.apiBaseUrl,
                         authorization: .bearer(credentials.idToken)
                     )
-                    return try await self.runLinkedSync(linkedSession: refreshedSession)
+                    return try await operation(refreshedSession)
                 }
             } catch {
                 if self.isCloudAccountDeletedError(error) {
@@ -361,6 +358,18 @@ extension FlashcardsStore {
 
                 throw error
             }
+        }
+    }
+
+    func runLinkedSyncPreservingSessionContext(
+        linkedSession: CloudLinkedSession
+    ) async throws -> CloudSyncResult {
+        if case .blocked(let message) = self.syncStatus {
+            throw LocalStoreError.validation(message)
+        }
+
+        return try await self.withCloudSessionPreservingStableContext(linkedSession: linkedSession) { refreshedSession in
+            try await self.runLinkedSync(linkedSession: refreshedSession)
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudRestore.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudRestore.swift
@@ -62,7 +62,7 @@ extension FlashcardsStore {
         )
 
         self.cloudRuntime.cancelForWorkspaceSwitch()
-        self.prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: linkedSession.workspaceId)
+        await self.prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: linkedSession.workspaceId)
         try database.switchActiveWorkspace(workspace: workspaceSummary, linkedSession: linkedSession)
         self.cloudRuntime.setActiveCloudSession(linkedSession: linkedSession)
         try self.reload()

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudWorkspace.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudWorkspace.swift
@@ -86,7 +86,7 @@ extension FlashcardsStore {
         }
 
         self.cloudRuntime.cancelForWorkspaceSwitch()
-        self.prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: selectedWorkspace.workspaceId)
+        await self.prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: selectedWorkspace.workspaceId)
         let database = try requireLocalDatabase(database: self.database)
         try database.switchActiveWorkspace(
             workspace: selectedWorkspace,
@@ -228,7 +228,7 @@ extension FlashcardsStore {
             )
             let database = try requireLocalDatabase(database: self.database)
             self.cloudRuntime.cancelForWorkspaceSwitch()
-            self.prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: replacementSession.workspaceId)
+            await self.prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: replacementSession.workspaceId)
             try database.replaceLocalWorkspaceAfterRemoteDelete(
                 localWorkspaceId: localWorkspaceId,
                 replacementWorkspace: deleteResult.1.workspace,

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
@@ -20,8 +20,8 @@ extension FlashcardsStore {
         self.clearTransientBanners()
     }
 
-    func prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: String) {
-        self.cachedAIChatStore?.prepareForWorkspaceChange()
+    func prepareWorkspaceScopedStateForSwitch(nextWorkspaceId: String) async {
+        await self.cachedAIChatStore?.prepareForWorkspaceChange()
         self.resetReviewRuntimeForWorkspace(nextWorkspaceId: nextWorkspaceId)
     }
 

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreRunStopTests.swift
@@ -112,6 +112,195 @@ final class AIChatStoreRunStopTests: XCTestCase {
         XCTAssertEqual(context.chatService.stopRunRequests.map { $0.runId }, ["run-1"])
     }
 
+    func testActiveCancelRestoresCloudSessionBeforeRemoteStop() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession(workspaceId: "workspace-1")
+        context.flashcardsStore.cloudRuntime.disconnectSession()
+        let store = context.makeStore()
+        let activeRun = AIChatStoreTestSupport.makeActiveRun()
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.transitionToStreaming(
+            activeRun: AIChatActiveRunSession(
+                sessionId: "session-1",
+                conversationScopeId: "session-1",
+                runId: activeRun.runId,
+                liveStream: activeRun.live.stream,
+                liveCursor: activeRun.live.cursor,
+                streamEpoch: nil
+            )
+        )
+
+        store.cancelStreaming()
+
+        let didSettle = await AIChatStoreTestSupport.waitForCondition(
+            description: "restored cloud session stop request",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.chatService.stopRunRequests.count == 1
+                    && store.composerPhase == .idle
+            }
+        )
+
+        XCTAssertTrue(didSettle)
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.sessionId }, ["session-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.runId }, ["run-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.workspaceId }, ["workspace-1"])
+    }
+
+    func testActiveCancelRefreshesCapturedLinkedSessionTokenBeforeRemoteStop() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession(workspaceId: "workspace-1")
+        try context.flashcardsStore.cloudRuntime.saveCredentials(
+            credentials: StoredCloudCredentials(
+                refreshToken: "refresh-token-1",
+                idToken: "token-2",
+                idTokenExpiresAt: "2099-01-01T00:00:00Z"
+            )
+        )
+        let store = context.makeStore()
+        let activeRun = AIChatStoreTestSupport.makeActiveRun()
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.transitionToStreaming(
+            activeRun: AIChatActiveRunSession(
+                sessionId: "session-1",
+                conversationScopeId: "session-1",
+                runId: activeRun.runId,
+                liveStream: activeRun.live.stream,
+                liveCursor: activeRun.live.cursor,
+                streamEpoch: nil
+            )
+        )
+
+        store.cancelStreaming()
+
+        let didSettle = await AIChatStoreTestSupport.waitForCondition(
+            description: "refreshed captured session stop request",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.chatService.stopRunRequests.count == 1
+                    && store.composerPhase == .idle
+            }
+        )
+
+        XCTAssertTrue(didSettle)
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.sessionId }, ["session-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.runId }, ["run-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.workspaceId }, ["workspace-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.authorizationHeader }, ["Bearer token-2"])
+    }
+
+    func testActiveCancelUsesCapturedCloudSessionWhenWorkspaceChangesBeforeStopRuns() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession(workspaceId: "workspace-1")
+        let store = context.makeStore()
+        let activeRun = AIChatStoreTestSupport.makeActiveRun()
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.transitionToStreaming(
+            activeRun: AIChatActiveRunSession(
+                sessionId: "session-1",
+                conversationScopeId: "session-1",
+                runId: activeRun.runId,
+                liveStream: activeRun.live.stream,
+                liveCursor: activeRun.live.cursor,
+                streamEpoch: nil
+            )
+        )
+
+        store.cancelStreaming()
+        try context.configureLinkedCloudSession(workspaceId: "workspace-2")
+
+        let didSettle = await AIChatStoreTestSupport.waitForCondition(
+            description: "captured workspace stop request",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.chatService.stopRunRequests.count == 1
+                    && store.composerPhase == .idle
+            }
+        )
+
+        XCTAssertTrue(didSettle)
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.sessionId }, ["session-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.runId }, ["run-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.workspaceId }, ["workspace-1"])
+    }
+
+    func testWorkspaceChangePreparationWaitsForRemoteStopBeforeReset() async throws {
+        let context = AIChatStoreTestSupport.Context.make()
+        defer {
+            context.tearDown()
+        }
+
+        try context.configureLinkedCloudSession(workspaceId: "workspace-1")
+        let store = context.makeStore()
+        let activeRun = AIChatStoreTestSupport.makeActiveRun()
+        store.chatSessionId = "session-1"
+        store.conversationScopeId = "session-1"
+        store.messages = [
+            AIChatStoreTestSupport.makeUserTextMessage(
+                id: "message-1",
+                text: "Question before workspace switch",
+                timestamp: "2026-04-08T10:00:00Z"
+            )
+        ]
+        store.transitionToStreaming(
+            activeRun: AIChatActiveRunSession(
+                sessionId: "session-1",
+                conversationScopeId: "session-1",
+                runId: activeRun.runId,
+                liveStream: activeRun.live.stream,
+                liveCursor: activeRun.live.cursor,
+                streamEpoch: nil
+            )
+        )
+
+        let stopRunGate = AIChatStoreTestSupport.AsyncGate()
+        context.chatService.stopRunGate = stopRunGate
+        let prepareTask = Task { @MainActor in
+            await store.prepareForWorkspaceChange()
+        }
+
+        let didReachStopRun = await AIChatStoreTestSupport.waitForCondition(
+            description: "workspace change stop request",
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(10),
+            condition: {
+                context.chatService.stopRunRequests.count == 1
+                    && store.composerPhase == .stopping
+            }
+        )
+        XCTAssertTrue(didReachStopRun)
+        XCTAssertEqual(store.messages.count, 1)
+
+        await stopRunGate.release()
+        await prepareTask.value
+
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.sessionId }, ["session-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.runId }, ["run-1"])
+        XCTAssertEqual(context.chatService.stopRunRequests.map { $0.workspaceId }, ["workspace-1"])
+        XCTAssertEqual(store.messages, [])
+        XCTAssertEqual(store.chatSessionId, "")
+        XCTAssertEqual(store.composerPhase, .idle)
+        XCTAssertEqual(store.bootstrapPhase, .loading)
+    }
+
     func testNoopStopClearsStoppingAndReloadsBootstrap() async throws {
         let context = AIChatStoreTestSupport.Context.make()
         defer {

--- a/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/AIChatStoreTestSupport.swift
@@ -216,7 +216,7 @@ enum AIChatStoreTestSupport {
         var loadBootstrapGate: AsyncGate?
         var startRunRequests: [AIChatStartRunRequestBody]
         var createNewSessionRequests: [AIChatNewSessionRequestBody]
-        var stopRunRequests: [(sessionId: String, runId: String?)]
+        var stopRunRequests: [(sessionId: String, runId: String?, workspaceId: String, authorizationHeader: String)]
         var stopRunGate: AsyncGate?
         var loadBootstrapHandler: ((String?) throws -> AIChatBootstrapResponse)?
         var startRunHandler: ((AIChatStartRunRequestBody) throws -> AIChatStartRunResponse)?
@@ -316,9 +316,13 @@ enum AIChatStoreTestSupport {
             sessionId: String,
             runId: String?
         ) async throws -> AIChatStopRunResponse {
-            _ = session
             self.events.append("stopRun:\(sessionId):\(runId ?? "nil")")
-            self.stopRunRequests.append((sessionId: sessionId, runId: runId))
+            self.stopRunRequests.append((
+                sessionId: sessionId,
+                runId: runId,
+                workspaceId: session.workspaceId,
+                authorizationHeader: session.authorizationHeaderValue
+            ))
             if let stopRunGate = self.stopRunGate {
                 await stopRunGate.wait()
                 self.stopRunGate = nil


### PR DESCRIPTION
## Summary
- Capture AI stop context before workspace switches can change the active cloud session
- Await workspace-change AI stop cleanup before swapping the active workspace session
- Refresh linked credentials while preserving the captured stop workspace/session context
- Add focused AI stop regression coverage and record stop workspace/auth details in the test fake

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse on changed Swift files

Simulator-backed xcodebuild tests were not run per repository instructions.