### PR TITLE
[codex] Fix iOS notification scheduling capacity

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -50,6 +50,7 @@ enum IOSWarningEvent: Sendable {
     case cloudRetry(CloudRetryWarning)
     case localDataRepair(LocalDataRepairWarning)
     case invalidCardDueAt(InvalidCardDueAtWarning)
+    case notificationSchedulingFailed(NotificationSchedulingFailureWarning)
     case notificationTapDropped(NotificationTapDroppedWarning)
     case progressCacheRemoved(ProgressCacheRemovedWarning)
     case staleGuestCredentials(StaleGuestCredentialsWarning)
@@ -221,6 +222,22 @@ struct NotificationTapDroppedWarning: Sendable, Hashable {
     let detailSummary: String?
 }
 
+struct NotificationSchedulingFailureWarning: Sendable, Hashable {
+    let action: String
+    let scope: IOSObservationScope
+    let notificationKind: String
+    let workspaceId: String?
+    let requestId: String?
+    let stage: String
+    let plannedCount: Int
+    let acceptedCount: Int
+    let pendingBeforeCount: Int
+    let pendingAfterCount: Int
+    let errorDomain: String?
+    let errorCode: Int?
+    let messageSummary: String?
+}
+
 struct CloudRetryWarning: Sendable, Hashable {
     let action: String
     let scope: IOSObservationScope
@@ -319,4 +336,3 @@ struct LocalDataRepairFailureDetails: Sendable, Hashable {
     let reason: String
     let messageSummary: String?
 }
-

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -269,6 +269,31 @@ extension SentryObservabilityAdapter {
                 context: context,
                 localFields: stringifyContext(context)
             )
+        case .notificationSchedulingFailed(let warning):
+            let context: [String: Any] = [
+                "notification_kind": warning.notificationKind,
+                "workspace_id": warning.workspaceId ?? "",
+                "notification_request_id_hash": warning.requestId.map {
+                    hashedObservationIdentifier($0, key: "notification_request_id")
+                } ?? "",
+                "stage": warning.stage,
+                "planned_count": String(warning.plannedCount),
+                "accepted_count": String(warning.acceptedCount),
+                "pending_before_count": String(warning.pendingBeforeCount),
+                "pending_after_count": String(warning.pendingAfterCount),
+                "error_domain": warning.errorDomain ?? "",
+                "error_code": warning.errorCode.map { errorCode in String(errorCode) } ?? "",
+                "message_summary": warning.messageSummary ?? ""
+            ]
+            return ObservationPayload(
+                message: "iOS notification scheduling warning: \(warning.action)",
+                action: warning.action,
+                scope: warning.scope,
+                statusCode: nil,
+                backendCode: nil,
+                context: context,
+                localFields: stringifyContext(context)
+            )
         case .notificationTapDropped(let warning):
             var context: [String: Any] = self.notificationTapContext(warning.observation)
             context["reason"] = warning.reason

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -339,7 +339,10 @@ extension FlashcardsStore {
             reviewFilter: self.selectedReviewFilter,
             now: now,
             settings: self.reviewNotificationsSettings,
-            lastActiveAt: lastActiveAt
+            lastActiveAt: lastActiveAt,
+            pendingRequestLimit: reviewNotificationPendingRequestsLimit(
+                strictRemindersSettings: self.strictRemindersSettings
+            )
         )
 
         let loadResult: ScheduledReviewNotificationLoadResult
@@ -379,6 +382,10 @@ extension FlashcardsStore {
         }
 
         let payloads = loadResult.payloads
+        let pendingBeforeRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
+        let pendingBeforeCount = pendingBeforeRequestIdentifiers.count
+        var addFailure: Error?
+        var failedRequestId: String?
 
         for payload in payloads {
             guard self.reviewNotificationsRescheduleGeneration == generation else {
@@ -403,7 +410,13 @@ extension FlashcardsStore {
                 content: content,
                 trigger: trigger
             )
-            try? await center.add(request)
+            do {
+                try await center.add(request)
+            } catch {
+                addFailure = error
+                failedRequestId = payload.requestId
+                break
+            }
         }
 
         guard self.reviewNotificationsRescheduleGeneration == generation else {
@@ -412,7 +425,78 @@ extension FlashcardsStore {
         guard Task.isCancelled == false else {
             return
         }
-        self.persistScheduledReviewNotifications(payloads: payloads)
+
+        let pendingAfterRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
+        guard self.reviewNotificationsRescheduleGeneration == generation else {
+            return
+        }
+        guard Task.isCancelled == false else {
+            return
+        }
+        let acceptedPayloads = acceptedReviewNotificationPayloads(
+            payloads: payloads,
+            pendingRequestIdentifiers: pendingAfterRequestIdentifiers
+        )
+        if let addFailure {
+            FlashcardsObservability.captureWarning(
+                .notificationSchedulingFailed(
+                    makeNotificationSchedulingFailureWarning(
+                        action: "review_schedule_add_failed",
+                        scope: IOSObservationScope(
+                            feature: .notifications,
+                            userId: nil,
+                            workspaceId: workspaceId,
+                            requestId: nil,
+                            clientRequestId: nil,
+                            sessionId: nil,
+                            runId: nil,
+                            cloudState: self.cloudSettings?.cloudState,
+                            configurationMode: nil
+                        ),
+                        notificationKind: .reviewReminder,
+                        workspaceId: workspaceId,
+                        requestId: failedRequestId,
+                        stage: "add",
+                        plannedCount: payloads.count,
+                        acceptedCount: acceptedPayloads.count,
+                        pendingBeforeCount: pendingBeforeCount,
+                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        error: addFailure,
+                        messageSummary: nil
+                    )
+                )
+            )
+        } else if acceptedPayloads.count != payloads.count {
+            FlashcardsObservability.captureWarning(
+                .notificationSchedulingFailed(
+                    makeNotificationSchedulingFailureWarning(
+                        action: "review_schedule_readback_mismatch",
+                        scope: IOSObservationScope(
+                            feature: .notifications,
+                            userId: nil,
+                            workspaceId: workspaceId,
+                            requestId: nil,
+                            clientRequestId: nil,
+                            sessionId: nil,
+                            runId: nil,
+                            cloudState: self.cloudSettings?.cloudState,
+                            configurationMode: nil
+                        ),
+                        notificationKind: .reviewReminder,
+                        workspaceId: workspaceId,
+                        requestId: nil,
+                        stage: "readback",
+                        plannedCount: payloads.count,
+                        acceptedCount: acceptedPayloads.count,
+                        pendingBeforeCount: pendingBeforeCount,
+                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        error: nil,
+                        messageSummary: "Notification Center accepted fewer review reminders than planned"
+                    )
+                )
+            )
+        }
+        self.persistScheduledReviewNotifications(payloads: acceptedPayloads)
     }
 
     private func persistScheduledReviewNotifications(payloads: [ScheduledReviewNotificationPayload]) {

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsSupport.swift
@@ -6,7 +6,7 @@ let reviewNotificationPermissionPromptThreshold: Int = 6
 let defaultDailyReminderHour: Int = 10
 let defaultDailyReminderMinute: Int = 0
 let dailyReminderSchedulingHorizonDays: Int = 7
-let reviewNotificationPendingRequestsLimit: Int = 64
+let appNotificationPendingRequestsLimit: Int = 64
 let defaultInactivityReminderWindowEndHour: Int = 19
 let defaultInactivityReminderWindowEndMinute: Int = 0
 let reviewNotificationFallbackBodyText: String = String(
@@ -291,6 +291,7 @@ struct ReviewNotificationSchedulingSnapshot: Sendable {
     let now: Date
     let settings: ReviewNotificationsSettings
     let lastActiveAt: Date?
+    let pendingRequestLimit: Int
 }
 
 struct ScheduledReviewNotificationLoadResult: Sendable {
@@ -376,6 +377,14 @@ func hasEnoughReviewHistoryForNotificationPrompt(reviewCount: Int) -> Bool {
     reviewCount >= reviewNotificationPermissionPromptThreshold
 }
 
+func reviewNotificationPendingRequestsLimit(strictRemindersSettings: StrictRemindersSettings) -> Int {
+    guard strictRemindersSettings.isEnabled else {
+        return appNotificationPendingRequestsLimit
+    }
+
+    return max(0, appNotificationPendingRequestsLimit - strictReminderPendingRequestsLimit)
+}
+
 func makeReviewNotificationsSettingsUserDefaultsKey(workspaceId: String) -> String {
     "\(reviewNotificationsSettingsUserDefaultsKeyPrefix)\(workspaceId)"
 }
@@ -454,6 +463,16 @@ func filterReviewNotificationRequestIdentifiers(identifiers: [String]) -> [Strin
     identifiers.filter(isReviewNotificationRequestIdentifier)
 }
 
+func pendingAppNotificationRequestIdentifiers(
+    center: UNUserNotificationCenter
+) async -> [String] {
+    await withCheckedContinuation { continuation in
+        center.getPendingNotificationRequests { requests in
+            continuation.resume(returning: requests.map(\.identifier))
+        }
+    }
+}
+
 /// Returns the identifiers of pending review reminders queued by the app.
 func pendingReviewNotificationRequestIdentifiers(
     center: UNUserNotificationCenter
@@ -509,6 +528,16 @@ func makeReviewNotificationRequestIdentifiers(
     scheduledPayloads: [ScheduledReviewNotificationPayload]
 ) -> [String] {
     scheduledPayloads.map(\.requestId)
+}
+
+func acceptedReviewNotificationPayloads(
+    payloads: [ScheduledReviewNotificationPayload],
+    pendingRequestIdentifiers: [String]
+) -> [ScheduledReviewNotificationPayload] {
+    let pendingRequestIdentifierSet: Set<String> = Set(pendingRequestIdentifiers)
+    return payloads.filter { payload in
+        pendingRequestIdentifierSet.contains(payload.requestId)
+    }
 }
 
 func buildDailyReviewNotificationDates(
@@ -729,7 +758,7 @@ func loadScheduledReviewNotificationPayloads(
             )
         }
 
-        let limitedScheduledDates = Array(scheduledDates.prefix(reviewNotificationPendingRequestsLimit))
+        let limitedScheduledDates = Array(scheduledDates.prefix(max(0, snapshot.pendingRequestLimit)))
         let payloads: [ScheduledReviewNotificationPayload]
         if let currentCard {
             payloads = buildRepeatedReviewNotificationPayloads(
@@ -807,6 +836,46 @@ func appNotificationTapType(request: AppNotificationTapRequest) -> String {
     case .fallback(let fallback):
         return fallback.notificationType ?? "fallback"
     }
+}
+
+func makeNotificationSchedulingFailureWarning(
+    action: String,
+    scope: IOSObservationScope,
+    notificationKind: AppNotificationTapType,
+    workspaceId: String?,
+    requestId: String?,
+    stage: String,
+    plannedCount: Int,
+    acceptedCount: Int,
+    pendingBeforeCount: Int,
+    pendingAfterCount: Int,
+    error: Error?,
+    messageSummary: String?
+) -> NotificationSchedulingFailureWarning {
+    let nsError: NSError? = error.map { value in value as NSError }
+    let safeErrorDomain: String?
+    if let rawDomain = nsError?.domain {
+        let candidateDomain = safeDiagnosticIdentifier(rawDomain)
+        safeErrorDomain = candidateDomain == filteredDiagnosticValue ? nil : candidateDomain
+    } else {
+        safeErrorDomain = nil
+    }
+
+    return NotificationSchedulingFailureWarning(
+        action: action,
+        scope: scope,
+        notificationKind: notificationKind.rawValue,
+        workspaceId: workspaceId,
+        requestId: requestId,
+        stage: stage,
+        plannedCount: plannedCount,
+        acceptedCount: acceptedCount,
+        pendingBeforeCount: pendingBeforeCount,
+        pendingAfterCount: pendingAfterCount,
+        errorDomain: safeErrorDomain,
+        errorCode: nsError?.code,
+        messageSummary: error.map { value in Flashcards.errorMessage(error: value) } ?? messageSummary
+    )
 }
 
 func savePendingAppNotificationTap(

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
@@ -21,7 +21,7 @@ extension FlashcardsStore {
     func updateStrictRemindersSettings(settings: StrictRemindersSettings) {
         self.strictRemindersSettings = settings
         self.persistStrictRemindersSettings()
-        self.reconcileStrictReminders(trigger: .settingsChanged, now: Date())
+        self.reconcileNotificationsAfterStrictRemindersSettingsChanged(now: Date())
     }
 
     func updateStrictRemindersEnabled(isEnabled: Bool) {
@@ -42,6 +42,44 @@ extension FlashcardsStore {
 
         self.activeStrictRemindersRescheduleTask = Task { @MainActor in
             await self.drainStrictRemindersReconcileRequests()
+        }
+    }
+
+    private func reconcileNotificationsAfterStrictRemindersSettingsChanged(now: Date) {
+        guard self.strictRemindersSettings.isEnabled else {
+            self.reconcileStrictReminders(trigger: .settingsChanged, now: now)
+            Task { @MainActor in
+                await self.waitForStrictRemindersReconcileToSettle()
+                guard Task.isCancelled == false else {
+                    return
+                }
+                guard self.strictRemindersSettings.isEnabled == false else {
+                    return
+                }
+                self.reconcileReviewNotifications(trigger: .settingsChanged, now: now)
+            }
+            return
+        }
+
+        self.reconcileReviewNotifications(trigger: .settingsChanged, now: now)
+        self.reconcileStrictReminders(trigger: .settingsChanged, now: now)
+    }
+
+    private func waitForStrictRemindersReconcileToSettle() async {
+        while let task = self.activeStrictRemindersRescheduleTask {
+            await task.value
+            guard Task.isCancelled == false else {
+                return
+            }
+        }
+    }
+
+    private func waitForReviewNotificationsReconcileToSettle() async {
+        while let task = self.activeReviewNotificationsRescheduleTask {
+            await task.value
+            guard Task.isCancelled == false else {
+                return
+            }
         }
     }
 
@@ -113,6 +151,10 @@ extension FlashcardsStore {
             self.persistScheduledStrictReminders(payloads: [])
             return
         }
+        await self.waitForReviewNotificationsReconcileToSettle()
+        guard Task.isCancelled == false else {
+            return
+        }
 
         let payloads: [ScheduledStrictReminderPayload]
         do {
@@ -178,37 +220,52 @@ extension FlashcardsStore {
             return
         }
 
-        do {
-            let notificationScope = loadStrictReminderNotificationScope(userDefaults: self.userDefaults)
-            for payload in payloads {
-                guard Task.isCancelled == false else {
-                    return
-                }
-                let content = UNMutableNotificationContent()
-                content.title = appDisplayName()
-                content.body = payload.notificationBodyText
-                content.sound = .default
-                content.userInfo = buildStrictReminderNotificationUserInfo(scope: notificationScope)
-
-                let interval = max(1, TimeInterval(payload.scheduledAtMillis) / 1_000 - request.now.timeIntervalSince1970)
-                let request = UNNotificationRequest(
-                    identifier: payload.requestId,
-                    content: content,
-                    trigger: UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
-                )
-
-                do {
-                    try await center.add(request)
-                } catch {
-                    throw LocalStoreError.validation(
-                        "Strict reminder request could not be scheduled: requestId=\(payload.requestId), message=\(Flashcards.errorMessage(error: error))"
-                    )
-                }
+        let notificationScope = loadStrictReminderNotificationScope(userDefaults: self.userDefaults)
+        let pendingBeforeRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
+        let pendingBeforeCount = pendingBeforeRequestIdentifiers.count
+        var addFailure: Error?
+        var failedRequestId: String?
+        for payload in payloads {
+            guard Task.isCancelled == false else {
+                return
             }
-        } catch {
+            let content = UNMutableNotificationContent()
+            content.title = appDisplayName()
+            content.body = payload.notificationBodyText
+            content.sound = .default
+            content.userInfo = buildStrictReminderNotificationUserInfo(scope: notificationScope)
+
+            let interval = max(1, TimeInterval(payload.scheduledAtMillis) / 1_000 - request.now.timeIntervalSince1970)
+            let request = UNNotificationRequest(
+                identifier: payload.requestId,
+                content: content,
+                trigger: UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
+            )
+
+            do {
+                try await center.add(request)
+            } catch {
+                addFailure = error
+                failedRequestId = payload.requestId
+                break
+            }
+        }
+        guard Task.isCancelled == false else {
+            return
+        }
+
+        let pendingAfterRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
+        guard Task.isCancelled == false else {
+            return
+        }
+        let acceptedPayloads = acceptedStrictReminderPayloads(
+            payloads: payloads,
+            pendingRequestIdentifiers: pendingAfterRequestIdentifiers
+        )
+        if let addFailure {
             FlashcardsObservability.captureWarning(
-                .localDataRepair(
-                    LocalDataRepairWarning(
+                .notificationSchedulingFailed(
+                    makeNotificationSchedulingFailureWarning(
                         action: "strict_schedule_add_failed",
                         scope: IOSObservationScope(
                             feature: .notifications,
@@ -221,16 +278,49 @@ extension FlashcardsStore {
                             cloudState: self.cloudSettings?.cloudState,
                             configurationMode: nil
                         ),
+                        notificationKind: .strictReminder,
                         workspaceId: self.workspace?.workspaceId,
-                        cardId: nil,
-                        reason: Flashcards.errorMessage(error: error),
-                        repair: "clear_scheduled_strict_reminders"
+                        requestId: failedRequestId,
+                        stage: "add",
+                        plannedCount: payloads.count,
+                        acceptedCount: acceptedPayloads.count,
+                        pendingBeforeCount: pendingBeforeCount,
+                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        error: addFailure,
+                        messageSummary: nil
                     )
                 )
             )
-            self.persistScheduledStrictReminders(payloads: [])
-            return
+        } else if acceptedPayloads.count != payloads.count {
+            FlashcardsObservability.captureWarning(
+                .notificationSchedulingFailed(
+                    makeNotificationSchedulingFailureWarning(
+                        action: "strict_schedule_readback_mismatch",
+                        scope: IOSObservationScope(
+                            feature: .notifications,
+                            userId: nil,
+                            workspaceId: self.workspace?.workspaceId,
+                            requestId: nil,
+                            clientRequestId: nil,
+                            sessionId: nil,
+                            runId: nil,
+                            cloudState: self.cloudSettings?.cloudState,
+                            configurationMode: nil
+                        ),
+                        notificationKind: .strictReminder,
+                        workspaceId: self.workspace?.workspaceId,
+                        requestId: nil,
+                        stage: "readback",
+                        plannedCount: payloads.count,
+                        acceptedCount: acceptedPayloads.count,
+                        pendingBeforeCount: pendingBeforeCount,
+                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        error: nil,
+                        messageSummary: "Notification Center accepted fewer strict reminders than planned"
+                    )
+                )
+            )
         }
-        self.persistScheduledStrictReminders(payloads: payloads)
+        self.persistScheduledStrictReminders(payloads: acceptedPayloads)
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
@@ -357,6 +357,16 @@ func filterStrictReminderRequestIdentifiers(identifiers: [String]) -> [String] {
     identifiers.filter(isStrictReminderRequestIdentifier)
 }
 
+func acceptedStrictReminderPayloads(
+    payloads: [ScheduledStrictReminderPayload],
+    pendingRequestIdentifiers: [String]
+) -> [ScheduledStrictReminderPayload] {
+    let pendingRequestIdentifierSet: Set<String> = Set(pendingRequestIdentifiers)
+    return payloads.filter { payload in
+        pendingRequestIdentifierSet.contains(payload.requestId)
+    }
+}
+
 func pendingStrictReminderRequestIdentifiers(
     center: UNUserNotificationCenter
 ) async -> [String] {

--- a/apps/ios/Flashcards/FlashcardsTests/Review/ReviewNotificationsSupportTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/ReviewNotificationsSupportTests.swift
@@ -81,6 +81,24 @@ final class ReviewNotificationsSupportTests: XCTestCase {
         XCTAssertTrue(settings.isEnabled)
     }
 
+    func testReviewNotificationPendingLimitReservesStrictReminderCapacityWhenEnabled() {
+        let settings = StrictRemindersSettings(isEnabled: true)
+
+        XCTAssertEqual(
+            reviewNotificationPendingRequestsLimit(strictRemindersSettings: settings),
+            appNotificationPendingRequestsLimit - strictReminderPendingRequestsLimit
+        )
+    }
+
+    func testReviewNotificationPendingLimitUsesFullLimitWhenStrictRemindersDisabled() {
+        let settings = StrictRemindersSettings(isEnabled: false)
+
+        XCTAssertEqual(
+            reviewNotificationPendingRequestsLimit(strictRemindersSettings: settings),
+            appNotificationPendingRequestsLimit
+        )
+    }
+
     func testStrictReminderNotificationScopePersistsAndValidatesCurrentNotification() {
         let suiteName = "ReviewNotificationsSupportTests-\(UUID().uuidString)"
         guard let userDefaults = UserDefaults(suiteName: suiteName) else {
@@ -573,6 +591,58 @@ final class ReviewNotificationsSupportTests: XCTestCase {
         )
     }
 
+    func testLoadScheduledReviewNotificationPayloadsRespectsExplicitLimit() async throws {
+        let (database, databaseURL) = try makeTemporaryLocalDatabase()
+        defer {
+            try? database.close()
+            try? removeTemporaryDatabase(at: databaseURL)
+        }
+
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        _ = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        let calendar = makeCalendar()
+        let now = try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 9, minute: 0, calendar: calendar))
+        let settings = ReviewNotificationsSettings(
+            isEnabled: true,
+            selectedMode: .daily,
+            daily: DailyReviewNotificationsSettings(
+                hour: defaultDailyReminderHour,
+                minute: defaultDailyReminderMinute
+            ),
+            inactivity: InactivityReviewNotificationsSettings(
+                windowStartHour: defaultDailyReminderHour,
+                windowStartMinute: defaultDailyReminderMinute,
+                windowEndHour: defaultInactivityReminderWindowEndHour,
+                windowEndMinute: defaultInactivityReminderWindowEndMinute,
+                idleMinutes: 120
+            ),
+            showAppIconBadge: true
+        )
+
+        let result = try await loadScheduledReviewNotificationPayloads(
+            snapshot: ReviewNotificationSchedulingSnapshot(
+                databaseURL: databaseURL,
+                workspaceId: workspace.workspaceId,
+                reviewFilter: .allCards,
+                now: now,
+                settings: settings,
+                lastActiveAt: nil,
+                pendingRequestLimit: 3
+            )
+        )
+
+        XCTAssertEqual(result.payloads.count, 3)
+    }
+
     func testRepeatedPayloadsUseReplacementCurrentCardAndUniqueIdentifiers() throws {
         let calendar = makeCalendar()
         let scheduledDates = [
@@ -671,6 +741,57 @@ final class ReviewNotificationsSupportTests: XCTestCase {
         )
     }
 
+    func testAcceptedNotificationPayloadFiltersKeepOnlyPendingReadbackIdentifiers() throws {
+        let calendar = makeCalendar()
+        let scheduledDates = [
+            try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 12, minute: 15, calendar: calendar)),
+            try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 14, minute: 15, calendar: calendar)),
+            try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 16, minute: 15, calendar: calendar))
+        ]
+        let reviewPayloads = buildFallbackReviewNotificationPayloads(
+            workspaceId: "workspace-1",
+            reviewFilter: .allCards,
+            scheduledDates: scheduledDates,
+            calendar: calendar,
+            mode: .daily
+        )
+        let strictPayloads = buildStrictReminderPayloadsForIncompleteDay(
+            dayStart: try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 0, minute: 0, calendar: calendar)),
+            startOfNextDay: try XCTUnwrap(makeDate(year: 2026, month: 4, day: 4, hour: 0, minute: 0, calendar: calendar)),
+            now: try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 9, minute: 0, calendar: calendar)),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(
+            acceptedReviewNotificationPayloads(
+                payloads: reviewPayloads,
+                pendingRequestIdentifiers: [
+                    reviewPayloads[0].requestId,
+                    "unrelated-request",
+                    reviewPayloads[2].requestId
+                ]
+            )
+            .map(\.requestId),
+            [
+                reviewPayloads[0].requestId,
+                reviewPayloads[2].requestId
+            ]
+        )
+        XCTAssertEqual(
+            acceptedStrictReminderPayloads(
+                payloads: strictPayloads,
+                pendingRequestIdentifiers: [
+                    strictPayloads[1].requestId,
+                    "review-notification::workspace-1::daily::2026-04-03-10-00"
+                ]
+            )
+            .map(\.requestId),
+            [
+                strictPayloads[1].requestId
+            ]
+        )
+    }
+
     func testStrictReminderPayloadsSkipCompletedDaysAndKeepOnlyFutureCandidates() throws {
         let calendar = makeCalendar()
         let now = try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 21, minute: 5, calendar: calendar))
@@ -693,6 +814,20 @@ final class ReviewNotificationsSupportTests: XCTestCase {
         )
         XCTAssertEqual(payloads.first?.offset, .twoHours)
         XCTAssertTrue(payloads.allSatisfy { $0.requestId.hasPrefix("strict-reminder::") })
+    }
+
+    func testStrictReminderPayloadsStayWithinPendingRequestLimit() throws {
+        let calendar = makeCalendar()
+        let now = try XCTUnwrap(makeDate(year: 2026, month: 4, day: 3, hour: 9, minute: 0, calendar: calendar))
+
+        let payloads = try buildStrictReminderPayloads(
+            now: now,
+            calendar: calendar,
+            completedDayStartMillis: []
+        )
+
+        XCTAssertEqual(payloads.count, strictReminderPendingRequestsLimit)
+        XCTAssertLessThanOrEqual(payloads.count, appNotificationPendingRequestsLimit)
     }
 
     func testLoadScheduledStrictReminderPayloadsSkipsTodayAfterAppWideReview() throws {


### PR DESCRIPTION
## Summary
- Reserve iOS local notification capacity for strict reminders when review reminders are reconciled.
- Persist only notification payloads confirmed by Notification Center read-back.
- Add structured notification scheduling warnings and focused notification support tests.

## Validation
- `git --no-pager diff --check`
- `xcrun swiftc -parse` on the changed Swift files

Simulator-backed iOS tests were not run because this repository requires explicit permission for simulator-backed runs.