### PR TITLE
[codex] Move iOS review reactions down

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionEasyDrawing.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionEasyDrawing.swift
@@ -13,7 +13,15 @@ extension ReviewReactionRenderer {
         }
 
         let phase = reviewReactionPhaseProgress(progress: progress, enterEnd: 0.44, exitStart: 0.82)
-        let targetCenter = CGPoint(x: size.width * 0.50, y: size.height * 0.40)
+        let sideLength: CGFloat = max(min(size.width, size.height) * 0.64, 1)
+        let targetCenter: CGPoint = CGPoint(
+            x: size.width * 0.50,
+            y: adjustedReviewReactionCenterY(
+                configuredCenterY: reviewReactionDefaultAnchorY,
+                sideLength: sideLength,
+                containerHeight: size.height
+            )
+        )
         let bounce = motionMode == .reduced ? sin(progress * CGFloat.pi) : sin(phase.hold * CGFloat.pi * 3) * (1 - phase.hold)
         let center = CGPoint(
             x: targetCenter.x + (motionMode == .reduced ? 0 : sin(progress * CGFloat.pi * 2) * 6 * (1 - phase.exit)),

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
@@ -1,5 +1,27 @@
 import SwiftUI
 
+let reviewReactionDefaultAnchorY: CGFloat = 0.50
+let reviewReactionTargetAnchorY: CGFloat = 0.70
+let reviewReactionVerticalShift: CGFloat = reviewReactionTargetAnchorY - reviewReactionDefaultAnchorY
+
+func adjustedReviewReactionCenterY(
+    configuredCenterY: CGFloat,
+    sideLength: CGFloat,
+    containerHeight: CGFloat
+) -> CGFloat {
+    let shiftedCenterY: CGFloat = (configuredCenterY + reviewReactionVerticalShift) * containerHeight
+    let halfSideLength: CGFloat = max(sideLength, 0) / 2
+
+    guard containerHeight > 0 else {
+        return 0
+    }
+    guard sideLength < containerHeight else {
+        return containerHeight / 2
+    }
+
+    return min(max(shiftedCenterY, halfSideLength), containerHeight - halfSideLength)
+}
+
 extension ReviewReactionRenderer {
     static func makeScallopedSealPath(
         radius: CGFloat,

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
@@ -179,6 +179,11 @@ private struct ReviewReactionLottieView: View {
                     min(proxy.size.width, proxy.size.height) * self.configuration.frameScale,
                     1
                 )
+                let centerY: CGFloat = adjustedReviewReactionCenterY(
+                    configuredCenterY: self.configuration.centerY,
+                    sideLength: sideLength,
+                    containerHeight: proxy.size.height
+                )
 
                 LottieView(animation: self.configuration.animation)
                     .resizable()
@@ -186,7 +191,7 @@ private struct ReviewReactionLottieView: View {
                     .frame(width: sideLength, height: sideLength)
                     .position(
                         x: proxy.size.width * self.configuration.centerX,
-                        y: proxy.size.height * self.configuration.centerY
+                        y: centerY
                     )
                     .opacity(ReviewReactionRenderer.reviewReactionOpacity(progress: progress))
             }


### PR DESCRIPTION
## Summary
- move iOS review reaction Lottie placement down with a shared vertical shift
- align fallback crown drawing with the shared reaction anchor
- clamp reaction centers so rendered square frames stay within the overlay when possible

## Validation
- git --no-pager diff --cached --check before commit
- generic local iOS build could not run because Xcode is missing the iOS 26.5 platform