### PR TITLE
[codex] Set iOS review reactions to 80 percent

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 let reviewReactionDefaultAnchorY: CGFloat = 0.50
-let reviewReactionTargetAnchorY: CGFloat = 0.70
+let reviewReactionTargetAnchorY: CGFloat = 0.80
 let reviewReactionVerticalShift: CGFloat = reviewReactionTargetAnchorY - reviewReactionDefaultAnchorY
 
 func adjustedReviewReactionCenterY(


### PR DESCRIPTION
## Summary
- move the shared iOS review reaction target anchor from 70% to 80%
- keep the existing shared geometry helper and reaction rendering paths unchanged

## Validation
- git --no-pager diff --check