### PR TITLE
Unify iOS review reaction placement

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionEasyDrawing.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionEasyDrawing.swift
@@ -13,14 +13,9 @@ extension ReviewReactionRenderer {
         }
 
         let phase = reviewReactionPhaseProgress(progress: progress, enterEnd: 0.44, exitStart: 0.82)
-        let sideLength: CGFloat = max(min(size.width, size.height) * 0.64, 1)
         let targetCenter: CGPoint = CGPoint(
-            x: size.width * 0.50,
-            y: adjustedReviewReactionCenterY(
-                configuredCenterY: reviewReactionDefaultAnchorY,
-                sideLength: sideLength,
-                containerHeight: size.height
-            )
+            x: size.width * reviewReactionCenterX,
+            y: size.height * reviewReactionCenterY
         )
         let bounce = motionMode == .reduced ? sin(progress * CGFloat.pi) : sin(phase.hold * CGFloat.pi * 3) * (1 - phase.hold)
         let center = CGPoint(

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
@@ -1,26 +1,7 @@
 import SwiftUI
 
-let reviewReactionDefaultAnchorY: CGFloat = 0.50
-let reviewReactionTargetAnchorY: CGFloat = 0.80
-let reviewReactionVerticalShift: CGFloat = reviewReactionTargetAnchorY - reviewReactionDefaultAnchorY
-
-func adjustedReviewReactionCenterY(
-    configuredCenterY: CGFloat,
-    sideLength: CGFloat,
-    containerHeight: CGFloat
-) -> CGFloat {
-    let shiftedCenterY: CGFloat = (configuredCenterY + reviewReactionVerticalShift) * containerHeight
-    let halfSideLength: CGFloat = max(sideLength, 0) / 2
-
-    guard containerHeight > 0 else {
-        return 0
-    }
-    guard sideLength < containerHeight else {
-        return containerHeight / 2
-    }
-
-    return min(max(shiftedCenterY, halfSideLength), containerHeight - halfSideLength)
-}
+let reviewReactionCenterX: CGFloat = 0.50
+let reviewReactionCenterY: CGFloat = 0.80
 
 extension ReviewReactionRenderer {
     static func makeScallopedSealPath(

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLayer.swift
@@ -8,8 +8,6 @@ private let reviewReactionLottieReducedMotionProgress: AnimationProgressTime = 0
 private struct ReviewReactionLottieConfiguration {
     let animation: LottieAnimation
     let frameScale: CGFloat
-    let centerX: CGFloat
-    let centerY: CGFloat
     let reducedMotionProgress: AnimationProgressTime
 }
 
@@ -35,8 +33,6 @@ private func reviewReactionLottieConfiguration(
     return ReviewReactionLottieConfiguration(
         animation: animation,
         frameScale: assetConfiguration.frameScale,
-        centerX: assetConfiguration.centerX,
-        centerY: assetConfiguration.centerY,
         reducedMotionProgress: reviewReactionLottieReducedMotionProgress
     )
 }
@@ -179,19 +175,14 @@ private struct ReviewReactionLottieView: View {
                     min(proxy.size.width, proxy.size.height) * self.configuration.frameScale,
                     1
                 )
-                let centerY: CGFloat = adjustedReviewReactionCenterY(
-                    configuredCenterY: self.configuration.centerY,
-                    sideLength: sideLength,
-                    containerHeight: proxy.size.height
-                )
 
                 LottieView(animation: self.configuration.animation)
                     .resizable()
                     .playbackMode(self.playbackMode(progress: progress))
                     .frame(width: sideLength, height: sideLength)
                     .position(
-                        x: proxy.size.width * self.configuration.centerX,
-                        y: centerY
+                        x: proxy.size.width * reviewReactionCenterX,
+                        y: proxy.size.height * reviewReactionCenterY
                     )
                     .opacity(ReviewReactionRenderer.reviewReactionOpacity(progress: progress))
             }

--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLottieAssetStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionLottieAssetStore.swift
@@ -15,8 +15,6 @@ struct ReviewReactionLottieAssetConfiguration: Hashable, Sendable {
     let assetName: String
     let assetDescription: String
     let frameScale: CGFloat
-    let centerX: CGFloat
-    let centerY: CGFloat
 }
 
 struct ReviewReactionLottieAssetFailure: Hashable, Sendable {
@@ -124,305 +122,229 @@ let reviewReactionLottieAssetConfigurations: [ReviewReactionLottieAssetConfigura
         variant: .againRainCloud,
         assetName: "ReviewAgainRainCloud",
         assetDescription: "rain cloud",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.44
+        frameScale: 0.62
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againTornado,
         assetName: "ReviewAgainTornado",
         assetDescription: "tornado",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.45
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againWindFace,
         assetName: "ReviewAgainWindFace",
         assetDescription: "wind face",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.45
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againSnowflake,
         assetName: "ReviewAgainSnowflake",
         assetDescription: "snowflake",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.45
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againSnailCrawl,
         assetName: "ReviewAgainSnail",
         assetDescription: "snail",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.48
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againTurtle,
         assetName: "ReviewAgainTurtle",
         assetDescription: "turtle",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againWiltedFlower,
         assetName: "ReviewAgainWiltedFlower",
         assetDescription: "wilted flower",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againSpider,
         assetName: "ReviewAgainSpider",
         assetDescription: "spider",
-        frameScale: 0.54,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.54
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againRat,
         assetName: "ReviewAgainRat",
         assetDescription: "rat",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .againWormWiggle,
         assetName: "ReviewAgainWorm",
         assetDescription: "worm",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.52
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardTiger,
         assetName: "ReviewHardTiger",
         assetDescription: "tiger",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.48
+        frameScale: 0.62
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardTRex,
         assetName: "ReviewHardTRex",
         assetDescription: "t rex",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.48
+        frameScale: 0.62
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardShark,
         assetName: "ReviewHardShark",
         assetDescription: "shark",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.47
+        frameScale: 0.62
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardOxCharge,
         assetName: "ReviewHardOx",
         assetDescription: "ox",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardRacehorseGallop,
         assetName: "ReviewHardRacehorse",
         assetDescription: "racehorse",
-        frameScale: 0.62,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.62
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardSnake,
         assetName: "ReviewHardSnake",
         assetDescription: "snake",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardVolcanoEruption,
         assetName: "ReviewHardVolcano",
         assetDescription: "volcano",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.64
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardScorpion,
         assetName: "ReviewHardScorpion",
         assetDescription: "scorpion",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardPawPrints,
         assetName: "ReviewHardPawPrints",
         assetDescription: "paw prints",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .hardRooster,
         assetName: "ReviewHardRooster",
         assetDescription: "rooster",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.48
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodOtter,
         assetName: "ReviewGoodOtter",
         assetDescription: "otter",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.48
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodOwl,
         assetName: "ReviewGoodOwl",
         assetDescription: "owl",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.42
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodRabbit,
         assetName: "ReviewGoodRabbit",
         assetDescription: "rabbit",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.47
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodSeal,
         assetName: "ReviewGoodSeal",
         assetDescription: "seal",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.47
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodServiceDog,
         assetName: "ReviewGoodServiceDog",
         assetDescription: "service dog",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.47
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodPoodle,
         assetName: "ReviewGoodPoodle",
         assetDescription: "poodle",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.43
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodChimpanzee,
         assetName: "ReviewGoodChimpanzee",
         assetDescription: "chimpanzee",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.46
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodWhale,
         assetName: "ReviewGoodWhale",
         assetDescription: "whale",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.42
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodPeacock,
         assetName: "ReviewGoodPeacock",
         assetDescription: "peacock",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.42
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .goodPig,
         assetName: "ReviewGoodPig",
         assetDescription: "pig",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easySunrise,
         assetName: "ReviewEasySunrise",
         assetDescription: "sunrise",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.42
+        frameScale: 0.64
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easySunriseOverMountains,
         assetName: "ReviewEasySunriseOverMountains",
         assetDescription: "sunrise over mountains",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.44
+        frameScale: 0.64
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easyRoseBloom,
         assetName: "ReviewEasyRose",
         assetDescription: "rose",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easyPeace,
         assetName: "ReviewEasyPeace",
         assetDescription: "peace",
-        frameScale: 0.56,
-        centerX: 0.50,
-        centerY: 0.48
+        frameScale: 0.56
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easyPlant,
         assetName: "ReviewEasyPlant",
         assetDescription: "plant",
-        frameScale: 0.58,
-        centerX: 0.50,
-        centerY: 0.50
+        frameScale: 0.58
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easyRainbowStreak,
         assetName: "ReviewEasyRainbow",
         assetDescription: "rainbow",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.42
+        frameScale: 0.64
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easyPhoenixRise,
         assetName: "ReviewEasyPhoenix",
         assetDescription: "phoenix",
-        frameScale: 0.64,
-        centerX: 0.50,
-        centerY: 0.42
+        frameScale: 0.64
     ),
     ReviewReactionLottieAssetConfiguration(
         variant: .easyUnicornFlyby,
         assetName: "ReviewEasyUnicorn",
         assetDescription: "unicorn",
-        frameScale: 0.52,
-        centerX: 0.56,
-        centerY: 0.30
+        frameScale: 0.52
     )
 ]
 


### PR DESCRIPTION
## Summary
- Add one shared iOS review reaction center at 50% x and 80% y.
- Use that shared center for Lottie and fallback/reduced-motion drawing.
- Remove per-asset centerX/centerY placement configuration and the old vertical shift helper.

## Validation
- git diff --check --cached
- rg audit confirmed old placement fields/helpers are absent from the review reaction runtime
- xcrun swiftc -parse on touched Swift files

## Notes
- No simulator-backed tests or smoke flows were run.
