### PR TITLE
[codex] Anchor review reactions at shared position

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionEasyRenderers.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionEasyRenderers.kt
@@ -67,30 +67,16 @@ private fun DrawScope.drawEasyCrownBounce(
         enterEnd = 0.44f,
         exitStart = 0.82f
     )
-    val targetCenter: Offset = Offset(x = size.width * 0.50f, y = size.height * 0.40f)
+    val targetCenter: Offset = Offset(
+        x = size.width * reviewReactionCenterX,
+        y = size.height * reviewReactionCenterY
+    )
     val bounce: Float = if (motionMode == ReviewReactionMotionMode.REDUCED) {
         sin(progress * PI.toFloat())
     } else {
         sin(phase.hold * PI.toFloat() * 3f) * (1f - phase.hold)
     }
-    val centerWaveX: Float = if (motionMode == ReviewReactionMotionMode.REDUCED) {
-        0f
-    } else {
-        sin(progress * PI.toFloat() * 2f) * 6f * (1f - phase.exit)
-    }
-    val centerY: Float = if (motionMode == ReviewReactionMotionMode.REDUCED) {
-        targetCenter.y
-    } else {
-        reviewReactionInterpolate(
-            start = -min(size.width, size.height) * 0.16f,
-            end = targetCenter.y,
-            progress = reviewReactionEaseOutBack(progress = phase.enter, overshoot = 1.10f)
-        ) - bounce * 28f + phase.exit * 18f
-    }
-    val center: Offset = Offset(
-        x = targetCenter.x + centerWaveX,
-        y = centerY
-    )
+    val center: Offset = targetCenter
     val scaleMultiplier: Float = if (motionMode == ReviewReactionMotionMode.REDUCED) {
         1f
     } else {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionGeometry.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionGeometry.kt
@@ -6,6 +6,9 @@ import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
 
+internal const val reviewReactionCenterX: Float = 0.50f
+internal const val reviewReactionCenterY: Float = 0.80f
+
 internal fun polygonPath(points: List<Offset>): Path {
     val path: Path = Path()
     points.forEachIndexed { index: Int, point: Offset ->

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionLottieState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionLottieState.kt
@@ -49,9 +49,7 @@ internal sealed interface ReviewReactionLottieReadiness {
 
 internal class ReviewReactionLottieConfiguration(
     initialReadiness: ReviewReactionLottieReadiness,
-    val frameScale: Float,
-    val centerX: Float,
-    val centerY: Float
+    val frameScale: Float
 ) {
     var readiness: ReviewReactionLottieReadiness by mutableStateOf(value = initialReadiness)
         internal set
@@ -61,9 +59,7 @@ private data class ReviewReactionLottieAssetConfiguration(
     val variant: ReviewReactionVariant,
     @RawRes val rawResourceId: Int,
     val assetName: String,
-    val frameScale: Float,
-    val centerX: Float,
-    val centerY: Float
+    val frameScale: Float
 )
 
 private val reviewReactionLottieAssetConfigurations: List<ReviewReactionLottieAssetConfiguration> = listOf(
@@ -71,305 +67,229 @@ private val reviewReactionLottieAssetConfigurations: List<ReviewReactionLottieAs
         variant = ReviewReactionVariant.AGAIN_RAIN_CLOUD,
         rawResourceId = R.raw.review_again_rain_cloud,
         assetName = "review_again_rain_cloud",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.44f
+        frameScale = 0.62f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_TORNADO,
         rawResourceId = R.raw.review_again_tornado,
         assetName = "review_again_tornado",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.45f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_WIND_FACE,
         rawResourceId = R.raw.review_again_wind_face,
         assetName = "review_again_wind_face",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.45f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_SNOWFLAKE,
         rawResourceId = R.raw.review_again_snowflake,
         assetName = "review_again_snowflake",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.45f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_SNAIL_CRAWL,
         rawResourceId = R.raw.review_again_snail,
         assetName = "review_again_snail",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.48f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_TURTLE,
         rawResourceId = R.raw.review_again_turtle,
         assetName = "review_again_turtle",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_WILTED_FLOWER,
         rawResourceId = R.raw.review_again_wilted_flower,
         assetName = "review_again_wilted_flower",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_SPIDER,
         rawResourceId = R.raw.review_again_spider,
         assetName = "review_again_spider",
-        frameScale = 0.54f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.54f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_RAT,
         rawResourceId = R.raw.review_again_rat,
         assetName = "review_again_rat",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.AGAIN_WORM_WIGGLE,
         rawResourceId = R.raw.review_again_worm,
         assetName = "review_again_worm",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.52f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_TIGER,
         rawResourceId = R.raw.review_hard_tiger,
         assetName = "review_hard_tiger",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.48f
+        frameScale = 0.62f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_T_REX,
         rawResourceId = R.raw.review_hard_t_rex,
         assetName = "review_hard_t_rex",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.48f
+        frameScale = 0.62f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_SHARK,
         rawResourceId = R.raw.review_hard_shark,
         assetName = "review_hard_shark",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.47f
+        frameScale = 0.62f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_OX_CHARGE,
         rawResourceId = R.raw.review_hard_ox,
         assetName = "review_hard_ox",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_RACEHORSE_GALLOP,
         rawResourceId = R.raw.review_hard_racehorse,
         assetName = "review_hard_racehorse",
-        frameScale = 0.62f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.62f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_SNAKE,
         rawResourceId = R.raw.review_hard_snake,
         assetName = "review_hard_snake",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_VOLCANO_ERUPTION,
         rawResourceId = R.raw.review_hard_volcano,
         assetName = "review_hard_volcano",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.64f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_SCORPION,
         rawResourceId = R.raw.review_hard_scorpion,
         assetName = "review_hard_scorpion",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_PAW_PRINTS,
         rawResourceId = R.raw.review_hard_paw_prints,
         assetName = "review_hard_paw_prints",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.HARD_ROOSTER,
         rawResourceId = R.raw.review_hard_rooster,
         assetName = "review_hard_rooster",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.48f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_OTTER,
         rawResourceId = R.raw.review_good_otter,
         assetName = "review_good_otter",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.48f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_OWL,
         rawResourceId = R.raw.review_good_owl,
         assetName = "review_good_owl",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.42f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_RABBIT,
         rawResourceId = R.raw.review_good_rabbit,
         assetName = "review_good_rabbit",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.47f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_SEAL,
         rawResourceId = R.raw.review_good_seal,
         assetName = "review_good_seal",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.47f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_SERVICE_DOG,
         rawResourceId = R.raw.review_good_service_dog,
         assetName = "review_good_service_dog",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.47f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_POODLE,
         rawResourceId = R.raw.review_good_poodle,
         assetName = "review_good_poodle",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.43f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_CHIMPANZEE,
         rawResourceId = R.raw.review_good_chimpanzee,
         assetName = "review_good_chimpanzee",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.46f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_WHALE,
         rawResourceId = R.raw.review_good_whale,
         assetName = "review_good_whale",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.42f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_PEACOCK,
         rawResourceId = R.raw.review_good_peacock,
         assetName = "review_good_peacock",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.42f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.GOOD_PIG,
         rawResourceId = R.raw.review_good_pig,
         assetName = "review_good_pig",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_SUNRISE,
         rawResourceId = R.raw.review_easy_sunrise,
         assetName = "review_easy_sunrise",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.42f
+        frameScale = 0.64f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_SUNRISE_OVER_MOUNTAINS,
         rawResourceId = R.raw.review_easy_sunrise_over_mountains,
         assetName = "review_easy_sunrise_over_mountains",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.44f
+        frameScale = 0.64f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_ROSE_BLOOM,
         rawResourceId = R.raw.review_easy_rose,
         assetName = "review_easy_rose",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_PEACE,
         rawResourceId = R.raw.review_easy_peace,
         assetName = "review_easy_peace",
-        frameScale = 0.56f,
-        centerX = 0.50f,
-        centerY = 0.48f
+        frameScale = 0.56f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_PLANT,
         rawResourceId = R.raw.review_easy_plant,
         assetName = "review_easy_plant",
-        frameScale = 0.58f,
-        centerX = 0.50f,
-        centerY = 0.50f
+        frameScale = 0.58f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_RAINBOW_STREAK,
         rawResourceId = R.raw.review_easy_rainbow,
         assetName = "review_easy_rainbow",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.42f
+        frameScale = 0.64f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_PHOENIX_RISE,
         rawResourceId = R.raw.review_easy_phoenix,
         assetName = "review_easy_phoenix",
-        frameScale = 0.64f,
-        centerX = 0.50f,
-        centerY = 0.42f
+        frameScale = 0.64f
     ),
     ReviewReactionLottieAssetConfiguration(
         variant = ReviewReactionVariant.EASY_UNICORN_FLYBY,
         rawResourceId = R.raw.review_easy_unicorn,
         assetName = "review_easy_unicorn",
-        frameScale = 0.52f,
-        centerX = 0.56f,
-        centerY = 0.30f
+        frameScale = 0.52f
     )
 )
 
@@ -398,9 +318,7 @@ private fun createReviewReactionLottieConfigurationStore(): ReviewReactionLottie
         reviewReactionLottieAssetConfigurations.associate { assetConfiguration: ReviewReactionLottieAssetConfiguration ->
             assetConfiguration.variant to ReviewReactionLottieConfiguration(
                 initialReadiness = ReviewReactionLottieReadiness.Pending,
-                frameScale = assetConfiguration.frameScale,
-                centerX = assetConfiguration.centerX,
-                centerY = assetConfiguration.centerY
+                frameScale = assetConfiguration.frameScale
             )
         }
 

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionOverlay.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionOverlay.kt
@@ -73,8 +73,6 @@ private fun ReviewReactionCanvas(
                     motionMode = motionMode,
                     composition = readiness.composition,
                     frameScale = lottieConfiguration.frameScale,
-                    centerX = lottieConfiguration.centerX,
-                    centerY = lottieConfiguration.centerY,
                     onEventFinished = onEventFinished
                 )
                 return
@@ -191,8 +189,6 @@ private fun ReviewReactionLottieAnimation(
     motionMode: ReviewReactionMotionMode,
     composition: LottieComposition,
     frameScale: Float,
-    centerX: Float,
-    centerY: Float,
     onEventFinished: (String) -> Unit
 ) {
     val durationMillis: Int = reviewReactionAnimationDurationMillis(
@@ -210,8 +206,6 @@ private fun ReviewReactionLottieAnimation(
             progress = reviewReactionReducedMotionDrawingProgress,
             alpha = 1f,
             frameScale = frameScale,
-            centerX = centerX,
-            centerY = centerY,
             composition = composition
         )
         return
@@ -242,8 +236,6 @@ private fun ReviewReactionLottieAnimation(
         progress = drawingProgress,
         alpha = alpha,
         frameScale = frameScale,
-        centerX = centerX,
-        centerY = centerY,
         composition = composition
     )
 }
@@ -253,8 +245,6 @@ private fun ReviewReactionLottieFrame(
     progress: Float,
     alpha: Float,
     frameScale: Float,
-    centerX: Float,
-    centerY: Float,
     composition: LottieComposition
 ) {
     BoxWithConstraints(
@@ -271,8 +261,8 @@ private fun ReviewReactionLottieFrame(
             modifier = Modifier
                 .size(size = sideLength)
                 .offset(
-                    x = maxWidth * centerX - sideLength / 2f,
-                    y = maxHeight * centerY - sideLength / 2f
+                    x = maxWidth * reviewReactionCenterX - sideLength / 2f,
+                    y = maxHeight * reviewReactionCenterY - sideLength / 2f
                 )
                 .align(alignment = Alignment.TopStart)
         )


### PR DESCRIPTION
## Summary
- Place Android review reaction Lottie frames at one shared 50% / 80% overlay anchor.
- Remove per-asset Lottie center placement configuration while preserving per-asset frame scale.
- Align the drawn fallback anchor with the same shared position.

## Validation
- `git --no-pager diff --check`
- Targeted code inspection with `rg`

Gradle and emulator checks were not run because local Gradle and emulator runs require explicit approval in this repository.