### PR TITLE
[codex] Move iOS review reaction center up

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 let reviewReactionCenterX: CGFloat = 0.50
-let reviewReactionCenterY: CGFloat = 0.80
+let reviewReactionCenterY: CGFloat = 0.75
 
 extension ReviewReactionRenderer {
     static func makeScallopedSealPath(


### PR DESCRIPTION
## Summary

- Move the iOS review reaction vertical center from 0.80 to 0.75.

## Validation

- Ran `git diff --check -- apps/ios/Flashcards/Flashcards/Review/Reaction/ReviewReactionGeometry.swift`.
- Did not run simulator-backed iOS tests because this repository requires explicit approval for those local runs.