### PR TITLE
[codex] Raise Android review reaction anchor

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionGeometry.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/reaction/ReviewReactionGeometry.kt
@@ -7,7 +7,7 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 internal const val reviewReactionCenterX: Float = 0.50f
-internal const val reviewReactionCenterY: Float = 0.80f
+internal const val reviewReactionCenterY: Float = 0.75f
 
 internal fun polygonPath(points: List<Offset>): Path {
     val path: Path = Path()


### PR DESCRIPTION
## Summary

- Moves the Android review reaction vertical anchor from 0.80 to 0.75.
- Keeps the change scoped to the shared review reaction geometry constant.

## Validation

- Ran `git --no-pager diff --check`.
- Did not run Gradle because local Gradle runs require explicit approval in this repository.