### PR TITLE
[codex] Center web review reactions

### DIFF
--- a/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
+++ b/apps/web/src/screens/review/reactions/ReviewRatingReactionLayer.tsx
@@ -159,13 +159,13 @@ function makeSparklePoints(
 function EasyCrownBounceReaction(): ReactElement {
   return (
     <g className="review-reaction-crown-mark">
-      <path className="review-reaction-yellow-fill" d="M27 62 L31 27 L43 47 L50 22 L57 47 L69 27 L73 62 Z" />
-      <path className="review-reaction-orange-stroke" d="M27 62 L31 27 L43 47 L50 22 L57 47 L69 27 L73 62 Z" strokeWidth="3" />
-      <rect className="review-reaction-orange-fill" x="25" y="58" width="50" height="11" rx="4" />
-      <circle className="review-reaction-pink-fill" cx="31" cy="27" r="4" />
-      <circle className="review-reaction-blue-fill" cx="50" cy="22" r="4" />
-      <circle className="review-reaction-green-fill" cx="69" cy="27" r="4" />
-      <polygon className="review-reaction-sparkle-fill" points={makeSparklePoints(78, 26, 5, 0.2)} />
+      <path className="review-reaction-yellow-fill" d="M27 69 L31 34 L43 54 L50 29 L57 54 L69 34 L73 69 Z" />
+      <path className="review-reaction-orange-stroke" d="M27 69 L31 34 L43 54 L50 29 L57 54 L69 34 L73 69 Z" strokeWidth="3" />
+      <rect className="review-reaction-orange-fill" x="25" y="65" width="50" height="11" rx="4" />
+      <circle className="review-reaction-pink-fill" cx="31" cy="34" r="4" />
+      <circle className="review-reaction-blue-fill" cx="50" cy="29" r="4" />
+      <circle className="review-reaction-green-fill" cx="69" cy="34" r="4" />
+      <polygon className="review-reaction-sparkle-fill" points={makeSparklePoints(78, 33, 5, 0.2)} />
     </g>
   );
 }

--- a/apps/web/src/styles/features/review/review-reactions.css
+++ b/apps/web/src/styles/features/review/review-reactions.css
@@ -146,225 +146,155 @@
 
 .review-rating-reaction-lottie-art > div {
   position: absolute;
+  top: 50%;
+  left: 50%;
   aspect-ratio: 1;
   transform: translate(-50%, -50%);
 }
 
 .review-reaction-rain-cloud-lottie-mark {
-  top: 44%;
-  left: 50%;
   width: min(62%, 270px);
 }
 
 .review-reaction-worm-lottie-mark {
-  top: 52%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-tornado-lottie-mark {
-  top: 45%;
-  left: 50%;
   width: min(58%, 255px);
 }
 
 .review-reaction-wind-face-lottie-mark {
-  top: 45%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-snowflake-lottie-mark {
-  top: 45%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-snail-lottie-mark {
-  top: 48%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-turtle-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-wilted-flower-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-spider-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(54%, 235px);
 }
 
 .review-reaction-rat-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-tiger-lottie-mark,
 .review-reaction-t-rex-lottie-mark {
-  top: 48%;
-  left: 50%;
   width: min(62%, 270px);
 }
 
 .review-reaction-shark-lottie-mark {
-  top: 47%;
-  left: 50%;
   width: min(62%, 270px);
 }
 
 .review-reaction-snake-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-scorpion-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-rooster-lottie-mark {
-  top: 48%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-otter-lottie-mark {
-  top: 48%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-owl-lottie-mark {
-  top: 42%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-rabbit-lottie-mark {
-  top: 47%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-seal-lottie-mark,
 .review-reaction-service-dog-lottie-mark {
-  top: 47%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-poodle-lottie-mark {
-  top: 43%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-chimpanzee-lottie-mark {
-  top: 46%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-whale-lottie-mark {
-  top: 42%;
-  left: 50%;
   width: min(58%, 255px);
 }
 
 .review-reaction-peacock-lottie-mark {
-  top: 42%;
-  left: 50%;
   width: min(58%, 255px);
 }
 
 .review-reaction-pig-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-ox-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(58%, 255px);
 }
 
 .review-reaction-paw-prints-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-racehorse-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(62%, 270px);
 }
 
 .review-reaction-volcano-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(64%, 280px);
 }
 
 .review-reaction-sunrise-lottie-mark {
-  top: 42%;
-  left: 50%;
   width: min(64%, 280px);
 }
 
 .review-reaction-sunrise-over-mountains-lottie-mark {
-  top: 44%;
-  left: 50%;
   width: min(64%, 280px);
 }
 
 .review-reaction-rose-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-peace-lottie-mark {
-  top: 48%;
-  left: 50%;
   width: min(56%, 245px);
 }
 
 .review-reaction-plant-lottie-mark {
-  top: 50%;
-  left: 50%;
   width: min(58%, 250px);
 }
 
 .review-reaction-rainbow-lottie-mark {
-  top: 42%;
-  left: 50%;
   width: min(64%, 280px);
 }
 
 .review-reaction-phoenix-lottie-mark {
-  top: 42%;
-  left: 50%;
   width: min(64%, 280px);
 }
 
 .review-reaction-unicorn-lottie-mark {
-  top: 30%;
-  left: 56%;
   width: min(52%, 230px);
 }
 
@@ -401,23 +331,23 @@
 
 @keyframes review-reaction-crown-art {
   0% {
-    transform: translate3d(0, -44%, 0) scale(0.58) rotate(-14deg);
+    transform: scale(0.58) rotate(-14deg);
   }
 
   44% {
-    transform: translate3d(0, 0, 0) scale(1.17) rotate(4deg);
+    transform: scale(1.17) rotate(4deg);
   }
 
   62% {
-    transform: translate3d(0, -5%, 0) scale(1.02) rotate(-2deg);
+    transform: scale(1.02) rotate(-2deg);
   }
 
   82% {
-    transform: translate3d(0, 0, 0) scale(1) rotate(1deg);
+    transform: scale(1) rotate(1deg);
   }
 
   100% {
-    transform: translate3d(0, 5%, 0) scale(0.88) rotate(0deg);
+    transform: scale(0.88) rotate(0deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- center every web review reaction Lottie container at the shared 50% / 50% layer position
- remove per-variant reaction placement offsets while preserving width sizing
- center the fallback crown geometry and remove fallback vertical animation shifts

## Validation
- npx vitest run src/screens/review/reactions/ReviewRatingReactionLayer.fallback.test.tsx src/screens/review/tests/ReviewScreen.controls.test.tsx
- npm run build
- CSS inspection confirmed no per-variant Lottie top/left placement rules
- headless browser fixture verified 38 Lottie classes centered across desktop, narrow, and split-pane viewport sizes