### PR TITLE
Fix web review reveal dock

### DIFF
--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -13,7 +13,8 @@
 
 .review-pane {
   position: relative;
-  align-content: start;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-gutter: stable;


### PR DESCRIPTION
## Summary
- make the web review pane a vertical flex container so the existing sticky actions dock can sit at the bottom before the answer is revealed
- keep the rating controls and reveal button on the same dock path

## Validation
- `npm exec -- vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx`