### PR TITLE
[codex] Add web sync restore loss observability

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -318,11 +318,11 @@ export function AppShell(): ReactElement {
         primeSessionCsrfToken(persistedCsrfToken);
       }
       await deleteMyAccount(deleteAccountConfirmationText);
-      await clearAllLocalBrowserData();
+      await clearAllLocalBrowserData("account_deletion_submit");
       window.location.href = buildLogoutLocalUrl();
     } catch (error) {
       if (error instanceof ApiError && error.code === "ACCOUNT_DELETED") {
-        await clearAllLocalBrowserData();
+        await clearAllLocalBrowserData("account_deletion_submit");
         window.location.href = buildLogoutLocalUrl();
         return;
       }

--- a/apps/web/src/accountDeletion.test.ts
+++ b/apps/web/src/accountDeletion.test.ts
@@ -11,7 +11,16 @@ import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "./i18n/runtime";
 import { loadCloudSettings, putCloudSettings } from "./localDb/cloudSettings";
 import { clearWebSyncCache } from "./localDb/cache";
+import { SYNC_RESTORE_HISTORY_STORAGE_KEY } from "./appData/sync/syncRestoreHistory";
 import type { CloudSettings } from "./types";
+
+const observabilityMocks = vi.hoisted(() => ({
+  addWebBreadcrumbMock: vi.fn(),
+}));
+
+vi.mock("./observability/webObservability", () => ({
+  addWebBreadcrumb: observabilityMocks.addWebBreadcrumbMock,
+}));
 
 const seededCloudSettings: CloudSettings = {
   installationId: "installation-1",
@@ -57,6 +66,10 @@ function seedLocalBrowserState(): void {
   window.localStorage.setItem("flashcards-chat-drafts::workspace-1", JSON.stringify({
     version: 1,
   }));
+  window.localStorage.setItem(SYNC_RESTORE_HISTORY_STORAGE_KEY, JSON.stringify({
+    version: 1,
+    entries: [],
+  }));
   window.localStorage.setItem("flashcards-auth-reset-required", "1");
   markBrowserReauthRequired();
 }
@@ -64,6 +77,7 @@ function seedLocalBrowserState(): void {
 function expectLocalBrowserStateCleared(): void {
   expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).toBeNull();
   expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+  expect(window.localStorage.getItem(SYNC_RESTORE_HISTORY_STORAGE_KEY)).toBeNull();
   expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBeNull();
   expect(isBrowserReauthRequired()).toBe(false);
   expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
@@ -88,6 +102,7 @@ beforeEach(async () => {
   });
   window.localStorage.clear();
   clearBrowserReauthRequired();
+  observabilityMocks.addWebBreadcrumbMock.mockReset();
 });
 
 afterEach(async () => {
@@ -102,9 +117,10 @@ describe("account deletion local cleanup helpers", () => {
     seedLocalBrowserState();
     mockBlockedDeleteDatabase();
 
-    await expect(clearAllLocalBrowserData()).rejects.toThrow("Failed to delete IndexedDB: delete request was blocked");
+    await expect(clearAllLocalBrowserData("logout_marker")).rejects.toThrow("Failed to delete IndexedDB: delete request was blocked");
     expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).toBeNull();
     expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
+    expect(window.localStorage.getItem(SYNC_RESTORE_HISTORY_STORAGE_KEY)).toBeNull();
     expect(window.localStorage.getItem("flashcards-browser-reauth-required")).toBe("1");
     expect(window.localStorage.getItem("flashcards-auth-reset-required")).toBe("1");
     expect(isBrowserReauthRequired()).toBe(true);
@@ -116,10 +132,19 @@ describe("account deletion local cleanup helpers", () => {
     seedLocalBrowserState();
     await putCloudSettings(seededCloudSettings);
 
-    await expect(clearAllLocalBrowserData()).resolves.toBeUndefined();
+    await expect(clearAllLocalBrowserData("confirmed_account_switch")).resolves.toBeUndefined();
 
     expectLocalBrowserStateCleared();
     await expect(loadCloudSettings()).resolves.toBeNull();
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "local_browser_data_cleanup",
+      details: expect.objectContaining({
+        eventName: "local_browser_data_cleanup_succeeded",
+        reason: "confirmed_account_switch",
+        indexedDbCleared: true,
+        localStorageCleared: true,
+      }),
+    }));
   });
 
   it("treats the legacy auth reset marker as reauth required", () => {

--- a/apps/web/src/accountDeletion.ts
+++ b/apps/web/src/accountDeletion.ts
@@ -1,7 +1,14 @@
 import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "./i18n/runtime";
 import { clearWebSyncCache } from "./localDb/cache";
+import {
+  addWebBreadcrumb,
+  type LocalBrowserDataCleanupReason,
+  type WebObservationScope,
+} from "./observability/webObservability";
 import { TEST_MODE_STORAGE_KEY } from "./testMode";
+
+export type { LocalBrowserDataCleanupReason } from "./observability/webObservability";
 
 export const deleteAccountConfirmationText: string = "delete my account";
 
@@ -112,6 +119,48 @@ function normalizeCleanupError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildCleanupObservationScope(browserStorage: Storage | null): WebObservationScope {
+  return {
+    app: "web",
+    feature: "auth",
+    userId: null,
+    workspaceId: null,
+    installationId: browserStorage?.getItem(INSTALLATION_ID_STORAGE_KEY) ?? null,
+    route: getCurrentRoute(),
+    requestId: null,
+    statusCode: null,
+    code: null,
+  };
+}
+
+function logLocalBrowserDataCleanup(
+  browserStorage: Storage | null,
+  input: Readonly<{
+    eventName:
+      | "local_browser_data_cleanup_started"
+      | "local_browser_data_cleanup_succeeded"
+      | "local_browser_data_cleanup_failed";
+    reason: LocalBrowserDataCleanupReason;
+    indexedDbCleared: boolean;
+    localStorageCleared: boolean;
+    errorMessage: string | null;
+  }>,
+): void {
+  addWebBreadcrumb({
+    action: "local_browser_data_cleanup",
+    scope: buildCleanupObservationScope(browserStorage),
+    details: input,
+  });
+}
+
 function clearUserScopedBrowserStorage(browserStorage: Storage, shouldRemoveStorageKey: BrowserStorageKeyPredicate): void {
   const storageKeysToRemove: Array<string> = [];
   for (let index = 0; index < browserStorage.length; index += 1) {
@@ -188,9 +237,17 @@ export function clearAuthResetRequired(): void {
  * UI language, and local tester tooling across re-login while still clearing
  * application data.
  */
-export async function clearAllLocalBrowserData(): Promise<void> {
+export async function clearAllLocalBrowserData(reason: LocalBrowserDataCleanupReason): Promise<void> {
   const browserStorage = getBrowserStorage();
   let indexedDbError: Error | null = null;
+
+  logLocalBrowserDataCleanup(browserStorage, {
+    eventName: "local_browser_data_cleanup_started",
+    reason,
+    indexedDbCleared: false,
+    localStorageCleared: false,
+    errorMessage: null,
+  });
 
   try {
     await clearWebSyncCache();
@@ -206,6 +263,21 @@ export async function clearAllLocalBrowserData(): Promise<void> {
   }
 
   if (indexedDbError !== null) {
+    logLocalBrowserDataCleanup(browserStorage, {
+      eventName: "local_browser_data_cleanup_failed",
+      reason,
+      indexedDbCleared: false,
+      localStorageCleared: browserStorage !== null,
+      errorMessage: indexedDbError.message,
+    });
     throw indexedDbError;
   }
+
+  logLocalBrowserDataCleanup(browserStorage, {
+    eventName: "local_browser_data_cleanup_succeeded",
+    reason,
+    indexedDbCleared: true,
+    localStorageCleared: browserStorage !== null,
+    errorMessage: null,
+  });
 }

--- a/apps/web/src/appData/session/useWorkspaceActivation.ts
+++ b/apps/web/src/appData/session/useWorkspaceActivation.ts
@@ -5,7 +5,10 @@ import {
   listWorkspaces,
   selectWorkspace,
 } from "../../api";
-import { clearAllLocalBrowserData } from "../../accountDeletion";
+import {
+  clearAllLocalBrowserData,
+  type LocalBrowserDataCleanupReason,
+} from "../../accountDeletion";
 import { putCloudSettings } from "../../localDb/cloudSettings";
 import type {
   SessionInfo,
@@ -61,7 +64,9 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
   const deferredBootstrapWorkspaceRef = useRef<WorkspaceSummary | null>(null);
   const [deferredBootstrapVersion, setDeferredBootstrapVersion] = useState<number>(0);
 
-  const clearConfirmedUserScopedState = useCallback(async function clearConfirmedUserScopedState(): Promise<void> {
+  const clearConfirmedUserScopedState = useCallback(async function clearConfirmedUserScopedState(
+    reason: LocalBrowserDataCleanupReason,
+  ): Promise<void> {
     workspaceBootstrapGenerationRef.current += 1;
     deferredBootstrapWorkspaceRef.current = null;
     setSession(null);
@@ -71,7 +76,9 @@ export function useWorkspaceActivation(params: UseWorkspaceActivationParams): Wo
     setSessionLoadState("loading");
     setSessionVerificationState("unverified");
     resetUserScopedUiState();
-    await discardAllSyncWork(clearAllLocalBrowserData);
+    await discardAllSyncWork(async (): Promise<void> => {
+      await clearAllLocalBrowserData(reason);
+    });
   }, [
     discardAllSyncWork,
     resetUserScopedUiState,

--- a/apps/web/src/appData/session/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/useWorkspaceLifecycle.ts
@@ -8,6 +8,7 @@ import {
   clearBrowserReauthRequired,
   consumeAccountDeletedMarker,
   isBrowserReauthRequired,
+  type LocalBrowserDataCleanupReason,
 } from "../../accountDeletion";
 import type { TranslationKey } from "../../i18n";
 import { loadCloudSettings, putCloudSettings } from "../../localDb/cloudSettings";
@@ -15,7 +16,7 @@ import { setWebObservabilityUser } from "../../observability/webObservability";
 import { getErrorMessage } from "../domain";
 import {
   buildLinkingReadyCloudSettings,
-  shouldClearLocalDataForVerifiedSession,
+  resolveLocalDataCleanupReasonForVerifiedSession,
 } from "./workspaceSessionCloud";
 import {
   consumeLoggedOutMarker,
@@ -41,7 +42,7 @@ type UseWorkspaceLifecycleParams =
     runSync: () => Promise<void>;
     runSyncSilently: () => Promise<void>;
     resolveInitialWorkspace: (currentSession: SessionInfo) => Promise<void>;
-    clearConfirmedUserScopedState: () => Promise<void>;
+    clearConfirmedUserScopedState: (reason: LocalBrowserDataCleanupReason) => Promise<void>;
   }>
   & WorkspaceSessionState
   & WorkspaceSessionSetters;
@@ -95,11 +96,11 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
 
     try {
       if (consumeLoggedOutMarker()) {
-        await clearConfirmedUserScopedState();
+        await clearConfirmedUserScopedState("logout_marker");
       }
 
       if (consumeAccountDeletedMarker()) {
-        await clearConfirmedUserScopedState();
+        await clearConfirmedUserScopedState("account_deleted_marker");
         setSession(null);
         setWebObservabilityUser(null);
         setSessionLoadState("deleted");
@@ -112,8 +113,13 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       const currentSession = await getSession();
       setWebObservabilityUser({ id: currentSession.userId });
       const persistedCloudSettings = await loadCloudSettings();
-      if (shouldClearLocalDataForVerifiedSession(persistedCloudSettings, currentSession, wasBrowserReauthRequired)) {
-        await clearConfirmedUserScopedState();
+      const localDataCleanupReason = resolveLocalDataCleanupReasonForVerifiedSession(
+        persistedCloudSettings,
+        currentSession,
+        wasBrowserReauthRequired,
+      );
+      if (localDataCleanupReason !== null) {
+        await clearConfirmedUserScopedState(localDataCleanupReason);
       }
 
       clearBrowserReauthRequired();
@@ -184,7 +190,7 @@ export function useWorkspaceLifecycle(params: UseWorkspaceLifecycleParams): Work
       if (currentSession.userId !== session.userId) {
         try {
           setWebObservabilityUser({ id: currentSession.userId });
-          await clearConfirmedUserScopedState();
+          await clearConfirmedUserScopedState("confirmed_account_switch");
           clearBrowserReauthRequired();
           const linkingReadyCloudSettings = buildLinkingReadyCloudSettings(currentSession);
           await putCloudSettings(linkingReadyCloudSettings);

--- a/apps/web/src/appData/session/workspaceSessionCloud.ts
+++ b/apps/web/src/appData/session/workspaceSessionCloud.ts
@@ -1,4 +1,5 @@
 import { getStableInstallationId } from "../../clientIdentity";
+import type { LocalBrowserDataCleanupReason } from "../../accountDeletion";
 import type { CloudSettings, SessionInfo } from "../../types";
 
 export function buildLinkingReadyCloudSettings(session: SessionInfo): CloudSettings {
@@ -25,22 +26,34 @@ export function buildLinkedCloudSettings(session: SessionInfo, workspaceId: stri
   };
 }
 
+export function resolveLocalDataCleanupReasonForVerifiedSession(
+  persistedCloudSettings: CloudSettings | null,
+  currentSession: SessionInfo,
+  wasBrowserReauthRequired: boolean,
+): LocalBrowserDataCleanupReason | null {
+  if (persistedCloudSettings === null) {
+    return wasBrowserReauthRequired ? "reauth_owner_unknown" : null;
+  }
+
+  if (persistedCloudSettings.linkedUserId === currentSession.userId) {
+    return null;
+  }
+
+  if (persistedCloudSettings.linkedUserId === null) {
+    return wasBrowserReauthRequired ? "reauth_owner_unknown" : null;
+  }
+
+  return "confirmed_account_switch";
+}
+
 export function shouldClearLocalDataForVerifiedSession(
   persistedCloudSettings: CloudSettings | null,
   currentSession: SessionInfo,
   wasBrowserReauthRequired: boolean,
 ): boolean {
-  if (persistedCloudSettings === null) {
-    return wasBrowserReauthRequired;
-  }
-
-  if (persistedCloudSettings.linkedUserId === currentSession.userId) {
-    return false;
-  }
-
-  if (persistedCloudSettings.linkedUserId === null) {
-    return wasBrowserReauthRequired;
-  }
-
-  return true;
+  return resolveLocalDataCleanupReasonForVerifiedSession(
+    persistedCloudSettings,
+    currentSession,
+    wasBrowserReauthRequired,
+  ) !== null;
 }

--- a/apps/web/src/appData/session/workspaceSessionTypes.ts
+++ b/apps/web/src/appData/session/workspaceSessionTypes.ts
@@ -1,4 +1,5 @@
 import type { Dispatch, SetStateAction } from "react";
+import type { LocalBrowserDataCleanupReason } from "../../accountDeletion";
 import type { TranslationKey } from "../../i18n";
 import type {
   CloudSettings,
@@ -73,5 +74,5 @@ export type WorkspaceSessionActivation = Readonly<{
     workspace: WorkspaceSummary,
   ) => Promise<void>;
   resolveInitialWorkspace: (currentSession: SessionInfo) => Promise<void>;
-  clearConfirmedUserScopedState: () => Promise<void>;
+  clearConfirmedUserScopedState: (reason: LocalBrowserDataCleanupReason) => Promise<void>;
 }>;

--- a/apps/web/src/appData/sync/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/syncLifecycleObservation.test.ts
@@ -1,15 +1,137 @@
-import { describe, expect, it, vi } from "vitest";
-import { observeSlowHotBootstrap } from "./syncLifecycleObservation";
+// @vitest-environment jsdom
+import "fake-indexeddb/auto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { webAppVersion } from "../../clientIdentity";
+import { clearWebSyncCache } from "../../localDb/cache";
+import { applyHotSyncPage } from "../../localDb/workspace";
+import { runWorkspaceRemoteSync, type WorkspaceRemoteSyncInput } from "./syncRemote";
+import {
+  observeSlowHotBootstrap,
+} from "./syncLifecycleObservation";
+import {
+  loadSyncRestoreHistoryEntry,
+  storeSyncRestoreHistoryEntry,
+} from "./syncRestoreHistory";
 
 const observabilityMocks = vi.hoisted(() => ({
   captureWebWarningMock: vi.fn(),
+}));
+
+const apiMocks = vi.hoisted(() => ({
+  bootstrapPullSyncStateMock: vi.fn(),
+  pullReviewHistorySyncMock: vi.fn(),
+  pullSyncChangesMock: vi.fn(),
+  pushSyncOperationsMock: vi.fn(),
 }));
 
 vi.mock("../../observability/webObservability", () => ({
   captureWebWarning: observabilityMocks.captureWebWarningMock,
 }));
 
+vi.mock("../../api", () => ({
+  bootstrapPullSyncState: apiMocks.bootstrapPullSyncStateMock,
+  pullReviewHistorySync: apiMocks.pullReviewHistorySyncMock,
+  pullSyncChanges: apiMocks.pullSyncChangesMock,
+  pushSyncOperations: apiMocks.pushSyncOperationsMock,
+}));
+
+function createRemoteSyncInput(): WorkspaceRemoteSyncInput {
+  return {
+    userId: "user-1",
+    workspaceId: "workspace-1",
+    installationId: "installation-1",
+    requireWorkspaceSyncNotDiscarded: (_workspaceId: string): void => {},
+    publishWorkspaceSettings: (_workspaceId, _settings): void => {},
+    refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {},
+  };
+}
+
+function createStorageMock(
+  options: Readonly<{
+    throwOnSetItem: boolean;
+  }>,
+): Storage {
+  const state = new Map<string, string>();
+
+  return {
+    get length(): number {
+      return state.size;
+    },
+    clear(): void {
+      state.clear();
+    },
+    getItem(key: string): string | null {
+      return state.get(key) ?? null;
+    },
+    key(index: number): string | null {
+      return [...state.keys()][index] ?? null;
+    },
+    removeItem(key: string): void {
+      state.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      if (options.throwOnSetItem) {
+        throw new DOMException("Storage quota exceeded", "QuotaExceededError");
+      }
+
+      state.set(key, value);
+    },
+  };
+}
+
+function primeEmptyRemoteSync(): void {
+  apiMocks.bootstrapPullSyncStateMock.mockResolvedValue({
+    entries: [],
+    bootstrapHotChangeId: 12,
+    nextCursor: null,
+    hasMore: false,
+    remoteIsEmpty: false,
+  });
+  apiMocks.pullSyncChangesMock.mockResolvedValue({
+    changes: [],
+    nextHotChangeId: 12,
+    hasMore: false,
+  });
+  apiMocks.pullReviewHistorySyncMock.mockResolvedValue({
+    reviewEvents: [],
+    nextReviewSequenceId: 0,
+    hasMore: false,
+  });
+  apiMocks.pushSyncOperationsMock.mockResolvedValue({
+    operations: [],
+  });
+}
+
+function findCapturedWarning(action: string): unknown {
+  return observabilityMocks.captureWebWarningMock.mock.calls
+    .map((call) => call[0] as Readonly<{ action: string }>)
+    .find((event) => event.action === action) ?? null;
+}
+
 describe("sync lifecycle observation", () => {
+  beforeEach(async () => {
+    await clearWebSyncCache();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock({
+        throwOnSetItem: false,
+      }),
+    });
+    window.localStorage.clear();
+    observabilityMocks.captureWebWarningMock.mockReset();
+    apiMocks.bootstrapPullSyncStateMock.mockReset();
+    apiMocks.pullReviewHistorySyncMock.mockReset();
+    apiMocks.pullSyncChangesMock.mockReset();
+    apiMocks.pushSyncOperationsMock.mockReset();
+    primeEmptyRemoteSync();
+  });
+
+  afterEach(async () => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+    await clearWebSyncCache();
+  });
+
   it("includes page size and local bootstrap state in slow restore warnings", () => {
     observeSlowHotBootstrap({
       userId: "user-1",
@@ -34,5 +156,87 @@ describe("sync lifecycle observation", () => {
         localBootstrapState: "no_sync_state_no_cards",
       }),
     }));
+  });
+
+  it("does not warn when an empty local database has no restore history", async () => {
+    await runWorkspaceRemoteSync(createRemoteSyncInput());
+
+    expect(findCapturedWarning("sync_local_db_missing")).toBeNull();
+  });
+
+  it("warns when an empty local database had previous restore history", async () => {
+    storeSyncRestoreHistoryEntry({
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      installationId: "installation-1",
+      lastAppliedHotChangeId: 301,
+      localCardCount: 42,
+    });
+
+    await runWorkspaceRemoteSync(createRemoteSyncInput());
+
+    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "sync_local_db_missing",
+      details: expect.objectContaining({
+        eventName: "sync_local_db_missing",
+        workspaceId: "workspace-1",
+        installationId: "installation-1",
+        localBootstrapState: "no_sync_state_no_cards",
+        localCardCountBefore: 0,
+        previousLastAppliedHotChangeId: 301,
+        previousLocalCardCount: 42,
+        currentWebAppVersion: webAppVersion,
+      }),
+    }));
+  });
+
+  it("stores restore history after a successful hot bootstrap", async () => {
+    await runWorkspaceRemoteSync(createRemoteSyncInput());
+
+    expect(loadSyncRestoreHistoryEntry({
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      installationId: "installation-1",
+    })).toEqual(expect.objectContaining({
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      installationId: "installation-1",
+      webAppVersion,
+      lastAppliedHotChangeId: 12,
+      localCardCount: 0,
+    }));
+  });
+
+  it("backfills restore history for an already hydrated local database without warning", async () => {
+    await applyHotSyncPage("workspace-1", [], {
+      lastAppliedHotChangeId: 88,
+      markHotStateHydrated: true,
+    });
+
+    await runWorkspaceRemoteSync(createRemoteSyncInput());
+
+    expect(apiMocks.bootstrapPullSyncStateMock).not.toHaveBeenCalled();
+    expect(findCapturedWarning("sync_local_db_missing")).toBeNull();
+    expect(loadSyncRestoreHistoryEntry({
+      userId: "user-1",
+      workspaceId: "workspace-1",
+      installationId: "installation-1",
+    })).toEqual(expect.objectContaining({
+      lastAppliedHotChangeId: 88,
+    }));
+  });
+
+  it("does not fail sync when restore history storage cannot be written", async () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock({
+        throwOnSetItem: true,
+      }),
+    });
+
+    await expect(runWorkspaceRemoteSync(createRemoteSyncInput())).resolves.toEqual({
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    });
   });
 });

--- a/apps/web/src/appData/sync/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/syncLifecycleObservation.ts
@@ -3,6 +3,7 @@ import {
   type SyncRestoreLocalBootstrapState,
   type WebObservationScope,
 } from "../../observability/webObservability";
+import type { SyncRestoreHistoryEntry } from "./syncRestoreHistory";
 
 export type HotBootstrapSlowObservationInput = Readonly<{
   userId: string;
@@ -18,6 +19,16 @@ export type HotBootstrapSlowObservationInput = Readonly<{
   lastAppliedHotChangeIdBefore: number | null;
   nextHotChangeId: number | null;
   remoteIsEmpty: boolean | null;
+}>;
+
+export type LocalDbMissingObservationInput = Readonly<{
+  userId: string;
+  workspaceId: string;
+  installationId: string;
+  localBootstrapState: SyncRestoreLocalBootstrapState;
+  localCardCountBefore: number;
+  previousRestoreHistory: SyncRestoreHistoryEntry;
+  currentWebAppVersion: string;
 }>;
 
 function getCurrentRoute(): string | null {
@@ -64,6 +75,25 @@ export function observeSlowHotBootstrap(input: HotBootstrapSlowObservationInput)
       lastAppliedHotChangeIdBefore: input.lastAppliedHotChangeIdBefore,
       nextHotChangeId: input.nextHotChangeId,
       remoteIsEmpty: input.remoteIsEmpty,
+    },
+  });
+}
+
+export function observeLocalDbMissing(input: LocalDbMissingObservationInput): void {
+  captureWebWarning({
+    action: "sync_local_db_missing",
+    scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
+    details: {
+      eventName: "sync_local_db_missing",
+      workspaceId: input.workspaceId,
+      installationId: input.installationId,
+      localBootstrapState: input.localBootstrapState,
+      localCardCountBefore: input.localCardCountBefore,
+      previousHydratedAt: input.previousRestoreHistory.hydratedAt,
+      previousWebAppVersion: input.previousRestoreHistory.webAppVersion,
+      previousLastAppliedHotChangeId: input.previousRestoreHistory.lastAppliedHotChangeId,
+      previousLocalCardCount: input.previousRestoreHistory.localCardCount,
+      currentWebAppVersion: input.currentWebAppVersion,
     },
   });
 }

--- a/apps/web/src/appData/sync/syncRemote.ts
+++ b/apps/web/src/appData/sync/syncRemote.ts
@@ -32,7 +32,15 @@ import {
   doesCardMutationAffectReviewSchedule,
   getErrorMessage,
 } from "../domain";
-import { observeSlowHotBootstrap } from "./syncLifecycleObservation";
+import {
+  observeLocalDbMissing,
+  observeSlowHotBootstrap,
+} from "./syncLifecycleObservation";
+import {
+  loadSyncRestoreHistoryEntry,
+  storeSyncRestoreHistoryEntry,
+  type SyncRestoreHistoryEntry,
+} from "./syncRestoreHistory";
 
 const syncPageSize = 500;
 const slowHotBootstrapWarningThresholdMs = 2000;
@@ -121,6 +129,40 @@ function determineLocalBootstrapState(
   return localCardCountBefore === 0 ? "unhydrated_sync_state" : "unhydrated_with_cards";
 }
 
+function loadWorkspaceRestoreHistory(input: WorkspaceRemoteSyncInput): SyncRestoreHistoryEntry | null {
+  return loadSyncRestoreHistoryEntry({
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    installationId: input.installationId,
+  });
+}
+
+async function storeCurrentWorkspaceRestoreHistory(
+  input: WorkspaceRemoteSyncInput,
+  lastAppliedHotChangeId: number,
+): Promise<void> {
+  const localCardCount = await loadActiveCardCount(input.workspaceId);
+  storeSyncRestoreHistoryEntry({
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    installationId: input.installationId,
+    lastAppliedHotChangeId,
+    localCardCount,
+  });
+}
+
+async function backfillRestoreHistoryForHydratedState(
+  input: WorkspaceRemoteSyncInput,
+  syncStateBefore: NonNullable<Awaited<ReturnType<typeof loadWorkspaceSyncState>>>,
+): Promise<void> {
+  const restoreHistory = loadWorkspaceRestoreHistory(input);
+  if (restoreHistory !== null) {
+    return;
+  }
+
+  await storeCurrentWorkspaceRestoreHistory(input, syncStateBefore.lastAppliedHotChangeId);
+}
+
 async function doHotSyncEntriesAffectReviewSchedule(
   workspaceId: string,
   entries: ReadonlyArray<HotSyncEntry>,
@@ -146,18 +188,37 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
   const hotStateHydrated = syncStateBefore?.hasHydratedHotState ?? false;
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   if (hotStateHydrated) {
+    if (syncStateBefore === null) {
+      throw new Error(`Workspace ${input.workspaceId} hot state is hydrated without sync state`);
+    }
+
+    await backfillRestoreHistoryForHydratedState(input, syncStateBefore);
+    input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     return createEmptyRemoteSyncFlags();
   }
 
   const startedAtMs = Date.now();
   const localCardCountBefore = await loadActiveCardCount(input.workspaceId);
   const localBootstrapState = determineLocalBootstrapState(syncStateBefore, localCardCountBefore);
+  const restoreHistoryBefore = loadWorkspaceRestoreHistory(input);
   let didChangeReviewSchedule = false;
   let bootstrapCursor: string | null = null;
   let pageCount = 0;
   let entriesCount = 0;
   let nextHotChangeId: number | null = null;
   let remoteIsEmpty: boolean | null = null;
+
+  if (syncStateBefore === null && localCardCountBefore === 0 && restoreHistoryBefore !== null) {
+    observeLocalDbMissing({
+      userId: input.userId,
+      workspaceId: input.workspaceId,
+      installationId: input.installationId,
+      localBootstrapState,
+      localCardCountBefore,
+      previousRestoreHistory: restoreHistoryBefore,
+      currentWebAppVersion: webAppVersion,
+    });
+  }
 
   while (true) {
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
@@ -204,6 +265,17 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   const durationMs = Date.now() - startedAtMs;
   const localCardCountAfter = await loadActiveCardCount(input.workspaceId);
+  if (nextHotChangeId === null) {
+    throw new Error(`Workspace ${input.workspaceId} bootstrap did not return a hot change id`);
+  }
+
+  storeSyncRestoreHistoryEntry({
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    installationId: input.installationId,
+    lastAppliedHotChangeId: nextHotChangeId,
+    localCardCount: localCardCountAfter,
+  });
   if (shouldObserveHotBootstrap(durationMs, pageCount)) {
     observeSlowHotBootstrap({
       userId: input.userId,

--- a/apps/web/src/appData/sync/syncRestoreHistory.ts
+++ b/apps/web/src/appData/sync/syncRestoreHistory.ts
@@ -1,0 +1,183 @@
+import { webAppVersion } from "../../clientIdentity";
+
+export const SYNC_RESTORE_HISTORY_STORAGE_KEY = "flashcards-sync-restore-history-v1";
+
+const syncRestoreHistoryVersion = 1;
+const maximumSyncRestoreHistoryEntries = 20;
+
+type SyncRestoreHistoryEnvelope = Readonly<{
+  version: 1;
+  entries: ReadonlyArray<SyncRestoreHistoryEntry>;
+}>;
+
+type JsonRecord = Record<string, unknown>;
+
+export type SyncRestoreHistoryEntry = Readonly<{
+  userId: string;
+  workspaceId: string;
+  installationId: string;
+  hydratedAt: string;
+  webAppVersion: string;
+  lastAppliedHotChangeId: number;
+  localCardCount: number;
+}>;
+
+export type SyncRestoreHistoryLookup = Readonly<{
+  userId: string;
+  workspaceId: string;
+  installationId: string;
+}>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && Array.isArray(value) === false;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isSyncRestoreHistoryEntry(value: unknown): value is SyncRestoreHistoryEntry {
+  return isRecord(value)
+    && isNonEmptyString(value.userId)
+    && isNonEmptyString(value.workspaceId)
+    && isNonEmptyString(value.installationId)
+    && isNonEmptyString(value.hydratedAt)
+    && isNonEmptyString(value.webAppVersion)
+    && isFiniteNumber(value.lastAppliedHotChangeId)
+    && isFiniteNumber(value.localCardCount);
+}
+
+function getBrowserStorage(): Storage | null {
+  let storageValue: Storage;
+  try {
+    storageValue = window.localStorage;
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof storageValue?.getItem !== "function"
+    || typeof storageValue.setItem !== "function"
+    || typeof storageValue.removeItem !== "function"
+  ) {
+    return null;
+  }
+
+  return storageValue;
+}
+
+function parseSyncRestoreHistoryEnvelope(rawValue: string | null): SyncRestoreHistoryEnvelope {
+  if (rawValue === null) {
+    return {
+      version: syncRestoreHistoryVersion,
+      entries: [],
+    };
+  }
+
+  try {
+    const parsedValue = JSON.parse(rawValue) as unknown;
+    if (
+      isRecord(parsedValue) === false
+      || parsedValue.version !== syncRestoreHistoryVersion
+      || Array.isArray(parsedValue.entries) === false
+    ) {
+      return {
+        version: syncRestoreHistoryVersion,
+        entries: [],
+      };
+    }
+
+    const entries = parsedValue.entries.filter(isSyncRestoreHistoryEntry);
+    return {
+      version: syncRestoreHistoryVersion,
+      entries,
+    };
+  } catch {
+    return {
+      version: syncRestoreHistoryVersion,
+      entries: [],
+    };
+  }
+}
+
+function isMatchingSyncRestoreHistoryEntry(
+  entry: SyncRestoreHistoryEntry,
+  lookup: SyncRestoreHistoryLookup,
+): boolean {
+  return entry.userId === lookup.userId
+    && entry.workspaceId === lookup.workspaceId
+    && entry.installationId === lookup.installationId;
+}
+
+function loadSyncRestoreHistoryEnvelope(): SyncRestoreHistoryEnvelope {
+  const browserStorage = getBrowserStorage();
+  if (browserStorage === null) {
+    return {
+      version: syncRestoreHistoryVersion,
+      entries: [],
+    };
+  }
+
+  try {
+    return parseSyncRestoreHistoryEnvelope(browserStorage.getItem(SYNC_RESTORE_HISTORY_STORAGE_KEY));
+  } catch {
+    return {
+      version: syncRestoreHistoryVersion,
+      entries: [],
+    };
+  }
+}
+
+function persistSyncRestoreHistoryEnvelope(envelope: SyncRestoreHistoryEnvelope): void {
+  const browserStorage = getBrowserStorage();
+  if (browserStorage === null) {
+    return;
+  }
+
+  try {
+    browserStorage.setItem(SYNC_RESTORE_HISTORY_STORAGE_KEY, JSON.stringify(envelope));
+  } catch {
+    return;
+  }
+}
+
+export function loadSyncRestoreHistoryEntry(lookup: SyncRestoreHistoryLookup): SyncRestoreHistoryEntry | null {
+  const envelope = loadSyncRestoreHistoryEnvelope();
+  return envelope.entries.find((entry) => isMatchingSyncRestoreHistoryEntry(entry, lookup)) ?? null;
+}
+
+export function storeSyncRestoreHistoryEntry(
+  input: Readonly<{
+    userId: string;
+    workspaceId: string;
+    installationId: string;
+    lastAppliedHotChangeId: number;
+    localCardCount: number;
+  }>,
+): SyncRestoreHistoryEntry {
+  const nextEntry: SyncRestoreHistoryEntry = {
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    installationId: input.installationId,
+    hydratedAt: new Date().toISOString(),
+    webAppVersion,
+    lastAppliedHotChangeId: input.lastAppliedHotChangeId,
+    localCardCount: input.localCardCount,
+  };
+  const envelope = loadSyncRestoreHistoryEnvelope();
+  const nextEntries = [
+    nextEntry,
+    ...envelope.entries.filter((entry) => isMatchingSyncRestoreHistoryEntry(entry, nextEntry) === false),
+  ].slice(0, maximumSyncRestoreHistoryEntries);
+
+  persistSyncRestoreHistoryEnvelope({
+    version: syncRestoreHistoryVersion,
+    entries: nextEntries,
+  });
+
+  return nextEntry;
+}

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -91,6 +91,24 @@ export type ProgressCacheMissBreadcrumbDetails = Readonly<{
   workspaceIds: ReadonlyArray<string>;
 }>;
 
+export type LocalBrowserDataCleanupReason =
+  | "logout_marker"
+  | "account_deleted_marker"
+  | "account_deletion_submit"
+  | "confirmed_account_switch"
+  | "reauth_owner_unknown";
+
+export type LocalBrowserDataCleanupBreadcrumbDetails = Readonly<{
+  eventName:
+    | "local_browser_data_cleanup_started"
+    | "local_browser_data_cleanup_succeeded"
+    | "local_browser_data_cleanup_failed";
+  reason: LocalBrowserDataCleanupReason;
+  indexedDbCleared: boolean;
+  localStorageCleared: boolean;
+  errorMessage: string | null;
+}>;
+
 export type WebBreadcrumbEvent =
   | Readonly<{
     action: "workspace_transition";
@@ -111,6 +129,11 @@ export type WebBreadcrumbEvent =
     action: "progress_cache_miss";
     scope: WebObservationScope;
     details: ProgressCacheMissBreadcrumbDetails;
+  }>
+  | Readonly<{
+    action: "local_browser_data_cleanup";
+    scope: WebObservationScope;
+    details: LocalBrowserDataCleanupBreadcrumbDetails;
   }>;
 
 export type ApiContractFailureDetails = Readonly<{
@@ -331,6 +354,19 @@ export type SyncRestoreWarningDetails = Readonly<{
   remoteIsEmpty: boolean | null;
 }>;
 
+export type SyncLocalDbMissingWarningDetails = Readonly<{
+  eventName: "sync_local_db_missing";
+  workspaceId: string;
+  installationId: string;
+  localBootstrapState: SyncRestoreLocalBootstrapState;
+  localCardCountBefore: number;
+  previousHydratedAt: string;
+  previousWebAppVersion: string;
+  previousLastAppliedHotChangeId: number;
+  previousLocalCardCount: number;
+  currentWebAppVersion: string;
+}>;
+
 export type WebWarningEvent =
   | Readonly<{
     action: "api_contract_warning";
@@ -346,6 +382,11 @@ export type WebWarningEvent =
     action: "sync_restore_slow";
     scope: WebObservationScope;
     details: SyncRestoreWarningDetails;
+  }>
+  | Readonly<{
+    action: "sync_local_db_missing";
+    scope: WebObservationScope;
+    details: SyncLocalDbMissingWarningDetails;
   }>;
 
 type SentryContextValue =


### PR DESCRIPTION
## What changed

- Added a web-local restore history marker for successful hot-state hydration.
- Added `web.sync_local_db_missing` warning when IndexedDB is empty but previous restore history exists.
- Added cleanup breadcrumbs with explicit local-data cleanup reasons.
- Added targeted tests for first bootstrap, repeated missing local DB, marker backfill, cleanup breadcrumbs, and storage write failure.

## Validation

- `npm run test -- src/appData/sync/syncLifecycleObservation.test.ts src/accountDeletion.test.ts src/appData/session/useWorkspaceSession.test.tsx`
- `npm run build`
