### PR TITLE
[codex] Position web review reactions in pane

### DIFF
--- a/apps/web/src/screens/review/ReviewScreen.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.tsx
@@ -32,14 +32,15 @@ export function ReviewScreen(): ReactElement {
         <ReviewScreenHeader {...headerProps} />
 
         <div className="review-layout">
-          <ReviewPane {...paneProps} />
+          <div className="review-pane-reaction-frame">
+            <ReviewPane {...paneProps} />
+            <ReviewRatingReactionLayer
+              events={reviewReactionEvents}
+              onReactionEventFallback={reviewReactionFallbackHandler}
+            />
+          </div>
           <ReviewQueuePanel {...queuePanelProps} />
         </div>
-
-        <ReviewRatingReactionLayer
-          events={reviewReactionEvents}
-          onReactionEventFallback={reviewReactionFallbackHandler}
-        />
       </section>
 
       <ReviewEditorModal {...editorModalProps} />

--- a/apps/web/src/styles/features/review/review-reactions.css
+++ b/apps/web/src/styles/features/review/review-reactions.css
@@ -1,4 +1,7 @@
 .review-rating-reaction-layer {
+  --review-reaction-center-x: 50%;
+  --review-reaction-center-y: 75%;
+  --review-reaction-center-y-offset: 25%;
   position: absolute;
   inset: 0;
   z-index: 20;
@@ -21,6 +24,10 @@
   height: 100%;
   overflow: visible;
   transform-origin: 50% 50%;
+}
+
+.review-rating-reaction-art:not(.review-rating-reaction-lottie-art) {
+  transform: translateY(var(--review-reaction-center-y-offset));
 }
 
 .review-rating-reaction-art * {
@@ -146,8 +153,8 @@
 
 .review-rating-reaction-lottie-art > div {
   position: absolute;
-  top: 50%;
-  left: 50%;
+  top: var(--review-reaction-center-y);
+  left: var(--review-reaction-center-x);
   aspect-ratio: 1;
   transform: translate(-50%, -50%);
 }
@@ -331,23 +338,23 @@
 
 @keyframes review-reaction-crown-art {
   0% {
-    transform: scale(0.58) rotate(-14deg);
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(0.58) rotate(-14deg);
   }
 
   44% {
-    transform: scale(1.17) rotate(4deg);
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(1.17) rotate(4deg);
   }
 
   62% {
-    transform: scale(1.02) rotate(-2deg);
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(1.02) rotate(-2deg);
   }
 
   82% {
-    transform: scale(1) rotate(1deg);
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(1) rotate(1deg);
   }
 
   100% {
-    transform: scale(0.88) rotate(0deg);
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(0.88) rotate(0deg);
   }
 }
 
@@ -394,6 +401,20 @@
   }
 }
 
+@keyframes review-reaction-reduced-shifted-pop {
+  0% {
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(0.94);
+  }
+
+  50% {
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(1.01);
+  }
+
+  100% {
+    transform: translateY(var(--review-reaction-center-y-offset)) scale(0.98);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .review-rating-reaction-event {
     animation-duration: 340ms !important;
@@ -404,5 +425,9 @@
   .review-rating-reaction-event .review-reaction-sparkle-fill {
     animation-duration: 340ms !important;
     animation-name: review-reaction-reduced-pop !important;
+  }
+
+  .review-rating-reaction-event .review-rating-reaction-art:not(.review-rating-reaction-lottie-art) {
+    animation-name: review-reaction-reduced-shifted-pop !important;
   }
 }

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -23,6 +23,14 @@
   min-height: 0;
 }
 
+.review-pane-reaction-frame {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  border-radius: var(--radius-lg);
+}
+
 .review-screen-head {
   align-items: flex-start;
 }


### PR DESCRIPTION
## Summary
- move the web review reaction overlay into the review pane frame
- align reaction visuals at 50% x / 75% y inside that pane
- keep fallback and reduced-motion reaction transforms aligned with the same center

## Validation
- npm run build
- npm exec -- vitest run src/screens/review