### PR TITLE
[codex] Bump version to 1.6.0

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-api",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "devDependencies": {
         "@redocly/cli": "^2.31.4"
       },

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "bundle": "redocly bundle src/openapi.yaml --output dist/openapi.json --ext json",

--- a/apps/admin/package-lock.json
+++ b/apps/admin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-admin",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "d3": "^7.9.0",
         "react": "^19.2.6",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-admin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -138,7 +138,7 @@ android {
         minSdk = 34
         targetSdk = 36
         versionCode = androidVersionCode ?: 1
-        versionName = "1.5.0"
+        versionName = "1.6.0"
         testInstrumentationRunner = "com.flashcardsopensourceapp.app.FlashcardsAndroidTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
         buildConfigField("String", "ANDROID_SENTRY_DSN", toBuildConfigString(androidSentryDsn))

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/ProgressContextRefreshControllerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/ProgressContextRefreshControllerTest.kt
@@ -153,7 +153,7 @@ class ProgressContextRefreshControllerTest {
     }
 }
 
-private const val testAppVersion: String = "1.5.0"
+private const val testAppVersion: String = "1.6.0"
 private const val testVersionCode: Int = 1
 
 private class TestAppObservability : AppObservability {

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
@@ -57,5 +57,5 @@ class SentryAppObservabilityTest {
     }
 }
 
-private const val testAppVersion: String = "1.5.0"
+private const val testAppVersion: String = "1.6.0"
 private const val testVersionCode: Int = 1

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
@@ -48,7 +48,7 @@ internal class CloudIdentityTestEnvironment private constructor(
     val resetCoordinator: CloudIdentityResetCoordinator,
     val aiChatRemoteService: AiChatRemoteService
 ) {
-    private val appVersion: String = "1.5.0"
+    private val appVersion: String = "1.6.0"
 
     companion object {
         suspend fun create(): CloudIdentityTestEnvironment {

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteTestFixtures.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/AiChatRemoteTestFixtures.kt
@@ -5,7 +5,7 @@ import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 import kotlinx.coroutines.Dispatchers
 
-internal const val AI_CHAT_TEST_APP_VERSION: String = "1.5.0"
+internal const val AI_CHAT_TEST_APP_VERSION: String = "1.6.0"
 internal const val AI_CHAT_TEST_UI_LOCALE: String = "es-ES"
 internal const val AI_CHAT_TEST_WORKSPACE_ID: String = "workspace-1"
 

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeTestSupport.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntimeTestSupport.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.withContext
 internal const val defaultTestWorkspaceId: String = "workspace-1"
 internal const val secondaryTestWorkspaceId: String = "workspace-2"
 
-private const val testAppVersion: String = "1.5.0"
+private const val testAppVersion: String = "1.6.0"
 private const val testVersionCode: Int = 10300
 internal const val testUiLocaleTag: String = "en-US"
 

--- a/apps/auth/package-lock.json
+++ b/apps/auth/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-auth",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-auth",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1054.0",
         "@hono/node-server": "^2.0.4",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-auth",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-backend",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.1054.0",
         "@aws-sdk/client-lambda": "^3.1054.0",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-backend",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "npm run bundle --prefix ../../api && tsx watch src/entrypoints/index.ts",

--- a/apps/backend/src/chat/config.ts
+++ b/apps/backend/src/chat/config.ts
@@ -68,7 +68,7 @@ export function getChatConfig(): ChatConfig {
       dictationEnabled: true,
       attachmentsEnabled: true,
     },
-    // First-party clients at 1.5.0 no longer read chatConfig.liveUrl at
+    // First-party clients at >1.5.0 no longer read chatConfig.liveUrl at
     // runtime. Keep returning it temporarily for backward compatibility with
     // older released clients, and remove it in a future legacy chat cleanup.
     liveUrl: process.env.CHAT_LIVE_URL || null,

--- a/apps/backend/src/chat/http/contract.ts
+++ b/apps/backend/src/chat/http/contract.ts
@@ -61,7 +61,7 @@ export type ChatContentPart =
   | ChatToolCallContentPart;
 
 export type ChatRequestBody = Readonly<{
-  // First-party clients at 1.5.0 no longer rely on omitting sessionId on
+  // First-party clients at >1.5.0 no longer rely on omitting sessionId on
   // /chat. Keep this optional only for temporary backward compatibility with
   // older released clients, and remove the session-less path in a future
   // legacy chat cleanup.
@@ -80,7 +80,7 @@ export type ChatRequestBody = Readonly<{
 }>;
 
 export type NewChatRequestBody = Readonly<{
-  // First-party clients at 1.5.0 no longer rely on omitting sessionId on
+  // First-party clients at >1.5.0 no longer rely on omitting sessionId on
   // /chat/new. Keep this optional only for temporary backward compatibility
   // with older released clients, and remove the session-less path in a future
   // legacy chat cleanup.
@@ -113,7 +113,7 @@ export type ChatPageQuery = Readonly<{
 const MAX_CHAT_PAGE_LIMIT = 50;
 
 const UNSUPPORTED_CHAT_REQUEST_FIELDS = [
-  // First-party clients at 1.5.0 no longer send these legacy request-shape
+  // First-party clients at >1.5.0 no longer send these legacy request-shape
   // fields. Keep rejecting them while the remaining compatibility branches are
   // still present, then revisit this guard in the future legacy chat cleanup.
   "messages",

--- a/apps/backend/src/chat/http/handlers.ts
+++ b/apps/backend/src/chat/http/handlers.ts
@@ -229,7 +229,7 @@ export function createPostChatNewHandler(dependencies: ChatRouteDependencies): H
     const workspaceId = await dependencies.resolveAccessibleChatWorkspaceIdFn(requestContext, body.workspaceId);
 
     // Preferred modern flow: clients send an explicit client-generated
-    // sessionId. First-party clients at 1.5.0 already follow that flow.
+    // sessionId. First-party clients at >1.5.0 already follow that flow.
     // When an explicit id is present, this route is idempotent: create exactly
     // that session if it does not exist yet, otherwise return the existing
     // session unchanged. The omitted-sessionId path below stays temporarily
@@ -349,7 +349,7 @@ export function createPostChatStopHandler(dependencies: ChatRouteDependencies): 
 
     return context.json({
       sessionId: stopState.sessionId,
-      // First-party clients at 1.5.0 no longer depend on these duplicate
+      // First-party clients at >1.5.0 no longer depend on these duplicate
       // legacy stop-response fields. Keep returning them temporarily for older
       // released clients and remove them in a future legacy chat cleanup.
       conversationScopeId: stopState.sessionId,

--- a/apps/backend/src/routes/chatTranscriptions.ts
+++ b/apps/backend/src/routes/chatTranscriptions.ts
@@ -53,7 +53,7 @@ async function resolveChatTranscriptionSessionId(
     throw new HttpError(400, "sessionId must be a UUID", "CHAT_SESSION_ID_INVALID");
   }
 
-  // First-party clients at 1.5.0 no longer omit sessionId here. Keep this
+  // First-party clients at >1.5.0 no longer omit sessionId here. Keep this
   // legacy session-less path temporarily for older released clients, then
   // remove it in a future legacy chat cleanup.
   try {

--- a/apps/ios/Flashcards/Config/Base.xcconfig
+++ b/apps/ios/Flashcards/Config/Base.xcconfig
@@ -1,6 +1,6 @@
 APP_DISPLAY_NAME = Flashcards
 APP_BUNDLE_IDENTIFIER = com.flashcards-open-source-app.app
-APP_MARKETING_VERSION = 1.5.0
+APP_MARKETING_VERSION = 1.6.0
 // Keep the repository default build number stable. Signed archives should
 // override this locally or in CI when a higher App Store Connect build number is required.
 APP_CURRENT_PROJECT_VERSION = 1

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-web",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@sentry/react": "^10.54.0",
         "heic-to": "^1.5.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-web",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/apps/web/src/api/transport.test.ts
+++ b/apps/web/src/api/transport.test.ts
@@ -604,7 +604,7 @@ describe("API transport network retry", () => {
       workspaceId,
       "installation-1",
       "web",
-      "1.5.0",
+      "1.6.0",
       0,
       200,
     )).resolves.toEqual({
@@ -643,7 +643,7 @@ describe("API transport network retry", () => {
       workspaceId,
       "installation-1",
       "web",
-      "1.5.0",
+      "1.6.0",
       0,
       200,
     )).resolves.toEqual({
@@ -818,7 +818,7 @@ describe("API transport network retry", () => {
       workspaceId,
       "installation-1",
       "web",
-      "1.5.0",
+      "1.6.0",
       0,
       200,
     );

--- a/infra/aws/package-lock.json
+++ b/infra/aws/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flashcards-open-source-app-aws",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@aws-crypto/client-node": "^5.0.0",
         "@aws-sdk/client-cloudwatch": "^3.1054.0",

--- a/infra/aws/package.json
+++ b/infra/aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashcards-open-source-app-aws",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Bump repo-owned release version surfaces from 1.5.0 to 1.6.0 across backend, API, auth, infra, web, admin, iOS, and Android.
- Update version-coupled web and Android test fixtures.
- Change backend compatibility comments to use the stable `>1.5.0` threshold instead of the current release version.

## Validation

- Parsed affected package JSON and lock root version fields.
- Checked stale release-surface references for `1.5.0`; remaining hits are dependency versions in lockfiles.
- Ran `npm ci --prefix apps/web`.
- Ran `npm run build --prefix apps/web`.
- Ran `git --no-pager diff --check`.

Android Gradle validation was not run locally because this repository requires explicit permission before local `./gradlew` runs.