### PR TITLE
[codex] Add iOS Store Review request flow

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -1,4 +1,11 @@
+import StoreKit
 import SwiftUI
+
+private struct StoreReviewRequestTaskID: Hashable {
+    let isSceneActive: Bool
+    let isPresentationBlocked: Bool
+    let requestAttemptId: String?
+}
 
 private struct GuestSignInAfterReviewPromptRecheckTaskID: Hashable {
     let isSceneActive: Bool
@@ -9,6 +16,7 @@ private struct GuestSignInAfterReviewPromptRecheckTaskID: Hashable {
 }
 
 struct RootTabView: View {
+    @Environment(\.requestReview) private var requestReview
     @Environment(\.scenePhase) private var scenePhase
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
@@ -25,6 +33,11 @@ struct RootTabView: View {
             || store.isReviewHardReminderPresented
     }
 
+    private var isStoreReviewRequestBlockedByPresentation: Bool {
+        self.isGuestSignInAfterReviewPromptBlockedByModal
+            || store.isGuestSignInAfterReviewPromptPresented
+    }
+
     private var guestSignInAfterReviewPromptRecheckTaskID: GuestSignInAfterReviewPromptRecheckTaskID {
         GuestSignInAfterReviewPromptRecheckTaskID(
             isSceneActive: self.scenePhase == .active,
@@ -32,6 +45,14 @@ struct RootTabView: View {
             reviewedCount: store.homeSnapshot.reviewedCount,
             promptState: store.guestSignInAfterReviewPromptState,
             isModalOrAuthFlowActive: self.isGuestSignInAfterReviewPromptBlockedByModal
+        )
+    }
+
+    private var storeReviewRequestTaskID: StoreReviewRequestTaskID {
+        StoreReviewRequestTaskID(
+            isSceneActive: self.scenePhase == .active,
+            isPresentationBlocked: self.isStoreReviewRequestBlockedByPresentation,
+            requestAttemptId: store.pendingStoreReviewRequestAttempt?.id
         )
     }
 
@@ -162,6 +183,25 @@ struct RootTabView: View {
         }
 
         self.reconcileGuestSignInAfterReviewPrompt()
+    }
+
+    @MainActor
+    private func requestStoreReviewIfNeeded() async {
+        guard self.scenePhase == .active else {
+            return
+        }
+        guard self.isStoreReviewRequestBlockedByPresentation == false else {
+            return
+        }
+        guard let requestAttempt = store.pendingStoreReviewRequestAttempt else {
+            return
+        }
+        guard store.recordStoreReviewRequestAttempt(requestAttempt: requestAttempt, now: Date()) else {
+            return
+        }
+
+        self.requestReview()
+        store.consumeStoreReviewRequestAttempt(attemptId: requestAttempt.id)
     }
 
     @MainActor
@@ -360,6 +400,9 @@ struct RootTabView: View {
         }
         .task(id: self.guestSignInAfterReviewPromptRecheckTaskID) {
             await self.waitForGuestSignInAfterReviewPromptRecheckIfNeeded()
+        }
+        .task(id: self.storeReviewRequestTaskID) {
+            await self.requestStoreReviewIfNeeded()
         }
         .overlay {
             ZStack {

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
@@ -275,6 +275,35 @@ extension CardStore {
         ) == 1
     }
 
+    func hasAppWideReviewEvent(before: Date) throws -> Bool {
+        try self.core.scalarInt(
+            sql: """
+            SELECT EXISTS(
+                SELECT 1
+                FROM review_events
+                WHERE reviewed_at_client < ?
+            )
+            """,
+            values: [
+                .text(formatIsoTimestamp(date: before))
+            ]
+        ) == 1
+    }
+
+    func loadAppWideReviewEventCount(start: Date, end: Date) throws -> Int {
+        try self.core.scalarInt(
+            sql: """
+            SELECT COUNT(*)
+            FROM review_events
+            WHERE reviewed_at_client >= ? AND reviewed_at_client < ?
+            """,
+            values: [
+                .text(formatIsoTimestamp(date: start)),
+                .text(formatIsoTimestamp(date: end))
+            ]
+        )
+    }
+
     func loadReviewCounts(
         workspaceId: String,
         reviewQueryDefinition: ReviewQueryDefinition,

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Read.swift
@@ -212,6 +212,14 @@ extension LocalDatabase {
         try self.cardStore.hasAppWideReviewEvent(start: start, end: end)
     }
 
+    func hasAppWideReviewEvent(before: Date) throws -> Bool {
+        try self.cardStore.hasAppWideReviewEvent(before: before)
+    }
+
+    func loadAppWideReviewEventCount(start: Date, end: Date) throws -> Int {
+        try self.cardStore.loadAppWideReviewEventCount(start: start, end: end)
+    }
+
     func loadCardsListSnapshot(
         workspaceId: String,
         searchText: String,

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore.swift
@@ -99,6 +99,7 @@ final class FlashcardsStore {
     var activeCloudSignInSheetCount: Int
     var accountDeletionState: AccountDeletionState
     var accountDeletionSuccessMessage: String?
+    var pendingStoreReviewRequestAttempt: StoreReviewRequestAttempt?
     var uiTestLaunchPreparationStatus: FlashcardsUITestLaunchPreparationStatus
     var localReadVersion: Int
 
@@ -388,6 +389,7 @@ final class FlashcardsStore {
         self.activeCloudSignInSheetCount = 0
         self.accountDeletionState = .hidden
         self.accountDeletionSuccessMessage = nil
+        self.pendingStoreReviewRequestAttempt = nil
         self.uiTestLaunchPreparationStatus = .hidden
         self.localReadVersion = 0
         self.database = database

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/FlashcardsStore+Review.swift
@@ -318,6 +318,7 @@ extension FlashcardsStore {
             if bootstrapRefreshOutcome.didChange || didReconcileReviewState {
                 self.localReadVersion += 1
             }
+            self.prepareStoreReviewRequestAttemptAfterSuccessfulReview(now: now)
             let reviewedAt = parseIsoTimestamp(value: request.reviewedAtClient) ?? now
             self.handleSuccessfulReviewNotificationTrigger(
                 reviewedAt: reviewedAt,

--- a/apps/ios/Flashcards/Flashcards/Review/StoreReview/FlashcardsStore+StoreReview.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/StoreReview/FlashcardsStore+StoreReview.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+@MainActor
+extension FlashcardsStore {
+    func prepareStoreReviewRequestAttemptAfterSuccessfulReview(now: Date) {
+        do {
+            try self.prepareStoreReviewRequestAttemptIfEligible(now: now)
+        } catch {
+            assertionFailure("Store review eligibility failed: \(Flashcards.errorMessage(error: error))")
+        }
+    }
+
+    func consumeStoreReviewRequestAttempt(attemptId: String) {
+        guard self.pendingStoreReviewRequestAttempt?.id == attemptId else {
+            return
+        }
+
+        self.pendingStoreReviewRequestAttempt = nil
+    }
+
+    func recordStoreReviewRequestAttempt(requestAttempt: StoreReviewRequestAttempt, now: Date) -> Bool {
+        guard self.pendingStoreReviewRequestAttempt?.id == requestAttempt.id else {
+            return false
+        }
+
+        persistStoreReviewPromptState(
+            userDefaults: self.userDefaults,
+            promptState: StoreReviewPromptState(
+                lastStoreReviewRequestedAt: now,
+                lastStoreReviewRequestedAppVersion: requestAttempt.appVersion
+            )
+        )
+        fireAndForgetStoreReviewRequestedAnalyticsEvent(
+            event: makeStoreReviewRequestedAnalyticsEvent(
+                appVersion: requestAttempt.appVersion,
+                localTimestamp: now,
+                installationId: requestAttempt.installationId
+            )
+        )
+
+        return true
+    }
+
+    func clearStoreReviewPromptStateForTests() {
+        clearStoreReviewPromptState(userDefaults: self.userDefaults)
+        self.pendingStoreReviewRequestAttempt = nil
+    }
+
+    private func prepareStoreReviewRequestAttemptIfEligible(now: Date) throws {
+        guard self.pendingStoreReviewRequestAttempt == nil else {
+            return
+        }
+
+        guard let database = self.database else {
+            throw LocalStoreError.uninitialized("Local database is unavailable")
+        }
+
+        let calendar = makeStoreReviewLocalCalendar(timeZone: .current)
+        let localDayRange = try makeStoreReviewCurrentLocalDayRange(now: now, calendar: calendar)
+        let promptState = try loadStoreReviewPromptState(userDefaults: self.userDefaults)
+        let appVersion = appMarketingVersion()
+        let context = StoreReviewEligibilityContext(
+            hasReviewActivityOnPreviousLocalDay: try database.hasAppWideReviewEvent(before: localDayRange.start),
+            currentLocalDayCompletedReviewCount: try database.loadAppWideReviewEventCount(
+                start: localDayRange.start,
+                end: localDayRange.end
+            ),
+            currentAppVersion: appVersion,
+            now: now,
+            localCalendar: calendar,
+            promptState: promptState
+        )
+        guard try shouldRequestStoreReview(context: context) else {
+            return
+        }
+
+        self.pendingStoreReviewRequestAttempt = StoreReviewRequestAttempt(
+            id: UUID().uuidString.lowercased(),
+            appVersion: appVersion,
+            requestedAt: now,
+            installationId: self.cloudSettings?.installationId
+        )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Review/StoreReview/StoreReviewSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/StoreReview/StoreReviewSupport.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+let lastStoreReviewRequestedAtUserDefaultsKey: String = "last-store-review-requested-at"
+let lastStoreReviewRequestedAppVersionUserDefaultsKey: String = "last-store-review-requested-app-version"
+let storeReviewMinimumCurrentDayReviewCount: Int = 5
+let storeReviewAttemptCooldownCalendarDays: Int = 90
+let storeReviewRequestedAnalyticsEventName: String = "store_review_requested"
+
+enum StoreReviewEligibilityError: LocalizedError {
+    case nextLocalDayUnavailable(Date)
+    case cooldownIntervalUnavailable(Date, Date)
+    case invalidStoredLastRequestedAt(String)
+    case invalidStoredLastRequestedAppVersion(String)
+    case emptyStoredLastRequestedAppVersion
+
+    var errorDescription: String? {
+        switch self {
+        case .nextLocalDayUnavailable(let date):
+            return "Store review local day boundary could not be calculated for \(formatIsoTimestamp(date: date))"
+        case .cooldownIntervalUnavailable(let lastRequestedAt, let now):
+            return "Store review cooldown interval could not be calculated from \(formatIsoTimestamp(date: lastRequestedAt)) to \(formatIsoTimestamp(date: now))"
+        case .invalidStoredLastRequestedAt(let typeDescription):
+            return "Stored Store review requested timestamp has unsupported type: \(typeDescription)"
+        case .invalidStoredLastRequestedAppVersion(let typeDescription):
+            return "Stored Store review requested app version has unsupported type: \(typeDescription)"
+        case .emptyStoredLastRequestedAppVersion:
+            return "Stored Store review requested app version must not be empty"
+        }
+    }
+}
+
+struct StoreReviewPromptState {
+    let lastStoreReviewRequestedAt: Date?
+    let lastStoreReviewRequestedAppVersion: String?
+}
+
+struct StoreReviewEligibilityContext {
+    let hasReviewActivityOnPreviousLocalDay: Bool
+    let currentLocalDayCompletedReviewCount: Int
+    let currentAppVersion: String
+    let now: Date
+    let localCalendar: Calendar
+    let promptState: StoreReviewPromptState
+}
+
+enum StoreReviewAnalyticsPlatform: String, Hashable, Sendable {
+    case ios
+}
+
+struct StoreReviewRequestedAnalyticsEvent: Hashable, Sendable {
+    let name: String
+    let platform: StoreReviewAnalyticsPlatform
+    let appVersion: String
+    let localTimestamp: Date
+    let installationId: String?
+}
+
+struct StoreReviewRequestAttempt: Identifiable, Hashable, Sendable {
+    let id: String
+    let appVersion: String
+    let requestedAt: Date
+    let installationId: String?
+}
+
+struct StoreReviewLocalDayRange: Hashable, Sendable {
+    let start: Date
+    let end: Date
+}
+
+func makeStoreReviewLocalCalendar(timeZone: TimeZone) -> Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.locale = Locale(identifier: "en_US_POSIX")
+    calendar.timeZone = timeZone
+    return calendar
+}
+
+func makeStoreReviewCurrentLocalDayRange(now: Date, calendar: Calendar) throws -> StoreReviewLocalDayRange {
+    let startOfToday = calendar.startOfDay(for: now)
+    guard let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday) else {
+        throw StoreReviewEligibilityError.nextLocalDayUnavailable(now)
+    }
+
+    return StoreReviewLocalDayRange(start: startOfToday, end: startOfTomorrow)
+}
+
+func loadStoreReviewPromptState(userDefaults: UserDefaults) throws -> StoreReviewPromptState {
+    StoreReviewPromptState(
+        lastStoreReviewRequestedAt: try loadLastStoreReviewRequestedAt(userDefaults: userDefaults),
+        lastStoreReviewRequestedAppVersion: try loadLastStoreReviewRequestedAppVersion(userDefaults: userDefaults)
+    )
+}
+
+func persistStoreReviewPromptState(userDefaults: UserDefaults, promptState: StoreReviewPromptState) {
+    if let lastStoreReviewRequestedAt = promptState.lastStoreReviewRequestedAt {
+        userDefaults.set(lastStoreReviewRequestedAt.timeIntervalSince1970, forKey: lastStoreReviewRequestedAtUserDefaultsKey)
+    } else {
+        userDefaults.removeObject(forKey: lastStoreReviewRequestedAtUserDefaultsKey)
+    }
+
+    if let lastStoreReviewRequestedAppVersion = promptState.lastStoreReviewRequestedAppVersion {
+        userDefaults.set(lastStoreReviewRequestedAppVersion, forKey: lastStoreReviewRequestedAppVersionUserDefaultsKey)
+    } else {
+        userDefaults.removeObject(forKey: lastStoreReviewRequestedAppVersionUserDefaultsKey)
+    }
+}
+
+func clearStoreReviewPromptState(userDefaults: UserDefaults) {
+    userDefaults.removeObject(forKey: lastStoreReviewRequestedAtUserDefaultsKey)
+    userDefaults.removeObject(forKey: lastStoreReviewRequestedAppVersionUserDefaultsKey)
+}
+
+func shouldRequestStoreReview(context: StoreReviewEligibilityContext) throws -> Bool {
+    guard context.hasReviewActivityOnPreviousLocalDay else {
+        return false
+    }
+    guard context.currentLocalDayCompletedReviewCount >= storeReviewMinimumCurrentDayReviewCount else {
+        return false
+    }
+    guard context.promptState.lastStoreReviewRequestedAppVersion != context.currentAppVersion else {
+        return false
+    }
+
+    return try storeReviewAttemptCooldownHasElapsed(
+        lastRequestedAt: context.promptState.lastStoreReviewRequestedAt,
+        now: context.now,
+        calendar: context.localCalendar
+    )
+}
+
+func makeStoreReviewRequestedAnalyticsEvent(
+    appVersion: String,
+    localTimestamp: Date,
+    installationId: String?
+) -> StoreReviewRequestedAnalyticsEvent {
+    StoreReviewRequestedAnalyticsEvent(
+        name: storeReviewRequestedAnalyticsEventName,
+        platform: .ios,
+        appVersion: appVersion,
+        localTimestamp: localTimestamp,
+        installationId: installationId
+    )
+}
+
+func fireAndForgetStoreReviewRequestedAnalyticsEvent(event: StoreReviewRequestedAnalyticsEvent) {
+    _ = event
+}
+
+private func loadLastStoreReviewRequestedAt(userDefaults: UserDefaults) throws -> Date? {
+    guard let rawValue = userDefaults.object(forKey: lastStoreReviewRequestedAtUserDefaultsKey) else {
+        return nil
+    }
+
+    if let timestamp = rawValue as? TimeInterval {
+        return Date(timeIntervalSince1970: timestamp)
+    }
+
+    throw StoreReviewEligibilityError.invalidStoredLastRequestedAt(String(describing: type(of: rawValue)))
+}
+
+private func loadLastStoreReviewRequestedAppVersion(userDefaults: UserDefaults) throws -> String? {
+    guard let rawValue = userDefaults.object(forKey: lastStoreReviewRequestedAppVersionUserDefaultsKey) else {
+        return nil
+    }
+
+    guard let appVersion = rawValue as? String else {
+        throw StoreReviewEligibilityError.invalidStoredLastRequestedAppVersion(String(describing: type(of: rawValue)))
+    }
+
+    let trimmedAppVersion = appVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedAppVersion.isEmpty == false else {
+        throw StoreReviewEligibilityError.emptyStoredLastRequestedAppVersion
+    }
+
+    return trimmedAppVersion
+}
+
+private func storeReviewAttemptCooldownHasElapsed(
+    lastRequestedAt: Date?,
+    now: Date,
+    calendar: Calendar
+) throws -> Bool {
+    guard let lastRequestedAt else {
+        return true
+    }
+
+    let lastRequestedLocalDay = calendar.startOfDay(for: lastRequestedAt)
+    let currentLocalDay = calendar.startOfDay(for: now)
+    let elapsedDays = calendar.dateComponents([.day], from: lastRequestedLocalDay, to: currentLocalDay).day
+    guard let elapsedDays else {
+        throw StoreReviewEligibilityError.cooldownIntervalUnavailable(lastRequestedAt, now)
+    }
+
+    return elapsedDays >= storeReviewAttemptCooldownCalendarDays
+}

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -91,7 +91,7 @@ struct SettingsView: View {
                     NavigationLink(value: SettingsNavigationDestination.test) {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("settings.row.test", "Test"),
-                            value: aiSettingsLocalized("settings.row.test.itemCount", "1 item"),
+                            value: aiSettingsLocalized("settings.row.test.itemCount", "2 items"),
                             systemImage: "wrench.and.screwdriver"
                         )
                     }

--- a/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct TestSettingsView: View {
+    @Environment(FlashcardsStore.self) private var store: FlashcardsStore
+
     var body: some View {
         List {
             Section(aiSettingsLocalized("settings.test.section.tools", "Tools")) {
@@ -12,6 +14,16 @@ struct TestSettingsView: View {
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.testSettingsAnimationsRow)
+
+                Button {
+                    store.clearStoreReviewPromptStateForTests()
+                } label: {
+                    SettingsNavigationRow(
+                        title: aiSettingsLocalized("settings.test.storeReviewPromptReset", "Reset App Store review prompt"),
+                        value: aiSettingsLocalized("settings.test.storeReviewPromptReset.value", "Local state"),
+                        systemImage: "star.bubble"
+                    )
+                }
             }
         }
         .listStyle(.insetGrouped)
@@ -161,6 +173,7 @@ private func testAnimationAccessibilityLabel(
 #Preview("Test") {
     NavigationStack {
         TestSettingsView()
+            .environment(FlashcardsStore())
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 عناصر";
 "settings.section.test" = "اختبار";
 "settings.row.test" = "اختبار";
-"settings.row.test.itemCount" = "عنصر واحد";
+"settings.row.test.itemCount" = "عنصران";
 "settings.sync.success" = "تمت المزامنة بنجاح";
 "settings.sync.guestAiActive" = "الذكاء الاصطناعي الضيف نشط";
 "settings.sync.notSyncing" = "لا توجد مزامنة";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "الرسوم المتحركة";
 "settings.test.animations.probability" = "احتمال %@";
 "settings.test.animations.playAccessibility" = "تشغيل حركة %@، %@";
+"settings.test.storeReviewPromptReset" = "إعادة ضبط مطالبة مراجعة App Store";
+"settings.test.storeReviewPromptReset.value" = "الحالة المحلية";
 
 "settings.access.title" = "الوصول";
 "settings.access.section.permissions" = "الأذونات";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 Artikel";
 "settings.section.test" = "Test";
 "settings.row.test" = "Test";
-"settings.row.test.itemCount" = "1 Element";
+"settings.row.test.itemCount" = "2 Elemente";
 "settings.sync.success" = "Erfolgreich synchronisiert";
 "settings.sync.guestAiActive" = "Gast-KI ist aktiv";
 "settings.sync.notSyncing" = "Keine Synchronisierung";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "Animationen";
 "settings.test.animations.probability" = "%@ Wahrscheinlichkeit";
 "settings.test.animations.playAccessibility" = "Animation %@ abspielen, %@";
+"settings.test.storeReviewPromptReset" = "App-Store-Bewertungsanfrage zurücksetzen";
+"settings.test.storeReviewPromptReset.value" = "Lokaler Status";
 
 "settings.access.title" = "Zugriff";
 "settings.access.section.permissions" = "Berechtigungen";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 elementos";
 "settings.section.test" = "Prueba";
 "settings.row.test" = "Prueba";
-"settings.row.test.itemCount" = "1 elemento";
+"settings.row.test.itemCount" = "2 elementos";
 "settings.sync.success" = "Sincronizado correctamente";
 "settings.sync.guestAiActive" = "La IA de invitado esta activa";
 "settings.sync.notSyncing" = "Sin sincronizacion";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "Animaciones";
 "settings.test.animations.probability" = "%@ de probabilidad";
 "settings.test.animations.playAccessibility" = "Reproducir la animacion %@, %@";
+"settings.test.storeReviewPromptReset" = "Restablecer solicitud de resena de App Store";
+"settings.test.storeReviewPromptReset.value" = "Estado local";
 
 "settings.access.title" = "Acceso";
 "settings.access.section.permissions" = "Permisos";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 elementos";
 "settings.section.test" = "Prueba";
 "settings.row.test" = "Prueba";
-"settings.row.test.itemCount" = "1 elemento";
+"settings.row.test.itemCount" = "2 elementos";
 "settings.sync.success" = "Sincronizado correctamente";
 "settings.sync.guestAiActive" = "La IA de invitado esta activa";
 "settings.sync.notSyncing" = "Sin sincronizacion";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "Animaciones";
 "settings.test.animations.probability" = "%@ de probabilidad";
 "settings.test.animations.playAccessibility" = "Reproducir la animacion %@, %@";
+"settings.test.storeReviewPromptReset" = "Restablecer solicitud de resena de App Store";
+"settings.test.storeReviewPromptReset.value" = "Estado local";
 
 "settings.access.title" = "Acceso";
 "settings.access.section.permissions" = "Permisos";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 आइटम";
 "settings.section.test" = "टेस्ट";
 "settings.row.test" = "टेस्ट";
-"settings.row.test.itemCount" = "1 आइटम";
+"settings.row.test.itemCount" = "2 आइटम";
 "settings.sync.success" = "सफलतापूर्वक समन्वयित";
 "settings.sync.guestAiActive" = "अतिथि AI सक्रिय है";
 "settings.sync.notSyncing" = "कोई सिंक्रनाइज़ेशन नहीं";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "ऐनिमेशन";
 "settings.test.animations.probability" = "%@ संभावना";
 "settings.test.animations.playAccessibility" = "%@ ऐनिमेशन चलाएं, %@";
+"settings.test.storeReviewPromptReset" = "App Store समीक्षा प्रॉम्प्ट रीसेट करें";
+"settings.test.storeReviewPromptReset.value" = "स्थानीय स्थिति";
 
 "settings.access.title" = "एक्सेस";
 "settings.access.section.permissions" = "अनुमतियाँ";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 アイテム";
 "settings.section.test" = "テスト";
 "settings.row.test" = "テスト";
-"settings.row.test.itemCount" = "1項目";
+"settings.row.test.itemCount" = "2項目";
 "settings.sync.success" = "正常に同期されました";
 "settings.sync.guestAiActive" = "ゲスト AI がアクティブです";
 "settings.sync.notSyncing" = "同期なし";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "アニメーション";
 "settings.test.animations.probability" = "確率 %@";
 "settings.test.animations.playAccessibility" = "%@ のアニメーションを再生、%@";
+"settings.test.storeReviewPromptReset" = "App Storeレビューのプロンプトをリセット";
+"settings.test.storeReviewPromptReset.value" = "ローカル状態";
 
 "settings.access.title" = "アクセス";
 "settings.access.section.permissions" = "権限";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 предмета";
 "settings.section.test" = "Тест";
 "settings.row.test" = "Тест";
-"settings.row.test.itemCount" = "1 пункт";
+"settings.row.test.itemCount" = "2 пункта";
 "settings.sync.success" = "Синхронизировано успешно";
 "settings.sync.guestAiActive" = "Гостевой AI активен";
 "settings.sync.notSyncing" = "Нет синхронизации";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "Анимации";
 "settings.test.animations.probability" = "Вероятность %@";
 "settings.test.animations.playAccessibility" = "Воспроизвести анимацию %@, %@";
+"settings.test.storeReviewPromptReset" = "Сбросить запрос отзыва в App Store";
+"settings.test.storeReviewPromptReset.value" = "Локальное состояние";
 
 "settings.access.title" = "Доступ";
 "settings.access.section.permissions" = "Разрешения";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -132,7 +132,7 @@
 "settings.row.access.itemCount" = "4 件";
 "settings.section.test" = "测试";
 "settings.row.test" = "测试";
-"settings.row.test.itemCount" = "1 项";
+"settings.row.test.itemCount" = "2 项";
 "settings.sync.success" = "同步成功";
 "settings.sync.guestAiActive" = "访客AI已激活";
 "settings.sync.notSyncing" = "不同步";
@@ -190,6 +190,8 @@
 "settings.test.animations.title" = "动画";
 "settings.test.animations.probability" = "%@ 概率";
 "settings.test.animations.playAccessibility" = "播放 %@ 动画，%@";
+"settings.test.storeReviewPromptReset" = "重置 App Store 评论提示";
+"settings.test.storeReviewPromptReset.value" = "本地状态";
 
 "settings.access.title" = "访问";
 "settings.access.section.permissions" = "权限";


### PR DESCRIPTION
## Summary
- Add a native SwiftUI StoreKit review request flow after successful card reviews.
- Keep eligibility local using SQLite review history, UserDefaults prompt state, app version, and local calendar days.
- Add a hidden test reset hook and localized Settings strings for development re-checks.

## Validation
- `git --no-pager diff --check`
- `xcrun swiftc -parse` for touched Swift files
- `plutil -lint` for modified `AISettings.strings`

No simulator-backed iOS tests were run.