### PR TITLE
Implement backend in-app feedback API

### DIFF
--- a/apps/backend/src/feedback/email.ts
+++ b/apps/backend/src/feedback/email.ts
@@ -1,0 +1,234 @@
+import { captureBackendWarning, type BackendObservationScope } from "../observability/sentry";
+import { feedbackNotificationRecipientEmail, type FeedbackNotificationEmailInput } from "./types";
+
+type FetchFunction = typeof fetch;
+
+type ResendEmailConfig = Readonly<{
+  apiKey: string;
+  fromEmail: string;
+  fromName: string;
+}>;
+
+type ResendEmailRequest = Readonly<{
+  config: ResendEmailConfig;
+  input: FeedbackNotificationEmailInput;
+}>;
+
+type EmailSendDependencies = Readonly<{
+  fetchFn: FetchFunction;
+  sleepFn: (delayMs: number) => Promise<void>;
+}>;
+
+type EmailErrorDetails = Readonly<{
+  errorClass: string;
+  errorMessage: string;
+  statusCode: number | null;
+  responseBody: string | null;
+}>;
+
+const resendEmailMaxAttempts = 3;
+const resendEmailRetryBaseDelayMs = 300;
+
+export class FeedbackEmailConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+export class FeedbackEmailSendError extends Error {
+  readonly statusCode: number;
+  readonly responseBody: string;
+
+  constructor(statusCode: number, responseBody: string) {
+    super(`Resend feedback notification failed with status ${statusCode}: ${responseBody}`);
+    this.statusCode = statusCode;
+    this.responseBody = responseBody;
+  }
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+function getRequiredEnvironmentValue(name: string): string {
+  const value = process.env[name]?.trim() ?? "";
+  if (value === "") {
+    throw new FeedbackEmailConfigurationError(`${name} is required to send feedback notification email.`);
+  }
+
+  return value;
+}
+
+function getResendEmailConfig(): ResendEmailConfig {
+  return {
+    apiKey: getRequiredEnvironmentValue("RESEND_API_KEY"),
+    fromEmail: getRequiredEnvironmentValue("RESEND_FROM_EMAIL"),
+    fromName: "Flashcards Open Source App",
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function formatNullableValue(value: string | null): string {
+  return value === null ? "" : value;
+}
+
+function createEmailField(label: string, value: string | null): string {
+  return `<tr><th align="left">${escapeHtml(label)}</th><td>${escapeHtml(formatNullableValue(value))}</td></tr>`;
+}
+
+function buildFeedbackNotificationHtml(input: FeedbackNotificationEmailInput): string {
+  const fields = [
+    createEmailField("Submission ID", input.feedbackSubmissionId),
+    createEmailField("Trigger", input.trigger),
+    createEmailField("Platform", input.platform),
+    createEmailField("App version", input.appVersion),
+    createEmailField("Locale", input.locale),
+    createEmailField("Timezone", input.timezone),
+    createEmailField("User ID", input.userId),
+    createEmailField("User email", input.userEmail),
+    createEmailField("Workspace ID", input.workspaceId),
+    createEmailField("Installation ID", input.installationId),
+    createEmailField("Created at client", input.createdAtClient),
+    createEmailField("Created at server", input.createdAtServer),
+    createEmailField("Request ID", input.requestId),
+  ].join("");
+
+  return [
+    "<h1>Flashcards feedback</h1>",
+    "<h2>Message</h2>",
+    `<p>${escapeHtml(input.message).replaceAll("\n", "<br>")}</p>`,
+    "<h2>Context</h2>",
+    `<table>${fields}</table>`,
+  ].join("");
+}
+
+function buildFeedbackNotificationSubject(input: FeedbackNotificationEmailInput): string {
+  return `Flashcards feedback (${input.trigger}, ${input.platform})`;
+}
+
+async function sendResendFeedbackEmail(request: ResendEmailRequest, fetchFn: FetchFunction): Promise<void> {
+  const response = await fetchFn("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${request.config.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: `${request.config.fromName} <${request.config.fromEmail}>`,
+      to: [feedbackNotificationRecipientEmail],
+      subject: buildFeedbackNotificationSubject(request.input),
+      html: buildFeedbackNotificationHtml(request.input),
+    }),
+  });
+
+  if (response.ok) {
+    return;
+  }
+
+  const responseBody = await response.text();
+  throw new FeedbackEmailSendError(response.status, responseBody);
+}
+
+function calculateRetryDelayMs(attempt: number): number {
+  return resendEmailRetryBaseDelayMs * attempt;
+}
+
+function getEmailErrorDetails(error: unknown): EmailErrorDetails {
+  if (error instanceof FeedbackEmailSendError) {
+    return {
+      errorClass: error.name,
+      errorMessage: error.message,
+      statusCode: error.statusCode,
+      responseBody: error.responseBody,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      errorClass: error.name,
+      errorMessage: error.message,
+      statusCode: null,
+      responseBody: null,
+    };
+  }
+
+  return {
+    errorClass: "UnknownError",
+    errorMessage: String(error),
+    statusCode: null,
+    responseBody: null,
+  };
+}
+
+function captureFeedbackEmailRetryWarning(
+  scope: BackendObservationScope,
+  input: FeedbackNotificationEmailInput,
+  attempt: number,
+  delayMs: number,
+  error: unknown,
+): void {
+  captureBackendWarning({
+    action: "feedback_notification_email_retry",
+    scope,
+    details: {
+      feedbackSubmissionId: input.feedbackSubmissionId,
+      attempt,
+      maxAttempts: resendEmailMaxAttempts,
+      delayMs,
+      ...getEmailErrorDetails(error),
+    },
+  });
+}
+
+async function sendFeedbackNotificationEmailWithDependencies(
+  input: FeedbackNotificationEmailInput,
+  scope: BackendObservationScope,
+  dependencies: EmailSendDependencies,
+): Promise<void> {
+  const config = getResendEmailConfig();
+  let attempt = 1;
+  let lastError: unknown = null;
+
+  while (attempt <= resendEmailMaxAttempts) {
+    try {
+      await sendResendFeedbackEmail({ config, input }, dependencies.fetchFn);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt === resendEmailMaxAttempts) {
+        throw error;
+      }
+
+      const delayMs = calculateRetryDelayMs(attempt);
+      captureFeedbackEmailRetryWarning(scope, input, attempt, delayMs, error);
+      await dependencies.sleepFn(delayMs);
+      attempt += 1;
+    }
+  }
+
+  throw lastError;
+}
+
+export async function sendFeedbackNotificationEmail(
+  input: FeedbackNotificationEmailInput,
+  scope: BackendObservationScope,
+): Promise<void> {
+  await sendFeedbackNotificationEmailWithDependencies(input, scope, {
+    fetchFn: fetch,
+    sleepFn: sleep,
+  });
+}
+
+export function createFeedbackEmailErrorMessage(error: unknown): string {
+  return getEmailErrorDetails(error).errorMessage;
+}

--- a/apps/backend/src/feedback/index.ts
+++ b/apps/backend/src/feedback/index.ts
@@ -1,0 +1,202 @@
+import { withTransientDatabaseRetry } from "../database/transient";
+import { captureBackendWarning, type BackendObservationScope } from "../observability/sentry";
+import { createFeedbackEmailErrorMessage, sendFeedbackNotificationEmail } from "./email";
+import {
+  loadFeedbackStateForUser,
+  recordFeedbackPromptEventForUser,
+  storeFeedbackSubmissionForUser,
+  updateFeedbackSubmissionEmailStatus,
+} from "./store";
+import type {
+  FeedbackNotificationEmailInput,
+  FeedbackPromptEventInput,
+  FeedbackState,
+  FeedbackSubmissionInput,
+  FeedbackSubmissionResponse,
+  StoredFeedbackSubmission,
+} from "./types";
+
+export type FeedbackRequestUser = Readonly<{
+  userId: string;
+  email: string | null;
+}>;
+
+export type FeedbackServiceDependencies = Readonly<{
+  loadFeedbackStateForUserFn: typeof loadFeedbackStateForUser;
+  recordFeedbackPromptEventForUserFn: typeof recordFeedbackPromptEventForUser;
+  storeFeedbackSubmissionForUserFn: typeof storeFeedbackSubmissionForUser;
+  updateFeedbackSubmissionEmailStatusFn: typeof updateFeedbackSubmissionEmailStatus;
+  sendFeedbackNotificationEmailFn: typeof sendFeedbackNotificationEmail;
+}>;
+
+export type WithTransientDatabaseRetry = typeof withTransientDatabaseRetry;
+
+export const feedbackServiceDependencies: FeedbackServiceDependencies = {
+  loadFeedbackStateForUserFn: loadFeedbackStateForUser,
+  recordFeedbackPromptEventForUserFn: recordFeedbackPromptEventForUser,
+  storeFeedbackSubmissionForUserFn: storeFeedbackSubmissionForUser,
+  updateFeedbackSubmissionEmailStatusFn: updateFeedbackSubmissionEmailStatus,
+  sendFeedbackNotificationEmailFn: sendFeedbackNotificationEmail,
+};
+
+function getCaughtErrorClass(error: unknown): string {
+  return error instanceof Error ? error.name : "UnknownError";
+}
+
+function getCaughtErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function captureEmailFailureWarning(
+  scope: BackendObservationScope,
+  storedSubmission: StoredFeedbackSubmission,
+  error: unknown,
+): void {
+  captureBackendWarning({
+    action: "feedback_notification_email_failed",
+    scope,
+    details: {
+      feedbackSubmissionId: storedSubmission.feedbackSubmissionId,
+      errorClass: getCaughtErrorClass(error),
+      errorMessage: getCaughtErrorMessage(error),
+    },
+  });
+}
+
+function createNotificationEmailInput(
+  user: FeedbackRequestUser,
+  input: FeedbackSubmissionInput,
+  storedSubmission: StoredFeedbackSubmission,
+  requestId: string,
+): FeedbackNotificationEmailInput {
+  return {
+    feedbackSubmissionId: storedSubmission.feedbackSubmissionId,
+    userId: user.userId,
+    userEmail: user.email,
+    workspaceId: input.workspaceId,
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion,
+    locale: input.locale,
+    timezone: input.timezone,
+    trigger: input.trigger,
+    message: input.message,
+    createdAtClient: input.createdAtClient,
+    createdAtServer: storedSubmission.createdAtServer,
+    requestId,
+  };
+}
+
+async function markSubmissionEmailStatus(
+  user: FeedbackRequestUser,
+  storedSubmission: StoredFeedbackSubmission,
+  status: "sent" | "failed",
+  errorMessage: string | null,
+  scope: BackendObservationScope,
+  withTransientDatabaseRetryFn: WithTransientDatabaseRetry,
+  dependencies: FeedbackServiceDependencies,
+): Promise<void> {
+  await withTransientDatabaseRetryFn(
+    async () => dependencies.updateFeedbackSubmissionEmailStatusFn(
+      user.userId,
+      storedSubmission.feedbackSubmissionId,
+      status,
+      errorMessage,
+    ),
+    () => scope,
+  );
+}
+
+async function sendNotificationForNewSubmission(
+  user: FeedbackRequestUser,
+  input: FeedbackSubmissionInput,
+  storedSubmission: StoredFeedbackSubmission,
+  requestId: string,
+  scope: BackendObservationScope,
+  withTransientDatabaseRetryFn: WithTransientDatabaseRetry,
+  dependencies: FeedbackServiceDependencies,
+): Promise<void> {
+  const notificationInput = createNotificationEmailInput(user, input, storedSubmission, requestId);
+  try {
+    await dependencies.sendFeedbackNotificationEmailFn(notificationInput, scope);
+  } catch (error) {
+    captureEmailFailureWarning(scope, storedSubmission, error);
+    await markSubmissionEmailStatus(
+      user,
+      storedSubmission,
+      "failed",
+      createFeedbackEmailErrorMessage(error),
+      scope,
+      withTransientDatabaseRetryFn,
+      dependencies,
+    );
+    return;
+  }
+
+  await markSubmissionEmailStatus(user, storedSubmission, "sent", null, scope, withTransientDatabaseRetryFn, dependencies);
+}
+
+export async function loadFeedbackStateForRequest(
+  user: FeedbackRequestUser,
+  scope: BackendObservationScope,
+  withTransientDatabaseRetryFn: WithTransientDatabaseRetry,
+  dependencies: FeedbackServiceDependencies,
+): Promise<FeedbackState> {
+  return withTransientDatabaseRetryFn(
+    async () => dependencies.loadFeedbackStateForUserFn(user.userId),
+    () => scope,
+  );
+}
+
+export async function recordFeedbackPromptEventForRequest(
+  user: FeedbackRequestUser,
+  input: FeedbackPromptEventInput,
+  scope: BackendObservationScope,
+  withTransientDatabaseRetryFn: WithTransientDatabaseRetry,
+  dependencies: FeedbackServiceDependencies,
+): Promise<FeedbackState> {
+  return withTransientDatabaseRetryFn(
+    async () => dependencies.recordFeedbackPromptEventForUserFn(user.userId, input),
+    () => scope,
+  );
+}
+
+export async function submitFeedbackForRequest(
+  user: FeedbackRequestUser,
+  input: FeedbackSubmissionInput,
+  requestId: string,
+  scope: BackendObservationScope,
+  withTransientDatabaseRetryFn: WithTransientDatabaseRetry,
+  dependencies: FeedbackServiceDependencies,
+): Promise<FeedbackSubmissionResponse> {
+  const storedSubmission = await withTransientDatabaseRetryFn(
+    async () => dependencies.storeFeedbackSubmissionForUserFn(user.userId, user.email, input),
+    () => scope,
+  );
+
+  if (storedSubmission.emailNotificationRequired) {
+    await sendNotificationForNewSubmission(
+      user,
+      input,
+      storedSubmission,
+      requestId,
+      scope,
+      withTransientDatabaseRetryFn,
+      dependencies,
+    );
+  }
+
+  const feedbackState = await loadFeedbackStateForRequest(user, scope, withTransientDatabaseRetryFn, dependencies);
+  return {
+    feedbackSubmissionId: storedSubmission.feedbackSubmissionId,
+    createdAtServer: storedSubmission.createdAtServer,
+    feedbackState,
+  };
+}
+
+export type {
+  FeedbackPromptEventInput,
+  FeedbackState,
+  FeedbackSubmissionInput,
+  FeedbackSubmissionResponse,
+};

--- a/apps/backend/src/feedback/input.ts
+++ b/apps/backend/src/feedback/input.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { HttpError, type HttpErrorDetails, type ValidationIssueSummary } from "../shared/errors";
+import {
+  feedbackMessageMaxCharacters,
+  type FeedbackPromptEventInput,
+  type FeedbackSubmissionInput,
+} from "./types";
+
+const uuidStringSchema = z.string().uuid().transform((value) => value.toLowerCase());
+const nullableUuidStringSchema = uuidStringSchema.nullable();
+const platformSchema = z.enum(["ios", "android", "web"]);
+const promptEventTypeSchema = z.enum(["automatic_prompt_shown", "automatic_prompt_dismissed"]);
+const submissionTriggerSchema = z.enum(["automatic", "settings"]);
+const requiredNullableTextSchema = z.string().trim().min(1).nullable();
+const isoTimestampSchema = z.string().datetime().transform((value) => new Date(value).toISOString());
+const messageSchema = z.string()
+  .transform((value) => value.trim())
+  .pipe(z.string().min(1).max(feedbackMessageMaxCharacters));
+
+const feedbackPromptEventInputSchema = z.strictObject({
+  feedbackPromptEventId: uuidStringSchema,
+  workspaceId: nullableUuidStringSchema,
+  installationId: nullableUuidStringSchema,
+  platform: platformSchema,
+  appVersion: requiredNullableTextSchema,
+  locale: requiredNullableTextSchema,
+  timezone: requiredNullableTextSchema,
+  eventType: promptEventTypeSchema,
+  createdAtClient: isoTimestampSchema,
+});
+
+const feedbackSubmissionInputSchema = z.strictObject({
+  feedbackSubmissionId: uuidStringSchema,
+  workspaceId: nullableUuidStringSchema,
+  installationId: nullableUuidStringSchema,
+  platform: platformSchema,
+  appVersion: requiredNullableTextSchema,
+  locale: requiredNullableTextSchema,
+  timezone: requiredNullableTextSchema,
+  trigger: submissionTriggerSchema,
+  message: messageSchema,
+  createdAtClient: isoTimestampSchema,
+});
+
+function summarizeValidationIssue(issue: z.core.$ZodIssue): ValidationIssueSummary {
+  const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+  return {
+    path,
+    code: issue.code,
+    message: issue.message,
+  };
+}
+
+function summarizeValidationDetails(error: z.ZodError): HttpErrorDetails {
+  return {
+    validationIssues: error.issues.map(summarizeValidationIssue),
+  };
+}
+
+function parseFeedbackInput<ParsedType>(schema: z.ZodSchema<ParsedType>, value: unknown): ParsedType {
+  const parsedInput = schema.safeParse(value);
+  if (parsedInput.success) {
+    return parsedInput.data;
+  }
+
+  throw new HttpError(
+    400,
+    "Feedback request is invalid.",
+    "FEEDBACK_INVALID_INPUT",
+    summarizeValidationDetails(parsedInput.error),
+  );
+}
+
+export function parseFeedbackPromptEventInput(value: unknown): FeedbackPromptEventInput {
+  return parseFeedbackInput(feedbackPromptEventInputSchema, value);
+}
+
+export function parseFeedbackSubmissionInput(value: unknown): FeedbackSubmissionInput {
+  return parseFeedbackInput(feedbackSubmissionInputSchema, value);
+}

--- a/apps/backend/src/feedback/store.ts
+++ b/apps/backend/src/feedback/store.ts
@@ -1,0 +1,381 @@
+import { queryWithUserScope, transactionWithUserScope, type DatabaseExecutor } from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  feedbackAutomaticPromptCooldownDays,
+  type FeedbackEmailNotificationStatus,
+  type FeedbackPromptEventInput,
+  type FeedbackState,
+  type FeedbackSubmissionInput,
+  type StoredFeedbackSubmission,
+} from "./types";
+
+const millisecondsPerDay = 86_400_000;
+
+type FeedbackStateRow = Readonly<{
+  last_automatic_prompt_at: Date | string | null;
+  last_submitted_at: Date | string | null;
+}>;
+
+type ExistingFeedbackRow = Readonly<{
+  id: string;
+}>;
+
+type StoredFeedbackSubmissionRow = Readonly<{
+  feedback_submission_id: string;
+  created_at_server: Date | string;
+}>;
+
+function toIsoString(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function toOptionalIsoString(value: Date | string | null): string | null {
+  return value === null ? null : toIsoString(value);
+}
+
+function addDaysToIsoTimestamp(value: string, days: number): string {
+  const date = new Date(value);
+  return new Date(date.getTime() + days * millisecondsPerDay).toISOString();
+}
+
+function getLaterIsoTimestamp(left: string | null, right: string | null): string | null {
+  if (left === null) {
+    return right;
+  }
+
+  if (right === null) {
+    return left;
+  }
+
+  return new Date(left).getTime() >= new Date(right).getTime() ? left : right;
+}
+
+function toFeedbackState(row: FeedbackStateRow): FeedbackState {
+  const lastAutomaticPromptAt = toOptionalIsoString(row.last_automatic_prompt_at);
+  const lastSubmittedAt = toOptionalIsoString(row.last_submitted_at);
+  const cooldownBaseAt = getLaterIsoTimestamp(lastAutomaticPromptAt, lastSubmittedAt);
+  return {
+    automaticPromptCooldownDays: feedbackAutomaticPromptCooldownDays,
+    lastAutomaticPromptAt,
+    lastSubmittedAt,
+    nextAutomaticPromptAt: cooldownBaseAt === null
+      ? null
+      : addDaysToIsoTimestamp(cooldownBaseAt, feedbackAutomaticPromptCooldownDays),
+  };
+}
+
+async function loadFeedbackStateInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+): Promise<FeedbackState> {
+  const result = await executor.query<FeedbackStateRow>(
+    [
+      "SELECT",
+      "MAX(feedback_prompt_events.created_at_server)",
+      "FILTER (WHERE feedback_prompt_events.event_type = 'automatic_prompt_shown') AS last_automatic_prompt_at,",
+      "(",
+      "SELECT MAX(feedback_submissions.created_at_server)",
+      "FROM support.feedback_submissions AS feedback_submissions",
+      "WHERE feedback_submissions.user_id = $1",
+      ") AS last_submitted_at",
+      "FROM support.feedback_prompt_events AS feedback_prompt_events",
+      "WHERE feedback_prompt_events.user_id = $1",
+    ].join(" "),
+    [userId],
+  );
+
+  return toFeedbackState(result.rows[0] ?? {
+    last_automatic_prompt_at: null,
+    last_submitted_at: null,
+  });
+}
+
+async function assertWorkspaceAccessInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string | null,
+): Promise<void> {
+  if (workspaceId === null) {
+    return;
+  }
+
+  const result = await executor.query<Readonly<{ ok: number }>>(
+    [
+      "SELECT 1 AS ok",
+      "FROM org.workspace_memberships",
+      "WHERE user_id = $1",
+      "AND workspace_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [userId, workspaceId],
+  );
+
+  if (result.rows.length === 0) {
+    throw new HttpError(
+      403,
+      "workspaceId must reference a workspace accessible to the authenticated user.",
+      "FEEDBACK_WORKSPACE_FORBIDDEN",
+    );
+  }
+}
+
+async function assertInstallationOwnershipInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  installationId: string | null,
+): Promise<void> {
+  if (installationId === null) {
+    return;
+  }
+
+  const result = await executor.query<Readonly<{ ok: number }>>(
+    [
+      "SELECT 1 AS ok",
+      "FROM sync.installations",
+      "WHERE user_id = $1",
+      "AND installation_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [userId, installationId],
+  );
+
+  if (result.rows.length === 0) {
+    throw new HttpError(
+      403,
+      "installationId must reference an installation owned by the authenticated user.",
+      "FEEDBACK_INSTALLATION_FORBIDDEN",
+    );
+  }
+}
+
+async function assertFeedbackReferencesInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string | null,
+  installationId: string | null,
+): Promise<void> {
+  await assertWorkspaceAccessInExecutor(executor, userId, workspaceId);
+  await assertInstallationOwnershipInExecutor(executor, userId, installationId);
+}
+
+async function assertExistingPromptEventIsVisibleInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  feedbackPromptEventId: string,
+): Promise<void> {
+  const existingRow = await loadExistingPromptEventInExecutor(executor, userId, feedbackPromptEventId);
+  if (existingRow === null) {
+    throw new HttpError(
+      409,
+      "feedbackPromptEventId is already used by another feedback prompt event.",
+      "FEEDBACK_PROMPT_EVENT_ID_CONFLICT",
+    );
+  }
+}
+
+async function loadExistingPromptEventInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  feedbackPromptEventId: string,
+): Promise<ExistingFeedbackRow | null> {
+  const result = await executor.query<ExistingFeedbackRow>(
+    [
+      "SELECT feedback_prompt_event_id AS id",
+      "FROM support.feedback_prompt_events",
+      "WHERE feedback_prompt_event_id = $1",
+      "AND user_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [feedbackPromptEventId, userId],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+async function findExistingSubmissionInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  feedbackSubmissionId: string,
+): Promise<StoredFeedbackSubmissionRow | null> {
+  const result = await executor.query<StoredFeedbackSubmissionRow>(
+    [
+      "SELECT feedback_submission_id, created_at_server",
+      "FROM support.feedback_submissions",
+      "WHERE feedback_submission_id = $1",
+      "AND user_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [feedbackSubmissionId, userId],
+  );
+
+  return result.rows[0] ?? null;
+}
+
+async function loadExistingSubmissionInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  feedbackSubmissionId: string,
+): Promise<StoredFeedbackSubmissionRow> {
+  const row = await findExistingSubmissionInExecutor(executor, userId, feedbackSubmissionId);
+  if (row === null) {
+    throw new HttpError(
+      409,
+      "feedbackSubmissionId is already used by another feedback submission.",
+      "FEEDBACK_SUBMISSION_ID_CONFLICT",
+    );
+  }
+
+  return row;
+}
+
+export async function loadFeedbackStateForUser(userId: string): Promise<FeedbackState> {
+  const result = await queryWithUserScope<FeedbackStateRow>(
+    { userId },
+    [
+      "SELECT",
+      "MAX(feedback_prompt_events.created_at_server)",
+      "FILTER (WHERE feedback_prompt_events.event_type = 'automatic_prompt_shown') AS last_automatic_prompt_at,",
+      "(",
+      "SELECT MAX(feedback_submissions.created_at_server)",
+      "FROM support.feedback_submissions AS feedback_submissions",
+      "WHERE feedback_submissions.user_id = $1",
+      ") AS last_submitted_at",
+      "FROM support.feedback_prompt_events AS feedback_prompt_events",
+      "WHERE feedback_prompt_events.user_id = $1",
+    ].join(" "),
+    [userId],
+  );
+
+  return toFeedbackState(result.rows[0] ?? {
+    last_automatic_prompt_at: null,
+    last_submitted_at: null,
+  });
+}
+
+export async function recordFeedbackPromptEventForUser(
+  userId: string,
+  input: FeedbackPromptEventInput,
+): Promise<FeedbackState> {
+  return transactionWithUserScope({ userId }, async (executor) => {
+    const existingRow = await loadExistingPromptEventInExecutor(executor, userId, input.feedbackPromptEventId);
+    if (existingRow !== null) {
+      return loadFeedbackStateInExecutor(executor, userId);
+    }
+
+    await assertFeedbackReferencesInExecutor(executor, userId, input.workspaceId, input.installationId);
+
+    const insertResult = await executor.query<ExistingFeedbackRow>(
+      [
+        "INSERT INTO support.feedback_prompt_events (",
+        "feedback_prompt_event_id, user_id, workspace_id, installation_id, platform,",
+        "app_version, locale, timezone, event_type, created_at_client",
+        ") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+        "ON CONFLICT (feedback_prompt_event_id) DO NOTHING",
+        "RETURNING feedback_prompt_event_id AS id",
+      ].join(" "),
+      [
+        input.feedbackPromptEventId,
+        userId,
+        input.workspaceId,
+        input.installationId,
+        input.platform,
+        input.appVersion,
+        input.locale,
+        input.timezone,
+        input.eventType,
+        input.createdAtClient,
+      ],
+    );
+
+    if (insertResult.rows.length === 0) {
+      await assertExistingPromptEventIsVisibleInExecutor(executor, userId, input.feedbackPromptEventId);
+    }
+
+    return loadFeedbackStateInExecutor(executor, userId);
+  });
+}
+
+export async function storeFeedbackSubmissionForUser(
+  userId: string,
+  email: string | null,
+  input: FeedbackSubmissionInput,
+): Promise<StoredFeedbackSubmission> {
+  return transactionWithUserScope({ userId }, async (executor) => {
+    const existingRow = await findExistingSubmissionInExecutor(executor, userId, input.feedbackSubmissionId);
+    if (existingRow !== null) {
+      return {
+        feedbackSubmissionId: existingRow.feedback_submission_id,
+        createdAtServer: toIsoString(existingRow.created_at_server),
+        emailNotificationRequired: false,
+      };
+    }
+
+    await assertFeedbackReferencesInExecutor(executor, userId, input.workspaceId, input.installationId);
+
+    const insertResult = await executor.query<StoredFeedbackSubmissionRow>(
+      [
+        "INSERT INTO support.feedback_submissions (",
+        "feedback_submission_id, user_id, email, workspace_id, installation_id, platform,",
+        "app_version, locale, timezone, trigger, message, created_at_client",
+        ") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+        "ON CONFLICT (feedback_submission_id) DO NOTHING",
+        "RETURNING feedback_submission_id, created_at_server",
+      ].join(" "),
+      [
+        input.feedbackSubmissionId,
+        userId,
+        email,
+        input.workspaceId,
+        input.installationId,
+        input.platform,
+        input.appVersion,
+        input.locale,
+        input.timezone,
+        input.trigger,
+        input.message,
+        input.createdAtClient,
+      ],
+    );
+
+    const insertedRow = insertResult.rows[0];
+    if (insertedRow !== undefined) {
+      return {
+        feedbackSubmissionId: insertedRow.feedback_submission_id,
+        createdAtServer: toIsoString(insertedRow.created_at_server),
+        emailNotificationRequired: true,
+      };
+    }
+
+    const conflictExistingRow = await loadExistingSubmissionInExecutor(executor, userId, input.feedbackSubmissionId);
+    return {
+      feedbackSubmissionId: conflictExistingRow.feedback_submission_id,
+      createdAtServer: toIsoString(conflictExistingRow.created_at_server),
+      emailNotificationRequired: false,
+    };
+  });
+}
+
+export async function updateFeedbackSubmissionEmailStatus(
+  userId: string,
+  feedbackSubmissionId: string,
+  status: FeedbackEmailNotificationStatus,
+  errorMessage: string | null,
+): Promise<void> {
+  await transactionWithUserScope({ userId }, async (executor) => {
+    const result = await executor.query<Readonly<{ feedback_submission_id: string }>>(
+      [
+        "UPDATE support.feedback_submissions",
+        "SET email_notification_status = $2,",
+        "email_notification_error = $3",
+        "WHERE feedback_submission_id = $1",
+        "AND user_id = $4",
+        "RETURNING feedback_submission_id",
+      ].join(" "),
+      [feedbackSubmissionId, status, errorMessage, userId],
+    );
+
+    if (result.rows.length !== 1) {
+      throw new Error(`Failed to update feedback submission email status for submission ${feedbackSubmissionId}`);
+    }
+  });
+}

--- a/apps/backend/src/feedback/types.ts
+++ b/apps/backend/src/feedback/types.ts
@@ -1,0 +1,69 @@
+export const feedbackAutomaticPromptCooldownDays = 30;
+export const feedbackMessageMaxCharacters = 5000;
+export const feedbackNotificationRecipientEmail = "kirill+flashcards@kirill-markin.com";
+
+export type FeedbackPlatform = "ios" | "android" | "web";
+export type FeedbackPromptEventType = "automatic_prompt_shown" | "automatic_prompt_dismissed";
+export type FeedbackSubmissionTrigger = "automatic" | "settings";
+export type FeedbackEmailNotificationStatus = "pending" | "sent" | "failed";
+
+export type FeedbackState = Readonly<{
+  automaticPromptCooldownDays: number;
+  lastAutomaticPromptAt: string | null;
+  lastSubmittedAt: string | null;
+  nextAutomaticPromptAt: string | null;
+}>;
+
+export type FeedbackPromptEventInput = Readonly<{
+  feedbackPromptEventId: string;
+  workspaceId: string | null;
+  installationId: string | null;
+  platform: FeedbackPlatform;
+  appVersion: string | null;
+  locale: string | null;
+  timezone: string | null;
+  eventType: FeedbackPromptEventType;
+  createdAtClient: string;
+}>;
+
+export type FeedbackSubmissionInput = Readonly<{
+  feedbackSubmissionId: string;
+  workspaceId: string | null;
+  installationId: string | null;
+  platform: FeedbackPlatform;
+  appVersion: string | null;
+  locale: string | null;
+  timezone: string | null;
+  trigger: FeedbackSubmissionTrigger;
+  message: string;
+  createdAtClient: string;
+}>;
+
+export type StoredFeedbackSubmission = Readonly<{
+  feedbackSubmissionId: string;
+  createdAtServer: string;
+  emailNotificationRequired: boolean;
+}>;
+
+export type FeedbackSubmissionResponse = Readonly<{
+  feedbackSubmissionId: string;
+  createdAtServer: string;
+  feedbackState: FeedbackState;
+}>;
+
+export type FeedbackNotificationEmailInput = Readonly<{
+  feedbackSubmissionId: string;
+  userId: string;
+  userEmail: string | null;
+  workspaceId: string | null;
+  installationId: string | null;
+  platform: FeedbackPlatform;
+  appVersion: string | null;
+  locale: string | null;
+  timezone: string | null;
+  trigger: FeedbackSubmissionTrigger;
+  message: string;
+  createdAtClient: string;
+  createdAtServer: string;
+  requestId: string;
+}>;

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -171,6 +171,22 @@ export type AccountDeleteDetails = Readonly<{
   transport: string;
 }>;
 
+export type FeedbackStateDetails = Readonly<{
+  statusCode: number;
+}>;
+
+export type FeedbackPromptEventDetails = Readonly<{
+  statusCode: number;
+  platform: string | null;
+  eventType: string | null;
+}>;
+
+export type FeedbackSubmissionDetails = Readonly<{
+  statusCode: number;
+  platform: string | null;
+  trigger: string | null;
+}>;
+
 export type WorkspaceTagsListDetails = Readonly<{
   statusCode: number;
   tagsCount: number | null;
@@ -528,6 +544,23 @@ export type GlobalMetricsS3RetryDetails = Readonly<{
   errorMessage: string;
 }>;
 
+export type FeedbackEmailRetryDetails = Readonly<{
+  feedbackSubmissionId: string;
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  errorClass: string;
+  errorMessage: string;
+  statusCode: number | null;
+  responseBody: string | null;
+}>;
+
+export type FeedbackEmailFailureDetails = Readonly<{
+  feedbackSubmissionId: string;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
 export type MigrationFailureDetails = Readonly<{
   migrationSurface: "lambda";
   operation: "run_migrations";
@@ -567,6 +600,12 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>>
   | EventByAction<"account_delete", AccountDeleteDetails>
   | EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>>
+  | EventByAction<"feedback_state", FeedbackStateDetails>
+  | EventByAction<"feedback_state_error", FailureDetailsFor<FeedbackStateDetails>>
+  | EventByAction<"feedback_prompt_event", FeedbackPromptEventDetails>
+  | EventByAction<"feedback_prompt_event_error", FailureDetailsFor<FeedbackPromptEventDetails>>
+  | EventByAction<"feedback_submission", FeedbackSubmissionDetails>
+  | EventByAction<"feedback_submission_error", FailureDetailsFor<FeedbackSubmissionDetails>>
   | EventByAction<"workspace_tags_list", WorkspaceTagsListDetails>
   | EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>>
   | EventByAction<"cards_query", CardsQueryDetails>
@@ -616,6 +655,8 @@ export type BackendWarningEvent =
   }>> & Readonly<{ message: string }>)
   | EventByAction<"unsafe_transaction_rollback_failed", DatabaseRollbackFailureDetails>
   | EventByAction<"database_pool_error", DatabasePoolErrorDetails>
+  | EventByAction<"feedback_notification_email_retry", FeedbackEmailRetryDetails>
+  | EventByAction<"feedback_notification_email_failed", FeedbackEmailFailureDetails>
   | EventByAction<"reporting_read_only_transaction_rollback_failed", DatabaseRollbackFailureDetails>
   | (EventByAction<"chat_live_backlog_failed", ChatLiveLifecycleDetails> & Readonly<{ message: string }>)
   | (EventByAction<"chat_live_write_failed", ChatLiveLifecycleDetails> & Readonly<{ message: string }>)
@@ -670,6 +711,9 @@ export type BackendExceptionEvent =
   | (EventByAction<"me_progress_review_schedule_error", FailureDetailsFor<ProgressReviewScheduleDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"feedback_state_error", FailureDetailsFor<FeedbackStateDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"feedback_prompt_event_error", FailureDetailsFor<FeedbackPromptEventDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"feedback_submission_error", FailureDetailsFor<FeedbackSubmissionDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"workspace_tags_list_error", FailureDetailsFor<WorkspaceTagsListDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"cards_query_error", FailureDetailsFor<CardsQueryDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"guest_upgrade_complete_error", FailureDetailsFor<GuestUpgradeCompleteDetails>> & Readonly<{ error: Error }>)

--- a/apps/backend/src/routes/feedback.test.ts
+++ b/apps/backend/src/routes/feedback.test.ts
@@ -1,0 +1,553 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { AuthError } from "../auth";
+import type { AppEnv } from "../server/app";
+import type { RequestContext } from "../server/requestContext";
+import { HttpError } from "../shared/errors";
+import type { BackendObservationScope } from "../observability/sentry";
+import type {
+  FeedbackNotificationEmailInput,
+  FeedbackPromptEventInput,
+  FeedbackState,
+  FeedbackSubmissionInput,
+  StoredFeedbackSubmission,
+} from "../feedback/types";
+import type { FeedbackServiceDependencies } from "../feedback";
+import { createFeedbackRoutes } from "./feedback";
+
+type PromptEventRecord = FeedbackPromptEventInput & Readonly<{
+  userId: string;
+  createdAtServer: string;
+}>;
+
+type SubmissionRecord = FeedbackSubmissionInput & Readonly<{
+  userId: string;
+  email: string | null;
+  createdAtServer: string;
+  emailNotificationStatus: "pending" | "sent" | "failed";
+  emailNotificationError: string | null;
+}>;
+
+type FeedbackStoreState = {
+  promptEvents: Map<string, PromptEventRecord>;
+  submissions: Map<string, SubmissionRecord>;
+  sentEmails: Array<FeedbackNotificationEmailInput>;
+  sendEmailError: Error | null;
+  nextTimestampIndex: number;
+};
+
+type FeedbackTestAppOptions = Readonly<{
+  transport: RequestContext["transport"];
+  state: FeedbackStoreState;
+  loadRequestContextError: AuthError | null;
+}>;
+
+const workspaceId = "11111111-1111-4111-8111-111111111111";
+const promptEventId = "22222222-2222-4222-8222-222222222222";
+const submissionId = "33333333-3333-4333-8333-333333333333";
+const installationId = "44444444-4444-4444-8444-444444444444";
+const serverTimestamps = [
+  "2026-06-03T10:00:00.000Z",
+  "2026-06-03T10:01:00.000Z",
+  "2026-06-03T10:02:00.000Z",
+] as const;
+
+function createRequestContext(transport: RequestContext["transport"]): RequestContext {
+  return {
+    userId: "user-1",
+    subjectUserId: "subject-1",
+    selectedWorkspaceId: workspaceId,
+    email: transport === "guest" ? null : "user@example.com",
+    locale: "en",
+    userSettingsCreatedAt: "2026-04-17T00:00:00.000Z",
+    transport,
+    connectionId: transport === "api_key" ? "connection-1" : null,
+  };
+}
+
+function createEmptyStoreState(sendEmailError: Error | null): FeedbackStoreState {
+  return {
+    promptEvents: new Map(),
+    submissions: new Map(),
+    sentEmails: [],
+    sendEmailError,
+    nextTimestampIndex: 0,
+  };
+}
+
+function nextServerTimestamp(state: FeedbackStoreState): string {
+  const timestamp = serverTimestamps[state.nextTimestampIndex];
+  if (timestamp === undefined) {
+    throw new Error("Test timestamp fixture exhausted");
+  }
+
+  state.nextTimestampIndex += 1;
+  return timestamp;
+}
+
+function addDaysToIsoTimestamp(value: string, days: number): string {
+  const date = new Date(value);
+  return new Date(date.getTime() + days * 86_400_000).toISOString();
+}
+
+function getLaterIsoTimestamp(left: string | null, right: string | null): string | null {
+  if (left === null) {
+    return right;
+  }
+
+  if (right === null) {
+    return left;
+  }
+
+  return new Date(left).getTime() >= new Date(right).getTime() ? left : right;
+}
+
+function createFeedbackStateForUser(state: FeedbackStoreState, userId: string): FeedbackState {
+  const promptTimes = Array.from(state.promptEvents.values())
+    .filter((event) => event.userId === userId && event.eventType === "automatic_prompt_shown")
+    .map((event) => event.createdAtServer);
+  const submissionTimes = Array.from(state.submissions.values())
+    .filter((submission) => submission.userId === userId)
+    .map((submission) => submission.createdAtServer);
+  const lastAutomaticPromptAt = promptTimes.length === 0
+    ? null
+    : promptTimes.reduce((latest, current) => getLaterIsoTimestamp(latest, current) ?? current);
+  const lastSubmittedAt = submissionTimes.length === 0
+    ? null
+    : submissionTimes.reduce((latest, current) => getLaterIsoTimestamp(latest, current) ?? current);
+  const cooldownBaseAt = getLaterIsoTimestamp(lastAutomaticPromptAt, lastSubmittedAt);
+
+  return {
+    automaticPromptCooldownDays: 30,
+    lastAutomaticPromptAt,
+    lastSubmittedAt,
+    nextAutomaticPromptAt: cooldownBaseAt === null ? null : addDaysToIsoTimestamp(cooldownBaseAt, 30),
+  };
+}
+
+function createFeedbackDependencies(state: FeedbackStoreState): FeedbackServiceDependencies {
+  return {
+    loadFeedbackStateForUserFn: async (userId) => createFeedbackStateForUser(state, userId),
+    recordFeedbackPromptEventForUserFn: async (userId, input) => {
+      const existing = state.promptEvents.get(input.feedbackPromptEventId);
+      if (existing !== undefined && existing.userId !== userId) {
+        throw new HttpError(
+          409,
+          "feedbackPromptEventId is already used by another feedback prompt event.",
+          "FEEDBACK_PROMPT_EVENT_ID_CONFLICT",
+        );
+      }
+
+      if (existing === undefined) {
+        state.promptEvents.set(input.feedbackPromptEventId, {
+          ...input,
+          userId,
+          createdAtServer: nextServerTimestamp(state),
+        });
+      }
+
+      return createFeedbackStateForUser(state, userId);
+    },
+    storeFeedbackSubmissionForUserFn: async (userId, email, input): Promise<StoredFeedbackSubmission> => {
+      const existing = state.submissions.get(input.feedbackSubmissionId);
+      if (existing !== undefined && existing.userId !== userId) {
+        throw new HttpError(
+          409,
+          "feedbackSubmissionId is already used by another feedback submission.",
+          "FEEDBACK_SUBMISSION_ID_CONFLICT",
+        );
+      }
+
+      if (existing !== undefined) {
+        return {
+          feedbackSubmissionId: existing.feedbackSubmissionId,
+          createdAtServer: existing.createdAtServer,
+          emailNotificationRequired: false,
+        };
+      }
+
+      const createdAtServer = nextServerTimestamp(state);
+      state.submissions.set(input.feedbackSubmissionId, {
+        ...input,
+        userId,
+        email,
+        createdAtServer,
+        emailNotificationStatus: "pending",
+        emailNotificationError: null,
+      });
+      return {
+        feedbackSubmissionId: input.feedbackSubmissionId,
+        createdAtServer,
+        emailNotificationRequired: true,
+      };
+    },
+    updateFeedbackSubmissionEmailStatusFn: async (userId, targetSubmissionId, status, errorMessage) => {
+      const existing = state.submissions.get(targetSubmissionId);
+      if (existing === undefined || existing.userId !== userId) {
+        throw new Error(`Missing submission ${targetSubmissionId}`);
+      }
+
+      state.submissions.set(targetSubmissionId, {
+        ...existing,
+        emailNotificationStatus: status,
+        emailNotificationError: errorMessage,
+      });
+    },
+    sendFeedbackNotificationEmailFn: async (input) => {
+      if (state.sendEmailError !== null) {
+        throw state.sendEmailError;
+      }
+
+      state.sentEmails.push(input);
+    },
+  };
+}
+
+async function runWithoutRetry<Result>(
+  operation: () => Promise<Result>,
+  _getObservationScope: () => BackendObservationScope,
+): Promise<Result> {
+  return operation();
+}
+
+function createFeedbackTestApp(options: FeedbackTestAppOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (context, next) => {
+    context.set("requestId", "request-1");
+    await next();
+  });
+  app.onError((error, context) => {
+    if (error instanceof AuthError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: error.message,
+        requestId: context.get("requestId"),
+        code: "AUTH_UNAUTHORIZED",
+      });
+    }
+
+    if (error instanceof HttpError) {
+      context.status(error.statusCode as ContentfulStatusCode);
+      return context.json({
+        error: error.message,
+        requestId: context.get("requestId"),
+        code: error.code,
+      });
+    }
+
+    context.status(500);
+    return context.json({
+      error: "Request failed. Try again.",
+      requestId: context.get("requestId"),
+      code: "INTERNAL_ERROR",
+    });
+  });
+  app.route("/", createFeedbackRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => {
+      if (options.loadRequestContextError !== null) {
+        throw options.loadRequestContextError;
+      }
+
+      return {
+        requestAuthInputs: {} as never,
+        requestContext: createRequestContext(options.transport),
+      };
+    },
+    feedbackServiceDependencies: createFeedbackDependencies(options.state),
+    withTransientDatabaseRetryFn: runWithoutRetry,
+  }));
+  return app;
+}
+
+function createPromptEventBody(): FeedbackPromptEventInput {
+  return {
+    feedbackPromptEventId: promptEventId,
+    workspaceId,
+    installationId,
+    platform: "ios",
+    appVersion: "1.2.3",
+    locale: "en-US",
+    timezone: "Europe/Madrid",
+    eventType: "automatic_prompt_shown",
+    createdAtClient: "2026-06-03T09:59:00.000Z",
+  };
+}
+
+function createSubmissionBody(message: string): FeedbackSubmissionInput {
+  return {
+    feedbackSubmissionId: submissionId,
+    workspaceId,
+    installationId,
+    platform: "web",
+    appVersion: "1.2.3",
+    locale: "en-US",
+    timezone: "Europe/Madrid",
+    trigger: "settings",
+    message,
+    createdAtClient: "2026-06-03T10:00:00.000Z",
+  };
+}
+
+async function postJson(app: Hono<AppEnv>, path: string, body: unknown): Promise<Response> {
+  return app.request(`http://localhost${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function postRawJson(app: Hono<AppEnv>, path: string, body: string): Promise<Response> {
+  return app.request(`http://localhost${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+}
+
+test("GET /feedback/state returns empty state", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: null,
+  });
+
+  const response = await app.request("http://localhost/feedback/state");
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    automaticPromptCooldownDays: 30,
+    lastAutomaticPromptAt: null,
+    lastSubmittedAt: null,
+    nextAutomaticPromptAt: null,
+  });
+});
+
+test("POST /feedback/prompt-events records automatic prompt state idempotently", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "session",
+    state,
+    loadRequestContextError: null,
+  });
+  const body = createPromptEventBody();
+
+  const firstResponse = await postJson(app, "/feedback/prompt-events", body);
+  const secondResponse = await postJson(app, "/feedback/prompt-events", body);
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 200);
+  assert.deepEqual(await firstResponse.json(), {
+    automaticPromptCooldownDays: 30,
+    lastAutomaticPromptAt: "2026-06-03T10:00:00.000Z",
+    lastSubmittedAt: null,
+    nextAutomaticPromptAt: "2026-07-03T10:00:00.000Z",
+  });
+  assert.deepEqual(await secondResponse.json(), {
+    automaticPromptCooldownDays: 30,
+    lastAutomaticPromptAt: "2026-06-03T10:00:00.000Z",
+    lastSubmittedAt: null,
+    nextAutomaticPromptAt: "2026-07-03T10:00:00.000Z",
+  });
+  assert.equal(state.promptEvents.size, 1);
+});
+
+test("POST /feedback/submissions records submission state and does not duplicate email on replay", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: null,
+  });
+  const body = createSubmissionBody(" Please make review faster. ");
+
+  const firstResponse = await postJson(app, "/feedback/submissions", body);
+  const secondResponse = await postJson(app, "/feedback/submissions", body);
+  const stateResponse = await app.request("http://localhost/feedback/state");
+
+  assert.equal(firstResponse.status, 200);
+  assert.equal(secondResponse.status, 200);
+  assert.deepEqual(await firstResponse.json(), {
+    feedbackSubmissionId: submissionId,
+    createdAtServer: "2026-06-03T10:00:00.000Z",
+    feedbackState: {
+      automaticPromptCooldownDays: 30,
+      lastAutomaticPromptAt: null,
+      lastSubmittedAt: "2026-06-03T10:00:00.000Z",
+      nextAutomaticPromptAt: "2026-07-03T10:00:00.000Z",
+    },
+  });
+  assert.deepEqual(await secondResponse.json(), {
+    feedbackSubmissionId: submissionId,
+    createdAtServer: "2026-06-03T10:00:00.000Z",
+    feedbackState: {
+      automaticPromptCooldownDays: 30,
+      lastAutomaticPromptAt: null,
+      lastSubmittedAt: "2026-06-03T10:00:00.000Z",
+      nextAutomaticPromptAt: "2026-07-03T10:00:00.000Z",
+    },
+  });
+  assert.deepEqual(await stateResponse.json(), {
+    automaticPromptCooldownDays: 30,
+    lastAutomaticPromptAt: null,
+    lastSubmittedAt: "2026-06-03T10:00:00.000Z",
+    nextAutomaticPromptAt: "2026-07-03T10:00:00.000Z",
+  });
+  assert.equal(state.submissions.size, 1);
+  assert.equal(state.sentEmails.length, 1);
+  assert.equal(state.sentEmails[0]?.message, "Please make review faster.");
+  assert.equal(state.submissions.get(submissionId)?.emailNotificationStatus, "sent");
+});
+
+test("POST /feedback/submissions rejects empty and too-long messages", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: null,
+  });
+
+  const emptyResponse = await postJson(app, "/feedback/submissions", createSubmissionBody("   "));
+  const tooLongResponse = await postJson(app, "/feedback/submissions", createSubmissionBody("x".repeat(5001)));
+
+  assert.equal(emptyResponse.status, 400);
+  assert.deepEqual(await emptyResponse.json(), {
+    error: "Feedback request is invalid.",
+    requestId: "request-1",
+    code: "FEEDBACK_INVALID_INPUT",
+  });
+  assert.equal(tooLongResponse.status, 400);
+  assert.deepEqual(await tooLongResponse.json(), {
+    error: "Feedback request is invalid.",
+    requestId: "request-1",
+    code: "FEEDBACK_INVALID_INPUT",
+  });
+  assert.equal(state.submissions.size, 0);
+});
+
+test("POST /feedback/submissions accepts a 5000-character escaped Unicode message", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: null,
+  });
+  const body = createSubmissionBody("placeholder");
+  const escapedMessage = "\\u0800".repeat(5000);
+  const rawBody = JSON.stringify({ ...body, message: "__MESSAGE__" })
+    .replace("\"__MESSAGE__\"", `"${escapedMessage}"`);
+
+  const response = await postRawJson(app, "/feedback/submissions", rawBody);
+
+  assert.equal(response.status, 200);
+  assert.equal(state.submissions.get(submissionId)?.message.length, 5000);
+  assert.equal(state.sentEmails.length, 1);
+});
+
+test("feedback routes accept human and guest auth and reject ApiKey auth", async () => {
+  const acceptedTransports: ReadonlyArray<RequestContext["transport"]> = ["session", "bearer", "guest"];
+  for (const transport of acceptedTransports) {
+    const state = createEmptyStoreState(null);
+    const app = createFeedbackTestApp({
+      transport,
+      state,
+      loadRequestContextError: null,
+    });
+    const response = await app.request("http://localhost/feedback/state");
+
+    assert.equal(response.status, 200);
+  }
+
+  const apiKeyState = createEmptyStoreState(null);
+  const apiKeyApp = createFeedbackTestApp({
+    transport: "api_key",
+    state: apiKeyState,
+    loadRequestContextError: null,
+  });
+  const apiKeyResponse = await apiKeyApp.request("http://localhost/feedback/state");
+
+  assert.equal(apiKeyResponse.status, 403);
+  assert.deepEqual(await apiKeyResponse.json(), {
+    error: "This endpoint requires Guest, Bearer, or Session authentication.",
+    requestId: "request-1",
+    code: "FEEDBACK_HUMAN_AUTH_REQUIRED",
+  });
+});
+
+test("feedback routes require authentication", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: new AuthError(401, "Missing authentication token"),
+  });
+
+  const response = await app.request("http://localhost/feedback/state");
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), {
+    error: "Missing authentication token",
+    requestId: "request-1",
+    code: "AUTH_UNAUTHORIZED",
+  });
+});
+
+test("POST feedback routes authenticate before parsing invalid bodies", async () => {
+  const state = createEmptyStoreState(null);
+  const app = createFeedbackTestApp({
+    transport: "bearer",
+    state,
+    loadRequestContextError: new AuthError(401, "Missing authentication token"),
+  });
+
+  const promptResponse = await postJson(app, "/feedback/prompt-events", { invalid: true });
+  const submissionResponse = await postJson(app, "/feedback/submissions", { invalid: true });
+
+  assert.equal(promptResponse.status, 401);
+  assert.deepEqual(await promptResponse.json(), {
+    error: "Missing authentication token",
+    requestId: "request-1",
+    code: "AUTH_UNAUTHORIZED",
+  });
+  assert.equal(submissionResponse.status, 401);
+  assert.deepEqual(await submissionResponse.json(), {
+    error: "Missing authentication token",
+    requestId: "request-1",
+    code: "AUTH_UNAUTHORIZED",
+  });
+  assert.equal(state.promptEvents.size, 0);
+  assert.equal(state.submissions.size, 0);
+});
+
+test("POST /feedback/submissions returns success when email notification fails", async () => {
+  const state = createEmptyStoreState(new Error("Resend is unavailable"));
+  const app = createFeedbackTestApp({
+    transport: "guest",
+    state,
+    loadRequestContextError: null,
+  });
+
+  const response = await postJson(app, "/feedback/submissions", createSubmissionBody("Offline mode needs a clearer badge."));
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    feedbackSubmissionId: submissionId,
+    createdAtServer: "2026-06-03T10:00:00.000Z",
+    feedbackState: {
+      automaticPromptCooldownDays: 30,
+      lastAutomaticPromptAt: null,
+      lastSubmittedAt: "2026-06-03T10:00:00.000Z",
+      nextAutomaticPromptAt: "2026-07-03T10:00:00.000Z",
+    },
+  });
+  assert.equal(state.sentEmails.length, 0);
+  assert.equal(state.submissions.get(submissionId)?.emailNotificationStatus, "failed");
+  assert.equal(state.submissions.get(submissionId)?.emailNotificationError, "Resend is unavailable");
+});

--- a/apps/backend/src/routes/feedback.ts
+++ b/apps/backend/src/routes/feedback.ts
@@ -1,0 +1,304 @@
+import { Hono } from "hono";
+import { withTransientDatabaseRetry } from "../database/transient";
+import {
+  feedbackServiceDependencies,
+  loadFeedbackStateForRequest,
+  recordFeedbackPromptEventForRequest,
+  submitFeedbackForRequest,
+  type FeedbackPromptEventInput,
+  type FeedbackRequestUser,
+  type FeedbackServiceDependencies,
+  type FeedbackSubmissionInput,
+} from "../feedback";
+import { parseFeedbackPromptEventInput, parseFeedbackSubmissionInput } from "../feedback/input";
+import { HttpError } from "../shared/errors";
+import { loadRequestContextFromRequest, type RequestContext } from "../server/requestContext";
+import { expectRecord, parseJsonBodyWithByteLimit } from "../server/requestParsing";
+import { createBackendFailureDetails } from "../server/logging";
+import {
+  addBackendBreadcrumb,
+  createBackendObservationScope,
+  normalizeCaughtError,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
+import type { AppEnv } from "../server/app";
+
+type FeedbackRoutesOptions = Readonly<{
+  allowedOrigins: ReadonlyArray<string>;
+  loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
+  feedbackServiceDependencies?: FeedbackServiceDependencies;
+  withTransientDatabaseRetryFn?: typeof withTransientDatabaseRetry;
+}>;
+
+const feedbackJsonBodyMaxBytes = 65_536;
+
+function getRequestContextUserId(requestContext: RequestContext | null): string | null {
+  return requestContext === null ? null : requestContext.userId;
+}
+
+function createFeedbackRouteScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string | null,
+  workspaceId: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+  );
+}
+
+function assertFeedbackTransport(requestContext: RequestContext): void {
+  if (requestContext.transport === "api_key") {
+    throw new HttpError(
+      403,
+      "This endpoint requires Guest, Bearer, or Session authentication.",
+      "FEEDBACK_HUMAN_AUTH_REQUIRED",
+    );
+  }
+}
+
+function toFeedbackRequestUser(requestContext: RequestContext): FeedbackRequestUser {
+  return {
+    userId: requestContext.userId,
+    email: requestContext.email,
+  };
+}
+
+async function parseFeedbackJsonBody(request: Request): Promise<Record<string, unknown>> {
+  return expectRecord(await parseJsonBodyWithByteLimit(
+    request,
+    feedbackJsonBodyMaxBytes,
+    "Feedback request body is too large.",
+    "FEEDBACK_BODY_TOO_LARGE",
+  ));
+}
+
+export function createFeedbackRoutes(options: FeedbackRoutesOptions): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
+  const dependencies = options.feedbackServiceDependencies ?? feedbackServiceDependencies;
+  const withTransientDatabaseRetryFn = options.withTransientDatabaseRetryFn ?? withTransientDatabaseRetry;
+
+  app.get("/feedback/state", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+
+    try {
+      const state = await withTransientDatabaseRetryFn(
+        async () => {
+          const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+          requestContext = loadedContext.requestContext;
+          assertFeedbackTransport(loadedContext.requestContext);
+          return loadFeedbackStateForRequest(
+            toFeedbackRequestUser(loadedContext.requestContext),
+            createFeedbackRouteScope(requestId, context.req.path, context.req.method, loadedContext.requestContext.userId, null),
+            withTransientDatabaseRetryFn,
+            dependencies,
+          );
+        },
+        () => createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          null,
+        ),
+      );
+
+      addBackendBreadcrumb({
+        action: "feedback_state",
+        scope: createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          null,
+        ),
+        details: {
+          statusCode: 200,
+        },
+      });
+      return context.json(state);
+    } catch (error) {
+      const scope = createFeedbackRouteScope(
+        requestId,
+        context.req.path,
+        context.req.method,
+        getRequestContextUserId(requestContext),
+        null,
+      );
+      const details = {
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "feedback_state_error", error: normalizeCaughtError(error), scope, details },
+        { action: "feedback_state_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.post("/feedback/prompt-events", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let input: FeedbackPromptEventInput | null = null;
+
+    try {
+      const loadedContext = await withTransientDatabaseRetryFn(
+        async () => {
+          const loadedContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+          requestContext = loadedContext.requestContext;
+          assertFeedbackTransport(loadedContext.requestContext);
+          return loadedContext;
+        },
+        () => createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          null,
+        ),
+      );
+      input = parseFeedbackPromptEventInput(await parseFeedbackJsonBody(context.req.raw));
+
+      const state = await recordFeedbackPromptEventForRequest(
+        toFeedbackRequestUser(loadedContext.requestContext),
+        input,
+        createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          loadedContext.requestContext.userId,
+          input.workspaceId,
+        ),
+        withTransientDatabaseRetryFn,
+        dependencies,
+      );
+
+      addBackendBreadcrumb({
+        action: "feedback_prompt_event",
+        scope: createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          input?.workspaceId ?? null,
+        ),
+        details: {
+          statusCode: 200,
+          platform: input?.platform ?? null,
+          eventType: input?.eventType ?? null,
+        },
+      });
+      return context.json(state);
+    } catch (error) {
+      const scope = createFeedbackRouteScope(
+        requestId,
+        context.req.path,
+        context.req.method,
+        getRequestContextUserId(requestContext),
+        input?.workspaceId ?? null,
+      );
+      const details = {
+        platform: input?.platform ?? null,
+        eventType: input?.eventType ?? null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "feedback_prompt_event_error", error: normalizeCaughtError(error), scope, details },
+        { action: "feedback_prompt_event_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.post("/feedback/submissions", async (context) => {
+    const requestId = context.get("requestId");
+    let requestContext: RequestContext | null = null;
+    let input: FeedbackSubmissionInput | null = null;
+
+    try {
+      const loadedContext = await withTransientDatabaseRetryFn(
+        async () => {
+          const loadedRequestContext = await loadRequestContextFromRequestFn(context.req.raw, options.allowedOrigins);
+          requestContext = loadedRequestContext.requestContext;
+          assertFeedbackTransport(loadedRequestContext.requestContext);
+          return loadedRequestContext;
+        },
+        () => createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          getRequestContextUserId(requestContext),
+          null,
+        ),
+      );
+      input = parseFeedbackSubmissionInput(await parseFeedbackJsonBody(context.req.raw));
+
+      const response = await submitFeedbackForRequest(
+        toFeedbackRequestUser(loadedContext.requestContext),
+        input,
+        requestId,
+        createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          loadedContext.requestContext.userId,
+          input.workspaceId,
+        ),
+        withTransientDatabaseRetryFn,
+        dependencies,
+      );
+
+      addBackendBreadcrumb({
+        action: "feedback_submission",
+        scope: createFeedbackRouteScope(
+          requestId,
+          context.req.path,
+          context.req.method,
+          loadedContext.requestContext.userId,
+          input.workspaceId,
+        ),
+        details: {
+          statusCode: 200,
+          platform: input.platform,
+          trigger: input.trigger,
+        },
+      });
+      return context.json(response);
+    } catch (error) {
+      const scope = createFeedbackRouteScope(
+        requestId,
+        context.req.path,
+        context.req.method,
+        getRequestContextUserId(requestContext),
+        input?.workspaceId ?? null,
+      );
+      const details = {
+        platform: input?.platform ?? null,
+        trigger: input?.trigger ?? null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "feedback_submission_error", error: normalizeCaughtError(error), scope, details },
+        { action: "feedback_submission_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  return app;
+}

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -13,6 +13,7 @@ import { createChatRoutes } from "../routes/chat";
 import { createChatTranscriptionsRoutes } from "../routes/chatTranscriptions";
 import { createAgentRoutes } from "../routes/agent";
 import { createCardsRoutes } from "../routes/cards";
+import { createFeedbackRoutes } from "../routes/feedback";
 import { createGlobalSnapshotRoutes, globalSnapshotPath } from "../routes/globalSnapshot";
 import { createSyncRoutes } from "../routes/sync";
 import { createSystemRoutes } from "../routes/system";
@@ -364,6 +365,7 @@ function createMountedApp(basePath: string, allowedOrigins: Array<string>): Hono
   app.route("/", createWorkspaceRoutes({ allowedOrigins }));
   app.route("/", createAdminRoutes({ allowedOrigins }));
   app.route("/", createCardsRoutes({ allowedOrigins }));
+  app.route("/", createFeedbackRoutes({ allowedOrigins }));
   app.route("/", createGlobalSnapshotRoutes({}));
   app.route("/", createGuestAuthRoutes());
   app.route("/", createChatTranscriptionsRoutes({ allowedOrigins }));

--- a/db/migrations/0052_in_app_feedback.sql
+++ b/db/migrations/0052_in_app_feedback.sql
@@ -1,0 +1,145 @@
+-- Migration status: Current / canonical.
+-- Introduces: backend-owned in-app product feedback storage and notification state.
+-- Current guidance: support.feedback_* tables are first-party app feedback, not app-store review state.
+
+CREATE SCHEMA IF NOT EXISTS support;
+
+CREATE TABLE IF NOT EXISTS support.feedback_prompt_events (
+  feedback_prompt_event_id UUID PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES org.user_settings(user_id) ON DELETE CASCADE,
+  workspace_id UUID REFERENCES org.workspaces(workspace_id) ON DELETE SET NULL,
+  installation_id UUID REFERENCES sync.installations(installation_id) ON DELETE SET NULL,
+  platform TEXT NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+  app_version TEXT,
+  locale TEXT,
+  timezone TEXT,
+  event_type TEXT NOT NULL CHECK (event_type IN ('automatic_prompt_shown', 'automatic_prompt_dismissed')),
+  created_at_client TIMESTAMPTZ NOT NULL,
+  created_at_server TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE support.feedback_prompt_events IS 'Cross-device in-app feedback prompt events used to enforce automatic prompt cooldown.';
+COMMENT ON COLUMN support.feedback_prompt_events.feedback_prompt_event_id IS 'Client-generated idempotency key for one prompt event.';
+COMMENT ON COLUMN support.feedback_prompt_events.event_type IS 'Automatic in-app feedback prompt lifecycle event. This is not store-review request state.';
+
+CREATE TABLE IF NOT EXISTS support.feedback_submissions (
+  feedback_submission_id UUID PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES org.user_settings(user_id) ON DELETE CASCADE,
+  email TEXT,
+  workspace_id UUID REFERENCES org.workspaces(workspace_id) ON DELETE SET NULL,
+  installation_id UUID REFERENCES sync.installations(installation_id) ON DELETE SET NULL,
+  platform TEXT NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+  app_version TEXT,
+  locale TEXT,
+  timezone TEXT,
+  trigger TEXT NOT NULL CHECK (trigger IN ('automatic', 'settings')),
+  message TEXT NOT NULL,
+  created_at_client TIMESTAMPTZ NOT NULL,
+  created_at_server TIMESTAMPTZ NOT NULL DEFAULT now(),
+  email_notification_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (email_notification_status IN ('pending', 'sent', 'failed')),
+  email_notification_error TEXT
+);
+
+COMMENT ON TABLE support.feedback_submissions IS 'Free-text first-party in-app product feedback submitted by users.';
+COMMENT ON COLUMN support.feedback_submissions.feedback_submission_id IS 'Client-generated idempotency key for one feedback submission.';
+COMMENT ON COLUMN support.feedback_submissions.trigger IS 'Client surface that submitted feedback. Automatic prompt cooldown uses this table, but manual settings feedback is never server-blocked.';
+COMMENT ON COLUMN support.feedback_submissions.email_notification_status IS 'Best-effort internal notification status. The saved row is the source of truth.';
+
+CREATE INDEX IF NOT EXISTS idx_feedback_prompt_events_user_created_at
+  ON support.feedback_prompt_events(user_id, created_at_server DESC);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_submissions_user_created_at
+  ON support.feedback_submissions(user_id, created_at_server DESC);
+
+ALTER TABLE support.feedback_prompt_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE support.feedback_submissions ENABLE ROW LEVEL SECURITY;
+
+GRANT USAGE ON SCHEMA support TO backend_app;
+GRANT SELECT, INSERT ON TABLE support.feedback_prompt_events TO backend_app;
+GRANT SELECT, INSERT ON TABLE support.feedback_submissions TO backend_app;
+GRANT UPDATE (email_notification_status, email_notification_error) ON TABLE support.feedback_submissions TO backend_app;
+
+DROP POLICY IF EXISTS feedback_prompt_events_self_select_runtime ON support.feedback_prompt_events;
+CREATE POLICY feedback_prompt_events_self_select_runtime
+  ON support.feedback_prompt_events
+  FOR SELECT
+  TO backend_app
+  USING (user_id = security.current_user_id());
+
+DROP POLICY IF EXISTS feedback_prompt_events_self_insert_runtime ON support.feedback_prompt_events;
+CREATE POLICY feedback_prompt_events_self_insert_runtime
+  ON support.feedback_prompt_events
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (
+    user_id = security.current_user_id()
+    AND (
+      workspace_id IS NULL
+      OR security.user_has_workspace_access(workspace_id)
+    )
+    AND (
+      installation_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM sync.installations AS scoped_installations
+        WHERE scoped_installations.installation_id = feedback_prompt_events.installation_id
+          AND scoped_installations.user_id = security.current_user_id()
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS feedback_submissions_self_select_runtime ON support.feedback_submissions;
+CREATE POLICY feedback_submissions_self_select_runtime
+  ON support.feedback_submissions
+  FOR SELECT
+  TO backend_app
+  USING (user_id = security.current_user_id());
+
+DROP POLICY IF EXISTS feedback_submissions_self_insert_runtime ON support.feedback_submissions;
+CREATE POLICY feedback_submissions_self_insert_runtime
+  ON support.feedback_submissions
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (
+    user_id = security.current_user_id()
+    AND (
+      workspace_id IS NULL
+      OR security.user_has_workspace_access(workspace_id)
+    )
+    AND (
+      installation_id IS NULL
+      OR EXISTS (
+        SELECT 1
+        FROM sync.installations AS scoped_installations
+        WHERE scoped_installations.installation_id = feedback_submissions.installation_id
+          AND scoped_installations.user_id = security.current_user_id()
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS feedback_submissions_self_email_status_update_runtime ON support.feedback_submissions;
+CREATE POLICY feedback_submissions_self_email_status_update_runtime
+  ON support.feedback_submissions
+  FOR UPDATE
+  TO backend_app
+  USING (user_id = security.current_user_id())
+  WITH CHECK (user_id = security.current_user_id());
+
+GRANT USAGE ON SCHEMA support TO reporting_readonly;
+GRANT SELECT ON TABLE support.feedback_prompt_events TO reporting_readonly;
+GRANT SELECT ON TABLE support.feedback_submissions TO reporting_readonly;
+
+DROP POLICY IF EXISTS feedback_prompt_events_reporting_readonly_select ON support.feedback_prompt_events;
+CREATE POLICY feedback_prompt_events_reporting_readonly_select
+  ON support.feedback_prompt_events
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS feedback_submissions_reporting_readonly_select ON support.feedback_submissions;
+CREATE POLICY feedback_submissions_reporting_readonly_select
+  ON support.feedback_submissions
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);

--- a/infra/aws/lib/api-gateway.ts
+++ b/infra/aws/lib/api-gateway.ts
@@ -27,6 +27,8 @@ export interface ApiGatewayProps {
   sentryEnvironment: string | undefined;
   sentryRelease: string | undefined;
   sentryTracesSampleRate: string | undefined;
+  resendApiKeySecretArn: string | undefined;
+  resendSenderEmail: string | undefined;
   demoEmailDostip: string | undefined;
   guestAiWeightedMonthlyTokenCap: string | undefined;
   globalMetricsVisible: boolean;
@@ -65,6 +67,8 @@ interface BackendFunctionProps {
   langfuseSecretKeySecretArn: string | undefined;
   langfuseBaseUrl: string | undefined;
   sentryConfig: BackendSentryConfig;
+  resendApiKeySecretArn: string | undefined;
+  resendSenderEmail: string | undefined;
   demoEmailDostip: string | undefined;
   guestAiWeightedMonthlyTokenCap: string | undefined;
   globalMetricsConfig: GlobalMetricsConfig | undefined;
@@ -354,6 +358,16 @@ function createBackendFunction(scope: Construct, props: BackendFunctionProps): l
     );
   }
   addBackendSentryEnvironment(scope, fn, props.sentryConfig, props.constructId);
+  addLambdaSecretEnvironment(
+    scope,
+    fn,
+    props.resendApiKeySecretArn,
+    `${props.constructId}ResendApiKeySecret`,
+    "RESEND_API_KEY",
+  );
+  if (hasConfiguredValue(props.resendSenderEmail)) {
+    fn.addEnvironment("RESEND_FROM_EMAIL", props.resendSenderEmail);
+  }
   if (props.demoEmailDostip !== undefined && props.demoEmailDostip !== "") {
     fn.addEnvironment("DEMO_EMAIL_DOSTIP", props.demoEmailDostip);
   }
@@ -424,6 +438,8 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       release: props.sentryRelease,
       tracesSampleRate: props.sentryTracesSampleRate,
     },
+    resendApiKeySecretArn: props.resendApiKeySecretArn,
+    resendSenderEmail: props.resendSenderEmail,
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: {
@@ -458,6 +474,8 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       release: props.sentryRelease,
       tracesSampleRate: props.sentryTracesSampleRate,
     },
+    resendApiKeySecretArn: undefined,
+    resendSenderEmail: undefined,
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
@@ -488,6 +506,8 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
       release: props.sentryRelease,
       tracesSampleRate: props.sentryTracesSampleRate,
     },
+    resendApiKeySecretArn: undefined,
+    resendSenderEmail: undefined,
     demoEmailDostip: props.demoEmailDostip,
     guestAiWeightedMonthlyTokenCap: props.guestAiWeightedMonthlyTokenCap,
     globalMetricsConfig: undefined,
@@ -597,6 +617,11 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   meProgress.addResource("review-schedule").addMethod("GET", integration);
   meProgress.addResource("series").addMethod("GET", integration);
   me.addResource("delete").addMethod("POST", integration);
+
+  const feedback = restApi.root.addResource("feedback");
+  feedback.addResource("state").addMethod("GET", integration);
+  feedback.addResource("prompt-events").addMethod("POST", integration);
+  feedback.addResource("submissions").addMethod("POST", integration);
 
   const admin = restApi.root.addResource("admin");
   admin.addResource("session").addMethod("GET", integration);

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -231,6 +231,8 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       langfuseSecretKeySecretArn,
       langfuseBaseUrl,
       ...sentryContext,
+      resendApiKeySecretArn,
+      resendSenderEmail,
       demoEmailDostip,
       guestAiWeightedMonthlyTokenCap,
       globalMetricsVisible,


### PR DESCRIPTION
## Summary
- add backend in-app feedback state, prompt-event, and submission routes
- persist feedback prompt/submission rows with cooldown state and idempotent writes
- wire Resend notification configuration into the backend Lambda and add API Gateway resources

## Validation
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend
- npm run build --prefix infra/aws