### PR TITLE
[codex] Fix Android review log fake DAO

### DIFF
--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -315,6 +315,14 @@ private class FakeReviewLogDao(
         return hasReviewLogsBetween
     }
 
+    override suspend fun hasReviewLogsBefore(endMillis: Long): Boolean {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
+    override suspend fun countReviewLogsBetween(startMillis: Long, endMillis: Long): Int {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
     override suspend fun loadReviewLogs(): List<ReviewLogEntity> {
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }


### PR DESCRIPTION
## Summary

- Add missing `ReviewLogDao` overrides to the strict reminders test fake.
- Keep the fake behavior explicit by throwing when those methods are unexpectedly used by these tests.

## Why

The Android unit test compilation path requires every `ReviewLogDao` implementation to match the current interface.

## Validation

- `git --no-pager diff --check`

Gradle was not run locally because this repository requires explicit approval before local `./gradlew` runs.