### PR TITLE
[codex] Fix iOS Store Review prompt ordering

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -189,7 +189,7 @@ extension FlashcardsStore {
         }
     }
 
-    func handleSuccessfulReviewNotificationTrigger(reviewedAt: Date, now: Date) {
+    func resolveSuccessfulReviewNotificationPrePromptDecision(reviewedAt: Date, now: Date) async -> Bool {
         let nextCount = self.userDefaults.integer(forKey: reviewNotificationSuccessfulReviewCountUserDefaultsKey) + 1
         self.userDefaults.set(nextCount, forKey: reviewNotificationSuccessfulReviewCountUserDefaultsKey)
         self.userDefaults.set(now.timeIntervalSince1970, forKey: reviewNotificationLastActiveAtUserDefaultsKey)
@@ -197,37 +197,52 @@ extension FlashcardsStore {
         self.clearAppIconBadge()
         self.recordSuccessfulStrictReminderReview(reviewedAt: reviewedAt, now: now)
         let reviewCount = self.loadReviewNotificationPromptReviewCount(persistedReviewCount: nextCount)
-        Task { @MainActor in
-            defer {
-                self.requestGuestSignInAfterReviewPromptReconciliation()
-            }
 
-            let permissionStatus = await resolveReviewNotificationPermissionStatus()
-            guard permissionStatus == .notRequested else {
-                return
-            }
-            guard hasEnoughReviewHistoryForNotificationPrompt(reviewCount: reviewCount) else {
-                return
-            }
-            guard self.notificationPermissionPromptState.hasShownPrePrompt == false else {
-                return
-            }
-            guard self.notificationPermissionPromptState.hasDismissedPrePrompt == false else {
-                return
-            }
-            guard self.notificationPermissionPromptState.hasRequestedSystemPermission == false else {
-                return
-            }
-
-            self.isReviewNotificationPrePromptPresented = true
-            self.updateNotificationPermissionPromptState(
-                state: NotificationPermissionPromptState(
-                    hasShownPrePrompt: true,
-                    hasRequestedSystemPermission: false,
-                    hasDismissedPrePrompt: false
-                )
-            )
+        defer {
+            self.requestGuestSignInAfterReviewPromptReconciliation()
         }
+
+        let permissionStatus = await resolveReviewNotificationPermissionStatus()
+        guard permissionStatus == .notRequested else {
+            return false
+        }
+        guard hasEnoughReviewHistoryForNotificationPrompt(reviewCount: reviewCount) else {
+            return false
+        }
+        guard self.notificationPermissionPromptState.hasShownPrePrompt == false else {
+            return false
+        }
+        guard self.notificationPermissionPromptState.hasDismissedPrePrompt == false else {
+            return false
+        }
+        guard self.notificationPermissionPromptState.hasRequestedSystemPermission == false else {
+            return false
+        }
+
+        return true
+    }
+
+    func presentReviewNotificationPrePromptIfAllowed() -> Bool {
+        guard self.notificationPermissionPromptState.hasShownPrePrompt == false else {
+            return false
+        }
+        guard self.notificationPermissionPromptState.hasDismissedPrePrompt == false else {
+            return false
+        }
+        guard self.notificationPermissionPromptState.hasRequestedSystemPermission == false else {
+            return false
+        }
+
+        self.isReviewNotificationPrePromptPresented = true
+        self.updateNotificationPermissionPromptState(
+            state: NotificationPermissionPromptState(
+                hasShownPrePrompt: true,
+                hasRequestedSystemPermission: false,
+                hasDismissedPrePrompt: false
+            )
+        )
+
+        return true
     }
 
     private func loadReviewNotificationPromptReviewCount(persistedReviewCount: Int) -> Int {

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/FlashcardsStore+Review.swift
@@ -318,29 +318,82 @@ extension FlashcardsStore {
             if bootstrapRefreshOutcome.didChange || didReconcileReviewState {
                 self.localReadVersion += 1
             }
-            self.prepareStoreReviewRequestAttemptAfterSuccessfulReview(now: now)
+            func triggerSuccessfulReviewCloudSync() {
+                self.triggerCloudSyncIfLinked(
+                    trigger: CloudSyncTrigger(
+                        source: .localMutation,
+                        now: now,
+                        extendsFastPolling: true,
+                        allowsVisibleChangeBanner: false,
+                        surfacesGlobalErrorMessage: false
+                    )
+                )
+            }
+
             let reviewedAt = parseIsoTimestamp(value: request.reviewedAtClient) ?? now
-            self.handleSuccessfulReviewNotificationTrigger(
+            let shouldShowReviewNotificationPrePrompt = await self.resolveSuccessfulReviewNotificationPrePromptDecision(
                 reviewedAt: reviewedAt,
                 now: now
             )
+            guard self.successfulReviewSubmissionPromptContextMatchesCurrentState(
+                request: request,
+                now: Date()
+            ) else {
+                triggerSuccessfulReviewCloudSync()
+                return
+            }
+
             self.handleSuccessfulReviewHardReminder(
                 rating: request.rating,
                 now: now
             )
+            let didShowReviewNotificationPrePrompt = self.isReviewHardReminderPresented == false
+                && shouldShowReviewNotificationPrePrompt
+                && self.presentReviewNotificationPrePromptIfAllowed()
+            if didShowReviewNotificationPrePrompt == false
+                && self.isReviewNotificationPrePromptPresented == false
+                && self.isReviewHardReminderPresented == false
+                && self.pendingStoreReviewRequestAttempt == nil {
+                self.prepareStoreReviewRequestAttemptAfterSuccessfulReview(now: now)
+            }
             self.startAutomaticFeedbackPromptCheckAfterSuccessfulReview(now: now)
-            self.triggerCloudSyncIfLinked(
-                trigger: CloudSyncTrigger(
-                    source: .localMutation,
-                    now: now,
-                    extendsFastPolling: true,
-                    allowsVisibleChangeBanner: false,
-                    surfacesGlobalErrorMessage: false
-                )
-            )
+            triggerSuccessfulReviewCloudSync()
         } catch {
             self.handleReviewSubmissionFailure(request: request, submissionError: error)
         }
+    }
+
+    private func successfulReviewSubmissionPromptContextMatchesCurrentState(
+        request: ReviewSubmissionRequest,
+        now: Date
+    ) -> Bool {
+        guard let validationContext = self.makeReviewSubmissionRollbackValidationContext(now: now) else {
+            return false
+        }
+        let currentReviewState = self.currentReviewPublishedState()
+        guard request.workspaceId == validationContext.currentWorkspaceId else {
+            return false
+        }
+        guard request.reviewContext.selectedReviewFilter == currentReviewState.selectedReviewFilter else {
+            return false
+        }
+
+        let currentReviewContext = makeReviewSubmissionContext(
+            selectedReviewFilter: currentReviewState.selectedReviewFilter,
+            decks: validationContext.decks,
+            cards: validationContext.cards
+        )
+        guard currentReviewContext == request.reviewContext else {
+            return false
+        }
+
+        let currentReviewSessionSignature = makeReviewSessionSignature(
+            selectedReviewFilter: currentReviewState.selectedReviewFilter,
+            reviewQueue: self.reviewRuntime.effectiveReviewQueue(publishedState: currentReviewState),
+            schedulerSettings: validationContext.schedulerSettings,
+            seedQueueSize: reviewSeedQueueSize
+        )
+        return currentReviewSessionSignature == request.reviewSessionSignature
     }
 
     private func reviewSubmissionRequestMatchesCurrentContext(


### PR DESCRIPTION
## Summary
- move iOS Store Review preparation behind other post-review prompt decisions
- split notification pre-prompt evaluation from presentation so the review context can be revalidated after async permission status lookup
- keep cloud sync triggering even when post-review prompt context becomes stale

## Validation
- `git --no-pager diff --check`
- `xcodebuild ... build` was attempted locally, but Xcode reported no available destination for the scheme before compilation