### PR TITLE
Fix Android review log fake DAO

### DIFF
--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -311,8 +311,16 @@ private class FakeReviewLogDao(
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }
 
+    override suspend fun countReviewLogsBetween(workspaceId: String, startMillis: Long, endMillis: Long): Int {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
     override suspend fun hasReviewLogsBetween(startMillis: Long, endMillis: Long): Boolean {
         return hasReviewLogsBetween
+    }
+
+    override suspend fun hasReviewLogsBefore(workspaceId: String, beforeMillis: Long): Boolean {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }
 
     override suspend fun hasReviewLogsBefore(endMillis: Long): Boolean {


### PR DESCRIPTION
Summary:
- Adds the missing workspace-scoped ReviewLogDao overrides to the StrictRemindersManagerTest fake.
- Keeps the fake behavior consistent by throwing for unused DAO methods.

Root cause:
- Android CI failed to compile app unit tests after ReviewLogDao gained workspace-scoped review activity methods and this test fake was not updated.

Validation:
- git --no-pager diff --check passed.
- Independent review found no P0-P4 issues.
- Android Gradle was not run locally because this repository requires explicit approval for Gradle runs.