### PR TITLE
[codex] Fix iOS Xcode Cloud failures

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudAccount.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudAccount.swift
@@ -329,7 +329,7 @@ extension FlashcardsStore {
 
     func withCloudSessionPreservingStableContext<Result>(
         linkedSession: CloudLinkedSession,
-        operation: (CloudLinkedSession) async throws -> Result
+        operation: @MainActor (CloudLinkedSession) async throws -> Result
     ) async throws -> Result {
         switch linkedSession.authorization {
         case .guest:

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudIdentity.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/FlashcardsStore+CloudIdentity.swift
@@ -258,7 +258,7 @@ extension FlashcardsStore {
     }
 
     func withStoredAuthenticatedCredentials<Result>(
-        operation: (StoredCloudCredentials, CloudServiceConfiguration) async throws -> Result
+        operation: @MainActor (StoredCloudCredentials, CloudServiceConfiguration) async throws -> Result
     ) async throws -> Result {
         try self.throwIfCloudCredentialRecoveryRequired()
         if try self.markLinkedCredentialRecoveryForMissingCredentialsIfNeeded(detectedAt: Date()) {

--- a/apps/ios/Flashcards/Flashcards/Feedback/FlashcardsStore+Feedback.swift
+++ b/apps/ios/Flashcards/Flashcards/Feedback/FlashcardsStore+Feedback.swift
@@ -188,7 +188,7 @@ extension FlashcardsStore {
     }
 
     private func withFeedbackCloudSession<Result>(
-        operation: (any CloudSyncServing, CloudLinkedSession) async throws -> Result
+        operation: @MainActor (any CloudSyncServing, CloudLinkedSession) async throws -> Result
     ) async throws -> Result {
         let cloudSyncService = try requireCloudSyncService(cloudSyncService: self.dependencies.cloudSyncService)
         let session = try await self.cloudSessionForFeedback()

--- a/apps/ios/Flashcards/Flashcards/FlashcardsStoreLoaders.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStoreLoaders.swift
@@ -45,6 +45,30 @@ typealias ReviewTimelinePageLoader = @Sendable (
 let reviewSeedQueueSize: Int = 8
 let reviewQueueReplenishmentThreshold: Int = 4
 
+private func withTemporaryReviewLoaderDatabase<Result>(
+    databaseURL: URL,
+    operation: (LocalDatabase) throws -> Result
+) throws -> Result {
+    let database = try LocalDatabase(databaseURL: databaseURL)
+    let result: Result
+    do {
+        result = try operation(database)
+    } catch {
+        let operationError = error
+        do {
+            try database.close()
+        } catch {
+            throw LocalStoreError.database(
+                "Failed to close temporary review loader database at \(databaseURL.path) after operation error: \(operationError.localizedDescription). Close error: \(error.localizedDescription)"
+            )
+        }
+        throw operationError
+    }
+
+    try database.close()
+    return result
+}
+
 func defaultReviewHeadLoader(
     databaseURL: URL,
     workspaceId: String,
@@ -55,14 +79,15 @@ func defaultReviewHeadLoader(
 ) async throws -> ReviewHeadLoadState {
     try await Task.detached(priority: .userInitiated) {
         try Task.checkCancellation()
-        let database = try LocalDatabase(databaseURL: databaseURL)
-        return try database.loadReviewHead(
-            workspaceId: workspaceId,
-            resolvedReviewFilter: resolvedReviewFilter,
-            reviewQueryDefinition: reviewQueryDefinition,
-            now: now,
-            limit: seedQueueSize
-        )
+        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+            try database.loadReviewHead(
+                workspaceId: workspaceId,
+                resolvedReviewFilter: resolvedReviewFilter,
+                reviewQueryDefinition: reviewQueryDefinition,
+                now: now,
+                limit: seedQueueSize
+            )
+        }
     }.value
 }
 
@@ -74,12 +99,13 @@ func defaultReviewCountsLoader(
 ) async throws -> ReviewCounts {
     try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        let database = try LocalDatabase(databaseURL: databaseURL)
-        return try database.loadReviewCounts(
-            workspaceId: workspaceId,
-            reviewQueryDefinition: reviewQueryDefinition,
-            now: now
-        )
+        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+            try database.loadReviewCounts(
+                workspaceId: workspaceId,
+                reviewQueryDefinition: reviewQueryDefinition,
+                now: now
+            )
+        }
     }.value
 }
 
@@ -93,14 +119,15 @@ func defaultReviewQueueChunkLoader(
 ) async throws -> ReviewQueueChunkLoadState {
     try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        let database = try LocalDatabase(databaseURL: databaseURL)
-        return try database.loadReviewQueueChunk(
-            workspaceId: workspaceId,
-            reviewQueryDefinition: reviewQueryDefinition,
-            now: now,
-            limit: chunkSize,
-            excludedCardIds: excludedCardIds
-        )
+        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+            try database.loadReviewQueueChunk(
+                workspaceId: workspaceId,
+                reviewQueryDefinition: reviewQueryDefinition,
+                now: now,
+                limit: chunkSize,
+                excludedCardIds: excludedCardIds
+            )
+        }
     }.value
 }
 
@@ -113,13 +140,14 @@ func defaultReviewQueueWindowLoader(
 ) async throws -> ReviewQueueWindowLoadState {
     return try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        let database = try LocalDatabase(databaseURL: databaseURL)
-        return try database.loadReviewQueueWindow(
-            workspaceId: workspaceId,
-            reviewQueryDefinition: reviewQueryDefinition,
-            now: now,
-            limit: limit
-        )
+        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+            try database.loadReviewQueueWindow(
+                workspaceId: workspaceId,
+                reviewQueryDefinition: reviewQueryDefinition,
+                now: now,
+                limit: limit
+            )
+        }
     }.value
 }
 
@@ -133,13 +161,14 @@ func defaultReviewTimelinePageLoader(
 ) async throws -> ReviewTimelinePage {
     try await Task.detached(priority: .utility) {
         try Task.checkCancellation()
-        let database = try LocalDatabase(databaseURL: databaseURL)
-        return try database.loadReviewTimelinePage(
-            workspaceId: workspaceId,
-            reviewQueryDefinition: reviewQueryDefinition,
-            now: now,
-            limit: limit,
-            offset: offset
-        )
+        return try withTemporaryReviewLoaderDatabase(databaseURL: databaseURL) { database in
+            try database.loadReviewTimelinePage(
+                workspaceId: workspaceId,
+                reviewQueryDefinition: reviewQueryDefinition,
+                now: now,
+                limit: limit,
+                offset: offset
+            )
+        }
     }.value
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Review/ReviewBackgroundReconcileTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/ReviewBackgroundReconcileTests.swift
@@ -63,7 +63,9 @@ final class ReviewBackgroundReconcileTests: ProgressStoreTestCase {
             reviewCountsLoader: { _, _, _, _ in
                 expectedCounts
             },
-            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueChunkLoader: { _, _, _, _, _, _ in
+                try failUnexpectedReviewQueueChunkLoadForBackgroundReconcileTest()
+            },
             reviewQueueWindowLoader: { _, _, _, _, limit in
                 XCTAssertEqual(currentQueue.count, limit)
                 return ReviewQueueWindowLoadState(
@@ -614,7 +616,9 @@ final class ReviewBackgroundReconcileTests: ProgressStoreTestCase {
             reviewCountsLoader: { _, _, _, _ in
                 reviewCounts
             },
-            reviewQueueChunkLoader: defaultReviewQueueChunkLoader,
+            reviewQueueChunkLoader: { _, _, _, _, _, _ in
+                try failUnexpectedReviewQueueChunkLoadForBackgroundReconcileTest()
+            },
             reviewQueueWindowLoader: { _, _, _, _, limit in
                 await windowLimitRecorder?.record(limit: limit)
                 XCTAssertEqual(expectedWindowLimit, limit)
@@ -649,6 +653,12 @@ private func makePinnedRefreshCard(cardId: String, dueAt: String, updatedAt: Str
         dueAt: dueAt,
         updatedAt: updatedAt
     )
+}
+
+private func failUnexpectedReviewQueueChunkLoadForBackgroundReconcileTest() throws -> ReviewQueueChunkLoadState {
+    let message: String = "Background reconcile test unexpectedly requested a review queue chunk"
+    XCTFail(message)
+    throw LocalStoreError.validation(message)
 }
 
 private func makeReviewSubmissionSessionSignatureForBackgroundTest(


### PR DESCRIPTION
## Summary

- Fix iOS cloud-session closure actor isolation for Swift concurrency checks.\n- Close temporary review-loader SQLite connections explicitly.\n- Make background reconcile tests fail explicitly on unexpected chunk loading.

## Validation\n- git --no-pager diff --check\n- xcrun swiftc -parse on changed Swift files\n- xcodebuild build-for-testing attempted locally, but local Xcode has no eligible iOS 26.5 destination/runtime for the scheme.
