### PR TITLE
[codex] Add web offline DB loss observability

### DIFF
--- a/apps/web/src/appData/sync/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/syncLifecycleObservation.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./syncRestoreHistory";
 
 const observabilityMocks = vi.hoisted(() => ({
+  addWebBreadcrumbMock: vi.fn(),
   captureWebWarningMock: vi.fn(),
 }));
 
@@ -25,6 +26,7 @@ const apiMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../observability/webObservability", () => ({
+  addWebBreadcrumb: observabilityMocks.addWebBreadcrumbMock,
   captureWebWarning: observabilityMocks.captureWebWarningMock,
 }));
 
@@ -79,6 +81,41 @@ function createStorageMock(
   };
 }
 
+type PersistentStorageMock = Readonly<{
+  persistedMock: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
+  persistMock: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
+  estimateMock: ReturnType<typeof vi.fn<() => Promise<StorageEstimate>>>;
+}>;
+
+function installPersistentStorageMock(): PersistentStorageMock {
+  let persisted = false;
+  const persistedMock = vi.fn<() => Promise<boolean>>().mockImplementation(async () => persisted);
+  const persistMock = vi.fn<() => Promise<boolean>>().mockImplementation(async () => {
+    persisted = true;
+    return persisted;
+  });
+  const estimateMock = vi.fn<() => Promise<StorageEstimate>>().mockResolvedValue({
+    quota: 456,
+    usage: 123,
+  });
+  const storageManager = {
+    persisted: persistedMock,
+    persist: persistMock,
+    estimate: estimateMock,
+  } satisfies Partial<StorageManager>;
+
+  Object.defineProperty(navigator, "storage", {
+    configurable: true,
+    value: storageManager,
+  });
+
+  return {
+    persistedMock,
+    persistMock,
+    estimateMock,
+  };
+}
+
 function primeEmptyRemoteSync(): void {
   apiMocks.bootstrapPullSyncStateMock.mockResolvedValue({
     entries: [],
@@ -118,6 +155,8 @@ describe("sync lifecycle observation", () => {
       }),
     });
     window.localStorage.clear();
+    installPersistentStorageMock();
+    observabilityMocks.addWebBreadcrumbMock.mockReset();
     observabilityMocks.captureWebWarningMock.mockReset();
     apiMocks.bootstrapPullSyncStateMock.mockReset();
     apiMocks.pullReviewHistorySyncMock.mockReset();
@@ -128,6 +167,10 @@ describe("sync lifecycle observation", () => {
 
   afterEach(async () => {
     window.localStorage.clear();
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: undefined,
+    });
     vi.restoreAllMocks();
     await clearWebSyncCache();
   });
@@ -165,6 +208,8 @@ describe("sync lifecycle observation", () => {
   });
 
   it("warns when an empty local database had previous restore history", async () => {
+    const persistentStorageMock = installPersistentStorageMock();
+
     storeSyncRestoreHistoryEntry({
       userId: "user-1",
       workspaceId: "workspace-1",
@@ -186,11 +231,18 @@ describe("sync lifecycle observation", () => {
         previousLastAppliedHotChangeId: 301,
         previousLocalCardCount: 42,
         currentWebAppVersion: webAppVersion,
+        storagePersisted: false,
+        storageUsage: 123,
+        storageQuota: 456,
+        storageErrorName: null,
       }),
     }));
+    expect(persistentStorageMock.persistMock).toHaveBeenCalledTimes(1);
   });
 
   it("stores restore history after a successful hot bootstrap", async () => {
+    const persistentStorageMock = installPersistentStorageMock();
+
     await runWorkspaceRemoteSync(createRemoteSyncInput());
 
     expect(loadSyncRestoreHistoryEntry({
@@ -205,9 +257,22 @@ describe("sync lifecycle observation", () => {
       lastAppliedHotChangeId: 12,
       localCardCount: 0,
     }));
+    expect(persistentStorageMock.persistMock).toHaveBeenCalledTimes(1);
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "persistent_storage",
+      details: expect.objectContaining({
+        eventName: "persistent_storage_checked",
+        storagePersisted: true,
+        storageUsage: 123,
+        storageQuota: 456,
+        storageErrorName: null,
+      }),
+    }));
   });
 
   it("backfills restore history for an already hydrated local database without warning", async () => {
+    const persistentStorageMock = installPersistentStorageMock();
+
     await applyHotSyncPage("workspace-1", [], {
       lastAppliedHotChangeId: 88,
       markHotStateHydrated: true,
@@ -223,6 +288,84 @@ describe("sync lifecycle observation", () => {
       installationId: "installation-1",
     })).toEqual(expect.objectContaining({
       lastAppliedHotChangeId: 88,
+    }));
+    expect(persistentStorageMock.persistMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not warn for a slow empty remote bootstrap", async () => {
+    let nowMs = 0;
+    vi.spyOn(Date, "now")
+      .mockImplementation(() => nowMs);
+    apiMocks.bootstrapPullSyncStateMock.mockResolvedValue({
+      entries: [],
+      bootstrapHotChangeId: 12,
+      nextCursor: null,
+      hasMore: false,
+      remoteIsEmpty: true,
+    });
+
+    await runWorkspaceRemoteSync({
+      ...createRemoteSyncInput(),
+      refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {
+        nowMs = 3000;
+      },
+    });
+
+    expect(findCapturedWarning("sync_restore_slow")).toBeNull();
+  });
+
+  it("keeps warning for a slow non-empty remote bootstrap", async () => {
+    let nowMs = 0;
+    vi.spyOn(Date, "now")
+      .mockImplementation(() => nowMs);
+    apiMocks.bootstrapPullSyncStateMock.mockResolvedValue({
+      entries: [],
+      bootstrapHotChangeId: 12,
+      nextCursor: null,
+      hasMore: false,
+      remoteIsEmpty: false,
+    });
+
+    await runWorkspaceRemoteSync({
+      ...createRemoteSyncInput(),
+      refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {
+        nowMs = 3000;
+      },
+    });
+
+    expect(findCapturedWarning("sync_restore_slow")).toEqual(expect.objectContaining({
+      action: "sync_restore_slow",
+    }));
+  });
+
+  it("does not fail sync when persistent storage observation fails", async () => {
+    const persistedMock = vi.fn<() => Promise<boolean>>().mockRejectedValue(new DOMException("Denied", "SecurityError"));
+    const persistMock = vi.fn<() => Promise<boolean>>().mockResolvedValue(false);
+    const estimateMock = vi.fn<() => Promise<StorageEstimate>>().mockResolvedValue({
+      quota: 456,
+      usage: 123,
+    });
+    Object.defineProperty(navigator, "storage", {
+      configurable: true,
+      value: {
+        persisted: persistedMock,
+        persist: persistMock,
+        estimate: estimateMock,
+      } satisfies Partial<StorageManager>,
+    });
+
+    await expect(runWorkspaceRemoteSync(createRemoteSyncInput())).resolves.toEqual({
+      didChangeProgressHistory: false,
+      didChangeReviewSchedule: false,
+    });
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "persistent_storage",
+      details: expect.objectContaining({
+        storagePersisted: null,
+        storageUsage: null,
+        storageQuota: null,
+        storageErrorName: "SecurityError",
+      }),
     }));
   });
 

--- a/apps/web/src/appData/sync/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/syncLifecycleObservation.ts
@@ -1,8 +1,10 @@
 import {
+  addWebBreadcrumb,
   captureWebWarning,
   type SyncRestoreLocalBootstrapState,
   type WebObservationScope,
 } from "../../observability/webObservability";
+import type { PersistentStorageState } from "../../localDb/cloudSettings";
 import type { SyncRestoreHistoryEntry } from "./syncRestoreHistory";
 
 export type HotBootstrapSlowObservationInput = Readonly<{
@@ -29,6 +31,14 @@ export type LocalDbMissingObservationInput = Readonly<{
   localCardCountBefore: number;
   previousRestoreHistory: SyncRestoreHistoryEntry;
   currentWebAppVersion: string;
+  persistentStorageState: PersistentStorageState;
+}>;
+
+export type PersistentStorageObservationInput = Readonly<{
+  userId: string;
+  workspaceId: string;
+  installationId: string;
+  persistentStorageState: PersistentStorageState;
 }>;
 
 function getCurrentRoute(): string | null {
@@ -94,6 +104,24 @@ export function observeLocalDbMissing(input: LocalDbMissingObservationInput): vo
       previousLastAppliedHotChangeId: input.previousRestoreHistory.lastAppliedHotChangeId,
       previousLocalCardCount: input.previousRestoreHistory.localCardCount,
       currentWebAppVersion: input.currentWebAppVersion,
+      storagePersisted: input.persistentStorageState.persisted,
+      storageUsage: input.persistentStorageState.usage,
+      storageQuota: input.persistentStorageState.quota,
+      storageErrorName: input.persistentStorageState.errorName,
+    },
+  });
+}
+
+export function observePersistentStorageState(input: PersistentStorageObservationInput): void {
+  addWebBreadcrumb({
+    action: "persistent_storage",
+    scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
+    details: {
+      eventName: "persistent_storage_checked",
+      storagePersisted: input.persistentStorageState.persisted,
+      storageUsage: input.persistentStorageState.usage,
+      storageQuota: input.persistentStorageState.quota,
+      storageErrorName: input.persistentStorageState.errorName,
     },
   });
 }

--- a/apps/web/src/appData/sync/syncRemote.ts
+++ b/apps/web/src/appData/sync/syncRemote.ts
@@ -7,6 +7,11 @@ import {
 import { webAppVersion } from "../../clientIdentity";
 import { loadActiveCardCount, loadCardsByIds } from "../../localDb/cards";
 import {
+  ensurePersistentStorage,
+  readPersistentStorageState,
+  type PersistentStorageState,
+} from "../../localDb/cloudSettings";
+import {
   deleteOutboxRecord,
   isScheduleRelevantCardOutboxRecord,
   listOutboxRecords,
@@ -34,6 +39,7 @@ import {
 } from "../domain";
 import {
   observeLocalDbMissing,
+  observePersistentStorageState,
   observeSlowHotBootstrap,
 } from "./syncLifecycleObservation";
 import {
@@ -114,8 +120,26 @@ function isCardHotSyncEntry(entry: HotSyncEntry): entry is CardHotSyncEntry {
   return entry.entityType === "card";
 }
 
-function shouldObserveHotBootstrap(durationMs: number, pageCount: number): boolean {
-  return durationMs >= slowHotBootstrapWarningThresholdMs || pageCount > 1;
+function isEmptyRemoteBootstrapNoise(
+  remoteIsEmpty: boolean | null,
+  entriesCount: number,
+  localCardCountAfter: number,
+): boolean {
+  return remoteIsEmpty === true && localCardCountAfter === 0 && entriesCount <= 1;
+}
+
+function shouldObserveHotBootstrap(input: Readonly<{
+  durationMs: number;
+  pageCount: number;
+  entriesCount: number;
+  localCardCountAfter: number;
+  remoteIsEmpty: boolean | null;
+}>): boolean {
+  if (isEmptyRemoteBootstrapNoise(input.remoteIsEmpty, input.entriesCount, input.localCardCountAfter)) {
+    return false;
+  }
+
+  return input.durationMs >= slowHotBootstrapWarningThresholdMs || input.pageCount > 1;
 }
 
 function determineLocalBootstrapState(
@@ -149,6 +173,19 @@ async function storeCurrentWorkspaceRestoreHistory(
     lastAppliedHotChangeId,
     localCardCount,
   });
+}
+
+async function observePersistentStorageForHydratedWorkspace(
+  input: WorkspaceRemoteSyncInput,
+): Promise<PersistentStorageState> {
+  const persistentStorageState = await ensurePersistentStorage();
+  observePersistentStorageState({
+    userId: input.userId,
+    workspaceId: input.workspaceId,
+    installationId: input.installationId,
+    persistentStorageState,
+  });
+  return persistentStorageState;
 }
 
 async function backfillRestoreHistoryForHydratedState(
@@ -193,6 +230,7 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
     }
 
     await backfillRestoreHistoryForHydratedState(input, syncStateBefore);
+    await observePersistentStorageForHydratedWorkspace(input);
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
     return createEmptyRemoteSyncFlags();
   }
@@ -209,6 +247,7 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
   let remoteIsEmpty: boolean | null = null;
 
   if (syncStateBefore === null && localCardCountBefore === 0 && restoreHistoryBefore !== null) {
+    const persistentStorageStateBeforeMissingWarning = await readPersistentStorageState();
     observeLocalDbMissing({
       userId: input.userId,
       workspaceId: input.workspaceId,
@@ -217,6 +256,7 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
       localCardCountBefore,
       previousRestoreHistory: restoreHistoryBefore,
       currentWebAppVersion: webAppVersion,
+      persistentStorageState: persistentStorageStateBeforeMissingWarning,
     });
   }
 
@@ -276,7 +316,14 @@ async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<Remot
     lastAppliedHotChangeId: nextHotChangeId,
     localCardCount: localCardCountAfter,
   });
-  if (shouldObserveHotBootstrap(durationMs, pageCount)) {
+  await observePersistentStorageForHydratedWorkspace(input);
+  if (shouldObserveHotBootstrap({
+    durationMs,
+    pageCount,
+    entriesCount,
+    localCardCountAfter,
+    remoteIsEmpty,
+  })) {
     observeSlowHotBootstrap({
       userId: input.userId,
       workspaceId: input.workspaceId,

--- a/apps/web/src/localDb/cloudSettings.ts
+++ b/apps/web/src/localDb/cloudSettings.ts
@@ -11,7 +11,35 @@ export type PersistentStorageState = Readonly<{
   persisted: boolean | null;
   quota: number | null;
   usage: number | null;
+  errorName: string | null;
 }>;
+
+function createPersistentStorageState(
+  persisted: boolean | null,
+  quota: number | null,
+  usage: number | null,
+  errorName: string | null,
+): PersistentStorageState {
+  return {
+    persisted,
+    quota,
+    usage,
+    errorName,
+  };
+}
+
+function readNamedErrorName(error: unknown): string | null {
+  if (typeof error !== "object" || error === null || "name" in error === false) {
+    return null;
+  }
+
+  const errorName = (error as Readonly<{ name: unknown }>).name;
+  return typeof errorName === "string" && errorName.trim() !== "" ? errorName : null;
+}
+
+function getStorageErrorName(error: unknown): string {
+  return readNamedErrorName(error) ?? "Error";
+}
 
 export async function loadCloudSettings(): Promise<CloudSettings | null> {
   const cloudSettingsRecord = await closeDatabaseAfter((database) => getFromStore<CloudSettingsRecord>(database, "meta", "cloud_settings"));
@@ -36,30 +64,47 @@ export async function clearCloudSettings(): Promise<void> {
 export async function ensurePersistentStorage(): Promise<PersistentStorageState> {
   const storageManager = navigator.storage;
   if (storageManager === undefined) {
-    return {
-      persisted: null,
-      quota: null,
-      usage: null,
-    };
+    return createPersistentStorageState(null, null, null, null);
   }
 
-  const persistedBefore = typeof storageManager.persisted === "function"
-    ? await storageManager.persisted()
-    : null;
-  if (persistedBefore === false && typeof storageManager.persist === "function") {
-    await storageManager.persist();
+  let persisted: boolean | null = null;
+  let quota: number | null = null;
+  let usage: number | null = null;
+  try {
+    persisted = typeof storageManager.persisted === "function"
+      ? await storageManager.persisted()
+      : null;
+    if (persisted === false && typeof storageManager.persist === "function") {
+      await storageManager.persist();
+    }
+
+    return await readPersistentStorageState();
+  } catch (error) {
+    return createPersistentStorageState(persisted, quota, usage, getStorageErrorName(error));
+  }
+}
+
+export async function readPersistentStorageState(): Promise<PersistentStorageState> {
+  const storageManager = navigator.storage;
+  if (storageManager === undefined) {
+    return createPersistentStorageState(null, null, null, null);
   }
 
-  const persisted = typeof storageManager.persisted === "function"
-    ? await storageManager.persisted()
-    : persistedBefore;
-  const estimate = typeof storageManager.estimate === "function"
-    ? await storageManager.estimate()
-    : null;
+  let persisted: boolean | null = null;
+  let quota: number | null = null;
+  let usage: number | null = null;
+  try {
+    persisted = typeof storageManager.persisted === "function"
+      ? await storageManager.persisted()
+      : null;
+    const estimate = typeof storageManager.estimate === "function"
+      ? await storageManager.estimate()
+      : null;
+    quota = estimate?.quota ?? null;
+    usage = estimate?.usage ?? null;
+  } catch (error) {
+    return createPersistentStorageState(persisted, quota, usage, getStorageErrorName(error));
+  }
 
-  return {
-    persisted,
-    quota: estimate?.quota ?? null,
-    usage: estimate?.usage ?? null,
-  };
+  return createPersistentStorageState(persisted, quota, usage, null);
 }

--- a/apps/web/src/localDb/core.migrations.test.ts
+++ b/apps/web/src/localDb/core.migrations.test.ts
@@ -10,6 +10,14 @@ import { loadReviewQueueSnapshot } from "./reviews";
 import { makeCard, workspaceId } from "./testSupport";
 import type { Card } from "../types";
 
+const observabilityMocks = vi.hoisted(() => ({
+  addWebBreadcrumbMock: vi.fn(),
+}));
+
+vi.mock("../observability/webObservability", () => ({
+  addWebBreadcrumb: observabilityMocks.addWebBreadcrumbMock,
+}));
+
 type LegacyStoredCard = Omit<StoredCard, "dueAt" | "dueAtMillis" | "dueAtBucketMillis" | "fsrsLastReviewedAtMillis"> & Readonly<{
   dueAt?: string | null;
 }>;
@@ -239,6 +247,46 @@ async function loadCardsStoreIndexNamesForTest(): Promise<ReadonlyArray<string>>
 }
 
 describe("localDb core migrations", () => {
+  it("adds IndexedDB open metadata and breadcrumb when opening database fails", async () => {
+    const sourceError = new DOMException("Open failed", "InvalidStateError");
+    const openRequest = {
+      error: sourceError,
+      onerror: null,
+      onsuccess: null,
+      onupgradeneeded: null,
+    } as unknown as IDBOpenDBRequest;
+    const openDatabaseSpy = vi.spyOn(indexedDB, "open").mockReturnValue(openRequest);
+    observabilityMocks.addWebBreadcrumbMock.mockReset();
+
+    try {
+      const openTask = openDatabase();
+      if (openRequest.onerror === null) {
+        throw new Error("IndexedDB open error handler was not registered");
+      }
+
+      openRequest.onerror.call(openRequest, new Event("error"));
+
+      await expect(openTask).rejects.toMatchObject({
+        indexedDbOperation: "open",
+        databaseName: webSyncDatabaseName,
+        databaseVersion: 13,
+        indexedDbErrorName: "InvalidStateError",
+      });
+      expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+        action: "indexed_db_operation",
+        details: expect.objectContaining({
+          eventName: "indexed_db_operation_failed",
+          indexedDbOperation: "open",
+          databaseName: webSyncDatabaseName,
+          databaseVersion: 13,
+          indexedDbErrorName: "InvalidStateError",
+        }),
+      }));
+    } finally {
+      openDatabaseSpy.mockRestore();
+    }
+  });
+
   it("waits for managed IndexedDB operations before deleting browser data", async () => {
     await clearWebSyncCache();
     const readStarted = createDeferredVoid();

--- a/apps/web/src/localDb/core.ts
+++ b/apps/web/src/localDb/core.ts
@@ -6,6 +6,11 @@ import type {
   WorkspaceSchedulerSettings,
 } from "../types";
 import { deriveDueAtBucketMillis, deriveDueAtMillis, parseDueAtMillis } from "../appData/domain/dueAt";
+import {
+  addWebBreadcrumb,
+  type IndexedDbOperation,
+  type WebObservationScope,
+} from "../observability/webObservability";
 
 export type StoredCard = Readonly<{
   workspaceId: string;
@@ -96,6 +101,19 @@ function isQuotaExceededError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "QuotaExceededError";
 }
 
+function readNamedErrorName(error: unknown): string | null {
+  if (typeof error !== "object" || error === null || "name" in error === false) {
+    return null;
+  }
+
+  const errorName = (error as Readonly<{ name: unknown }>).name;
+  return typeof errorName === "string" && errorName.trim() !== "" ? errorName : null;
+}
+
+function getIndexedDbErrorName(error: unknown): string | null {
+  return readNamedErrorName(error);
+}
+
 export function describeIndexedDbError(prefix: string, error: unknown): Error {
   if (isQuotaExceededError(error)) {
     return new Error(`${prefix}: browser storage quota was exceeded`);
@@ -106,6 +124,69 @@ export function describeIndexedDbError(prefix: string, error: unknown): Error {
   }
 
   return new Error(`${prefix}: unknown error`);
+}
+
+function attachIndexedDbOperationMetadata(
+  error: Error,
+  operation: IndexedDbOperation,
+  sourceError: unknown,
+): Error {
+  Object.assign(error, {
+    indexedDbOperation: operation,
+    databaseName,
+    databaseVersion,
+    indexedDbErrorName: getIndexedDbErrorName(sourceError),
+  });
+  return error;
+}
+
+function describeIndexedDbOperationError(
+  prefix: string,
+  error: unknown,
+  operation: IndexedDbOperation,
+): Error {
+  return attachIndexedDbOperationMetadata(describeIndexedDbError(prefix, error), operation, error);
+}
+
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildIndexedDbObservationScope(): WebObservationScope {
+  return {
+    app: "web",
+    feature: "sync",
+    userId: null,
+    workspaceId: null,
+    installationId: null,
+    route: getCurrentRoute(),
+    requestId: null,
+    statusCode: null,
+    code: null,
+  };
+}
+
+function addIndexedDbOperationFailedBreadcrumb(
+  operation: IndexedDbOperation,
+  sourceError: unknown,
+  error: Error,
+): void {
+  addWebBreadcrumb({
+    action: "indexed_db_operation",
+    scope: buildIndexedDbObservationScope(),
+    details: {
+      eventName: "indexed_db_operation_failed",
+      indexedDbOperation: operation,
+      databaseName,
+      databaseVersion,
+      indexedDbErrorName: getIndexedDbErrorName(sourceError),
+      errorMessage: error.message,
+    },
+  });
 }
 
 function deleteExistingStore(database: IDBDatabase, storeName: string): void {
@@ -332,7 +413,9 @@ export function openDatabase(): Promise<IDBDatabase> {
     const request = indexedDB.open(databaseName, databaseVersion);
 
     request.onerror = () => {
-      reject(describeIndexedDbError("Failed to open IndexedDB", request.error));
+      const error = describeIndexedDbOperationError("Failed to open IndexedDB", request.error, "open");
+      addIndexedDbOperationFailedBreadcrumb("open", request.error, error);
+      reject(error);
     };
 
     request.onupgradeneeded = (event) => {

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -110,6 +110,25 @@ export type LocalBrowserDataCleanupBreadcrumbDetails = Readonly<{
   errorMessage: string | null;
 }>;
 
+export type PersistentStorageBreadcrumbDetails = Readonly<{
+  eventName: "persistent_storage_checked";
+  storagePersisted: boolean | null;
+  storageUsage: number | null;
+  storageQuota: number | null;
+  storageErrorName: string | null;
+}>;
+
+export type IndexedDbOperation = "open";
+
+export type IndexedDbOperationBreadcrumbDetails = Readonly<{
+  eventName: "indexed_db_operation_failed";
+  indexedDbOperation: IndexedDbOperation;
+  databaseName: string;
+  databaseVersion: number;
+  indexedDbErrorName: string | null;
+  errorMessage: string;
+}>;
+
 export type WebBreadcrumbEvent =
   | Readonly<{
     action: "workspace_transition";
@@ -135,6 +154,16 @@ export type WebBreadcrumbEvent =
     action: "local_browser_data_cleanup";
     scope: WebObservationScope;
     details: LocalBrowserDataCleanupBreadcrumbDetails;
+  }>
+  | Readonly<{
+    action: "persistent_storage";
+    scope: WebObservationScope;
+    details: PersistentStorageBreadcrumbDetails;
+  }>
+  | Readonly<{
+    action: "indexed_db_operation";
+    scope: WebObservationScope;
+    details: IndexedDbOperationBreadcrumbDetails;
   }>;
 
 export type ApiContractFailureDetails = Readonly<{
@@ -370,6 +399,10 @@ export type SyncLocalDbMissingWarningDetails = Readonly<{
   previousLastAppliedHotChangeId: number;
   previousLocalCardCount: number;
   currentWebAppVersion: string;
+  storagePersisted: boolean | null;
+  storageUsage: number | null;
+  storageQuota: number | null;
+  storageErrorName: string | null;
 }>;
 
 export type WebWarningEvent =
@@ -415,6 +448,10 @@ type ErrorMetadata = Readonly<{
   bodyKind: string | null;
   networkAttemptCount: number | null;
   networkErrorName: string | null;
+  indexedDbOperation: string | null;
+  databaseName: string | null;
+  databaseVersion: number | null;
+  indexedDbErrorName: string | null;
 }>;
 
 type ErrorMetadataValue = string | number | null;
@@ -525,6 +562,10 @@ function readErrorMetadata(error: Error): ErrorMetadata {
       bodyKind: null,
       networkAttemptCount: null,
       networkErrorName: null,
+      indexedDbOperation: null,
+      databaseName: null,
+      databaseVersion: null,
+      indexedDbErrorName: null,
     };
   }
 
@@ -537,6 +578,10 @@ function readErrorMetadata(error: Error): ErrorMetadata {
     bodyKind: readStringMetadata(error, "responseBodyKind"),
     networkAttemptCount: readNumberMetadata(error, "attemptCount"),
     networkErrorName: readStringMetadata(error, "originalErrorName"),
+    indexedDbOperation: readStringMetadata(error, "indexedDbOperation"),
+    databaseName: readStringMetadata(error, "databaseName"),
+    databaseVersion: readNumberMetadata(error, "databaseVersion"),
+    indexedDbErrorName: readStringMetadata(error, "indexedDbErrorName"),
   };
 }
 
@@ -550,6 +595,10 @@ function errorMetadataToContext(metadata: ErrorMetadata): SentryContext {
     bodyKind: metadata.bodyKind,
     networkAttemptCount: metadata.networkAttemptCount,
     networkErrorName: metadata.networkErrorName,
+    indexedDbOperation: metadata.indexedDbOperation,
+    databaseName: metadata.databaseName,
+    databaseVersion: metadata.databaseVersion,
+    indexedDbErrorName: metadata.indexedDbErrorName,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add browser storage persistence observability around successful web hot-state hydration.
- Include read-only storage state in sync_local_db_missing warnings.
- Add IndexedDB open failure metadata and breadcrumbs.
- Reduce sync_restore_slow noise for empty remote bootstraps.

## Validation
- npm exec vitest -- src/appData/sync/syncLifecycleObservation.test.ts src/accountDeletion.test.ts src/appData/session/useWorkspaceSession.test.tsx src/localDb/core.migrations.test.ts src/observability/instrument.test.ts
- npm run build
