### PR TITLE
[codex] Fix iOS AI handoff request ordering

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -77,6 +77,9 @@ struct AIChatView: View {
             .onChange(of: self.chatStore.composerPhase) { _, nextPhase in
                 self.handleComposerPhaseChange(nextPhase: nextPhase)
             }
+            .onChange(of: self.chatStore.hasExternalProviderConsent) { _, hasConsent in
+                self.handleExternalProviderConsentChange(hasConsent: hasConsent)
+            }
             .onChange(of: self.scenePhase) { _, nextPhase in
                 self.handleScenePhaseChange(nextPhase: nextPhase)
             }
@@ -604,6 +607,15 @@ struct AIChatView: View {
             return
         }
 
+        self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
+    }
+
+    func handleExternalProviderConsentChange(hasConsent: Bool) {
+        guard hasConsent else {
+            return
+        }
+
+        self.syncChatSurface(refreshConsent: false)
         self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
     }
 

--- a/apps/ios/Flashcards/Flashcards/App/AppNavigationModel.swift
+++ b/apps/ios/Flashcards/Flashcards/App/AppNavigationModel.swift
@@ -85,13 +85,13 @@ final class AppNavigationModel {
     }
 
     func openAICardCreation() {
-        self.aiChatPresentationRequest = .createCard
         self.selectedTab = .ai
+        self.aiChatPresentationRequest = .createCard
     }
 
     func openAICardHandoff(card: AIChatCardReference) {
-        self.aiChatPresentationRequest = .attachCard(card)
         self.selectedTab = .ai
+        self.aiChatPresentationRequest = .attachCard(card)
     }
 
     func openSettings(destination: SettingsNavigationDestination) {


### PR DESCRIPTION
## Summary
- Publish AI presentation requests after selecting the AI tab, so handoff/create requests arrive on the target surface instead of before navigation settles.
- Retry deferred AI presentation requests when external provider consent changes to accepted.

## Root Cause
Xcode Cloud build 430 still had one red optional test issue: `LiveSmokeCardsTests.testLiveSmokeCardsEditorAiHandoffFlow()`. The flow reached the AI screen after accepting consent, but the composer card attachment chip never appeared. The handoff request could be emitted before the AI surface was selected/ready, leaving the flow dependent on deferred state timing.

## Validation
- `git --no-pager diff --check`
- `xcrun swiftc -sdk "$(xcrun --sdk iphonesimulator26.5 --show-sdk-path)" -parse apps/ios/Flashcards/Flashcards/App/AppNavigationModel.swift`
- `xcrun swiftc -sdk "$(xcrun --sdk iphonesimulator26.5 --show-sdk-path)" -parse apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift`
- Full simulator UI validation is left to Xcode Cloud because local iOS simulator-backed tests are heavy and local Xcode destination selection remains unavailable on this machine.