### PR TITLE
[codex] Split Android navigation packages

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptDialogTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/GuestSignInAfterReviewPromptDialogTest.kt
@@ -13,7 +13,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.flashcardsopensourceapp.app.navigation.SettingsAccountSignInEmailDestination
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsAccountSignInEmailDestination
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInEmailRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInUiState

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -59,11 +59,11 @@ import com.flashcardsopensourceapp.app.navigation.AppNotificationTapHandoffReque
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
 import com.flashcardsopensourceapp.app.navigation.ReviewDestination
-import com.flashcardsopensourceapp.app.navigation.SettingsAccountSignInEmailDestination
 import com.flashcardsopensourceapp.app.navigation.TopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.currentVisibleAppScreen
 import com.flashcardsopensourceapp.app.navigation.currentTopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsAccountSignInEmailDestination
 import com.flashcardsopensourceapp.app.navigation.topLevelDestinations
 import com.flashcardsopensourceapp.data.local.model.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.CloudAccountState

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
@@ -9,6 +9,14 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.ai.registerAiNavGraph
+import com.flashcardsopensourceapp.app.navigation.cards.registerCardsNavGraph
+import com.flashcardsopensourceapp.app.navigation.progress.registerProgressNavGraph
+import com.flashcardsopensourceapp.app.navigation.review.ReviewPreviewDestination
+import com.flashcardsopensourceapp.app.navigation.review.registerReviewNavGraph
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsCurrentWorkspaceDestination
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsWorkspaceOverviewDestination
+import com.flashcardsopensourceapp.app.navigation.settings.registerSettingsNavGraph
 import com.flashcardsopensourceapp.app.notifications.AppNotificationTapType
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavigationSupport.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavigationSupport.kt
@@ -7,6 +7,10 @@ import androidx.compose.runtime.remember
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
+import com.flashcardsopensourceapp.app.navigation.cards.CardEditorDestination
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsWorkspaceDecksDestination
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsWorkspaceDestination
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsWorkspaceTagsDestination
 
 @Composable
 internal fun rememberRouteBackStackEntry(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ai/AiNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/ai/AiNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.ai
 
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -8,6 +8,8 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.AiDestination
+import com.flashcardsopensourceapp.app.navigation.settings.SettingsAccountSignInEmailDestination
 import com.flashcardsopensourceapp.data.local.ai.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.feature.ai.AiCardHandoffResult
 import com.flashcardsopensourceapp.feature.ai.AiRoute

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.cards
 
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
@@ -10,6 +10,9 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.AiDestination
+import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
+import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
 import com.flashcardsopensourceapp.feature.cards.CardEditorRoute
 import com.flashcardsopensourceapp.feature.cards.CardTagsRoute
 import com.flashcardsopensourceapp.feature.cards.CardTextEditorRoute

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsDestinations.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.cards
 
 data object CardEditorDestination {
     const val routePrefix: String = "cards/editor"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.cards
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsRootNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.cards
 
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.CardsDestination
+import com.flashcardsopensourceapp.app.navigation.SettingsNavigationTarget
 import com.flashcardsopensourceapp.feature.cards.CardsRoute
 import com.flashcardsopensourceapp.feature.cards.createCardsViewModelFactory
 import kotlinx.coroutines.CoroutineScope

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/progress/ProgressNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/progress/ProgressNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.progress
 
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.ProgressDestination
 import com.flashcardsopensourceapp.feature.progress.ProgressRoute
 import com.flashcardsopensourceapp.feature.progress.ProgressViewModel
 import com.flashcardsopensourceapp.feature.progress.createProgressViewModelFactory

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewDestinations.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.review
 
 data object ReviewPreviewDestination {
     const val route: String = "review/preview"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.review
 
 import android.Manifest
 import androidx.activity.ComponentActivity
@@ -12,9 +12,15 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import com.flashcardsopensourceapp.data.local.ai.AiChatDiagnosticsLogger
-import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.AiDestination
+import com.flashcardsopensourceapp.app.navigation.ProgressDestination
+import com.flashcardsopensourceapp.app.navigation.ReviewDestination
+import com.flashcardsopensourceapp.app.navigation.SettingsNavigationTarget
+import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
+import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
+import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
+import com.flashcardsopensourceapp.data.local.ai.AiChatDiagnosticsLogger
 import com.flashcardsopensourceapp.data.local.model.ReviewFilter
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccessNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccessNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -12,6 +12,9 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.SettingsDestination
+import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
+import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudPostAuthRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSendCodeNavigationOutcome
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInCodeRoute

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsDestinations.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.settings
 
 internal data object SettingsRootGraph {
     const val route: String = "settings/root"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsNavGraph.kt
@@ -1,9 +1,11 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.navigation
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.app.navigation.AppPackageInfo
+import com.flashcardsopensourceapp.app.navigation.SettingsDestination
 import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
 import kotlinx.coroutines.CoroutineScope
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.settings
 
 import android.os.SystemClock
 import androidx.compose.runtime.Composable
@@ -12,8 +12,11 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
-import com.flashcardsopensourceapp.feature.review.reaction.TestAnimationsRoute
+import com.flashcardsopensourceapp.app.navigation.AppPackageInfo
+import com.flashcardsopensourceapp.app.navigation.SettingsDestination
+import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
 import com.flashcardsopensourceapp.feature.review.reaction.ReviewReactionLottieConfigurationStore
+import com.flashcardsopensourceapp.feature.review.reaction.TestAnimationsRoute
 import com.flashcardsopensourceapp.feature.settings.SettingsRoute
 import com.flashcardsopensourceapp.feature.settings.TestSettingsRoute
 import com.flashcardsopensourceapp.feature.settings.createSettingsViewModelFactory

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.navigation
+package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext


### PR DESCRIPTION
## Summary
- Split the flat Android app navigation package into feature subpackages for AI, cards, progress, review, and settings.
- Updated app-level imports and Android test imports for the moved navigation contracts.
- Kept route strings and navigation behavior unchanged.

## Validation
- git --no-pager diff --cached --check before commit
- diff-related review pass
- Gradle not run per task constraint