### PR TITLE
[codex] Move backend chat live tests

### DIFF
--- a/apps/backend/src/chat/tests/live/diff.test.ts
+++ b/apps/backend/src/chat/tests/live/diff.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { diffAssistantContent } from "../live/diff";
-import type { ContentPart } from "../types";
+import { diffAssistantContent } from "../../live/diff";
+import type { ContentPart } from "../../types";
 
 function createToolCallPart(params: Readonly<{
   id: string;

--- a/apps/backend/src/chat/tests/live/errors.test.ts
+++ b/apps/backend/src/chat/tests/live/errors.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { HttpError } from "../../shared/errors";
+import { HttpError } from "../../../shared/errors";
 import {
   CHAT_LIVE_RUN_ID_REQUIRED_CODE,
   createChatLiveErrorResponse,
-} from "../live/errors";
-import { handleLiveRequest, readOptionalChatRequestIdHeader } from "../live/request";
+} from "../../live/errors";
+import { handleLiveRequest, readOptionalChatRequestIdHeader } from "../../live/request";
 
 const EXPLICIT_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";
 

--- a/apps/backend/src/chat/tests/live/resume.test.ts
+++ b/apps/backend/src/chat/tests/live/resume.test.ts
@@ -4,11 +4,11 @@ import { PassThrough } from "node:stream";
 import {
   runLiveStreamWithDependencies,
   type ChatLiveStreamResult,
-} from "../live";
-import type { ChatComposerSuggestion } from "../composerSuggestions";
-import type { ChatRunSnapshot } from "../runs";
-import type { PersistedChatMessageItem } from "../store";
-import type { ContentPart } from "../types";
+} from "../../live";
+import type { ChatComposerSuggestion } from "../../composerSuggestions";
+import type { ChatRunSnapshot } from "../../runs";
+import type { PersistedChatMessageItem } from "../../store";
+import type { ContentPart } from "../../types";
 
 function makeAssistantMessage(
   params: Readonly<{


### PR DESCRIPTION
## Summary
- Move backend chat live-stream tests into apps/backend/src/chat/tests/live
- Update relative imports for the deeper test directory

## Validation
- rg "chat-live-" apps/backend/src/chat/tests
- npm test
- npm run lint