### PR TITLE
[codex] Move backend chat tests into subdirectories

### DIFF
--- a/apps/backend/src/chat/tests/transcriptions/transcriptions.test.ts
+++ b/apps/backend/src/chat/tests/transcriptions/transcriptions.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import * as Sentry from "@sentry/aws-serverless";
-import { HttpError } from "../../shared/errors";
-import { transcribeChatAudioUploadWithDependencies } from "../transcriptions";
+import { HttpError } from "../../../shared/errors";
+import { transcribeChatAudioUploadWithDependencies } from "../../transcriptions";
 
 type MutableSentryModule = typeof Sentry & {
   addBreadcrumb: (

--- a/apps/backend/src/chat/tests/worker/event.test.ts
+++ b/apps/backend/src/chat/tests/worker/event.test.ts
@@ -6,13 +6,13 @@ import type {
   BackendObservationScope,
   BackendTraceCarrier,
   ChatWorkerDispatchFailureDetails,
-} from "../../observability/sentry";
-import type { ChatWorkerEvent } from "../worker";
+} from "../../../observability/sentry";
+import type { ChatWorkerEvent } from "../../worker";
 import {
   invokeChatWorkerOrPersistFailureWithDependencies,
   invokeChatWorkerWithDependencies,
   type ChatWorkerInvocation,
-} from "../worker/invoke";
+} from "../../worker/invoke";
 
 type ChatWorkerDispatchFailureEvent = Readonly<{
   action: "chat_worker_dispatch_failed";


### PR DESCRIPTION
## Summary

Move the remaining backend chat worker and direct transcription tests out of the flat `apps/backend/src/chat/tests` directory into dedicated `worker/` and `transcriptions/` subdirectories.

## Validation

- `rg "chat-worker-event|tests/transcriptions\\.test" apps/backend/src/chat/tests`
- `npm test` from `apps/backend` (339 passed, 0 failed)
- `npm run lint` from `apps/backend`
