### PR TITLE
Move chat route tests into routes folder

### DIFF
--- a/apps/backend/src/chat/tests/routes/contract.test.ts
+++ b/apps/backend/src/chat/tests/routes/contract.test.ts
@@ -2,21 +2,21 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { HttpError } from "../../shared/errors";
-import { createChatRoutes } from "../../routes/chat";
-import type { AppEnv } from "../../server/app";
-import type { RequestContext } from "../../server/requestContext";
+import { HttpError } from "../../../shared/errors";
+import { createChatRoutes } from "../../../routes/chat";
+import type { AppEnv } from "../../../server/app";
+import type { RequestContext } from "../../../server/requestContext";
 import {
   chatMaximumStartRunRequestBytes,
   chatRequestTooLargeCode,
   chatRequestTooLargeMessage,
   parseChatRequestBody,
-} from "../http/contract";
+} from "../../http/contract";
 import {
   chatAttachmentUnsupportedTypeCode,
   chatAttachmentUnsupportedTypeMessage,
-} from "../attachmentPolicy";
-import type { ChatSessionSnapshot, PersistedChatMessageItem } from "../store";
+} from "../../attachmentPolicy";
+import type { ChatSessionSnapshot, PersistedChatMessageItem } from "../../store";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
 const PLAIN_TEXT_BASE64 = "cGxhaW4gdGV4dA==";

--- a/apps/backend/src/chat/tests/routes/history.test.ts
+++ b/apps/backend/src/chat/tests/routes/history.test.ts
@@ -1,9 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { HttpError } from "../../shared/errors";
-import { createChatRoutes } from "../../routes/chat";
-import { createChatSessionRequestedSessionIdConflictError } from "../errors";
-import type { RecoveredPaginatedSession } from "../runs";
+import { HttpError } from "../../../shared/errors";
+import { createChatRoutes } from "../../../routes/chat";
+import { createChatSessionRequestedSessionIdConflictError } from "../../errors";
+import type { RecoveredPaginatedSession } from "../../runs";
 import {
   EXPLICIT_WORKSPACE_ID,
   LEGACY_WORKSPACE_ID,
@@ -14,7 +14,7 @@ import {
   createRequestContext,
   createRequestContextWithSelectedWorkspace,
   createSnapshot,
-} from "./chat-routes-test-support";
+} from "./testSupport";
 
 test("DELETE /chat is no longer routed", async () => {
   const app = createChatRoutes({

--- a/apps/backend/src/chat/tests/routes/new.test.ts
+++ b/apps/backend/src/chat/tests/routes/new.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createChatRoutes } from "../../routes/chat";
-import { buildInitialChatComposerSuggestions } from "../composerSuggestions";
-import { createChatSessionRequestedSessionIdConflictError } from "../errors";
+import { createChatRoutes } from "../../../routes/chat";
+import { buildInitialChatComposerSuggestions } from "../../composerSuggestions";
+import { createChatSessionRequestedSessionIdConflictError } from "../../errors";
 import {
   EXPLICIT_WORKSPACE_ID,
   LEGACY_WORKSPACE_ID,
@@ -14,7 +14,7 @@ import {
   createRequestContextWithSelectedWorkspace,
   createRunningSnapshot,
   createSnapshot,
-} from "./chat-routes-test-support";
+} from "./testSupport";
 
 test("POST /chat/new returns the current session when history is empty", async () => {
   let rolloverCallCount = 0;
@@ -530,4 +530,3 @@ test("POST /chat/new uses an explicit workspaceId from JSON before the legacy se
   assert.equal(response.status, 200);
   assert.deepEqual(requestedWorkspaceIds, [EXPLICIT_WORKSPACE_ID]);
 });
-

--- a/apps/backend/src/chat/tests/routes/start.test.ts
+++ b/apps/backend/src/chat/tests/routes/start.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
-import { HttpError } from "../../shared/errors";
-import type { AppEnv } from "../../server/app";
-import type { BackendTraceCarrier } from "../../observability/sentry";
-import { createChatRoutes } from "../../routes/chat";
-import { ChatSessionConflictError } from "../store";
+import { HttpError } from "../../../shared/errors";
+import type { AppEnv } from "../../../server/app";
+import type { BackendTraceCarrier } from "../../../observability/sentry";
+import { createChatRoutes } from "../../../routes/chat";
+import { ChatSessionConflictError } from "../../store";
 import {
   EXPLICIT_WORKSPACE_ID,
   LEGACY_WORKSPACE_ID,
@@ -15,7 +15,7 @@ import {
   createRequestContext,
   createRequestContextWithSelectedWorkspace,
   createRunningSnapshot,
-} from "./chat-routes-test-support";
+} from "./testSupport";
 
 test("POST /chat can return an active run before the current turn appears in messages", async () => {
   let preparedClientRequestId: string | null = null;

--- a/apps/backend/src/chat/tests/routes/stop.test.ts
+++ b/apps/backend/src/chat/tests/routes/stop.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createChatRoutes } from "../../routes/chat";
+import { createChatRoutes } from "../../../routes/chat";
 import {
   EXPLICIT_WORKSPACE_ID,
   LEGACY_WORKSPACE_ID,
@@ -10,7 +10,7 @@ import {
   createRequestContext,
   createRoutesWithHttpErrorJson,
   createRequestContextWithSelectedWorkspace,
-} from "./chat-routes-test-support";
+} from "./testSupport";
 
 test("POST /chat/stop returns not found for an unknown explicit session id", async () => {
   const routes = createChatRoutes({

--- a/apps/backend/src/chat/tests/routes/testSupport.ts
+++ b/apps/backend/src/chat/tests/routes/testSupport.ts
@@ -1,8 +1,8 @@
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { HttpError } from "../../shared/errors";
-import type { ChatSessionSnapshot } from "../store";
-import type { RequestContext } from "../../server/requestContext";
+import { HttpError } from "../../../shared/errors";
+import type { ChatSessionSnapshot } from "../../store";
+import type { RequestContext } from "../../../server/requestContext";
 
 export const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
 export const SESSION_TWO = "22222222-2222-4222-8222-222222222222";

--- a/apps/backend/src/chat/tests/routes/transcriptions.test.ts
+++ b/apps/backend/src/chat/tests/routes/transcriptions.test.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import { createChatSessionRequestedSessionIdConflictError } from "../errors";
-import { HttpError } from "../../shared/errors";
-import { createChatTranscriptionsRoutes } from "../../routes/chatTranscriptions";
-import type { RequestContext } from "../../server/requestContext";
+import { createChatSessionRequestedSessionIdConflictError } from "../../errors";
+import { HttpError } from "../../../shared/errors";
+import { createChatTranscriptionsRoutes } from "../../../routes/chatTranscriptions";
+import type { RequestContext } from "../../../server/requestContext";
 
 const SESSION_ONE = "11111111-1111-4111-8111-111111111111";
 const EXPLICIT_WORKSPACE_ID = "33333333-3333-4333-8333-333333333333";


### PR DESCRIPTION
## Summary
- Move backend chat route tests into `apps/backend/src/chat/tests/routes`.
- Move route-only test support to `routes/testSupport.ts`.
- Update relative imports for the new directory depth.

## Validation
- `rg "chat-(history|new|start|stop|route|transcriptions)-routes|chat-routes-test-support" apps/backend/src/chat/tests`
- `npm test` from `apps/backend`
- `npm run lint` from `apps/backend`