### PR TITLE
[codex] Move chat runtime tests into runtime directory

### DIFF
--- a/apps/backend/src/chat/tests/runtime/cancellation.test.ts
+++ b/apps/backend/src/chat/tests/runtime/cancellation.test.ts
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   runPersistedChatSessionWithDeps,
-} from "../runtime";
+} from "../../runtime";
 import type {
   OpenAILoopCompletion,
   OpenAILoopEventSink,
   StartOpenAILoopParams,
-} from "../openai/loop";
+} from "../../openai/loop";
 import {
   CHAT_WORKER_PRE_TIMEOUT_BUFFER_MS,
   createAbortError,
@@ -18,7 +18,7 @@ import {
   findLog,
   withCapturedLogs,
   withControlledHeartbeat,
-} from "./chat-runtime-test-support";
+} from "./testSupport";
 
 test("runPersistedChatSessionWithDeps finalizes a cancelled run when the user stops during the provider call", async () => {
   let heartbeatCallCount = 0;

--- a/apps/backend/src/chat/tests/runtime/deadline.test.ts
+++ b/apps/backend/src/chat/tests/runtime/deadline.test.ts
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   runPersistedChatSessionWithDeps,
-} from "../runtime";
+} from "../../runtime";
 import type {
   OpenAILoopCompletion,
   OpenAILoopEventSink,
   StartOpenAILoopParams,
-} from "../openai/loop";
+} from "../../openai/loop";
 import {
   CHAT_WORKER_PRE_TIMEOUT_BUFFER_MS,
   DEADLINE_REACHED_MESSAGE,
@@ -19,7 +19,7 @@ import {
   findLog,
   withCapturedLogs,
   withControlledHeartbeat,
-} from "./chat-runtime-test-support";
+} from "./testSupport";
 
 test("runPersistedChatSessionWithDeps interrupts immediately when the lambda is already inside the pre-timeout buffer", async () => {
   let startOpenAILoopCalled = false;

--- a/apps/backend/src/chat/tests/runtime/finalization.test.ts
+++ b/apps/backend/src/chat/tests/runtime/finalization.test.ts
@@ -2,21 +2,21 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ChatRunRowNotFoundError,
-} from "../errors";
+} from "../../errors";
 import {
   runPersistedChatSessionWithDeps,
-} from "../runtime";
+} from "../../runtime";
 import type {
   OpenAILoopCompletion,
   OpenAILoopEventSink,
   StartOpenAILoopParams,
-} from "../openai/loop";
+} from "../../openai/loop";
 import {
   createDependencies,
   createParams,
   findLog,
   withCapturedLogs,
-} from "./chat-runtime-test-support";
+} from "./testSupport";
 
 test("runPersistedChatSessionWithDeps exits without failing when the claimed run disappears before completion persistence", async () => {
   let cancelledPersistCount = 0;

--- a/apps/backend/src/chat/tests/runtime/providerErrors.test.ts
+++ b/apps/backend/src/chat/tests/runtime/providerErrors.test.ts
@@ -3,18 +3,18 @@ import test from "node:test";
 import {
   chatAttachmentUnsupportedTypeCode,
   chatAttachmentUnsupportedTypeMessage,
-} from "../attachmentPolicy";
+} from "../../attachmentPolicy";
 import {
   runPersistedChatSessionWithDeps,
-} from "../runtime";
+} from "../../runtime";
 import type {
   OpenAILoopCompletion,
   OpenAILoopEventSink,
   StartOpenAILoopParams,
-} from "../openai/loop";
+} from "../../openai/loop";
 import {
   HttpError,
-} from "../../shared/errors";
+} from "../../../shared/errors";
 import {
   type PersistAssistantTerminalErrorParams,
   createCompletedLoopCompletion,
@@ -25,7 +25,7 @@ import {
   findLog,
   requireTerminalPersistParams,
   withCapturedLogs,
-} from "./chat-runtime-test-support";
+} from "./testSupport";
 
 test("runPersistedChatSessionWithDeps persists a failed run for real provider errors", async () => {
   let terminalPersistCount = 0;

--- a/apps/backend/src/chat/tests/runtime/testSupport.ts
+++ b/apps/backend/src/chat/tests/runtime/testSupport.ts
@@ -2,10 +2,10 @@ import assert from "node:assert/strict";
 import type {
   ChatRuntimeDependencies,
   StartPersistedChatRunParams,
-} from "../runtime";
+} from "../../runtime";
 import type {
   OpenAILoopCompletion,
-} from "../openai/loop";
+} from "../../openai/loop";
 
 type ConsoleMethod = "log" | "warn" | "error";
 type StructuredLogRecord = Readonly<Record<string, unknown> & {


### PR DESCRIPTION
## Summary

Move backend chat runtime tests and runtime-only test support into `apps/backend/src/chat/tests/runtime`.

## Validation

- `rg "chat-runtime-" apps/backend/src/chat/tests`
- `npm test` from `apps/backend`
- `npm run lint` from `apps/backend`
