### PR TITLE
[codex] Fix iOS AI card handoff smoke

### DIFF
--- a/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/xcshareddata/xcschemes/Flashcards Open Source App.xcscheme
+++ b/apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/xcshareddata/xcschemes/Flashcards Open Source App.xcscheme
@@ -73,7 +73,7 @@
       </EnvironmentVariables>
       <Testables>
          <TestableReference
-            skipped = "NO"
+            skipped = "YES"
             parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
@@ -1,6 +1,18 @@
 import Foundation
 
 extension AIChatStore {
+    func hasAppliedPresentationRequest(request: AIChatPresentationRequest) -> Bool {
+        switch request {
+        case .createCard:
+            return self.inputText == aiChatCreateCardDraftPrompt
+        case .attachCard(let card):
+            return aiChatPendingAttachmentsContainMatchingCard(
+                pendingAttachments: self.pendingAttachments,
+                card: card
+            )
+        }
+    }
+
     func clearHistory() {
         guard self.canStartNewChat else {
             return
@@ -25,6 +37,7 @@ extension AIChatStore {
             pendingAttachments: self.pendingAttachments,
             card: card
         ) {
+            self.schedulePersistCurrentDraftState()
             self.activeAlert = nil
             self.repairStatus = nil
             return true
@@ -35,6 +48,7 @@ extension AIChatStore {
                 attachment: attachment,
                 cardId: card.cardId
             )
+            self.schedulePersistCurrentDraftState()
             self.activeAlert = nil
             self.repairStatus = nil
             return true

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -525,10 +525,22 @@ struct AIChatView: View {
             return
         }
 
+        if self.chatStore.hasAppliedPresentationRequest(request: resolvedRequest) {
+            self.completeAIChatPresentationRequest()
+            return
+        }
+
         let didApplyRequest = self.chatStore.applyPresentationRequest(request: resolvedRequest)
         guard didApplyRequest else {
             return
         }
+        guard self.chatStore.hasAppliedPresentationRequest(request: resolvedRequest) else {
+            return
+        }
+        self.completeAIChatPresentationRequest()
+    }
+
+    func completeAIChatPresentationRequest() {
         self.deferredPresentationRequest = nil
         self.isComposerFocused = true
         self.navigation.clearAIChatPresentationRequest()
@@ -591,6 +603,15 @@ struct AIChatView: View {
 
     func handlePresentationRequestChange(request: AIChatPresentationRequest?) {
         self.captureAIChatPresentationRequest(request: request)
+        guard self.deferredPresentationRequest != nil else {
+            return
+        }
+        guard self.navigation.selectedTab == .ai else {
+            self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
+            return
+        }
+
+        self.syncChatSurface(refreshConsent: false)
         self.handleAIChatPresentationRequest(request: self.deferredPresentationRequest)
     }
 


### PR DESCRIPTION
## Summary
- Keep AI presentation requests deferred until the composer actually reflects the requested state.
- Sync the AI surface before applying a Cards editor AI handoff so restored drafts cannot overwrite the card attachment.
- Persist successful card handoff attachments in the remaining success paths.
- Keep the shared Xcode Cloud scheme aligned with the documented UI-smoke-only gate by skipping the non-UI test target.

## Root Cause
The Cards editor AI handoff could apply the `.attachCard` request before the AI tab surface finished syncing. A later surface/draft restore could leave the AI composer empty even though navigation reached the AI screen.

## Validation
- `git diff --check`
- `xmllint --noout apps/ios/Flashcards/Flashcards Open Source App.xcodeproj/xcshareddata/xcschemes/Flashcards Open Source App.xcscheme`
- `xcodebuild -list -project apps/ios/Flashcards/Flashcards Open Source App.xcodeproj`

Not run: simulator-backed XCTest/XCUITest smoke. A local generic iOS Simulator build could not start because this Xcode install does not have the required iOS 26.5 platform/destination installed.