### PR TITLE
Fix review progress badge flicker

### DIFF
--- a/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/FlashcardsStore+Bootstrap.swift
@@ -147,6 +147,17 @@ extension FlashcardsStore {
 
     @discardableResult
     func refreshBootstrapSnapshotWithoutReset(now: Date) throws -> BootstrapSnapshotRefreshOutcome {
+        let outcome = try self.refreshBootstrapSnapshotContentWithoutReset(now: now)
+        self.handleProgressContextDidChange(now: now)
+        return outcome
+    }
+
+    @discardableResult
+    func refreshBootstrapSnapshotWithoutProgressContextRefresh(now: Date) throws -> BootstrapSnapshotRefreshOutcome {
+        try self.refreshBootstrapSnapshotContentWithoutReset(now: now)
+    }
+
+    private func refreshBootstrapSnapshotContentWithoutReset(now: Date) throws -> BootstrapSnapshotRefreshOutcome {
         let database = try requireLocalDatabase(database: self.database)
         let bootstrapSnapshot = try database.loadBootstrapSnapshot()
         let nextCards = try database.loadActiveCards(workspaceId: bootstrapSnapshot.workspace.workspaceId)
@@ -194,7 +205,6 @@ extension FlashcardsStore {
         }
         self.reconcileReviewNotifications(trigger: .workspaceChanged, now: now)
         self.reconcileStrictReminders(trigger: .workspaceChanged, now: now)
-        self.handleProgressContextDidChange(now: now)
 
         return BootstrapSnapshotRefreshOutcome(
             didChange: didChange,

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/FlashcardsStore+Review.swift
@@ -290,7 +290,7 @@ extension FlashcardsStore {
                 return
             }
 
-            let bootstrapRefreshOutcome = try self.refreshBootstrapSnapshotWithoutReset(now: now)
+            let bootstrapRefreshOutcome = try self.refreshBootstrapSnapshotWithoutProgressContextRefresh(now: now)
             let didReconcileReviewState = try await self.reconcileReviewState(
                 now: now,
                 trigger: .localReview

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressContextChangeTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressContextChangeTests.swift
@@ -156,6 +156,70 @@ final class ProgressContextChangeTests: ProgressStoreTestCase {
     }
 
     @MainActor
+    func testReviewSubmissionBootstrapRefreshSkipsProgressBadgeRefresh() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        context.store.updateCurrentVisibleTab(tab: .review)
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: "\(requestRange.to)T09:00:00.000Z"
+        )
+
+        _ = try context.store.refreshBootstrapSnapshotWithoutProgressContextRefresh(now: now)
+
+        XCTAssertEqual(makeEmptyReviewProgressBadgeState(), context.store.reviewProgressBadgeState)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressSummaryCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressSeriesCallCount)
+
+        _ = try context.store.refreshBootstrapSnapshotWithoutReset(now: now)
+
+        XCTAssertEqual(
+            ReviewProgressBadgeState(
+                streakDays: 1,
+                hasReviewedToday: true,
+                isInteractive: true
+            ),
+            context.store.reviewProgressBadgeState
+        )
+        await self.waitForProgressRefreshCallCounts(
+            cloudSyncService: context.cloudSyncService,
+            summaryCount: 1,
+            seriesCount: 0
+        )
+    }
+
+    @MainActor
     func testHandleProgressContextDidChangeClearsReviewedTodayBadgeAfterLocalDayRollover() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()

--- a/apps/web/src/appData/progress/snapshots/progressSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSnapshots.ts
@@ -125,43 +125,118 @@ export function buildLocalFallbackSeries(
   };
 }
 
+type ProgressSeriesMergeResult = Readonly<{
+  series: ProgressSeries;
+  hasOverlay: boolean;
+}>;
+
 function mergeProgressSeriesWithOverlay(
   serverBase: ProgressSeries,
   overlay: ProgressChartData | null,
-): ProgressSeries {
-  if (overlay === null || overlay.dailyReviews.length === 0) {
-    return normalizeProgressSeries(serverBase);
-  }
-
-  const pendingReviewCounts = buildDailyReviewCountMap(overlay.dailyReviews);
+  localFallback: ProgressSeriesSnapshot | null,
+): ProgressSeriesMergeResult {
+  const pendingReviewCounts = buildDailyReviewCountMap(overlay?.dailyReviews ?? []);
+  const localFallbackReviewCounts = localFallback === null
+    ? new Map<string, number>()
+    : buildDailyReviewCountMap(localFallback.dailyReviews);
   const normalizedServerBase = normalizeProgressSeries(serverBase);
   let hasOverlay = false;
   const dailyReviews = normalizedServerBase.dailyReviews.map((day) => {
     const pendingReviewCount = pendingReviewCounts.get(day.date) ?? 0;
+    const localFallbackReviewCount = localFallbackReviewCounts.get(day.date) ?? 0;
+    const reviewCountWithPendingOverlay = day.reviewCount + pendingReviewCount;
+    const reviewCount = Math.max(reviewCountWithPendingOverlay, localFallbackReviewCount);
 
-    if (pendingReviewCount === 0) {
+    if (reviewCount === day.reviewCount) {
       return day;
     }
 
     hasOverlay = true;
     return {
       date: day.date,
-      reviewCount: day.reviewCount + pendingReviewCount,
+      reviewCount,
     };
   });
 
   if (hasOverlay === false) {
-    return normalizedServerBase;
+    return {
+      series: normalizedServerBase,
+      hasOverlay: false,
+    };
   }
 
   return {
-    ...normalizedServerBase,
-    dailyReviews,
+    series: {
+      ...normalizedServerBase,
+      dailyReviews,
+    },
+    hasOverlay: true,
   };
 }
 
-function hasPendingOverlayActivity(overlay: ProgressChartData | null): boolean {
-  return overlay?.dailyReviews.some((day) => day.reviewCount > 0) ?? false;
+function isLocalDateAfter(
+  first: string | null,
+  second: string | null,
+): boolean {
+  if (first === null) {
+    return false;
+  }
+
+  if (second === null) {
+    return true;
+  }
+
+  return first > second;
+}
+
+function maxLocalDate(
+  first: string | null,
+  second: string | null,
+): string | null {
+  if (first === null) {
+    return second;
+  }
+
+  if (second === null) {
+    return first;
+  }
+
+  return first >= second ? first : second;
+}
+
+function hasProgressSummaryOverlay(
+  localFallback: ProgressSummarySnapshot,
+  serverBase: ProgressSummarySnapshot,
+): boolean {
+  return localFallback.summary.currentStreakDays > serverBase.summary.currentStreakDays
+    || (localFallback.summary.hasReviewedToday && serverBase.summary.hasReviewedToday === false)
+    || isLocalDateAfter(localFallback.summary.lastReviewedOn, serverBase.summary.lastReviewedOn)
+    || localFallback.summary.activeReviewDays > serverBase.summary.activeReviewDays;
+}
+
+function mergeProgressSummary(
+  serverBase: ProgressSummarySnapshot,
+  localFallback: ProgressSummarySnapshot,
+): ProgressSummaryPayload {
+  return {
+    timeZone: serverBase.timeZone,
+    generatedAt: serverBase.generatedAt,
+    summary: {
+      currentStreakDays: Math.max(
+        serverBase.summary.currentStreakDays,
+        localFallback.summary.currentStreakDays,
+      ),
+      hasReviewedToday: serverBase.summary.hasReviewedToday || localFallback.summary.hasReviewedToday,
+      lastReviewedOn: maxLocalDate(
+        serverBase.summary.lastReviewedOn,
+        localFallback.summary.lastReviewedOn,
+      ),
+      activeReviewDays: Math.max(
+        serverBase.summary.activeReviewDays,
+        localFallback.summary.activeReviewDays,
+      ),
+    },
+  };
 }
 
 function isProgressReviewScheduleServerBaseStale(
@@ -190,7 +265,19 @@ function buildRenderedSummary(
   hasPendingLocalReviews: boolean,
   canRenderServerBase: boolean,
 ): ProgressSummarySnapshot | null {
-  if (canRenderServerBase && serverBase !== null && hasPendingLocalReviews === false) {
+  if (canRenderServerBase && serverBase !== null) {
+    if (hasPendingLocalReviews) {
+      return localFallback;
+    }
+
+    if (localFallback !== null && hasProgressSummaryOverlay(localFallback, serverBase)) {
+      return createProgressSummarySnapshot(
+        mergeProgressSummary(serverBase, localFallback),
+        "server",
+        true,
+      );
+    }
+
     return serverBase;
   }
 
@@ -204,8 +291,12 @@ function buildRenderedSeries(
   canRenderServerBase: boolean,
 ): ProgressSeriesSnapshot | null {
   if (canRenderServerBase && serverBase !== null) {
-    const mergedSeries = mergeProgressSeriesWithOverlay(serverBase, pendingLocalOverlay);
-    return createProgressSeriesSnapshot(mergedSeries, "server", hasPendingOverlayActivity(pendingLocalOverlay));
+    const mergeResult = mergeProgressSeriesWithOverlay(serverBase, pendingLocalOverlay, localFallback);
+    return createProgressSeriesSnapshot(
+      mergeResult.series,
+      "server",
+      mergeResult.hasOverlay,
+    );
   }
 
   return localFallback;

--- a/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
@@ -92,6 +92,75 @@ describe("useProgressSource summary and series", () => {
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(8);
   });
 
+  it("keeps reviewed-today summary visible after pending uploads clear before the server summary catches up", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    hasPendingProgressReviewEventsMock.mockResolvedValue(false);
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      summary: {
+        currentStreakDays: 1,
+        hasReviewedToday: false,
+        lastReviewedOn: "2026-04-19",
+        activeReviewDays: 7,
+      },
+    });
+    loadProgressSeriesMock.mockResolvedValue({
+      timeZone: currentSeriesInput.timeZone,
+      from: currentSeriesInput.from,
+      to: currentSeriesInput.to,
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      dailyReviews: [
+        {
+          date: currentSeriesInput.to,
+          reviewCount: 0,
+        },
+      ],
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue({
+      currentStreakDays: 2,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 8,
+    });
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      {
+        date: currentSeriesInput.to,
+        reviewCount: 1,
+      },
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.serverBase?.summary.hasReviewedToday).toBe(false);
+    expect(harness.getApi().progressSourceState.summary.hasPendingLocalReviews).toBe(false);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(true);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
+      currentStreakDays: 2,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 8,
+    });
+    expect(harness.getApi().progressSourceState.series.serverBase?.dailyReviews).toContainEqual({
+      date: currentSeriesInput.to,
+      reviewCount: 0,
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("server");
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.isApproximate).toBe(true);
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+      date: currentSeriesInput.to,
+      reviewCount: 1,
+    });
+  });
+
   it("renders server series with pending local review overlay as approximate", async () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSeriesMock.mockResolvedValue(buildServerSeries(4, "2026-04-18T09:18:00.000Z"));


### PR DESCRIPTION
## Summary
- Avoid premature iOS progress badge refresh during successful review bootstrap reconciliation
- Keep web progress summary and series rendering aligned when local progress is ahead of stale server data
- Add targeted iOS and web regression coverage

## Validation
- npm exec vitest -- run src/appData/progress/source/progressSource.summarySeries.test.tsx src/appData/progress/source/progressSource.lifecycle.test.tsx src/appData/progress/source/progressSource.cache.test.tsx src/appData/progress/source/progressSource.reviewSchedule.test.tsx
- npm run build

Note: iOS simulator-backed tests were not run locally.