### PR TITLE
[codex] Update App Store metadata

### DIFF
--- a/docs/app-store-connect-metadata.md
+++ b/docs/app-store-connect-metadata.md
@@ -10,11 +10,11 @@ Flashcards Open Source App
 
 ### Subtitle
 
-AI Flashcards for Real Study
+AI Notes to Flashcards
 
 ### Description
 
-Flashcards Open Source App is an AI-powered flashcards app for people who study with purpose.
+Create AI flashcards from notes, then review them with spaced repetition for exams, languages, and serious daily study.
 
 Use it for:
 - exam prep and coursework
@@ -23,18 +23,18 @@ Use it for:
 - AI-assisted card improvement and study planning
 - fast daily review with decks, tags, and spaced repetition
 
-Create cards in seconds, organize your study system with decks and tags, and review with spaced repetition that helps you retain more with less busywork.
+Create cards in seconds, organize your study system with decks and tags, and review on a focused schedule that helps you retain more with less busywork.
 
 AI is part of the study flow. Use it to sharpen card wording, unpack difficult topics, and decide what to study next without leaving your flashcards.
 
-The app is open source, and the full stack can be self-hosted. Support, privacy policy, and terms are available inside the app.
+For learners who care about transparency, the app is open source, and the full stack can be self-hosted. Support, privacy policy, and terms are available inside the app.
 
 All code for the app, backend, and infrastructure is open and available on GitHub:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-study,spaced repetition,ai,vocabulary,language,exam prep,med school,decks,tags,fsrs,memory
+spaced,repetition,study,cards,vocab,language,exam,prep,medical,review,memorize,fsrs,decks,tags
 
 ## Arabic
 
@@ -44,11 +44,11 @@ study,spaced repetition,ai,vocabulary,language,exam prep,med school,decks,tags,f
 
 ### Subtitle
 
-بطاقات مراجعة ذكية
+بطاقات من ملاحظاتك
 
 ### Description
 
-بطاقات تعليم مفتوحة المصدر هو تطبيق بطاقات مراجعة مدعوم بالذكاء الاصطناعي لمن يذاكر بجدية.
+حوّل ملاحظاتك إلى بطاقات مراجعة بالذكاء الاصطناعي، ثم راجعها بالتكرار المتباعد للاختبارات واللغات والدراسة الجادة اليومية.
 
 استخدمه من أجل:
 - التحضير للاختبارات والدراسة الجامعية
@@ -57,18 +57,18 @@ study,spaced repetition,ai,vocabulary,language,exam prep,med school,decks,tags,f
 - تحسين البطاقات والتخطيط للدراسة بمساعدة الذكاء الاصطناعي
 - مراجعة يومية سريعة باستخدام المجموعات والوسوم والتكرار المتباعد
 
-أنشئ البطاقات وعدلها بسرعة، ونظّم دراستك عبر المجموعات والوسوم، وراجع بالتكرار المتباعد لتتذكر أكثر وتضيّع وقتا أقل.
+أنشئ البطاقات وعدلها بسرعة، ونظّم دراستك عبر المجموعات والوسوم، وراجع وفق جدول مركّز يساعدك على التذكر أكثر وتضييع وقت أقل.
 
 الذكاء الاصطناعي حاضر داخل تجربة المذاكرة نفسها. استخدمه لاستكشاف المادة، وصقل محتوى البطاقات، وفهم النقاط الصعبة، وترتيب ما ستذاكره لاحقا من داخل بطاقاتك.
 
-التطبيق مفتوح المصدر، ويمكن استضافة البنية الكاملة ذاتيا. الدعم وسياسة الخصوصية والشروط متاحة داخل التطبيق.
+للمتعلمين الذين يهتمون بالشفافية، التطبيق مفتوح المصدر، ويمكن استضافة البنية الكاملة ذاتيا. الدعم وسياسة الخصوصية والشروط متاحة داخل التطبيق.
 
 جميع شيفرات التطبيق والخلفية والبنية التحتية متاحة بشكل مفتوح على GitHub:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-مذاكرة,تكرار متباعد,ذكاء اصطناعي,مفردات,لغات,اختبارات,طب,بطاقات,وسوم,ذاكرة
+مذاكرة,تكرار,متباعد,ذكاء,اصطناعي,مفردات,لغات,اختبارات,طب,وسوم,ذاكرة
 
 ## Chinese (Simplified)
 
@@ -78,11 +78,11 @@ https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Subtitle
 
-AI 闪卡，认真学习更高效
+AI 笔记转闪卡
 
 ### Description
 
-开源闪卡是一款面向认真学习者的 AI 闪卡应用。
+用 AI 把笔记生成闪卡，再用间隔重复复习，适合备考、语言学习和认真坚持的日常学习。
 
 适合用来：
 - 备考和课程复习
@@ -91,18 +91,18 @@ AI 闪卡，认真学习更高效
 - 用 AI 优化卡片并规划学习节奏
 - 通过牌组、标签和间隔重复进行高效日常复习
 
-你可以快速创建和编辑卡片，用牌组和标签搭建自己的学习系统，再通过间隔重复记住更多内容、减少无效重复。
+你可以快速创建和编辑卡片，用牌组和标签搭建自己的学习系统，再按清晰的复习节奏记住更多内容、减少无效重复。
 
 AI 已经融入整个学习流程。你可以直接围绕卡片梳理知识、改写内容、拆解难点，并安排下一步学习。
 
-这是一个开源项目，整套应用、后端和基础设施都可自托管。支持、隐私政策和条款可在应用内查看。
+如果你重视透明度，这也是一个开源项目，整套应用、后端和基础设施都可自托管。支持、隐私政策和条款可在应用内查看。
 
 应用、后端和基础设施的全部代码都已在 GitHub 开放：
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-学习,间隔重复,AI,词汇,语言,考试,医学,卡组,标签,记忆
+学习,间隔,重复,词汇,语言,考试,备考,医学,卡组,标签,记忆,复习
 
 ## German
 
@@ -112,11 +112,11 @@ Open-Source-Karteikarten
 
 ### Subtitle
 
-KI-Karteikarten zum Lernen
+KI-Notizen zu Karten
 
 ### Description
 
-Open-Source-Karteikarten ist eine KI-gestützte Karteikarten-App für Menschen, die ernsthaft lernen.
+Erstelle aus Notizen KI-Karten und lerne sie mit Spaced Repetition für Prüfungen, Sprachen und ernsthaftes tägliches Lernen.
 
 Nutze sie für:
 - Prüfungsvorbereitung und Studium
@@ -125,18 +125,18 @@ Nutze sie für:
 - KI-gestützte Verbesserung deiner Karten und Studienplanung
 - Schnelle tägliche Wiederholung mit Stapeln, Tags und Spaced Repetition
 
-Erstelle und bearbeite Karten schnell, organisiere dein Lernsystem mit Stapeln und Tags und lerne mit Spaced Repetition so, dass mehr hängen bleibt und weniger Leerlauf entsteht.
+Erstelle und bearbeite Karten schnell, organisiere dein Lernsystem mit Stapeln und Tags und wiederhole nach einem klaren Plan, damit mehr hängen bleibt und weniger Leerlauf entsteht.
 
 KI gehört zum Lernfluss. Nutze sie, um Inhalte zu durchdringen, Formulierungen auf Karten zu verbessern, schwierige Themen zu entwirren und direkt aus deinen Karteikarten die nächsten Lernschritte festzulegen.
 
-Die App ist Open Source, und der komplette technische Stack kann selbst gehostet werden. Support, Datenschutzrichtlinie und Nutzungsbedingungen sind in der App verfügbar.
+Für Lernende, denen Transparenz wichtig ist, bleibt die App Open Source, und der komplette technische Stack kann selbst gehostet werden. Support, Datenschutzrichtlinie und Nutzungsbedingungen sind in der App verfügbar.
 
 Der gesamte Code für App, Backend und Infrastruktur ist offen auf GitHub verfügbar:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-lernen,karteikarten,ki,vokabeln,sprachen,prüfungen,medizin,decks,tags,gedächtnis
+lernen,spaced,repetition,vokabeln,sprachen,prüfungen,medizin,wiederholen,merken,decks,tags,fsrs
 
 ## Hindi
 
@@ -146,11 +146,11 @@ lernen,karteikarten,ki,vokabeln,sprachen,prüfungen,medizin,decks,tags,gedächtn
 
 ### Subtitle
 
-AI फ्लैशकार्ड से पढ़ाई
+नोट्स से AI कार्ड
 
 ### Description
 
-ओपन सोर्स फ्लैशकार्ड गंभीरता से पढ़ने वालों के लिए बना AI-संचालित फ्लैशकार्ड ऐप है।
+AI से नोट्स को फ्लैशकार्ड में बदलें, फिर परीक्षा, भाषा सीखने और गंभीर रोज़ाना पढ़ाई के लिए स्पेस्ड रिपिटीशन से रिव्यू करें।
 
 इसे इन कामों के लिए इस्तेमाल करें:
 - परीक्षा की तैयारी और कोर्सवर्क
@@ -159,18 +159,18 @@ AI फ्लैशकार्ड से पढ़ाई
 - AI की मदद से कार्ड बेहतर बनाना और पढ़ाई की योजना करना
 - डेक, टैग और स्पेस्ड रिपिटीशन के साथ तेज़ रोज़ाना रिव्यू
 
-कार्ड जल्दी बनाएं और एडिट करें, डेक और टैग से अपनी पढ़ाई व्यवस्थित करें, और स्पेस्ड रिपिटीशन के साथ ज़्यादा याद रखें और कम समय बर्बाद करें।
+कार्ड जल्दी बनाएं और एडिट करें, डेक और टैग से अपनी पढ़ाई व्यवस्थित करें, और साफ रिव्यू शेड्यूल के साथ ज़्यादा याद रखें और कम समय बर्बाद करें।
 
 AI पढ़ाई की प्रक्रिया का हिस्सा है। अपने फ्लैशकार्ड्स के भीतर ही सामग्री समझें, कार्ड बेहतर करें, मुश्किल विषय साफ करें, और आगे क्या पढ़ना है यह तय करें।
 
-यह ऐप ओपन सोर्स है, और पूरा तकनीकी स्टैक स्वयं होस्ट किया जा सकता है। सपोर्ट, प्राइवेसी पॉलिसी और टर्म्स ऐप के अंदर उपलब्ध हैं।
+जो विद्यार्थी पारदर्शिता चाहते हैं, उनके लिए यह ऐप ओपन सोर्स है, और पूरा तकनीकी स्टैक स्वयं होस्ट किया जा सकता है। सपोर्ट, प्राइवेसी पॉलिसी और टर्म्स ऐप के अंदर उपलब्ध हैं।
 
 ऐप, बैकएंड और इन्फ्रास्ट्रक्चर का पूरा कोड GitHub पर खुला उपलब्ध है:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-पढ़ाई,स्पेस्ड रिपिटीशन,एआई,शब्दावली,भाषा,परीक्षा,मेडिकल,डेक,टैग,याददाश्त
+पढ़ाई,स्पेस्ड,रिपिटीशन,शब्दावली,भाषा,परीक्षा,मेडिकल,रिव्यू,याददाश्त,डेक,टैग
 
 ## Japanese
 
@@ -180,11 +180,11 @@ https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Subtitle
 
-本気で学ぶ人のためのAI単語カード
+AIでノートをカード化
 
 ### Description
 
-オープンソース暗記カードは、本気で学びたい人のための AI 搭載フラッシュカードアプリです。
+AIでノートを暗記カードにし、試験対策、語学、本気の毎日の学習を間隔反復で復習できます。
 
 こんな用途に向いています:
 - 試験対策や授業の復習
@@ -193,18 +193,18 @@ https://github.com/kirill-markin/flashcards-open-source-app
 - AI を使ったカード改善と学習計画
 - デッキ、タグ、間隔反復による毎日の効率的な復習
 
-カードをすばやく作成・編集し、デッキやタグで学習内容を整理し、間隔反復でより多くを無駄なく定着させられます。
+カードをすばやく作成・編集し、デッキやタグで学習内容を整理し、明確な復習スケジュールでより多くを無駄なく定着させられます。
 
 AI は学習フローの中にあります。カードを離れずに内容を深掘りし、表現を整え、難しいテーマを整理し、次に何を学ぶかを決められます。
 
-このアプリはオープンソースで、アプリ、バックエンド、インフラを含むスタック全体をセルフホストすることもできます。サポート、プライバシーポリシー、利用規約はアプリ内で確認できます。
+透明性を重視する学習者のために、このアプリはオープンソースで、アプリ、バックエンド、インフラを含むスタック全体をセルフホストすることもできます。サポート、プライバシーポリシー、利用規約はアプリ内で確認できます。
 
 アプリ、バックエンド、インフラのすべてのコードは GitHub で公開されています:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-勉強,間隔反復,AI,単語,語学,試験,医学,デッキ,タグ,記憶
+勉強,間隔,反復,単語,語学,試験,医学,復習,記憶,デッキ,タグ
 
 ## Russian
 
@@ -214,11 +214,11 @@ https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Subtitle
 
-ИИ-флешкарты для учебы
+ИИ: заметки в карточки
 
 ### Description
 
-Флешкарты с открытым кодом — это приложение для флешкарт с ИИ для тех, кто учится всерьез.
+Создавайте ИИ-флешкарты из заметок, а затем повторяйте их интервально для экзаменов, языков и ежедневной учебы.
 
 Подходит для:
 - подготовки к экзаменам и учебным курсам
@@ -227,18 +227,18 @@ https://github.com/kirill-markin/flashcards-open-source-app
 - улучшения карточек и планирования учебы с помощью ИИ
 - быстрой ежедневной практики с колодами, тегами и интервальными повторениями
 
-Быстро создавайте и редактируйте карточки, выстраивайте свою систему обучения с помощью колод и тегов и запоминайте больше без лишней рутины благодаря интервальным повторениям.
+Быстро создавайте и редактируйте карточки, выстраивайте свою систему обучения с помощью колод и тегов и запоминайте больше без лишней рутины по понятному расписанию повторений.
 
 ИИ встроен в сам процесс обучения. Используйте его, чтобы разбирать материал, улучшать формулировки карточек, прояснять сложные темы и понимать, что учить дальше, не выходя из своих флешкарт.
 
-Приложение имеет открытый исходный код, и весь стек можно развернуть самостоятельно. Поддержка, политика конфиденциальности и условия доступны внутри приложения.
+Для тех, кому важна прозрачность, приложение имеет открытый исходный код, и весь стек можно развернуть самостоятельно. Поддержка, политика конфиденциальности и условия доступны внутри приложения.
 
 Весь код приложения, бэкенда и инфраструктуры открыт и доступен на GitHub:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-учеба,интервальные повторения,ai,словарь,языки,экзамены,медицина,колоды,теги,память
+учеба,интервалы,повторение,словарь,языки,экзамены,медицина,память,колоды,теги,fsrs
 
 ## Spanish (Mexico)
 
@@ -248,11 +248,11 @@ Flashcards de código abierto
 
 ### Subtitle
 
-Fichas con IA para estudiar
+Notas con IA a fichas
 
 ### Description
 
-Flashcards de código abierto es una app de flashcards con IA para quienes estudian en serio.
+Convierte notas en flashcards con IA y repásalas con repetición espaciada para exámenes, idiomas y estudio diario serio.
 
 Úsala para:
 - preparar exámenes y materias
@@ -261,18 +261,18 @@ Flashcards de código abierto es una app de flashcards con IA para quienes estud
 - mejorar tus tarjetas y planear tu estudio con ayuda de IA
 - hacer repasos diarios rápidos con mazos, etiquetas y repetición espaciada
 
-Crea y edita tarjetas rápido, organiza tu sistema de estudio con mazos y etiquetas, y repasa con repetición espaciada para retener más y perder menos tiempo en trabajo repetitivo.
+Crea y edita tarjetas rápido, organiza tu sistema de estudio con mazos y etiquetas, y repasa con un calendario claro para retener más y perder menos tiempo en trabajo repetitivo.
 
 La IA forma parte del flujo de estudio. Úsala para explorar tu material, pulir el contenido de tus tarjetas, aclarar temas difíciles y decidir qué estudiar después sin salir de tus tarjetas.
 
-La app es de código abierto y todo el stack puede alojarse por tu cuenta. El soporte, la política de privacidad y los términos están disponibles dentro de la app.
+Para estudiantes que valoran la transparencia, la app es de código abierto y todo el stack puede alojarse por tu cuenta. El soporte, la política de privacidad y los términos están disponibles dentro de la app.
 
 Todo el código de la app, el backend y la infraestructura está abierto y disponible en GitHub:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-estudio,repetición espaciada,ia,vocabulario,idiomas,exámenes,medicina,mazos,etiquetas,memoria
+estudio,repetición,espaciada,vocabulario,idiomas,exámenes,medicina,repaso,memoria,mazos,etiquetas
 
 ## Spanish (Spain)
 
@@ -282,11 +282,11 @@ Flashcards de código abierto
 
 ### Subtitle
 
-Fichas con IA para repasar
+Notas con IA a fichas
 
 ### Description
 
-Flashcards de código abierto es una app de flashcards con IA para quienes estudian en serio.
+Convierte notas en flashcards con IA y repásalas con repetición espaciada para exámenes, idiomas y estudio diario serio.
 
 Úsala para:
 - preparar exámenes y asignaturas
@@ -295,15 +295,15 @@ Flashcards de código abierto es una app de flashcards con IA para quienes estud
 - mejorar tus tarjetas y planificar el estudio con ayuda de IA
 - hacer repasos diarios rápidos con mazos, etiquetas y repetición espaciada
 
-Crea y edita tarjetas rápidamente, organiza tu sistema de estudio con mazos y etiquetas, y repasa con repetición espaciada para retener más y perder menos tiempo en tareas repetitivas.
+Crea y edita tarjetas rápidamente, organiza tu sistema de estudio con mazos y etiquetas, y repasa con un calendario claro para retener más y perder menos tiempo en tareas repetitivas.
 
 La IA forma parte del flujo de estudio. Úsala para explorar tu material, pulir el contenido de tus tarjetas, aclarar temas difíciles y decidir qué estudiar después sin salir de tus tarjetas.
 
-La app es de código abierto y todo el stack puede alojarse por tu cuenta. El soporte, la política de privacidad y los términos están disponibles dentro de la app.
+Para estudiantes que valoran la transparencia, la app es de código abierto y todo el stack puede alojarse por tu cuenta. El soporte, la política de privacidad y los términos están disponibles dentro de la app.
 
 Todo el código de la app, el backend y la infraestructura está abierto y disponible en GitHub:
 https://github.com/kirill-markin/flashcards-open-source-app
 
 ### Keywords
 
-estudio,repetición espaciada,ia,vocabulario,idiomas,exámenes,medicina,mazos,etiquetas,memoria
+estudio,repetición,espaciada,vocabulario,idiomas,exámenes,medicina,repaso,memoria,mazos,etiquetas


### PR DESCRIPTION
## Summary

Updates localized App Store Connect metadata to make the product positioning more outcome-oriented across all supported App Store locales.

## Changes

- Rewrites subtitles around the notes-to-flashcards outcome.
- Moves open-source/self-hosted positioning lower in each description as a transparency differentiator.
- Refreshes localized keyword fields while keeping them within App Store limits.

## Validation

- Ran `git diff --check`.
- Ran a local metadata limit check for `Name` <= 30, `Subtitle` <= 30, and `Keywords` <= 100 across every locale.