### PR TITLE
[codex] Split web localDb cards domain

### DIFF
--- a/apps/web/src/localDb/cards/cards/index.ts
+++ b/apps/web/src/localDb/cards/cards/index.ts
@@ -2,13 +2,13 @@ import type {
   Card,
   QueryCardsInput,
   QueryCardsPage,
-} from "../../types";
+} from "../../../types";
 import {
   matchesCardFilter,
   matchesDeckFilterDefinition,
-} from "../../appData/domain";
-import { deriveDueAtBucketMillis, deriveDueAtMillis } from "../../appData/domain/dueAt";
-import { loadAllowedCardIdsForTags, putCardTagRecords, writeCardTagRecords } from "./cardTags";
+} from "../../../appData/domain";
+import { deriveDueAtBucketMillis, deriveDueAtMillis } from "../../../appData/domain/dueAt";
+import { loadAllowedCardIdsForTags, putCardTagRecords, writeCardTagRecords } from "../tags";
 import {
   closeDatabaseAfter,
   closeDatabaseAfterWrite,
@@ -16,8 +16,8 @@ import {
   getFromStore,
   runReadwrite,
   type StoredCard,
-} from "../core/database";
-import { encodeCursor, decodeCursor } from "../core/queryShared";
+} from "../../core/database";
+import { encodeCursor, decodeCursor } from "../../core/queryShared";
 
 type CardCursorIndexName =
   | "workspaceId_createdAt_cardId"

--- a/apps/web/src/localDb/cards/decks/index.ts
+++ b/apps/web/src/localDb/cards/decks/index.ts
@@ -3,21 +3,21 @@ import type {
   Deck,
   DeckCardStats,
   DecksListSnapshot,
-} from "../../types";
+} from "../../../types";
 import {
   isCardDue,
   isCardNew,
   isCardReviewed,
   matchesDeckFilterDefinition,
-} from "../../appData/domain";
-import { iterateCardsByCreatedAtDesc } from "./cards";
+} from "../../../appData/domain";
+import { iterateCardsByCreatedAtDesc } from "../cards";
 import {
   closeDatabaseAfter,
   closeDatabaseAfterWrite,
   describeIndexedDbError,
   getFromStore,
   runReadwrite,
-} from "../core/database";
+} from "../../core/database";
 
 type DeckStatsAccumulator = Readonly<{
   totalCards: number;

--- a/apps/web/src/localDb/cards/index.ts
+++ b/apps/web/src/localDb/cards/index.ts
@@ -1,4 +1,4 @@
-export * from "./cardTags";
 export * from "./cards";
 export * from "./decks";
+export * from "./tags";
 export * from "./workspace";

--- a/apps/web/src/localDb/cards/tags/index.ts
+++ b/apps/web/src/localDb/cards/tags/index.ts
@@ -1,6 +1,6 @@
-import type { Card } from "../../types";
-import { normalizeTagKey } from "../../appData/domain";
-import { describeIndexedDbError } from "../core/database";
+import type { Card } from "../../../types";
+import { normalizeTagKey } from "../../../appData/domain";
+import { describeIndexedDbError } from "../../core/database";
 
 export type CardTagRecord = Readonly<{
   workspaceId: string;

--- a/apps/web/src/localDb/cards/workspace/index.ts
+++ b/apps/web/src/localDb/cards/workspace/index.ts
@@ -5,9 +5,9 @@ import type {
   WorkspaceSchedulerSettings,
   WorkspaceSummary,
   WorkspaceTagsSummary,
-} from "../../types";
-import { iterateAllCardTags } from "./cardTags";
-import { loadActiveCardCountWithDatabase, putCardInTransaction } from "./cards";
+} from "../../../types";
+import { iterateAllCardTags } from "../tags";
+import { loadActiveCardCountWithDatabase, putCardInTransaction } from "../cards";
 import {
   closeDatabaseAfter,
   closeDatabaseAfterWrite,
@@ -16,10 +16,10 @@ import {
   runReadwrite,
   type WorkspaceSettingsRecord,
   type WorkspaceSyncStateRecord,
-} from "../core/database";
-import { loadDecksListSnapshot, putDeckInTransaction } from "./decks";
-import { loadProgressCacheState, markProgressCacheDirtyInTransaction } from "../progress/progress";
-import { putReviewEventInTransaction } from "../reviews/reviews";
+} from "../../core/database";
+import { loadDecksListSnapshot, putDeckInTransaction } from "../decks";
+import { loadProgressCacheState, markProgressCacheDirtyInTransaction } from "../../progress/progress";
+import { putReviewEventInTransaction } from "../../reviews/reviews";
 
 type HotSyncStateUpdate = Readonly<{
   lastAppliedHotChangeId: number;

--- a/apps/web/src/localDb/reviews/reviews.ts
+++ b/apps/web/src/localDb/reviews/reviews.ts
@@ -12,7 +12,7 @@ import {
   matchesDeckFilterDefinition,
   recentDuePriorityWindow,
 } from "../../appData/domain";
-import { loadAllowedCardIdsForTag } from "../cards/cardTags";
+import { loadAllowedCardIdsForTag } from "../cards/tags";
 import {
   iterateLocalStoredCardsByCreatedAtDesc,
   iterateLocalStoredCardsByDueAtMillisAscAfter,


### PR DESCRIPTION
## Summary

- Split the web localDb cards domain modules into cards, decks, tags, and workspace directory modules.
- Kept the cards compatibility barrel exporting the same public function names.
- Updated the reviews tag lookup import to the new tags module path.

## Validation

- `npm exec vitest run src/localDb/cards/cards.test.ts src/localDb/reviews/reviews.test.ts src/localDb/reviews/reviewSchedule.test.ts src/appData/sync/syncLifecycleObservation.test.ts`
- `npm run build`
- `npm run test`