### PR TITLE
[codex] Split Android cloud remote packages

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreHotRowPreservationContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreHotRowPreservationContractTest.kt
@@ -1,7 +1,7 @@
 package com.flashcardsopensourceapp.data.local.cloud.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapEntry
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapEntry
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreReviewHistoryEventContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreReviewHistoryEventContractTest.kt
@@ -1,7 +1,7 @@
 package com.flashcardsopensourceapp.data.local.cloud.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryEvent
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryEvent
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreTimestampPayloadContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreTimestampPayloadContractTest.kt
@@ -2,7 +2,7 @@ package com.flashcardsopensourceapp.data.local.cloud.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapEntry
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapEntry
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepositoryGuestUpgradeDrainTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepositoryGuestUpgradeDrainTest.kt
@@ -3,8 +3,8 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
 import androidx.room.withTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPullResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPushResponse
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
@@ -2,7 +2,7 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepositoryPendingGuestUpgradeRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepositoryPendingGuestUpgradeRecoveryTest.kt
@@ -2,10 +2,10 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPullResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePullResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryPullResponse
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
@@ -2,13 +2,13 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.support
 
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPullResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPushResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePullResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushOperationResult
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryImportResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushOperationResult
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryImportResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryPullResponse
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryHotRowReplayTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryHotRowReplayTest.kt
@@ -2,12 +2,12 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapEntry
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPullResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePullResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushOperationResult
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteSyncChange
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapEntry
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushOperationResult
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteSyncChange
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryReviewHistoryImportRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryReviewHistoryImportRecoveryTest.kt
@@ -2,8 +2,8 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPushResponse
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryImportResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryImportResponse
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.CloudIdentityTestEnvironment

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositorySyncBlockingTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositorySyncBlockingTest.kt
@@ -3,7 +3,7 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.sync
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
 import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryWorkspaceForkRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/LocalSyncRepositoryWorkspaceForkRecoveryTest.kt
@@ -2,8 +2,8 @@ package com.flashcardsopensourceapp.data.local.repository.cloudsync.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushOperationResult
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushOperationResult
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
@@ -1,5 +1,11 @@
 package com.flashcardsopensourceapp.data.local.cloud.remote
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryImportResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryPullResponse
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
@@ -1,6 +1,23 @@
 package com.flashcardsopensourceapp.data.local.cloud.remote
 
 import com.flashcardsopensourceapp.core.observability.AppObservability
+import com.flashcardsopensourceapp.data.local.cloud.remote.agent.CloudAgentConnectionRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.auth.CloudAuthRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.feedback.CloudFeedbackRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.guest.CloudGuestUpgradeRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.progress.CloudProgressRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.CloudSyncRemoteApi
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryImportResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudHttpObservationVersions
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.NoopCloudHttpObservability
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.createCloudHttpObservationVersions
+import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.CloudAccountWorkspaceRemoteApi
 import com.flashcardsopensourceapp.data.local.model.cloud.AgentApiKeyConnectionsResult
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackPromptEventRequest

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/agent/CloudAgentConnectionRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/agent/CloudAgentConnectionRemoteApi.kt
@@ -1,5 +1,7 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.agent
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildPaginatedCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudIsoTimestampMillis
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableIsoTimestampMillis

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/auth/CloudAuthRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/auth/CloudAuthRemoteApi.kt
@@ -1,5 +1,6 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.auth
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudIntOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/feedback/CloudFeedbackRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/feedback/CloudFeedbackRemoteApi.kt
@@ -1,5 +1,6 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.feedback
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
 import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableString
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableIsoTimestampMillis

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/guest/CloudGuestUpgradeRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/guest/CloudGuestUpgradeRemoteApi.kt
@@ -1,5 +1,7 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.guest
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.workspace.parseCloudWorkspace
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudArrayOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudObjectOrNull

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -1,5 +1,9 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.progress
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgressReviewScheduleCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgressSeriesCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgressSummaryCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/sync/CloudSyncRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/sync/CloudSyncRemoteApi.kt
@@ -1,5 +1,7 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.sync
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudLongOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.transport
 
 import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
 import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
@@ -6,6 +6,8 @@ import com.flashcardsopensourceapp.core.observability.AndroidObservationFeature
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudSyncConflictDetails
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudBooleanOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudIntOrNull

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.transport
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/workspace/CloudAccountWorkspaceRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/workspace/CloudAccountWorkspaceRemoteApi.kt
@@ -1,5 +1,7 @@
-package com.flashcardsopensourceapp.data.local.cloud.remote
+package com.flashcardsopensourceapp.data.local.cloud.remote.workspace
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHttpClient
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildPaginatedCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncBootstrapLocalStore.kt
@@ -2,7 +2,7 @@ package com.flashcardsopensourceapp.data.local.cloud.sync
 
 import androidx.room.withTransaction
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapEntry
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapEntry
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildCardBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildDeckBootstrapEntryJson
 import com.flashcardsopensourceapp.data.local.cloud.wire.buildReviewHistoryImportEventJson

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncHotStateLocalStore.kt
@@ -7,7 +7,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceSchedulerSettingsEntity
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteSyncChange
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteSyncChange
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudDoubleOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudIntOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.parseEffortLevel

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStore.kt
@@ -2,9 +2,9 @@ package com.flashcardsopensourceapp.data.local.cloud.sync
 
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.identity.WorkspaceIdentityLocalStore
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapEntry
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryEvent
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteSyncChange
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapEntry
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryEvent
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteSyncChange
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.DeckEntity

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncReviewHistoryLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncReviewHistoryLocalStore.kt
@@ -3,7 +3,7 @@ package com.flashcardsopensourceapp.data.local.cloud.sync
 import androidx.room.withTransaction
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteReviewHistoryEvent
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteReviewHistoryEvent
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.cloud.parseIsoTimestamp
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -6,7 +6,7 @@ import com.flashcardsopensourceapp.data.local.bootstrap.ensureLocalWorkspaceShel
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
@@ -6,7 +6,7 @@ import com.flashcardsopensourceapp.data.local.cloud.sync.PendingLocalHotEntityKe
 import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableDouble
 import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableInt
 import com.flashcardsopensourceapp.data.local.cloud.wire.putNullableString
-import com.flashcardsopensourceapp.data.local.cloud.remote.RemoteBootstrapPullResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapPullResponse
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -1,6 +1,11 @@
 package com.flashcardsopensourceapp.data.local.cloud.remote
 
 import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRequiredErrorCode
+import com.flashcardsopensourceapp.data.local.cloud.remote.guest.buildGuestUpgradeCompleteRequest
+import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressReviewScheduleResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSummaryResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.sync.parseRemotePushResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.parseCloudErrorPayload
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey


### PR DESCRIPTION
## What changed

- Split Android cloud remote endpoint APIs into endpoint-specific subpackages.
- Moved transport-only HTTP client and path helpers into `remote.transport`.
- Kept `CloudRemoteGateway` and `CloudRemoteService` as the public composition boundary.
- Updated sync response model imports across production code, fakes, and tests.

## Validation

- `git --no-pager diff --check`
- `git --no-pager diff --cached --check`
- Diff-focused review of moved files and dependent gateway implementations/fakes/tests.

Gradle was not run because this repository requires explicit approval before local `./gradlew` runs.