### PR TITLE
Split Android data local tests by package

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cards/LocalCardsDecksRepositoryContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cards/LocalCardsDecksRepositoryContractTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.cards
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
@@ -9,6 +9,13 @@ import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createTestCardsRepository
+import com.flashcardsopensourceapp.data.local.support.createTestDecksRepository
+import com.flashcardsopensourceapp.data.local.support.createTestWorkspaceRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration10To14Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration10To14Test.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.migrations
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration14To17Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration14To17Test.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.migrations
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration5To6Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration5To6Test.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.migrations
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration9To10Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration9To10Test.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.migrations
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigrationTestSupport.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigrationTestSupport.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.migrations
 
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/CloudPreferencesStoreMigrationContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/CloudPreferencesStoreMigrationContractTest.kt
@@ -1,10 +1,12 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.migrations
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
+import com.flashcardsopensourceapp.data.local.support.clearLocalDatabaseSharedPreferences
+import com.flashcardsopensourceapp.data.local.support.createInMemoryAppDatabase
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/CardDaoReviewQueueContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/CardDaoReviewQueueContractTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.review
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
@@ -6,6 +6,12 @@ import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.database.review.loadTopActiveReviewCard
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.makeDueReviewOrderingCardEntity
+import com.flashcardsopensourceapp.data.local.support.makeNewReviewOrderingCardEntity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewFilterContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewFilterContractTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.review
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
@@ -10,6 +10,13 @@ import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createTestDecksRepository
+import com.flashcardsopensourceapp.data.local.support.createTestReviewRepository
+import com.flashcardsopensourceapp.data.local.support.makeNewReviewOrderingCardEntity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewQueueContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewQueueContractTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.review
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
@@ -11,6 +11,15 @@ import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.review.ReviewIntervalDescription
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createTestCardsRepository
+import com.flashcardsopensourceapp.data.local.support.createTestDecksRepository
+import com.flashcardsopensourceapp.data.local.support.createTestReviewRepository
+import com.flashcardsopensourceapp.data.local.support.makeDueReviewOrderingCardEntity
+import com.flashcardsopensourceapp.data.local.support.makeNewReviewOrderingCardEntity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewRollbackContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/review/LocalReviewRollbackContractTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.review
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
@@ -10,6 +10,14 @@ import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCardQueueStatus
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createTestDecksRepository
+import com.flashcardsopensourceapp.data.local.support.createTestReviewRepository
+import com.flashcardsopensourceapp.data.local.support.makeDueReviewOrderingCardEntity
+import com.flashcardsopensourceapp.data.local.support.makeNewReviewOrderingCardEntity
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.support
 
 import android.content.Context
 import androidx.room.Room

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/sync/LocalSyncOutboxContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/sync/LocalSyncOutboxContractTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.sync
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
@@ -7,6 +7,14 @@ import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createTestCardsRepository
+import com.flashcardsopensourceapp.data.local.support.createTestDecksRepository
+import com.flashcardsopensourceapp.data.local.support.createTestReviewRepository
+import com.flashcardsopensourceapp.data.local.support.createTestWorkspaceRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.json.JSONObject

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/workspace/LocalWorkspaceBootstrapContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/workspace/LocalWorkspaceBootstrapContractTest.kt
@@ -1,8 +1,13 @@
-package com.flashcardsopensourceapp.data.local
+package com.flashcardsopensourceapp.data.local.workspace
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
+import com.flashcardsopensourceapp.data.local.support.LocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.bootstrapTestWorkspace
+import com.flashcardsopensourceapp.data.local.support.closeLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createLocalDatabaseTestRuntime
+import com.flashcardsopensourceapp.data.local.support.createTestWorkspaceRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After


### PR DESCRIPTION
## Summary
- Move Android data-local root androidTest files into workflow-specific packages.
- Keep migration support with migration tests and shared database fixtures in support.
- Update package declarations and explicit support imports without changing test behavior.

## Validation
- Reviewed the working-tree diff and package references.
- Did not run ./gradlew because this task did not approve a Gradle run.