### PR TITLE
[codex] Split Android settings cloud package

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
@@ -17,10 +17,10 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecover
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudCredentialRecoveryGateRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudCredentialRecoveryGateStep
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudPostAuthUiState
-import com.flashcardsopensourceapp.feature.settings.cloud.CloudSendCodeNavigationOutcome
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInUiState
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInViewModel
 import com.flashcardsopensourceapp.feature.settings.cloud.createCloudSignInViewModelFactory
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSendCodeNavigationOutcome
 import com.flashcardsopensourceapp.feature.settings.R as SettingsR
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -16,10 +16,10 @@ import com.flashcardsopensourceapp.app.navigation.SettingsDestination
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudPostAuthRoute
-import com.flashcardsopensourceapp.feature.settings.cloud.CloudSendCodeNavigationOutcome
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInCodeRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInEmailRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.createCloudSignInViewModelFactory
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSendCodeNavigationOutcome
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
@@ -1,0 +1,182 @@
+package com.flashcardsopensourceapp.feature.settings.cloud
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.ViewModelProvider
+import com.flashcardsopensourceapp.core.ui.TransientMessageController
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
+import com.flashcardsopensourceapp.data.local.repository.SyncRepository
+import com.flashcardsopensourceapp.feature.settings.cloud.credentialRecovery.CloudCredentialRecoveryGateRoute as CloudCredentialRecoveryGateRouteImpl
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthRoute as CloudPostAuthRouteImpl
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInCodeRoute as CloudSignInCodeRouteImpl
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInEmailRoute as CloudSignInEmailRouteImpl
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInErrorCard as CloudSignInErrorCardImpl
+
+typealias CloudCredentialRecoveryGateStep =
+    com.flashcardsopensourceapp.feature.settings.cloud.credentialRecovery.CloudCredentialRecoveryGateStep
+typealias CloudPostAuthMode = com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthMode
+typealias CloudPostAuthUiState = com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthUiState
+typealias CloudSendCodeNavigationOutcome =
+    com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSendCodeNavigationOutcome
+typealias CloudSignInUiState = com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInUiState
+typealias CloudSignInViewModel = com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInViewModel
+
+const val cloudCredentialRecoveryGateTag: String = "cloud_credential_recovery_gate"
+const val cloudCredentialRecoveryGateSignInButtonTag: String =
+    "cloud_credential_recovery_gate_sign_in_button"
+const val cloudCredentialRecoveryGateEraseButtonTag: String =
+    "cloud_credential_recovery_gate_erase_button"
+const val cloudCredentialRecoveryGateEraseDialogTag: String =
+    "cloud_credential_recovery_gate_erase_dialog"
+const val cloudCredentialRecoveryGateConfirmEraseButtonTag: String =
+    "cloud_credential_recovery_gate_confirm_erase_button"
+
+const val cloudPostAuthExistingButtonTagPrefix: String = "cloud_post_auth_existing_button:"
+const val cloudPostAuthWorkspaceRowTag: String = "cloud_post_auth_workspace_row"
+const val cloudPostAuthSelectedIndicatorTagPrefix: String =
+    "cloud_post_auth_selected_indicator:"
+
+const val cloudSignInEmailFieldTag: String = "cloud_sign_in_email_field"
+const val cloudSignInSendCodeButtonTag: String = "cloud_sign_in_send_code_button"
+
+fun cloudPostAuthExistingButtonTag(workspaceId: String): String {
+    return com.flashcardsopensourceapp.feature.settings.cloud.postAuth.cloudPostAuthExistingButtonTag(
+        workspaceId = workspaceId
+    )
+}
+
+fun cloudPostAuthSelectedIndicatorTag(workspaceId: String): String {
+    return com.flashcardsopensourceapp.feature.settings.cloud.postAuth.cloudPostAuthSelectedIndicatorTag(
+        workspaceId = workspaceId
+    )
+}
+
+@Composable
+fun CloudSignInEmailRoute(
+    uiState: CloudSignInUiState,
+    onEmailChange: (String) -> Unit,
+    onSendCode: () -> Unit,
+    onBack: () -> Unit
+) {
+    CloudSignInEmailRouteImpl(
+        uiState = uiState,
+        onEmailChange = onEmailChange,
+        onSendCode = onSendCode,
+        onBack = onBack
+    )
+}
+
+@Composable
+fun CloudSignInCodeRoute(
+    uiState: CloudSignInUiState,
+    onCodeChange: (String) -> Unit,
+    onVerifyCode: () -> Unit,
+    onBack: () -> Unit
+) {
+    CloudSignInCodeRouteImpl(
+        uiState = uiState,
+        onCodeChange = onCodeChange,
+        onVerifyCode = onVerifyCode,
+        onBack = onBack
+    )
+}
+
+@Composable
+fun CloudSignInErrorCard(
+    message: String,
+    technicalDetails: String?,
+    modifier: Modifier
+) {
+    CloudSignInErrorCardImpl(
+        message = message,
+        technicalDetails = technicalDetails,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun CloudPostAuthRoute(
+    uiState: CloudPostAuthUiState,
+    onAutoContinue: () -> Unit,
+    onSelectWorkspace: (CloudWorkspaceLinkSelection) -> Unit,
+    onRetry: () -> Unit,
+    onFailureAction: () -> Unit,
+    onBack: () -> Unit,
+    canNavigateBack: Boolean
+) {
+    CloudPostAuthRouteImpl(
+        uiState = uiState,
+        onAutoContinue = onAutoContinue,
+        onSelectWorkspace = onSelectWorkspace,
+        onRetry = onRetry,
+        onFailureAction = onFailureAction,
+        onBack = onBack,
+        canNavigateBack = canNavigateBack
+    )
+}
+
+@Composable
+fun CloudCredentialRecoveryGateRoute(
+    recoveryState: CloudCredentialRecoveryState,
+    isRecoveryStateActive: Boolean,
+    step: CloudCredentialRecoveryGateStep,
+    signInUiState: CloudSignInUiState,
+    postAuthUiState: CloudPostAuthUiState,
+    isEraseConfirmationVisible: Boolean,
+    isErasing: Boolean,
+    eraseErrorMessage: String,
+    onSignIn: () -> Unit,
+    onEmailChange: (String) -> Unit,
+    onSendCode: () -> Unit,
+    onCodeChange: (String) -> Unit,
+    onVerifyCode: () -> Unit,
+    onAutoContinue: () -> Unit,
+    onSelectWorkspace: (CloudWorkspaceLinkSelection) -> Unit,
+    onRetryPostAuth: () -> Unit,
+    onBackToOverview: () -> Unit,
+    onBackToEmail: () -> Unit,
+    onRequestEraseConfirmation: () -> Unit,
+    onDismissEraseConfirmation: () -> Unit,
+    onConfirmErase: () -> Unit
+) {
+    CloudCredentialRecoveryGateRouteImpl(
+        recoveryState = recoveryState,
+        isRecoveryStateActive = isRecoveryStateActive,
+        step = step,
+        signInUiState = signInUiState,
+        postAuthUiState = postAuthUiState,
+        isEraseConfirmationVisible = isEraseConfirmationVisible,
+        isErasing = isErasing,
+        eraseErrorMessage = eraseErrorMessage,
+        onSignIn = onSignIn,
+        onEmailChange = onEmailChange,
+        onSendCode = onSendCode,
+        onCodeChange = onCodeChange,
+        onVerifyCode = onVerifyCode,
+        onAutoContinue = onAutoContinue,
+        onSelectWorkspace = onSelectWorkspace,
+        onRetryPostAuth = onRetryPostAuth,
+        onBackToOverview = onBackToOverview,
+        onBackToEmail = onBackToEmail,
+        onRequestEraseConfirmation = onRequestEraseConfirmation,
+        onDismissEraseConfirmation = onDismissEraseConfirmation,
+        onConfirmErase = onConfirmErase
+    )
+}
+
+fun createCloudSignInViewModelFactory(
+    cloudAccountRepository: CloudAccountRepository,
+    syncRepository: SyncRepository,
+    messageController: TransientMessageController,
+    applicationContext: Context
+): ViewModelProvider.Factory {
+    return com.flashcardsopensourceapp.feature.settings.cloud.signIn.createCloudSignInViewModelFactory(
+        cloudAccountRepository = cloudAccountRepository,
+        syncRepository = syncRepository,
+        messageController = messageController,
+        applicationContext = applicationContext
+    )
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/credentialRecovery/CloudCredentialRecoveryGateRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/credentialRecovery/CloudCredentialRecoveryGateRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.credentialRecovery
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +27,13 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecover
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
 import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthMode
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthRoute
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthUiState
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInCodeRoute
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInEmailRoute
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInErrorCard
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInUiState
 
 const val cloudCredentialRecoveryGateTag: String = "cloud_credential_recovery_gate"
 const val cloudCredentialRecoveryGateSignInButtonTag: String =

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/credentialRecovery/CloudCredentialRecoveryPostAuthSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/credentialRecovery/CloudCredentialRecoveryPostAuthSupport.kt
@@ -1,0 +1,85 @@
+package com.flashcardsopensourceapp.feature.settings.cloud.credentialRecovery
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkContext
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspacePostAuthRoute
+import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
+import com.flashcardsopensourceapp.feature.settings.cloud.buildAutomaticWorkspaceSelection
+
+internal fun buildCloudPostAuthPendingSelection(
+    linkContext: CloudWorkspaceLinkContext
+): CloudWorkspaceLinkSelection? {
+    return when (linkContext.postAuthRoute) {
+        CloudWorkspacePostAuthRoute.NONE -> buildAutomaticWorkspaceSelection(
+            preferredWorkspaceId = linkContext.preferredWorkspaceId,
+            workspaces = linkContext.workspaces
+        )
+
+        CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE -> {
+            val preferredWorkspaceId = linkContext.preferredWorkspaceId ?: return null
+            if (linkContext.workspaces.any { workspace -> workspace.workspaceId == preferredWorkspaceId }) {
+                CloudWorkspaceLinkSelection.Existing(workspaceId = preferredWorkspaceId)
+            } else {
+                null
+            }
+        }
+
+        CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> CloudWorkspaceLinkSelection.CreateNew
+
+        CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY,
+        CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> null
+    }
+}
+
+internal fun cloudPostAuthRecoveryErrorMessage(
+    linkContext: CloudWorkspaceLinkContext,
+    pendingSelection: CloudWorkspaceLinkSelection?,
+    strings: SettingsStringResolver
+): String {
+    return when (linkContext.postAuthRoute) {
+        CloudWorkspacePostAuthRoute.NONE -> ""
+        CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE -> {
+            if (pendingSelection == null) {
+                strings.get(R.string.settings_post_auth_linked_recovery_blocked)
+            } else {
+                ""
+            }
+        }
+        CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> {
+            ""
+        }
+        CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY -> {
+            strings.get(R.string.settings_post_auth_pending_guest_upgrade_recovery_required)
+        }
+        CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> {
+            strings.get(R.string.settings_post_auth_invalid_recovery_state)
+        }
+    }
+}
+
+internal fun cloudPostAuthRecoveryExceptionMessage(
+    error: CloudCredentialRecoveryRequiredException,
+    strings: SettingsStringResolver
+): String {
+    return when (error.recoveryState.reason) {
+        CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING -> {
+            if (error.recoveryState.previousCloudState == CloudAccountState.GUEST) {
+                strings.get(R.string.settings_post_auth_pending_guest_upgrade_recovery_required)
+            } else {
+                strings.get(R.string.settings_post_auth_linked_recovery_blocked)
+            }
+        }
+
+        CloudCredentialRecoveryReason.GUEST_SESSION_MISSING -> {
+            strings.get(R.string.settings_post_auth_guest_local_recovery_required)
+        }
+
+        CloudCredentialRecoveryReason.INVALID_STORED_STATE -> {
+            strings.get(R.string.settings_post_auth_invalid_recovery_state)
+        }
+    }
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthOperations.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthOperations.kt
@@ -1,0 +1,43 @@
+package com.flashcardsopensourceapp.feature.settings.cloud.postAuth
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkContext
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspacePostAuthRoute
+import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
+import com.flashcardsopensourceapp.data.local.repository.SyncRepository
+
+internal data class CloudPostAuthWorkspaceCompletion(
+    val workspaceTitle: String,
+    val requiresInitialSync: Boolean
+)
+
+internal suspend fun completeCloudPostAuthWorkspaceSelection(
+    cloudAccountRepository: CloudAccountRepository,
+    linkContext: CloudWorkspaceLinkContext,
+    selection: CloudWorkspaceLinkSelection
+): CloudPostAuthWorkspaceCompletion {
+    val workspace = if (requiresCloudGuestUpgrade(linkContext = linkContext)) {
+        cloudAccountRepository.completeGuestUpgrade(
+            linkContext = linkContext,
+            selection = selection
+        )
+    } else {
+        cloudAccountRepository.completeCloudLink(
+            linkContext = linkContext,
+            selection = selection
+        )
+    }
+    return CloudPostAuthWorkspaceCompletion(
+        workspaceTitle = workspace.name,
+        requiresInitialSync = requiresCloudPostAuthInitialSync(linkContext = linkContext)
+    )
+}
+
+internal suspend fun completeCloudPostAuthSyncOnly(syncRepository: SyncRepository) {
+    syncRepository.syncNow()
+}
+
+private fun requiresCloudPostAuthInitialSync(linkContext: CloudWorkspaceLinkContext): Boolean {
+    return linkContext.postAuthRoute != CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE &&
+        linkContext.postAuthRoute != CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.postAuth
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthStateReducers.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthStateReducers.kt
@@ -1,0 +1,149 @@
+package com.flashcardsopensourceapp.feature.settings.cloud.postAuth
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkContext
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspacePostAuthRoute
+import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInDraftState
+
+internal fun prepareCloudPostAuthWorkspaceCompletion(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    linkContext: CloudWorkspaceLinkContext,
+    selection: CloudWorkspaceLinkSelection,
+    strings: SettingsStringResolver
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    val isGuestUpgrade = linkContext.guestUpgradeMode != null
+    return state.copy(
+        pendingSelection = null,
+        processingTitle = if (isGuestUpgrade) {
+            strings.get(R.string.settings_post_auth_upgrading_title)
+        } else {
+            strings.get(R.string.settings_post_auth_linking_title)
+        },
+        processingMessage = if (isGuestUpgrade) {
+            strings.get(R.string.settings_post_auth_upgrading_body)
+        } else {
+            strings.get(R.string.settings_post_auth_linking_body)
+        },
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = if (requiresCloudGuestUpgrade(linkContext = linkContext)) {
+            CloudPostAuthRetryAction.CompleteGuestUpgrade(
+                authAttemptId = authAttemptId,
+                linkContext = linkContext,
+                selection = selection
+            )
+        } else {
+            CloudPostAuthRetryAction.CompleteCloudLink(
+                authAttemptId = authAttemptId,
+                linkContext = linkContext,
+                selection = selection
+            )
+        }
+    )
+}
+
+internal fun prepareCloudPostAuthGuestLocalRecovery(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    linkContext: CloudWorkspaceLinkContext,
+    strings: SettingsStringResolver
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        pendingSelection = null,
+        processingTitle = strings.get(R.string.settings_post_auth_recovering_local_data_title),
+        processingMessage = strings.get(R.string.settings_post_auth_recovering_local_data_body),
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = CloudPostAuthRetryAction.CompleteGuestLocalRecovery(
+            authAttemptId = authAttemptId,
+            linkContext = linkContext
+        )
+    )
+}
+
+internal fun prepareCloudPostAuthSyncOnly(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    workspaceTitle: String,
+    strings: SettingsStringResolver
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        processingTitle = strings.get(R.string.settings_post_auth_syncing_title),
+        processingMessage = strings.get(R.string.settings_post_auth_syncing_body),
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = CloudPostAuthRetryAction.SyncOnly(
+            authAttemptId = authAttemptId,
+            workspaceTitle = workspaceTitle
+        )
+    )
+}
+
+internal fun failCloudPostAuth(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    errorMessage: String,
+    recoveryErrorBlocked: Boolean,
+    postAuthResetAllowed: Boolean
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        processingTitle = "",
+        processingMessage = "",
+        postAuthErrorMessage = errorMessage,
+        postAuthRecoveryBlocked = recoveryErrorBlocked,
+        postAuthResetAllowed = postAuthResetAllowed,
+        retryAction = if (recoveryErrorBlocked) {
+            null
+        } else {
+            state.retryAction
+        }
+    )
+}
+
+internal fun finishCloudPostAuthSuccess(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    completionToken: Long
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        email = "",
+        code = "",
+        challenge = null,
+        linkContext = null,
+        pendingSelection = null,
+        processingTitle = "",
+        processingMessage = "",
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = null,
+        completionToken = completionToken
+    )
+}
+
+internal fun requiresCloudGuestUpgrade(linkContext: CloudWorkspaceLinkContext): Boolean {
+    return linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.NONE &&
+        linkContext.guestUpgradeMode == CloudGuestUpgradeMode.MERGE_REQUIRED
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthSupport.kt
@@ -1,0 +1,73 @@
+package com.flashcardsopensourceapp.feature.settings.cloud.postAuth
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryReason
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkContext
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspacePostAuthRoute
+import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInDraftState
+
+internal sealed interface CloudPostAuthRetryAction {
+    data class CompleteCloudLink(
+        val authAttemptId: Long,
+        val linkContext: CloudWorkspaceLinkContext,
+        val selection: CloudWorkspaceLinkSelection
+    ) : CloudPostAuthRetryAction
+
+    data class CompleteGuestUpgrade(
+        val authAttemptId: Long,
+        val linkContext: CloudWorkspaceLinkContext,
+        val selection: CloudWorkspaceLinkSelection
+    ) : CloudPostAuthRetryAction
+
+    data class CompleteGuestLocalRecovery(
+        val authAttemptId: Long,
+        val linkContext: CloudWorkspaceLinkContext
+    ) : CloudPostAuthRetryAction
+
+    data class SyncOnly(
+        val authAttemptId: Long,
+        val workspaceTitle: String
+    ) : CloudPostAuthRetryAction
+}
+
+internal enum class CloudPostAuthFailureAction {
+    RESET_INVALID_RECOVERY,
+    LOGOUT
+}
+
+internal fun canRunCloudPostAuthFailureAction(draft: CloudSignInDraftState): Boolean {
+    return resolveCloudPostAuthFailureAction(draft = draft) != null
+}
+
+internal fun resolveCloudPostAuthFailureAction(
+    draft: CloudSignInDraftState
+): CloudPostAuthFailureAction? {
+    return when {
+        draft.postAuthResetAllowed -> CloudPostAuthFailureAction.RESET_INVALID_RECOVERY
+        draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE &&
+            draft.postAuthRecoveryBlocked.not() -> CloudPostAuthFailureAction.LOGOUT
+        else -> null
+    }
+}
+
+internal fun cloudPostAuthFailureActionLabel(
+    resetAllowed: Boolean,
+    strings: SettingsStringResolver
+): String {
+    return if (resetAllowed) {
+        strings.get(R.string.settings_post_auth_reset_cloud_identity_button)
+    } else {
+        strings.get(R.string.settings_logout)
+    }
+}
+
+internal fun isCloudPostAuthProcessing(state: CloudSignInDraftState): Boolean {
+    return state.processingTitle.isNotEmpty()
+}
+
+internal fun isInvalidCloudCredentialRecovery(error: CloudCredentialRecoveryRequiredException?): Boolean {
+    return error?.recoveryState?.reason == CloudCredentialRecoveryReason.INVALID_STORED_STATE
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthUiState.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.postAuth
 
 import com.flashcardsopensourceapp.feature.settings.workspace.current.CurrentWorkspaceItemUiState
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSendCodeNavigationOutcome.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSendCodeNavigationOutcome.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.signIn
 
 /**
  * Distinguishes the two valid navigation paths after `sendCode()`.

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInCodeRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInCodeRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.signIn
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,7 +12,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.R
@@ -20,20 +19,17 @@ import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
 
-const val cloudSignInEmailFieldTag: String = "cloud_sign_in_email_field"
-const val cloudSignInSendCodeButtonTag: String = "cloud_sign_in_send_code_button"
-
 @Composable
-fun CloudSignInEmailRoute(
+fun CloudSignInCodeRoute(
     uiState: CloudSignInUiState,
-    onEmailChange: (String) -> Unit,
-    onSendCode: () -> Unit,
+    onCodeChange: (String) -> Unit,
+    onVerifyCode: () -> Unit,
     onBack: () -> Unit
 ) {
     SettingsScreenScaffold(
-        title = stringResource(R.string.settings_sign_in_title),
+        title = stringResource(R.string.settings_sign_in_verify_title),
         onBack = onBack,
-        isBackEnabled = uiState.isSendingCode.not()
+        isBackEnabled = uiState.isVerifyingCode.not()
     ) { innerPadding ->
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
@@ -44,9 +40,15 @@ fun CloudSignInEmailRoute(
                 Card(modifier = Modifier.fillMaxWidth()) {
                     Text(
                         text = if (uiState.isGuestUpgrade) {
-                            stringResource(R.string.settings_sign_in_guest_upgrade_body)
+                            stringResource(
+                                R.string.settings_sign_in_verify_guest_body,
+                                uiState.challengeEmail ?: stringResource(R.string.settings_sign_in_email_fallback)
+                            )
                         } else {
-                            stringResource(R.string.settings_sign_in_device_link_body)
+                            stringResource(
+                                R.string.settings_sign_in_verify_body,
+                                uiState.challengeEmail ?: stringResource(R.string.settings_sign_in_email_fallback)
+                            )
                         },
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(20.dp)
@@ -66,30 +68,26 @@ fun CloudSignInEmailRoute(
 
             item {
                 OutlinedTextField(
-                    value = uiState.email,
-                    onValueChange = onEmailChange,
+                    value = uiState.code,
+                    onValueChange = onCodeChange,
                     label = {
-                        Text(stringResource(R.string.settings_sign_in_email_title))
+                        Text(stringResource(R.string.settings_sign_in_code_label))
                     },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag(tag = cloudSignInEmailFieldTag)
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
 
             item {
                 Button(
-                    onClick = onSendCode,
-                    enabled = uiState.isSendingCode.not(),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag(tag = cloudSignInSendCodeButtonTag)
+                    onClick = onVerifyCode,
+                    enabled = uiState.isVerifyingCode.not(),
+                    modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
-                        if (uiState.isSendingCode) {
-                            stringResource(R.string.settings_sign_in_sending_code)
+                        if (uiState.isVerifyingCode) {
+                            stringResource(R.string.settings_sign_in_verifying)
                         } else {
-                            stringResource(R.string.settings_sign_in_send_code_button)
+                            stringResource(R.string.settings_sign_in_verify_button)
                         }
                     )
                 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInEmailRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInEmailRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.signIn
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +12,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.R
@@ -19,17 +20,20 @@ import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
 
+const val cloudSignInEmailFieldTag: String = "cloud_sign_in_email_field"
+const val cloudSignInSendCodeButtonTag: String = "cloud_sign_in_send_code_button"
+
 @Composable
-fun CloudSignInCodeRoute(
+fun CloudSignInEmailRoute(
     uiState: CloudSignInUiState,
-    onCodeChange: (String) -> Unit,
-    onVerifyCode: () -> Unit,
+    onEmailChange: (String) -> Unit,
+    onSendCode: () -> Unit,
     onBack: () -> Unit
 ) {
     SettingsScreenScaffold(
-        title = stringResource(R.string.settings_sign_in_verify_title),
+        title = stringResource(R.string.settings_sign_in_title),
         onBack = onBack,
-        isBackEnabled = uiState.isVerifyingCode.not()
+        isBackEnabled = uiState.isSendingCode.not()
     ) { innerPadding ->
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
@@ -40,15 +44,9 @@ fun CloudSignInCodeRoute(
                 Card(modifier = Modifier.fillMaxWidth()) {
                     Text(
                         text = if (uiState.isGuestUpgrade) {
-                            stringResource(
-                                R.string.settings_sign_in_verify_guest_body,
-                                uiState.challengeEmail ?: stringResource(R.string.settings_sign_in_email_fallback)
-                            )
+                            stringResource(R.string.settings_sign_in_guest_upgrade_body)
                         } else {
-                            stringResource(
-                                R.string.settings_sign_in_verify_body,
-                                uiState.challengeEmail ?: stringResource(R.string.settings_sign_in_email_fallback)
-                            )
+                            stringResource(R.string.settings_sign_in_device_link_body)
                         },
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(20.dp)
@@ -68,26 +66,30 @@ fun CloudSignInCodeRoute(
 
             item {
                 OutlinedTextField(
-                    value = uiState.code,
-                    onValueChange = onCodeChange,
+                    value = uiState.email,
+                    onValueChange = onEmailChange,
                     label = {
-                        Text(stringResource(R.string.settings_sign_in_code_label))
+                        Text(stringResource(R.string.settings_sign_in_email_title))
                     },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(tag = cloudSignInEmailFieldTag)
                 )
             }
 
             item {
                 Button(
-                    onClick = onVerifyCode,
-                    enabled = uiState.isVerifyingCode.not(),
-                    modifier = Modifier.fillMaxWidth()
+                    onClick = onSendCode,
+                    enabled = uiState.isSendingCode.not(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(tag = cloudSignInSendCodeButtonTag)
                 ) {
                     Text(
-                        if (uiState.isVerifyingCode) {
-                            stringResource(R.string.settings_sign_in_verifying)
+                        if (uiState.isSendingCode) {
+                            stringResource(R.string.settings_sign_in_sending_code)
                         } else {
-                            stringResource(R.string.settings_sign_in_verify_button)
+                            stringResource(R.string.settings_sign_in_send_code_button)
                         }
                     )
                 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInErrorCard.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInErrorCard.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.signIn
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInStateReducers.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInStateReducers.kt
@@ -1,0 +1,233 @@
+package com.flashcardsopensourceapp.feature.settings.cloud.signIn
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudOtpChallenge
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkContext
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspacePostAuthRoute
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthRetryAction
+
+internal data class CloudSignInDraftState(
+    val authAttemptId: Long,
+    val email: String,
+    val code: String,
+    val challenge: CloudOtpChallenge?,
+    val linkContext: CloudWorkspaceLinkContext?,
+    val isSendingCode: Boolean,
+    val isVerifyingCode: Boolean,
+    val errorMessage: String,
+    val errorTechnicalDetails: String?,
+    val pendingSelection: CloudWorkspaceLinkSelection?,
+    val processingTitle: String,
+    val processingMessage: String,
+    val postAuthErrorMessage: String,
+    val postAuthRecoveryBlocked: Boolean,
+    val postAuthResetAllowed: Boolean,
+    val retryAction: CloudPostAuthRetryAction?,
+    val completionToken: Long?
+)
+
+internal data class CloudSignInErrorPresentation(
+    val message: String,
+    val technicalDetails: String?
+)
+
+internal fun initialCloudSignInDraftState(): CloudSignInDraftState {
+    return CloudSignInDraftState(
+        authAttemptId = 0L,
+        email = "",
+        code = "",
+        challenge = null,
+        linkContext = null,
+        isSendingCode = false,
+        isVerifyingCode = false,
+        errorMessage = "",
+        errorTechnicalDetails = null,
+        pendingSelection = null,
+        processingTitle = "",
+        processingMessage = "",
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = null,
+        completionToken = null
+    )
+}
+
+internal fun nextCloudAuthAttemptId(state: CloudSignInDraftState): Long {
+    return state.authAttemptId + 1L
+}
+
+internal fun updateCloudSignInEmail(
+    state: CloudSignInDraftState,
+    email: String
+): CloudSignInDraftState {
+    return state.copy(email = email, errorMessage = "", errorTechnicalDetails = null)
+}
+
+internal fun updateCloudSignInCode(
+    state: CloudSignInDraftState,
+    code: String
+): CloudSignInDraftState {
+    return state.copy(code = code, errorMessage = "", errorTechnicalDetails = null)
+}
+
+internal fun startCloudSendCodeAttempt(
+    state: CloudSignInDraftState,
+    authAttemptId: Long
+): CloudSignInDraftState {
+    return state.copy(
+        authAttemptId = authAttemptId,
+        code = "",
+        challenge = null,
+        linkContext = null,
+        isSendingCode = true,
+        isVerifyingCode = false,
+        errorMessage = "",
+        errorTechnicalDetails = null,
+        pendingSelection = null,
+        processingTitle = "",
+        processingMessage = "",
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = null,
+        completionToken = null
+    )
+}
+
+internal fun acceptCloudOtpChallenge(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    challenge: CloudOtpChallenge
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        isSendingCode = false,
+        errorMessage = "",
+        errorTechnicalDetails = null,
+        challenge = challenge,
+        linkContext = null,
+        pendingSelection = null,
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        completionToken = null
+    )
+}
+
+internal fun failCloudSendCode(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    errorPresentation: CloudSignInErrorPresentation
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        isSendingCode = false,
+        errorMessage = errorPresentation.message,
+        errorTechnicalDetails = errorPresentation.technicalDetails
+    )
+}
+
+internal fun startCloudVerifyCodeAttempt(
+    state: CloudSignInDraftState,
+    authAttemptId: Long
+): CloudSignInDraftState {
+    return state.copy(
+        authAttemptId = authAttemptId,
+        linkContext = null,
+        isSendingCode = false,
+        isVerifyingCode = true,
+        errorMessage = "",
+        errorTechnicalDetails = null,
+        pendingSelection = null,
+        processingTitle = "",
+        processingMessage = "",
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = null,
+        completionToken = null
+    )
+}
+
+internal fun failCloudVerifyCode(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    errorPresentation: CloudSignInErrorPresentation
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        isVerifyingCode = false,
+        errorMessage = errorPresentation.message,
+        errorTechnicalDetails = errorPresentation.technicalDetails
+    )
+}
+
+internal fun publishCloudVerifiedLinkContext(
+    state: CloudSignInDraftState,
+    authAttemptId: Long,
+    linkContext: CloudWorkspaceLinkContext,
+    pendingSelection: CloudWorkspaceLinkSelection?,
+    recoveryErrorMessage: String,
+    isSendingCode: Boolean,
+    isVerifyingCode: Boolean
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(
+        isSendingCode = isSendingCode,
+        isVerifyingCode = isVerifyingCode,
+        errorMessage = "",
+        errorTechnicalDetails = null,
+        challenge = null,
+        linkContext = linkContext,
+        pendingSelection = if (recoveryErrorMessage.isEmpty()) {
+            pendingSelection
+        } else {
+            null
+        },
+        processingTitle = "",
+        processingMessage = "",
+        postAuthErrorMessage = recoveryErrorMessage,
+        postAuthRecoveryBlocked = recoveryErrorMessage.isNotEmpty(),
+        postAuthResetAllowed = isCloudPostAuthResetAllowed(linkContext = linkContext),
+        retryAction = null,
+        completionToken = null
+    )
+}
+
+internal fun acknowledgeCloudPostAuthCompletion(state: CloudSignInDraftState): CloudSignInDraftState {
+    return state.copy(completionToken = null)
+}
+
+internal fun clearCloudPostAuthDraftState(state: CloudSignInDraftState): CloudSignInDraftState {
+    return state.copy(
+        authAttemptId = nextCloudAuthAttemptId(state = state),
+        email = "",
+        code = "",
+        challenge = null,
+        linkContext = null,
+        isSendingCode = false,
+        isVerifyingCode = false,
+        pendingSelection = null,
+        processingTitle = "",
+        processingMessage = "",
+        postAuthErrorMessage = "",
+        postAuthRecoveryBlocked = false,
+        postAuthResetAllowed = false,
+        retryAction = null,
+        completionToken = null,
+        errorMessage = "",
+        errorTechnicalDetails = null
+    )
+}
+
+private fun isCloudPostAuthResetAllowed(linkContext: CloudWorkspaceLinkContext): Boolean {
+    return linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.INVALID_STORED_STATE
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInUiState.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.signIn
 
 data class CloudSignInUiState(
     val email: String,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.settings.cloud
+package com.flashcardsopensourceapp.feature.settings.cloud.signIn
 
 import android.content.Context
 import androidx.lifecycle.ViewModel
@@ -7,11 +7,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
-import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
-import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryReason
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
-import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
-import com.flashcardsopensourceapp.data.local.model.cloud.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSendCodeResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkContext
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
@@ -20,6 +16,28 @@ import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
+import com.flashcardsopensourceapp.feature.settings.cloud.buildCloudPostAuthWorkspaceItems
+import com.flashcardsopensourceapp.feature.settings.cloud.credentialRecovery.buildCloudPostAuthPendingSelection
+import com.flashcardsopensourceapp.feature.settings.cloud.credentialRecovery.cloudPostAuthRecoveryErrorMessage
+import com.flashcardsopensourceapp.feature.settings.cloud.credentialRecovery.cloudPostAuthRecoveryExceptionMessage
+import com.flashcardsopensourceapp.feature.settings.cloud.workspaceSelectionTitle
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthFailureAction
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthMode
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthRetryAction
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthUiState
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.canRunCloudPostAuthFailureAction
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.cloudPostAuthFailureActionLabel
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.completeCloudPostAuthSyncOnly
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.completeCloudPostAuthWorkspaceSelection
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.failCloudPostAuth
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.finishCloudPostAuthSuccess
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.isCloudPostAuthProcessing
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.isInvalidCloudCredentialRecovery
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.prepareCloudPostAuthGuestLocalRecovery
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.prepareCloudPostAuthSyncOnly
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.prepareCloudPostAuthWorkspaceCompletion
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.requiresCloudGuestUpgrade
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.resolveCloudPostAuthFailureAction
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
 import java.io.IOException
 import kotlinx.coroutines.CoroutineScope
@@ -32,60 +50,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
-private sealed interface CloudPostAuthRetryAction {
-    data class CompleteCloudLink(
-        val authAttemptId: Long,
-        val linkContext: CloudWorkspaceLinkContext,
-        val selection: CloudWorkspaceLinkSelection
-    ) : CloudPostAuthRetryAction
-
-    data class CompleteGuestUpgrade(
-        val authAttemptId: Long,
-        val linkContext: CloudWorkspaceLinkContext,
-        val selection: CloudWorkspaceLinkSelection
-    ) : CloudPostAuthRetryAction
-
-    data class CompleteGuestLocalRecovery(
-        val authAttemptId: Long,
-        val linkContext: CloudWorkspaceLinkContext
-    ) : CloudPostAuthRetryAction
-
-    data class SyncOnly(
-        val authAttemptId: Long,
-        val workspaceTitle: String
-    ) : CloudPostAuthRetryAction
-}
-
-private enum class CloudPostAuthFailureAction {
-    RESET_INVALID_RECOVERY,
-    LOGOUT
-}
-
-private data class CloudSignInDraftState(
-    val authAttemptId: Long,
-    val email: String,
-    val code: String,
-    val challenge: CloudOtpChallenge?,
-    val linkContext: CloudWorkspaceLinkContext?,
-    val isSendingCode: Boolean,
-    val isVerifyingCode: Boolean,
-    val errorMessage: String,
-    val errorTechnicalDetails: String?,
-    val pendingSelection: CloudWorkspaceLinkSelection?,
-    val processingTitle: String,
-    val processingMessage: String,
-    val postAuthErrorMessage: String,
-    val postAuthRecoveryBlocked: Boolean,
-    val postAuthResetAllowed: Boolean,
-    val retryAction: CloudPostAuthRetryAction?,
-    val completionToken: Long?
-)
-
-private data class CloudSignInErrorPresentation(
-    val message: String,
-    val technicalDetails: String?
-)
-
 class CloudSignInViewModel(
     private val cloudAccountRepository: CloudAccountRepository,
     private val syncRepository: SyncRepository,
@@ -93,25 +57,7 @@ class CloudSignInViewModel(
     private val strings: SettingsStringResolver
 ) : ViewModel() {
     private val draftState = MutableStateFlow(
-        value = CloudSignInDraftState(
-            authAttemptId = 0L,
-            email = "",
-            code = "",
-            challenge = null,
-            linkContext = null,
-            isSendingCode = false,
-            isVerifyingCode = false,
-            errorMessage = "",
-            errorTechnicalDetails = null,
-            pendingSelection = null,
-            processingTitle = "",
-            processingMessage = "",
-            postAuthErrorMessage = "",
-            postAuthRecoveryBlocked = false,
-            postAuthResetAllowed = false,
-            retryAction = null,
-            completionToken = null
-        )
+        value = initialCloudSignInDraftState()
     )
 
     val uiState: StateFlow<CloudSignInUiState> = draftState.mapToStateIn(
@@ -183,8 +129,11 @@ class CloudSignInViewModel(
                 processingMessage = draft.processingMessage,
                 errorMessage = draft.postAuthErrorMessage,
                 canRetry = draft.retryAction != null && draft.postAuthRecoveryBlocked.not(),
-                canLogout = canRunPostAuthFailureAction(draft = draft),
-                failureActionLabel = postAuthFailureActionLabel(resetAllowed = draft.postAuthResetAllowed),
+                canLogout = canRunCloudPostAuthFailureAction(draft = draft),
+                failureActionLabel = cloudPostAuthFailureActionLabel(
+                    resetAllowed = draft.postAuthResetAllowed,
+                    strings = strings
+                ),
                 completionToken = draft.completionToken
             )
         },
@@ -207,111 +156,22 @@ class CloudSignInViewModel(
 
     fun updateEmail(email: String) {
         draftState.update { state ->
-            state.copy(email = email, errorMessage = "", errorTechnicalDetails = null)
+            updateCloudSignInEmail(state = state, email = email)
         }
     }
 
     fun updateCode(code: String) {
         draftState.update { state ->
-            state.copy(code = code, errorMessage = "", errorTechnicalDetails = null)
+            updateCloudSignInCode(state = state, code = code)
         }
     }
 
     private fun nextAuthAttemptId(state: CloudSignInDraftState): Long {
-        return state.authAttemptId + 1L
+        return nextCloudAuthAttemptId(state = state)
     }
 
     private fun isCurrentAuthAttempt(authAttemptId: Long): Boolean {
         return draftState.value.authAttemptId == authAttemptId
-    }
-
-    private fun canRunPostAuthFailureAction(draft: CloudSignInDraftState): Boolean {
-        return resolvePostAuthFailureAction(draft = draft) != null
-    }
-
-    private fun resolvePostAuthFailureAction(draft: CloudSignInDraftState): CloudPostAuthFailureAction? {
-        return when {
-            draft.postAuthResetAllowed -> CloudPostAuthFailureAction.RESET_INVALID_RECOVERY
-            draft.linkContext?.postAuthRoute == CloudWorkspacePostAuthRoute.NONE &&
-                draft.postAuthRecoveryBlocked.not() -> CloudPostAuthFailureAction.LOGOUT
-            else -> null
-        }
-    }
-
-    private fun postAuthFailureActionLabel(resetAllowed: Boolean): String {
-        return if (resetAllowed) {
-            strings.get(R.string.settings_post_auth_reset_cloud_identity_button)
-        } else {
-            strings.get(R.string.settings_logout)
-        }
-    }
-
-    private fun buildPendingSelection(linkContext: CloudWorkspaceLinkContext): CloudWorkspaceLinkSelection? {
-        return when (linkContext.postAuthRoute) {
-            CloudWorkspacePostAuthRoute.NONE -> buildAutomaticWorkspaceSelection(
-                preferredWorkspaceId = linkContext.preferredWorkspaceId,
-                workspaces = linkContext.workspaces
-            )
-
-            CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE -> {
-                val preferredWorkspaceId = linkContext.preferredWorkspaceId ?: return null
-                if (linkContext.workspaces.any { workspace -> workspace.workspaceId == preferredWorkspaceId }) {
-                    CloudWorkspaceLinkSelection.Existing(workspaceId = preferredWorkspaceId)
-                } else {
-                    null
-                }
-            }
-
-            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> CloudWorkspaceLinkSelection.CreateNew
-
-            CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY,
-            CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> null
-        }
-    }
-
-    private fun postAuthRecoveryErrorMessage(
-        linkContext: CloudWorkspaceLinkContext,
-        pendingSelection: CloudWorkspaceLinkSelection?
-    ): String {
-        return when (linkContext.postAuthRoute) {
-            CloudWorkspacePostAuthRoute.NONE -> ""
-            CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE -> {
-                if (pendingSelection == null) {
-                    strings.get(R.string.settings_post_auth_linked_recovery_blocked)
-                } else {
-                    ""
-                }
-            }
-            CloudWorkspacePostAuthRoute.GUEST_LOCAL_RECOVERY -> {
-                ""
-            }
-            CloudWorkspacePostAuthRoute.PENDING_GUEST_UPGRADE_RECOVERY -> {
-                strings.get(R.string.settings_post_auth_pending_guest_upgrade_recovery_required)
-            }
-            CloudWorkspacePostAuthRoute.INVALID_STORED_STATE -> {
-                strings.get(R.string.settings_post_auth_invalid_recovery_state)
-            }
-        }
-    }
-
-    private fun postAuthRecoveryExceptionMessage(error: CloudCredentialRecoveryRequiredException): String {
-        return when (error.recoveryState.reason) {
-            CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING -> {
-                if (error.recoveryState.previousCloudState == CloudAccountState.GUEST) {
-                    strings.get(R.string.settings_post_auth_pending_guest_upgrade_recovery_required)
-                } else {
-                    strings.get(R.string.settings_post_auth_linked_recovery_blocked)
-                }
-            }
-
-            CloudCredentialRecoveryReason.GUEST_SESSION_MISSING -> {
-                strings.get(R.string.settings_post_auth_guest_local_recovery_required)
-            }
-
-            CloudCredentialRecoveryReason.INVALID_STORED_STATE -> {
-                strings.get(R.string.settings_post_auth_invalid_recovery_state)
-            }
-        }
     }
 
     private fun publishVerifiedLinkContext(
@@ -324,34 +184,21 @@ class CloudSignInViewModel(
             return false
         }
 
-        val pendingSelection = buildPendingSelection(linkContext)
-        val recoveryErrorMessage = postAuthRecoveryErrorMessage(
+        val pendingSelection = buildCloudPostAuthPendingSelection(linkContext = linkContext)
+        val recoveryErrorMessage = cloudPostAuthRecoveryErrorMessage(
             linkContext = linkContext,
-            pendingSelection = pendingSelection
+            pendingSelection = pendingSelection,
+            strings = strings
         )
         draftState.update { state ->
-            if (state.authAttemptId != authAttemptId) {
-                return@update state
-            }
-            state.copy(
-                isSendingCode = isSendingCode,
-                isVerifyingCode = isVerifyingCode,
-                errorMessage = "",
-                errorTechnicalDetails = null,
-                challenge = null,
+            publishCloudVerifiedLinkContext(
+                state = state,
+                authAttemptId = authAttemptId,
                 linkContext = linkContext,
-                pendingSelection = if (recoveryErrorMessage.isEmpty()) {
-                    pendingSelection
-                } else {
-                    null
-                },
-                processingTitle = "",
-                processingMessage = "",
-                postAuthErrorMessage = recoveryErrorMessage,
-                postAuthRecoveryBlocked = recoveryErrorMessage.isNotEmpty(),
-                postAuthResetAllowed = linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.INVALID_STORED_STATE,
-                retryAction = null,
-                completionToken = null
+                pendingSelection = pendingSelection,
+                recoveryErrorMessage = recoveryErrorMessage,
+                isSendingCode = isSendingCode,
+                isVerifyingCode = isVerifyingCode
             )
         }
         return true
@@ -360,24 +207,7 @@ class CloudSignInViewModel(
     suspend fun sendCode(): CloudSendCodeNavigationOutcome {
         val authAttemptId = nextAuthAttemptId(draftState.value)
         draftState.update { state ->
-            state.copy(
-                authAttemptId = authAttemptId,
-                code = "",
-                challenge = null,
-                linkContext = null,
-                isSendingCode = true,
-                isVerifyingCode = false,
-                errorMessage = "",
-                errorTechnicalDetails = null,
-                pendingSelection = null,
-                processingTitle = "",
-                processingMessage = "",
-                postAuthErrorMessage = "",
-                postAuthRecoveryBlocked = false,
-                postAuthResetAllowed = false,
-                retryAction = null,
-                completionToken = null
-            )
+            startCloudSendCodeAttempt(state = state, authAttemptId = authAttemptId)
         }
         return try {
             when (val result = cloudAccountRepository.sendCode(draftState.value.email)) {
@@ -386,19 +216,10 @@ class CloudSignInViewModel(
                         return CloudSendCodeNavigationOutcome.NoNavigation
                     }
                     draftState.update { state ->
-                        if (state.authAttemptId != authAttemptId) {
-                            return@update state
-                        }
-                        state.copy(
-                            isSendingCode = false,
-                            errorMessage = "",
-                            errorTechnicalDetails = null,
-                            challenge = result.challenge,
-                            linkContext = null,
-                            pendingSelection = null,
-                            postAuthRecoveryBlocked = false,
-                            postAuthResetAllowed = false,
-                            completionToken = null
+                        acceptCloudOtpChallenge(
+                            state = state,
+                            authAttemptId = authAttemptId,
+                            challenge = result.challenge
                         )
                     }
                     CloudSendCodeNavigationOutcome.OtpRequired
@@ -425,13 +246,10 @@ class CloudSignInViewModel(
             }
             val errorPresentation = createSendCodeErrorPresentation(error = error, strings = strings)
             draftState.update { state ->
-                if (state.authAttemptId != authAttemptId) {
-                    return@update state
-                }
-                state.copy(
-                    isSendingCode = false,
-                    errorMessage = errorPresentation.message,
-                    errorTechnicalDetails = errorPresentation.technicalDetails
+                failCloudSendCode(
+                    state = state,
+                    authAttemptId = authAttemptId,
+                    errorPresentation = errorPresentation
                 )
             }
             CloudSendCodeNavigationOutcome.NoNavigation
@@ -444,22 +262,7 @@ class CloudSignInViewModel(
         }
         val authAttemptId = nextAuthAttemptId(draftState.value)
         draftState.update { state ->
-            state.copy(
-                authAttemptId = authAttemptId,
-                linkContext = null,
-                isSendingCode = false,
-                isVerifyingCode = true,
-                errorMessage = "",
-                errorTechnicalDetails = null,
-                pendingSelection = null,
-                processingTitle = "",
-                processingMessage = "",
-                postAuthErrorMessage = "",
-                postAuthRecoveryBlocked = false,
-                postAuthResetAllowed = false,
-                retryAction = null,
-                completionToken = null
-            )
+            startCloudVerifyCodeAttempt(state = state, authAttemptId = authAttemptId)
         }
         return try {
             val linkContext = cloudAccountRepository.verifyCode(
@@ -478,13 +281,10 @@ class CloudSignInViewModel(
             }
             val errorPresentation = createVerifyCodeErrorPresentation(error = error, strings = strings)
             draftState.update { state ->
-                if (state.authAttemptId != authAttemptId) {
-                    return@update state
-                }
-                state.copy(
-                    isVerifyingCode = false,
-                    errorMessage = errorPresentation.message,
-                    errorTechnicalDetails = errorPresentation.technicalDetails
+                failCloudVerifyCode(
+                    state = state,
+                    authAttemptId = authAttemptId,
+                    errorPresentation = errorPresentation
                 )
             }
             false
@@ -495,7 +295,7 @@ class CloudSignInViewModel(
         val state = draftState.value
         val selection = state.pendingSelection ?: return
         val linkContext = state.linkContext ?: return
-        if (isPostAuthProcessing(state = state) || state.postAuthErrorMessage.isNotEmpty()) {
+        if (isCloudPostAuthProcessing(state = state) || state.postAuthErrorMessage.isNotEmpty()) {
             return
         }
         completePostAuth(
@@ -579,7 +379,7 @@ class CloudSignInViewModel(
     }
 
     suspend fun runPostAuthFailureAction() {
-        when (resolvePostAuthFailureAction(draft = draftState.value) ?: return) {
+        when (resolveCloudPostAuthFailureAction(draft = draftState.value) ?: return) {
             CloudPostAuthFailureAction.RESET_INVALID_RECOVERY -> {
                 cloudAccountRepository.resetInvalidCloudCredentialRecoveryState()
                 clearPostAuthState()
@@ -604,12 +404,8 @@ class CloudSignInViewModel(
 
     fun acknowledgePostAuthCompletion() {
         draftState.update { state ->
-            state.copy(completionToken = null)
+            acknowledgeCloudPostAuthCompletion(state = state)
         }
-    }
-
-    private fun isPostAuthProcessing(state: CloudSignInDraftState): Boolean {
-        return state.processingTitle.isNotEmpty()
     }
 
     private suspend fun completePostAuth(
@@ -621,7 +417,7 @@ class CloudSignInViewModel(
             return
         }
 
-        if (isPostAuthProcessing(state = draftState.value)) {
+        if (isCloudPostAuthProcessing(state = draftState.value)) {
             return
         }
 
@@ -636,41 +432,13 @@ class CloudSignInViewModel(
             return
         }
 
-        val requiresGuestUpgrade = linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.NONE &&
-            linkContext.guestUpgradeMode == CloudGuestUpgradeMode.MERGE_REQUIRED
-        val isGuestUpgrade = linkContext.guestUpgradeMode != null
         draftState.update { state ->
-            if (state.authAttemptId != authAttemptId) {
-                return@update state
-            }
-            state.copy(
-                pendingSelection = null,
-                processingTitle = if (isGuestUpgrade) {
-                    strings.get(R.string.settings_post_auth_upgrading_title)
-                } else {
-                    strings.get(R.string.settings_post_auth_linking_title)
-                },
-                processingMessage = if (isGuestUpgrade) {
-                    strings.get(R.string.settings_post_auth_upgrading_body)
-                } else {
-                    strings.get(R.string.settings_post_auth_linking_body)
-                },
-                postAuthErrorMessage = "",
-                postAuthRecoveryBlocked = false,
-                postAuthResetAllowed = false,
-                retryAction = if (requiresGuestUpgrade) {
-                    CloudPostAuthRetryAction.CompleteGuestUpgrade(
-                        authAttemptId = authAttemptId,
-                        linkContext = linkContext,
-                        selection = selection
-                    )
-                } else {
-                    CloudPostAuthRetryAction.CompleteCloudLink(
-                        authAttemptId = authAttemptId,
-                        linkContext = linkContext,
-                        selection = selection
-                    )
-                }
+            prepareCloudPostAuthWorkspaceCompletion(
+                state = state,
+                authAttemptId = authAttemptId,
+                linkContext = linkContext,
+                selection = selection,
+                strings = strings
             )
         }
 
@@ -679,26 +447,20 @@ class CloudSignInViewModel(
         }
 
         try {
-            val workspace = if (requiresGuestUpgrade) {
-                cloudAccountRepository.completeGuestUpgrade(
-                    linkContext = linkContext,
-                    selection = selection
-                )
-            } else {
-                cloudAccountRepository.completeCloudLink(
-                    linkContext = linkContext,
-                    selection = selection
-                )
-            }
-            if (linkContext.postAuthRoute == CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE) {
-                finishPostAuthSuccess(
-                    authAttemptId = authAttemptId,
-                    workspaceTitle = workspace.name
-                )
-            } else {
+            val completion = completeCloudPostAuthWorkspaceSelection(
+                cloudAccountRepository = cloudAccountRepository,
+                linkContext = linkContext,
+                selection = selection
+            )
+            if (completion.requiresInitialSync) {
                 runPostAuthSyncOnly(
                     authAttemptId = authAttemptId,
-                    workspaceTitle = workspace.name
+                    workspaceTitle = completion.workspaceTitle
+                )
+            } else {
+                finishPostAuthSuccess(
+                    authAttemptId = authAttemptId,
+                    workspaceTitle = completion.workspaceTitle
                 )
             }
         } catch (error: Exception) {
@@ -706,30 +468,22 @@ class CloudSignInViewModel(
                 return
             }
             val recoveryError = error as? CloudCredentialRecoveryRequiredException
-            draftState.update { state ->
-                if (state.authAttemptId != authAttemptId) {
-                    return@update state
+            val errorMessage = if (recoveryError != null) {
+                cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings)
+            } else {
+                error.message ?: if (requiresCloudGuestUpgrade(linkContext = linkContext)) {
+                    strings.get(R.string.settings_post_auth_guest_upgrade_failed)
+                } else {
+                    strings.get(R.string.settings_post_auth_setup_failed)
                 }
-                state.copy(
-                    processingTitle = "",
-                    processingMessage = "",
-                    postAuthErrorMessage = if (recoveryError != null) {
-                        postAuthRecoveryExceptionMessage(error = recoveryError)
-                    } else {
-                        error.message ?: if (requiresGuestUpgrade) {
-                            strings.get(R.string.settings_post_auth_guest_upgrade_failed)
-                        } else {
-                            strings.get(R.string.settings_post_auth_setup_failed)
-                        }
-                    },
-                    postAuthRecoveryBlocked = recoveryError != null,
-                    postAuthResetAllowed = recoveryError?.recoveryState?.reason ==
-                        CloudCredentialRecoveryReason.INVALID_STORED_STATE,
-                    retryAction = if (recoveryError != null) {
-                        null
-                    } else {
-                        state.retryAction
-                    }
+            }
+            draftState.update { state ->
+                failCloudPostAuth(
+                    state = state,
+                    authAttemptId = authAttemptId,
+                    errorMessage = errorMessage,
+                    recoveryErrorBlocked = recoveryError != null,
+                    postAuthResetAllowed = isInvalidCloudCredentialRecovery(error = recoveryError)
                 )
             }
         }
@@ -743,29 +497,16 @@ class CloudSignInViewModel(
             return
         }
 
-        if (isPostAuthProcessing(state = draftState.value)) {
+        if (isCloudPostAuthProcessing(state = draftState.value)) {
             return
         }
 
         draftState.update { state ->
-            if (state.authAttemptId != authAttemptId) {
-                return@update state
-            }
-            state.copy(
-                pendingSelection = null,
-                processingTitle = strings.get(
-                    R.string.settings_post_auth_recovering_local_data_title
-                ),
-                processingMessage = strings.get(
-                    R.string.settings_post_auth_recovering_local_data_body
-                ),
-                postAuthErrorMessage = "",
-                postAuthRecoveryBlocked = false,
-                postAuthResetAllowed = false,
-                retryAction = CloudPostAuthRetryAction.CompleteGuestLocalRecovery(
-                    authAttemptId = authAttemptId,
-                    linkContext = linkContext
-                )
+            prepareCloudPostAuthGuestLocalRecovery(
+                state = state,
+                authAttemptId = authAttemptId,
+                linkContext = linkContext,
+                strings = strings
             )
         }
 
@@ -774,41 +515,32 @@ class CloudSignInViewModel(
         }
 
         try {
-            val workspace = cloudAccountRepository.completeCloudLink(
+            val completion = completeCloudPostAuthWorkspaceSelection(
+                cloudAccountRepository = cloudAccountRepository,
                 linkContext = linkContext,
                 selection = CloudWorkspaceLinkSelection.CreateNew
             )
             finishPostAuthSuccess(
                 authAttemptId = authAttemptId,
-                workspaceTitle = workspace.name
+                workspaceTitle = completion.workspaceTitle
             )
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
             }
             val recoveryError = error as? CloudCredentialRecoveryRequiredException
+            val errorMessage = if (recoveryError != null) {
+                cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings)
+            } else {
+                error.message ?: strings.get(R.string.settings_post_auth_guest_local_recovery_failed)
+            }
             draftState.update { state ->
-                if (state.authAttemptId != authAttemptId) {
-                    return@update state
-                }
-                state.copy(
-                    processingTitle = "",
-                    processingMessage = "",
-                    postAuthErrorMessage = if (recoveryError != null) {
-                        postAuthRecoveryExceptionMessage(error = recoveryError)
-                    } else {
-                        error.message ?: strings.get(
-                            R.string.settings_post_auth_guest_local_recovery_failed
-                        )
-                    },
-                    postAuthRecoveryBlocked = recoveryError != null,
-                    postAuthResetAllowed = recoveryError?.recoveryState?.reason ==
-                        CloudCredentialRecoveryReason.INVALID_STORED_STATE,
-                    retryAction = if (recoveryError != null) {
-                        null
-                    } else {
-                        state.retryAction
-                    }
+                failCloudPostAuth(
+                    state = state,
+                    authAttemptId = authAttemptId,
+                    errorMessage = errorMessage,
+                    recoveryErrorBlocked = recoveryError != null,
+                    postAuthResetAllowed = isInvalidCloudCredentialRecovery(error = recoveryError)
                 )
             }
         }
@@ -823,26 +555,18 @@ class CloudSignInViewModel(
         }
 
         if (
-            isPostAuthProcessing(state = draftState.value) &&
+            isCloudPostAuthProcessing(state = draftState.value) &&
             draftState.value.processingTitle == strings.get(R.string.settings_post_auth_syncing_title)
         ) {
             return
         }
 
         draftState.update { state ->
-            if (state.authAttemptId != authAttemptId) {
-                return@update state
-            }
-            state.copy(
-                processingTitle = strings.get(R.string.settings_post_auth_syncing_title),
-                processingMessage = strings.get(R.string.settings_post_auth_syncing_body),
-                postAuthErrorMessage = "",
-                postAuthRecoveryBlocked = false,
-                postAuthResetAllowed = false,
-                retryAction = CloudPostAuthRetryAction.SyncOnly(
-                    authAttemptId = authAttemptId,
-                    workspaceTitle = workspaceTitle
-                )
+            prepareCloudPostAuthSyncOnly(
+                state = state,
+                authAttemptId = authAttemptId,
+                workspaceTitle = workspaceTitle,
+                strings = strings
             )
         }
 
@@ -851,7 +575,7 @@ class CloudSignInViewModel(
         }
 
         try {
-            syncRepository.syncNow()
+            completeCloudPostAuthSyncOnly(syncRepository = syncRepository)
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
             }
@@ -864,26 +588,18 @@ class CloudSignInViewModel(
                 return
             }
             val recoveryError = error as? CloudCredentialRecoveryRequiredException
+            val errorMessage = if (recoveryError != null) {
+                cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings)
+            } else {
+                error.message ?: strings.get(R.string.settings_post_auth_sync_failed)
+            }
             draftState.update { state ->
-                if (state.authAttemptId != authAttemptId) {
-                    return@update state
-                }
-                state.copy(
-                    processingTitle = "",
-                    processingMessage = "",
-                    postAuthErrorMessage = if (recoveryError != null) {
-                        postAuthRecoveryExceptionMessage(error = recoveryError)
-                    } else {
-                        error.message ?: strings.get(R.string.settings_post_auth_sync_failed)
-                    },
-                    postAuthRecoveryBlocked = recoveryError != null,
-                    postAuthResetAllowed = recoveryError?.recoveryState?.reason ==
-                        CloudCredentialRecoveryReason.INVALID_STORED_STATE,
-                    retryAction = if (recoveryError != null) {
-                        null
-                    } else {
-                        state.retryAction
-                    }
+                failCloudPostAuth(
+                    state = state,
+                    authAttemptId = authAttemptId,
+                    errorMessage = errorMessage,
+                    recoveryErrorBlocked = recoveryError != null,
+                    postAuthResetAllowed = isInvalidCloudCredentialRecovery(error = recoveryError)
                 )
             }
         }
@@ -897,21 +613,9 @@ class CloudSignInViewModel(
             return
         }
         draftState.update { state ->
-            if (state.authAttemptId != authAttemptId) {
-                return@update state
-            }
-            state.copy(
-                email = "",
-                code = "",
-                challenge = null,
-                linkContext = null,
-                pendingSelection = null,
-                processingTitle = "",
-                processingMessage = "",
-                postAuthErrorMessage = "",
-                postAuthRecoveryBlocked = false,
-                postAuthResetAllowed = false,
-                retryAction = null,
+            finishCloudPostAuthSuccess(
+                state = state,
+                authAttemptId = authAttemptId,
                 completionToken = System.currentTimeMillis()
             )
         }
@@ -922,25 +626,7 @@ class CloudSignInViewModel(
 
     private fun clearPostAuthState() {
         draftState.update { state ->
-            state.copy(
-                authAttemptId = nextAuthAttemptId(state),
-                email = "",
-                code = "",
-                challenge = null,
-                linkContext = null,
-                isSendingCode = false,
-                isVerifyingCode = false,
-                pendingSelection = null,
-                processingTitle = "",
-                processingMessage = "",
-                postAuthErrorMessage = "",
-                postAuthRecoveryBlocked = false,
-                postAuthResetAllowed = false,
-                retryAction = null,
-                completionToken = null,
-                errorMessage = "",
-                errorTechnicalDetails = null
-            )
+            clearCloudPostAuthDraftState(state = state)
         }
     }
 }

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -29,9 +29,9 @@ import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.model.cloud.makeOfficialCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
-import com.flashcardsopensourceapp.feature.settings.cloud.CloudPostAuthMode
-import com.flashcardsopensourceapp.feature.settings.cloud.CloudSendCodeNavigationOutcome
-import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInViewModel
+import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuthMode
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSendCodeNavigationOutcome
+import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInViewModel
 import java.io.IOException
 import java.util.Locale
 import kotlinx.coroutines.CompletableDeferred


### PR DESCRIPTION
## Summary
- Split Android settings cloud code into signIn, postAuth, and credentialRecovery packages.
- Added a root cloud package compatibility facade for existing app call sites.
- Extracted sign-in draft reducers, post-auth retry/completion helpers, and credential-recovery post-auth helpers.

## Validation
- git --no-pager diff --check
- Targeted import/reference scans
- Standalone Kotlin compiler checks for typealias behavior

Gradle was not run because this repository treats ./gradlew as resource-heavy unless explicitly approved.