### PR TITLE
Split Android cloudsync account androidTests

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryCredentialRecoveryEraseTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryCredentialRecoveryEraseTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.credentialRecovery
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryGuestLocalRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryGuestLocalRecoveryTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.credentialRecovery
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryInvalidRecoveryStateTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryInvalidRecoveryStateTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.credentialRecovery
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryLinkedCredentialRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryLinkedCredentialRecoveryTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.credentialRecovery
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryPendingGuestUpgradeRecoveryTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryPendingGuestUpgradeRecoveryTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.credentialRecovery
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryRecoverySyncFailureTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/credentialRecovery/LocalCloudAccountRepositoryRecoverySyncFailureTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.credentialRecovery
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeDrainTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeDrainTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.guestUpgrade
 
 import androidx.room.withTransaction
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.guestUpgrade
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteGateway

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeVerificationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeVerificationTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.guestUpgrade
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.identity
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.bootstrap.localWorkspaceName

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/signIn/LocalCloudAccountRepositorySignInPreparationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/signIn/LocalCloudAccountRepositorySignInPreparationTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.signIn
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/workspace/LocalCloudAccountRepositoryWorkspaceContextValidationTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/workspace/LocalCloudAccountRepositoryWorkspaceContextValidationTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.data.local.repository.cloudsync.account
+package com.flashcardsopensourceapp.data.local.repository.cloudsync.account.workspace
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState


### PR DESCRIPTION
## Summary

- Move cloudsync account androidTest classes into workflow-specific packages.
- Keep test class names, fixture setup, and assertions unchanged.

## Validation

- Verified the staged diff is twelve renames with one package declaration update per file.
- Did not run `./gradlew` because local Gradle runs require explicit approval for this repository.