### PR TITLE
Split web workspace session package

### DIFF
--- a/apps/web/src/appData/context/provider.tsx
+++ b/apps/web/src/appData/context/provider.tsx
@@ -22,8 +22,8 @@ import { useProgressInvalidationRefresh } from "../progress/invalidation/progres
 import { isTestSeedBridgeEnabled, type AppDataTestSeedBridge } from "../sync/testSeedBridge";
 import { useSyncEngine } from "../sync/useSyncEngine";
 import { useWorkspaceSession } from "../session/useWorkspaceSession";
-import type { SessionVerificationState } from "../session/warmStart";
-import { loadWarmStartSnapshot, storeWarmStartSnapshot } from "../session/warmStart";
+import type { SessionVerificationState } from "../session/workspaceSessionTypes";
+import { loadWarmStartSnapshot, storeWarmStartSnapshot } from "../session/activation/warmStart";
 
 const AppDataContext = createContext<AppDataContextValue | null>(null);
 const SELECTED_REVIEW_FILTER_STORAGE_KEY = "selected-review-filter";

--- a/apps/web/src/appData/context/types.ts
+++ b/apps/web/src/appData/context/types.ts
@@ -14,7 +14,7 @@ import type {
   WorkspaceSchedulerSettings,
   WorkspaceSummary,
 } from "../../types";
-import type { SessionVerificationState } from "../session/warmStart";
+import type { SessionVerificationState } from "../session/workspaceSessionTypes";
 
 export type SessionLoadState = "loading" | "ready" | "redirecting" | "selecting_workspace" | "error" | "deleted";
 

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -27,7 +27,7 @@ import {
 } from "../../../progress/progressDates";
 import { buildProgressSummaryScopeKey } from "../state/progressScope";
 import { resetProgressTimeContextStateForTests } from "../time/progressTimeContext";
-import type { SessionVerificationState } from "../../session/warmStart";
+import type { SessionVerificationState } from "../../session/workspaceSessionTypes";
 
 const progressSourceMocks = vi.hoisted(() => ({
   loadProgressSummaryMock: vi.fn<(input: Readonly<{ timeZone: string; today: string }>) => Promise<ProgressSummaryPayload>>(),

--- a/apps/web/src/appData/progress/source/useProgressSource.ts
+++ b/apps/web/src/appData/progress/source/useProgressSource.ts
@@ -44,7 +44,7 @@ import {
   buildProgressSeriesInputForDateContext,
   buildProgressSummaryInputForDateContext,
 } from "../../../progress/progressDates";
-import type { SessionVerificationState } from "../../session/warmStart";
+import type { SessionVerificationState } from "../../session/workspaceSessionTypes";
 import { useProgressTimeContext } from "../time/progressTimeContext";
 import {
   createInitialProgressSourceState,

--- a/apps/web/src/appData/progress/state/progressScope.ts
+++ b/apps/web/src/appData/progress/state/progressScope.ts
@@ -6,7 +6,7 @@ import type {
   ProgressSummaryInput,
   WorkspaceSummary,
 } from "../../../types";
-import type { SessionVerificationState } from "../../session/warmStart";
+import type { SessionVerificationState } from "../../session/workspaceSessionTypes";
 
 export type ProgressSourceSections = Readonly<{
   includeSummary: boolean;

--- a/apps/web/src/appData/session/actions/useWorkspaceActions.ts
+++ b/apps/web/src/appData/session/actions/useWorkspaceActions.ts
@@ -7,31 +7,31 @@ import {
   renameWorkspace as renameWorkspaceRequest,
   resetWorkspaceProgress as resetWorkspaceProgressRequest,
   selectWorkspace,
-} from "../../api";
-import type { TranslationKey } from "../../i18n";
-import { captureApiContractError } from "../../observability/apiContractObservation";
+} from "../../../api";
+import type { TranslationKey } from "../../../i18n";
+import { captureApiContractError } from "../../../observability/apiContractObservation";
 import type {
   ResetWorkspaceProgressResponse,
   SessionInfo,
   WorkspaceResetProgressPreview,
   WorkspaceSummary,
-} from "../../types";
-import { getErrorMessage } from "../domain";
-import type { SessionVerificationState } from "./warmStart";
+} from "../../../types";
+import { getErrorMessage } from "../../domain";
 import {
   createRemoteActionLockedError,
   replaceWorkspaceSummary,
-} from "./workspaceSessionHelpers";
+} from "./workspaceActionHelpers";
 import {
   buildWorkspaceInteractionLogDetails,
   captureWorkspaceTransitionError,
   logWorkspaceTransition,
-} from "./workspaceSessionObservation";
+} from "../observation/workspaceSessionObservation";
 import type {
+  SessionVerificationState,
   WorkspaceSessionCommands,
   WorkspaceSessionSetters,
   WorkspaceSessionState,
-} from "./workspaceSessionTypes";
+} from "../workspaceSessionTypes";
 
 type UseWorkspaceActionsParams =
   & Readonly<{

--- a/apps/web/src/appData/session/actions/workspaceActionHelpers.ts
+++ b/apps/web/src/appData/session/actions/workspaceActionHelpers.ts
@@ -1,0 +1,23 @@
+import type { TranslationKey } from "../../../i18n";
+import type { WorkspaceSummary } from "../../../types";
+
+export function replaceWorkspaceSummary(
+  workspaces: ReadonlyArray<WorkspaceSummary>,
+  workspace: WorkspaceSummary,
+): ReadonlyArray<WorkspaceSummary> {
+  let didReplace = false;
+  const nextWorkspaces = workspaces.map((currentWorkspace) => {
+    if (currentWorkspace.workspaceId !== workspace.workspaceId) {
+      return currentWorkspace;
+    }
+
+    didReplace = true;
+    return workspace;
+  });
+
+  return didReplace ? nextWorkspaces : [...workspaces, workspace];
+}
+
+export function createRemoteActionLockedError(t: (key: TranslationKey) => string): Error {
+  return new Error(t("app.sessionRestoringActionLocked"));
+}

--- a/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
+++ b/apps/web/src/appData/session/activation/useWorkspaceActivation.ts
@@ -4,39 +4,39 @@ import {
   isAuthRedirectError,
   listWorkspaces,
   selectWorkspace,
-} from "../../api";
+} from "../../../api";
 import {
   clearAllLocalBrowserData,
   type LocalBrowserDataCleanupReason,
-} from "../../accountDeletion";
-import { putCloudSettings } from "../../localDb/sync/cloudSettings";
+} from "../../../accountDeletion";
+import { putCloudSettings } from "../../../localDb/sync/cloudSettings";
 import type {
   SessionInfo,
   WorkspaceSummary,
-} from "../../types";
+} from "../../../types";
 import {
   findWorkspaceById,
   getErrorMessage,
   markSelectedWorkspaces,
-} from "../domain";
+} from "../../domain";
 import {
   buildLinkedCloudSettings,
-} from "./workspaceSessionCloud";
+} from "../cloud/workspaceSessionCloud";
 import {
   defaultWorkspaceName,
-} from "./workspaceSessionHelpers";
+} from "./workspaceActivationHelpers";
 import {
   captureWorkspaceTransitionError,
   logWorkspaceTransition,
-} from "./workspaceSessionObservation";
+} from "../observation/workspaceSessionObservation";
 import type {
   WorkspaceSessionActivation,
   WorkspaceSessionSetters,
   WorkspaceSessionState,
   WorkspaceSessionSyncActions,
   WorkspaceSessionUiActions,
-} from "./workspaceSessionTypes";
-import type { WorkspaceActivationBootstrapPhase } from "../../observability/webObservability";
+} from "../workspaceSessionTypes";
+import type { WorkspaceActivationBootstrapPhase } from "../../../observability/webObservability";
 
 type UseWorkspaceActivationParams =
   & Pick<WorkspaceSessionState, "activeWorkspace" | "sessionVerificationState">

--- a/apps/web/src/appData/session/activation/warmStart.ts
+++ b/apps/web/src/appData/session/activation/warmStart.ts
@@ -1,7 +1,7 @@
-import { isBrowserReauthRequired } from "../../accountDeletion";
-import type { SessionInfo, WorkspaceSummary } from "../../types";
+import { isBrowserReauthRequired } from "../../../accountDeletion";
+import type { SessionInfo, WorkspaceSummary } from "../../../types";
 
-export type SessionVerificationState = "unverified" | "verified";
+export type { SessionVerificationState } from "../workspaceSessionTypes";
 
 export type WarmStartSnapshot = Readonly<{
   version: 1;

--- a/apps/web/src/appData/session/activation/workspaceActivationHelpers.ts
+++ b/apps/web/src/appData/session/activation/workspaceActivationHelpers.ts
@@ -1,0 +1,1 @@
+export const defaultWorkspaceName: string = "Personal";

--- a/apps/web/src/appData/session/cloud/workspaceSessionCloud.ts
+++ b/apps/web/src/appData/session/cloud/workspaceSessionCloud.ts
@@ -1,6 +1,6 @@
-import { getStableInstallationId } from "../../clientIdentity";
-import type { LocalBrowserDataCleanupReason } from "../../accountDeletion";
-import type { CloudSettings, SessionInfo } from "../../types";
+import { getStableInstallationId } from "../../../clientIdentity";
+import type { LocalBrowserDataCleanupReason } from "../../../accountDeletion";
+import type { CloudSettings, SessionInfo } from "../../../types";
 
 export function buildLinkingReadyCloudSettings(session: SessionInfo): CloudSettings {
   return {

--- a/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
+++ b/apps/web/src/appData/session/lifecycle/useWorkspaceLifecycle.ts
@@ -3,21 +3,21 @@ import {
   getSession,
   isAuthRedirectError,
   revalidateSession as revalidateSessionRequest,
-} from "../../api";
+} from "../../../api";
 import {
   clearBrowserReauthRequired,
   consumeAccountDeletedMarker,
   isBrowserReauthRequired,
   type LocalBrowserDataCleanupReason,
-} from "../../accountDeletion";
-import type { TranslationKey } from "../../i18n";
-import { loadCloudSettings, putCloudSettings } from "../../localDb/sync/cloudSettings";
-import { setWebObservabilityUser } from "../../observability/webObservability";
-import { getErrorMessage } from "../domain";
+} from "../../../accountDeletion";
+import type { TranslationKey } from "../../../i18n";
+import { loadCloudSettings, putCloudSettings } from "../../../localDb/sync/cloudSettings";
+import { setWebObservabilityUser } from "../../../observability/webObservability";
+import { getErrorMessage } from "../../domain";
 import {
   buildLinkingReadyCloudSettings,
   resolveLocalDataCleanupReasonForVerifiedSession,
-} from "./workspaceSessionCloud";
+} from "../cloud/workspaceSessionCloud";
 import {
   consumeLoggedOutMarker,
   createSessionAccountSwitchError,
@@ -25,16 +25,16 @@ import {
   resumeRetryCount,
   resumeRetryDelayMs,
   waitForDelay,
-} from "./workspaceSessionHelpers";
+} from "./workspaceLifecycleHelpers";
 import {
   captureWorkspaceTransitionError,
   logWorkspaceTransition,
-} from "./workspaceSessionObservation";
+} from "../observation/workspaceSessionObservation";
 import type {
   WorkspaceSessionSetters,
   WorkspaceSessionState,
-} from "./workspaceSessionTypes";
-import type { SessionInfo } from "../../types";
+} from "../workspaceSessionTypes";
+import type { SessionInfo } from "../../../types";
 
 type UseWorkspaceLifecycleParams =
   & Readonly<{

--- a/apps/web/src/appData/session/lifecycle/workspaceLifecycleHelpers.ts
+++ b/apps/web/src/appData/session/lifecycle/workspaceLifecycleHelpers.ts
@@ -1,7 +1,3 @@
-import type { TranslationKey } from "../../i18n";
-import type { WorkspaceSummary } from "../../types";
-
-export const defaultWorkspaceName: string = "Personal";
 export const resumeRetryDelayMs: number = 750;
 export const resumeRetryCount: number = 2;
 
@@ -10,23 +6,6 @@ const sessionAccountSwitchErrorName = "SessionAccountSwitchError";
 export type SessionAccountSwitchError = Error & Readonly<{
   name: typeof sessionAccountSwitchErrorName;
 }>;
-
-export function replaceWorkspaceSummary(
-  workspaces: ReadonlyArray<WorkspaceSummary>,
-  workspace: WorkspaceSummary,
-): ReadonlyArray<WorkspaceSummary> {
-  let didReplace = false;
-  const nextWorkspaces = workspaces.map((currentWorkspace) => {
-    if (currentWorkspace.workspaceId !== workspace.workspaceId) {
-      return currentWorkspace;
-    }
-
-    didReplace = true;
-    return workspace;
-  });
-
-  return didReplace ? nextWorkspaces : [...workspaces, workspace];
-}
 
 export function consumeLoggedOutMarker(): boolean {
   const url = new URL(window.location.href);
@@ -38,10 +17,6 @@ export function consumeLoggedOutMarker(): boolean {
   const nextUrl = `${url.pathname}${url.search}${url.hash}`;
   window.history.replaceState({}, document.title, nextUrl);
   return true;
-}
-
-export function createRemoteActionLockedError(t: (key: TranslationKey) => string): Error {
-  return new Error(t("app.sessionRestoringActionLocked"));
 }
 
 export function createSessionAccountSwitchError(errorMessage: string): SessionAccountSwitchError {

--- a/apps/web/src/appData/session/observation/workspaceSessionObservation.ts
+++ b/apps/web/src/appData/session/observation/workspaceSessionObservation.ts
@@ -1,9 +1,9 @@
 import {
   ApiContractError,
   ApiError,
-} from "../../api";
-import { getStableInstallationId } from "../../clientIdentity";
-import type { CloudSettings, SessionInfo, WorkspaceSummary } from "../../types";
+} from "../../../api";
+import { getStableInstallationId } from "../../../clientIdentity";
+import type { CloudSettings, SessionInfo, WorkspaceSummary } from "../../../types";
 import {
   addWebBreadcrumb,
   captureWebException,
@@ -12,8 +12,8 @@ import {
   type WebObservationScope,
   type WorkspaceActivationBootstrapPhase,
   type WorkspaceTransitionBreadcrumbDetails,
-} from "../../observability/webObservability";
-import type { SessionVerificationState } from "./warmStart";
+} from "../../../observability/webObservability";
+import type { SessionVerificationState } from "../workspaceSessionTypes";
 
 export type WorkspaceTransitionLogDetails = Readonly<{
   sessionVerificationState?: SessionVerificationState;

--- a/apps/web/src/appData/session/useWorkspaceSession.test.tsx
+++ b/apps/web/src/appData/session/useWorkspaceSession.test.tsx
@@ -10,14 +10,14 @@ import {
 import { setNavigationHandlerForTests, resetApiClientStateForTests } from "../../api";
 import { INSTALLATION_ID_STORAGE_KEY } from "../../clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "../../i18n/runtime";
-import { loadWarmStartSnapshot, WARM_START_SNAPSHOT_STORAGE_KEY } from "./warmStart";
+import { loadWarmStartSnapshot, WARM_START_SNAPSHOT_STORAGE_KEY } from "./activation/warmStart";
 import { useWorkspaceSession } from "./useWorkspaceSession";
-import { captureWorkspaceTransitionError } from "./workspaceSessionObservation";
+import { captureWorkspaceTransitionError } from "./observation/workspaceSessionObservation";
 import { putCloudSettings, loadCloudSettings } from "../../localDb/sync/cloudSettings";
 import type { CloudSettings, SessionInfo, WorkspaceSummary } from "../../types";
 import type { TranslationKey } from "../../i18n";
 import type { SessionLoadState } from "../context/types";
-import type { SessionVerificationState } from "./warmStart";
+import type { SessionVerificationState } from "./workspaceSessionTypes";
 import { clearWebSyncCache } from "../../localDb/cache";
 
 const observabilityMocks = vi.hoisted(() => ({

--- a/apps/web/src/appData/session/useWorkspaceSession.ts
+++ b/apps/web/src/appData/session/useWorkspaceSession.ts
@@ -1,6 +1,6 @@
-import { useWorkspaceActions } from "./useWorkspaceActions";
-import { useWorkspaceActivation } from "./useWorkspaceActivation";
-import { useWorkspaceLifecycle } from "./useWorkspaceLifecycle";
+import { useWorkspaceActions } from "./actions/useWorkspaceActions";
+import { useWorkspaceActivation } from "./activation/useWorkspaceActivation";
+import { useWorkspaceLifecycle } from "./lifecycle/useWorkspaceLifecycle";
 import type {
   UseWorkspaceSessionParams,
   WorkspaceSession,

--- a/apps/web/src/appData/session/workspaceSessionTypes.ts
+++ b/apps/web/src/appData/session/workspaceSessionTypes.ts
@@ -9,7 +9,8 @@ import type {
   WorkspaceSummary,
 } from "../../types";
 import type { SessionLoadState } from "../context/types";
-import type { SessionVerificationState } from "./warmStart";
+
+export type SessionVerificationState = "unverified" | "verified";
 
 export type WorkspaceSessionState = Readonly<{
   sessionLoadState: SessionLoadState;

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -68,7 +68,7 @@ import {
 } from "../local/syncSeed";
 import type { TestSeedRequest, TestSeedResult } from "../local/testSeedBridge";
 import type { SessionLoadState } from "../../context/types";
-import type { SessionVerificationState } from "../../session/warmStart";
+import type { SessionVerificationState } from "../../session/workspaceSessionTypes";
 
 type UseSyncEngineParams = Readonly<{
   sessionLoadState: SessionLoadState;


### PR DESCRIPTION
## Summary
- split the web workspace session package into activation, lifecycle, actions, cloud, and observation folders
- keep useWorkspaceSession as the public composition hook
- update dependent warm-start and SessionVerificationState imports for the current appData package layout

## Validation
- npm run build
- npx vitest run src/appData/session/useWorkspaceSession.test.tsx
- npm test