### PR TITLE
[codex] Split Android instrumentation test packages

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -175,7 +175,7 @@ The Android app uses native Android and Compose testing:
 
 - targeted integration coverage runs through native instrumentation and Compose UI testing in `apps/android/app/src/androidTest` and `apps/android/data/local/src/androidTest`
 - shared FSRS scheduler parity stays in `apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/model/FsrsSchedulerParityTest.kt` and uses `tests/fsrs-full-vectors.json`
-- release-gate app UI instrumentation runs through the full `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app` package in Firebase Test Lab, with `LiveSmokeTest.kt` and `NotificationTapSmokeTest.kt` kept as the highest-confidence stateful flows inside that package
+- release-gate app UI instrumentation runs through the full `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app` instrumentation tree in Firebase Test Lab, with `livesmoke/LiveSmokeTest.kt` and `notifications/NotificationTapSmokeTest.kt` kept as the highest-confidence stateful flows there
 - the live smoke flow relies on stable Compose test tags from the production UI modules, not on a separate mock shell
 
 The Android live smoke scenario matches the other clients on purpose:

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.R as AppR
+import com.flashcardsopensourceapp.app.support.AppStateResetRule
 import com.flashcardsopensourceapp.feature.ai.R as AiFeatureR
 import com.flashcardsopensourceapp.feature.ai.aiComposerMessageFieldTag
 import com.flashcardsopensourceapp.feature.ai.aiConversationLoadingTag

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import com.flashcardsopensourceapp.app.AppStateResetRule
 import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.app.MainActivity
 import com.flashcardsopensourceapp.app.livesmoke.flows.assertWorkspaceTodayCounts
@@ -22,6 +21,7 @@ import com.flashcardsopensourceapp.app.livesmoke.support.externalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.rateVisibleReviewCardGood
 import com.flashcardsopensourceapp.app.livesmoke.support.reviewEmailArgumentKey
+import com.flashcardsopensourceapp.app.support.AppStateResetRule
 import com.flashcardsopensourceapp.app.livesmoke.support.seedCardViaRepository
 import com.flashcardsopensourceapp.app.livesmoke.support.startNewChatAndAssertConversationReset
 import com.flashcardsopensourceapp.app.livesmoke.support.step

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioCardHelpers.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioCardHelpers.kt
@@ -7,9 +7,9 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
-import com.flashcardsopensourceapp.app.RepositorySeedCard
-import com.flashcardsopensourceapp.app.RepositorySeedScenario
-import com.flashcardsopensourceapp.app.createRepositorySeedExecutor
+import com.flashcardsopensourceapp.app.support.RepositorySeedCard
+import com.flashcardsopensourceapp.app.support.RepositorySeedScenario
+import com.flashcardsopensourceapp.app.support.createRepositorySeedExecutor
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickContentDescription
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickNode
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickTag

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingAllScreenshotsScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingAllScreenshotsScript.kt
@@ -2,7 +2,7 @@ package com.flashcardsopensourceapp.app.marketing.screenshots
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.ManualOnlyAndroidTest
-import com.flashcardsopensourceapp.app.createRepositorySeedExecutor
+import com.flashcardsopensourceapp.app.support.createRepositorySeedExecutor
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Rule

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingRepositorySeedScenarios.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingRepositorySeedScenarios.kt
@@ -1,8 +1,8 @@
 package com.flashcardsopensourceapp.app.marketing.screenshots
 
-import com.flashcardsopensourceapp.app.RepositorySeedCard
-import com.flashcardsopensourceapp.app.RepositorySeedReview
-import com.flashcardsopensourceapp.app.RepositorySeedScenario
+import com.flashcardsopensourceapp.app.support.RepositorySeedCard
+import com.flashcardsopensourceapp.app.support.RepositorySeedReview
+import com.flashcardsopensourceapp.app.support.RepositorySeedScenario
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import java.time.Instant

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotAppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotAppStateResetRule.kt
@@ -6,8 +6,8 @@ import android.content.Context
 import android.os.LocaleList
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
-import com.flashcardsopensourceapp.app.AppStateResetRule
 import com.flashcardsopensourceapp.app.FlashcardsApplication
+import com.flashcardsopensourceapp.app.support.AppStateResetRule
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotGuestCleanupScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotGuestCleanupScript.kt
@@ -5,7 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.FlashcardsApplication
 import com.flashcardsopensourceapp.app.ManualOnlyAndroidTest
-import com.flashcardsopensourceapp.app.resetAndroidTestAppState
+import com.flashcardsopensourceapp.app.support.resetAndroidTestAppState
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.junit.Test

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt
@@ -1,14 +1,16 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.notifications
 
 import android.content.Context
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
+import com.flashcardsopensourceapp.app.MainActivity
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForFlowValue
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilAtLeastOneExistsOrFail
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilWithMitigation
@@ -18,6 +20,7 @@ import com.flashcardsopensourceapp.app.livesmoke.support.appGraph
 import com.flashcardsopensourceapp.app.livesmoke.support.externalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.step
+import com.flashcardsopensourceapp.app.support.AppStateResetRule
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import org.junit.Rule
 import org.junit.Test

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.notifications
 
 import android.Manifest
 import android.app.Notification

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDangerZoneRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDangerZoneRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
 import androidx.annotation.StringRes
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.settings.DestructiveActionState
 import com.flashcardsopensourceapp.feature.settings.R as SettingsR

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDeletionBlockingSurfaceTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDeletionBlockingSurfaceTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -6,6 +6,8 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.AccountDeletionBlockingSurface
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.cloud.AccountDeletionState
 import org.junit.Assert.assertEquals

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountStatusRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountStatusRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
 import androidx.annotation.StringRes
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.settings.R as SettingsR
 import com.flashcardsopensourceapp.feature.settings.account.AccountStatusRoute

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AgentConnectionsRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AgentConnectionsRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.settings.agent.AgentConnectionItemUiState
 import com.flashcardsopensourceapp.feature.settings.agent.AgentConnectionsRoute

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import android.content.ClipboardManager
 import androidx.activity.ComponentActivity
@@ -30,6 +30,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.bidiWrap
 import com.flashcardsopensourceapp.core.ui.currentResourceLocale
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/CloudPostAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/CloudPostAuthRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudPostAuthMode

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.feature.review.R as ReviewStringResources

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.feature.review.R as ReviewStringResources

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import android.app.LocaleManager
 import android.os.LocaleList
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsAuthRouteTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.routes
 
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.getValue
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInCodeRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudSignInEmailRoute

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/AppStateResetRule.kt
@@ -1,10 +1,11 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.support
 
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.flashcardsopensourceapp.app.FlashcardsApplication
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.currentBlockingSystemDialogSummaryOrNull
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.dismissBlockingSystemDialogIfPresent
 import com.flashcardsopensourceapp.app.prompts.guestreview.guestSignInAfterReviewPromptPreferencesName

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/RepositorySeedExecutor.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/support/RepositorySeedExecutor.kt
@@ -1,23 +1,24 @@
-package com.flashcardsopensourceapp.app
+package com.flashcardsopensourceapp.app.support
 
 import android.content.Context
 import androidx.room.withTransaction
 import androidx.test.core.app.ApplicationProvider
+import com.flashcardsopensourceapp.app.FlashcardsApplication
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardTagEntity
 import com.flashcardsopensourceapp.data.local.database.entities.CardWithRelations
 import com.flashcardsopensourceapp.data.local.database.entities.TagEntity
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.scheduling.FsrsCardState
-import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
+import java.util.UUID
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
-import java.util.UUID
-import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
 
 internal data class RepositorySeedReview(
     val rating: ReviewRating,

--- a/apps/android/docs/add-language-checklist.md
+++ b/apps/android/docs/add-language-checklist.md
@@ -166,16 +166,16 @@ rg -n 'onNodeWithText\\(|assertTextEquals\\(|assertTextContains\\(' \
 Current examples worth checking:
 
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt`
-- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/SettingsAuthRouteTest.kt`
-- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/CloudPostAuthRouteTest.kt`
-- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/AccountDeletionBlockingSurfaceTest.kt`
+- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsAuthRouteTest.kt`
+- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/CloudPostAuthRouteTest.kt`
+- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDeletionBlockingSurfaceTest.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioAiHelpers.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioCardHelpers.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioAccountAssertions.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceProgressFlows.kt`
 - `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt`
-- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/ReviewPreviewRouteTest.kt`
+- `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt`
 
 When updating tests:
 
@@ -183,7 +183,7 @@ When updating tests:
 - Leave seeded card content or other user-generated text alone unless the test is specifically about localization.
 - Prefer one or two focused instrumentation checks for RTL mirroring over broad churn across unrelated test files.
 - Keep RTL instrumentation layout-oriented and predictable: assert start/end mirroring on existing routes instead of rewriting the suite around translated copy.
-- The current focused RTL entry point is `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/RtlLayoutTest.kt`. Extend that path first if a new screen needs explicit RTL coverage.
+- The current focused RTL entry point is `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt`. Extend that path first if a new screen needs explicit RTL coverage.
 
 For RTL validation in tests:
 

--- a/docs/android-ci-cd.md
+++ b/docs/android-ci-cd.md
@@ -155,7 +155,7 @@ Android app-internal translations are Play-first:
 Cross-client live smoke references:
 
 - Android: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt`
-- Android notification tap gate: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/NotificationTapSmokeTest.kt`
+- Android notification tap gate: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt`
 - iOS: `apps/ios/Flashcards/FlashcardsUITests/LiveSmoke*Tests.swift`
 - Web: `apps/web/e2e/live-smoke.spec.ts`
 
@@ -429,7 +429,7 @@ Run another app instrumentation class on a local emulator:
 
 ```bash
 adb devices
-cd apps/android && ./gradlew clean :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.flashcardsopensourceapp.app.NotificationTapSmokeTest
+cd apps/android && ./gradlew clean :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.flashcardsopensourceapp.app.notifications.NotificationTapSmokeTest
 ```
 
 Run the full app instrumentation package in Firebase Test Lab directly after authenticating with `gcloud`:

--- a/docs/release-gates.md
+++ b/docs/release-gates.md
@@ -18,7 +18,7 @@ Cross-client live smoke references:
 
 - iOS: `apps/ios/Flashcards/FlashcardsUITests/LiveSmoke*Tests.swift`
 - Android: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/LiveSmokeTest.kt`
-- Android notification tap gate: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/NotificationTapSmokeTest.kt`
+- Android notification tap gate: `apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt`
 - Web: `apps/web/e2e/live-smoke.spec.ts`
 
 These live smoke flows are the highest-confidence checks in the repository because they exercise the real app closest to production conditions.


### PR DESCRIPTION
## Summary
- Move route-level Android instrumentation tests into `app.routes`
- Move notification smoke tests into `app.notifications`
- Move shared instrumentation helpers into `app.support`
- Update dependent imports and Android docs/runbook references

## Validation
- `git --no-pager diff --check`
- static stale package/import/path reference scans
- Gradle not run per repository instruction without explicit approval