### PR TITLE
Remove Android AI model metadata

### DIFF
--- a/apps/android/app/src/marketingScreenshot/res/values-ar/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ar/strings.xml
@@ -66,7 +66,7 @@
     <string name="ai_privacy_policy">سياسة الخصوصية</string>
     <string name="ai_terms_of_service">شروط الخدمة</string>
     <string name="ai_support">الدعم</string>
-    <string name="ai_consent_workspace_disclosure">قد ترسل طلبات AI من مساحة العمل &quot;%1$s&quot; المطالبات والملفات المرفوعة والصور والصوت المملى إلى OpenAI.</string>
+    <string name="ai_consent_workspace_disclosure">قد ترسل طلبات AI من مساحة العمل &quot;%1$s&quot; المطالبات والملفات المرفوعة والصور والصوت المملى إلى خدمة AI المستضافة.</string>
     <string name="ai_message_label">الرسالة</string>
     <string name="ai_attach">إرفاق</string>
     <string name="ai_dictate">إملاء</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-b+es+419/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-b+es+419/strings.xml
@@ -54,7 +54,7 @@
     <string name="ai_privacy_policy">Política de privacidad</string>
     <string name="ai_terms_of_service">Términos del servicio</string>
     <string name="ai_support">Soporte</string>
-    <string name="ai_consent_workspace_disclosure">Las solicitudes de AI del espacio de trabajo &quot;%1$s&quot; pueden enviar a OpenAI indicaciones, archivos subidos, imágenes y audio dictado.</string>
+    <string name="ai_consent_workspace_disclosure">Las solicitudes de AI del espacio de trabajo &quot;%1$s&quot; pueden enviar indicaciones, archivos subidos, imágenes y audio dictado al servicio de AI alojado.</string>
     <string name="ai_message_label">Mensaje</string>
     <string name="ai_attach">Adjuntar</string>
     <string name="ai_dictate">Dictar</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-de-rDE/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-de-rDE/strings.xml
@@ -54,7 +54,7 @@
     <string name="ai_privacy_policy">Datenschutz</string>
     <string name="ai_terms_of_service">Nutzungsbedingungen</string>
     <string name="ai_support">Support</string>
-    <string name="ai_consent_workspace_disclosure">AI-Anfragen aus dem Arbeitsbereich &quot;%1$s&quot; können Eingaben, hochgeladene Dateien, Bilder und diktierte Audiodaten an OpenAI senden.</string>
+    <string name="ai_consent_workspace_disclosure">AI-Anfragen aus dem Arbeitsbereich &quot;%1$s&quot; können Eingaben, hochgeladene Dateien, Bilder und diktierte Audiodaten an den gehosteten AI-Dienst senden.</string>
     <string name="ai_message_label">Nachricht</string>
     <string name="ai_attach">Anhängen</string>
     <string name="ai_dictate">Diktieren</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-es-rES/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-es-rES/strings.xml
@@ -54,7 +54,7 @@
     <string name="ai_privacy_policy">Política de privacidad</string>
     <string name="ai_terms_of_service">Términos del servicio</string>
     <string name="ai_support">Soporte</string>
-    <string name="ai_consent_workspace_disclosure">Las solicitudes de AI del espacio de trabajo &quot;%1$s&quot; pueden enviar a OpenAI indicaciones, archivos subidos, imágenes y audio dictado.</string>
+    <string name="ai_consent_workspace_disclosure">Las solicitudes de AI del espacio de trabajo &quot;%1$s&quot; pueden enviar indicaciones, archivos subidos, imágenes y audio dictado al servicio de AI alojado.</string>
     <string name="ai_message_label">Mensaje</string>
     <string name="ai_attach">Adjuntar</string>
     <string name="ai_dictate">Dictar</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-es-rUS/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-es-rUS/strings.xml
@@ -54,7 +54,7 @@
     <string name="ai_privacy_policy">Política de privacidad</string>
     <string name="ai_terms_of_service">Términos del servicio</string>
     <string name="ai_support">Soporte</string>
-    <string name="ai_consent_workspace_disclosure">Las solicitudes de AI del espacio de trabajo &quot;%1$s&quot; pueden enviar a OpenAI indicaciones, archivos subidos, imágenes y audio dictado.</string>
+    <string name="ai_consent_workspace_disclosure">Las solicitudes de AI del espacio de trabajo &quot;%1$s&quot; pueden enviar indicaciones, archivos subidos, imágenes y audio dictado al servicio de AI alojado.</string>
     <string name="ai_message_label">Mensaje</string>
     <string name="ai_attach">Adjuntar</string>
     <string name="ai_dictate">Dictar</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-hi-rIN/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-hi-rIN/strings.xml
@@ -54,7 +54,7 @@
     <string name="ai_privacy_policy">गोपनीयता नीति</string>
     <string name="ai_terms_of_service">सेवा की शर्तें</string>
     <string name="ai_support">सहायता</string>
-    <string name="ai_consent_workspace_disclosure">&quot;%1$s&quot; वर्कस्पेस से किए गए AI अनुरोध प्रॉम्प्ट, अपलोड की गई फाइलें, छवियां और बोलकर दर्ज किया गया ऑडियो OpenAI को भेज सकते हैं।</string>
+    <string name="ai_consent_workspace_disclosure">&quot;%1$s&quot; वर्कस्पेस से किए गए AI अनुरोध प्रॉम्प्ट, अपलोड की गई फाइलें, छवियां और बोलकर दर्ज किया गया ऑडियो होस्ट की गई AI सेवा को भेज सकते हैं।</string>
     <string name="ai_message_label">संदेश</string>
     <string name="ai_attach">संलग्न करें</string>
     <string name="ai_dictate">बोलकर लिखें</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-ja-rJP/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ja-rJP/strings.xml
@@ -51,7 +51,7 @@
     <string name="ai_privacy_policy">プライバシーポリシー</string>
     <string name="ai_terms_of_service">利用規約</string>
     <string name="ai_support">サポート</string>
-    <string name="ai_consent_workspace_disclosure">「%1$s」ワークスペースからのAIリクエストでは、プロンプト、アップロードしたファイル、画像、音声入力がOpenAIに送信されることがあります。</string>
+    <string name="ai_consent_workspace_disclosure">「%1$s」ワークスペースからのAIリクエストでは、プロンプト、アップロードしたファイル、画像、音声入力がホスト型AIサービスに送信されることがあります。</string>
     <string name="ai_message_label">メッセージ</string>
     <string name="ai_attach">添付</string>
     <string name="ai_dictate">音声入力</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-ru-rRU/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-ru-rRU/strings.xml
@@ -60,7 +60,7 @@
     <string name="ai_privacy_policy">Политика конфиденциальности</string>
     <string name="ai_terms_of_service">Условия использования</string>
     <string name="ai_support">Поддержка</string>
-    <string name="ai_consent_workspace_disclosure">AI-запросы из рабочего пространства &quot;%1$s&quot; могут отправлять в OpenAI подсказки, загруженные файлы, изображения и продиктованное аудио.</string>
+    <string name="ai_consent_workspace_disclosure">AI-запросы из рабочего пространства &quot;%1$s&quot; могут отправлять подсказки, загруженные файлы, изображения и продиктованное аудио в размещенный AI-сервис.</string>
     <string name="ai_message_label">Сообщение</string>
     <string name="ai_attach">Прикрепить</string>
     <string name="ai_dictate">Диктовать</string>

--- a/apps/android/app/src/marketingScreenshot/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values-zh-rCN/strings.xml
@@ -51,7 +51,7 @@
     <string name="ai_privacy_policy">隐私政策</string>
     <string name="ai_terms_of_service">服务条款</string>
     <string name="ai_support">支持</string>
-    <string name="ai_consent_workspace_disclosure">来自“%1$s”工作区的 AI 请求可能会将提示、上传的文件、图片和语音输入发送给 OpenAI。</string>
+    <string name="ai_consent_workspace_disclosure">来自“%1$s”工作区的 AI 请求可能会将提示、上传的文件、图片和语音输入发送给托管式 AI 服务。</string>
     <string name="ai_message_label">消息</string>
     <string name="ai_attach">附加</string>
     <string name="ai_dictate">语音输入</string>

--- a/apps/android/app/src/marketingScreenshot/res/values/strings.xml
+++ b/apps/android/app/src/marketingScreenshot/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="ai_privacy_policy">Privacy Policy</string>
     <string name="ai_terms_of_service">Terms of Service</string>
     <string name="ai_support">Support</string>
-    <string name="ai_consent_workspace_disclosure">AI requests from the &quot;%1$s&quot; workspace can send prompts, uploaded files, images, and dictated audio to OpenAI.</string>
+    <string name="ai_consent_workspace_disclosure">AI requests from the &quot;%1$s&quot; workspace can send prompts, uploaded files, images, and dictated audio to the hosted AI service.</string>
     <string name="ai_message_label">Message</string>
     <string name="ai_attach">Attach</string>
     <string name="ai_dictate">Dictate</string>

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStoreTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStoreTest.kt
@@ -10,6 +10,7 @@ import com.flashcardsopensourceapp.data.local.model.ai.AiChatMessage
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatPersistedState
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatRole
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+import com.flashcardsopensourceapp.data.local.model.ai.defaultAiChatServerConfig
 import com.flashcardsopensourceapp.data.local.model.ai.makeDefaultAiChatPersistedState
 import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
@@ -157,6 +158,69 @@ class AiChatHistoryStoreTest {
 
         val loadedState = store.loadState(workspaceId = "workspace-1")
         assertEquals(state, loadedState)
+    }
+
+    @Test
+    fun saveStatePersistsOnlyChatFeatureConfig() = runBlocking {
+        val state = AiChatPersistedState(
+            messages = emptyList(),
+            chatSessionId = "session-1",
+            lastKnownChatConfig = defaultAiChatServerConfig,
+            pendingToolRunPostSync = false,
+            requiresRemoteSessionProvisioning = false
+        )
+
+        store.saveState(workspaceId = "workspace-1", state = state)
+
+        val preferences = context.getSharedPreferences("flashcards-ai-chat-history", Context.MODE_PRIVATE)
+        val savedState = JSONObject(requireNotNull(preferences.getString(historyKey(workspaceId = "workspace-1"), null)))
+        val savedConfig = savedState.getJSONObject("lastKnownChatConfig")
+        val savedFeatures = savedConfig.getJSONObject("features")
+
+        assertFalse(savedConfig.has("provider"))
+        assertFalse(savedConfig.has("model"))
+        assertFalse(savedConfig.has("reasoning"))
+        assertTrue(savedFeatures.getBoolean("dictationEnabled"))
+        assertTrue(savedFeatures.getBoolean("attachmentsEnabled"))
+        assertEquals(state, store.loadState(workspaceId = "workspace-1"))
+    }
+
+    @Test
+    fun loadStateReadsLegacyChatConfigFeatures() = runBlocking {
+        val preferences = context.getSharedPreferences("flashcards-ai-chat-history", Context.MODE_PRIVATE)
+        preferences.edit()
+            .putString(
+                historyKey(workspaceId = "workspace-1"),
+                JSONObject()
+                    .put("messages", JSONArray())
+                    .put("chatSessionId", "session-1")
+                    .put(
+                        "lastKnownChatConfig",
+                        JSONObject()
+                            .put("provider", JSONObject().put("id", "legacy-provider").put("label", "Legacy provider"))
+                            .put(
+                                "model",
+                                JSONObject()
+                                    .put("id", "legacy-model")
+                                    .put("label", "Legacy model")
+                                    .put("badgeLabel", "Legacy model · legacy reasoning")
+                            )
+                            .put("reasoning", JSONObject().put("effort", "legacy").put("label", "Legacy reasoning"))
+                            .put(
+                                "features",
+                                JSONObject()
+                                    .put("dictationEnabled", false)
+                                    .put("attachmentsEnabled", false)
+                            )
+                    )
+                    .toString()
+            )
+            .commit()
+
+        val loadedConfig = requireNotNull(store.loadState(workspaceId = "workspace-1").lastKnownChatConfig)
+
+        assertFalse(loadedConfig.features.dictationEnabled)
+        assertFalse(loadedConfig.features.attachmentsEnabled)
     }
 
     @Test

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
@@ -106,12 +106,11 @@ class CloudIdentityResetCoordinatorTest {
         assertEquals(localWorkspaceName, resetWorkspace.name)
         assertEquals(1, environment.database.workspaceDao().countWorkspaces())
         assertEquals(0, environment.database.outboxDao().countOutboxEntries())
-        assertEquals(
-            "gpt-5.4",
-            effectiveAiChatServerConfig(
-                environment.aiChatHistoryStore.loadState(workspaceId = resetWorkspace.workspaceId).lastKnownChatConfig
-            ).model.id
+        val resetChatConfig = effectiveAiChatServerConfig(
+            environment.aiChatHistoryStore.loadState(workspaceId = resetWorkspace.workspaceId).lastKnownChatConfig
         )
+        assertTrue(resetChatConfig.features.dictationEnabled)
+        assertTrue(resetChatConfig.features.attachmentsEnabled)
         assertNull(
             environment.guestAiSessionStore.loadSession(
                 localWorkspaceId = resetWorkspace.workspaceId,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/store/AiChatHistoryStore.kt
@@ -7,6 +7,7 @@ import com.flashcardsopensourceapp.data.local.ai.diagnostics.AiChatDiagnosticsLo
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatAttachment
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatContentPart
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatDraftState
+import com.flashcardsopensourceapp.data.local.model.ai.AiChatFeatures
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatMessage
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatPersistedState
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatReasoningSummary
@@ -236,59 +237,21 @@ class AiChatHistoryStore(
     private fun encodeChatConfig(config: AiChatServerConfig): JSONObject {
         return JSONObject()
             .put(
-                "provider",
-                JSONObject()
-                    .put("id", config.provider.id)
-                    .put("label", config.provider.label)
-            )
-            .put(
-                "model",
-                JSONObject()
-                    .put("id", config.model.id)
-                    .put("label", config.model.label)
-                    .put("badgeLabel", config.model.badgeLabel)
-            )
-            .put(
-                "reasoning",
-                JSONObject()
-                    .put("effort", config.reasoning.effort)
-                    .put("label", config.reasoning.label)
-            )
-            .put(
                 "features",
                 JSONObject()
-                    .put("modelPickerEnabled", config.features.modelPickerEnabled)
                     .put("dictationEnabled", config.features.dictationEnabled)
                     .put("attachmentsEnabled", config.features.attachmentsEnabled)
             )
     }
 
     private fun decodeChatConfig(jsonObject: JSONObject): AiChatServerConfig {
-        val provider = jsonObject.optJSONObject("provider")
-        val model = jsonObject.optJSONObject("model")
-        val reasoning = jsonObject.optJSONObject("reasoning")
         val features = jsonObject.optJSONObject("features")
-
-        if (provider == null || model == null || reasoning == null || features == null) {
+        if (features == null) {
             return defaultAiChatServerConfig
         }
 
         return AiChatServerConfig(
-            provider = com.flashcardsopensourceapp.data.local.model.ai.AiChatProvider(
-                id = provider.optString("id", defaultAiChatServerConfig.provider.id),
-                label = provider.optString("label", defaultAiChatServerConfig.provider.label)
-            ),
-            model = com.flashcardsopensourceapp.data.local.model.ai.AiChatServerModel(
-                id = model.optString("id", defaultAiChatServerConfig.model.id),
-                label = model.optString("label", defaultAiChatServerConfig.model.label),
-                badgeLabel = model.optString("badgeLabel", defaultAiChatServerConfig.model.badgeLabel)
-            ),
-            reasoning = com.flashcardsopensourceapp.data.local.model.ai.AiChatReasoning(
-                effort = reasoning.optString("effort", defaultAiChatServerConfig.reasoning.effort),
-                label = reasoning.optString("label", defaultAiChatServerConfig.reasoning.label)
-            ),
-            features = com.flashcardsopensourceapp.data.local.model.ai.AiChatFeatures(
-                modelPickerEnabled = features.optBoolean("modelPickerEnabled", false),
+            features = AiChatFeatures(
                 dictationEnabled = features.optBoolean("dictationEnabled", true),
                 attachmentsEnabled = features.optBoolean("attachmentsEnabled", true)
             )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/wire/AiChatConversationRemoteWire.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/wire/AiChatConversationRemoteWire.kt
@@ -11,11 +11,8 @@ import com.flashcardsopensourceapp.data.local.model.ai.AiChatConversationEnvelop
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatFeatures
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatLiveStreamEnvelope
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatMessage
-import com.flashcardsopensourceapp.data.local.model.ai.AiChatProvider
-import com.flashcardsopensourceapp.data.local.model.ai.AiChatReasoning
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatRole
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatServerConfig
-import com.flashcardsopensourceapp.data.local.model.ai.AiChatServerModel
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatSessionSnapshot
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatStartRunResponse
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatStopRunResponse
@@ -33,36 +30,13 @@ private enum class AiChatRoleWire {
 }
 
 @Serializable
-private data class AiChatProviderWire(
-    val id: StrictRemoteString,
-    val label: StrictRemoteString
-)
-
-@Serializable
-private data class AiChatServerModelWire(
-    val id: StrictRemoteString,
-    val label: StrictRemoteString,
-    val badgeLabel: StrictRemoteString
-)
-
-@Serializable
-private data class AiChatReasoningWire(
-    val effort: StrictRemoteString,
-    val label: StrictRemoteString
-)
-
-@Serializable
 private data class AiChatFeaturesWire(
-    val modelPickerEnabled: StrictRemoteBoolean,
     val dictationEnabled: StrictRemoteBoolean,
     val attachmentsEnabled: StrictRemoteBoolean
 )
 
 @Serializable
 private data class AiChatServerConfigWire(
-    val provider: AiChatProviderWire,
-    val model: AiChatServerModelWire,
-    val reasoning: AiChatReasoningWire,
     val features: AiChatFeaturesWire
 )
 
@@ -238,18 +212,7 @@ private fun AiChatRoleWire.asDomain(): AiChatRole {
 
 private fun AiChatServerConfigWire.asDomain(): AiChatServerConfig {
     return AiChatServerConfig(
-        provider = AiChatProvider(id = this.provider.id.value, label = this.provider.label.value),
-        model = AiChatServerModel(
-            id = this.model.id.value,
-            label = this.model.label.value,
-            badgeLabel = this.model.badgeLabel.value
-        ),
-        reasoning = AiChatReasoning(
-            effort = this.reasoning.effort.value,
-            label = this.reasoning.label.value
-        ),
         features = AiChatFeatures(
-            modelPickerEnabled = this.features.modelPickerEnabled.value,
             dictationEnabled = this.features.dictationEnabled.value,
             attachmentsEnabled = this.features.attachmentsEnabled.value
         )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ai/AiChatModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ai/AiChatModels.kt
@@ -4,11 +4,6 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurat
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import java.util.UUID
 
-const val aiChatDefaultModelId: String = "gpt-5.4"
-const val aiChatDefaultModelLabel: String = "GPT-5.4"
-const val aiChatDefaultProviderLabel: String = "OpenAI"
-const val aiChatDefaultReasoningEffort: String = "medium"
-const val aiChatDefaultReasoningLabel: String = "Medium"
 const val aiChatOptimisticAssistantStatusToken: String = "__ai_optimistic_assistant_status__"
 const val aiChatMaximumAttachmentBytes: Int = 3 * 1024 * 1024
 const val aiChatMaximumStartRunRequestBytes: Int = 5 * 1024 * 1024
@@ -55,32 +50,12 @@ private val aiChatCanonicalFileMediaTypesByExtension: Map<String, String> = mapO
     "yml" to "application/x-yaml"
 )
 
-data class AiChatProvider(
-    val id: String,
-    val label: String
-)
-
-data class AiChatReasoning(
-    val effort: String,
-    val label: String
-)
-
 data class AiChatFeatures(
-    val modelPickerEnabled: Boolean,
     val dictationEnabled: Boolean,
     val attachmentsEnabled: Boolean
 )
 
-data class AiChatServerModel(
-    val id: String,
-    val label: String,
-    val badgeLabel: String
-)
-
 data class AiChatServerConfig(
-    val provider: AiChatProvider,
-    val model: AiChatServerModel,
-    val reasoning: AiChatReasoning,
     val features: AiChatFeatures
 )
 
@@ -122,21 +97,7 @@ data class AiChatConversationEnvelope(
 typealias AiChatSessionSnapshot = AiChatConversationEnvelope
 
 val defaultAiChatServerConfig: AiChatServerConfig = AiChatServerConfig(
-    provider = AiChatProvider(
-        id = "openai",
-        label = aiChatDefaultProviderLabel
-    ),
-    model = AiChatServerModel(
-        id = aiChatDefaultModelId,
-        label = aiChatDefaultModelLabel,
-        badgeLabel = "$aiChatDefaultModelLabel · $aiChatDefaultReasoningLabel"
-    ),
-    reasoning = AiChatReasoning(
-        effort = aiChatDefaultReasoningEffort,
-        label = aiChatDefaultReasoningLabel
-    ),
     features = AiChatFeatures(
-        modelPickerEnabled = false,
         dictationEnabled = true,
         attachmentsEnabled = true
     )

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteTransportRequestTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteTransportRequestTest.kt
@@ -459,11 +459,7 @@ class AiChatRemoteTransportRequestTest {
               },
               "composerSuggestions": [],
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -489,11 +485,7 @@ class AiChatRemoteTransportRequestTest {
               },
               "composerSuggestions": [],
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -518,11 +510,7 @@ class AiChatRemoteTransportRequestTest {
               },
               "composerSuggestions": [],
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -550,11 +538,7 @@ class AiChatRemoteTransportRequestTest {
             {
               "sessionId": "session-1",
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/wire/AiChatConversationDecodingTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/ai/wire/AiChatConversationDecodingTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class AiChatConversationDecodingTest {
     @Test
-    fun decodeAcceptedEnvelopeIncludesActiveRun() {
+    fun decodeAcceptedEnvelopeIncludesActiveRunAndIgnoresLegacyChatMetadata() {
         val response = decodeAiChatStartRunResponse(
             payload = """
             {
@@ -58,6 +58,8 @@ class AiChatConversationDecodingTest {
         assertEquals("run-1", response.activeRun?.runId)
         assertEquals("9", response.activeRun?.live?.cursor)
         assertEquals(false, response.deduplicated)
+        assertTrue(response.chatConfig.features.dictationEnabled)
+        assertTrue(response.chatConfig.features.attachmentsEnabled)
     }
 
     @Test
@@ -76,11 +78,7 @@ class AiChatConversationDecodingTest {
                 "oldestCursor": null
               },
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -110,11 +108,7 @@ class AiChatConversationDecodingTest {
               },
               "composerSuggestions": [],
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -162,11 +156,7 @@ class AiChatConversationDecodingTest {
               },
               "composerSuggestions": [],
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -198,11 +188,7 @@ class AiChatConversationDecodingTest {
                 "oldestCursor": null
               },
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -231,11 +217,7 @@ class AiChatConversationDecodingTest {
                 "oldestCursor": null
               },
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -265,11 +247,7 @@ class AiChatConversationDecodingTest {
               },
               "composerSuggestions": [],
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -305,11 +283,7 @@ class AiChatConversationDecodingTest {
             {
               "sessionId": "session-1",
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },
@@ -353,11 +327,7 @@ class AiChatConversationDecodingTest {
               },
               "composerSuggestions": [],
               "chatConfig": {
-                "provider": { "id": "openai", "label": "OpenAI" },
-                "model": { "id": "gpt-5.4", "label": "GPT-5.4", "badgeLabel": "GPT-5.4 · Medium" },
-                "reasoning": { "effort": "medium", "label": "Medium" },
                 "features": {
-                  "modelPickerEnabled": false,
                   "dictationEnabled": true,
                   "attachmentsEnabled": true
                 },

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiComposerContent.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiComposerContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -79,7 +80,6 @@ internal fun AiComposer(
     val context = LocalContext.current
     val textProvider = remember(context) { aiTextProvider(context = context) }
     val focusRequester = remember { FocusRequester() }
-    val providerAndModelLabel = "${uiState.chatConfig.provider.label} · ${uiState.chatConfig.model.badgeLabel}"
     val primaryActionLabel = stringResource(
         id = if (uiState.canStopStreaming) {
             R.string.ai_stop
@@ -297,14 +297,7 @@ internal fun AiComposer(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text(
-                    text = providerAndModelLabel,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
-                )
+                Spacer(modifier = Modifier.weight(1f))
 
                 if (uiState.isStreaming) {
                     CircularProgressIndicator(

--- a/apps/android/feature/ai/src/main/res/values/strings.xml
+++ b/apps/android/feature/ai/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="ai_privacy_policy">Privacy Policy</string>
     <string name="ai_terms_of_service">Terms of Service</string>
     <string name="ai_support">Support</string>
-    <string name="ai_consent_workspace_disclosure">AI requests from the &quot;%1$s&quot; workspace can send prompts, uploaded files, images, and dictated audio to OpenAI.</string>
+    <string name="ai_consent_workspace_disclosure">AI requests from the &quot;%1$s&quot; workspace can send prompts, uploaded files, images, and dictated audio to the hosted AI service.</string>
     <string name="ai_attachment_take_photo">Take photo</string>
     <string name="ai_attachment_take_photo_body">Capture a photo directly from Android.</string>
     <string name="ai_attachment_open_camera">Open camera</string>


### PR DESCRIPTION
## Summary
- remove provider/model/reasoning metadata from Android AI chat config
- persist and decode only Android AI feature flags while preserving legacy payload compatibility
- remove Android AI provider/model UI copy and make consent strings provider-neutral

## Validation
- git --no-pager diff --check
- rg -n "OpenAI|GPT-5.4|aiChatDefaultModel|aiChatDefaultProvider|aiChatDefaultReasoning|provider\.label|model\.badgeLabel|modelPickerEnabled" apps/android

Gradle was not run per repository guidance.