### PR TITLE
[codex] Keep backend AI model authority

### DIFF
--- a/apps/backend/src/chat/config.ts
+++ b/apps/backend/src/chat/config.ts
@@ -46,10 +46,15 @@ export const CHAT_MODEL: ChatModelDef = {
 };
 
 /**
- * Returns the fixed backend-owned chat configuration that clients can render but not override.
+ * Returns backend-owned runtime configuration plus legacy client display metadata.
+ * `provider`, `model`, `reasoning`, and `features.modelPickerEnabled` are legacy
+ * response metadata for older released clients; clients can render them but
+ * cannot override model/provider/reasoning selection.
  */
 export function getChatConfig(): ChatConfig {
   return {
+    // Legacy response metadata for older released clients. The backend remains
+    // the runtime authority for provider, model, and reasoning selection.
     provider: {
       id: CHAT_VENDOR,
       label: CHAT_PROVIDER_LABEL,
@@ -64,6 +69,8 @@ export function getChatConfig(): ChatConfig {
       label: CHAT_MODEL_REASONING_LABEL,
     },
     features: {
+      // Legacy response metadata for older released clients; model selection is
+      // intentionally not client-selectable.
       modelPickerEnabled: false,
       dictationEnabled: true,
       attachmentsEnabled: true,

--- a/apps/backend/src/chat/http/contract.ts
+++ b/apps/backend/src/chat/http/contract.ts
@@ -116,6 +116,8 @@ const UNSUPPORTED_CHAT_REQUEST_FIELDS = [
   // First-party clients at >1.5.0 no longer send these legacy request-shape
   // fields. Keep rejecting them while the remaining compatibility branches are
   // still present, then revisit this guard in the future legacy chat cleanup.
+  // Model selection fields and legacy vendor/thinking aliases stay rejected
+  // because the server owns runtime model/provider/reasoning selection.
   "messages",
   "model",
   "selectedModel",

--- a/apps/backend/src/chat/runtime/providerErrors.ts
+++ b/apps/backend/src/chat/runtime/providerErrors.ts
@@ -14,10 +14,10 @@ import type {
 } from "../../observability/sentry";
 
 const GENERIC_RUNTIME_ERROR_MESSAGE = "The AI response failed before it could finish. Please try again.";
-const PROVIDER_ERROR_MESSAGE = "The AI provider could not complete the response. Please try again.";
-const PROVIDER_AUTH_ERROR_MESSAGE = "The AI provider could not authenticate the request. Please try again later.";
-const PROVIDER_RATE_LIMITED_ERROR_MESSAGE = "The AI provider is rate limited right now. Please try again in a few minutes.";
-const PROVIDER_UNAVAILABLE_ERROR_MESSAGE = "The AI provider is temporarily unavailable. Please try again soon.";
+const PROVIDER_ERROR_MESSAGE = "The AI service could not complete the response. Please try again.";
+const PROVIDER_AUTH_ERROR_MESSAGE = "The AI service could not authenticate the request. Please try again later.";
+const PROVIDER_RATE_LIMITED_ERROR_MESSAGE = "The AI service is rate limited right now. Please try again in a few minutes.";
+const PROVIDER_UNAVAILABLE_ERROR_MESSAGE = "The AI service is temporarily unavailable. Please try again soon.";
 const PROVIDER_ABORT_ERROR_MESSAGE = "The AI request was interrupted. Please try again.";
 
 type SafeProviderErrorDetails = Pick<

--- a/apps/backend/src/chat/tests/routes/testSupport.ts
+++ b/apps/backend/src/chat/tests/routes/testSupport.ts
@@ -58,6 +58,7 @@ export function createRunningSnapshot(messages: ChatSessionSnapshot["messages"])
 
 export function createExpectedChatConfig(): Record<string, unknown> {
   return {
+    // Legacy response metadata kept in route responses for older released clients.
     provider: {
       id: "openai",
       label: "OpenAI",

--- a/apps/backend/src/chat/tests/runtime/providerErrors.test.ts
+++ b/apps/backend/src/chat/tests/runtime/providerErrors.test.ts
@@ -68,7 +68,7 @@ test("runPersistedChatSessionWithDeps persists a failed run for real provider er
   assert.equal(terminalPersistCount, 1);
   assert.equal(
     requireTerminalPersistParams(terminalPersistParams).errorMessage,
-    "The AI provider is rate limited right now. Please try again in a few minutes.",
+    "The AI service is rate limited right now. Please try again in a few minutes.",
   );
   assert.equal(findLog(logs, "chat_worker_provider_call_aborted"), undefined);
   const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
@@ -241,7 +241,7 @@ test("runPersistedChatSessionWithDeps does not log raw provider terminal event m
 
   assert.equal(
     requireTerminalPersistParams(terminalPersistParams).errorMessage,
-    "The AI provider could not complete the response. Please try again.",
+    "The AI service could not complete the response. Please try again.",
   );
   const terminalLog = findLog(logs, "chat_worker_terminal_state_persisted");
   assert.equal(terminalLog?.consoleMethod, "warn");


### PR DESCRIPTION
## Summary
- keep backend-owned model/provider/reasoning selection documented in the chat contract
- preserve legacy chatConfig provider/model/reasoning response metadata for older clients
- replace public chat terminal error copy that said AI provider with AI service while keeping internal provider diagnostics unchanged

## Validation
- npm --prefix apps/backend test
- rg -n "The AI provider|AI provider is|AI provider could" apps/backend/src