### PR TITLE
[codex] document AI chat legacy cutoff

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteService.kt
@@ -686,7 +686,7 @@ class AiChatRemoteService private constructor(
         payload: JSONObject,
         uiLocale: String?
     ): JSONObject {
-        // Keep uiLocale optional so older backend deployments still accept requests during rollout.
+        // Keep uiLocale optional until the minimum supported backend version is greater than 1.5.0.
         uiLocale?.takeIf { value -> value.isNotBlank() }?.let { locale ->
             payload.put("uiLocale", locale)
         }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ai/AiChatModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/ai/AiChatModels.kt
@@ -296,7 +296,8 @@ data class AiChatNewSessionRequest(
 data class AiChatStopRunRequest(
     val sessionId: String,
     val workspaceId: String?,
-    // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+    // TODO: Make runId required once the minimum supported first-party AI client
+    // version is greater than 1.5.0. This optional path supports older releases.
     val runId: String?,
 )
 

--- a/apps/backend/src/chat/composerSuggestions.ts
+++ b/apps/backend/src/chat/composerSuggestions.ts
@@ -332,12 +332,11 @@ function normalizeLocaleTag(value: string): string | null {
 }
 
 /**
- * `uiLocale` stays optional while older clients migrate to the explicit request
- * field. Missing locale therefore falls back to English on purpose, but an
- * invalid provided locale is rejected by the route parser instead of silently
- * changing languages. This path can be simplified after every supported client
- * sends `uiLocale` and the minimum supported client versions no longer depend
- * on the legacy English fallback.
+ * `uiLocale` stays optional while released clients at 1.5.0 and older migrate
+ * to the explicit request field. Missing locale therefore falls back to English
+ * on purpose, but an invalid provided locale is rejected by the route parser
+ * instead of silently changing languages. This path can be simplified once the
+ * minimum supported first-party AI client version is greater than 1.5.0.
  */
 export function normalizeChatComposerSuggestionsUiLocale(
   uiLocale: string | null | undefined,

--- a/apps/backend/src/chat/config.ts
+++ b/apps/backend/src/chat/config.ts
@@ -73,14 +73,15 @@ export function parseChatRuntimeReasoningEffort(value: string): ChatRuntimeReaso
 
 /**
  * Returns backend-owned runtime configuration plus legacy client display metadata.
- * `provider`, `model`, `reasoning`, and `features.modelPickerEnabled` are legacy
- * response metadata for older released clients; clients can render them but
+ * First-party AI clients newer than 1.5.0 no longer read `provider`, `model`,
+ * `reasoning`, or `features.modelPickerEnabled`. Keep these response fields
+ * only for released clients at 1.5.0 and older; clients can render them but
  * cannot override model/provider/reasoning selection.
  */
 export function getChatConfig(): ChatConfig {
   return {
-    // Legacy response metadata for older released clients. The backend remains
-    // the runtime authority for provider, model, and reasoning selection.
+    // Legacy response metadata for released clients at 1.5.0 and older. The
+    // backend remains the runtime authority for provider, model, and reasoning.
     provider: {
       id: CHAT_VENDOR,
       label: CHAT_PROVIDER_LABEL,
@@ -95,15 +96,15 @@ export function getChatConfig(): ChatConfig {
       label: CHAT_MODEL_REASONING_LABEL,
     },
     features: {
-      // Legacy response metadata for older released clients; model selection is
-      // intentionally not client-selectable.
+      // Legacy response metadata for released clients at 1.5.0 and older;
+      // model selection is intentionally not client-selectable.
       modelPickerEnabled: false,
       dictationEnabled: true,
       attachmentsEnabled: true,
     },
-    // First-party clients at >1.5.0 no longer read chatConfig.liveUrl at
-    // runtime. Keep returning it temporarily for backward compatibility with
-    // older released clients, and remove it in a future legacy chat cleanup.
+    // First-party AI clients newer than 1.5.0 no longer read chatConfig.liveUrl
+    // at runtime. Keep returning it temporarily for released clients at 1.5.0
+    // and older, and remove it in a future legacy chat cleanup.
     liveUrl: process.env.CHAT_LIVE_URL || null,
   };
 }

--- a/apps/backend/src/chat/http/contract.ts
+++ b/apps/backend/src/chat/http/contract.ts
@@ -61,47 +61,47 @@ export type ChatContentPart =
   | ChatToolCallContentPart;
 
 export type ChatRequestBody = Readonly<{
-  // First-party clients at >1.5.0 no longer rely on omitting sessionId on
-  // /chat. Keep this optional only for temporary backward compatibility with
-  // older released clients, and remove the session-less path in a future
-  // legacy chat cleanup.
+  // First-party AI clients newer than 1.5.0 no longer rely on omitting
+  // sessionId on /chat. Keep this optional only for released clients at 1.5.0
+  // and older, and remove the session-less path in a future legacy chat cleanup.
   sessionId?: string;
   clientRequestId: string;
   content: ReadonlyArray<ChatContentPart>;
   timezone: string;
-  // Optional explicit routing during the workspaceId client migration. Older
-  // released clients still rely on the server-side selected-workspace
-  // fallback until every supported build sends workspaceId.
+  // Optional explicit routing during the workspaceId client migration.
+  // First-party AI clients newer than 1.5.0 send workspaceId; keep the
+  // selected-workspace fallback only for released clients at 1.5.0 and older.
   workspaceId?: string;
-  // Optional for backward compatibility with released clients that still send
-  // the pre-uiLocale request shape. Remove once the minimum supported client
-  // versions all send uiLocale.
+  // Optional for released clients at 1.5.0 and older that still send the
+  // pre-uiLocale request shape. Remove once the minimum supported first-party
+  // AI client version is greater than 1.5.0.
   uiLocale?: ChatComposerSuggestionsLocale;
 }>;
 
 export type NewChatRequestBody = Readonly<{
-  // First-party clients at >1.5.0 no longer rely on omitting sessionId on
-  // /chat/new. Keep this optional only for temporary backward compatibility
-  // with older released clients, and remove the session-less path in a future
-  // legacy chat cleanup.
+  // First-party AI clients newer than 1.5.0 no longer rely on omitting
+  // sessionId on /chat/new. Keep this optional only for released clients at
+  // 1.5.0 and older, and remove the session-less path in a future legacy chat
+  // cleanup.
   sessionId?: string;
-  // Optional explicit routing during the workspaceId client migration. Older
-  // released clients still rely on the server-side selected-workspace
-  // fallback until every supported build sends workspaceId.
+  // Optional explicit routing during the workspaceId client migration.
+  // First-party AI clients newer than 1.5.0 send workspaceId; keep the
+  // selected-workspace fallback only for released clients at 1.5.0 and older.
   workspaceId?: string;
-  // Optional for backward compatibility with released clients that still send
-  // the pre-uiLocale request shape. Remove once the minimum supported client
-  // versions all send uiLocale.
+  // Optional for released clients at 1.5.0 and older that still send the
+  // pre-uiLocale request shape. Remove once the minimum supported first-party
+  // AI client version is greater than 1.5.0.
   uiLocale?: ChatComposerSuggestionsLocale;
 }>;
 
 export type StopChatRequestBody = Readonly<{
   sessionId: string;
-  // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+  // TODO: Make runId required once the minimum supported first-party AI client
+  // version is greater than 1.5.0. This optional path supports older releases.
   runId?: string;
-  // Optional explicit routing during the workspaceId client migration. Older
-  // released clients still rely on the server-side selected-workspace
-  // fallback until every supported build sends workspaceId.
+  // Optional explicit routing during the workspaceId client migration.
+  // First-party AI clients newer than 1.5.0 send workspaceId; keep the
+  // selected-workspace fallback only for released clients at 1.5.0 and older.
   workspaceId?: string;
 }>;
 
@@ -113,9 +113,10 @@ export type ChatPageQuery = Readonly<{
 const MAX_CHAT_PAGE_LIMIT = 50;
 
 const UNSUPPORTED_CHAT_REQUEST_FIELDS = [
-  // First-party clients at >1.5.0 no longer send these legacy request-shape
-  // fields. Keep rejecting them while the remaining compatibility branches are
-  // still present, then revisit this guard in the future legacy chat cleanup.
+  // First-party AI clients newer than 1.5.0 no longer send these legacy
+  // request-shape fields. Keep rejecting them while the remaining compatibility
+  // branches are still present, then revisit this guard in the future legacy
+  // chat cleanup.
   // Model selection fields and legacy vendor/thinking aliases stay rejected
   // because the server owns runtime model/provider/reasoning selection.
   "messages",
@@ -154,9 +155,10 @@ function expectString(value: unknown, fieldName: string): string {
 
 /**
  * `uiLocale` remains optional for backward compatibility while clients migrate
- * to the explicit request field. Older clients still omit it and intentionally
- * receive the English fallback path. Once every supported client sends
- * `uiLocale`, this parser branch can be simplified.
+ * to the explicit request field. Released clients at 1.5.0 and older still omit
+ * it and intentionally receive the English fallback path. This branch can be
+ * simplified once the minimum supported first-party AI client version is greater
+ * than 1.5.0.
  */
 function parseOptionalUiLocale(
   value: unknown,

--- a/apps/backend/src/chat/http/dependencies.ts
+++ b/apps/backend/src/chat/http/dependencies.ts
@@ -87,8 +87,9 @@ export function createChatRouteDependencies(options: ChatRoutesOptions): ChatRou
 
         // Route tests often stub request context directly and do not exercise
         // the real workspace access path, so keep a minimal local fallback.
-        // Legacy fallback for released AI clients that still omit workspaceId.
-        // TODO: Remove this fallback once every supported AI client sends workspaceId.
+        // Legacy fallback for released AI clients at 1.5.0 and older that still
+        // omit workspaceId. TODO: Remove once the minimum supported first-party
+        // AI client version is greater than 1.5.0.
         if (requestContext.selectedWorkspaceId === null) {
           throw new HttpError(
             409,

--- a/apps/backend/src/chat/http/handlers.ts
+++ b/apps/backend/src/chat/http/handlers.ts
@@ -173,8 +173,9 @@ export function createPostChatHandler(dependencies: ChatRouteDependencies): Hand
         body.content,
         body.clientRequestId,
         body.timezone,
-        // Older clients still omit uiLocale, so keep the null fallback until
-        // every supported app version has migrated to the explicit field.
+        // Released clients at 1.5.0 and older still omit uiLocale, so keep the
+        // null fallback until the minimum supported first-party AI client
+        // version is greater than 1.5.0.
         body.uiLocale ?? null,
       ));
     } catch (error) {
@@ -229,12 +230,12 @@ export function createPostChatNewHandler(dependencies: ChatRouteDependencies): H
     const workspaceId = await dependencies.resolveAccessibleChatWorkspaceIdFn(requestContext, body.workspaceId);
 
     // Preferred modern flow: clients send an explicit client-generated
-    // sessionId. First-party clients at >1.5.0 already follow that flow.
+    // sessionId. First-party AI clients newer than 1.5.0 already follow that flow.
     // When an explicit id is present, this route is idempotent: create exactly
     // that session if it does not exist yet, otherwise return the existing
     // session unchanged. The omitted-sessionId path below stays temporarily
-    // for backward compatibility with older clients and should be removed in a
-    // future legacy chat cleanup.
+    // for released clients at 1.5.0 and older and should be removed in a future
+    // legacy chat cleanup.
     if (body.sessionId !== undefined) {
       let existingSessionId: string | null;
       try {
@@ -349,9 +350,10 @@ export function createPostChatStopHandler(dependencies: ChatRouteDependencies): 
 
     return context.json({
       sessionId: stopState.sessionId,
-      // First-party clients at >1.5.0 no longer depend on these duplicate
-      // legacy stop-response fields. Keep returning them temporarily for older
-      // released clients and remove them in a future legacy chat cleanup.
+      // First-party AI clients newer than 1.5.0 no longer depend on these
+      // duplicate legacy stop-response fields. Keep returning them temporarily
+      // for released clients at 1.5.0 and older and remove them in a future
+      // legacy chat cleanup.
       conversationScopeId: stopState.sessionId,
       runId: stopState.runId,
       stopped: stopState.stopped,

--- a/apps/backend/src/chat/tests/routes/testSupport.ts
+++ b/apps/backend/src/chat/tests/routes/testSupport.ts
@@ -58,7 +58,8 @@ export function createRunningSnapshot(messages: ChatSessionSnapshot["messages"])
 
 export function createExpectedChatConfig(): Record<string, unknown> {
   return {
-    // Legacy response metadata kept in route responses for older released clients.
+    // Legacy response metadata kept in route responses for released clients at
+    // 1.5.0 and older.
     provider: {
       id: "openai",
       label: "OpenAI",

--- a/apps/ios/Flashcards/Flashcards/AI/Models/AIChatConversationModels.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Models/AIChatConversationModels.swift
@@ -48,9 +48,9 @@ struct AIChatStartRunRequestBody: Codable, Hashable, Sendable {
     let clientRequestId: String
     let content: [AIChatContentPart]
     let timezone: String
-    // Keep this additive field optional while older client and backend builds roll out independently.
+    // Keep optional until minimum supported backend and first-party AI client versions are greater than 1.5.0.
     let uiLocale: String?
-    // Keep this additive field optional while older client and backend builds roll out independently.
+    // Keep optional until minimum supported backend and first-party AI client versions are greater than 1.5.0.
     let workspaceId: String?
 }
 
@@ -150,9 +150,9 @@ struct AIChatLiveStreamEnvelope: Codable, Hashable, Sendable {
 
 struct AIChatNewSessionRequestBody: Codable, Hashable, Sendable {
     let sessionId: String?
-    // Keep this additive field optional while older client and backend builds roll out independently.
+    // Keep optional until minimum supported backend and first-party AI client versions are greater than 1.5.0.
     let uiLocale: String?
-    // Keep this additive field optional while older client and backend builds roll out independently.
+    // Keep optional until minimum supported backend and first-party AI client versions are greater than 1.5.0.
     let workspaceId: String?
 }
 
@@ -189,9 +189,10 @@ struct AIChatStopRunResponse: Decodable, Hashable, Sendable {
 
 struct AIChatStopRunRequestBody: Codable, Hashable, Sendable {
     let sessionId: String
-    // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+    // TODO: Make runId required once the minimum supported first-party AI client
+    // version is greater than 1.5.0. This optional path supports older releases.
     let runId: String?
-    // Keep this additive field optional while older client and backend builds roll out independently.
+    // Keep optional until minimum supported backend and first-party AI client versions are greater than 1.5.0.
     let workspaceId: String?
 }
 

--- a/apps/web/src/api/ApiTestSupport.ts
+++ b/apps/web/src/api/ApiTestSupport.ts
@@ -9,6 +9,7 @@ type SessionResponseProfile = Readonly<{
   createdAt: string;
 }>;
 
+// Mirrors backend legacy chatConfig metadata kept for released clients at 1.5.0 and older.
 type LegacyChatConfigResponseValue = Readonly<{
   provider: Readonly<{ id: "openai"; label: string }>;
   model: Readonly<{ id: string; label: string; badgeLabel: string }>;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -354,12 +354,14 @@ export type ChatSessionSnapshot = Readonly<{
 
 export type StartChatRunRequestBody = Readonly<{
   sessionId: string;
-  // Optional on the wire so older backend/client contract phases keep working.
+  // Optional on the wire until the minimum supported backend and first-party AI
+  // client versions are greater than 1.5.0.
   workspaceId?: string;
   clientRequestId: string;
   content: ReadonlyArray<ContentPart>;
   timezone: string;
-  // Optional so newer clients can hint the active UI locale without breaking older contract phases.
+  // Optional on the wire until the minimum supported backend and first-party AI
+  // client versions are greater than 1.5.0.
   uiLocale?: Locale;
 }>;
 
@@ -370,9 +372,11 @@ export type StartChatRunResponse = ChatSessionSnapshot & Readonly<{
 
 export type NewChatSessionRequestBody = Readonly<{
   sessionId: string;
-  // Optional on the wire so older backend/client contract phases keep working.
+  // Optional on the wire until the minimum supported backend and first-party AI
+  // client versions are greater than 1.5.0.
   workspaceId?: string;
-  // Optional so newer clients can hint the active UI locale without breaking older contract phases.
+  // Optional on the wire until the minimum supported backend and first-party AI
+  // client versions are greater than 1.5.0.
   uiLocale?: Locale;
 }>;
 
@@ -391,9 +395,11 @@ export type StopChatRunResponse = Readonly<{
 
 export type StopChatRunRequestBody = Readonly<{
   sessionId: string;
-  // Optional on the wire so older backend/client contract phases keep working.
+  // Optional on the wire until the minimum supported backend and first-party AI
+  // client versions are greater than 1.5.0.
   workspaceId?: string;
-  // TODO: Remove optional runId and make it required after most users have updated to the latest version. This is a legacy path.
+  // TODO: Make runId required once the minimum supported first-party AI client
+  // version is greater than 1.5.0. This optional path supports older releases.
   runId?: string;
 }>;
 


### PR DESCRIPTION
## Summary
- Clarify AI chat legacy comments with the 1.5.0 cutoff across backend, web, iOS, and Android.
- Mark legacy chatConfig metadata, request fallbacks, and optional stop runId paths as support for released clients at 1.5.0 and older.

## Validation
- git diff --cached --check before commit
- comment-only change; no runtime tests run for this commit