### PR TITLE
[codex] Fix Android AI warm-up retries

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapRetryPolicy.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapRetryPolicy.kt
@@ -10,6 +10,8 @@ import java.net.ProtocolException
 import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.security.cert.CertPathValidatorException
+import java.security.cert.CertificateException
 import javax.net.ssl.SSLException
 import javax.net.ssl.SSLHandshakeException
 import javax.net.ssl.SSLPeerUnverifiedException
@@ -71,12 +73,11 @@ private fun isLikelyTransientBootstrapIoException(error: IOException): Boolean {
     if (error is MalformedURLException || error is ProtocolException) {
         return false
     }
-    if (
-        error is SSLHandshakeException ||
-        error is SSLPeerUnverifiedException ||
-        error is SSLProtocolException
-    ) {
+    if (error is SSLPeerUnverifiedException || error is SSLProtocolException) {
         return false
+    }
+    if (error is SSLHandshakeException) {
+        return isTransientSslHandshakeException(error = error)
     }
     if (
         error is SocketTimeoutException ||
@@ -93,7 +94,20 @@ private fun isLikelyTransientBootstrapIoException(error: IOException): Boolean {
     return hasTransientTransportMessage(error = error)
 }
 
+private fun isTransientSslHandshakeException(error: SSLHandshakeException): Boolean {
+    if (hasNonRetryableTlsCause(error = error)) {
+        return false
+    }
+    if (hasTransientTransportCause(error = error)) {
+        return true
+    }
+    return hasTransientTransportMessage(error = error)
+}
+
 private fun isTransportLikeSslException(error: SSLException): Boolean {
+    if (hasNonRetryableTlsCause(error = error)) {
+        return false
+    }
     if (hasTransientTransportCause(error = error)) {
         return true
     }
@@ -116,11 +130,26 @@ private fun hasTransientTransportMessage(error: Throwable): Boolean {
     return transportMessageFragments.any { fragment -> message.contains(fragment) }
 }
 
+private fun hasNonRetryableTlsCause(error: Throwable): Boolean {
+    var currentCause: Throwable? = error.cause
+    while (currentCause != null) {
+        if (
+            currentCause is SSLPeerUnverifiedException ||
+            currentCause is SSLProtocolException ||
+            currentCause is CertPathValidatorException ||
+            currentCause is CertificateException
+        ) {
+            return true
+        }
+        currentCause = currentCause.cause
+    }
+    return false
+}
+
 private fun hasTransientTransportCause(error: Throwable): Boolean {
     var currentCause: Throwable? = error.cause
     while (currentCause != null) {
         if (
-            currentCause is SSLHandshakeException ||
             currentCause is SSLPeerUnverifiedException ||
             currentCause is SSLProtocolException
         ) {

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/lifecycle/AiChatRuntimeLifecycleCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/lifecycle/AiChatRuntimeLifecycleCoordinator.kt
@@ -13,7 +13,8 @@ import com.flashcardsopensourceapp.feature.ai.runtime.conversation.resolveAiChat
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.runtimeKey
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.shouldBootstrapConversation
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.shouldPrepareGuestAccess
-import com.flashcardsopensourceapp.feature.ai.runtime.errors.AiErrorSurface
+import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.nextBootstrapRetryDelayMillis
+import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.shouldRetryBootstrap
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.AiChatBreadcrumb
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.AiChatExceptionEvent
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.AiChatFailureIssueDisposition
@@ -21,14 +22,13 @@ import com.flashcardsopensourceapp.feature.ai.runtime.observability.AiChatWarnin
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.aiChatFailureIssueDisposition
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.aiChatFailureWarningMessage
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.aiChatRemoteErrorDetails
-import com.flashcardsopensourceapp.feature.ai.runtime.observability.makeAiUserFacingErrorMessage
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.recordAiChatBreadcrumb
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.recordAiChatException
 import com.flashcardsopensourceapp.feature.ai.runtime.observability.recordAiChatWarning
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal class AiChatRuntimeLifecycleCoordinator(
@@ -186,7 +186,7 @@ internal class AiChatRuntimeLifecycleCoordinator(
                         hasConsent = context.hasConsent()
                     )
                 ) {
-                    context.aiChatRepository.prepareSessionForAi(workspaceId = accessContext.workspaceId)
+                    prepareGuestAccessWithRetry(accessContext = accessContext)
                 } else if (shouldBootstrapConversation(
                         accessContext = accessContext,
                         hasConsent = context.hasConsent()
@@ -231,18 +231,6 @@ internal class AiChatRuntimeLifecycleCoordinator(
                         )
                     }
                 }
-                val message = makeAiUserFacingErrorMessage(
-                    error = error,
-                    surface = AiErrorSurface.CHAT,
-                    configuration = context.currentServerConfiguration(),
-                    textProvider = context.textProvider
-                )
-                context.runtimeStateMutable.update { state ->
-                    state.copy(
-                        activeAlert = context.textProvider.generalError(message = message),
-                        errorMessage = ""
-                    )
-                }
             } finally {
                 val shouldRetryWarmUp = shouldRetryWarmUpAfterWorkspaceSwitch()
                 if (context.activeWarmUpJob === warmUpJob) {
@@ -285,6 +273,24 @@ internal class AiChatRuntimeLifecycleCoordinator(
             return
         }
         warmUpLinkedSessionIfNeeded(resumeDiagnostics = null)
+    }
+
+    private suspend fun prepareGuestAccessWithRetry(accessContext: AiAccessContext) {
+        var retryCount: Int = 0
+        while (true) {
+            try {
+                context.aiChatRepository.prepareSessionForAi(workspaceId = accessContext.workspaceId)
+                return
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                if (shouldRetryBootstrap(error = error, retryCount = retryCount).not()) {
+                    throw error
+                }
+                delay(timeMillis = nextBootstrapRetryDelayMillis(retryCount = retryCount))
+                retryCount += 1
+            }
+        }
     }
 
     private fun shouldRetryWarmUpAfterWorkspaceSwitch(): Boolean {

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapProvisioningTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapProvisioningTest.kt
@@ -18,6 +18,7 @@ import java.io.IOException
 import java.net.MalformedURLException
 import java.net.SocketException
 import java.net.SocketTimeoutException
+import javax.net.ssl.SSLHandshakeException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -276,6 +277,68 @@ class AiChatRuntimeBootstrapProvisioningTest {
     }
 
     @Test
+    fun bootstrapRetriesTransientSslHandshakeFailure() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.loadBootstrapErrors += SSLHandshakeException("connection closed")
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.GUEST
+        )
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId)
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
+            repository.prepareSessionRequests
+        )
+        assertEquals(2, repository.loadBootstrapCalls)
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+    }
+
+    @Test
+    fun bootstrapDoesNotRetryNonTransientSslHandshakeFailure() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
+            chatSessionId = "session-1"
+        )
+        repository.loadBootstrapErrors += SSLHandshakeException("Trust anchor for certification path not found.")
+        repository.bootstrapResponses += makeBootstrapResponse(
+            sessionId = "session-1",
+            activeRun = null
+        )
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.GUEST
+        )
+
+        runtime.onScreenVisible()
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId)
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf(defaultTestWorkspaceId), repository.prepareSessionRequests)
+        assertEquals(1, repository.loadBootstrapCalls)
+        assertEquals(AiConversationBootstrapState.FAILED, runtime.state.value.conversationBootstrapState)
+        assertEquals("session-1", runtime.state.value.persistedState.chatSessionId)
+    }
+
+    @Test
     fun bootstrapDoesNotRetryRemoteCallsWhenDraftLoadingFailsLocally() = runTest {
         val repository = FakeAiChatRepository()
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
@@ -506,6 +569,55 @@ class AiChatRuntimeBootstrapProvisioningTest {
             repository.prepareSessionRequests
         )
         assertEquals(listOf("session-1"), repository.loadBootstrapSessionIds)
+    }
+
+    @Test
+    fun disconnectedGuestAccessWarmUpRetriesTransientPrepareSessionFailure() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.prepareSessionErrors += SSLHandshakeException("connection closed")
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.DISCONNECTED
+        )
+
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId).copy(
+                cloudState = CloudAccountState.DISCONNECTED
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(defaultTestWorkspaceId, defaultTestWorkspaceId),
+            repository.prepareSessionRequests
+        )
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+        assertNull(runtime.state.value.activeAlert)
+    }
+
+    @Test
+    fun disconnectedGuestAccessWarmUpFailureDoesNotShowAlert() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.prepareSessionErrors += MalformedURLException("bad guest auth URL")
+        val runtime = makeRuntimeWithCloudState(
+            scope = this,
+            repository = repository,
+            autoSyncEventRepository = FakeAutoSyncEventRepository(),
+            cloudState = CloudAccountState.DISCONNECTED
+        )
+
+        runtime.updateAccessContext(
+            makeAccessContext(workspaceId = defaultTestWorkspaceId).copy(
+                cloudState = CloudAccountState.DISCONNECTED
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf(defaultTestWorkspaceId), repository.prepareSessionRequests)
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+        assertNull(runtime.state.value.activeAlert)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Retry Android AI warm-up/bootstrap on transient TLS transport closures.

- Keep certificate/protocol TLS failures non-retryable and stop surfacing background warm-up failures as alerts.

- Add focused AI runtime tests for transient/non-transient TLS and disconnected warm-up behavior.


## Validation

- git --no-pager diff --check

- Gradle tests not run because repository policy requires explicit approval for ./gradlew.
