### PR TITLE
[codex] Make iOS Sentry observability raw by default

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
@@ -1,17 +1,7 @@
-import CryptoKit
 import Foundation
 import Sentry
 
 let filteredDiagnosticValue: String = "[Filtered]"
-
-func appSpecificObservabilityHash(_ value: String, namespace: String) -> String {
-    let hashInput: String = "\(appBundleIdentifier()):observability:\(namespace):\(value)"
-    let digest: SHA256.Digest = SHA256.hash(data: Data(hashInput.utf8))
-    return digest.map { byte in
-        String(format: "%02x", byte)
-    }
-    .joined()
-}
 
 func safeDiagnosticIdentifier(_ value: String) -> String {
     let trimmedValue: String = value.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -67,10 +57,7 @@ func sanitizeSentrySpan(_ span: any Span) -> (any Span)? {
 
 private func sanitizedSpanDataValue(_ value: Any, key: String) -> Any {
     let normalizedKey: String = normalizedDiagnosticKey(key)
-    if stableObservationIdentifierHashKey(key) != nil {
-        return hashedObservationIdentifierValue(value, key: key)
-    }
-    if isSensitiveKey(key) || normalizedKey.contains("query") || normalizedKey.contains("fragment") {
+    if isSensitiveKey(key) || isSensitiveURLComponentKey(key) {
         return filteredDiagnosticValue
     }
     if normalizedKey.contains("url"), let urlString = value as? String {
@@ -104,14 +91,10 @@ private func sanitizedBreadcrumbData(_ dictionary: [String: Any]?) -> [String: A
     var sanitized: [String: Any] = [:]
     for (key, value) in dictionary {
         let normalizedKey: String = normalizedDiagnosticKey(key)
-        if let hashKey: String = stableObservationIdentifierHashKey(key) {
-            sanitized[hashKey] = hashedObservationIdentifierValue(value, key: key)
-        } else if isSensitiveKey(key) {
+        if isSensitiveKey(key) || isSensitiveURLComponentKey(key) {
             sanitized[key] = "[Filtered]"
         } else if normalizedKey == "url", let urlString = value as? String {
             sanitized[key] = redactedURLString(urlString)
-        } else if normalizedKey == "httpquery" || normalizedKey == "httpfragment" {
-            sanitized[key] = "[Filtered]"
         } else {
             sanitized[key] = sanitizedValue(value)
         }
@@ -154,10 +137,11 @@ func sanitizedDictionary(_ dictionary: [String: Any]?) -> [String: Any]? {
 
     var sanitized: [String: Any] = [:]
     for (key, value) in dictionary {
-        if let hashKey: String = stableObservationIdentifierHashKey(key) {
-            sanitized[hashKey] = hashedObservationIdentifierValue(value, key: key)
-        } else if isSensitiveKey(key) {
+        let normalizedKey: String = normalizedDiagnosticKey(key)
+        if isSensitiveKey(key) || isSensitiveURLComponentKey(key) {
             sanitized[key] = "[Filtered]"
+        } else if normalizedKey == "url", let urlString = value as? String {
+            sanitized[key] = redactedURLString(urlString)
         } else {
             sanitized[key] = sanitizedValue(value)
         }
@@ -172,10 +156,11 @@ func sanitizedStringDictionary(_ dictionary: [String: String]?) -> [String: Stri
 
     var sanitized: [String: String] = [:]
     for (key, value) in dictionary {
-        if let hashKey: String = stableObservationIdentifierHashKey(key) {
-            sanitized[hashKey] = hashedObservationIdentifier(value, key: key)
-        } else if isSensitiveKey(key) {
+        let normalizedKey: String = normalizedDiagnosticKey(key)
+        if isSensitiveKey(key) || isSensitiveURLComponentKey(key) {
             sanitized[key] = "[Filtered]"
+        } else if normalizedKey == "url" {
+            sanitized[key] = redactedURLString(value)
         } else {
             sanitized[key] = redactedString(value)
         }
@@ -199,87 +184,8 @@ private func sanitizedValue(_ value: Any) -> Any {
     return value
 }
 
-private func stableObservationIdentifierHashKey(_ key: String) -> String? {
-    let normalizedKey: String = normalizedDiagnosticKey(key)
-    let passThroughIdentifierKeys: Set<String> = [
-        "requestid",
-        "clientrequestid",
-        "backendrequestid"
-    ]
-    guard passThroughIdentifierKeys.contains(normalizedKey) == false else {
-        return nil
-    }
-
-    if normalizedKey == "userid" ||
-        normalizedKey == "cardid" ||
-        normalizedKey == "entityid" ||
-        normalizedKey == "conversationscopeid" ||
-        normalizedKey == "eventconversationscopeid" ||
-        normalizedKey == "cursor" ||
-        normalizedKey == "aftercursor" ||
-        normalizedKey == "eventcursor" ||
-        normalizedKey == "livecursor" ||
-        normalizedKey == "oldestcursor" ||
-        normalizedKey == "streamepoch" ||
-        normalizedKey == "eventstreamepoch" ||
-        normalizedKey == "activestreamepoch" ||
-        normalizedKey == "installationid" ||
-        normalizedKey.hasSuffix("sessionid") ||
-        normalizedKey.hasSuffix("runid") ||
-        normalizedKey.hasSuffix("itemid") ||
-        normalizedKey.hasSuffix("messageid") ||
-        normalizedKey.hasSuffix("toolcallid") ||
-        normalizedKey.hasSuffix("workspaceid") {
-        return key.hasSuffix("_hash") ? key : "\(key)_hash"
-    }
-
-    return nil
-}
-
-private func hashedObservationIdentifierValue(_ value: Any, key: String) -> Any {
-    if let stringValue: String = value as? String {
-        return hashedObservationIdentifier(stringValue, key: key)
-    }
-    if let stringArray: [String] = value as? [String] {
-        return stringArray.map { item in
-            hashedObservationIdentifier(item, key: key)
-        }
-    }
-    return filteredDiagnosticValue
-}
-
-func hashedObservationIdentifierLogValue(_ value: String?, key: String) -> String {
-    guard let value, value.isEmpty == false else {
-        return "-"
-    }
-    return hashedObservationIdentifier(value, key: key)
-}
-
-func hashedObservationIdentifier(_ value: String, key: String) -> String {
-    guard value.isEmpty == false else {
-        return value
-    }
-    return appSpecificObservabilityHash(
-        value,
-        namespace: "observation_\(normalizedDiagnosticKey(key))"
-    )
-}
-
 func isSensitiveKey(_ key: String) -> Bool {
     let normalizedKey: String = normalizedDiagnosticKey(key)
-    let safeDiagnosticKeys: Set<String> = [
-        "codingpath",
-        "decodersummarylength",
-        "eventtype",
-        "hasdecodersummary",
-        "payloadbytes",
-        "payloadlength",
-        "rawsnippetlength"
-    ]
-    if safeDiagnosticKeys.contains(normalizedKey) {
-        return false
-    }
-
     let sensitiveFragments: [String] = [
         "authorization",
         "cookie",
@@ -288,28 +194,33 @@ func isSensitiveKey(_ key: String) -> Bool {
         "idtoken",
         "otpsessiontoken",
         "token",
-        "fronttext",
-        "backtext",
-        "prompt",
-        "rawoutput",
-        "rawsnippet",
-        "payloadsnippet",
-        "responsebody",
-        "requestbody",
-        "body",
-        "localizeddescription",
-        "debugdescription",
-        "decodersummary",
-        "underlyingerror",
-        "messagesummary",
-        "errorsummary",
-        "detailsummary",
-        "base64data",
+        "password",
+        "secret",
         "email"
     ]
     return sensitiveFragments.contains { fragment in
         normalizedKey.contains(fragment)
     }
+}
+
+private func isSensitiveURLComponentKey(_ key: String) -> Bool {
+    let normalizedKey: String = normalizedDiagnosticKey(key)
+    let sensitiveKeys: Set<String> = [
+        "query",
+        "querystring",
+        "httpquery",
+        "urlquery",
+        "fragment",
+        "httpfragment",
+        "urlfragment"
+    ]
+    if sensitiveKeys.contains(normalizedKey) {
+        return true
+    }
+
+    return normalizedKey.hasSuffix("query") ||
+        normalizedKey.hasSuffix("querystring") ||
+        normalizedKey.hasSuffix("fragment")
 }
 
 private func normalizedDiagnosticKey(_ key: String) -> String {
@@ -473,4 +384,12 @@ func stringifyContext(_ context: [String: Any]) -> [String: String] {
         fields[key] = String(describing: value)
     }
     return fields
+}
+
+func sanitizedObservationLogValue(_ value: String?) -> String {
+    guard let value, value.isEmpty == false else {
+        return "-"
+    }
+
+    return redactedString(value)
 }

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -26,19 +26,9 @@ extension SentryObservabilityAdapter {
             return
         }
 
-        let hashedUserId: String = appSpecificObservabilityHash(
-            identity.userId,
-            namespace: "sentry_user_id"
-        )
-        let hashedWorkspaceId: String? = identity.workspaceId.map { workspaceId in
-            appSpecificObservabilityHash(
-                workspaceId,
-                namespace: "sentry_workspace_id"
-            )
-        }
-        let user: User = User(userId: hashedUserId)
+        let user: User = User(userId: identity.userId)
         user.data = [
-            "workspace_id_hash": hashedWorkspaceId ?? "",
+            "workspace_id": identity.workspaceId ?? "",
             "account_kind": identity.accountKind.rawValue
         ]
         SentrySDK.setUser(user)
@@ -241,8 +231,8 @@ extension SentryObservabilityAdapter {
         case .localDataRepair(let warning):
             let context: [String: Any] = [
                 "workspace_id": warning.workspaceId ?? "",
-                "card_id_hash": hashedObservationIdentifierLogValue(warning.cardId, key: "card_id"),
-                "reason_hash": hashedObservationIdentifier(warning.reason, key: "local_data_repair_reason"),
+                "card_id": warning.cardId ?? "",
+                "reason": warning.reason,
                 "reason_length": warning.reason.count,
                 "repair": warning.repair
             ]
@@ -257,7 +247,7 @@ extension SentryObservabilityAdapter {
             )
         case .invalidCardDueAt(let warning):
             let context: [String: Any] = [
-                "card_id_hash": hashedObservationIdentifier(warning.cardId, key: "card_id"),
+                "card_id": warning.cardId,
                 "due_at": warning.dueAt
             ]
             return ObservationPayload(
@@ -273,9 +263,7 @@ extension SentryObservabilityAdapter {
             let context: [String: Any] = [
                 "notification_kind": warning.notificationKind,
                 "workspace_id": warning.workspaceId ?? "",
-                "notification_request_id_hash": warning.requestId.map {
-                    hashedObservationIdentifier($0, key: "notification_request_id")
-                } ?? "",
+                "notification_request_id": warning.requestId ?? "",
                 "stage": warning.stage,
                 "planned_count": String(warning.plannedCount),
                 "accepted_count": String(warning.acceptedCount),
@@ -320,17 +308,10 @@ extension SentryObservabilityAdapter {
         case .progressCacheRemoved(let warning):
             let context: [String: Any] = [
                 "cache_kind": warning.cacheKind,
-                "cache_key_hash": hashedObservationIdentifier(
-                    warning.key,
-                    key: "progress_cache_key"
-                ),
+                "cache_key": warning.key,
                 "reason": warning.reason,
-                "expected_scope_key_hash": warning.expectedScopeKey.map {
-                    hashedObservationIdentifier($0, key: "progress_expected_scope_key")
-                } ?? "",
-                "actual_scope_key_hash": warning.actualScopeKey.map {
-                    hashedObservationIdentifier($0, key: "progress_actual_scope_key")
-                } ?? "",
+                "expected_scope_key": warning.expectedScopeKey ?? "",
+                "actual_scope_key": warning.actualScopeKey ?? "",
                 "has_actual_scope_key": warning.actualScopeKey == nil ? "false" : "true",
                 "error_summary": warning.errorSummary ?? ""
             ]
@@ -488,8 +469,8 @@ extension SentryObservabilityAdapter {
         case .localDataRepairFailed(let error, let scope, let details):
             let context: [String: Any] = [
                 "workspace_id": details.workspaceId ?? "",
-                "entity_id_hash": hashedObservationIdentifierLogValue(details.entityId, key: "entity_id"),
-                "reason_hash": hashedObservationIdentifier(details.reason, key: "local_data_repair_failure_reason"),
+                "entity_id": details.entityId ?? "",
+                "reason": details.reason,
                 "reason_length": details.reason.count,
                 "message_summary": details.messageSummary ?? ""
             ]
@@ -680,22 +661,10 @@ extension SentryObservabilityAdapter {
     }
 
     private static func logCloudFlow(_ observation: CloudFlowObservation) {
-        let workspaceIdHash: String = hashedObservationIdentifierLogValue(
-            observation.workspaceId,
-            key: "workspace_id"
-        )
-        let installationIdHash: String = hashedObservationIdentifierLogValue(
-            observation.installationId,
-            key: "installation_id"
-        )
-        let sourceWorkspaceIdHash: String = hashedObservationIdentifierLogValue(
-            observation.sourceWorkspaceId,
-            key: "source_workspace_id"
-        )
-        let targetWorkspaceIdHash: String = hashedObservationIdentifierLogValue(
-            observation.targetWorkspaceId,
-            key: "target_workspace_id"
-        )
+        let workspaceId: String = sanitizedObservationLogValue(observation.workspaceId)
+        let installationId: String = sanitizedObservationLogValue(observation.installationId)
+        let sourceWorkspaceId: String = sanitizedObservationLogValue(observation.sourceWorkspaceId)
+        let targetWorkspaceId: String = sanitizedObservationLogValue(observation.targetWorkspaceId)
         self.cloudLogger.log(
             """
             phase=\(observation.phase.rawValue, privacy: .public) \
@@ -703,11 +672,11 @@ extension SentryObservabilityAdapter {
             requestId=\(observation.requestId ?? "-", privacy: .public) \
             code=\(observation.backendCode ?? "-", privacy: .public) \
             status=\(observation.statusCode.map { statusCode in String(statusCode) } ?? "-", privacy: .public) \
-            workspaceIdHash=\(workspaceIdHash, privacy: .public) \
-            installationIdHash=\(installationIdHash, privacy: .public) \
+            workspaceId=\(workspaceId, privacy: .public) \
+            installationId=\(installationId, privacy: .public) \
             selection=\(observation.selection ?? "-", privacy: .public) \
-            sourceWorkspaceIdHash=\(sourceWorkspaceIdHash, privacy: .public) \
-            targetWorkspaceIdHash=\(targetWorkspaceIdHash, privacy: .public) \
+            sourceWorkspaceId=\(sourceWorkspaceId, privacy: .public) \
+            targetWorkspaceId=\(targetWorkspaceId, privacy: .public) \
             migrationKind=\(observation.migrationKind ?? "-", privacy: .public) \
             remoteWorkspaceIsEmpty=\(observation.remoteWorkspaceIsEmpty.map { remoteWorkspaceIsEmpty in String(remoteWorkspaceIsEmpty) } ?? "-", privacy: .public) \
             operations=\(observation.operationsCount.map { operationsCount in String(operationsCount) } ?? "-", privacy: .public) \


### PR DESCRIPTION
## Summary
- Remove iOS Sentry's generic key-name based identifier hashing.
- Keep explicit hiding for auth/token/cookie/password/secret/email-like keys and URL query/fragment data.
- Emit ordinary iOS observability identifiers as raw values in Sentry contexts, user data, and local cloud logs.

## Validation
- `git --no-pager diff --check`
- `git --no-pager diff --check HEAD~1 HEAD`
- Static searches for removed hash helpers and ordinary `*_hash` observability fields.

Simulator-backed iOS tests were not run per repository instructions.