### PR TITLE
[codex] Treat deferred AI handoff as breadcrumb

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
@@ -320,8 +320,8 @@ internal class AiChatRuntime(
             || currentState.conversationBootstrapState != AiConversationBootstrapState.READY
             || currentState.dictationState != AiChatDictationState.IDLE
         ) {
-            context.observability.recordAiChatWarning(
-                warning = AiChatWarning.RuntimeHandoffRejectedNotReady(
+            context.observability.recordAiChatBreadcrumb(
+                breadcrumb = AiChatBreadcrumb.RuntimeHandoffDeferredNotReady(
                     workspaceId = currentState.workspaceId,
                     cardId = cardId,
                     conversationBootstrapState = currentState.conversationBootstrapState.name,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiChatObservability.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiChatObservability.kt
@@ -88,6 +88,13 @@ internal sealed interface AiChatBreadcrumb {
         val messageCount: Int
     ) : AiChatBreadcrumb
 
+    data class RuntimeHandoffDeferredNotReady(
+        val workspaceId: String?,
+        val cardId: String,
+        val conversationBootstrapState: String,
+        val dictationState: String
+    ) : AiChatBreadcrumb
+
     data class RuntimeHandoffAppliedToRunningDraft(
         val workspaceId: String?,
         val cardId: String,
@@ -151,13 +158,6 @@ internal sealed interface AiChatWarning {
         val cloudState: String,
         val remoteError: AiChatRemoteErrorDetails?,
         val message: String?
-    ) : AiChatWarning
-
-    data class RuntimeHandoffRejectedNotReady(
-        val workspaceId: String?,
-        val cardId: String,
-        val conversationBootstrapState: String,
-        val dictationState: String
     ) : AiChatWarning
 
     data class RuntimeHandoffRejectedLockedPhase(
@@ -526,6 +526,13 @@ private fun AiChatBreadcrumb.toAndroidEvent(): AndroidBreadcrumbEvent.AiRuntimeB
             pendingAttachmentCount = pendingAttachmentCount,
             draftLength = draftLength
         )
+        is AiChatBreadcrumb.RuntimeHandoffDeferredNotReady -> aiBreadcrumb(
+            name = AndroidAiObservationName.RUNTIME_HANDOFF_REJECTED_NOT_READY,
+            workspaceId = workspaceId,
+            cardId = cardId,
+            bootstrapState = conversationBootstrapState,
+            dictationState = dictationState
+        )
         is AiChatBreadcrumb.RuntimeHandoffAppliedToRunningDraft -> aiBreadcrumb(
             name = AndroidAiObservationName.RUNTIME_HANDOFF_APPLIED_TO_RUNNING_DRAFT,
             workspaceId = workspaceId,
@@ -604,13 +611,6 @@ private fun AiChatWarning.toAndroidEvent(): AndroidWarningIssueEvent {
             bootstrapState = null,
             remoteError = remoteError,
             message = message
-        )
-        is AiChatWarning.RuntimeHandoffRejectedNotReady -> aiWarning(
-            name = AndroidAiObservationName.RUNTIME_HANDOFF_REJECTED_NOT_READY,
-            workspaceId = workspaceId,
-            cardId = cardId,
-            bootstrapState = conversationBootstrapState,
-            dictationState = dictationState
         )
         is AiChatWarning.RuntimeHandoffRejectedLockedPhase -> aiWarning(
             name = AndroidAiObservationName.RUNTIME_HANDOFF_REJECTED_LOCKED_PHASE,


### PR DESCRIPTION
## Summary
- record not-ready AI card handoffs as runtime breadcrumbs instead of warning issues
- keep deferred handoff behavior unchanged so pending requests can retry when AI bootstrap is ready

## Validation
- git --no-pager diff --check

Gradle was not run because the repository instructions require explicit approval for local Gradle runs.