### PR TITLE
[codex] Make Android Sentry hiding explicit-only

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentrySanitization.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentrySanitization.kt
@@ -83,21 +83,20 @@ internal fun sanitizeSentryQueryString(value: String?): String? {
 }
 
 internal fun isUnsafeSentryFieldName(fieldName: String): Boolean {
-    val normalizedName = fieldName.lowercase()
-    return normalizedName.contains("fronttext") ||
-        normalizedName.contains("backtext") ||
-        normalizedName.contains("prompt") ||
-        normalizedName.contains("responsebody") ||
-        normalizedName.contains("rawbody") ||
-        normalizedName.contains("body") ||
-        normalizedName.contains("attachment") ||
-        normalizedName.contains("token") ||
+    val normalizedName: String = normalizeSentryFieldName(fieldName = fieldName)
+    return normalizedName.contains("token") ||
         normalizedName.contains("authorization") ||
         normalizedName.contains("cookie") ||
         normalizedName.contains("email") ||
         normalizedName.contains("password") ||
         normalizedName.contains("secret") ||
-        normalizedName.contains("query")
+        normalizedName.contains("apikey") ||
+        normalizedName.contains("query") ||
+        normalizedName.contains("fragment")
+}
+
+private fun normalizeSentryFieldName(fieldName: String): String {
+    return fieldName.lowercase().filter { character: Char -> character.isLetterOrDigit() }
 }
 
 private fun sanitizeSentryString(
@@ -153,13 +152,13 @@ private fun topStackFrame(error: Throwable): String? {
 }
 
 private val rawBodyPattern: Regex = Regex(
-    pattern = """(?i)\b((?:response\s+body|raw\s+body|raw\s+response|payload)\s*[:=]\s*).*$"""
+    pattern = """(?i)\b((?:response\s+body|raw\s+body|raw\s+response)\s*[:=]\s*).*$"""
 )
 private val urlQueryPattern: Regex = Regex(
     pattern = """\b((?:https?|wss?)://[^\s?#]+)\?[^\s]+"""
 )
 private val queryParameterPattern: Regex = Regex(
-    pattern = """(?i)\b(sessionId|runId|workspaceId|userId|installationId|afterCursor|cursor|token|code|email|key|api[-_]?key)=([^&\s]+)"""
+    pattern = """(?i)\b(token|code|email|key|api[-_]?key|password|secret)=([^&\s]+)"""
 )
 private val authHeaderPattern: Regex = Regex(
     pattern = """(?i)\b(authorization|x-api-key|api[-_]?key|token|secret|password)\b\s*[:=]\s*[^,\s]+"""

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
@@ -7,6 +7,120 @@ import org.junit.Test
 
 class SentryAppObservabilityTest {
     @Test
+    fun ordinaryIdentifiersStayRawInSentrySanitizers(): Unit {
+        val identifiers: Map<String, String> = mapOf(
+            "userId" to "user-raw-1",
+            "workspaceId" to "workspace-raw-1",
+            "cardId" to "card-raw-1",
+            "sessionId" to "session-raw-1",
+            "runId" to "run-raw-1",
+            "installationId" to "installation-raw-1"
+        )
+
+        identifiers.forEach { entry: Map.Entry<String, String> ->
+            assertEquals(entry.value, sanitizeSentryIdentifier(value = entry.value))
+            assertEquals(entry.value, sanitizeSentryTagValue(fieldName = entry.key, value = entry.value))
+            assertEquals(entry.value, sanitizeSentryContextValue(fieldName = entry.key, value = entry.value))
+            assertEquals(entry.value, sanitizeSentryLogValue(fieldName = entry.key, value = entry.value))
+        }
+    }
+
+    @Test
+    fun ordinaryContentFieldNamesStayRawInSentrySanitizers(): Unit {
+        val contentFields: Map<String, String> = mapOf(
+            "frontText" to "What is spaced repetition?",
+            "backText" to "A scheduling system for memory.",
+            "prompt" to "Create a concise flashcard.",
+            "body" to "Plain response body text.",
+            "attachment" to "attachment-reference-1"
+        )
+
+        contentFields.forEach { entry: Map.Entry<String, String> ->
+            assertEquals(entry.value, sanitizeSentryContextValue(fieldName = entry.key, value = entry.value))
+        }
+    }
+
+    @Test
+    fun queryParameterSanitizationKeepsOrdinaryIdsAndMasksExplicitSecrets(): Unit {
+        val rawQuery: String = listOf(
+            "sessionId=s1",
+            "runId=r1",
+            "workspaceId=w1",
+            "userId=u1",
+            "installationId=i1",
+            "afterCursor=a1",
+            "cursor=c1",
+            "token=t1",
+            "code=c2",
+            "email=user@example.test",
+            "key=k1",
+            "api-key=ak1",
+            "api_key=ak2",
+            "password=p1",
+            "secret=s2"
+        ).joinToString(separator = "&")
+
+        val sanitizedQuery: String = sanitizeSentryText(fieldName = "message", value = rawQuery)
+
+        assertEquals(
+            "sessionId=s1&runId=r1&workspaceId=w1&userId=u1&installationId=i1&" +
+                "afterCursor=a1&cursor=c1&token=[redacted]&code=[redacted]&email=[redacted]&" +
+                "key=[redacted]&api-key=[redacted]&api_key=[redacted]&password=[redacted]&secret=[redacted]",
+            sanitizedQuery
+        )
+    }
+
+    @Test
+    fun genericPayloadStaysRawWhileExplicitSecretsAreMasked(): Unit {
+        val payload: String = "payload: workspaceId=w1 cardId=c1 token=t1 secret=s1"
+
+        val sanitizedPayload: String = sanitizeSentryText(fieldName = "message", value = payload)
+
+        assertEquals(
+            "payload: workspaceId=w1 cardId=c1 token=[redacted] secret=[redacted]",
+            sanitizedPayload
+        )
+    }
+
+    @Test
+    fun rawHttpBodyLabelsStayRedacted(): Unit {
+        val rawBodyLabels: Map<String, String> = mapOf(
+            "response body" to "response body: workspaceId=w1 token=t1",
+            "raw body" to "raw body: workspaceId=w1 token=t1",
+            "raw response" to "raw response: workspaceId=w1 token=t1"
+        )
+
+        rawBodyLabels.forEach { entry: Map.Entry<String, String> ->
+            assertEquals(
+                "${entry.key}: [redacted]",
+                sanitizeSentryText(fieldName = "message", value = entry.value)
+            )
+        }
+    }
+
+    @Test
+    fun explicitSecretFieldNamesStayRedacted(): Unit {
+        val unsafeFieldNames: List<String> = listOf(
+            "token",
+            "authorization",
+            "cookie",
+            "email",
+            "password",
+            "secret",
+            "apiKey",
+            "apikey",
+            "api-key",
+            "api_key",
+            "queryString",
+            "fragment"
+        )
+
+        unsafeFieldNames.forEach { fieldName: String ->
+            assertEquals("[redacted]", sanitizeSentryContextValue(fieldName = fieldName, value = "secret-value"))
+        }
+    }
+
+    @Test
     fun warningIssueFingerprintUsesStableWarningDimensions(): Unit {
         val progressWarning: AndroidWarningIssueEvent.ProgressRefreshWarning =
             AndroidWarningIssueEvent.ProgressRefreshWarning(


### PR DESCRIPTION
## Summary
- keep Android Sentry ordinary IDs and content field names raw by default
- narrow query-parameter masking to explicit secret-like keys
- keep raw HTTP body labels redacted while allowing generic payload text through secret-pattern masking

## Validation
- git --no-pager diff --check
- focused rg checks for Android observability hashes and broad sanitizer terms

Gradle was not run because local Gradle validation requires explicit approval in this repository.