### PR TITLE
Deduplicate recovery warning observations

### DIFF
--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -228,8 +228,11 @@ describe("sync lifecycle observation", () => {
     expect(findCapturedWarning("sync_local_db_missing")).toBeNull();
   });
 
-  it("warns when an empty local database had previous restore history", async () => {
+  it("deduplicates slow warnings for successful local database recovery", async () => {
     const persistentStorageMock = installPersistentStorageMock();
+    let nowMs = 0;
+    vi.spyOn(Date, "now")
+      .mockImplementation(() => nowMs);
 
     storeSyncRestoreHistoryEntry({
       userId: "user-1",
@@ -240,7 +243,12 @@ describe("sync lifecycle observation", () => {
       persistentStorageState: createPersistentStorageState(true, 321, 654, null, true, true),
     });
 
-    await runWorkspaceRemoteSync(createRemoteSyncInput());
+    await runWorkspaceRemoteSync({
+      ...createRemoteSyncInput(),
+      refreshWorkspaceView: async (_workspaceId: string): Promise<void> => {
+        nowMs = 3000;
+      },
+    });
 
     expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledWith(expect.objectContaining({
       action: "sync_local_db_missing",
@@ -281,6 +289,7 @@ describe("sync lifecycle observation", () => {
         storagePersistGrantedAfter: true,
       }),
     }));
+    expect(findCapturedWarning("sync_restore_slow")).toBeNull();
     expect(persistentStorageMock.persistMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -270,13 +270,16 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     }
 
     recoveryFailurePhase = "slow_bootstrap_observation";
-    if (shouldObserveHotBootstrap({
-      durationMs,
-      pageCount,
-      entriesCount,
-      localCardCountAfter,
-      remoteIsEmpty,
-    })) {
+    if (
+      isLocalDbRecovery === false
+      && shouldObserveHotBootstrap({
+        durationMs,
+        pageCount,
+        entriesCount,
+        localCardCountAfter,
+        remoteIsEmpty,
+      })
+    ) {
       observeSlowHotBootstrap({
         userId: input.userId,
         workspaceId: input.workspaceId,


### PR DESCRIPTION
## Summary

Deduplicates successful local DB recovery observations so a recovery run still emits `sync_local_db_missing` and `sync_local_db_recovery_succeeded`, but no longer also emits `sync_restore_slow`. Normal slow bootstrap observation remains unchanged.

## Validation

- `npm exec vitest -- src/appData/sync/observation/syncLifecycleObservation.test.ts`
- `npm run build`
