### PR TITLE
[codex] Throttle progress timezone warnings

### DIFF
--- a/apps/web/src/progress/progressDates.test.ts
+++ b/apps/web/src/progress/progressDates.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildProgressDateContext } from "./progressDates";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { INSTALLATION_ID_STORAGE_KEY } from "../clientIdentity";
+import type { WebWarningEvent } from "../observability/webObservability";
+
+const progressTimezoneWarningHistoryStorageKey = "flashcards-progress-timezone-warning-history-v1";
 
 const observabilityMocks = vi.hoisted(() => ({
   captureWebWarningMock: vi.fn(),
@@ -10,30 +13,143 @@ vi.mock("../observability/webObservability", () => ({
   captureWebWarning: observabilityMocks.captureWebWarningMock,
 }));
 
+type ProgressDatesModule = typeof import("./progressDates");
+
+function createStorageMock(): Storage {
+  const state = new Map<string, string>();
+
+  return {
+    get length(): number {
+      return state.size;
+    },
+    clear(): void {
+      state.clear();
+    },
+    getItem(key: string): string | null {
+      return state.get(key) ?? null;
+    },
+    key(index: number): string | null {
+      return [...state.keys()][index] ?? null;
+    },
+    removeItem(key: string): void {
+      state.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      state.set(key, value);
+    },
+  };
+}
+
+async function loadProgressDatesModule(): Promise<ProgressDatesModule> {
+  return await import("./progressDates");
+}
+
+function mockBrowserTimeZone(timeZone: string): void {
+  const resolvedOptions = new Intl.DateTimeFormat().resolvedOptions();
+  vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+    ...resolvedOptions,
+    timeZone,
+  });
+}
+
+function readCapturedWarning(callIndex: number): WebWarningEvent {
+  const event = observabilityMocks.captureWebWarningMock.mock.calls[callIndex]?.[0] as WebWarningEvent | undefined;
+  if (event === undefined) {
+    throw new Error(`Expected captured warning at index ${callIndex}`);
+  }
+
+  return event;
+}
+
 describe("progress date context", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+    vi.resetModules();
+    window.localStorage.clear();
     observabilityMocks.captureWebWarningMock.mockReset();
   });
 
-  it("falls back to UTC when the browser timezone is invalid", () => {
-    const resolvedOptions = new Intl.DateTimeFormat().resolvedOptions();
-    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
-      ...resolvedOptions,
-      timeZone: "Etc/Unknown",
-    });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+    observabilityMocks.captureWebWarningMock.mockReset();
+  });
+
+  it("falls back to UTC when the browser timezone is invalid", async () => {
+    mockBrowserTimeZone("Etc/Unknown");
+    const { buildProgressDateContext } = await loadProgressDatesModule();
 
     expect(buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"))).toEqual({
       timeZone: "UTC",
       today: "2026-06-04",
     });
-    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledWith(expect.objectContaining({
+  });
+
+  it("emits progress_timezone_invalid for the first invalid timezone", async () => {
+    mockBrowserTimeZone("Etc/Unknown");
+    const { buildProgressDateContext } = await loadProgressDatesModule();
+
+    buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
+
+    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledTimes(1);
+    expect(readCapturedWarning(0)).toEqual(expect.objectContaining({
       action: "progress_timezone_invalid",
-      details: expect.objectContaining({
+      details: {
         eventName: "progress_timezone_invalid",
         observedTimeZone: "Etc/Unknown",
         fallbackTimeZone: "UTC",
         errorName: "RangeError",
+      },
+    }));
+  });
+
+  it("does not emit a second invalid timezone warning within the throttle window after reload", async () => {
+    mockBrowserTimeZone("Etc/Unknown");
+    const firstModule = await loadProgressDatesModule();
+    firstModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
+
+    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(progressTimezoneWarningHistoryStorageKey)).not.toBeNull();
+
+    observabilityMocks.captureWebWarningMock.mockReset();
+    vi.resetModules();
+    const secondModule = await loadProgressDatesModule();
+    secondModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
+
+    expect(observabilityMocks.captureWebWarningMock).not.toHaveBeenCalled();
+  });
+
+  it("emits a new first warning after localStorage is cleared across reloads", async () => {
+    mockBrowserTimeZone("Etc/Unknown");
+    const firstModule = await loadProgressDatesModule();
+    firstModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
+
+    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledTimes(1);
+
+    observabilityMocks.captureWebWarningMock.mockReset();
+    vi.resetModules();
+    window.localStorage.clear();
+    const secondModule = await loadProgressDatesModule();
+    secondModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
+
+    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes installationId in the warning scope when localStorage is available", async () => {
+    window.localStorage.setItem(INSTALLATION_ID_STORAGE_KEY, "installation-1");
+    mockBrowserTimeZone("Etc/Unknown");
+    const { buildProgressDateContext } = await loadProgressDatesModule();
+
+    buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
+
+    expect(readCapturedWarning(0)).toEqual(expect.objectContaining({
+      scope: expect.objectContaining({
+        userId: null,
+        workspaceId: null,
+        installationId: "installation-1",
       }),
     }));
   });

--- a/apps/web/src/progress/progressDates.ts
+++ b/apps/web/src/progress/progressDates.ts
@@ -7,16 +7,32 @@ import {
   captureWebWarning,
   type WebObservationScope,
 } from "../observability/webObservability";
+import { getStableInstallationId } from "../clientIdentity";
 
 export const progressRangeDayCount: number = 140;
 export const progressRangeStartOffsetDays: number = 1 - progressRangeDayCount;
 const fallbackProgressTimeZone = "UTC";
+const progressTimezoneWarningHistoryStorageKey = "flashcards-progress-timezone-warning-history-v1";
+const progressTimezoneWarningHistoryEntryLimit: number = 20;
+const progressTimezoneWarningThrottleMs: number = 7 * 24 * 60 * 60 * 1000;
 const observedInvalidProgressTimeZoneWarnings = new Set<string>();
 
 export type ProgressDateContext = Readonly<{
   timeZone: string;
   today: string;
 }>;
+
+type ProgressTimezoneWarningHistoryEntry = Readonly<{
+  observedTimeZone: string | null;
+  errorName: string;
+  lastObservedAt: string;
+}>;
+
+type ProgressTimezoneWarningHistoryEnvelope = Readonly<{
+  entries: ReadonlyArray<ProgressTimezoneWarningHistoryEntry>;
+}>;
+
+type UnknownRecord = Readonly<Record<string, unknown>>;
 
 function getRequiredDatePart(
   parts: ReadonlyArray<Intl.DateTimeFormatPart>,
@@ -39,13 +55,37 @@ function getCurrentRoute(): string | null {
   return `${window.location.pathname}${window.location.search}${window.location.hash}`;
 }
 
+function getBrowserLocalStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function loadProgressObservationInstallationId(): string | null {
+  if (getBrowserLocalStorage() === null) {
+    return null;
+  }
+
+  try {
+    return getStableInstallationId();
+  } catch {
+    return null;
+  }
+}
+
 function buildProgressObservationScope(): WebObservationScope {
   return {
     app: "web",
     feature: "progress",
     userId: null,
     workspaceId: null,
-    installationId: null,
+    installationId: loadProgressObservationInstallationId(),
     route: getCurrentRoute(),
     requestId: null,
     statusCode: null,
@@ -62,12 +102,129 @@ function readErrorName(error: unknown): string {
   return typeof errorName === "string" && errorName.trim() !== "" ? errorName : "Error";
 }
 
+function isUnknownRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object"
+    && value !== null
+    && Array.isArray(value) === false;
+}
+
+function isProgressTimezoneWarningHistoryEntry(value: unknown): value is ProgressTimezoneWarningHistoryEntry {
+  if (isUnknownRecord(value) === false) {
+    return false;
+  }
+
+  const observedTimeZone = value.observedTimeZone;
+  const errorName = value.errorName;
+  const lastObservedAt = value.lastObservedAt;
+
+  return (typeof observedTimeZone === "string" || observedTimeZone === null)
+    && typeof errorName === "string"
+    && errorName.trim() !== ""
+    && typeof lastObservedAt === "string"
+    && Number.isFinite(Date.parse(lastObservedAt));
+}
+
+function isProgressTimezoneWarningHistoryEnvelope(value: unknown): value is ProgressTimezoneWarningHistoryEnvelope {
+  if (isUnknownRecord(value) === false || Array.isArray(value.entries) === false) {
+    return false;
+  }
+
+  return value.entries.every((entry: unknown): boolean => {
+    return isProgressTimezoneWarningHistoryEntry(entry);
+  });
+}
+
+function readProgressTimezoneWarningHistory(storage: Storage): ReadonlyArray<ProgressTimezoneWarningHistoryEntry> | null {
+  try {
+    const rawValue = storage.getItem(progressTimezoneWarningHistoryStorageKey);
+    if (rawValue === null) {
+      return [];
+    }
+
+    const parsedValue = JSON.parse(rawValue) as unknown;
+    if (isProgressTimezoneWarningHistoryEnvelope(parsedValue) === false) {
+      return null;
+    }
+
+    return parsedValue.entries;
+  } catch {
+    return null;
+  }
+}
+
+function matchesProgressTimezoneWarningHistoryEntry(
+  entry: ProgressTimezoneWarningHistoryEntry,
+  observedTimeZone: string | null,
+  errorName: string,
+): boolean {
+  return entry.observedTimeZone === observedTimeZone && entry.errorName === errorName;
+}
+
+function hasRecentProgressTimezoneWarning(
+  entries: ReadonlyArray<ProgressTimezoneWarningHistoryEntry>,
+  observedTimeZone: string | null,
+  errorName: string,
+  nowMs: number,
+): boolean {
+  return entries.some((entry: ProgressTimezoneWarningHistoryEntry): boolean => {
+    if (matchesProgressTimezoneWarningHistoryEntry(entry, observedTimeZone, errorName) === false) {
+      return false;
+    }
+
+    const lastObservedMs = Date.parse(entry.lastObservedAt);
+    const elapsedMs = nowMs - lastObservedMs;
+    return elapsedMs >= 0 && elapsedMs < progressTimezoneWarningThrottleMs;
+  });
+}
+
+function upsertProgressTimezoneWarningHistoryEntry(
+  entries: ReadonlyArray<ProgressTimezoneWarningHistoryEntry>,
+  observedTimeZone: string | null,
+  errorName: string,
+  nowMs: number,
+): ReadonlyArray<ProgressTimezoneWarningHistoryEntry> {
+  const nextEntry: ProgressTimezoneWarningHistoryEntry = {
+    observedTimeZone,
+    errorName,
+    lastObservedAt: new Date(nowMs).toISOString(),
+  };
+  const previousEntries = entries.filter((entry: ProgressTimezoneWarningHistoryEntry): boolean => {
+    return matchesProgressTimezoneWarningHistoryEntry(entry, observedTimeZone, errorName) === false;
+  });
+
+  return [nextEntry, ...previousEntries].slice(0, progressTimezoneWarningHistoryEntryLimit);
+}
+
+function writeProgressTimezoneWarningHistory(
+  storage: Storage,
+  entries: ReadonlyArray<ProgressTimezoneWarningHistoryEntry>,
+): void {
+  const envelope: ProgressTimezoneWarningHistoryEnvelope = { entries };
+
+  try {
+    storage.setItem(progressTimezoneWarningHistoryStorageKey, JSON.stringify(envelope));
+  } catch {
+    return;
+  }
+}
+
 function observeInvalidProgressTimeZone(
   observedTimeZone: string | null,
   errorName: string,
 ): void {
   const warningKey = `${observedTimeZone ?? "null"}:${errorName}`;
   if (observedInvalidProgressTimeZoneWarnings.has(warningKey)) {
+    return;
+  }
+
+  const storage = getBrowserLocalStorage();
+  const nowMs = Date.now();
+  const storedHistory = storage === null ? null : readProgressTimezoneWarningHistory(storage);
+  if (
+    storedHistory !== null
+    && hasRecentProgressTimezoneWarning(storedHistory, observedTimeZone, errorName, nowMs)
+  ) {
+    observedInvalidProgressTimeZoneWarnings.add(warningKey);
     return;
   }
 
@@ -82,6 +239,16 @@ function observeInvalidProgressTimeZone(
       errorName,
     },
   });
+
+  if (storage !== null) {
+    const nextHistory = upsertProgressTimezoneWarningHistoryEntry(
+      storedHistory ?? [],
+      observedTimeZone,
+      errorName,
+      nowMs,
+    );
+    writeProgressTimezoneWarningHistory(storage, nextHistory);
+  }
 }
 
 function assertUsableTimeZone(timeZone: string): void {


### PR DESCRIPTION
Summary: Throttle invalid progress timezone warnings across browser reloads with a localStorage history, while preserving the UTC fallback and adding installationId to the warning scope when available. Checks: npm exec vitest -- src/progress/progressDates.test.ts src/observability/instrument.test.ts; npm run build.