### PR TITLE
[codex] Add IndexedDB open lifecycle diagnostics

### DIFF
--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { webAppVersion } from "../../../clientIdentity";
 import { clearWebSyncCache } from "../../../localDb/cache";
 import { applyHotSyncPage } from "../../../localDb/cards/workspace";
-import type { PersistentStorageState } from "../../../localDb/sync/cloudSettings";
+import { loadCloudSettings, type PersistentStorageState } from "../../../localDb/sync/cloudSettings";
 import type {
   SyncBootstrapEntry,
   SyncBootstrapPullResult,
@@ -366,6 +366,7 @@ describe("sync lifecycle observation", () => {
       localCardCount: 42,
       persistentStorageState: createPersistentStorageState(true, 321, 654, null, true, true),
     });
+    await expect(loadCloudSettings()).resolves.toBeNull();
 
     await runWorkspaceRemoteSync({
       ...createRemoteSyncInput(),
@@ -398,6 +399,11 @@ describe("sync lifecycle observation", () => {
         storageErrorName: null,
         storagePersistAttempted: false,
         storagePersistGranted: null,
+        indexedDbOpenObservedAt: expect.any(String),
+        indexedDbOpenOldVersion: 0,
+        indexedDbOpenNewVersion: 13,
+        indexedDbDatabaseCreated: true,
+        indexedDbDatabaseUpgraded: false,
       }),
     }));
     expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -417,6 +423,11 @@ describe("sync lifecycle observation", () => {
         finalRefreshDurationMs: 15,
         persistentStorageDurationMs: 7,
         bootstrapPageDurationMs: [40],
+        indexedDbOpenObservedAt: expect.any(String),
+        indexedDbOpenOldVersion: 0,
+        indexedDbOpenNewVersion: 13,
+        indexedDbDatabaseCreated: true,
+        indexedDbDatabaseUpgraded: false,
       }),
     }));
     expect(findCapturedWarning("sync_restore_slow")).toBeNull();

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
@@ -6,6 +6,7 @@ import {
   type SyncRestoreLocalBootstrapState,
   type WebObservationScope,
 } from "../../../observability/webObservability";
+import type { IndexedDbOpenLifecycleSnapshot } from "../../../localDb/core/database";
 import type { PersistentStorageState } from "../../../localDb/sync/cloudSettings";
 import type { SyncRestoreHistoryEntry } from "../restore/syncRestoreHistory";
 
@@ -36,6 +37,7 @@ export type LocalDbMissingObservationInput = Readonly<{
   previousRestoreHistory: SyncRestoreHistoryEntry;
   currentWebAppVersion: string;
   persistentStorageState: PersistentStorageState;
+  indexedDbOpenLifecycleSnapshot: IndexedDbOpenLifecycleSnapshot | null;
 }>;
 
 export type PersistentStorageObservationInput = Readonly<{
@@ -64,6 +66,7 @@ export type LocalDbRecoveryObservationInput = SyncBootstrapTimingDetails & Reado
   remoteIsEmpty: boolean | null;
   persistentStorageStateBefore: PersistentStorageState | null;
   persistentStorageStateAfter: PersistentStorageState | null;
+  indexedDbOpenLifecycleSnapshot: IndexedDbOpenLifecycleSnapshot | null;
 }>;
 
 export type LocalDbRecoveryFailedObservationInput = LocalDbRecoveryObservationInput & Readonly<{
@@ -107,6 +110,36 @@ function buildSyncBootstrapTimingDetails(input: SyncBootstrapTimingDetails): Syn
   };
 }
 
+type IndexedDbOpenLifecycleObservationFields = Readonly<{
+  indexedDbOpenObservedAt: string | null;
+  indexedDbOpenOldVersion: number | null;
+  indexedDbOpenNewVersion: number | null;
+  indexedDbDatabaseCreated: boolean | null;
+  indexedDbDatabaseUpgraded: boolean | null;
+}>;
+
+function buildIndexedDbOpenLifecycleObservationFields(
+  snapshot: IndexedDbOpenLifecycleSnapshot | null,
+): IndexedDbOpenLifecycleObservationFields {
+  if (snapshot === null) {
+    return {
+      indexedDbOpenObservedAt: null,
+      indexedDbOpenOldVersion: null,
+      indexedDbOpenNewVersion: null,
+      indexedDbDatabaseCreated: null,
+      indexedDbDatabaseUpgraded: null,
+    };
+  }
+
+  return {
+    indexedDbOpenObservedAt: snapshot.observedAt,
+    indexedDbOpenOldVersion: snapshot.oldVersion,
+    indexedDbOpenNewVersion: snapshot.newVersion,
+    indexedDbDatabaseCreated: snapshot.databaseCreated,
+    indexedDbDatabaseUpgraded: snapshot.databaseUpgraded,
+  };
+}
+
 export function observeSlowHotBootstrap(input: HotBootstrapSlowObservationInput): void {
   captureWebWarning({
     action: "sync_restore_slow",
@@ -132,6 +165,9 @@ export function observeSlowHotBootstrap(input: HotBootstrapSlowObservationInput)
 }
 
 export function observeLocalDbMissing(input: LocalDbMissingObservationInput): void {
+  const indexedDbOpenLifecycleFields = buildIndexedDbOpenLifecycleObservationFields(
+    input.indexedDbOpenLifecycleSnapshot,
+  );
   captureWebWarning({
     action: "sync_local_db_missing",
     scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
@@ -160,6 +196,7 @@ export function observeLocalDbMissing(input: LocalDbMissingObservationInput): vo
       storageErrorName: input.persistentStorageState.errorName,
       storagePersistAttempted: input.persistentStorageState.persistAttempted,
       storagePersistGranted: input.persistentStorageState.persistGranted,
+      ...indexedDbOpenLifecycleFields,
     },
   });
 }
@@ -182,6 +219,9 @@ function persistentStorageStateOrNull(state: PersistentStorageState | null): Per
 export function observeLocalDbRecoverySucceeded(input: LocalDbRecoveryObservationInput): void {
   const persistentStorageStateBefore = persistentStorageStateOrNull(input.persistentStorageStateBefore);
   const persistentStorageStateAfter = persistentStorageStateOrNull(input.persistentStorageStateAfter);
+  const indexedDbOpenLifecycleFields = buildIndexedDbOpenLifecycleObservationFields(
+    input.indexedDbOpenLifecycleSnapshot,
+  );
   captureWebWarning({
     action: "sync_local_db_recovery_succeeded",
     scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
@@ -225,6 +265,7 @@ export function observeLocalDbRecoverySucceeded(input: LocalDbRecoveryObservatio
       storagePersistAttemptedAfter: persistentStorageStateAfter.persistAttempted,
       storagePersistGrantedAfter: persistentStorageStateAfter.persistGranted,
       ...buildSyncBootstrapTimingDetails(input),
+      ...indexedDbOpenLifecycleFields,
     },
   });
 }
@@ -232,6 +273,9 @@ export function observeLocalDbRecoverySucceeded(input: LocalDbRecoveryObservatio
 export function observeLocalDbRecoveryFailed(input: LocalDbRecoveryFailedObservationInput): void {
   const persistentStorageStateBefore = persistentStorageStateOrNull(input.persistentStorageStateBefore);
   const persistentStorageStateAfter = persistentStorageStateOrNull(input.persistentStorageStateAfter);
+  const indexedDbOpenLifecycleFields = buildIndexedDbOpenLifecycleObservationFields(
+    input.indexedDbOpenLifecycleSnapshot,
+  );
   captureWebWarning({
     action: "sync_local_db_recovery_failed",
     scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
@@ -281,6 +325,7 @@ export function observeLocalDbRecoveryFailed(input: LocalDbRecoveryFailedObserva
         : persistentStorageStateAfter.persistAttempted,
       storagePersistGrantedAfter: persistentStorageStateAfter.persistGranted,
       ...buildSyncBootstrapTimingDetails(input),
+      ...indexedDbOpenLifecycleFields,
     },
   });
 }

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -2,6 +2,7 @@ import { bootstrapPullSyncState } from "../../../api";
 import { webAppVersion } from "../../../clientIdentity";
 import { loadActiveCardCount } from "../../../localDb/cards/cards";
 import { applyHotSyncPage, loadWorkspaceSyncState } from "../../../localDb/cards/workspace";
+import { readIndexedDbOpenLifecycleSnapshotForDiagnostics } from "../../../localDb/core/database";
 import {
   ensurePersistentStorage,
   readPersistentStorageState,
@@ -140,6 +141,7 @@ function readErrorName(error: unknown): string {
 
 export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promise<RemoteSyncFlags> {
   const syncStateBefore = await loadWorkspaceSyncState(input.workspaceId);
+  const indexedDbOpenLifecycleSnapshot = readIndexedDbOpenLifecycleSnapshotForDiagnostics();
   const hotStateHydrated = syncStateBefore?.hasHydratedHotState ?? false;
   input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
   if (hotStateHydrated) {
@@ -205,6 +207,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         previousRestoreHistory: restoreHistoryBefore,
         currentWebAppVersion: webAppVersion,
         persistentStorageState: persistentStorageStateBeforeRecovery,
+        indexedDbOpenLifecycleSnapshot,
       });
     }
 
@@ -303,6 +306,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         persistentStorageStateBefore: persistentStorageStateBeforeRecovery,
         persistentStorageStateAfter: persistentStorageStateAfterRecovery,
         ...readBootstrapTimingDetails(),
+        indexedDbOpenLifecycleSnapshot,
       });
     }
 
@@ -364,6 +368,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         persistentStorageStateBefore: persistentStorageStateBeforeRecovery,
         persistentStorageStateAfter: persistentStorageStateAfterRecovery,
         ...readBootstrapTimingDetails(),
+        indexedDbOpenLifecycleSnapshot,
       });
     }
 

--- a/apps/web/src/localDb/core/core.migrations.test.ts
+++ b/apps/web/src/localDb/core/core.migrations.test.ts
@@ -4,7 +4,15 @@ import "fake-indexeddb/auto";
 import { describe, expect, it, vi } from "vitest";
 import { malformedDueAtBucketMillis, nullDueAtBucketMillis, parseDueAtMillis } from "../../appData/domain/dueAt";
 import { clearWebSyncCache } from "./cache";
-import { closeDatabaseAfter, deleteDatabase, getAllFromStore, openDatabase, type StoredCard } from "./database";
+import {
+  closeDatabaseAfter,
+  deleteDatabase,
+  getAllFromStore,
+  openDatabase,
+  readIndexedDbOpenLifecycleSnapshotForDiagnostics,
+  readLastIndexedDbOpenLifecycleSnapshot,
+  type StoredCard,
+} from "./database";
 import { listOutboxRecords, type PersistedOutboxRecord } from "../sync/outbox";
 import { loadReviewQueueSnapshot } from "../reviews/reviews";
 import { makeCard, workspaceId } from "./testSupport";
@@ -285,6 +293,58 @@ describe("localDb core migrations", () => {
     } finally {
       openDatabaseSpy.mockRestore();
     }
+  });
+
+  it("records IndexedDB open lifecycle for a newly created database", async () => {
+    await clearWebSyncCache();
+    observabilityMocks.addWebBreadcrumbMock.mockReset();
+
+    const database = await openDatabase();
+    database.close();
+
+    expect(readLastIndexedDbOpenLifecycleSnapshot()).toEqual(expect.objectContaining({
+      observedAt: expect.any(String),
+      databaseName: webSyncDatabaseName,
+      databaseVersion: 13,
+      oldVersion: 0,
+      newVersion: 13,
+      databaseCreated: true,
+      databaseUpgraded: false,
+    }));
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "indexed_db_operation",
+      details: expect.objectContaining({
+        eventName: "indexed_db_open_lifecycle",
+        databaseName: webSyncDatabaseName,
+        databaseVersion: 13,
+        indexedDbOldVersion: 0,
+        indexedDbNewVersion: 13,
+        indexedDbDatabaseCreated: true,
+        indexedDbDatabaseUpgraded: false,
+      }),
+    }));
+
+    const reopenedDatabase = await openDatabase();
+    reopenedDatabase.close();
+
+    expect(readLastIndexedDbOpenLifecycleSnapshot()).toEqual(expect.objectContaining({
+      databaseName: webSyncDatabaseName,
+      databaseVersion: 13,
+      oldVersion: null,
+      newVersion: 13,
+      databaseCreated: false,
+      databaseUpgraded: false,
+    }));
+    expect(readIndexedDbOpenLifecycleSnapshotForDiagnostics()).toEqual(expect.objectContaining({
+      databaseName: webSyncDatabaseName,
+      databaseVersion: 13,
+      oldVersion: 0,
+      newVersion: 13,
+      databaseCreated: true,
+      databaseUpgraded: false,
+    }));
+
+    await clearWebSyncCache();
   });
 
   it("waits for managed IndexedDB operations before deleting browser data", async () => {

--- a/apps/web/src/localDb/core/database.ts
+++ b/apps/web/src/localDb/core/database.ts
@@ -84,11 +84,23 @@ export type DatabaseStores =
   | "outbox"
   | "meta";
 
+export type IndexedDbOpenLifecycleSnapshot = Readonly<{
+  observedAt: string;
+  databaseName: string;
+  databaseVersion: number;
+  oldVersion: number | null;
+  newVersion: number;
+  databaseCreated: boolean;
+  databaseUpgraded: boolean;
+}>;
+
 const databaseName = "flashcards-web-sync";
 const databaseVersion = 13;
 const activeDatabaseOperationPromises = new Set<Promise<unknown>>();
 let isDatabaseDeleteInProgress = false;
 let activeDatabaseDeletePromise: Promise<void> | null = null;
+let lastIndexedDbOpenLifecycleSnapshot: IndexedDbOpenLifecycleSnapshot | null = null;
+let lastIndexedDbVersionChangeLifecycleSnapshot: IndexedDbOpenLifecycleSnapshot | null = null;
 
 type StoredCardDueAtMigrationRecord = Omit<StoredCard, "dueAt" | "dueAtMillis" | "dueAtBucketMillis" | "fsrsLastReviewedAtMillis"> & Readonly<{
   dueAt?: string | null;
@@ -187,6 +199,14 @@ function addIndexedDbOperationFailedBreadcrumb(
       errorMessage: error.message,
     },
   });
+}
+
+export function readLastIndexedDbOpenLifecycleSnapshot(): IndexedDbOpenLifecycleSnapshot | null {
+  return lastIndexedDbOpenLifecycleSnapshot;
+}
+
+export function readIndexedDbOpenLifecycleSnapshotForDiagnostics(): IndexedDbOpenLifecycleSnapshot | null {
+  return lastIndexedDbVersionChangeLifecycleSnapshot ?? lastIndexedDbOpenLifecycleSnapshot;
 }
 
 function deleteExistingStore(database: IDBDatabase, storeName: string): void {
@@ -411,6 +431,7 @@ function upgradeToVersion13(transaction: IDBTransaction): void {
 export function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(databaseName, databaseVersion);
+    let oldVersionDuringUpgrade: number | null = null;
 
     request.onerror = () => {
       const error = describeIndexedDbOperationError("Failed to open IndexedDB", request.error, "open");
@@ -420,6 +441,7 @@ export function openDatabase(): Promise<IDBDatabase> {
 
     request.onupgradeneeded = (event) => {
       const oldVersion = event.oldVersion;
+      oldVersionDuringUpgrade = oldVersion;
 
       if (oldVersion < 4) {
         upgradeToVersion4(request.result);
@@ -494,6 +516,34 @@ export function openDatabase(): Promise<IDBDatabase> {
     };
 
     request.onsuccess = () => {
+      const indexedDbOpenLifecycleSnapshot: IndexedDbOpenLifecycleSnapshot = {
+        observedAt: new Date().toISOString(),
+        databaseName,
+        databaseVersion,
+        oldVersion: oldVersionDuringUpgrade,
+        newVersion: request.result.version,
+        databaseCreated: oldVersionDuringUpgrade === 0,
+        databaseUpgraded: oldVersionDuringUpgrade !== null && oldVersionDuringUpgrade > 0,
+      };
+      lastIndexedDbOpenLifecycleSnapshot = indexedDbOpenLifecycleSnapshot;
+
+      if (oldVersionDuringUpgrade !== null) {
+        lastIndexedDbVersionChangeLifecycleSnapshot = indexedDbOpenLifecycleSnapshot;
+        addWebBreadcrumb({
+          action: "indexed_db_operation",
+          scope: buildIndexedDbObservationScope(),
+          details: {
+            eventName: "indexed_db_open_lifecycle",
+            databaseName,
+            databaseVersion,
+            indexedDbOldVersion: oldVersionDuringUpgrade,
+            indexedDbNewVersion: request.result.version,
+            indexedDbDatabaseCreated: indexedDbOpenLifecycleSnapshot.databaseCreated,
+            indexedDbDatabaseUpgraded: indexedDbOpenLifecycleSnapshot.databaseUpgraded,
+          },
+        });
+      }
+
       resolve(request.result);
     };
   });

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -131,7 +131,7 @@ export type PersistentStorageBreadcrumbDetails = Readonly<{
 
 export type IndexedDbOperation = "open";
 
-export type IndexedDbOperationBreadcrumbDetails = Readonly<{
+export type IndexedDbOperationFailedBreadcrumbDetails = Readonly<{
   eventName: "indexed_db_operation_failed";
   indexedDbOperation: IndexedDbOperation;
   databaseName: string;
@@ -139,6 +139,20 @@ export type IndexedDbOperationBreadcrumbDetails = Readonly<{
   indexedDbErrorName: string | null;
   errorMessage: string;
 }>;
+
+export type IndexedDbOpenLifecycleBreadcrumbDetails = Readonly<{
+  eventName: "indexed_db_open_lifecycle";
+  databaseName: string;
+  databaseVersion: number;
+  indexedDbOldVersion: number;
+  indexedDbNewVersion: number;
+  indexedDbDatabaseCreated: boolean;
+  indexedDbDatabaseUpgraded: boolean;
+}>;
+
+export type IndexedDbOperationBreadcrumbDetails =
+  | IndexedDbOperationFailedBreadcrumbDetails
+  | IndexedDbOpenLifecycleBreadcrumbDetails;
 
 export type WebBreadcrumbEvent =
   | Readonly<{
@@ -435,6 +449,11 @@ export type SyncLocalDbMissingWarningDetails = Readonly<{
   storageErrorName: string | null;
   storagePersistAttempted: boolean;
   storagePersistGranted: boolean | null;
+  indexedDbOpenObservedAt: string | null;
+  indexedDbOpenOldVersion: number | null;
+  indexedDbOpenNewVersion: number | null;
+  indexedDbDatabaseCreated: boolean | null;
+  indexedDbDatabaseUpgraded: boolean | null;
 }>;
 
 export type SyncLocalDbRecoverySucceededWarningDetails = SyncBootstrapTimingDetails & Readonly<{
@@ -476,6 +495,11 @@ export type SyncLocalDbRecoverySucceededWarningDetails = SyncBootstrapTimingDeta
   storageErrorNameAfter: string | null;
   storagePersistAttemptedAfter: boolean;
   storagePersistGrantedAfter: boolean | null;
+  indexedDbOpenObservedAt: string | null;
+  indexedDbOpenOldVersion: number | null;
+  indexedDbOpenNewVersion: number | null;
+  indexedDbDatabaseCreated: boolean | null;
+  indexedDbDatabaseUpgraded: boolean | null;
 }>;
 
 export type SyncLocalDbRecoveryFailurePhase =
@@ -530,6 +554,11 @@ export type SyncLocalDbRecoveryFailedWarningDetails = SyncBootstrapTimingDetails
   storageErrorNameAfter: string | null;
   storagePersistAttemptedAfter: boolean | null;
   storagePersistGrantedAfter: boolean | null;
+  indexedDbOpenObservedAt: string | null;
+  indexedDbOpenOldVersion: number | null;
+  indexedDbOpenNewVersion: number | null;
+  indexedDbDatabaseCreated: boolean | null;
+  indexedDbDatabaseUpgraded: boolean | null;
 }>;
 
 export type ProgressTimezoneInvalidWarningDetails = Readonly<{


### PR DESCRIPTION
## Summary

Add web diagnostics for the IndexedDB open lifecycle so local DB recovery warnings can distinguish a normal existing database open, a browser-created fresh database, and an upgrade from an older database version.

## Details

- Record the latest IndexedDB open lifecycle snapshot and preserve the latest create/upgrade snapshot for recovery diagnostics.
- Emit an `indexed_db_open_lifecycle` breadcrumb only for create/upgrade opens.
- Include nullable IndexedDB lifecycle fields in local DB missing/recovery warning payloads.
- Add regression coverage for fresh database creation and the production path where cloud settings opens IndexedDB before sync.

## Validation

- `npm exec vitest -- src/appData/sync/observation/syncLifecycleObservation.test.ts src/localDb/core/core.migrations.test.ts src/observability/instrument.test.ts`
- `npm run build`

Note: the build still emits the existing large chunk warning.