### PR TITLE
[codex] Increase bootstrap sync page size

### DIFF
--- a/apps/backend/src/routes/sync.test.ts
+++ b/apps/backend/src/routes/sync.test.ts
@@ -565,7 +565,7 @@ test("POST /sync/bootstrap logs successful pull timing and cursor details", asyn
       }
 
       assert.equal(input.cursor, null);
-      assert.equal(input.limit, 500);
+      assert.equal(input.limit, 1000);
       return {
         mode: "pull",
         entries: [],
@@ -592,7 +592,7 @@ test("POST /sync/bootstrap logs successful pull timing and cursor details", asyn
         platform: "web",
         appVersion: "1.0.0",
         cursor: null,
-        limit: 500,
+        limit: 1000,
       }),
     });
     responseStatus = response.status;
@@ -617,7 +617,50 @@ test("POST /sync/bootstrap logs successful pull timing and cursor details", asyn
   assert.equal(syncLog?.hasMore, true);
   assert.equal(syncLog?.nextCursorPresent, true);
   assert.equal(syncLog?.cursorPresent, false);
-  assert.equal(syncLog?.limit, 500);
+  assert.equal(syncLog?.limit, 1000);
+});
+
+test("POST /sync/bootstrap rejects pull limit above bootstrap max", async () => {
+  let processCalls = 0;
+  const routes = createSyncRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, requestedWorkspaceId) => {
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, workspaceId);
+    },
+    processSyncBootstrapFn: async () => {
+      processCalls += 1;
+      throw new Error("Invalid bootstrap limit should be rejected before sync processing");
+    },
+  });
+  const app = createSyncTestApp(routes);
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/sync/bootstrap`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      mode: "pull",
+      installationId: "install-1",
+      platform: "web",
+      appVersion: "1.0.0",
+      cursor: null,
+      limit: 1001,
+    }),
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Cloud sync failed. Try again.",
+    requestId: "request-1",
+    code: "SYNC_INVALID_INPUT",
+  });
+  assert.equal(processCalls, 0);
 });
 
 test("POST /sync/bootstrap logs failure timing before returning sync errors", async () => {

--- a/apps/backend/src/sync/contracts/input.ts
+++ b/apps/backend/src/sync/contracts/input.ts
@@ -14,6 +14,9 @@ const reviewRatingSchema = z.union([z.literal(0), z.literal(1), z.literal(2), z.
 const platformSchema = z.enum(["ios", "android", "web"]);
 const isoTimestampStringSchema = z.string().datetime();
 const isoDatePrefixPattern = /^(\d{4})-(\d{2})-(\d{2})T/i;
+const syncIncrementalPullLimit = 500;
+const syncReviewHistoryPullLimit = 500;
+const syncBootstrapPullLimit = 1000;
 const commonDaysByMonth: ReadonlyArray<number> = [
   31,
   28,
@@ -287,7 +290,7 @@ const syncPullInputSchema = z.object({
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   afterHotChangeId: z.number().int().nonnegative(),
-  limit: z.number().int().positive().max(500),
+  limit: z.number().int().positive().max(syncIncrementalPullLimit),
 });
 
 const syncBootstrapPullInputSchema = z.object({
@@ -296,7 +299,7 @@ const syncBootstrapPullInputSchema = z.object({
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   cursor: z.string().min(1).nullable(),
-  limit: z.number().int().positive().max(500),
+  limit: z.number().int().positive().max(syncBootstrapPullLimit),
 });
 
 const syncBootstrapPushInputSchema = z.object({
@@ -333,7 +336,7 @@ const syncReviewHistoryPullInputSchema = z.object({
   platform: platformSchema,
   appVersion: z.string().min(1).nullable().optional(),
   afterReviewSequenceId: z.number().int().nonnegative(),
-  limit: z.number().int().positive().max(500),
+  limit: z.number().int().positive().max(syncReviewHistoryPullLimit),
 });
 
 const syncReviewHistoryImportInputSchema = z.object({

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -308,7 +308,7 @@ describe("sync lifecycle observation", () => {
       installationId: "installation-1",
       syncRunId: "sync-run-1",
       durationMs: 3000,
-      pageSize: 500,
+      pageSize: 1000,
       pageCount: 5,
       entriesCount: 2026,
       localCardCountBefore: 0,
@@ -327,7 +327,7 @@ describe("sync lifecycle observation", () => {
     expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledWith(expect.objectContaining({
       action: "sync_restore_slow",
       details: expect.objectContaining({
-        pageSize: 500,
+        pageSize: 1000,
         localBootstrapState: "no_sync_state_no_cards",
         bootstrapPullDurationMs: 1200,
         applyHotPagesDurationMs: 900,
@@ -342,6 +342,35 @@ describe("sync lifecycle observation", () => {
     await runWorkspaceRemoteSync(createRemoteSyncInput());
 
     expect(findCapturedWarning("sync_local_db_missing")).toBeNull();
+  });
+
+  it("uses separate page sizes for bootstrap and incremental pulls", async () => {
+    await runWorkspaceRemoteSync(createRemoteSyncInput());
+
+    expect(apiMocks.bootstrapPullSyncStateMock).toHaveBeenCalledWith(
+      "workspace-1",
+      "installation-1",
+      "web",
+      webAppVersion,
+      null,
+      1000,
+    );
+    expect(apiMocks.pullSyncChangesMock).toHaveBeenCalledWith(
+      "workspace-1",
+      "installation-1",
+      "web",
+      webAppVersion,
+      12,
+      500,
+    );
+    expect(apiMocks.pullReviewHistorySyncMock).toHaveBeenCalledWith(
+      "workspace-1",
+      "installation-1",
+      "web",
+      webAppVersion,
+      0,
+      500,
+    );
   });
 
   it("deduplicates slow warnings for successful local database recovery", async () => {
@@ -418,6 +447,7 @@ describe("sync lifecycle observation", () => {
         storagePersistAttemptedAfter: true,
         storagePersistGrantedAfter: true,
         durationMs: 55,
+        pageSize: 1000,
         bootstrapPullDurationMs: 40,
         applyHotPagesDurationMs: 0,
         finalRefreshDurationMs: 15,
@@ -571,6 +601,7 @@ describe("sync lifecycle observation", () => {
         storagePersistedBefore: false,
         storagePersistedAfter: null,
         durationMs: 25,
+        pageSize: 1000,
         bootstrapPullDurationMs: 25,
         applyHotPagesDurationMs: 0,
         finalRefreshDurationMs: 0,
@@ -627,6 +658,7 @@ describe("sync lifecycle observation", () => {
       action: "sync_restore_slow",
       details: expect.objectContaining({
         durationMs: 2000,
+        pageSize: 1000,
         bootstrapPullDurationMs: 800,
         applyHotPagesDurationMs: 0,
         finalRefreshDurationMs: 1200,

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -27,7 +27,7 @@ import {
 } from "../restore/syncRestoreHistory";
 import {
   slowHotBootstrapWarningThresholdMs,
-  syncPageSize,
+  syncBootstrapPageSize,
 } from "./constants";
 import {
   doHotSyncEntriesAffectReviewSchedule,
@@ -221,7 +221,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         "web",
         webAppVersion,
         bootstrapCursor,
-        syncPageSize,
+        syncBootstrapPageSize,
       );
       const bootstrapPullElapsedMs = Date.now() - bootstrapPullStartedAtMs;
       bootstrapPullDurationMs += bootstrapPullElapsedMs;
@@ -297,7 +297,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         previousRestoreHistory: restoreHistoryBefore,
         currentWebAppVersion: webAppVersion,
         durationMs,
-        pageSize: syncPageSize,
+        pageSize: syncBootstrapPageSize,
         pageCount,
         entriesCount,
         lastAppliedHotChangeIdBefore,
@@ -327,7 +327,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         installationId: input.installationId,
         syncRunId: input.syncRunId,
         durationMs,
-        pageSize: syncPageSize,
+        pageSize: syncBootstrapPageSize,
         pageCount,
         entriesCount,
         localCardCountBefore,
@@ -359,7 +359,7 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
         previousRestoreHistory: restoreHistoryBefore,
         currentWebAppVersion: webAppVersion,
         durationMs: Date.now() - startedAtMs,
-        pageSize: syncPageSize,
+        pageSize: syncBootstrapPageSize,
         pageCount,
         entriesCount,
         lastAppliedHotChangeIdBefore,

--- a/apps/web/src/appData/sync/remote/constants.ts
+++ b/apps/web/src/appData/sync/remote/constants.ts
@@ -1,2 +1,3 @@
-export const syncPageSize = 500;
+export const syncIncrementalPageSize = 500;
+export const syncBootstrapPageSize = 1000;
 export const slowHotBootstrapWarningThresholdMs = 2000;

--- a/apps/web/src/appData/sync/remote/pullHotChanges.ts
+++ b/apps/web/src/appData/sync/remote/pullHotChanges.ts
@@ -4,7 +4,7 @@ import {
   applyHotSyncPage,
   loadLastAppliedHotChangeId,
 } from "../../../localDb/cards/workspace";
-import { syncPageSize } from "./constants";
+import { syncIncrementalPageSize } from "./constants";
 import {
   doHotSyncEntriesAffectReviewSchedule,
   publishWorkspaceSettingsFromEntries,
@@ -27,7 +27,7 @@ export async function pullHotChanges(input: WorkspaceRemoteSyncInput): Promise<R
       "web",
       webAppVersion,
       afterHotChangeId,
-      syncPageSize,
+      syncIncrementalPageSize,
     );
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 

--- a/apps/web/src/appData/sync/remote/pullReviewHistory.ts
+++ b/apps/web/src/appData/sync/remote/pullReviewHistory.ts
@@ -5,7 +5,7 @@ import {
   hasHydratedReviewHistory,
   loadLastAppliedReviewSequenceId,
 } from "../../../localDb/cards/workspace";
-import { syncPageSize } from "./constants";
+import { syncIncrementalPageSize } from "./constants";
 import type {
   RemoteSyncFlags,
   WorkspaceRemoteSyncInput,
@@ -25,7 +25,7 @@ export async function pullReviewHistory(input: WorkspaceRemoteSyncInput): Promis
       "web",
       webAppVersion,
       afterReviewSequenceId,
-      syncPageSize,
+      syncIncrementalPageSize,
     );
     input.requireWorkspaceSyncNotDiscarded(input.workspaceId);
 


### PR DESCRIPTION
## Summary

- Split the web sync page-size constant into bootstrap and incremental limits.
- Use a 1000-entry page only for `/sync/bootstrap` recovery/bootstrap pulls.
- Keep incremental hot pull and review-history pull at 500 entries.
- Raise backend bootstrap pull validation to 1000 while preserving 500 for the other pull endpoints.

## Validation

- `npm exec vitest -- src/appData/sync/observation/syncLifecycleObservation.test.ts`
- `npm run build`
- `npm run bundle --prefix ../../api`
- `node --test --import tsx src/routes/sync.test.ts`