### PR TITLE
[codex] Fix Android Sentry query sanitization

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentrySanitization.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentrySanitization.kt
@@ -161,7 +161,7 @@ private val queryParameterPattern: Regex = Regex(
     pattern = """(?i)\b(token|code|email|key|api[-_]?key|password|secret)=([^&\s]+)"""
 )
 private val authHeaderPattern: Regex = Regex(
-    pattern = """(?i)\b(authorization|x-api-key|api[-_]?key|token|secret|password)\b\s*[:=]\s*[^,\s]+"""
+    pattern = """(?i)\b(authorization|x-api-key|api[-_]?key|token|secret|password)\b\s*[:=]\s*[^,&\s]+"""
 )
 private val emailPattern: Regex = Regex(
     pattern = """(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"""


### PR DESCRIPTION
## Summary
- stop Android Sentry header-value masking at query-string ampersands
- preserve ordinary query parameters after explicit secret parameters are redacted

## Root Cause
The Android Sentry sanitizer first redacted explicit query secrets such as `token=...`, then the auth/header regex treated the remaining `&...` query tail as part of the same header-like value. That caused `SentryAppObservabilityTest.queryParameterSanitizationKeepsOrdinaryIdsAndMasksExplicitSecrets` to fail in Android Release #340.

## Validation
- `git --no-pager diff --check`
- focused regex reproduction for the failing query sanitizer case

Gradle was not run locally because this repository requires explicit approval for local Gradle runs.