### PR TITLE
Fix web chat draft smoke race

### DIFF
--- a/apps/web/e2e/live-smoke/flows/auth-workspace.ts
+++ b/apps/web/e2e/live-smoke/flows/auth-workspace.ts
@@ -73,13 +73,13 @@ async function signInWithReviewAccount(session: LiveSmokeSession): Promise<void>
     diagnostics,
     "confirm primary navigation is visible after auth",
     page.locator("nav.nav"),
-    localUiTimeoutMs,
+    externalUiTimeoutMs,
   );
   await trackedExpectVisible(
     diagnostics,
     "confirm review navigation link is visible after auth",
     page.locator('nav.nav a[href="/review"]').first(),
-    localUiTimeoutMs,
+    externalUiTimeoutMs,
   );
 }
 

--- a/apps/web/e2e/live-smoke/observations/ai.ts
+++ b/apps/web/e2e/live-smoke/observations/ai.ts
@@ -17,8 +17,11 @@ type AiChatRunState = "idle" | "running" | "interrupted";
 type AiSendPhase = "idle" | "preparingSend" | "startingRun";
 type AiDraftState = "empty" | "filled";
 type AiCanSend = "true" | "false";
+type AiHistoryLoaded = "true" | "false";
 
 export type AiComposerContract = Readonly<{
+  sessionId: string | null;
+  historyLoaded: AiHistoryLoaded;
   composerState: AiComposerState;
   composerAction: AiComposerAction;
   chatRunState: AiChatRunState;
@@ -159,6 +162,32 @@ export async function waitForAiChatSendReadiness(
       }),
       { timeout: externalUiTimeoutMs },
     ).toBe(0);
+  });
+
+  await diagnostics.runAction("wait for AI chat composer to have a stable ready session before send", async () => {
+    let previousReadySessionId: string | null = null;
+    let readySince = 0;
+
+    await expect.poll(
+      async () => {
+        const composerContract = await readAiComposerContract(page);
+        const isComposerReady = isAiComposerReadyForDraftInput(composerContract);
+        if (isComposerReady === false || composerContract.sessionId === null) {
+          previousReadySessionId = null;
+          readySince = 0;
+          return false;
+        }
+
+        if (previousReadySessionId !== composerContract.sessionId) {
+          previousReadySessionId = composerContract.sessionId;
+          readySince = Date.now();
+          return false;
+        }
+
+        return Date.now() - readySince >= 500;
+      },
+      { timeout: externalUiTimeoutMs },
+    ).toBe(true);
   });
 }
 
@@ -428,7 +457,28 @@ export async function readAiComposerContract(page: Page): Promise<AiComposerCont
       return attributeValue;
     }
 
+    function readHistoryLoaded(attributeName: string): AiHistoryLoaded {
+      const attributeValue = readRequiredAttribute(attributeName);
+      if (attributeValue !== "true" && attributeValue !== "false") {
+        throw new Error(`Unsupported AI history-loaded state "${attributeValue}".`);
+      }
+
+      return attributeValue;
+    }
+
+    function readSessionId(attributeName: string): string | null {
+      const attributeValue = element.getAttribute(attributeName);
+      if (attributeValue === null) {
+        throw new Error(`Missing AI composer contract attribute "${attributeName}".`);
+      }
+
+      const trimmedAttributeValue = attributeValue.trim();
+      return trimmedAttributeValue === "" ? null : trimmedAttributeValue;
+    }
+
     return {
+      sessionId: readSessionId("data-chat-session-id"),
+      historyLoaded: readHistoryLoaded("data-history-loaded"),
       composerState: readComposerState("data-composer-state"),
       composerAction: readComposerAction("data-composer-action"),
       chatRunState: readChatRunState("data-chat-run-state"),
@@ -460,4 +510,12 @@ export function isAiComposerTerminalIdle(contract: AiComposerContract): boolean 
     && contract.sendPhase === "idle"
     && contract.draftState === "empty"
     && contract.canSend === "false";
+}
+
+function isAiComposerReadyForDraftInput(contract: AiComposerContract): boolean {
+  if (isAiComposerTerminalIdle(contract) === false) {
+    return false;
+  }
+
+  return contract.sessionId !== null && contract.historyLoaded === "true";
 }

--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -45,6 +45,7 @@ export function ChatPanel(props: Props): ReactElement {
     clearDraftForSession,
     composerSendPhase: sendPhase,
     replaceComposerSendPhase: setSendPhase,
+    suppressNextSessionDraftCarryover,
   } = useChatDraft();
   const { setIsOpen, chatWidth, setChatWidth } = useChatLayout();
   const draftInputText = draft.inputText;
@@ -252,6 +253,7 @@ export function ChatPanel(props: Props): ReactElement {
             type="button"
             className="chat-close-btn"
             onClick={() => {
+              suppressNextSessionDraftCarryover(currentSessionId);
               startNewConversationComposerReset(currentSessionId);
               discardDictation();
               void clearConversation()
@@ -324,6 +326,8 @@ export function ChatPanel(props: Props): ReactElement {
         data-composer-action={composerAction}
         data-chat-run-state={runState}
         data-send-phase={sendPhase}
+        data-chat-session-id={currentSessionId ?? ""}
+        data-history-loaded={isHistoryLoaded ? "true" : "false"}
         data-assistant-run-active={isAssistantRunActive ? "true" : "false"}
         data-stopping={isStopping ? "true" : "false"}
         data-draft-state={hasDraftContent ? "filled" : "empty"}

--- a/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx
@@ -6,7 +6,9 @@ import {
   createChatSnapshot,
   createNewChatSessionMock,
   getChatSnapshotMock,
+  readStoredDraftInputText,
   setupChatPanelTest,
+  setTextareaValue,
   useAppDataMock,
 } from "../support/ChatPanelTestSupport";
 import {
@@ -97,6 +99,51 @@ describe("ChatPanel hydration lifecycle", () => {
     await flushAsync();
 
     expect(getChatSnapshotMock).toHaveBeenCalledWith("session-local-fresh", "workspace-1");
+  });
+
+  it("keeps a typed draft when hydration accepts a replacement session id", async () => {
+    let resolveHydrationSnapshot: ((snapshot: ReturnType<typeof createChatSnapshot>) => void) | null = null;
+    storeChatSessionWarmStartSnapshot("workspace-1", createChatSnapshot({
+      sessionId: "session-pending",
+      conversationScopeId: "session-pending",
+      conversation: {
+        updatedAt: 1,
+        mainContentInvalidationVersion: 0,
+        messages: [],
+      },
+    }), false);
+    getChatSnapshotMock.mockImplementationOnce((sessionId: string) => new Promise((resolve) => {
+      resolveHydrationSnapshot = (snapshot) => resolve(snapshot);
+      expect(sessionId).toBe("session-pending");
+    }));
+
+    await renderChatPanel();
+    await flushAsync();
+
+    const textarea = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
+    expect(textarea).not.toBeNull();
+
+    await setTextareaValue(textarea as HTMLTextAreaElement, "draft typed during hydration");
+    await flushAsync();
+
+    expect(readStoredDraftInputText("workspace-1", "session-pending")).toBe("draft typed during hydration");
+
+    resolveHydrationSnapshot?.(createChatSnapshot({
+      sessionId: "session-accepted",
+      conversationScopeId: "session-accepted",
+      conversation: {
+        updatedAt: 2,
+        mainContentInvalidationVersion: 0,
+        messages: [],
+      },
+    }));
+    await flushAsync();
+    await flushAsync();
+
+    const acceptedTextarea = getContainer().querySelector('textarea[name="chatMessage"]') as HTMLTextAreaElement | null;
+    expect(acceptedTextarea?.value).toBe("draft typed during hydration");
+    expect(readStoredDraftInputText("workspace-1", "session-pending")).toBeNull();
+    expect(readStoredDraftInputText("workspace-1", "session-accepted")).toBe("draft typed during hydration");
   });
 
   it("opens a stale warm-start session as a fresh local chat without loading the stale session", async () => {

--- a/apps/web/src/chat/composer/ChatDraftContext.tsx
+++ b/apps/web/src/chat/composer/ChatDraftContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState, type ReactElement, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useRef, useState, type MutableRefObject, type ReactElement, type ReactNode } from "react";
 import { useAppData } from "../../appData";
 import type { PendingAttachment } from "../attachments/FileAttachment";
 import {
@@ -35,6 +35,7 @@ type ChatDraftContextValue = Readonly<{
   replaceDraftForSession: (sessionId: string | null, nextDraft: ChatDraftContent) => void;
   replaceComposerSendPhase: (nextSendPhase: ChatComposerSendPhase) => void;
   requestComposerFocus: () => void;
+  suppressNextSessionDraftCarryover: (sourceSessionId: string | null) => void;
   clearDraft: () => void;
   clearDraftForSession: (sessionId: string | null) => void;
 }>;
@@ -46,6 +47,11 @@ type Props = Readonly<{
 type TransientChatDraft = Readonly<{
   workspaceId: string | null;
   draft: ChatDraftContent;
+}>;
+
+type DraftTarget = Readonly<{
+  workspaceId: string | null;
+  sessionId: string | null;
 }>;
 
 const ChatDraftContext = createContext<ChatDraftContextValue | null>(null);
@@ -72,6 +78,11 @@ export function ChatDraftProvider(props: Props): ReactElement {
   const [transientDraft, setTransientDraft] = useState<TransientChatDraft | null>(null);
   const [composerSendPhase, setComposerSendPhase] = useState<ChatComposerSendPhase>("idle");
   const [focusComposerRequestVersion, setFocusComposerRequestVersion] = useState<number>(0);
+  const previousDraftTargetRef = useRef<DraftTarget>({
+    workspaceId: activeWorkspaceId,
+    sessionId: activeSessionId,
+  });
+  const suppressedDraftCarryoverRef = useRef<DraftTarget | null>(null);
 
   useEffect(() => {
     const nextDraftsBySessionId = loadChatDraftWorkspaceState(activeWorkspaceId);
@@ -117,6 +128,41 @@ export function ChatDraftProvider(props: Props): ReactElement {
     setTransientDraft(null);
   }, [activeSessionId, activeWorkspaceId, transientDraft]);
 
+  useEffect(() => {
+    const previousDraftTarget = previousDraftTargetRef.current;
+
+    if (previousDraftTarget.workspaceId !== activeWorkspaceId) {
+      previousDraftTargetRef.current = {
+        workspaceId: activeWorkspaceId,
+        sessionId: activeSessionId,
+      };
+      suppressedDraftCarryoverRef.current = null;
+      return;
+    }
+
+    if (previousDraftTarget.sessionId === activeSessionId) {
+      return;
+    }
+
+    const shouldSuppressCarryover = consumeSuppressedDraftCarryover(
+      suppressedDraftCarryoverRef,
+      previousDraftTarget,
+    );
+
+    if (
+      shouldSuppressCarryover === false
+      && activeWorkspaceId !== null
+      && activeSessionId !== null
+    ) {
+      carryDraftToSession(previousDraftTarget.sessionId, activeSessionId);
+    }
+
+    previousDraftTargetRef.current = {
+      workspaceId: activeWorkspaceId,
+      sessionId: activeSessionId,
+    };
+  }, [activeSessionId, activeWorkspaceId, transientDraft]);
+
   const draft = getActiveDraft(activeWorkspaceId, activeSessionId, draftsBySessionId, transientDraft);
 
   function replaceDraftForSession(sessionId: string | null, nextDraft: ChatDraftContent): void {
@@ -139,6 +185,47 @@ export function ChatDraftProvider(props: Props): ReactElement {
     draftsBySessionIdRef.current = nextDraftsBySessionId;
     storeChatDraftWorkspaceState(activeWorkspaceId, nextDraftsBySessionId);
     setDraftsBySessionId(nextDraftsBySessionId);
+  }
+
+  function carryDraftToSession(
+    sourceSessionId: string | null,
+    targetSessionId: string,
+  ): void {
+    const currentDraftsBySessionId = draftsBySessionIdRef.current;
+    const targetDraft = readStoredChatDraftForSession(currentDraftsBySessionId, targetSessionId);
+    if (targetDraft !== null) {
+      return;
+    }
+
+    const carriedDraft = readDraftContentForCarryover(
+      currentDraftsBySessionId,
+      sourceSessionId,
+      activeWorkspaceId,
+      transientDraft,
+    );
+    if (carriedDraft === null) {
+      return;
+    }
+
+    const targetDraftsBySessionId = replaceChatDraftForSession(
+      currentDraftsBySessionId,
+      targetSessionId,
+      carriedDraft,
+    );
+    const nextDraftsBySessionId = sourceSessionId === null
+      ? targetDraftsBySessionId
+      : replaceChatDraftForSession(
+        targetDraftsBySessionId,
+        sourceSessionId,
+        createChatDraftContent("", []),
+      );
+
+    draftsBySessionIdRef.current = nextDraftsBySessionId;
+    storeChatDraftWorkspaceState(activeWorkspaceId, nextDraftsBySessionId);
+    setDraftsBySessionId(nextDraftsBySessionId);
+    if (sourceSessionId === null) {
+      setTransientDraft(null);
+    }
   }
 
   function moveDraftToSession(
@@ -210,6 +297,13 @@ export function ChatDraftProvider(props: Props): ReactElement {
     setFocusComposerRequestVersion((currentVersion) => currentVersion + 1);
   }
 
+  function suppressNextSessionDraftCarryover(sourceSessionId: string | null): void {
+    suppressedDraftCarryoverRef.current = {
+      workspaceId: activeWorkspaceId,
+      sessionId: sourceSessionId,
+    };
+  }
+
   return (
     <ChatDraftContext.Provider
       value={{
@@ -223,6 +317,7 @@ export function ChatDraftProvider(props: Props): ReactElement {
         replaceDraftForSession,
         replaceComposerSendPhase,
         requestComposerFocus,
+        suppressNextSessionDraftCarryover,
         clearDraft,
         clearDraftForSession,
       }}
@@ -268,6 +363,48 @@ function getActiveDraft(
 
 function isChatDraftContentEmpty(draft: ChatDraftContent): boolean {
   return draft.inputText.trim() === "" && draft.pendingAttachments.length === 0;
+}
+
+function consumeSuppressedDraftCarryover(
+  suppressedDraftCarryoverRef: MutableRefObject<DraftTarget | null>,
+  previousDraftTarget: DraftTarget,
+): boolean {
+  const suppressedDraftCarryover = suppressedDraftCarryoverRef.current;
+  if (suppressedDraftCarryover === null) {
+    return false;
+  }
+
+  suppressedDraftCarryoverRef.current = null;
+  return suppressedDraftCarryover.workspaceId === previousDraftTarget.workspaceId
+    && suppressedDraftCarryover.sessionId === previousDraftTarget.sessionId;
+}
+
+function readDraftContentForCarryover(
+  draftsBySessionId: Readonly<Record<string, StoredChatDraft>>,
+  sourceSessionId: string | null,
+  workspaceId: string | null,
+  transientDraft: TransientChatDraft | null,
+): ChatDraftContent | null {
+  const carriedDraft = sourceSessionId === null
+    ? readTransientDraftContentForCarryover(workspaceId, transientDraft)
+    : readStoredChatDraftForSession(draftsBySessionId, sourceSessionId);
+
+  if (carriedDraft === null || isChatDraftContentEmpty(carriedDraft)) {
+    return null;
+  }
+
+  return createChatDraftContent(carriedDraft.inputText, carriedDraft.pendingAttachments);
+}
+
+function readTransientDraftContentForCarryover(
+  workspaceId: string | null,
+  transientDraft: TransientChatDraft | null,
+): ChatDraftContent | null {
+  if (transientDraft === null || transientDraft.workspaceId !== workspaceId) {
+    return null;
+  }
+
+  return transientDraft.draft;
 }
 
 export function useChatDraft(): ChatDraftContextValue {

--- a/apps/web/src/chat/handoff/useAiCardHandoff.test.tsx
+++ b/apps/web/src/chat/handoff/useAiCardHandoff.test.tsx
@@ -112,6 +112,7 @@ describe("useAiCardHandoff", () => {
   it("switches dirty handoff into a fresh session and preserves source ownership", async () => {
     const replaceDraftForSession = vi.fn();
     const requestComposerFocus = vi.fn();
+    const suppressNextSessionDraftCarryover = vi.fn();
     const clearConversation = vi.fn(async (): Promise<string> => "session-2");
     const setIsOpen = vi.fn();
     const onResult = vi.fn();
@@ -131,6 +132,7 @@ describe("useAiCardHandoff", () => {
       replaceDraftForSession,
       replaceComposerSendPhase: vi.fn(),
       requestComposerFocus,
+      suppressNextSessionDraftCarryover,
     });
     useOptionalChatSessionMock.mockReturnValue({
       currentSessionId: "session-1",
@@ -159,7 +161,12 @@ describe("useAiCardHandoff", () => {
     });
 
     expect(onResult).toHaveBeenCalledWith(true);
+    expect(suppressNextSessionDraftCarryover).toHaveBeenCalledTimes(1);
+    expect(suppressNextSessionDraftCarryover).toHaveBeenCalledWith("session-1");
     expect(clearConversation).toHaveBeenCalledTimes(1);
+    expect(suppressNextSessionDraftCarryover.mock.invocationCallOrder[0]).toBeLessThan(
+      clearConversation.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(replaceDraftForSession).toHaveBeenCalledTimes(1);
     expect(replaceDraftForSession).toHaveBeenCalledWith("session-2", {
       inputText: "",
@@ -199,6 +206,7 @@ describe("useAiCardHandoff", () => {
       replaceDraftForSession,
       replaceComposerSendPhase: vi.fn(),
       requestComposerFocus,
+      suppressNextSessionDraftCarryover: vi.fn(),
     });
     useOptionalChatSessionMock.mockReturnValue({
       currentSessionId: "session-1",
@@ -261,6 +269,7 @@ describe("useAiCardHandoff", () => {
         replaceDraftForSession,
         replaceComposerSendPhase: vi.fn(),
         requestComposerFocus,
+        suppressNextSessionDraftCarryover: vi.fn(),
       });
       useOptionalChatSessionMock.mockReturnValue({
         currentSessionId: "session-1",
@@ -322,6 +331,7 @@ describe("useAiCardHandoff", () => {
       replaceDraftForSession,
       replaceComposerSendPhase: vi.fn(),
       requestComposerFocus,
+      suppressNextSessionDraftCarryover: vi.fn(),
     });
     useOptionalChatSessionMock.mockReturnValue({
       currentSessionId: "session-1",
@@ -396,6 +406,7 @@ describe("useAiCardHandoff", () => {
       replaceDraftForSession,
       replaceComposerSendPhase: vi.fn(),
       requestComposerFocus,
+      suppressNextSessionDraftCarryover: vi.fn(),
     });
     useOptionalChatSessionMock.mockReturnValue({
       currentSessionId: "session-1",

--- a/apps/web/src/chat/handoff/useAiCardHandoff.ts
+++ b/apps/web/src/chat/handoff/useAiCardHandoff.ts
@@ -55,6 +55,7 @@ export function useAiCardHandoff(): (card: Card) => Promise<boolean> {
 
     try {
       if (sourceSessionId === null || isDirtyConversation) {
+        draftContext.suppressNextSessionDraftCarryover(sourceSessionId);
         const clearedSessionId = await session.clearConversation();
         if (clearedSessionId !== null) {
           targetSessionId = clearedSessionId;


### PR DESCRIPTION
## Summary
- preserve non-empty AI chat drafts across automatic same-workspace session changes
- suppress draft carryover for deliberate New chat and AI card handoff resets
- harden live smoke readiness around a stable loaded chat composer session

## Validation
- npm exec --prefix apps/web -- vitest run src/chat/handoff/useAiCardHandoff.test.tsx src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx src/chat/ChatPanel/tests/lifecycle/ChatPanel.new-chat.test.tsx src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx
- npm run build --prefix apps/web
