### PR TITLE
[codex] Add progress review history watermarks

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration14To17Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration14To17Test.kt
@@ -11,6 +11,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.cardsReviewQueue
 import com.flashcardsopensourceapp.data.local.database.migrations.migration14To15
 import com.flashcardsopensourceapp.data.local.database.migrations.migration15To16
 import com.flashcardsopensourceapp.data.local.database.migrations.migration16To17
+import com.flashcardsopensourceapp.data.local.database.migrations.migration17To18
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -20,6 +21,7 @@ import org.junit.runner.RunWith
 private const val migration14To15DatabaseName: String = "migration-14-to-15-test.db"
 private const val migration15To16DatabaseName: String = "migration-15-to-16-test.db"
 private const val migration16To17DatabaseName: String = "migration-16-to-17-test.db"
+private const val migration17To18DatabaseName: String = "migration-17-to-18-test.db"
 
 @RunWith(AndroidJUnit4::class)
 class AppDatabaseMigration14To17Test {
@@ -37,6 +39,10 @@ class AppDatabaseMigration14To17Test {
         deleteMigrationDatabaseFixture(
             context = context,
             databaseName = migration16To17DatabaseName
+        )
+        deleteMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration17To18DatabaseName
         )
     }
 
@@ -154,6 +160,48 @@ class AppDatabaseMigration14To17Test {
                 readMigrationIndexColumns(
                     database = database,
                     indexName = cardsRecentlyReviewedDueIndexName
+                )
+            )
+        } finally {
+            database.close()
+            openHelper.close()
+        }
+    }
+
+    @Test
+    fun migration17To18AddsProgressWatermarkCacheColumns(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        createVersion17Database(context = context)
+
+        val openHelper: SupportSQLiteOpenHelper = openMigrationDatabaseAtVersion(
+            context = context,
+            databaseName = migration17To18DatabaseName,
+            version = 17
+        )
+        val database: SupportSQLiteDatabase = openHelper.writableDatabase
+
+        try {
+            migration17To18.migrate(database)
+
+            assertEquals(
+                "[]",
+                readMigrationSingleString(
+                    database = database,
+                    sql = "SELECT reviewHistoryWatermarksJson FROM progress_summary_cache WHERE scopeKey = 'summary-scope'"
+                )
+            )
+            assertEquals(
+                "[]",
+                readMigrationSingleString(
+                    database = database,
+                    sql = "SELECT reviewHistoryWatermarksJson FROM progress_series_cache WHERE scopeKey = 'series-scope'"
+                )
+            )
+            assertEquals(
+                "[]",
+                readMigrationSingleString(
+                    database = database,
+                    sql = "SELECT reviewHistoryWatermarksJson FROM progress_review_schedule_cache WHERE scopeKey = 'schedule-scope'"
                 )
             )
         } finally {
@@ -328,6 +376,129 @@ class AppDatabaseMigration14To17Test {
                 """
                 CREATE INDEX $cardsReviewQueueIndexName
                 ON cards(workspaceId, dueAtMillis, createdAtMillis, cardId)
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun createVersion17Database(context: Context): Unit {
+        createMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration17To18DatabaseName,
+            version = 17
+        ) { sqliteDatabase: SQLiteDatabase ->
+            sqliteDatabase.execSQL(
+                """
+                CREATE TABLE progress_summary_cache (
+                    scopeKey TEXT NOT NULL PRIMARY KEY,
+                    scopeId TEXT NOT NULL,
+                    timeZone TEXT NOT NULL,
+                    generatedAt TEXT,
+                    currentStreakDays INTEGER NOT NULL,
+                    hasReviewedToday INTEGER NOT NULL,
+                    lastReviewedOn TEXT,
+                    activeReviewDays INTEGER NOT NULL,
+                    updatedAtMillis INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                INSERT INTO progress_summary_cache (
+                    scopeKey,
+                    scopeId,
+                    timeZone,
+                    generatedAt,
+                    currentStreakDays,
+                    hasReviewedToday,
+                    lastReviewedOn,
+                    activeReviewDays,
+                    updatedAtMillis
+                ) VALUES (
+                    'summary-scope',
+                    'scope-1',
+                    'Europe/Madrid',
+                    NULL,
+                    3,
+                    1,
+                    '2026-04-18',
+                    12,
+                    100
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                CREATE TABLE progress_series_cache (
+                    scopeKey TEXT NOT NULL PRIMARY KEY,
+                    scopeId TEXT NOT NULL,
+                    timeZone TEXT NOT NULL,
+                    fromLocalDate TEXT NOT NULL,
+                    toLocalDate TEXT NOT NULL,
+                    generatedAt TEXT,
+                    dailyReviewsJson TEXT NOT NULL,
+                    updatedAtMillis INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                INSERT INTO progress_series_cache (
+                    scopeKey,
+                    scopeId,
+                    timeZone,
+                    fromLocalDate,
+                    toLocalDate,
+                    generatedAt,
+                    dailyReviewsJson,
+                    updatedAtMillis
+                ) VALUES (
+                    'series-scope',
+                    'scope-1',
+                    'Europe/Madrid',
+                    '2026-04-12',
+                    '2026-04-18',
+                    '2026-04-18T10:00:00Z',
+                    '[]',
+                    100
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                CREATE TABLE progress_review_schedule_cache (
+                    scopeKey TEXT NOT NULL PRIMARY KEY,
+                    scopeId TEXT NOT NULL,
+                    timeZone TEXT NOT NULL,
+                    referenceLocalDate TEXT NOT NULL,
+                    generatedAt TEXT,
+                    totalCards INTEGER NOT NULL,
+                    bucketsJson TEXT NOT NULL,
+                    updatedAtMillis INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                INSERT INTO progress_review_schedule_cache (
+                    scopeKey,
+                    scopeId,
+                    timeZone,
+                    referenceLocalDate,
+                    generatedAt,
+                    totalCards,
+                    bucketsJson,
+                    updatedAtMillis
+                ) VALUES (
+                    'schedule-scope',
+                    'scope-1',
+                    'Europe/Madrid',
+                    '2026-04-18',
+                    '2026-04-18T10:00:00Z',
+                    0,
+                    '[]',
+                    100
+                )
                 """.trimIndent()
             )
         }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -9,6 +9,7 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt
+import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudLong
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudNullableString
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudObject
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
@@ -18,6 +19,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReview
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import org.json.JSONObject
 
 internal class CloudProgressRemoteApi(
@@ -76,6 +78,9 @@ internal class CloudProgressRemoteApi(
                 }
             },
             generatedAt = response.optCloudStringOrNull("generatedAt", "progress.generatedAt"),
+            reviewHistoryWatermarks = response.requireProgressReviewHistoryWatermarks(
+                fieldPath = "progress"
+            ),
             summary = null
         )
     }
@@ -101,19 +106,25 @@ internal fun parseCloudProgressSummaryResponse(
     response: JSONObject,
     fieldPath: String
 ): CloudProgressSummary {
+    val reviewHistoryWatermarks = response.requireProgressReviewHistoryWatermarks(
+        fieldPath = fieldPath
+    )
     return response.requireCloudObject("summary", "$fieldPath.summary").toCloudProgressSummary(
-        fieldPath = "$fieldPath.summary"
+        fieldPath = "$fieldPath.summary",
+        reviewHistoryWatermarks = reviewHistoryWatermarks
     )
 }
 
 private fun JSONObject.toCloudProgressSummary(
-    fieldPath: String
+    fieldPath: String,
+    reviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>
 ): CloudProgressSummary {
     return CloudProgressSummary(
         currentStreakDays = requireCloudInt("currentStreakDays", "$fieldPath.currentStreakDays"),
         hasReviewedToday = requireCloudBoolean("hasReviewedToday", "$fieldPath.hasReviewedToday"),
         lastReviewedOn = requireCloudNullableString("lastReviewedOn", "$fieldPath.lastReviewedOn"),
-        activeReviewDays = requireCloudInt("activeReviewDays", "$fieldPath.activeReviewDays")
+        activeReviewDays = requireCloudInt("activeReviewDays", "$fieldPath.activeReviewDays"),
+        reviewHistoryWatermarks = reviewHistoryWatermarks
     )
 }
 
@@ -169,9 +180,49 @@ internal fun parseCloudProgressReviewScheduleResponse(
     return CloudProgressReviewSchedule(
         timeZone = response.requireCloudString("timeZone", "$fieldPath.timeZone"),
         generatedAt = response.requireCloudString("generatedAt", "$fieldPath.generatedAt"),
+        reviewHistoryWatermarks = response.requireProgressReviewHistoryWatermarks(
+            fieldPath = fieldPath
+        ),
         totalCards = totalCards,
         buckets = buckets
     )
+}
+
+private fun JSONObject.requireProgressReviewHistoryWatermarks(
+    fieldPath: String
+): List<ProgressReviewHistoryWatermark> {
+    val watermarksArray = requireCloudArray("reviewHistoryWatermarks", "$fieldPath.reviewHistoryWatermarks")
+    return buildList {
+        for (index in 0 until watermarksArray.length()) {
+            val watermark = watermarksArray.requireCloudObject(index, "$fieldPath.reviewHistoryWatermarks[$index]")
+            add(
+                ProgressReviewHistoryWatermark(
+                    workspaceId = watermark.requireCloudString(
+                        "workspaceId",
+                        "$fieldPath.reviewHistoryWatermarks[$index].workspaceId"
+                    ),
+                    reviewSequenceId = requireNonNegativeReviewHistorySequenceId(
+                        value = watermark.requireCloudLong(
+                            "reviewSequenceId",
+                            "$fieldPath.reviewHistoryWatermarks[$index].reviewSequenceId"
+                        ),
+                        fieldPath = "$fieldPath.reviewHistoryWatermarks[$index].reviewSequenceId"
+                    )
+                )
+            )
+        }
+    }
+}
+
+private fun requireNonNegativeReviewHistorySequenceId(
+    value: Long,
+    fieldPath: String
+): Long {
+    if (value < 0L) {
+        throw CloudContractMismatchException("$fieldPath must not be negative.")
+    }
+
+    return value
 }
 
 private fun requireNonNegativeReviewScheduleInt(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -58,7 +58,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 17,
+    version = 18,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
@@ -11,6 +11,7 @@ data class ProgressSummaryCacheEntity(
     val scopeId: String,
     val timeZone: String,
     val generatedAt: String?,
+    val reviewHistoryWatermarksJson: String,
     val currentStreakDays: Int,
     val hasReviewedToday: Boolean,
     val lastReviewedOn: String?,
@@ -26,6 +27,7 @@ data class ProgressSeriesCacheEntity(
     val fromLocalDate: String,
     val toLocalDate: String,
     val generatedAt: String?,
+    val reviewHistoryWatermarksJson: String,
     val dailyReviewsJson: String,
     val updatedAtMillis: Long
 )
@@ -37,6 +39,7 @@ data class ProgressReviewScheduleCacheEntity(
     val timeZone: String,
     val referenceLocalDate: String,
     val generatedAt: String?,
+    val reviewHistoryWatermarksJson: String,
     val totalCards: Int,
     val bucketsJson: String,
     val updatedAtMillis: Long

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -23,7 +23,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration13To14,
         migration14To15,
         migration15To16,
-        migration16To17
+        migration16To17,
+        migration17To18
     )
 }
 
@@ -682,6 +683,29 @@ val migration16To17: Migration = object : Migration(16, 17) {
             """
             CREATE INDEX IF NOT EXISTS $cardsRecentlyReviewedDueIndexName
             ON cards(workspaceId, fsrsLastReviewedAtMillis, dueAtMillis, createdAtMillis, cardId)
+            """.trimIndent()
+        )
+    }
+}
+
+val migration17To18: Migration = object : Migration(17, 18) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN reviewHistoryWatermarksJson TEXT NOT NULL DEFAULT '[]'
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_series_cache
+            ADD COLUMN reviewHistoryWatermarksJson TEXT NOT NULL DEFAULT '[]'
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_review_schedule_cache
+            ADD COLUMN reviewHistoryWatermarksJson TEXT NOT NULL DEFAULT '[]'
             """.trimIndent()
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
@@ -5,11 +5,17 @@ data class CloudDailyReviewPoint(
     val reviewCount: Int
 )
 
+data class ProgressReviewHistoryWatermark(
+    val workspaceId: String,
+    val reviewSequenceId: Long
+)
+
 data class CloudProgressSummary(
     val currentStreakDays: Int,
     val hasReviewedToday: Boolean,
     val lastReviewedOn: String?,
-    val activeReviewDays: Int
+    val activeReviewDays: Int,
+    val reviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>
 )
 
 data class CloudProgressSeries(
@@ -18,6 +24,7 @@ data class CloudProgressSeries(
     val to: String,
     val dailyReviews: List<CloudDailyReviewPoint>,
     val generatedAt: String?,
+    val reviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>,
     val summary: CloudProgressSummary?
 )
 
@@ -60,6 +67,7 @@ data class CloudProgressReviewScheduleBucket(
 data class CloudProgressReviewSchedule(
     val timeZone: String,
     val generatedAt: String?,
+    val reviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>,
     val totalCards: Int,
     val buckets: List<CloudProgressReviewScheduleBucket>
 )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
@@ -8,6 +8,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReview
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewScheduleBucket
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
@@ -32,6 +33,9 @@ internal fun CloudProgressSummary.toCacheEntity(
         scopeId = scopeKey.scopeId,
         timeZone = scopeKey.timeZone,
         generatedAt = null,
+        reviewHistoryWatermarksJson = serializeProgressReviewHistoryWatermarks(
+            watermarks = reviewHistoryWatermarks
+        ),
         currentStreakDays = currentStreakDays,
         hasReviewedToday = hasReviewedToday,
         lastReviewedOn = lastReviewedOn,
@@ -51,6 +55,9 @@ internal fun CloudProgressSeries.toCacheEntity(
         fromLocalDate = from,
         toLocalDate = to,
         generatedAt = generatedAt,
+        reviewHistoryWatermarksJson = serializeProgressReviewHistoryWatermarks(
+            watermarks = reviewHistoryWatermarks
+        ),
         dailyReviewsJson = JSONArray().apply {
             dailyReviews.forEach { point ->
                 put(
@@ -74,6 +81,9 @@ internal fun CloudProgressReviewSchedule.toCacheEntity(
         timeZone = timeZone,
         referenceLocalDate = scopeKey.referenceLocalDate,
         generatedAt = generatedAt,
+        reviewHistoryWatermarksJson = serializeProgressReviewHistoryWatermarks(
+            watermarks = reviewHistoryWatermarks
+        ),
         totalCards = totalCards,
         bucketsJson = JSONArray().apply {
             buckets.forEach { bucket ->
@@ -167,11 +177,15 @@ internal fun ProgressSummaryCacheEntity.toCloudProgressSummaryOrNull(): CloudPro
         lastReviewedOn?.let { cachedLastReviewedOn ->
             parseLocalDate(rawDate = cachedLastReviewedOn)
         }
+        val reviewHistoryWatermarks = parseProgressReviewHistoryWatermarks(
+            rawJson = reviewHistoryWatermarksJson
+        )
         CloudProgressSummary(
             currentStreakDays = currentStreakDays,
             hasReviewedToday = hasReviewedToday,
             lastReviewedOn = lastReviewedOn,
-            activeReviewDays = activeReviewDays
+            activeReviewDays = activeReviewDays,
+            reviewHistoryWatermarks = reviewHistoryWatermarks
         )
     }.getOrElse { error ->
         logProgressRepositoryWarning(
@@ -208,9 +222,13 @@ internal fun ProgressReviewScheduleCacheEntity.toCloudProgressReviewScheduleOrNu
             buckets = buckets,
             totalCards = totalCards
         )
+        val reviewHistoryWatermarks = parseProgressReviewHistoryWatermarks(
+            rawJson = reviewHistoryWatermarksJson
+        )
         CloudProgressReviewSchedule(
             timeZone = timeZone,
             generatedAt = generatedAt,
+            reviewHistoryWatermarks = reviewHistoryWatermarks,
             totalCards = totalCards,
             buckets = buckets
         )
@@ -239,6 +257,9 @@ internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgr
         }
 
         val dailyReviewsArray = JSONArray(dailyReviewsJson)
+        val reviewHistoryWatermarks = parseProgressReviewHistoryWatermarks(
+            rawJson = reviewHistoryWatermarksJson
+        )
         CloudProgressSeries(
             timeZone = timeZone,
             from = fromLocalDate,
@@ -257,6 +278,7 @@ internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgr
                 }
             },
             generatedAt = generatedAt,
+            reviewHistoryWatermarks = reviewHistoryWatermarks,
             summary = null
         )
     }.getOrElse { error ->
@@ -272,4 +294,55 @@ internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgr
         )
         null
     }
+}
+
+private fun serializeProgressReviewHistoryWatermarks(
+    watermarks: List<ProgressReviewHistoryWatermark>
+): String {
+    return JSONArray().apply {
+        watermarks.forEach { watermark ->
+            put(
+                JSONObject()
+                    .put("workspaceId", watermark.workspaceId)
+                    .put("reviewSequenceId", watermark.reviewSequenceId)
+            )
+        }
+    }.toString()
+}
+
+private fun parseProgressReviewHistoryWatermarks(
+    rawJson: String
+): List<ProgressReviewHistoryWatermark> {
+    val watermarksArray = JSONArray(rawJson)
+    return buildList {
+        for (index in 0 until watermarksArray.length()) {
+            val watermark = watermarksArray.getJSONObject(index)
+            val workspaceId = watermark.getString("workspaceId")
+            if (workspaceId.isBlank()) {
+                throw IllegalArgumentException("Progress review-history watermark workspaceId must not be blank.")
+            }
+            add(
+                ProgressReviewHistoryWatermark(
+                    workspaceId = workspaceId,
+                    reviewSequenceId = parseProgressReviewHistorySequenceId(
+                        watermark = watermark
+                    )
+                )
+            )
+        }
+    }
+}
+
+private fun parseProgressReviewHistorySequenceId(watermark: JSONObject): Long {
+    val value = watermark.get("reviewSequenceId") as? Number
+    if (value == null) {
+        throw IllegalArgumentException("Progress review-history watermark reviewSequenceId must be an integer.")
+    }
+
+    val longValue = value.toLong()
+    if (value.toDouble() != longValue.toDouble() || longValue < 0L) {
+        throw IllegalArgumentException("Progress review-history watermark reviewSequenceId must be non-negative.")
+    }
+
+    return longValue
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotCalculations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotCalculations.kt
@@ -132,7 +132,8 @@ internal fun createLocalFallbackSummary(
         currentStreakDays = currentStreakDays,
         hasReviewedToday = activeReviewDateSet.contains(today.toString()),
         lastReviewedOn = lastReviewedOn,
-        activeReviewDays = activeReviewDates.size
+        activeReviewDays = activeReviewDates.size,
+        reviewHistoryWatermarks = emptyList()
     )
 }
 
@@ -174,6 +175,7 @@ internal fun createLocalFallbackSeries(
             )
         },
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         summary = null
     )
 }
@@ -207,6 +209,7 @@ internal fun createLocalFallbackReviewSchedule(
     return CloudProgressReviewSchedule(
         timeZone = scopeKey.timeZone,
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         totalCards = bucketCounts.values.sum(),
         buckets = ProgressReviewScheduleBucketKey.orderedEntries.map { key ->
             CloudProgressReviewScheduleBucket(
@@ -250,6 +253,7 @@ internal fun createPendingLocalOverlaySeries(
             )
         },
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         summary = null
     )
 }
@@ -394,7 +398,8 @@ internal fun mergeProgressSummary(
             first = base.lastReviewedOn,
             second = localFallback.lastReviewedOn
         ),
-        activeReviewDays = maxOf(base.activeReviewDays, localFallback.activeReviewDays)
+        activeReviewDays = maxOf(base.activeReviewDays, localFallback.activeReviewDays),
+        reviewHistoryWatermarks = base.reviewHistoryWatermarks
     )
 }
 
@@ -417,6 +422,7 @@ internal fun mergeProgressSeries(
         to = base.to,
         dailyReviews = mergedDailyReviews,
         generatedAt = base.generatedAt,
+        reviewHistoryWatermarks = base.reviewHistoryWatermarks,
         summary = null
     )
 }
@@ -619,7 +625,8 @@ internal fun createEmptyProgressSummary(): CloudProgressSummary {
         currentStreakDays = 0,
         hasReviewedToday = false,
         lastReviewedOn = null,
-        activeReviewDays = 0
+        activeReviewDays = 0,
+        reviewHistoryWatermarks = emptyList()
     )
 }
 
@@ -640,6 +647,7 @@ internal fun createEmptyProgressSeries(
             )
         },
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         summary = null
     )
 }
@@ -650,6 +658,7 @@ internal fun createEmptyProgressReviewSchedule(
     return CloudProgressReviewSchedule(
         timeZone = scopeKey.timeZone,
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         totalCards = 0,
         buckets = ProgressReviewScheduleBucketKey.orderedEntries.map { key ->
             CloudProgressReviewScheduleBucket(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -67,6 +67,9 @@ class CloudRemoteServiceTest {
                 "lastReviewedOn": "2026-04-18",
                 "activeReviewDays": 21
               },
+              "reviewHistoryWatermarks": [
+                { "workspaceId": "workspace-1", "reviewSequenceId": 42 }
+              ],
               "generatedAt": "2026-04-18T12:00:00Z"
             }
             """.trimIndent()
@@ -81,6 +84,7 @@ class CloudRemoteServiceTest {
         assertEquals(true, summary.hasReviewedToday)
         assertEquals("2026-04-18", summary.lastReviewedOn)
         assertEquals(21, summary.activeReviewDays)
+        assertEquals(42L, summary.reviewHistoryWatermarks.single().reviewSequenceId)
     }
 
     @Test(expected = CloudContractMismatchException::class)
@@ -93,6 +97,9 @@ class CloudRemoteServiceTest {
               "hasReviewedToday": true,
               "lastReviewedOn": "2026-04-18",
               "activeReviewDays": 21,
+              "reviewHistoryWatermarks": [
+                { "workspaceId": "workspace-1", "reviewSequenceId": 42 }
+              ],
               "generatedAt": "2026-04-18T12:00:00Z"
             }
             """.trimIndent()
@@ -111,6 +118,9 @@ class CloudRemoteServiceTest {
             {
               "timeZone": "Europe/Madrid",
               "generatedAt": "2026-05-03T12:00:00Z",
+              "reviewHistoryWatermarks": [
+                { "workspaceId": "workspace-1", "reviewSequenceId": 42 }
+              ],
               "totalCards": 8,
               "buckets": [
                 { "key": "new", "count": 1 },
@@ -133,6 +143,7 @@ class CloudRemoteServiceTest {
 
         assertEquals("Europe/Madrid", schedule.timeZone)
         assertEquals("2026-05-03T12:00:00Z", schedule.generatedAt)
+        assertEquals(42L, schedule.reviewHistoryWatermarks.single().reviewSequenceId)
         assertEquals(8, schedule.totalCards)
         assertEquals(ProgressReviewScheduleBucketKey.orderedEntries, schedule.buckets.map { bucket -> bucket.key })
     }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
@@ -127,6 +127,7 @@ internal fun createReviewSchedule(
     return CloudProgressReviewSchedule(
         timeZone = timeZone,
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         totalCards = buckets.sumOf(CloudProgressReviewScheduleBucket::count),
         buckets = buckets
     )

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
@@ -4,7 +4,12 @@ import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewSc
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSeriesCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSummaryCacheEntity
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.findProgressReviewScheduleServerBase
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCacheEntity
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressReviewScheduleOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressSeriesOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressSummaryOrNull
@@ -25,6 +30,7 @@ class ProgressCacheValidationTest {
             scopeId = "local:installation-1",
             timeZone = "Europe/Madrid",
             generatedAt = "2026-04-18T10:00:00Z",
+            reviewHistoryWatermarksJson = """[]""",
             currentStreakDays = 2,
             hasReviewedToday = true,
             lastReviewedOn = "not-a-date",
@@ -44,6 +50,7 @@ class ProgressCacheValidationTest {
             fromLocalDate = "2026-04-01",
             toLocalDate = "2026-04-18",
             generatedAt = "2026-04-18T10:00:00Z",
+            reviewHistoryWatermarksJson = """[]""",
             dailyReviewsJson = "{not-json}",
             updatedAtMillis = 1L
         )
@@ -59,6 +66,7 @@ class ProgressCacheValidationTest {
             timeZone = "Europe/Madrid",
             referenceLocalDate = "2026-05-03",
             generatedAt = "2026-05-03T10:00:00Z",
+            reviewHistoryWatermarksJson = """[]""",
             totalCards = 1,
             bucketsJson = """[{"key":"today","count":1},{"key":"new","count":0}]""",
             updatedAtMillis = 1L
@@ -105,6 +113,7 @@ class ProgressCacheValidationTest {
             timeZone = "UTC",
             referenceLocalDate = scopeKey.referenceLocalDate,
             generatedAt = "2026-05-03T10:00:00Z",
+            reviewHistoryWatermarksJson = """[]""",
             totalCards = 0,
             bucketsJson = """[]""",
             updatedAtMillis = 1L
@@ -116,6 +125,84 @@ class ProgressCacheValidationTest {
                 reviewScheduleCaches = listOf(cacheEntity),
                 scopeKey = scopeKey
             )
+        )
+    }
+
+    @Test
+    fun progressServerCachesPreserveReviewHistoryWatermarks(): Unit {
+        val watermarks = listOf(
+            ProgressReviewHistoryWatermark(
+                workspaceId = "workspace-1",
+                reviewSequenceId = 42L
+            ),
+            ProgressReviewHistoryWatermark(
+                workspaceId = "workspace-2",
+                reviewSequenceId = 7L
+            )
+        )
+        val summaryScopeKey = createProgressSummaryScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val seriesScopeKey = createProgressSeriesScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val scheduleScopeKey = createProgressReviewScheduleScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid"),
+            workspaceIds = listOf("workspace-1", "workspace-2")
+        )
+        val summary = CloudProgressSummary(
+            currentStreakDays = 3,
+            hasReviewedToday = true,
+            lastReviewedOn = "2026-04-18",
+            activeReviewDays = 9,
+            reviewHistoryWatermarks = watermarks
+        )
+        val series = CloudProgressSeries(
+            timeZone = seriesScopeKey.timeZone,
+            from = seriesScopeKey.from,
+            to = seriesScopeKey.to,
+            dailyReviews = listOf(
+                CloudDailyReviewPoint(
+                    date = seriesScopeKey.to,
+                    reviewCount = 2
+                )
+            ),
+            generatedAt = "2026-04-18T10:00:00Z",
+            reviewHistoryWatermarks = watermarks,
+            summary = null
+        )
+        val schedule = createReviewSchedule(
+            timeZone = scheduleScopeKey.timeZone,
+            newCount = 1,
+            todayCount = 2
+        ).copy(reviewHistoryWatermarks = watermarks)
+
+        assertEquals(
+            watermarks,
+            summary.toCacheEntity(
+                scopeKey = summaryScopeKey,
+                updatedAtMillis = 1L
+            ).toCloudProgressSummaryOrNull()?.reviewHistoryWatermarks
+        )
+        assertEquals(
+            watermarks,
+            series.toCacheEntity(
+                scopeKey = seriesScopeKey,
+                updatedAtMillis = 1L
+            ).toCloudProgressSeriesOrNull()?.reviewHistoryWatermarks
+        )
+        assertEquals(
+            watermarks,
+            schedule.toCacheEntity(
+                scopeKey = scheduleScopeKey,
+                updatedAtMillis = 1L
+            ).toCloudProgressReviewScheduleOrNull()?.reviewHistoryWatermarks
         )
     }
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
@@ -75,6 +75,7 @@ class ProgressSeriesSnapshotTest {
                 )
             ),
             generatedAt = null,
+            reviewHistoryWatermarks = emptyList(),
             summary = null
         )
         val serverBase = CloudProgressSeries(
@@ -92,6 +93,7 @@ class ProgressSeriesSnapshotTest {
                 )
             ),
             generatedAt = "2026-04-18T12:00:00Z",
+            reviewHistoryWatermarks = emptyList(),
             summary = null
         )
 

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
@@ -92,13 +92,15 @@ class ProgressSummarySnapshotTest {
             currentStreakDays = 10,
             hasReviewedToday = true,
             lastReviewedOn = "2026-04-18",
-            activeReviewDays = 33
+            activeReviewDays = 33,
+            reviewHistoryWatermarks = emptyList()
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 9,
             hasReviewedToday = false,
             lastReviewedOn = "2026-04-17",
-            activeReviewDays = 32
+            activeReviewDays = 32,
+            reviewHistoryWatermarks = emptyList()
         )
 
         val snapshot = createProgressSummarySnapshot(

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
@@ -396,19 +396,22 @@ private fun createProgressSummarySnapshot(): ProgressSummarySnapshot {
             currentStreakDays = 12,
             hasReviewedToday = true,
             lastReviewedOn = "2026-04-18",
-            activeReviewDays = 50
+            activeReviewDays = 50,
+            reviewHistoryWatermarks = emptyList()
         ),
         localFallback = CloudProgressSummary(
             currentStreakDays = 12,
             hasReviewedToday = true,
             lastReviewedOn = "2026-04-18",
-            activeReviewDays = 50
+            activeReviewDays = 50,
+            reviewHistoryWatermarks = emptyList()
         ),
         serverBase = CloudProgressSummary(
             currentStreakDays = 12,
             hasReviewedToday = true,
             lastReviewedOn = "2026-04-18",
-            activeReviewDays = 50
+            activeReviewDays = 50,
+            reviewHistoryWatermarks = emptyList()
         ),
         source = ProgressSnapshotSource.SERVER_BASE,
         isApproximate = false
@@ -445,6 +448,7 @@ private fun createProgressSeriesSnapshot(
         to = scopeKey.to,
         dailyReviews = dailyReviews,
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         summary = null
     )
     return ProgressSeriesSnapshot(
@@ -460,6 +464,7 @@ private fun createProgressSeriesSnapshot(
                 point.copy(reviewCount = 0)
             },
             generatedAt = null,
+            reviewHistoryWatermarks = emptyList(),
             summary = null
         ),
         source = ProgressSnapshotSource.LOCAL_ONLY,
@@ -477,6 +482,7 @@ private fun createProgressReviewScheduleSnapshot(): ProgressReviewScheduleSnapsh
     val schedule = CloudProgressReviewSchedule(
         timeZone = scopeKey.timeZone,
         generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
         totalCards = 4,
         buckets = ProgressReviewScheduleBucketKey.orderedEntries.map { key ->
             CloudProgressReviewScheduleBucket(

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
@@ -57,7 +57,8 @@ private fun createProgressSummarySnapshot(
         currentStreakDays = currentStreakDays,
         hasReviewedToday = hasReviewedToday,
         lastReviewedOn = "2026-04-18",
-        activeReviewDays = 32
+        activeReviewDays = 32,
+        reviewHistoryWatermarks = emptyList()
     )
 
     return ProgressSummarySnapshot(

--- a/apps/backend/src/database/core.test.ts
+++ b/apps/backend/src/database/core.test.ts
@@ -205,6 +205,23 @@ test("unsafeTransaction classifies transaction failures and discards clients whe
         rollbackErrorMessage: "terminating connection due to administrator command",
       },
     ]);
+
+    rollbackError = null;
+    queries.length = 0;
+    releaseArguments.length = 0;
+
+    const repeatableReadResult = await dbCore.unsafeRepeatableReadTransaction(async (executor) => {
+      await executor.query("SELECT app.progress()", []);
+      return "ok";
+    });
+
+    assert.equal(repeatableReadResult, "ok");
+    assert.deepEqual(queries, [
+      { text: "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ", params: null },
+      { text: "SELECT app.progress()", params: [] },
+      { text: "COMMIT", params: null },
+    ]);
+    assert.deepEqual(releaseArguments, [undefined]);
   } finally {
     (pg as unknown as { Pool: typeof pg.Pool }).Pool = originalPool;
     console.warn = originalWarn;

--- a/apps/backend/src/database/core.ts
+++ b/apps/backend/src/database/core.ts
@@ -155,6 +155,22 @@ export async function unsafeQuery<Row extends pg.QueryResultRow>(
 export async function unsafeTransaction<Result>(
   callback: (executor: DatabaseExecutor) => Promise<Result>,
 ): Promise<Result> {
+  return unsafeTransactionWithBeginStatement("BEGIN", callback);
+}
+
+export async function unsafeRepeatableReadTransaction<Result>(
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+): Promise<Result> {
+  return unsafeTransactionWithBeginStatement(
+    "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ",
+    callback,
+  );
+}
+
+async function unsafeTransactionWithBeginStatement<Result>(
+  beginStatement: string,
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+): Promise<Result> {
   let client: pg.PoolClient;
   try {
     client = await (await getPool()).connect();
@@ -174,7 +190,7 @@ export async function unsafeTransaction<Result>(
   let releaseError: Error | undefined;
   try {
     try {
-      await client.query("BEGIN");
+      await client.query(beginStatement);
     } catch (error) {
       releaseError = toClientReleaseError(error);
       throw toDatabaseBoundaryError(error);

--- a/apps/backend/src/database/unsafe.ts
+++ b/apps/backend/src/database/unsafe.ts
@@ -1,4 +1,5 @@
 export {
   unsafeQuery,
+  unsafeRepeatableReadTransaction,
   unsafeTransaction,
 } from "./core";

--- a/apps/backend/src/progress/index.test.ts
+++ b/apps/backend/src/progress/index.test.ts
@@ -36,6 +36,11 @@ type ReviewScheduleCountRow = Readonly<{
   later_count: string | number;
 }>;
 
+type ReviewHistoryWatermarkRow = Readonly<{
+  workspace_id: string;
+  review_sequence_id: string | number;
+}>;
+
 type WorkspaceMembershipRow = Readonly<{
   workspace_id: string;
 }>;
@@ -45,6 +50,7 @@ type ProgressExecutorFixture = Readonly<{
   reviewRowsByRequest: Readonly<Record<string, ReadonlyArray<DailyReviewCountRow>>>;
   allReviewDateRowsByRequest: Readonly<Record<string, ReadonlyArray<ReviewDateRow>>>;
   reviewScheduleRowsByRequest: Readonly<Record<string, ReadonlyArray<ReviewScheduleCountRow>>>;
+  reviewSequenceIdsByWorkspaceId: Readonly<Record<string, string | number>>;
 }>;
 
 type RecordedQuery = Readonly<{
@@ -177,6 +183,10 @@ function createQueryResult<Row extends QueryResultRow>(rows: ReadonlyArray<Row>)
   };
 }
 
+function isStringArray(value: SqlValue | undefined): value is ReadonlyArray<string> {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
 function createProgressExecutor(
   fixture: ProgressExecutorFixture,
 ): Readonly<{
@@ -218,6 +228,38 @@ function createProgressExecutor(
         return createQueryResult<WorkspaceMembershipRow>(
           (fixture.workspaceIdsByUser[userId] ?? []).map((workspaceId) => ({ workspace_id: workspaceId })),
         ) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.includes("COALESCE(MAX(review_events.review_sequence), 0) AS review_sequence_id")
+        && text.includes("FROM unnest($1::uuid[]) AS requested_workspace_ids(workspace_id)")
+      ) {
+        const workspaceIdsParam = params[0];
+        if (!isStringArray(workspaceIdsParam)) {
+          throw new Error("Review-history watermark query requires workspace id array parameter");
+        }
+
+        if (scope.userId === null || scope.workspaceId === null) {
+          throw new Error("Review-history watermark query requires workspace scope");
+        }
+
+        const rows = workspaceIdsParam.map((workspaceId) => {
+          if (workspaceId !== scope.workspaceId) {
+            throw new Error("Review-history watermark query requires matching workspace scope");
+          }
+
+          const reviewSequenceId = fixture.reviewSequenceIdsByWorkspaceId[workspaceId];
+          if (reviewSequenceId === undefined) {
+            throw new Error(`Missing review-history watermark fixture for ${workspaceId}`);
+          }
+
+          return {
+            workspace_id: workspaceId,
+            review_sequence_id: reviewSequenceId,
+          };
+        }).sort((left, right) => left.workspace_id.localeCompare(right.workspace_id));
+
+        return createQueryResult<ReviewHistoryWatermarkRow>(rows) as unknown as pg.QueryResult<Row>;
       }
 
       if (
@@ -323,6 +365,9 @@ test("loadUserProgressSeriesInExecutor returns a zero-filled series for an empty
     reviewRowsByRequest: {},
     allReviewDateRowsByRequest: {},
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 0,
+    },
   });
 
   const progress = await loadUserProgressSeriesInExecutor(executor, {
@@ -337,6 +382,7 @@ test("loadUserProgressSeriesInExecutor returns a zero-filled series for an empty
     from: progress.from,
     to: progress.to,
     dailyReviews: progress.dailyReviews,
+    reviewHistoryWatermarks: progress.reviewHistoryWatermarks,
   }, {
     timeZone: "Europe/Madrid",
     from: "2026-04-11",
@@ -345,6 +391,9 @@ test("loadUserProgressSeriesInExecutor returns a zero-filled series for an empty
       { date: "2026-04-11", reviewCount: 0 },
       { date: "2026-04-12", reviewCount: 0 },
       { date: "2026-04-13", reviewCount: 0 },
+    ],
+    reviewHistoryWatermarks: [
+      { workspaceId: "workspace-1", reviewSequenceId: 0 },
     ],
   });
   assert.match(progress.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
@@ -358,6 +407,9 @@ test("loadUserProgressSummaryInExecutor returns zero summary metrics for an empt
     reviewRowsByRequest: {},
     allReviewDateRowsByRequest: {},
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 0,
+    },
   });
 
   const progress = await loadUserProgressSummaryInExecutor(executor, {
@@ -374,6 +426,9 @@ test("loadUserProgressSummaryInExecutor returns zero summary metrics for an empt
       activeReviewDays: 0,
     },
     generatedAt: progress.generatedAt,
+    reviewHistoryWatermarks: [
+      { workspaceId: "workspace-1", reviewSequenceId: 0 },
+    ],
   });
   assert.match(progress.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
 });
@@ -390,6 +445,9 @@ test("loadUserProgressReviewScheduleInExecutor returns stable zero buckets for a
         createEmptyReviewScheduleCountRow(),
       ],
     },
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 0,
+    },
   });
 
   const progress = await loadUserProgressReviewScheduleInExecutor(executor, {
@@ -403,7 +461,116 @@ test("loadUserProgressReviewScheduleInExecutor returns stable zero buckets for a
   })));
   assert.equal(progress.timeZone, "Europe/Madrid");
   assert.equal(progress.totalCards, 0);
+  assert.deepEqual(progress.reviewHistoryWatermarks, [
+    { workspaceId: "workspace-1", reviewSequenceId: 0 },
+  ]);
   assert.match(progress.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("progress responses include sorted review-history watermarks for accessible workspaces", async () => {
+  const expectedWatermarks = [
+    { workspaceId: "workspace-1", reviewSequenceId: 42 },
+    { workspaceId: "workspace-2", reviewSequenceId: 7 },
+  ];
+  const { executor, recordedQueries } = createProgressExecutor({
+    workspaceIdsByUser: {
+      "user-1": ["workspace-2", "workspace-1"],
+    },
+    reviewRowsByRequest: {},
+    allReviewDateRowsByRequest: {},
+    reviewScheduleRowsByRequest: {
+      "workspace-1|Europe/Madrid": [
+        createEmptyReviewScheduleCountRow(),
+      ],
+      "workspace-2|Europe/Madrid": [
+        createEmptyReviewScheduleCountRow(),
+      ],
+    },
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": "42",
+      "workspace-2": 7,
+    },
+  });
+
+  const summary = await loadUserProgressSummaryInExecutor(executor, {
+    userId: "user-1",
+    timeZone: "Europe/Madrid",
+  });
+  const series = await loadUserProgressSeriesInExecutor(executor, {
+    userId: "user-1",
+    timeZone: "Europe/Madrid",
+    from: "2026-04-11",
+    to: "2026-04-12",
+  });
+  const reviewSchedule = await loadUserProgressReviewScheduleInExecutor(executor, {
+    userId: "user-1",
+    timeZone: "Europe/Madrid",
+  });
+
+  assert.deepEqual(summary.reviewHistoryWatermarks, expectedWatermarks);
+  assert.deepEqual(series.reviewHistoryWatermarks, expectedWatermarks);
+  assert.deepEqual(reviewSchedule.reviewHistoryWatermarks, expectedWatermarks);
+
+  const watermarkQueries = recordedQueries.filter((query) => (
+    query.text.includes("COALESCE(MAX(review_events.review_sequence), 0) AS review_sequence_id")
+  ));
+  assert.ok(watermarkQueries.length > 0);
+  assert.ok(watermarkQueries.every((query) => (
+    query.text.includes("WHERE security.current_workspace_access_allowed(requested_workspace_ids.workspace_id)")
+  )));
+});
+
+test("progress responses return empty review-history watermarks when the user has no workspaces", async () => {
+  const { executor } = createProgressExecutor({
+    workspaceIdsByUser: {
+      "user-1": [],
+    },
+    reviewRowsByRequest: {},
+    allReviewDateRowsByRequest: {},
+    reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {},
+  });
+
+  const summary = await loadUserProgressSummaryInExecutor(executor, {
+    userId: "user-1",
+    timeZone: "Europe/Madrid",
+  });
+  const series = await loadUserProgressSeriesInExecutor(executor, {
+    userId: "user-1",
+    timeZone: "Europe/Madrid",
+    from: "2026-04-11",
+    to: "2026-04-12",
+  });
+  const reviewSchedule = await loadUserProgressReviewScheduleInExecutor(executor, {
+    userId: "user-1",
+    timeZone: "Europe/Madrid",
+  });
+
+  assert.deepEqual(summary.reviewHistoryWatermarks, []);
+  assert.deepEqual(series.reviewHistoryWatermarks, []);
+  assert.deepEqual(reviewSchedule.reviewHistoryWatermarks, []);
+});
+
+test("loadUserProgressSummaryInExecutor raises workspace context for invalid review-history sequence", async () => {
+  const { executor } = createProgressExecutor({
+    workspaceIdsByUser: {
+      "user-1": ["workspace-1"],
+    },
+    reviewRowsByRequest: {},
+    allReviewDateRowsByRequest: {},
+    reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": "42-invalid",
+    },
+  });
+
+  await assert.rejects(
+    () => loadUserProgressSummaryInExecutor(executor, {
+      userId: "user-1",
+      timeZone: "Europe/Madrid",
+    }),
+    /Invalid review_sequence returned for progress watermark: workspaceId=workspace-1/,
+  );
 });
 
 test("loadUserProgressSeriesInExecutor fills gaps and merges review counts across multiple workspaces", async () => {
@@ -423,6 +590,10 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges review counts acros
     },
     allReviewDateRowsByRequest: {},
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 4,
+      "workspace-2": 3,
+    },
   });
 
   const progress = await loadUserProgressSeriesInExecutor(executor, {
@@ -437,6 +608,10 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges review counts acros
     { date: "2026-04-12", reviewCount: 0 },
     { date: "2026-04-13", reviewCount: 4 },
     { date: "2026-04-14", reviewCount: 3 },
+  ]);
+  assert.deepEqual(progress.reviewHistoryWatermarks, [
+    { workspaceId: "workspace-1", reviewSequenceId: 4 },
+    { workspaceId: "workspace-2", reviewSequenceId: 3 },
   ]);
 });
 
@@ -473,6 +648,10 @@ test("loadUserProgressReviewScheduleInExecutor merges bucket counts across works
         }),
       ],
     },
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 8,
+      "workspace-2": "80",
+    },
   });
 
   const progress = await loadUserProgressReviewScheduleInExecutor(executor, {
@@ -491,6 +670,10 @@ test("loadUserProgressReviewScheduleInExecutor merges bucket counts across works
     { key: "later", count: 88 },
   ]);
   assert.equal(progress.totalCards, 396);
+  assert.deepEqual(progress.reviewHistoryWatermarks, [
+    { workspaceId: "workspace-1", reviewSequenceId: 8 },
+    { workspaceId: "workspace-2", reviewSequenceId: 80 },
+  ]);
 
   const scheduleQueries = recordedQueries.filter((query) => (
     query.text.includes("COUNT(*) FILTER (WHERE cards.due_at IS NULL)::int AS new_count")
@@ -524,6 +707,10 @@ test("loadUserProgressSummaryInExecutor merges all-time review dates across work
       ],
     },
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 3,
+      "workspace-2": 2,
+    },
   });
 
   const progress = await loadUserProgressSummaryInExecutor(executor, {
@@ -537,6 +724,10 @@ test("loadUserProgressSummaryInExecutor merges all-time review dates across work
     lastReviewedOn: "2026-04-14",
     activeReviewDays: 4,
   });
+  assert.deepEqual(progress.reviewHistoryWatermarks, [
+    { workspaceId: "workspace-1", reviewSequenceId: 3 },
+    { workspaceId: "workspace-2", reviewSequenceId: 2 },
+  ]);
 });
 
 test("loadUserProgressReviewScheduleInExecutor uses timezone calendar boundaries in SQL aggregate buckets", async () => {
@@ -550,6 +741,9 @@ test("loadUserProgressReviewScheduleInExecutor uses timezone calendar boundaries
       "workspace-1|America/Los_Angeles": [
         createEmptyReviewScheduleCountRow(),
       ],
+    },
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 0,
     },
   });
 
@@ -597,6 +791,9 @@ test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_clie
     },
     allReviewDateRowsByRequest: {},
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 1,
+    },
   });
 
   await loadUserProgressSeriesInExecutor(executor, {
@@ -634,6 +831,9 @@ test("loadUserProgressSummaryInExecutor derives active review dates from reviewe
       ],
     },
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 1,
+    },
   });
 
   await loadUserProgressSummaryInExecutor(executor, {
@@ -670,6 +870,10 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
     },
     allReviewDateRowsByRequest: {},
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 3,
+      "workspace-2": 1,
+    },
   });
 
   await loadUserProgressSeriesInExecutor(executor, {
@@ -706,6 +910,10 @@ test("loadUserProgressSummaryInExecutor applies user scope for memberships and w
       ],
     },
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 1,
+      "workspace-2": 1,
+    },
   });
 
   await loadUserProgressSummaryInExecutor(executor, {
@@ -749,6 +957,9 @@ test("loadUserProgressSummaryInExecutor keeps summary independent from the reque
       ],
     },
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 4,
+    },
   });
 
   const progress = await loadUserProgressSummaryInExecutor(executor, {
@@ -782,6 +993,9 @@ test("loadUserProgressSummaryInExecutor keeps hasReviewedToday true when a futur
       ],
     },
     reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {
+      "workspace-1": 3,
+    },
   });
 
   const progress = await loadUserProgressSummaryInExecutor(executor, {

--- a/apps/backend/src/progress/index.ts
+++ b/apps/backend/src/progress/index.ts
@@ -4,7 +4,7 @@ import {
   type DatabaseExecutor,
   type SqlValue,
 } from "../database";
-import { unsafeTransaction } from "../database/unsafe";
+import { unsafeRepeatableReadTransaction } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import { listUserWorkspaceIdsInExecutor } from "../workspaces/queries";
 
@@ -64,11 +64,20 @@ export type ProgressSummary = Readonly<{
   activeReviewDays: number;
 }>;
 
+export type ProgressReviewHistoryWatermark = Readonly<{
+  workspaceId: string;
+  reviewSequenceId: number;
+}>;
+
+export type ProgressReviewHistoryWatermarkPayload = Readonly<{
+  reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark>;
+}>;
+
 export type ProgressSummaryResponse = Readonly<{
   timeZone: string;
   summary: ProgressSummary;
   generatedAt: string;
-}>;
+}> & ProgressReviewHistoryWatermarkPayload;
 
 export type ProgressSeries = Readonly<{
   timeZone: string;
@@ -76,14 +85,14 @@ export type ProgressSeries = Readonly<{
   to: string;
   dailyReviews: ReadonlyArray<DailyReviewPoint>;
   generatedAt: string;
-}>;
+}> & ProgressReviewHistoryWatermarkPayload;
 
 export type ProgressReviewSchedule = Readonly<{
   timeZone: string;
   generatedAt: string;
   totalCards: number;
   buckets: ReadonlyArray<ReviewScheduleBucket>;
-}>;
+}> & ProgressReviewHistoryWatermarkPayload;
 
 type DailyReviewCountRow = Readonly<{
   review_date: string;
@@ -103,6 +112,11 @@ type ReviewScheduleCountRow = Readonly<{
   days_91_to_360_count: string | number;
   years_1_to_2_count: string | number;
   later_count: string | number;
+}>;
+
+type ReviewHistoryWatermarkRow = Readonly<{
+  workspace_id: string;
+  review_sequence_id: string | number;
 }>;
 
 type ReviewScheduleBucketCounts = Readonly<Record<ReviewScheduleBucketKey, number>>;
@@ -357,6 +371,72 @@ function normalizeNonNegativeIntegerFromQuery(value: string | number, fieldName:
   return normalizedValue;
 }
 
+function parseReviewSequenceId(value: string | number): number {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  const trimmedValue = value.trim();
+  if (!/^\d+$/.test(trimmedValue)) {
+    return Number.NaN;
+  }
+
+  return Number.parseInt(trimmedValue, 10);
+}
+
+function normalizeReviewSequenceId(value: string | number, workspaceId: string): number {
+  const normalizedValue = parseReviewSequenceId(value);
+  if (!Number.isSafeInteger(normalizedValue) || normalizedValue < 0) {
+    throw new Error(
+      `Invalid review_sequence returned for progress watermark: workspaceId=${workspaceId}, value=${String(value)}`,
+    );
+  }
+
+  return normalizedValue;
+}
+
+function mapReviewHistoryWatermarkRow(row: ReviewHistoryWatermarkRow): ProgressReviewHistoryWatermark {
+  const workspaceId = row.workspace_id.trim();
+  if (workspaceId === "") {
+    throw new Error("Invalid workspace_id returned for progress watermark");
+  }
+
+  return {
+    workspaceId,
+    reviewSequenceId: normalizeReviewSequenceId(row.review_sequence_id, workspaceId),
+  };
+}
+
+function createSortedWorkspaceIds(workspaceIds: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(workspaceIds)].sort((left, right) => left.localeCompare(right));
+}
+
+function assertWatermarkRowsCoverWorkspaceIds(
+  workspaceIds: ReadonlyArray<string>,
+  rows: ReadonlyArray<ReviewHistoryWatermarkRow>,
+): void {
+  const expectedWorkspaceIds = createSortedWorkspaceIds(workspaceIds);
+  const actualWorkspaceIds = createSortedWorkspaceIds(rows.map((row) => row.workspace_id));
+  const hasMismatchedWorkspaceIds = expectedWorkspaceIds.length !== actualWorkspaceIds.length
+    || expectedWorkspaceIds.some((workspaceId, index) => workspaceId !== actualWorkspaceIds[index]);
+
+  if (hasMismatchedWorkspaceIds) {
+    throw new Error(
+      [
+        "Review-history watermark query did not return one row per workspace",
+        `expectedWorkspaceIds=${expectedWorkspaceIds.join(",")}`,
+        `returnedWorkspaceIds=${actualWorkspaceIds.join(",")}`,
+      ].join("; "),
+    );
+  }
+}
+
+function sortReviewHistoryWatermarks(
+  watermarks: ReadonlyArray<ProgressReviewHistoryWatermark>,
+): ReadonlyArray<ProgressReviewHistoryWatermark> {
+  return [...watermarks].sort((left, right) => left.workspaceId.localeCompare(right.workspaceId));
+}
+
 function createEmptyReviewScheduleBucketCounts(): ReviewScheduleBucketCounts {
   return Object.fromEntries(
     reviewScheduleBucketKeys.map((key) => [key, 0]),
@@ -419,6 +499,37 @@ function createDailyReviews(
     date,
     reviewCount: aggregate.get(date) ?? 0,
   }));
+}
+
+async function loadReviewHistoryWatermarksInExecutor(
+  executor: DatabaseExecutor,
+  workspaceIds: ReadonlyArray<string>,
+): Promise<ReadonlyArray<ProgressReviewHistoryWatermark>> {
+  if (workspaceIds.length === 0) {
+    return [];
+  }
+
+  const result = await executor.query<ReviewHistoryWatermarkRow>(
+    [
+      "WITH requested_workspaces AS (",
+      "SELECT requested_workspace_ids.workspace_id",
+      "FROM unnest($1::uuid[]) AS requested_workspace_ids(workspace_id)",
+      "WHERE security.current_workspace_access_allowed(requested_workspace_ids.workspace_id)",
+      ")",
+      "SELECT",
+      "requested_workspaces.workspace_id::text AS workspace_id,",
+      "COALESCE(MAX(review_events.review_sequence), 0) AS review_sequence_id",
+      "FROM requested_workspaces",
+      "LEFT JOIN content.review_events AS review_events",
+      "ON review_events.workspace_id = requested_workspaces.workspace_id",
+      "GROUP BY requested_workspaces.workspace_id",
+      "ORDER BY requested_workspaces.workspace_id ASC",
+    ].join(" "),
+    [workspaceIds],
+  );
+
+  assertWatermarkRowsCoverWorkspaceIds(workspaceIds, result.rows);
+  return result.rows.map(mapReviewHistoryWatermarkRow);
 }
 
 async function loadDailyReviewCountRowsInExecutor(
@@ -577,6 +688,7 @@ async function buildUserProgressSummaryInExecutor(
   // user can still access; AI workspace routing does not change that contract.
   const workspaceIds = await listUserWorkspaceIdsInExecutor(executor, request.userId);
   let lastReviewedOn: string | null = null;
+  let reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> = [];
 
   for (const workspaceId of workspaceIds) {
     await applyWorkspaceDatabaseScopeInExecutor(executor, {
@@ -589,6 +701,9 @@ async function buildUserProgressSummaryInExecutor(
     });
     accumulateReviewDates(reviewDates, rows);
     lastReviewedOn = findLatestReviewedOn(lastReviewedOn, rows[0]?.review_date ?? null);
+    reviewHistoryWatermarks = reviewHistoryWatermarks.concat(
+      await loadReviewHistoryWatermarksInExecutor(executor, [workspaceId]),
+    );
   }
 
   const today = formatDateAsTimeZoneLocalDate(generatedAtDate, request.timeZone);
@@ -606,6 +721,7 @@ async function buildUserProgressSummaryInExecutor(
       lastReviewedOn,
     ),
     generatedAt: generatedAtDate.toISOString(),
+    reviewHistoryWatermarks: sortReviewHistoryWatermarks(reviewHistoryWatermarks),
   };
 }
 
@@ -617,6 +733,7 @@ async function buildUserProgressReviewScheduleInExecutor(
   let counts = createEmptyReviewScheduleBucketCounts();
   await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
   const workspaceIds = await listUserWorkspaceIdsInExecutor(executor, request.userId);
+  let reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> = [];
 
   for (const workspaceId of workspaceIds) {
     await applyWorkspaceDatabaseScopeInExecutor(executor, {
@@ -629,6 +746,9 @@ async function buildUserProgressReviewScheduleInExecutor(
       generatedAt: generatedAtDate,
     });
     counts = addReviewScheduleCountRow(counts, row);
+    reviewHistoryWatermarks = reviewHistoryWatermarks.concat(
+      await loadReviewHistoryWatermarksInExecutor(executor, [workspaceId]),
+    );
   }
 
   return {
@@ -636,6 +756,7 @@ async function buildUserProgressReviewScheduleInExecutor(
     generatedAt: generatedAtDate.toISOString(),
     totalCards: calculateReviewScheduleTotalCards(counts),
     buckets: createReviewScheduleBuckets(counts),
+    reviewHistoryWatermarks: sortReviewHistoryWatermarks(reviewHistoryWatermarks),
   };
 }
 
@@ -647,6 +768,7 @@ async function buildUserProgressSeriesInExecutor(
   const dailyReviewCounts = new Map<string, number>();
   await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
   const workspaceIds = await listUserWorkspaceIdsInExecutor(executor, request.userId);
+  let reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> = [];
 
   for (const workspaceId of workspaceIds) {
     // review_events reads are workspace-scoped by RLS, so aggregate one
@@ -662,6 +784,9 @@ async function buildUserProgressSeriesInExecutor(
       to: request.to,
     });
     accumulateDailyReviewCounts(dailyReviewCounts, rows);
+    reviewHistoryWatermarks = reviewHistoryWatermarks.concat(
+      await loadReviewHistoryWatermarksInExecutor(executor, [workspaceId]),
+    );
   }
 
   return {
@@ -673,6 +798,7 @@ async function buildUserProgressSeriesInExecutor(
       dailyReviewCounts,
     ),
     generatedAt: generatedAtDate.toISOString(),
+    reviewHistoryWatermarks: sortReviewHistoryWatermarks(reviewHistoryWatermarks),
   };
 }
 
@@ -698,15 +824,17 @@ export async function loadUserProgressSeriesInExecutor(
 }
 
 export async function loadUserProgressSummary(request: ProgressSummaryRequest): Promise<ProgressSummaryResponse> {
-  return unsafeTransaction(async (executor) => loadUserProgressSummaryInExecutor(executor, request));
+  return unsafeRepeatableReadTransaction(async (executor) => loadUserProgressSummaryInExecutor(executor, request));
 }
 
 export async function loadUserProgressReviewSchedule(
   request: ProgressReviewScheduleRequest,
 ): Promise<ProgressReviewSchedule> {
-  return unsafeTransaction(async (executor) => loadUserProgressReviewScheduleInExecutor(executor, request));
+  return unsafeRepeatableReadTransaction(
+    async (executor) => loadUserProgressReviewScheduleInExecutor(executor, request),
+  );
 }
 
 export async function loadUserProgressSeries(request: ProgressSeriesRequest): Promise<ProgressSeries> {
-  return unsafeTransaction(async (executor) => loadUserProgressSeriesInExecutor(executor, request));
+  return unsafeRepeatableReadTransaction(async (executor) => loadUserProgressSeriesInExecutor(executor, request));
 }

--- a/apps/backend/src/routes/system.test.ts
+++ b/apps/backend/src/routes/system.test.ts
@@ -48,6 +48,9 @@ function createProgressSummaryResponse(): ProgressSummaryResponse {
       activeReviewDays: 12,
     },
     generatedAt: "2026-04-17T10:11:12.000Z",
+    reviewHistoryWatermarks: [
+      { workspaceId: "workspace-1", reviewSequenceId: 42 },
+    ],
   };
 }
 
@@ -66,6 +69,9 @@ function createProgressSeries(): ProgressSeries {
       { date: "2026-04-17", reviewCount: 4 },
     ],
     generatedAt: "2026-04-17T10:11:12.000Z",
+    reviewHistoryWatermarks: [
+      { workspaceId: "workspace-1", reviewSequenceId: 42 },
+    ],
   };
 }
 
@@ -83,6 +89,9 @@ function createProgressReviewSchedule(): ProgressReviewSchedule {
       { key: "days91To360", count: 12 },
       { key: "years1To2", count: 14 },
       { key: "later", count: 16 },
+    ],
+    reviewHistoryWatermarks: [
+      { workspaceId: "workspace-1", reviewSequenceId: 42 },
     ],
   };
 }

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
@@ -132,6 +132,7 @@ extension CardStore {
         let schedule = makeReviewSchedule(
             timeZone: timeZone,
             generatedAt: nil,
+            reviewHistoryWatermarks: [],
             totalCards: totalCards,
             buckets: buckets
         )

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
@@ -193,7 +193,8 @@ func makeProgressSeriesFromReviewedAtClients(
         to: requestRange.to,
         dailyReviews: progressDays,
         summary: nil,
-        generatedAt: nil
+        generatedAt: nil,
+        reviewHistoryWatermarks: []
     )
 }
 
@@ -250,7 +251,8 @@ func mergeProgressSeries(
         to: serverBase.to,
         dailyReviews: mergedDailyReviews,
         summary: nil,
-        generatedAt: serverBase.generatedAt
+        generatedAt: serverBase.generatedAt,
+        reviewHistoryWatermarks: serverBase.reviewHistoryWatermarks
     )
 }
 
@@ -319,7 +321,8 @@ func patchProgressSnapshot(
         to: scopeKey.to,
         dailyReviews: dailyReviews,
         summary: nil,
-        generatedAt: snapshot.generatedAt
+        generatedAt: snapshot.generatedAt,
+        reviewHistoryWatermarks: []
     )
 
     return try makeProgressSnapshot(

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressTypes.swift
@@ -21,15 +21,52 @@ struct ProgressSummary: Codable, Hashable, Sendable {
     let activeReviewDays: Int
 }
 
+struct ProgressReviewHistoryWatermark: Codable, Hashable, Sendable {
+    let workspaceId: String
+    let reviewSequenceId: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case workspaceId
+        case reviewSequenceId
+    }
+
+    init(
+        workspaceId: String,
+        reviewSequenceId: Int64
+    ) {
+        self.workspaceId = workspaceId
+        self.reviewSequenceId = reviewSequenceId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let reviewSequenceId = try container.decode(Int64.self, forKey: .reviewSequenceId)
+        guard reviewSequenceId >= 0 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .reviewSequenceId,
+                in: container,
+                debugDescription: "reviewSequenceId must not be negative"
+            )
+        }
+
+        self.init(
+            workspaceId: try container.decode(String.self, forKey: .workspaceId),
+            reviewSequenceId: reviewSequenceId
+        )
+    }
+}
+
 struct UserProgressSummary: Codable, Hashable, Sendable {
     let timeZone: String?
     let summary: ProgressSummary
     let generatedAt: String?
+    let reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
 
     enum CodingKeys: String, CodingKey {
         case timeZone
         case summary
         case generatedAt
+        case reviewHistoryWatermarks
         case currentStreakDays
         case hasReviewedToday
         case lastReviewedOn
@@ -39,11 +76,13 @@ struct UserProgressSummary: Codable, Hashable, Sendable {
     init(
         timeZone: String?,
         summary: ProgressSummary,
-        generatedAt: String?
+        generatedAt: String?,
+        reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
     ) {
         self.timeZone = timeZone
         self.summary = summary
         self.generatedAt = generatedAt
+        self.reviewHistoryWatermarks = reviewHistoryWatermarks
     }
 
     init(from decoder: Decoder) throws {
@@ -52,7 +91,11 @@ struct UserProgressSummary: Codable, Hashable, Sendable {
             self.init(
                 timeZone: try container.decodeIfPresent(String.self, forKey: .timeZone),
                 summary: try container.decode(ProgressSummary.self, forKey: .summary),
-                generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt)
+                generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt),
+                reviewHistoryWatermarks: try container.decode(
+                    [ProgressReviewHistoryWatermark].self,
+                    forKey: .reviewHistoryWatermarks
+                )
             )
             return
         }
@@ -65,7 +108,11 @@ struct UserProgressSummary: Codable, Hashable, Sendable {
                 lastReviewedOn: try container.decodeIfPresent(String.self, forKey: .lastReviewedOn),
                 activeReviewDays: try container.decode(Int.self, forKey: .activeReviewDays)
             ),
-            generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt)
+            generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt),
+            reviewHistoryWatermarks: try container.decode(
+                [ProgressReviewHistoryWatermark].self,
+                forKey: .reviewHistoryWatermarks
+            )
         )
     }
 
@@ -74,6 +121,7 @@ struct UserProgressSummary: Codable, Hashable, Sendable {
         try container.encodeIfPresent(self.timeZone, forKey: .timeZone)
         try container.encode(self.summary, forKey: .summary)
         try container.encodeIfPresent(self.generatedAt, forKey: .generatedAt)
+        try container.encode(self.reviewHistoryWatermarks, forKey: .reviewHistoryWatermarks)
     }
 }
 
@@ -84,6 +132,7 @@ struct UserProgressSeries: Codable, Hashable, Sendable {
     let dailyReviews: [ProgressDay]
     let summary: ProgressSummary?
     let generatedAt: String?
+    let reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
 
     init(
         timeZone: String,
@@ -91,7 +140,8 @@ struct UserProgressSeries: Codable, Hashable, Sendable {
         to: String,
         dailyReviews: [ProgressDay],
         summary: ProgressSummary?,
-        generatedAt: String?
+        generatedAt: String?,
+        reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
     ) {
         self.timeZone = timeZone
         self.from = from
@@ -99,6 +149,7 @@ struct UserProgressSeries: Codable, Hashable, Sendable {
         self.dailyReviews = dailyReviews
         self.summary = summary
         self.generatedAt = generatedAt
+        self.reviewHistoryWatermarks = reviewHistoryWatermarks
     }
 }
 
@@ -140,6 +191,7 @@ struct ReviewScheduleBucket: Codable, Hashable, Identifiable, Sendable {
 struct UserReviewSchedule: Codable, Hashable, Sendable {
     let timeZone: String
     let generatedAt: String?
+    let reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
     let totalCards: Int
     let buckets: [ReviewScheduleBucket]
 }
@@ -523,7 +575,8 @@ func makeProgressSeries(
     to: String,
     dailyReviews: [ProgressDay],
     summary: ProgressSummary?,
-    generatedAt: String?
+    generatedAt: String?,
+    reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
 ) -> UserProgressSeries {
     UserProgressSeries(
         timeZone: timeZone,
@@ -531,19 +584,22 @@ func makeProgressSeries(
         to: to,
         dailyReviews: dailyReviews,
         summary: summary,
-        generatedAt: generatedAt
+        generatedAt: generatedAt,
+        reviewHistoryWatermarks: reviewHistoryWatermarks
     )
 }
 
 func makeReviewSchedule(
     timeZone: String,
     generatedAt: String?,
+    reviewHistoryWatermarks: [ProgressReviewHistoryWatermark],
     totalCards: Int,
     buckets: [ReviewScheduleBucket]
 ) -> UserReviewSchedule {
     UserReviewSchedule(
         timeZone: timeZone,
         generatedAt: generatedAt,
+        reviewHistoryWatermarks: reviewHistoryWatermarks,
         totalCards: totalCards,
         buckets: buckets
     )

--- a/apps/ios/Flashcards/FlashcardsTests/AI/Store/Support/AIChatStoreTestCloudSyncService.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/Store/Support/AIChatStoreTestCloudSyncService.swift
@@ -91,7 +91,8 @@ extension AIChatStoreTestSupport {
                     lastReviewedOn: nil,
                     activeReviewDays: 0
                 ),
-                generatedAt: "2026-04-25T00:00:00.000Z"
+                generatedAt: "2026-04-25T00:00:00.000Z",
+                reviewHistoryWatermarks: []
             )
         }
 
@@ -122,7 +123,8 @@ extension AIChatStoreTestSupport {
                     lastReviewedOn: nil,
                     activeReviewDays: 0
                 ),
-                generatedAt: "2026-04-25T00:00:00.000Z"
+                generatedAt: "2026-04-25T00:00:00.000Z",
+                reviewHistoryWatermarks: []
             )
         }
 
@@ -141,6 +143,7 @@ extension AIChatStoreTestSupport {
             return makeReviewSchedule(
                 timeZone: timeZone,
                 generatedAt: "2026-04-25T00:00:00.000Z",
+                reviewHistoryWatermarks: [],
                 totalCards: 0,
                 buckets: ReviewScheduleBucketKey.stableOrder.map { bucketKey in
                     ReviewScheduleBucket(key: bucketKey, count: 0)

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/GuestCloudUpgradeTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/GuestCloudUpgradeTestSupport.swift
@@ -119,7 +119,8 @@ final class GuestUpgradeDrainCloudSyncService: CloudSyncServing {
                 lastReviewedOn: nil,
                 activeReviewDays: 0
             ),
-            generatedAt: "2026-04-25T00:00:00.000Z"
+            generatedAt: "2026-04-25T00:00:00.000Z",
+            reviewHistoryWatermarks: []
         )
     }
 
@@ -143,7 +144,8 @@ final class GuestUpgradeDrainCloudSyncService: CloudSyncServing {
                 lastReviewedOn: nil,
                 activeReviewDays: 0
             ),
-            generatedAt: "2026-04-25T00:00:00.000Z"
+            generatedAt: "2026-04-25T00:00:00.000Z",
+            reviewHistoryWatermarks: []
         )
     }
 
@@ -157,6 +159,7 @@ final class GuestUpgradeDrainCloudSyncService: CloudSyncServing {
         return makeReviewSchedule(
             timeZone: timeZone,
             generatedAt: "2026-04-25T00:00:00.000Z",
+            reviewHistoryWatermarks: [],
             totalCards: 0,
             buckets: ReviewScheduleBucketKey.stableOrder.map { bucketKey in
                 ReviewScheduleBucket(key: bucketKey, count: 0)

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -78,7 +78,8 @@ func makeTestProgressSeries(
         to: requestRange.to,
         dailyReviews: dailyReviews,
         summary: summary,
-        generatedAt: generatedAt
+        generatedAt: generatedAt,
+        reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
     )
 }
 
@@ -95,7 +96,8 @@ func makeTestProgressSummary(
             timeZone: timeZone,
             generatedAt: generatedAtDate
         ),
-        generatedAt: generatedAt
+        generatedAt: generatedAt,
+        reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
     )
 }
 
@@ -113,11 +115,21 @@ func makeTestReviewSchedule(
     return makeReviewSchedule(
         timeZone: timeZone,
         generatedAt: generatedAt,
+        reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42),
         totalCards: buckets.reduce(0) { partialResult, bucket in
             partialResult + bucket.count
         },
         buckets: buckets
     )
+}
+
+func makeTestProgressReviewHistoryWatermarks(reviewSequenceId: Int64) -> [ProgressReviewHistoryWatermark] {
+    [
+        ProgressReviewHistoryWatermark(
+            workspaceId: "workspace-1",
+            reviewSequenceId: reviewSequenceId
+        ),
+    ]
 }
 
 func makeEmptyReviewScheduleForTests(timeZone: String) -> UserReviewSchedule {

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
@@ -28,7 +28,8 @@ final class ProgressServerValidationRefreshTests: ProgressStoreTestCase {
             to: requestRange.to,
             dailyReviews: [],
             summary: nil,
-            generatedAt: "2026-04-18T11:59:00.000Z"
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: []
         )
         let serverSummary = try makeTestProgressSummary(
             timeZone: requestRange.timeZone,
@@ -94,7 +95,8 @@ final class ProgressServerValidationRefreshTests: ProgressStoreTestCase {
                 )
             ],
             summary: nil,
-            generatedAt: "2026-04-18T11:59:00.000Z"
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: []
         )
         let serverSummary = try makeTestProgressSummary(
             timeZone: requestRange.timeZone,

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
@@ -37,7 +37,8 @@ final class ProgressSnapshotValidationTests: XCTestCase {
                     )
                 ],
                 summary: nil,
-                generatedAt: nil
+                generatedAt: nil,
+                reviewHistoryWatermarks: []
             )
 
             XCTAssertThrowsError(
@@ -77,7 +78,8 @@ final class ProgressSnapshotValidationTests: XCTestCase {
                 ProgressDay(date: "2026-02-03", reviewCount: 2),
             ],
             summary: nil,
-            generatedAt: nil
+            generatedAt: nil,
+            reviewHistoryWatermarks: []
         )
 
         XCTAssertThrowsError(
@@ -115,7 +117,8 @@ final class ProgressSnapshotValidationTests: XCTestCase {
                 ProgressDay(date: "2026-02-03", reviewCount: -1)
             ],
             summary: nil,
-            generatedAt: nil
+            generatedAt: nil,
+            reviewHistoryWatermarks: []
         )
 
         XCTAssertThrowsError(

--- a/apps/web/src/api/ApiTestSupport.ts
+++ b/apps/web/src/api/ApiTestSupport.ts
@@ -231,6 +231,9 @@ export function createProgressReviewScheduleResponseValue(): ProgressReviewSched
   return {
     timeZone: "Europe/Madrid",
     generatedAt: "2026-04-18T09:15:00.000Z",
+    reviewHistoryWatermarks: [
+      { workspaceId: "workspace-1", reviewSequenceId: 42 },
+    ],
     totalCards: 12,
     buckets: [
       { key: "new", count: 2 },

--- a/apps/web/src/api/endpoints/endpoints.test.ts
+++ b/apps/web/src/api/endpoints/endpoints.test.ts
@@ -124,6 +124,9 @@ describe("progress API endpoints", () => {
       .mockResolvedValueOnce(new Response(JSON.stringify({
         timeZone: "Europe/Madrid",
         generatedAt: "2026-04-18T09:15:00.000Z",
+        reviewHistoryWatermarks: [
+          { workspaceId: "workspace-1", reviewSequenceId: 42 },
+        ],
         summary: {
           currentStreakDays: 1,
           hasReviewedToday: true,
@@ -144,6 +147,9 @@ describe("progress API endpoints", () => {
     })).resolves.toEqual({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-18T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
       summary: {
         currentStreakDays: 1,
         hasReviewedToday: true,
@@ -160,6 +166,9 @@ describe("progress API endpoints", () => {
         from: "2026-04-01",
         to: "2026-04-03",
         generatedAt: "2026-04-18T09:15:00.000Z",
+        reviewHistoryWatermarks: [
+          { workspaceId: "workspace-1", reviewSequenceId: 42 },
+        ],
         dailyReviews: [
           {
             date: "2026-04-01",
@@ -191,6 +200,9 @@ describe("progress API endpoints", () => {
       from: "2026-04-01",
       to: "2026-04-03",
       generatedAt: "2026-04-18T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
       dailyReviews: [
         {
           date: "2026-04-01",

--- a/apps/web/src/apiContracts/progress.ts
+++ b/apps/web/src/apiContracts/progress.ts
@@ -1,4 +1,5 @@
 import type {
+  ProgressReviewHistoryWatermark,
   ProgressReviewSchedule,
   ProgressSeries,
   ProgressSummaryPayload,
@@ -30,6 +31,38 @@ function parseDailyReviewPoint(
   };
 }
 
+function parseProgressReviewHistoryWatermarkSequenceId(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ProgressReviewHistoryWatermark["reviewSequenceId"] {
+  const reviewSequenceId = parseNumber(value, endpoint, path);
+
+  if (Number.isSafeInteger(reviewSequenceId) === false || reviewSequenceId < 0) {
+    throw new ApiContractError(endpoint, describePath(path), "a non-negative safe integer");
+  }
+
+  return reviewSequenceId;
+}
+
+function parseProgressReviewHistoryWatermark(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ProgressReviewHistoryWatermark {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    workspaceId: parseRequiredField(objectValue, "workspaceId", endpoint, path, parseString),
+    reviewSequenceId: parseRequiredField(
+      objectValue,
+      "reviewSequenceId",
+      endpoint,
+      path,
+      parseProgressReviewHistoryWatermarkSequenceId,
+    ),
+  };
+}
+
 function parseProgressReviewScheduleBucketKey(
   value: unknown,
   endpoint: string,
@@ -56,6 +89,14 @@ function parseDailyReviewPointArray(
   path: string,
 ): ProgressSeries["dailyReviews"] {
   return parseArray(value, endpoint, path, parseDailyReviewPoint);
+}
+
+function parseProgressReviewHistoryWatermarkArray(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ReadonlyArray<ProgressReviewHistoryWatermark> {
+  return parseArray(value, endpoint, path, parseProgressReviewHistoryWatermark);
 }
 
 function parseProgressReviewScheduleBucketArray(
@@ -98,6 +139,13 @@ export function parseProgressSeriesResponse(value: unknown, endpoint: string): P
     from: parseRequiredField(objectValue, "from", endpoint, "", parseString),
     to: parseRequiredField(objectValue, "to", endpoint, "", parseString),
     generatedAt: parseRequiredField(objectValue, "generatedAt", endpoint, "", parseString),
+    reviewHistoryWatermarks: parseRequiredField(
+      objectValue,
+      "reviewHistoryWatermarks",
+      endpoint,
+      "",
+      parseProgressReviewHistoryWatermarkArray,
+    ),
     dailyReviews: parseRequiredField(objectValue, "dailyReviews", endpoint, "", parseDailyReviewPointArray),
   };
 }
@@ -108,6 +156,13 @@ export function parseProgressSummaryResponse(value: unknown, endpoint: string): 
   return {
     timeZone: parseRequiredField(objectValue, "timeZone", endpoint, "", parseString),
     generatedAt: parseRequiredField(objectValue, "generatedAt", endpoint, "", parseString),
+    reviewHistoryWatermarks: parseRequiredField(
+      objectValue,
+      "reviewHistoryWatermarks",
+      endpoint,
+      "",
+      parseProgressReviewHistoryWatermarkArray,
+    ),
     summary: parseRequiredField(objectValue, "summary", endpoint, "", parseProgressSummary),
   };
 }
@@ -117,6 +172,13 @@ export function parseProgressReviewScheduleResponse(value: unknown, endpoint: st
   const schedule: ProgressReviewSchedule = {
     timeZone: parseRequiredField(objectValue, "timeZone", endpoint, "", parseString),
     generatedAt: parseRequiredField(objectValue, "generatedAt", endpoint, "", parseString),
+    reviewHistoryWatermarks: parseRequiredField(
+      objectValue,
+      "reviewHistoryWatermarks",
+      endpoint,
+      "",
+      parseProgressReviewHistoryWatermarkArray,
+    ),
     totalCards: parseRequiredField(objectValue, "totalCards", endpoint, "", parseNumber),
     buckets: parseRequiredField(objectValue, "buckets", endpoint, "", parseProgressReviewScheduleBucketArray),
   };

--- a/apps/web/src/appData/progress/snapshots/progressSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSnapshots.ts
@@ -5,6 +5,7 @@ import type {
   ProgressReviewScheduleBucket,
   ProgressReviewScheduleSnapshot,
   ProgressReviewScheduleSourceState,
+  ProgressReviewHistoryWatermark,
   ProgressSeries,
   ProgressSeriesInput,
   ProgressSeriesSnapshot,
@@ -64,6 +65,7 @@ export function normalizeProgressSeries(series: ProgressSeries): ProgressSeries 
     from: series.from,
     to: series.to,
     generatedAt: series.generatedAt,
+    reviewHistoryWatermarks: series.reviewHistoryWatermarks,
     dailyReviews: expandProgressDailyReviews(input, series.dailyReviews),
   };
 }
@@ -76,6 +78,7 @@ export function createProgressSummarySnapshot(
   return {
     timeZone: payload.timeZone,
     generatedAt: payload.generatedAt,
+    reviewHistoryWatermarks: payload.reviewHistoryWatermarks,
     summary: payload.summary,
     source,
     isApproximate,
@@ -105,6 +108,7 @@ export function createProgressReviewScheduleSnapshot(
   return {
     timeZone: reviewSchedule.timeZone,
     generatedAt: reviewSchedule.generatedAt,
+    reviewHistoryWatermarks: reviewSchedule.reviewHistoryWatermarks,
     totalCards: reviewSchedule.totalCards,
     buckets: reviewSchedule.buckets,
     source,
@@ -121,6 +125,7 @@ export function buildLocalFallbackSeries(
     from: input.from,
     to: input.to,
     generatedAt: null,
+    reviewHistoryWatermarks: [],
     dailyReviews: expandProgressDailyReviews(input, dailyReviews),
   };
 }
@@ -221,6 +226,7 @@ function mergeProgressSummary(
   return {
     timeZone: serverBase.timeZone,
     generatedAt: serverBase.generatedAt,
+    reviewHistoryWatermarks: serverBase.reviewHistoryWatermarks,
     summary: {
       currentStreakDays: Math.max(
         serverBase.summary.currentStreakDays,
@@ -453,6 +459,29 @@ function areProgressSummariesEqual(left: ProgressSummary, right: ProgressSummary
     && left.activeReviewDays === right.activeReviewDays;
 }
 
+function areProgressReviewHistoryWatermarksEqual(
+  left: ReadonlyArray<ProgressReviewHistoryWatermark>,
+  right: ReadonlyArray<ProgressReviewHistoryWatermark>,
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    const leftWatermark = left[index];
+    const rightWatermark = right[index];
+
+    if (
+      leftWatermark?.workspaceId !== rightWatermark?.workspaceId
+      || leftWatermark?.reviewSequenceId !== rightWatermark?.reviewSequenceId
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function areProgressSummaryPayloadsEqual(
   left: ProgressSummaryPayload | null,
   right: ProgressSummaryPayload | null,
@@ -467,6 +496,7 @@ function areProgressSummaryPayloadsEqual(
 
   return left.timeZone === right.timeZone
     && left.generatedAt === right.generatedAt
+    && areProgressReviewHistoryWatermarksEqual(left.reviewHistoryWatermarks, right.reviewHistoryWatermarks)
     && areProgressSummariesEqual(left.summary, right.summary);
 }
 
@@ -500,6 +530,7 @@ function areProgressSeriesEqual(left: ProgressSeries | null, right: ProgressSeri
     && left.from === right.from
     && left.to === right.to
     && left.generatedAt === right.generatedAt
+    && areProgressReviewHistoryWatermarksEqual(left.reviewHistoryWatermarks, right.reviewHistoryWatermarks)
     && areDailyReviewsEqual(left.dailyReviews, right.dailyReviews);
 }
 
@@ -554,6 +585,7 @@ function areProgressReviewSchedulesEqual(
 
   return left.timeZone === right.timeZone
     && left.generatedAt === right.generatedAt
+    && areProgressReviewHistoryWatermarksEqual(left.reviewHistoryWatermarks, right.reviewHistoryWatermarks)
     && left.totalCards === right.totalCards
     && areProgressReviewScheduleBucketsEqual(left.buckets, right.buckets);
 }

--- a/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
@@ -126,7 +126,7 @@ describe("useProgressSource cache", () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     const seriesScopeKey = buildCurrentSeriesScopeKey();
     const malformedCachedSeries = {
-      version: 1,
+      version: 2,
       scopeKey: seriesScopeKey,
       savedAt: "2026-04-18T09:00:00.000Z",
       serverBase: {
@@ -134,6 +134,9 @@ describe("useProgressSource cache", () => {
         from: "not-a-local-date",
         to: currentSeriesInput.to,
         generatedAt: "2026-04-18T09:10:00.000Z",
+        reviewHistoryWatermarks: [
+          { workspaceId: "workspace-1", reviewSequenceId: 12 },
+        ],
         dailyReviews: [
           {
             date: currentSeriesInput.to,

--- a/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
@@ -98,6 +98,9 @@ describe("useProgressSource summary and series", () => {
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
       summary: {
         currentStreakDays: 1,
         hasReviewedToday: false,
@@ -110,6 +113,9 @@ describe("useProgressSource summary and series", () => {
       from: currentSeriesInput.from,
       to: currentSeriesInput.to,
       generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
       dailyReviews: [
         {
           date: currentSeriesInput.to,

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -325,6 +325,9 @@ export function buildServerSummary(activeReviewDays: number, generatedAt: string
   return {
     timeZone: "Europe/Madrid",
     generatedAt,
+    reviewHistoryWatermarks: [
+      { workspaceId: workspace.workspaceId, reviewSequenceId: activeReviewDays },
+    ],
     summary: {
       currentStreakDays: activeReviewDays,
       hasReviewedToday: true,
@@ -342,6 +345,9 @@ export function buildServerSeries(reviewCount: number, generatedAt: string): Pro
     from: input.from,
     to: input.to,
     generatedAt,
+    reviewHistoryWatermarks: [
+      { workspaceId: workspace.workspaceId, reviewSequenceId: reviewCount },
+    ],
     dailyReviews: [
       {
         date: input.to,
@@ -355,6 +361,9 @@ export function buildServerReviewSchedule(newCount: number, generatedAt: string 
   return {
     timeZone: "Europe/Madrid",
     generatedAt,
+    reviewHistoryWatermarks: [
+      { workspaceId: workspace.workspaceId, reviewSequenceId: newCount },
+    ],
     totalCards: newCount + 3,
     buckets: [
       { key: "new", count: newCount },
@@ -438,7 +447,7 @@ export function storePersistedProgressSummaryForTest(
   serverBase: ProgressSummaryPayload,
 ): void {
   window.localStorage.setItem(`flashcards-progress-server-summary:${scopeKey}`, JSON.stringify({
-    version: 1,
+    version: 2,
     scopeKey,
     savedAt: "2026-04-18T09:00:00.000Z",
     serverBase,
@@ -450,7 +459,7 @@ export function storePersistedProgressSeriesForTest(
   serverBase: ProgressSeries,
 ): void {
   window.localStorage.setItem(`flashcards-progress-server-series:${scopeKey}`, JSON.stringify({
-    version: 1,
+    version: 2,
     scopeKey,
     savedAt: "2026-04-18T09:00:00.000Z",
     serverBase,
@@ -462,7 +471,7 @@ export function storePersistedProgressReviewScheduleForTest(
   serverBase: ProgressReviewSchedule,
 ): void {
   window.localStorage.setItem(`flashcards-progress-server-review-schedule:${scopeKey}`, JSON.stringify({
-    version: 1,
+    version: 2,
     scopeKey,
     savedAt: "2026-04-18T09:00:00.000Z",
     serverBase,

--- a/apps/web/src/appData/progress/source/useProgressSource.ts
+++ b/apps/web/src/appData/progress/source/useProgressSource.ts
@@ -328,6 +328,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
         localFallback: createProgressSummarySnapshot({
           timeZone: summaryInput.timeZone,
           generatedAt: null,
+          reviewHistoryWatermarks: [],
           summary: localSummary,
         }, "local_only", true),
         hasPendingLocalReviews,

--- a/apps/web/src/appData/progress/storage/progressStorage.ts
+++ b/apps/web/src/appData/progress/storage/progressStorage.ts
@@ -1,5 +1,6 @@
 import type {
   DailyReviewPoint,
+  ProgressReviewHistoryWatermark,
   ProgressReviewSchedule,
   ProgressReviewScheduleBucket,
   ProgressScopeKey,
@@ -15,26 +16,26 @@ import { normalizeProgressSeries } from "../snapshots/progressSnapshots";
 const progressSummaryStorageKeyPrefix = "flashcards-progress-server-summary";
 const progressSeriesStorageKeyPrefix = "flashcards-progress-server-series";
 const progressReviewScheduleStorageKeyPrefix = "flashcards-progress-server-review-schedule";
-const progressServerSummaryVersion = 1;
-const progressServerSeriesVersion = 1;
-const progressServerReviewScheduleVersion = 1;
+const progressServerSummaryVersion = 2;
+const progressServerSeriesVersion = 2;
+const progressServerReviewScheduleVersion = 2;
 
 type PersistedProgressSummary = Readonly<{
-  version: 1;
+  version: 2;
   scopeKey: ProgressScopeKey;
   savedAt: string;
   serverBase: ProgressSummaryPayload;
 }>;
 
 type PersistedProgressSeries = Readonly<{
-  version: 1;
+  version: 2;
   scopeKey: ProgressScopeKey;
   savedAt: string;
   serverBase: ProgressSeries;
 }>;
 
 type PersistedProgressReviewSchedule = Readonly<{
-  version: 1;
+  version: 2;
   scopeKey: ProgressScopeKey;
   savedAt: string;
   serverBase: ProgressReviewSchedule;
@@ -57,6 +58,41 @@ const localDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && Array.isArray(value) === false;
+}
+
+function isValidProgressReviewHistoryWatermark(value: unknown): value is ProgressReviewHistoryWatermark {
+  return isRecord(value)
+    && typeof value.workspaceId === "string"
+    && typeof value.reviewSequenceId === "number"
+    && Number.isSafeInteger(value.reviewSequenceId)
+    && value.reviewSequenceId >= 0;
+}
+
+function parsePersistedProgressReviewHistoryWatermarks(
+  value: unknown,
+): ReadonlyArray<ProgressReviewHistoryWatermark> | null {
+  if (Array.isArray(value) === false) {
+    return null;
+  }
+
+  const watermarks = value
+    .map((watermark): ProgressReviewHistoryWatermark | null => {
+      if (isValidProgressReviewHistoryWatermark(watermark) === false) {
+        return null;
+      }
+
+      return {
+        workspaceId: watermark.workspaceId,
+        reviewSequenceId: watermark.reviewSequenceId,
+      };
+    })
+    .filter((watermark): watermark is ProgressReviewHistoryWatermark => watermark !== null);
+
+  if (watermarks.length !== value.length) {
+    return null;
+  }
+
+  return watermarks;
 }
 
 function isValidLocalDateValue(value: string): boolean {
@@ -254,15 +290,26 @@ function parsePersistedProgressSummary(rawValue: string | null): ProgressCacheRe
     };
   }
 
+  const reviewHistoryWatermarks = parsePersistedProgressReviewHistoryWatermarks(
+    parsedValue.serverBase.reviewHistoryWatermarks,
+  );
+  if (reviewHistoryWatermarks === null) {
+    return {
+      status: "miss",
+      reason: "invalid_shape",
+    };
+  }
+
   return {
     status: "hit",
     value: {
-      version: 1,
+      version: 2,
       scopeKey: parsedValue.scopeKey,
       savedAt: parsedValue.savedAt,
       serverBase: {
         timeZone: parsedValue.serverBase.timeZone,
         generatedAt: parsedValue.serverBase.generatedAt,
+        reviewHistoryWatermarks,
         summary: {
           currentStreakDays: parsedValue.serverBase.summary.currentStreakDays,
           hasReviewedToday: parsedValue.serverBase.summary.hasReviewedToday,
@@ -325,11 +372,22 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
     };
   }
 
+  const reviewHistoryWatermarks = parsePersistedProgressReviewHistoryWatermarks(
+    parsedValue.serverBase.reviewHistoryWatermarks,
+  );
+  if (reviewHistoryWatermarks === null) {
+    return {
+      status: "miss",
+      reason: "invalid_shape",
+    };
+  }
+
   const normalizedServerBase = normalizePersistedProgressSeries({
     timeZone: parsedValue.serverBase.timeZone,
     from: parsedValue.serverBase.from,
     to: parsedValue.serverBase.to,
     generatedAt: parsedValue.serverBase.generatedAt,
+    reviewHistoryWatermarks,
     dailyReviews,
   });
   if (normalizedServerBase.status === "miss") {
@@ -342,7 +400,7 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
   return {
     status: "hit",
     value: {
-      version: 1,
+      version: 2,
       scopeKey: parsedValue.scopeKey,
       savedAt: parsedValue.savedAt,
       serverBase: normalizedServerBase.value,
@@ -386,6 +444,16 @@ function parsePersistedProgressReviewSchedule(
     };
   }
 
+  const reviewHistoryWatermarks = parsePersistedProgressReviewHistoryWatermarks(
+    parsedValue.serverBase.reviewHistoryWatermarks,
+  );
+  if (reviewHistoryWatermarks === null) {
+    return {
+      status: "miss",
+      reason: "invalid_shape",
+    };
+  }
+
   const buckets = parsedValue.serverBase.buckets
     .map((bucket): ProgressReviewScheduleBucket | null => {
       if (
@@ -413,6 +481,7 @@ function parsePersistedProgressReviewSchedule(
   const serverBase: ProgressReviewSchedule = {
     timeZone: parsedValue.serverBase.timeZone,
     generatedAt: parsedValue.serverBase.generatedAt,
+    reviewHistoryWatermarks,
     totalCards: parsedValue.serverBase.totalCards,
     buckets,
   };
@@ -428,7 +497,7 @@ function parsePersistedProgressReviewSchedule(
   return {
     status: "hit",
     value: {
-      version: 1,
+      version: 2,
       scopeKey: parsedValue.scopeKey,
       savedAt: parsedValue.savedAt,
       serverBase,
@@ -515,7 +584,7 @@ function assertProgressReviewScheduleTimeZone(
 
 export function storePersistedProgressSummary(scopeKey: ProgressScopeKey, serverBase: ProgressSummaryPayload): void {
   const persistedValue: PersistedProgressSummary = {
-    version: 1,
+    version: 2,
     scopeKey,
     savedAt: new Date().toISOString(),
     serverBase,
@@ -526,7 +595,7 @@ export function storePersistedProgressSummary(scopeKey: ProgressScopeKey, server
 
 export function storePersistedProgressSeries(scopeKey: ProgressScopeKey, serverBase: ProgressSeries): void {
   const persistedValue: PersistedProgressSeries = {
-    version: 1,
+    version: 2,
     scopeKey,
     savedAt: new Date().toISOString(),
     serverBase: normalizeProgressSeries(serverBase),
@@ -543,7 +612,7 @@ export function storePersistedProgressReviewSchedule(
   assertProgressReviewScheduleTimeZone(serverBase, expectedTimeZone);
 
   const persistedValue: PersistedProgressReviewSchedule = {
-    version: 1,
+    version: 2,
     scopeKey,
     savedAt: new Date().toISOString(),
     serverBase,

--- a/apps/web/src/localDb/reviews/reviewSchedule.ts
+++ b/apps/web/src/localDb/reviews/reviewSchedule.ts
@@ -600,6 +600,7 @@ export async function loadLocalProgressReviewSchedule(
     return {
       timeZone: input.timeZone,
       generatedAt: null,
+      reviewHistoryWatermarks: [],
       totalCards: 0,
       buckets,
     };
@@ -612,6 +613,7 @@ export async function loadLocalProgressReviewSchedule(
     return {
       timeZone: input.timeZone,
       generatedAt: null,
+      reviewHistoryWatermarks: [],
       totalCards: sumBucketCounts(buckets),
       buckets,
     };

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -154,6 +154,7 @@ function createProgressSummarySnapshot(): ProgressSummarySnapshot {
   return {
     timeZone: "UTC",
     generatedAt: "2026-04-21T10:00:00.000Z",
+    reviewHistoryWatermarks: [],
     summary: {
       currentStreakDays: 2,
       hasReviewedToday: true,
@@ -183,6 +184,7 @@ function createProgressSeriesSnapshot(): ProgressSeriesSnapshot {
     from: "2026-04-13",
     to: "2026-04-21",
     generatedAt: "2026-04-21T10:00:00.000Z",
+    reviewHistoryWatermarks: [],
     dailyReviews,
     chartData: {
       dailyReviews,
@@ -196,6 +198,7 @@ function createReviewScheduleSnapshot(): ProgressReviewScheduleSnapshot {
   return {
     timeZone: "UTC",
     generatedAt: "2026-04-21T10:00:00.000Z",
+    reviewHistoryWatermarks: [],
     totalCards: 10,
     buckets: [
       { key: "new", count: 2 },

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -112,6 +112,11 @@ export type ProgressSummary = Readonly<{
   activeReviewDays: number;
 }>;
 
+export type ProgressReviewHistoryWatermark = Readonly<{
+  workspaceId: string;
+  reviewSequenceId: number;
+}>;
+
 export type ReviewProgressBadgeState = Readonly<{
   streakDays: number;
   hasReviewedToday: boolean;
@@ -125,6 +130,7 @@ export type ProgressChartData = Readonly<{
 export type ProgressSummaryPayload = Readonly<{
   timeZone: string;
   generatedAt: string | null;
+  reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark>;
   summary: ProgressSummary;
 }>;
 
@@ -133,6 +139,7 @@ export type ProgressSeries = Readonly<{
   from: string;
   to: string;
   generatedAt: string | null;
+  reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark>;
   dailyReviews: ReadonlyArray<DailyReviewPoint>;
 }>;
 
@@ -158,6 +165,7 @@ export type ProgressReviewScheduleBucket = Readonly<{
 export type ProgressReviewSchedule = Readonly<{
   timeZone: string;
   generatedAt: string | null;
+  reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark>;
   totalCards: number;
   buckets: ReadonlyArray<ProgressReviewScheduleBucket>;
 }>;


### PR DESCRIPTION
## Summary
- add review-history watermarks to progress summary, series, and review-schedule responses
- read progress aggregates and watermarks inside a repeatable-read backend snapshot
- keep web, iOS, and Android progress parsing/cache paths aligned with the additive field

## Validation
- git --no-pager diff --check
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend
- npm run build --prefix apps/web
- npx vitest run src/api/endpoints/endpoints.test.ts src/appData/progress/source/progressSource.summarySeries.test.tsx src/appData/progress/source/progressSource.cache.test.tsx src/screens/progress/ProgressScreen.render.test.tsx (apps/web)

## Not run
- Android Gradle checks, per repo policy requiring explicit permission
- iOS simulator-backed checks, per repo policy requiring explicit permission