### PR TITLE
Fix Android progress series local merge

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotCalculations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotCalculations.kt
@@ -303,20 +303,24 @@ internal fun createProgressSeriesSnapshot(
     pendingLocalOverlay: CloudProgressSeries,
     cloudState: CloudAccountState
 ): ProgressSeriesSnapshot {
-    val hasPendingLocalOverlay = pendingLocalOverlay.dailyReviews.any { point ->
-        point.reviewCount > 0
-    }
     val renderedSeries = if (serverBase == null) {
         localFallback
     } else {
         mergeProgressSeries(
             base = serverBase,
-            overlay = pendingLocalOverlay
+            pendingLocalOverlay = pendingLocalOverlay,
+            localFallback = localFallback
         )
     }
+    val hasLocalOverlay = serverBase?.let { base ->
+        hasProgressSeriesOverlay(
+            base = base,
+            renderedSeries = renderedSeries
+        )
+    } ?: false
     val source = when {
         serverBase == null -> ProgressSnapshotSource.LOCAL_ONLY
-        hasPendingLocalOverlay -> ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY
+        hasLocalOverlay -> ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY
         else -> ProgressSnapshotSource.SERVER_BASE
     }
     return ProgressSeriesSnapshot(
@@ -327,7 +331,7 @@ internal fun createProgressSeriesSnapshot(
         pendingLocalOverlay = pendingLocalOverlay,
         source = source,
         isApproximate = source == ProgressSnapshotSource.LOCAL_ONLY ||
-            hasPendingLocalOverlay ||
+            hasLocalOverlay ||
             cloudState == CloudAccountState.DISCONNECTED ||
             cloudState == CloudAccountState.LINKING_READY
     )
@@ -405,15 +409,24 @@ internal fun mergeProgressSummary(
 
 internal fun mergeProgressSeries(
     base: CloudProgressSeries,
-    overlay: CloudProgressSeries
+    pendingLocalOverlay: CloudProgressSeries,
+    localFallback: CloudProgressSeries
 ): CloudProgressSeries {
-    val overlayCountsByDate = overlay.dailyReviews.associate { point ->
-        point.date to point.reviewCount
-    }
+    validateProgressSeriesMergeInputs(
+        base = base,
+        pendingLocalOverlay = pendingLocalOverlay,
+        localFallback = localFallback
+    )
+    val pendingCountsByDate = buildProgressSeriesReviewCountsByDate(series = pendingLocalOverlay)
+    val localFallbackCountsByDate = buildProgressSeriesReviewCountsByDate(series = localFallback)
     val mergedDailyReviews = base.dailyReviews.map { point ->
+        val serverPlusPending = point.reviewCount + (pendingCountsByDate[point.date] ?: 0)
         CloudDailyReviewPoint(
             date = point.date,
-            reviewCount = point.reviewCount + (overlayCountsByDate[point.date] ?: 0)
+            reviewCount = maxOf(
+                serverPlusPending,
+                localFallbackCountsByDate[point.date] ?: 0
+            )
         )
     }
     return CloudProgressSeries(
@@ -425,6 +438,73 @@ internal fun mergeProgressSeries(
         reviewHistoryWatermarks = base.reviewHistoryWatermarks,
         summary = null
     )
+}
+
+private fun validateProgressSeriesMergeInputs(
+    base: CloudProgressSeries,
+    pendingLocalOverlay: CloudProgressSeries,
+    localFallback: CloudProgressSeries
+) {
+    validateProgressSeriesMergeInput(
+        base = base,
+        candidate = pendingLocalOverlay,
+        candidateName = "pendingLocalOverlay"
+    )
+    validateProgressSeriesMergeInput(
+        base = base,
+        candidate = localFallback,
+        candidateName = "localFallback"
+    )
+}
+
+private fun validateProgressSeriesMergeInput(
+    base: CloudProgressSeries,
+    candidate: CloudProgressSeries,
+    candidateName: String
+) {
+    val mismatches: List<String> = buildList {
+        if (base.timeZone != candidate.timeZone) {
+            add("timeZone base='${base.timeZone}' $candidateName='${candidate.timeZone}'")
+        }
+        if (base.from != candidate.from) {
+            add("from base='${base.from}' $candidateName='${candidate.from}'")
+        }
+        if (base.to != candidate.to) {
+            add("to base='${base.to}' $candidateName='${candidate.to}'")
+        }
+    }
+    if (mismatches.isEmpty()) {
+        return
+    }
+
+    throw IllegalArgumentException(
+        "Progress series merge inputs must share the same scope. " +
+            "Mismatches: ${mismatches.joinToString(separator = "; ")}."
+    )
+}
+
+private fun buildProgressSeriesReviewCountsByDate(
+    series: CloudProgressSeries
+): Map<String, Int> {
+    val reviewCountsByDate = linkedMapOf<String, Int>()
+    series.dailyReviews.forEach { point ->
+        reviewCountsByDate[point.date] = (reviewCountsByDate[point.date] ?: 0) + point.reviewCount
+    }
+    return reviewCountsByDate
+}
+
+private fun hasProgressSeriesOverlay(
+    base: CloudProgressSeries,
+    renderedSeries: CloudProgressSeries
+): Boolean {
+    if (base.dailyReviews.size != renderedSeries.dailyReviews.size) {
+        return true
+    }
+
+    return base.dailyReviews.zip(renderedSeries.dailyReviews).any { pair ->
+        pair.first.date != pair.second.date ||
+            pair.first.reviewCount != pair.second.reviewCount
+    }
 }
 
 internal fun createReviewHistoryFingerprint(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
@@ -3,6 +3,7 @@ package com.flashcardsopensourceapp.data.local.repository.progress.snapshots
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
 import com.flashcardsopensourceapp.data.local.repository.progress.createCloudSettings
 import com.flashcardsopensourceapp.data.local.repository.progress.createPendingReviewOutboxEntry
@@ -11,6 +12,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class ProgressSeriesSnapshotTest {
@@ -55,46 +57,34 @@ class ProgressSeriesSnapshotTest {
 
     @Test
     fun pendingOverlayCountsUnsyncedLocalReviewsDirectly() {
-        val scopeKey = createProgressSeriesScopeKey(
-            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
-            today = LocalDate.parse("2026-04-18"),
-            zoneId = ZoneId.of("Europe/Madrid")
-        )
-        val localFallback = CloudProgressSeries(
-            timeZone = scopeKey.timeZone,
-            from = scopeKey.from,
-            to = scopeKey.to,
+        val scopeKey = createLinkedProgressSeriesScopeKey()
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
             dailyReviews = listOf(
-                CloudDailyReviewPoint(
-                    date = "2026-04-17",
-                    reviewCount = 5
-                ),
-                CloudDailyReviewPoint(
-                    date = "2026-04-18",
-                    reviewCount = 1
-                )
-            ),
-            generatedAt = null,
-            reviewHistoryWatermarks = emptyList(),
-            summary = null
-        )
-        val serverBase = CloudProgressSeries(
-            timeZone = scopeKey.timeZone,
-            from = scopeKey.from,
-            to = scopeKey.to,
-            dailyReviews = listOf(
-                CloudDailyReviewPoint(
+                createPoint(
                     date = "2026-04-17",
                     reviewCount = 3
                 ),
-                CloudDailyReviewPoint(
+                createPoint(
                     date = "2026-04-18",
                     reviewCount = 2
                 )
             ),
-            generatedAt = "2026-04-18T12:00:00Z",
-            reviewHistoryWatermarks = emptyList(),
-            summary = null
+            generatedAt = null
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-17",
+                    reviewCount = 3
+                ),
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 2
+                )
+            ),
+            generatedAt = "2026-04-18T12:00:00Z"
         )
 
         val overlay = createPendingLocalOverlaySeries(
@@ -129,6 +119,245 @@ class ProgressSeriesSnapshotTest {
     }
 
     @Test
+    fun staleServerBaseRendersAckedCanonicalLocalReview() {
+        val scopeKey = createLinkedProgressSeriesScopeKey()
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 1
+                )
+            ),
+            generatedAt = null
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 0
+                )
+            ),
+            generatedAt = "2026-04-18T12:00:00Z"
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 0
+                )
+            ),
+            generatedAt = null
+        )
+
+        val snapshot = createProgressSeriesSnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            serverBase = serverBase,
+            pendingLocalOverlay = pendingLocalOverlay,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(1, snapshot.renderedSeries.dailyReviews.single().reviewCount)
+        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(true, snapshot.isApproximate)
+        assertEquals("2026-04-18T12:00:00Z", snapshot.renderedSeries.generatedAt)
+        assertEquals(null, snapshot.renderedSeries.summary)
+    }
+
+    @Test
+    fun serverCatchUpDoesNotDoubleCountCanonicalLocalReview() {
+        val scopeKey = createLinkedProgressSeriesScopeKey()
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 1
+                )
+            ),
+            generatedAt = null
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 1
+                )
+            ),
+            generatedAt = "2026-04-18T12:00:00Z"
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 0
+                )
+            ),
+            generatedAt = null
+        )
+
+        val snapshot = createProgressSeriesSnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            serverBase = serverBase,
+            pendingLocalOverlay = pendingLocalOverlay,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(1, snapshot.renderedSeries.dailyReviews.single().reviewCount)
+        assertEquals(ProgressSnapshotSource.SERVER_BASE, snapshot.source)
+        assertEquals(false, snapshot.isApproximate)
+    }
+
+    @Test
+    fun mixedServerPendingAndCanonicalLocalCountsUseLargestSafeCount() {
+        val scopeKey = createLinkedProgressSeriesScopeKey()
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 2
+                )
+            ),
+            generatedAt = null
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 2
+                )
+            ),
+            generatedAt = "2026-04-18T12:00:00Z"
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 1
+                )
+            ),
+            generatedAt = null
+        )
+
+        val snapshot = createProgressSeriesSnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            serverBase = serverBase,
+            pendingLocalOverlay = pendingLocalOverlay,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(3, snapshot.renderedSeries.dailyReviews.single().reviewCount)
+        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(true, snapshot.isApproximate)
+    }
+
+    @Test
+    fun serverBaseSourceWhenLocalFallbackIsNotAheadAndPendingOverlayIsEmpty() {
+        val scopeKey = createLinkedProgressSeriesScopeKey()
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 1
+                )
+            ),
+            generatedAt = null
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 2
+                )
+            ),
+            generatedAt = "2026-04-18T12:00:00Z"
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 0
+                )
+            ),
+            generatedAt = null
+        )
+
+        val snapshot = createProgressSeriesSnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            serverBase = serverBase,
+            pendingLocalOverlay = pendingLocalOverlay,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(2, snapshot.renderedSeries.dailyReviews.single().reviewCount)
+        assertEquals(ProgressSnapshotSource.SERVER_BASE, snapshot.source)
+        assertEquals(false, snapshot.isApproximate)
+    }
+
+    @Test
+    fun seriesMergeRequiresMatchingScopes() {
+        val scopeKey = createLinkedProgressSeriesScopeKey()
+        val base = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 1
+                )
+            ),
+            generatedAt = "2026-04-18T12:00:00Z"
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey.copy(timeZone = "UTC"),
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 0
+                )
+            ),
+            generatedAt = null
+        )
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(
+                    date = "2026-04-18",
+                    reviewCount = 1
+                )
+            ),
+            generatedAt = null
+        )
+
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            mergeProgressSeries(
+                base = base,
+                pendingLocalOverlay = pendingLocalOverlay,
+                localFallback = localFallback
+            )
+        }
+
+        assertEquals(
+            "Progress series merge inputs must share the same scope. " +
+                "Mismatches: timeZone base='Europe/Madrid' pendingLocalOverlay='UTC'.",
+            error.message
+        )
+    }
+
+    @Test
     fun invalidPendingReviewOutboxEntryIsSkippedFromOverlay() {
         val scopeKey = createProgressSeriesScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
@@ -160,6 +389,40 @@ class ProgressSeriesSnapshotTest {
         assertEquals(
             1,
             overlay.dailyReviews.last { point -> point.date == scopeKey.to }.reviewCount
+        )
+    }
+
+    private fun createLinkedProgressSeriesScopeKey(): ProgressSeriesScopeKey {
+        return createProgressSeriesScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+    }
+
+    private fun createSeries(
+        scopeKey: ProgressSeriesScopeKey,
+        dailyReviews: List<CloudDailyReviewPoint>,
+        generatedAt: String?
+    ): CloudProgressSeries {
+        return CloudProgressSeries(
+            timeZone = scopeKey.timeZone,
+            from = scopeKey.from,
+            to = scopeKey.to,
+            dailyReviews = dailyReviews,
+            generatedAt = generatedAt,
+            reviewHistoryWatermarks = emptyList(),
+            summary = null
+        )
+    }
+
+    private fun createPoint(
+        date: String,
+        reviewCount: Int
+    ): CloudDailyReviewPoint {
+        return CloudDailyReviewPoint(
+            date = date,
+            reviewCount = reviewCount
         )
     }
 }


### PR DESCRIPTION
## Summary

- merge Android progress series with pending outbox counts and canonical local fallback counts
- mark series snapshots as overlay only when rendered counts differ from server base
- add focused progress series tests for stale server, pending, catch-up, mixed, and validation cases

## Validation

- `git --no-pager diff --check HEAD~1 HEAD`

Gradle was not run because repository instructions require explicit approval for local Gradle runs.