### PR TITLE
[codex] Make progress watermarks optional in clients

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -57,31 +57,9 @@ internal class CloudProgressRemoteApi(
             ),
             authorizationHeader = authorizationHeader
         )
-        val dailyReviews = response.requireCloudArray("dailyReviews", "progress.dailyReviews")
-
-        return CloudProgressSeries(
-            timeZone = response.requireCloudString("timeZone", "progress.timeZone"),
-            from = response.requireCloudString("from", "progress.from"),
-            to = response.requireCloudString("to", "progress.to"),
-            dailyReviews = buildList {
-                for (index in 0 until dailyReviews.length()) {
-                    val point = dailyReviews.requireCloudObject(index, "progress.dailyReviews[$index]")
-                    add(
-                        CloudDailyReviewPoint(
-                            date = point.requireCloudString("date", "progress.dailyReviews[$index].date"),
-                            reviewCount = point.requireCloudInt(
-                                "reviewCount",
-                                "progress.dailyReviews[$index].reviewCount"
-                            )
-                        )
-                    )
-                }
-            },
-            generatedAt = response.optCloudStringOrNull("generatedAt", "progress.generatedAt"),
-            reviewHistoryWatermarks = response.requireProgressReviewHistoryWatermarks(
-                fieldPath = "progress"
-            ),
-            summary = null
+        return parseCloudProgressSeriesResponse(
+            response = response,
+            fieldPath = "progress"
         )
     }
 
@@ -112,6 +90,38 @@ internal fun parseCloudProgressSummaryResponse(
     return response.requireCloudObject("summary", "$fieldPath.summary").toCloudProgressSummary(
         fieldPath = "$fieldPath.summary",
         reviewHistoryWatermarks = reviewHistoryWatermarks
+    )
+}
+
+internal fun parseCloudProgressSeriesResponse(
+    response: JSONObject,
+    fieldPath: String
+): CloudProgressSeries {
+    val dailyReviews = response.requireCloudArray("dailyReviews", "$fieldPath.dailyReviews")
+
+    return CloudProgressSeries(
+        timeZone = response.requireCloudString("timeZone", "$fieldPath.timeZone"),
+        from = response.requireCloudString("from", "$fieldPath.from"),
+        to = response.requireCloudString("to", "$fieldPath.to"),
+        dailyReviews = buildList {
+            for (index in 0 until dailyReviews.length()) {
+                val point = dailyReviews.requireCloudObject(index, "$fieldPath.dailyReviews[$index]")
+                add(
+                    CloudDailyReviewPoint(
+                        date = point.requireCloudString("date", "$fieldPath.dailyReviews[$index].date"),
+                        reviewCount = point.requireCloudInt(
+                            "reviewCount",
+                            "$fieldPath.dailyReviews[$index].reviewCount"
+                        )
+                    )
+                )
+            }
+        },
+        generatedAt = response.optCloudStringOrNull("generatedAt", "$fieldPath.generatedAt"),
+        reviewHistoryWatermarks = response.requireProgressReviewHistoryWatermarks(
+            fieldPath = fieldPath
+        ),
+        summary = null
     )
 }
 
@@ -191,6 +201,10 @@ internal fun parseCloudProgressReviewScheduleResponse(
 private fun JSONObject.requireProgressReviewHistoryWatermarks(
     fieldPath: String
 ): List<ProgressReviewHistoryWatermark> {
+    if (has("reviewHistoryWatermarks").not()) {
+        return emptyList()
+    }
+
     val watermarksArray = requireCloudArray("reviewHistoryWatermarks", "$fieldPath.reviewHistoryWatermarks")
     return buildList {
         for (index in 0 until watermarksArray.length()) {

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -3,6 +3,7 @@ package com.flashcardsopensourceapp.data.local.cloud.remote
 import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.cloud.remote.guest.buildGuestUpgradeCompleteRequest
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressReviewScheduleResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSeriesResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSummaryResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.parseRemotePushResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.parseCloudErrorPayload
@@ -87,6 +88,31 @@ class CloudRemoteServiceTest {
         assertEquals(42L, summary.reviewHistoryWatermarks.single().reviewSequenceId)
     }
 
+    @Test
+    fun parseCloudProgressSummaryResponseAcceptsMissingReviewHistoryWatermarks() {
+        val response = JSONObject(
+            """
+            {
+              "timeZone": "Europe/Madrid",
+              "summary": {
+                "currentStreakDays": 8,
+                "hasReviewedToday": true,
+                "lastReviewedOn": "2026-04-18",
+                "activeReviewDays": 21
+              },
+              "generatedAt": "2026-04-18T12:00:00Z"
+            }
+            """.trimIndent()
+        )
+
+        val summary = parseCloudProgressSummaryResponse(
+            response = response,
+            fieldPath = "progressSummary"
+        )
+
+        assertTrue(summary.reviewHistoryWatermarks.isEmpty())
+    }
+
     @Test(expected = CloudContractMismatchException::class)
     fun parseCloudProgressSummaryResponseRequiresNestedSummaryObject() {
         val response = JSONObject(
@@ -109,6 +135,61 @@ class CloudRemoteServiceTest {
             response = response,
             fieldPath = "progressSummary"
         )
+    }
+
+    @Test
+    fun parseCloudProgressSeriesResponseReadsWatermarks() {
+        val response = JSONObject(
+            """
+            {
+              "timeZone": "Europe/Madrid",
+              "from": "2026-04-01",
+              "to": "2026-04-03",
+              "dailyReviews": [
+                { "date": "2026-04-01", "reviewCount": 3 }
+              ],
+              "reviewHistoryWatermarks": [
+                { "workspaceId": "workspace-1", "reviewSequenceId": 42 }
+              ],
+              "generatedAt": "2026-04-18T12:00:00Z"
+            }
+            """.trimIndent()
+        )
+
+        val series = parseCloudProgressSeriesResponse(
+            response = response,
+            fieldPath = "progress"
+        )
+
+        assertEquals("Europe/Madrid", series.timeZone)
+        assertEquals("2026-04-01", series.from)
+        assertEquals("2026-04-03", series.to)
+        assertEquals(3, series.dailyReviews.single().reviewCount)
+        assertEquals(42L, series.reviewHistoryWatermarks.single().reviewSequenceId)
+    }
+
+    @Test
+    fun parseCloudProgressSeriesResponseAcceptsMissingReviewHistoryWatermarks() {
+        val response = JSONObject(
+            """
+            {
+              "timeZone": "Europe/Madrid",
+              "from": "2026-04-01",
+              "to": "2026-04-03",
+              "dailyReviews": [
+                { "date": "2026-04-01", "reviewCount": 3 }
+              ],
+              "generatedAt": "2026-04-18T12:00:00Z"
+            }
+            """.trimIndent()
+        )
+
+        val series = parseCloudProgressSeriesResponse(
+            response = response,
+            fieldPath = "progress"
+        )
+
+        assertTrue(series.reviewHistoryWatermarks.isEmpty())
     }
 
     @Test
@@ -146,6 +227,96 @@ class CloudRemoteServiceTest {
         assertEquals(42L, schedule.reviewHistoryWatermarks.single().reviewSequenceId)
         assertEquals(8, schedule.totalCards)
         assertEquals(ProgressReviewScheduleBucketKey.orderedEntries, schedule.buckets.map { bucket -> bucket.key })
+    }
+
+    @Test
+    fun parseCloudProgressReviewScheduleResponseAcceptsMissingReviewHistoryWatermarks() {
+        val response = JSONObject(
+            """
+            {
+              "timeZone": "Europe/Madrid",
+              "generatedAt": "2026-05-03T12:00:00Z",
+              "totalCards": 8,
+              "buckets": [
+                { "key": "new", "count": 1 },
+                { "key": "today", "count": 1 },
+                { "key": "days1To7", "count": 1 },
+                { "key": "days8To30", "count": 1 },
+                { "key": "days31To90", "count": 1 },
+                { "key": "days91To360", "count": 1 },
+                { "key": "years1To2", "count": 1 },
+                { "key": "later", "count": 1 }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val schedule = parseCloudProgressReviewScheduleResponse(
+            response = response,
+            fieldPath = "progress.reviewSchedule"
+        )
+
+        assertTrue(schedule.reviewHistoryWatermarks.isEmpty())
+    }
+
+    @Test
+    fun parseCloudProgressSummaryResponseRejectsNegativeReviewHistoryWatermarkSequenceId() {
+        val response = JSONObject(
+            """
+            {
+              "timeZone": "Europe/Madrid",
+              "summary": {
+                "currentStreakDays": 8,
+                "hasReviewedToday": true,
+                "lastReviewedOn": "2026-04-18",
+                "activeReviewDays": 21
+              },
+              "reviewHistoryWatermarks": [
+                { "workspaceId": "workspace-1", "reviewSequenceId": -1 }
+              ],
+              "generatedAt": "2026-04-18T12:00:00Z"
+            }
+            """.trimIndent()
+        )
+
+        val error = assertThrows(CloudContractMismatchException::class.java) {
+            parseCloudProgressSummaryResponse(
+                response = response,
+                fieldPath = "progressSummary"
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("progressSummary.reviewHistoryWatermarks[0].reviewSequenceId"))
+    }
+
+    @Test
+    fun parseCloudProgressSummaryResponseRejectsMalformedReviewHistoryWatermarkItem() {
+        val response = JSONObject(
+            """
+            {
+              "timeZone": "Europe/Madrid",
+              "summary": {
+                "currentStreakDays": 8,
+                "hasReviewedToday": true,
+                "lastReviewedOn": "2026-04-18",
+                "activeReviewDays": 21
+              },
+              "reviewHistoryWatermarks": [
+                "not-an-object"
+              ],
+              "generatedAt": "2026-04-18T12:00:00Z"
+            }
+            """.trimIndent()
+        )
+
+        val error = assertThrows(CloudContractMismatchException::class.java) {
+            parseCloudProgressSummaryResponse(
+                response = response,
+                fieldPath = "progressSummary"
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("progressSummary.reviewHistoryWatermarks[0]"))
     }
 
     @Test(expected = CloudContractMismatchException::class)

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressTypes.swift
@@ -56,6 +56,17 @@ struct ProgressReviewHistoryWatermark: Codable, Hashable, Sendable {
     }
 }
 
+private func decodeProgressReviewHistoryWatermarksIfAvailable<Key: CodingKey>(
+    container: KeyedDecodingContainer<Key>,
+    key: Key
+) throws -> [ProgressReviewHistoryWatermark] {
+    guard container.contains(key) else {
+        return []
+    }
+
+    return try container.decode([ProgressReviewHistoryWatermark].self, forKey: key)
+}
+
 struct UserProgressSummary: Codable, Hashable, Sendable {
     let timeZone: String?
     let summary: ProgressSummary
@@ -92,9 +103,9 @@ struct UserProgressSummary: Codable, Hashable, Sendable {
                 timeZone: try container.decodeIfPresent(String.self, forKey: .timeZone),
                 summary: try container.decode(ProgressSummary.self, forKey: .summary),
                 generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt),
-                reviewHistoryWatermarks: try container.decode(
-                    [ProgressReviewHistoryWatermark].self,
-                    forKey: .reviewHistoryWatermarks
+                reviewHistoryWatermarks: try decodeProgressReviewHistoryWatermarksIfAvailable(
+                    container: container,
+                    key: .reviewHistoryWatermarks
                 )
             )
             return
@@ -109,9 +120,9 @@ struct UserProgressSummary: Codable, Hashable, Sendable {
                 activeReviewDays: try container.decode(Int.self, forKey: .activeReviewDays)
             ),
             generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt),
-            reviewHistoryWatermarks: try container.decode(
-                [ProgressReviewHistoryWatermark].self,
-                forKey: .reviewHistoryWatermarks
+            reviewHistoryWatermarks: try decodeProgressReviewHistoryWatermarksIfAvailable(
+                container: container,
+                key: .reviewHistoryWatermarks
             )
         )
     }
@@ -134,6 +145,16 @@ struct UserProgressSeries: Codable, Hashable, Sendable {
     let generatedAt: String?
     let reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
 
+    enum CodingKeys: String, CodingKey {
+        case timeZone
+        case from
+        case to
+        case dailyReviews
+        case summary
+        case generatedAt
+        case reviewHistoryWatermarks
+    }
+
     init(
         timeZone: String,
         from: String,
@@ -150,6 +171,22 @@ struct UserProgressSeries: Codable, Hashable, Sendable {
         self.summary = summary
         self.generatedAt = generatedAt
         self.reviewHistoryWatermarks = reviewHistoryWatermarks
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            timeZone: try container.decode(String.self, forKey: .timeZone),
+            from: try container.decode(String.self, forKey: .from),
+            to: try container.decode(String.self, forKey: .to),
+            dailyReviews: try container.decode([ProgressDay].self, forKey: .dailyReviews),
+            summary: try container.decodeIfPresent(ProgressSummary.self, forKey: .summary),
+            generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt),
+            reviewHistoryWatermarks: try decodeProgressReviewHistoryWatermarksIfAvailable(
+                container: container,
+                key: .reviewHistoryWatermarks
+            )
+        )
     }
 }
 
@@ -194,6 +231,42 @@ struct UserReviewSchedule: Codable, Hashable, Sendable {
     let reviewHistoryWatermarks: [ProgressReviewHistoryWatermark]
     let totalCards: Int
     let buckets: [ReviewScheduleBucket]
+
+    enum CodingKeys: String, CodingKey {
+        case timeZone
+        case generatedAt
+        case reviewHistoryWatermarks
+        case totalCards
+        case buckets
+    }
+
+    init(
+        timeZone: String,
+        generatedAt: String?,
+        reviewHistoryWatermarks: [ProgressReviewHistoryWatermark],
+        totalCards: Int,
+        buckets: [ReviewScheduleBucket]
+    ) {
+        self.timeZone = timeZone
+        self.generatedAt = generatedAt
+        self.reviewHistoryWatermarks = reviewHistoryWatermarks
+        self.totalCards = totalCards
+        self.buckets = buckets
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            timeZone: try container.decode(String.self, forKey: .timeZone),
+            generatedAt: try container.decodeIfPresent(String.self, forKey: .generatedAt),
+            reviewHistoryWatermarks: try decodeProgressReviewHistoryWatermarksIfAvailable(
+                container: container,
+                key: .reviewHistoryWatermarks
+            ),
+            totalCards: try container.decode(Int.self, forKey: .totalCards),
+            buckets: try container.decode([ReviewScheduleBucket].self, forKey: .buckets)
+        )
+    }
 }
 
 enum ProgressSourceState: String, Codable, Hashable, Sendable {

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
@@ -3,6 +3,91 @@ import XCTest
 @testable import Flashcards
 
 final class ProgressSnapshotValidationTests: XCTestCase {
+    func testProgressSummaryDecodesMissingReviewHistoryWatermarksAsEmpty() throws {
+        let json = """
+        {
+          "timeZone": "Europe/Madrid",
+          "generatedAt": "2026-04-18T09:15:00.000Z",
+          "summary": {
+            "currentStreakDays": 1,
+            "hasReviewedToday": true,
+            "lastReviewedOn": "2026-04-03",
+            "activeReviewDays": 2
+          }
+        }
+        """
+
+        let summary = try JSONDecoder().decode(UserProgressSummary.self, from: Data(json.utf8))
+
+        XCTAssertTrue(summary.reviewHistoryWatermarks.isEmpty)
+    }
+
+    func testProgressSeriesDecodesMissingReviewHistoryWatermarksAsEmpty() throws {
+        let json = """
+        {
+          "timeZone": "Europe/Madrid",
+          "from": "2026-04-01",
+          "to": "2026-04-03",
+          "dailyReviews": [
+            {
+              "date": "2026-04-01",
+              "reviewCount": 3
+            }
+          ],
+          "generatedAt": "2026-04-18T09:15:00.000Z"
+        }
+        """
+
+        let series = try JSONDecoder().decode(UserProgressSeries.self, from: Data(json.utf8))
+
+        XCTAssertTrue(series.reviewHistoryWatermarks.isEmpty)
+    }
+
+    func testReviewScheduleDecodesMissingReviewHistoryWatermarksAsEmpty() throws {
+        let json = """
+        {
+          "timeZone": "Europe/Madrid",
+          "generatedAt": "2026-05-03T12:00:00.000Z",
+          "totalCards": 1,
+          "buckets": [
+            {
+              "key": "new",
+              "count": 1
+            }
+          ]
+        }
+        """
+
+        let schedule = try JSONDecoder().decode(UserReviewSchedule.self, from: Data(json.utf8))
+
+        XCTAssertTrue(schedule.reviewHistoryWatermarks.isEmpty)
+    }
+
+    func testProgressSummaryDecodingRejectsNegativeReviewHistoryWatermarkSequenceId() throws {
+        let json = """
+        {
+          "timeZone": "Europe/Madrid",
+          "generatedAt": "2026-04-18T09:15:00.000Z",
+          "reviewHistoryWatermarks": [
+            {
+              "workspaceId": "workspace-1",
+              "reviewSequenceId": -1
+            }
+          ],
+          "summary": {
+            "currentStreakDays": 1,
+            "hasReviewedToday": true,
+            "lastReviewedOn": "2026-04-03",
+            "activeReviewDays": 2
+          }
+        }
+        """
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(UserProgressSummary.self, from: Data(json.utf8))
+        )
+    }
+
     func testProgressSnapshotRejectsInvalidDailyReviewDates() throws {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))

--- a/apps/web/src/api/endpoints/endpoints.test.ts
+++ b/apps/web/src/api/endpoints/endpoints.test.ts
@@ -159,6 +159,41 @@ describe("progress API endpoints", () => {
     });
   });
 
+  it("decodes progress summary responses without review-history watermark metadata", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        timeZone: "Europe/Madrid",
+        generatedAt: "2026-04-18T09:15:00.000Z",
+        summary: {
+          currentStreakDays: 1,
+          hasReviewedToday: true,
+          lastReviewedOn: "2026-04-03",
+          activeReviewDays: 2,
+        },
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressSummary({
+      timeZone: "Europe/Madrid",
+      today: "2026-04-18",
+    })).resolves.toEqual({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-18T09:15:00.000Z",
+      reviewHistoryWatermarks: [],
+      summary: {
+        currentStreakDays: 1,
+        hasReviewedToday: true,
+        lastReviewedOn: "2026-04-03",
+        activeReviewDays: 2,
+      },
+    });
+  });
+
   it("decodes progress series responses without summary metadata", async () => {
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(new Response(JSON.stringify({
@@ -220,6 +255,62 @@ describe("progress API endpoints", () => {
     });
   });
 
+  it("decodes progress series responses without review-history watermark metadata", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        timeZone: "Europe/Madrid",
+        from: "2026-04-01",
+        to: "2026-04-03",
+        generatedAt: "2026-04-18T09:15:00.000Z",
+        dailyReviews: [
+          {
+            date: "2026-04-01",
+            reviewCount: 3,
+          },
+          {
+            date: "2026-04-02",
+            reviewCount: 0,
+          },
+          {
+            date: "2026-04-03",
+            reviewCount: 1,
+          },
+        ],
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressSeries({
+      timeZone: "Europe/Madrid",
+      from: "2026-04-01",
+      to: "2026-04-03",
+    })).resolves.toEqual({
+      timeZone: "Europe/Madrid",
+      from: "2026-04-01",
+      to: "2026-04-03",
+      generatedAt: "2026-04-18T09:15:00.000Z",
+      reviewHistoryWatermarks: [],
+      dailyReviews: [
+        {
+          date: "2026-04-01",
+          reviewCount: 3,
+        },
+        {
+          date: "2026-04-02",
+          reviewCount: 0,
+        },
+        {
+          date: "2026-04-03",
+          reviewCount: 1,
+        },
+      ],
+    });
+  });
+
   it("decodes review schedule responses and sends only the timezone query", async () => {
     const responseValue = createProgressReviewScheduleResponseValue();
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
@@ -235,6 +326,27 @@ describe("progress API endpoints", () => {
       "http://localhost:8080/v1/me/progress/review-schedule?timeZone=Europe%2FMadrid",
       expect.objectContaining({ method: "GET" }),
     );
+  });
+
+  it("decodes review schedule responses without review-history watermark metadata", async () => {
+    const baseResponse = createProgressReviewScheduleResponseValue();
+    const responseWithoutWatermarks = {
+      timeZone: baseResponse.timeZone,
+      generatedAt: baseResponse.generatedAt,
+      totalCards: baseResponse.totalCards,
+      buckets: baseResponse.buckets,
+    };
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(createJsonResponse(responseWithoutWatermarks));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressReviewSchedule({
+      timeZone: "Europe/Madrid",
+      today: "2026-04-18",
+    })).resolves.toEqual({
+      ...baseResponse,
+      reviewHistoryWatermarks: [],
+    });
   });
 
   const invalidProgressReviewScheduleCases: ReadonlyArray<Readonly<{
@@ -393,6 +505,34 @@ describe("progress API endpoints", () => {
       to: "2026-04-03",
     })).rejects.toThrow(
       "Invalid API response for GET /me/progress/series: generatedAt must be string",
+    );
+  });
+
+  it("rejects progress summary responses with malformed review-history watermark metadata", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        timeZone: "Europe/Madrid",
+        generatedAt: "2026-04-18T09:15:00.000Z",
+        reviewHistoryWatermarks: [
+          { workspaceId: "workspace-1", reviewSequenceId: -1 },
+        ],
+        summary: {
+          currentStreakDays: 1,
+          hasReviewedToday: true,
+          lastReviewedOn: "2026-04-03",
+          activeReviewDays: 2,
+        },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressSummary({
+      timeZone: "Europe/Madrid",
+      today: "2026-04-18",
+    })).rejects.toThrow(
+      "Invalid API response for GET /me/progress/summary: reviewHistoryWatermarks[0].reviewSequenceId must be a non-negative safe integer",
     );
   });
 });

--- a/apps/web/src/apiContracts/progress.ts
+++ b/apps/web/src/apiContracts/progress.ts
@@ -9,12 +9,14 @@ import { findProgressReviewScheduleValidationIssue } from "../progress/progressR
 import {
   ApiContractError,
   describePath,
+  type JsonObject,
   parseArray,
   parseBoolean,
   parseEnum,
   parseNullableString,
   parseNumber,
   parseObject,
+  parseOptionalField,
   parseRequiredField,
   parseString,
 } from "./core";
@@ -99,6 +101,20 @@ function parseProgressReviewHistoryWatermarkArray(
   return parseArray(value, endpoint, path, parseProgressReviewHistoryWatermark);
 }
 
+function parseOptionalProgressReviewHistoryWatermarkArray(
+  objectValue: JsonObject,
+  endpoint: string,
+  parentPath: string,
+): ReadonlyArray<ProgressReviewHistoryWatermark> {
+  return parseOptionalField(
+    objectValue,
+    "reviewHistoryWatermarks",
+    endpoint,
+    parentPath,
+    parseProgressReviewHistoryWatermarkArray,
+  ) ?? [];
+}
+
 function parseProgressReviewScheduleBucketArray(
   value: unknown,
   endpoint: string,
@@ -139,12 +155,10 @@ export function parseProgressSeriesResponse(value: unknown, endpoint: string): P
     from: parseRequiredField(objectValue, "from", endpoint, "", parseString),
     to: parseRequiredField(objectValue, "to", endpoint, "", parseString),
     generatedAt: parseRequiredField(objectValue, "generatedAt", endpoint, "", parseString),
-    reviewHistoryWatermarks: parseRequiredField(
+    reviewHistoryWatermarks: parseOptionalProgressReviewHistoryWatermarkArray(
       objectValue,
-      "reviewHistoryWatermarks",
       endpoint,
       "",
-      parseProgressReviewHistoryWatermarkArray,
     ),
     dailyReviews: parseRequiredField(objectValue, "dailyReviews", endpoint, "", parseDailyReviewPointArray),
   };
@@ -156,12 +170,10 @@ export function parseProgressSummaryResponse(value: unknown, endpoint: string): 
   return {
     timeZone: parseRequiredField(objectValue, "timeZone", endpoint, "", parseString),
     generatedAt: parseRequiredField(objectValue, "generatedAt", endpoint, "", parseString),
-    reviewHistoryWatermarks: parseRequiredField(
+    reviewHistoryWatermarks: parseOptionalProgressReviewHistoryWatermarkArray(
       objectValue,
-      "reviewHistoryWatermarks",
       endpoint,
       "",
-      parseProgressReviewHistoryWatermarkArray,
     ),
     summary: parseRequiredField(objectValue, "summary", endpoint, "", parseProgressSummary),
   };
@@ -172,12 +184,10 @@ export function parseProgressReviewScheduleResponse(value: unknown, endpoint: st
   const schedule: ProgressReviewSchedule = {
     timeZone: parseRequiredField(objectValue, "timeZone", endpoint, "", parseString),
     generatedAt: parseRequiredField(objectValue, "generatedAt", endpoint, "", parseString),
-    reviewHistoryWatermarks: parseRequiredField(
+    reviewHistoryWatermarks: parseOptionalProgressReviewHistoryWatermarkArray(
       objectValue,
-      "reviewHistoryWatermarks",
       endpoint,
       "",
-      parseProgressReviewHistoryWatermarkArray,
     ),
     totalCards: parseRequiredField(objectValue, "totalCards", endpoint, "", parseNumber),
     buckets: parseRequiredField(objectValue, "buckets", endpoint, "", parseProgressReviewScheduleBucketArray),


### PR DESCRIPTION
## Summary
- Treat missing progress review-history watermark metadata as empty in web, iOS, and Android clients
- Keep malformed present watermark metadata strict
- Add focused parser/decoding tests across clients

## Validation
- npm ci in apps/web
- npx vitest run src/api/endpoints/endpoints.test.ts src/appData/progress/source/progressSource.cache.test.tsx
- npx tsc -b
- git --no-pager diff --check

Android Gradle and iOS simulator-backed tests were not run locally per repository policy.