### PR TITLE
[codex] Clarify iOS deck smart filters

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
@@ -70,12 +70,13 @@ extension FlashcardsStore {
         return result
     }
 
-    func createDeck(input: DeckEditorInput) throws {
+    func createDeck(input: DeckEditorInput) throws -> Deck {
         let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
-        _ = try context.database.createDeck(workspaceId: context.workspaceId, input: input)
+        let createdDeck = try context.database.createDeck(workspaceId: context.workspaceId, input: input)
         self.refreshLocalReadModels(now: now)
         self.triggerCloudSyncIfLinked(trigger: self.localMutationCloudSyncTrigger(now: now))
+        return createdDeck
     }
 
     func updateDeck(deckId: String, input: DeckEditorInput) throws {

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Decks/DecksScreen.swift
@@ -8,6 +8,8 @@ struct DecksScreen: View {
     @State private var isEditorPresented: Bool = false
     @State private var deckFormState: DeckFormState = emptyDeckFormState()
     @State private var screenErrorMessage: String = ""
+    @State private var editorErrorMessage: String = ""
+    @State private var createdDeckDestination: DeckScreenDestination? = nil
     @State private var decksSnapshot: DecksListSnapshot = DecksListSnapshot(
         deckSummaries: [],
         allCardsStats: DeckCardStats(totalCards: 0, dueCards: 0, newCards: 0, reviewedCards: 0)
@@ -37,7 +39,7 @@ struct DecksScreen: View {
             }
 
             Section {
-                Text(aiSettingsLocalized("settings.workspace.decks.description", "Decks group related cards so you can study a topic together."))
+                Text(aiSettingsLocalized("settings.workspace.decks.description", "Decks are smart filters that include cards matching the effort levels and tags you choose."))
                     .foregroundStyle(.secondary)
             }
 
@@ -89,6 +91,9 @@ struct DecksScreen: View {
         .task(id: store.localReadVersion) {
             await self.reloadDecksSnapshot()
         }
+        .navigationDestination(item: self.$createdDeckDestination) { destination in
+            DeckDetailScreen(destination: destination)
+        }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
@@ -103,6 +108,7 @@ struct DecksScreen: View {
                 DeckEditorView(
                     title: aiSettingsLocalized("settings.workspace.decks.newDeck", "New deck"),
                     availableTagSuggestions: self.availableTagSuggestions,
+                    errorMessage: self.editorErrorMessage,
                     formState: $deckFormState,
                     onCancel: {
                         isEditorPresented = false
@@ -119,6 +125,7 @@ struct DecksScreen: View {
         self.dismissDecksSearch()
         self.deckFormState = emptyDeckFormState()
         self.screenErrorMessage = ""
+        self.editorErrorMessage = ""
         self.isEditorPresented = true
     }
 
@@ -128,12 +135,19 @@ struct DecksScreen: View {
     }
 
     private func saveDeck() {
+        guard deckFormStateHasFilterRules(formState: self.deckFormState) else {
+            self.editorErrorMessage = deckEditorEmptyRulesValidationMessage()
+            return
+        }
+
         do {
-            try store.createDeck(input: makeDeckEditorInput(formState: deckFormState))
+            let createdDeck: Deck = try store.createDeck(input: makeDeckEditorInput(formState: deckFormState))
             self.screenErrorMessage = ""
+            self.editorErrorMessage = ""
             self.isEditorPresented = false
+            self.createdDeckDestination = .deck(deckId: createdDeck.deckId)
         } catch {
-            self.screenErrorMessage = Flashcards.errorMessage(error: error)
+            self.editorErrorMessage = Flashcards.errorMessage(error: error)
         }
     }
 
@@ -237,9 +251,18 @@ private struct DeckListRow: View {
     }
 }
 
-private enum DeckScreenDestination: Hashable {
+private enum DeckScreenDestination: Hashable, Identifiable {
     case allCards
     case deck(deckId: String)
+
+    var id: String {
+        switch self {
+        case .allCards:
+            return "all-cards"
+        case .deck(let deckId):
+            return "deck-\(deckId)"
+        }
+    }
 }
 
 private struct DeckScreenListItem: Identifiable, Hashable {
@@ -313,6 +336,15 @@ private enum DeckDetailScreenState {
             return true
         }
     }
+
+    var hasEmptyDeckRules: Bool {
+        switch self {
+        case .allCards:
+            return false
+        case .deck(let deckItem, _):
+            return deckFilterDefinitionHasRules(filterDefinition: deckItem.deck.filterDefinition) == false
+        }
+    }
 }
 
 private struct DeckDetailScreen: View {
@@ -325,6 +357,7 @@ private struct DeckDetailScreen: View {
     @State private var isEditorPresented: Bool = false
     @State private var deckFormState: DeckFormState = emptyDeckFormState()
     @State private var screenErrorMessage: String = ""
+    @State private var editorErrorMessage: String = ""
     @State private var detailState: DeckDetailScreenState? = nil
     @State private var availableTagSuggestions: [TagSuggestion] = []
 
@@ -373,13 +406,18 @@ private struct DeckDetailScreen: View {
                     )
                     Text(detailState.filterSummary)
                         .foregroundStyle(.secondary)
+
+                    if detailState.hasEmptyDeckRules {
+                        Text(aiSettingsLocalized("settings.workspace.decks.emptyRulesIncludesAllCards", "This deck has no rules, so it includes all cards."))
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 Section {
                     Button {
                         self.openReview()
                     } label: {
-                        Label(aiSettingsLocalized("settings.workspace.decks.openReview", "Open review"), systemImage: "rectangle.on.rectangle")
+                        Label(reviewActionTitle(detailState: detailState), systemImage: "rectangle.on.rectangle")
                     }
                 }
 
@@ -427,6 +465,7 @@ private struct DeckDetailScreen: View {
                 DeckEditorView(
                     title: aiSettingsLocalized("settings.workspace.decks.editDeck", "Edit deck"),
                     availableTagSuggestions: self.availableTagSuggestions,
+                    errorMessage: self.editorErrorMessage,
                     formState: $deckFormState,
                     onCancel: {
                         isEditorPresented = false
@@ -452,6 +491,7 @@ private struct DeckDetailScreen: View {
             do {
                 self.deckFormState = try makeDeckFormState(deck: deckItem.deck)
                 self.screenErrorMessage = ""
+                self.editorErrorMessage = ""
                 self.isEditorPresented = true
             } catch {
                 self.screenErrorMessage = Flashcards.errorMessage(error: error)
@@ -461,16 +501,22 @@ private struct DeckDetailScreen: View {
 
     private func saveDeckChanges() {
         guard let deckId = currentDeckId else {
-            self.screenErrorMessage = aiSettingsLocalized("settings.workspace.decks.notFound", "Deck not found.")
+            self.editorErrorMessage = aiSettingsLocalized("settings.workspace.decks.notFound", "Deck not found.")
+            return
+        }
+
+        guard deckFormStateHasFilterRules(formState: self.deckFormState) else {
+            self.editorErrorMessage = deckEditorEmptyRulesValidationMessage()
             return
         }
 
         do {
             try store.updateDeck(deckId: deckId, input: makeDeckEditorInput(formState: deckFormState))
             self.screenErrorMessage = ""
+            self.editorErrorMessage = ""
             self.isEditorPresented = false
         } catch {
-            self.screenErrorMessage = Flashcards.errorMessage(error: error)
+            self.editorErrorMessage = Flashcards.errorMessage(error: error)
         }
     }
 
@@ -532,6 +578,7 @@ private struct DeckDetailScreen: View {
 private struct DeckEditorView: View {
     let title: String
     let availableTagSuggestions: [TagSuggestion]
+    let errorMessage: String
     @Binding var formState: DeckFormState
     let onCancel: () -> Void
     let onSave: () -> Void
@@ -542,6 +589,18 @@ private struct DeckEditorView: View {
             horizontalPadding: 0
         ) {
             Form {
+                if errorMessage.isEmpty == false {
+                    Section {
+                        CopyableErrorMessageView(message: errorMessage)
+                    }
+                }
+
+                Section {
+                    Text(aiSettingsLocalized("settings.workspace.decks.editorSmartFilterDescription", "A Deck is a smart filter."))
+                    Text(aiSettingsLocalized("settings.workspace.decks.editorMatchingRulesDescription", "Cards match by the effort levels and tags you select. You can select the Deck from the top-left menu on Review."))
+                }
+                .foregroundStyle(.secondary)
+
                 Section(aiSettingsLocalized("settings.workspace.decks.section.name", "Name")) {
                     TextField(aiSettingsLocalized("settings.workspace.decks.deckName", "Deck name"), text: $formState.name)
                 }
@@ -634,6 +693,35 @@ private func makeDeckFormState(deck: Deck) throws -> DeckFormState {
         selectedEffortLevels: deck.filterDefinition.effortLevels,
         tags: deck.filterDefinition.tags
     )
+}
+
+private func deckFormStateHasFilterRules(formState: DeckFormState) -> Bool {
+    deckFilterDefinitionHasRules(
+        filterDefinition: buildDeckFilterDefinition(
+            effortLevels: formState.selectedEffortLevels,
+            tags: formState.tags
+        )
+    )
+}
+
+private func deckFilterDefinitionHasRules(filterDefinition: DeckFilterDefinition) -> Bool {
+    filterDefinition.effortLevels.isEmpty == false || filterDefinition.tags.isEmpty == false
+}
+
+private func deckEditorEmptyRulesValidationMessage() -> String {
+    aiSettingsLocalized(
+        "settings.workspace.decks.emptyRuleValidation",
+        "Choose at least one effort level or tag, or use All Cards on Review."
+    )
+}
+
+private func reviewActionTitle(detailState: DeckDetailScreenState) -> String {
+    switch detailState {
+    case .allCards:
+        return aiSettingsLocalized("settings.workspace.decks.openReview", "Open review")
+    case .deck:
+        return aiSettingsLocalized("settings.workspace.decks.reviewThisDeck", "Review this deck")
+    }
 }
 
 private func makeDeckScreenListItems(decksSnapshot: DecksListSnapshot) -> [DeckScreenListItem] {

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "الملف الذي تم تصديره غير متوفر.";
 "settings.workspace.export.workspaceUnavailable" = "مساحة العمل غير متاحة";
 
-"settings.workspace.decks.description" = "تقوم التشكيلات بتجميع البطاقات ذات الصلة معًا حتى تتمكنوا من دراسة موضوع ما معًا.";
+"settings.workspace.decks.description" = "التشكيلات مرشحات ذكية تضم البطاقات المطابقة لمستويات الجهد والوسوم التي تختارها.";
+"settings.workspace.decks.editorSmartFilterDescription" = "المجموعة مرشح ذكي.";
+"settings.workspace.decks.editorMatchingRulesDescription" = "تتطابق البطاقات حسب مستويات الجهد والوسوم التي تحددها. يمكنك اختيار المجموعة من القائمة العلوية اليسرى في المراجعة.";
+"settings.workspace.decks.emptyRuleValidation" = "اختر مستوى جهد واحدًا أو وسمًا واحدًا على الأقل، أو استخدم كل البطاقات في المراجعة.";
 "settings.workspace.decks.loading" = "جارٍ تحميل التشكيلات...";
 "settings.workspace.decks.noMatching" = "لا توجد تشكيلات مطابقة";
 "settings.workspace.decks.searchPrompt" = "مجموعات البحث";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "لا تحتوي هذه المجموعة على بطاقات مطابقة بعد.";
 "settings.workspace.decks.section.deckRules" = "قواعد المجموعة";
 "settings.workspace.decks.openReview" = "مراجعة مفتوحة";
+"settings.workspace.decks.reviewThisDeck" = "راجع هذه المجموعة";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "لا تحتوي هذه المجموعة على قواعد، لذلك تشمل كل البطاقات.";
 "settings.workspace.decks.section.matchingCards" = "بطاقات المطابقة";
 "settings.workspace.decks.deleteDeck" = "حذف المجموعة";
 "settings.workspace.decks.deck" = "مجموعة";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "Die exportierte Datei ist nicht verfügbar.";
 "settings.workspace.export.workspaceUnavailable" = "Arbeitsbereich ist nicht verfügbar";
 
-"settings.workspace.decks.description" = "Decks gruppieren verwandte Karten, sodass Sie gemeinsam ein Thema studieren können.";
+"settings.workspace.decks.description" = "Decks sind intelligente Filter, die Karten einschließen, die den gewählten Aufwandsstufen und Tags entsprechen.";
+"settings.workspace.decks.editorSmartFilterDescription" = "Ein Deck ist ein intelligenter Filter.";
+"settings.workspace.decks.editorMatchingRulesDescription" = "Karten werden über die Aufwandsstufen und Tags gefunden, die Sie auswählen. Sie können das Deck im Menü oben links unter „Wiederholen“ auswählen.";
+"settings.workspace.decks.emptyRuleValidation" = "Wählen Sie mindestens eine Aufwandsstufe oder ein Tag aus, oder verwenden Sie „Alle Karten“ unter „Wiederholen“.";
 "settings.workspace.decks.loading" = "Ladedecks...";
 "settings.workspace.decks.noMatching" = "Keine passenden Decks";
 "settings.workspace.decks.searchPrompt" = "Decks durchsuchen";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "Zu diesem Deck gibt es noch keine passenden Karten.";
 "settings.workspace.decks.section.deckRules" = "Deckregeln";
 "settings.workspace.decks.openReview" = "Rezension öffnen";
+"settings.workspace.decks.reviewThisDeck" = "Dieses Deck wiederholen";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "Dieses Deck hat keine Regeln und enthält daher alle Karten.";
 "settings.workspace.decks.section.matchingCards" = "Passende Karten";
 "settings.workspace.decks.deleteDeck" = "Deck löschen";
 "settings.workspace.decks.deck" = "Hammer";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "El archivo exportado no esta disponible.";
 "settings.workspace.export.workspaceUnavailable" = "El espacio de trabajo no esta disponible";
 
-"settings.workspace.decks.description" = "Los mazos agrupan tarjetas relacionadas para que puedas estudiar un tema en conjunto.";
+"settings.workspace.decks.description" = "Los mazos son filtros inteligentes que incluyen tarjetas que coinciden con los niveles de esfuerzo y las etiquetas que elijas.";
+"settings.workspace.decks.editorSmartFilterDescription" = "Un mazo es un filtro inteligente.";
+"settings.workspace.decks.editorMatchingRulesDescription" = "Las tarjetas coinciden con los niveles de esfuerzo y las etiquetas que selecciones. Puedes elegir el mazo desde el menú superior izquierdo en Repasar.";
+"settings.workspace.decks.emptyRuleValidation" = "Elige al menos un nivel de esfuerzo o una etiqueta, o usa Todas las tarjetas en Repasar.";
 "settings.workspace.decks.loading" = "Cargando mazos...";
 "settings.workspace.decks.noMatching" = "No hay mazos coincidentes";
 "settings.workspace.decks.searchPrompt" = "Buscar mazos";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "Este mazo todavia no tiene tarjetas coincidentes.";
 "settings.workspace.decks.section.deckRules" = "Reglas del mazo";
 "settings.workspace.decks.openReview" = "Abrir repaso";
+"settings.workspace.decks.reviewThisDeck" = "Repasar este mazo";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "Este mazo no tiene reglas, por lo que incluye todas las tarjetas.";
 "settings.workspace.decks.section.matchingCards" = "Tarjetas coincidentes";
 "settings.workspace.decks.deleteDeck" = "Eliminar mazo";
 "settings.workspace.decks.deck" = "Mazo";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "El archivo exportado no esta disponible.";
 "settings.workspace.export.workspaceUnavailable" = "El espacio de trabajo no esta disponible";
 
-"settings.workspace.decks.description" = "Los mazos agrupan tarjetas relacionadas para que puedas estudiar un tema en conjunto.";
+"settings.workspace.decks.description" = "Los mazos son filtros inteligentes que incluyen tarjetas que coinciden con los niveles de esfuerzo y las etiquetas que elijas.";
+"settings.workspace.decks.editorSmartFilterDescription" = "Un mazo es un filtro inteligente.";
+"settings.workspace.decks.editorMatchingRulesDescription" = "Las tarjetas coinciden con los niveles de esfuerzo y las etiquetas que selecciones. Puedes elegir el mazo desde el menú superior izquierdo en Repasar.";
+"settings.workspace.decks.emptyRuleValidation" = "Elige al menos un nivel de esfuerzo o una etiqueta, o usa Todas las tarjetas en Repasar.";
 "settings.workspace.decks.loading" = "Cargando mazos...";
 "settings.workspace.decks.noMatching" = "No hay mazos coincidentes";
 "settings.workspace.decks.searchPrompt" = "Buscar mazos";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "Este mazo todavia no tiene tarjetas coincidentes.";
 "settings.workspace.decks.section.deckRules" = "Reglas del mazo";
 "settings.workspace.decks.openReview" = "Abrir repaso";
+"settings.workspace.decks.reviewThisDeck" = "Repasar este mazo";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "Este mazo no tiene reglas, por lo que incluye todas las tarjetas.";
 "settings.workspace.decks.section.matchingCards" = "Tarjetas coincidentes";
 "settings.workspace.decks.deleteDeck" = "Eliminar mazo";
 "settings.workspace.decks.deck" = "Mazo";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "निर्यात की गई फ़ाइल उपलब्ध नहीं है.";
 "settings.workspace.export.workspaceUnavailable" = "कार्यस्थल उपलब्ध नहीं है";
 
-"settings.workspace.decks.description" = "डेक संबंधित कार्डों को एक साथ समूहित करते हैं ताकि आप एक साथ किसी विषय का अध्ययन कर सकें।";
+"settings.workspace.decks.description" = "डेक स्मार्ट फ़िल्टर हैं जो आपके चुने गए प्रयास स्तरों और टैग से मेल खाने वाले कार्ड शामिल करते हैं।";
+"settings.workspace.decks.editorSmartFilterDescription" = "डेक एक स्मार्ट फ़िल्टर है।";
+"settings.workspace.decks.editorMatchingRulesDescription" = "कार्ड आपके चुने गए प्रयास स्तरों और टैग से मेल खाते हैं। आप समीक्षा में ऊपर-बाएं मेनू से डेक चुन सकते हैं।";
+"settings.workspace.decks.emptyRuleValidation" = "कम से कम एक प्रयास स्तर या टैग चुनें, या समीक्षा में सभी कार्ड का उपयोग करें.";
 "settings.workspace.decks.loading" = "डेक लोड हो रहा है...";
 "settings.workspace.decks.noMatching" = "कोई मेल खाता डेक नहीं";
 "settings.workspace.decks.searchPrompt" = "खोज डेक";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "इस डेक में अभी तक मेल खाने वाले कार्ड नहीं हैं.";
 "settings.workspace.decks.section.deckRules" = "डेक नियम";
 "settings.workspace.decks.openReview" = "खुली समीक्षा";
+"settings.workspace.decks.reviewThisDeck" = "इस डेक की समीक्षा करें";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "इस डेक में कोई नियम नहीं हैं, इसलिए इसमें सभी कार्ड शामिल हैं.";
 "settings.workspace.decks.section.matchingCards" = "मिलान कार्ड";
 "settings.workspace.decks.deleteDeck" = "डेक हटाएं";
 "settings.workspace.decks.deck" = "डेक";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "エクスポートされたファイルは利用できません。";
 "settings.workspace.export.workspaceUnavailable" = "ワークスペースが利用できません";
 
-"settings.workspace.decks.description" = "デッキは関連するカードをグループ化しているため、トピックを一緒に学ぶことができます。";
+"settings.workspace.decks.description" = "デッキはスマートフィルターです。選択した努力レベルとタグに一致するカードが含まれます。";
+"settings.workspace.decks.editorSmartFilterDescription" = "デッキはスマートフィルターです。";
+"settings.workspace.decks.editorMatchingRulesDescription" = "選択した努力レベルとタグでカードが一致します。復習の左上メニューからデッキを選択できます。";
+"settings.workspace.decks.emptyRuleValidation" = "少なくとも 1 つの努力レベルまたはタグを選択するか、復習ですべてのカードを使用してください。";
 "settings.workspace.decks.loading" = "デッキをロード中...";
 "settings.workspace.decks.noMatching" = "一致するデッキがありません";
 "settings.workspace.decks.searchPrompt" = "デッキを検索";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "このデッキには一致するカードがまだありません。";
 "settings.workspace.decks.section.deckRules" = "デッキルール";
 "settings.workspace.decks.openReview" = "レビューを開く";
+"settings.workspace.decks.reviewThisDeck" = "このデッキを復習";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "このデッキにはルールがないため、すべてのカードが含まれます。";
 "settings.workspace.decks.section.matchingCards" = "一致するカード";
 "settings.workspace.decks.deleteDeck" = "デッキを削除";
 "settings.workspace.decks.deck" = "デッキ";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "Экспортированный файл недоступен.";
 "settings.workspace.export.workspaceUnavailable" = "Рабочая область недоступна";
 
-"settings.workspace.decks.description" = "Колоды группируют связанные карты, чтобы вы могли вместе изучать тему.";
+"settings.workspace.decks.description" = "Колоды — это умные фильтры, которые включают карточки, соответствующие выбранным уровням усилия и тегам.";
+"settings.workspace.decks.editorSmartFilterDescription" = "Колода — это умный фильтр.";
+"settings.workspace.decks.editorMatchingRulesDescription" = "Карточки подбираются по выбранным уровням усилия и тегам. Колоду можно выбрать в меню сверху слева на экране «Повторение».";
+"settings.workspace.decks.emptyRuleValidation" = "Выберите хотя бы один уровень усилия или тег либо используйте «Все карточки» на экране «Повторение».";
 "settings.workspace.decks.loading" = "Загрузка колод...";
 "settings.workspace.decks.noMatching" = "Нет подходящих колод";
 "settings.workspace.decks.searchPrompt" = "Поиск колод";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "В этой колоде еще нет подходящих карт.";
 "settings.workspace.decks.section.deckRules" = "Правила колоды";
 "settings.workspace.decks.openReview" = "Открыть обзор";
+"settings.workspace.decks.reviewThisDeck" = "Повторять эту колоду";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "У этой колоды нет правил, поэтому она включает все карточки.";
 "settings.workspace.decks.section.matchingCards" = "Соответствующие карты";
 "settings.workspace.decks.deleteDeck" = "Удалить колоду";
 "settings.workspace.decks.deck" = "Молоток";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -524,7 +524,10 @@
 "settings.workspace.export.fileUnavailable" = "导出的文件不可用。";
 "settings.workspace.export.workspaceUnavailable" = "工作区不可用";
 
-"settings.workspace.decks.description" = "甲板将相关卡片组合在一起，以便您可以一起研究主题。";
+"settings.workspace.decks.description" = "牌组是智能筛选器，会包含符合你选择的努力级别和标签的卡片。";
+"settings.workspace.decks.editorSmartFilterDescription" = "牌组是智能筛选器。";
+"settings.workspace.decks.editorMatchingRulesDescription" = "卡片会按你选择的努力级别和标签匹配。你可以在“复习”左上角菜单中选择该牌组。";
+"settings.workspace.decks.emptyRuleValidation" = "请选择至少一个努力级别或标签，或在“复习”中使用“所有卡片”。";
 "settings.workspace.decks.loading" = "正在加载牌组...";
 "settings.workspace.decks.noMatching" = "没有匹配的牌组";
 "settings.workspace.decks.searchPrompt" = "搜索套牌";
@@ -537,6 +540,8 @@
 "settings.workspace.decks.emptyDeck" = "该套牌还没有匹配的牌。";
 "settings.workspace.decks.section.deckRules" = "牌组规则";
 "settings.workspace.decks.openReview" = "开放审核";
+"settings.workspace.decks.reviewThisDeck" = "复习此牌组";
+"settings.workspace.decks.emptyRulesIncludesAllCards" = "这个牌组没有规则，因此包含所有卡片。";
 "settings.workspace.decks.section.matchingCards" = "配套卡";
 "settings.workspace.decks.deleteDeck" = "删除牌组";
 "settings.workspace.decks.deck" = "牌组";


### PR DESCRIPTION
## Summary
- Clarify iOS Decks as saved smart filters over effort levels and tags.
- Add local editor validation so user-created decks need at least one effort level or tag.
- Navigate to the created deck detail after save and make the deck review action explicit.
- Add localized Settings strings for the new deck copy.

## Validation
- git --no-pager diff --check origin/main..HEAD
- plutil -lint for all updated AISettings.strings locale files

## Notes
- iOS simulator-backed tests were not run.