### PR TITLE
Clarify Android decks as smart filters

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppHandoffCoordinator.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppHandoffCoordinator.kt
@@ -1,8 +1,9 @@
 package com.flashcardsopensourceapp.app.navigation
 
 import com.flashcardsopensourceapp.app.notifications.AppNotificationTapRequest
-import com.flashcardsopensourceapp.feature.ai.AiEntryPrefill
+import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+import com.flashcardsopensourceapp.feature.ai.AiEntryPrefill
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +28,11 @@ data class CardEditorRequest(
     val cardId: String?
 )
 
+data class ReviewFilterRequest(
+    val requestId: Long,
+    val reviewFilter: ReviewFilter
+)
+
 data class AppNotificationTapHandoffRequest(
     val requestId: Long,
     val request: AppNotificationTapRequest
@@ -48,6 +54,7 @@ class AppHandoffCoordinator {
     private val aiEntryPrefillState = MutableStateFlow<AiEntryPrefillRequest?>(value = null)
     private val aiCardHandoffState = MutableStateFlow<AiCardHandoffRequest?>(value = null)
     private val cardEditorState = MutableStateFlow<CardEditorRequest?>(value = null)
+    private val reviewFilterState = MutableStateFlow<ReviewFilterRequest?>(value = null)
     private val settingsNavigationState = MutableStateFlow<SettingsNavigationRequest?>(value = null)
 
     fun observeAiEntryPrefill(): StateFlow<AiEntryPrefillRequest?> {
@@ -60,6 +67,10 @@ class AppHandoffCoordinator {
 
     fun observeCardEditor(): StateFlow<CardEditorRequest?> {
         return cardEditorState.asStateFlow()
+    }
+
+    fun observeReviewFilter(): StateFlow<ReviewFilterRequest?> {
+        return reviewFilterState.asStateFlow()
     }
 
     fun observeSettingsNavigation(): StateFlow<SettingsNavigationRequest?> {
@@ -119,6 +130,21 @@ class AppHandoffCoordinator {
         }
 
         cardEditorState.value = null
+    }
+
+    fun requestReviewFilter(reviewFilter: ReviewFilter) {
+        reviewFilterState.value = ReviewFilterRequest(
+            requestId = nextRequestId.incrementAndGet(),
+            reviewFilter = reviewFilter
+        )
+    }
+
+    fun consumeReviewFilter(requestId: Long) {
+        if (reviewFilterState.value?.requestId != requestId) {
+            return
+        }
+
+        reviewFilterState.value = null
     }
 
     fun requestSettingsNavigation(target: SettingsNavigationTarget) {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
@@ -31,6 +31,7 @@ fun AppNavHost(
 ) {
     val coroutineScope = rememberCoroutineScope()
     val cardEditorRequest by appGraph.appHandoffCoordinator.observeCardEditor().collectAsStateWithLifecycle()
+    val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
     val settingsNavigationRequest by appGraph.appHandoffCoordinator.observeSettingsNavigation().collectAsStateWithLifecycle()
     val packageInfo = appGraph.appPackageInfo
 
@@ -41,6 +42,16 @@ fun AppNavHost(
             cardId = request.cardId
         )
         appGraph.appHandoffCoordinator.consumeCardEditor(requestId = request.requestId)
+    }
+
+    LaunchedEffect(reviewFilterRequest?.requestId) {
+        if (reviewFilterRequest == null) {
+            return@LaunchedEffect
+        }
+        navigateToTopLevelDestination(
+            navController = navController,
+            destination = ReviewDestination
+        )
     }
 
     LaunchedEffect(appNotificationTapRequest?.requestId) {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -98,6 +99,15 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
             )
         )
         val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
+        val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
+
+        LaunchedEffect(reviewFilterRequest?.requestId, uiState) {
+            val request = reviewFilterRequest ?: return@LaunchedEffect
+            val didSelectFilter = reviewViewModel.selectFilterForHandoff(reviewFilter = request.reviewFilter)
+            if (didSelectFilter) {
+                appGraph.appHandoffCoordinator.consumeReviewFilter(requestId = request.requestId)
+            }
+        }
 
         ReviewRoute(
             uiState = uiState,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -11,9 +11,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
 import com.flashcardsopensourceapp.feature.settings.deck.DeckDetailRoute
+import com.flashcardsopensourceapp.feature.settings.deck.DeckEditorSaveResult
 import com.flashcardsopensourceapp.feature.settings.deck.DeckEditorRoute
 import com.flashcardsopensourceapp.feature.settings.deck.DeckListTargetUiState
 import com.flashcardsopensourceapp.feature.settings.deck.DecksRoute
@@ -224,6 +226,7 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
             DeckDetailRoute(
                 uiState = uiState,
                 onEditDeck = {},
+                onReviewDeck = {},
                 onOpenCard = { cardId ->
                     appGraph.appHandoffCoordinator.requestCardEditor(cardId = cardId)
                 },
@@ -259,6 +262,11 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
                 uiState = uiState,
                 onEditDeck = { editingDeckId ->
                     navController.navigate(route = SettingsWorkspaceDeckEditorDestination.createRoute(deckId = editingDeckId))
+                },
+                onReviewDeck = { reviewingDeckId ->
+                    appGraph.appHandoffCoordinator.requestReviewFilter(
+                        reviewFilter = ReviewFilter.Deck(deckId = reviewingDeckId)
+                    )
                 },
                 onOpenCard = { cardId ->
                     appGraph.appHandoffCoordinator.requestCardEditor(cardId = cardId)
@@ -305,10 +313,23 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
                 onToggleTag = deckEditorViewModel::toggleTag,
                 onSave = {
                     coroutineScope.launch {
-                        val didSave = deckEditorViewModel.save(editingDeckId = editingDeckId)
-                        if (didSave) {
-                            withContext(Dispatchers.Main.immediate) {
-                                navController.popBackStack()
+                        val saveResult = deckEditorViewModel.save(editingDeckId = editingDeckId)
+                        withContext(Dispatchers.Main.immediate) {
+                            when (saveResult) {
+                                is DeckEditorSaveResult.Created -> {
+                                    navController.popBackStack()
+                                    navController.navigate(
+                                        route = SettingsWorkspaceDeckDetailDestination.createRoute(deckId = saveResult.deckId)
+                                    ) {
+                                        launchSingleTop = true
+                                    }
+                                }
+
+                                DeckEditorSaveResult.Updated -> {
+                                    navController.popBackStack()
+                                }
+
+                                null -> Unit
                             }
                         }
                     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -69,7 +69,7 @@ interface DecksRepository {
     fun observeDecks(): Flow<List<DeckSummary>>
     fun observeDeck(deckId: String): Flow<DeckSummary?>
     fun observeDeckCards(deckId: String): Flow<List<CardSummary>>
-    suspend fun createDeck(deckDraft: DeckDraft)
+    suspend fun createDeck(deckDraft: DeckDraft): String
     suspend fun updateDeck(deckId: String, deckDraft: DeckDraft)
     suspend fun deleteDeck(deckId: String)
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/decks/LocalDecksRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/decks/LocalDecksRepository.kt
@@ -72,7 +72,7 @@ class LocalDecksRepository(
         }
     }
 
-    override suspend fun createDeck(deckDraft: DeckDraft) {
+    override suspend fun createDeck(deckDraft: DeckDraft): String {
         val workspace: WorkspaceEntity = requireCurrentWorkspace(
             database = database,
             preferencesStore = preferencesStore,
@@ -99,6 +99,8 @@ class LocalDecksRepository(
             database.deckDao().insertDeck(deck = deck)
             syncLocalStore.enqueueDeckUpsert(deck)
         }
+
+        return deck.deckId
     }
 
     override suspend fun updateDeck(deckId: String, deckDraft: DeckDraft) {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -162,6 +162,15 @@ class ReviewViewModel(
         onReviewNotificationsChanged(ReviewNotificationsReconcileTrigger.FILTER_CHANGED)
     }
 
+    fun selectFilterForHandoff(reviewFilter: ReviewFilter): Boolean {
+        if (activeWorkspaceId == null) {
+            return false
+        }
+
+        selectFilter(reviewFilter = reviewFilter)
+        return true
+    }
+
     private fun persistSelectedReviewFilter(reviewFilter: ReviewFilter) {
         val workspaceId = activeWorkspaceId ?: return
         reviewPreferencesStore.saveSelectedReviewFilter(

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -47,12 +47,12 @@
     <string name="review_scope_title">Review scope</string>
     <string name="review_scope_subtitle_all_cards">Review the full local queue</string>
     <string name="review_decks_title">Decks</string>
-    <string name="review_filtered_deck_subtitle">Filtered deck</string>
+    <string name="review_filtered_deck_subtitle">Smart filter</string>
     <string name="review_effort_title">Effort</string>
     <string name="review_virtual_effort_filter_subtitle">Virtual effort filter</string>
     <string name="review_tags_title">Tags</string>
     <string name="review_workspace_tag_subtitle">Workspace tag</string>
-    <string name="review_manage_filtered_decks">Manage filtered decks</string>
+    <string name="review_manage_filtered_decks">Manage decks</string>
     <string name="review_current_chip">Current</string>
     <string name="review_updated_on_another_device">This review updated on another device.</string>
     <string name="review_could_not_be_saved">Review could not be saved.</string>

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckDetailRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckDetailRoute.kt
@@ -33,6 +33,7 @@ import com.flashcardsopensourceapp.feature.settings.R
 fun DeckDetailRoute(
     uiState: DeckDetailUiState,
     onEditDeck: (String) -> Unit,
+    onReviewDeck: (String) -> Unit,
     onOpenCard: (String) -> Unit,
     onDeleteDeck: (String) -> Unit,
     onBack: () -> Unit
@@ -113,25 +114,38 @@ fun DeckDetailRoute(
 
             item {
                 if (detail is DeckDetailInfoUiState.PersistedDeck) {
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        OutlinedButton(
-                            onClick = {
-                                onEditDeck(detail.deckId)
-                            },
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text(stringResource(R.string.settings_deck_detail_edit_button))
-                        }
                         Button(
                             onClick = {
-                                onDeleteDeck(detail.deckId)
+                                onReviewDeck(detail.deckId)
                             },
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier.fillMaxWidth()
                         ) {
-                            Text(stringResource(R.string.settings_deck_detail_delete_button))
+                            Text(stringResource(R.string.settings_deck_detail_review_button))
+                        }
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            OutlinedButton(
+                                onClick = {
+                                    onEditDeck(detail.deckId)
+                                },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(stringResource(R.string.settings_deck_detail_edit_button))
+                            }
+                            OutlinedButton(
+                                onClick = {
+                                    onDeleteDeck(detail.deckId)
+                                },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(stringResource(R.string.settings_deck_detail_delete_button))
+                            }
                         }
                     }
                 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorRoute.kt
@@ -74,6 +74,24 @@ fun DeckEditorRoute(
             }
 
             item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.padding(16.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_deck_editor_explainer_title),
+                            style = MaterialTheme.typography.titleSmall
+                        )
+                        Text(
+                            text = stringResource(R.string.settings_deck_editor_explainer_body),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            item {
                 OutlinedTextField(
                     value = uiState.name,
                     onValueChange = onNameChange,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
-import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
+import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.repository.DecksRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.feature.settings.R
@@ -21,6 +21,14 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+
+sealed interface DeckEditorSaveResult {
+    data class Created(
+        val deckId: String
+    ) : DeckEditorSaveResult
+
+    data object Updated : DeckEditorSaveResult
+}
 
 class DeckEditorViewModel(
     private val decksRepository: DecksRepository,
@@ -105,7 +113,7 @@ class DeckEditorViewModel(
         }
     }
 
-    suspend fun save(editingDeckId: String?): Boolean {
+    suspend fun save(editingDeckId: String?): DeckEditorSaveResult? {
         val state = uiState.value
         val trimmedName = state.name.trim()
 
@@ -113,7 +121,19 @@ class DeckEditorViewModel(
             inputState.update { currentState ->
                 currentState.copy(errorMessage = strings.get(R.string.settings_deck_editor_name_required))
             }
-            return false
+            return null
+        }
+
+        if (
+            isDeckFilterEmpty(
+                selectedEffortLevels = state.selectedEffortLevels,
+                selectedTags = state.selectedTags
+            )
+        ) {
+            inputState.update { currentState ->
+                currentState.copy(errorMessage = strings.get(R.string.settings_deck_editor_filter_required))
+            }
+            return null
         }
 
         val deckDraft = DeckDraft(
@@ -125,11 +145,12 @@ class DeckEditorViewModel(
         )
 
         return if (editingDeckId == null) {
-            decksRepository.createDeck(deckDraft = deckDraft)
-            true
+            DeckEditorSaveResult.Created(
+                deckId = decksRepository.createDeck(deckDraft = deckDraft)
+            )
         } else {
             decksRepository.updateDeck(deckId = editingDeckId, deckDraft = deckDraft)
-            true
+            DeckEditorSaveResult.Updated
         }
     }
 
@@ -175,4 +196,8 @@ private fun toggleTagSelection(selectedTags: List<String>, tag: String): List<St
     }
 
     return selectedTags + tag
+}
+
+private fun isDeckFilterEmpty(selectedEffortLevels: List<EffortLevel>, selectedTags: List<String>): Boolean {
+    return selectedEffortLevels.isEmpty() && selectedTags.isEmpty()
 }

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -321,12 +321,15 @@
     <string name="settings_deck_matching_cards_title">Matching cards</string>
     <string name="settings_deck_empty_all_cards">This workspace does not have any cards yet.</string>
     <string name="settings_deck_empty_filtered">This filtered deck has no matching cards yet.</string>
+    <string name="settings_deck_detail_review_button">Review this deck</string>
     <string name="settings_deck_detail_edit_button">Edit deck</string>
     <string name="settings_deck_detail_delete_button">Delete deck</string>
     <string name="settings_deck_detail_cards_title">Cards</string>
     <string name="settings_deck_detail_empty">No cards match this deck yet.</string>
     <string name="settings_deck_editor_new_title">New deck</string>
     <string name="settings_deck_editor_edit_title">Edit deck</string>
+    <string name="settings_deck_editor_explainer_title">Decks are smart filters</string>
+    <string name="settings_deck_editor_explainer_body">Selected effort levels and tags decide which cards match. Select this deck from the Review filter.</string>
     <string name="settings_deck_editor_name_label">Deck name</string>
     <string name="settings_deck_editor_effort_title">Effort</string>
     <string name="settings_deck_editor_tags_title">Tags</string>
@@ -335,6 +338,7 @@
     <string name="settings_deck_editor_cancel_button">Cancel</string>
     <string name="settings_deck_editor_delete_button">Delete deck</string>
     <string name="settings_deck_editor_name_required">Deck name is required.</string>
+    <string name="settings_deck_editor_filter_required">Choose at least one effort level or tag, or use All cards in Review.</string>
     <string name="settings_deck_editor_save_failed">Could not save the deck.</string>
     <string name="settings_deck_filter_effort">effort in %1$s</string>
     <string name="settings_deck_filter_tags_any">tags any of %1$s</string>


### PR DESCRIPTION
## Summary

- Explain Android decks as saved smart filters in the deck editor and review filter sheet.
- Block empty deck filters before saving and navigate new deck saves to the created deck detail.
- Add a deck-detail Review action that opens Review with the deck filter selected.

## Validation

- `git --no-pager diff --check`
- Diff-focused review of repository contract and navigation handoff paths

`./gradlew` was not run because local Gradle runs require explicit permission in this repository.