### PR TITLE
[codex] Show Android empty deck rules warning

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckDetailRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckDetailRoute.kt
@@ -104,6 +104,12 @@ fun DeckDetailRoute(
                             text = detail.filterSummary,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
+                        if (detail is DeckDetailInfoUiState.PersistedDeck && !detail.hasFilterRules) {
+                            Text(
+                                text = stringResource(R.string.settings_deck_empty_rules_includes_all_cards),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                         OverviewRow(title = stringResource(R.string.settings_cards_title), value = detail.totalCards)
                         OverviewRow(title = stringResource(R.string.settings_workspace_due_title), value = detail.dueCards)
                         OverviewRow(title = stringResource(R.string.settings_workspace_new_title), value = detail.newCards)

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckDetailUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckDetailUiState.kt
@@ -23,6 +23,7 @@ sealed interface DeckDetailInfoUiState {
         val deckId: String,
         override val title: String,
         override val filterSummary: String,
+        val hasFilterRules: Boolean,
         override val totalCards: Int,
         override val dueCards: Int,
         override val newCards: Int,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckSupport.kt
@@ -65,11 +65,16 @@ internal fun toPersistedDeckDetailInfo(
         deckId = deck.deckId,
         title = deck.name,
         filterSummary = formatDeckFilter(filterDefinition = deck.filterDefinition, strings = strings),
+        hasFilterRules = hasDeckFilterRules(filterDefinition = deck.filterDefinition),
         totalCards = deck.totalCards,
         dueCards = deck.dueCards,
         newCards = deck.newCards,
         reviewedCards = deck.reviewedCards
     )
+}
+
+private fun hasDeckFilterRules(filterDefinition: DeckFilterDefinition): Boolean {
+    return filterDefinition.effortLevels.isNotEmpty() || filterDefinition.tags.isNotEmpty()
 }
 
 internal fun formatDeckFilter(

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -321,6 +321,7 @@
     <string name="settings_deck_matching_cards_title">Matching cards</string>
     <string name="settings_deck_empty_all_cards">This workspace does not have any cards yet.</string>
     <string name="settings_deck_empty_filtered">This filtered deck has no matching cards yet.</string>
+    <string name="settings_deck_empty_rules_includes_all_cards">This deck has no rules, so it includes all cards.</string>
     <string name="settings_deck_detail_review_button">Review this deck</string>
     <string name="settings_deck_detail_edit_button">Edit deck</string>
     <string name="settings_deck_detail_delete_button">Delete deck</string>


### PR DESCRIPTION
## Summary

Show the existing empty-rule deck explanation on Android deck detail for persisted decks whose smart filter has no effort or tag rules.

## Impact

- All Cards detail stays unchanged.
- Persisted decks with effort or tag rules stay unchanged.
- Persisted decks with empty rules now explain that they include all cards.

## Validation

- Reviewed the Android deck detail diff and related state construction paths.
- Ran `git diff --check` before commit.
- Did not run `./gradlew` because this PR explicitly disallows local Gradle runs unless separately approved.