### PR TITLE
Fix Android deck editor draft initialization

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorRoute.kt
@@ -42,6 +42,7 @@ fun DeckEditorRoute(
     onBack: () -> Unit
 ) {
     val strings = createSettingsStringResolver(context = LocalContext.current)
+    val isEditorEnabled: Boolean = uiState.isLoading.not() && uiState.isDeckMissing.not()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -51,6 +52,37 @@ fun DeckEditorRoute(
             )
         }
     ) { innerPadding ->
+        if (uiState.isDeckMissing) {
+            LazyColumn(
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    top = innerPadding.calculateTopPadding() + 16.dp,
+                    end = 16.dp,
+                    bottom = innerPadding.calculateBottomPadding() + 32.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxSize()
+            ) {
+                item {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = stringResource(R.string.settings_deck_not_found),
+                            modifier = Modifier.padding(20.dp)
+                        )
+                    }
+                }
+                item {
+                    OutlinedButton(
+                        onClick = onBack,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.settings_deck_editor_cancel_button))
+                    }
+                }
+            }
+            return@Scaffold
+        }
+
         LazyColumn(
             contentPadding = PaddingValues(
                 start = 16.dp,
@@ -95,6 +127,7 @@ fun DeckEditorRoute(
                 OutlinedTextField(
                     value = uiState.name,
                     onValueChange = onNameChange,
+                    enabled = isEditorEnabled,
                     label = {
                         Text(stringResource(R.string.settings_deck_editor_name_label))
                     },
@@ -117,6 +150,7 @@ fun DeckEditorRoute(
                     EffortLevel.entries.forEach { effortLevel ->
                         FilterChip(
                             selected = uiState.selectedEffortLevels.contains(effortLevel),
+                            enabled = isEditorEnabled,
                             onClick = {
                                 onToggleEffortLevel(effortLevel)
                             },
@@ -157,6 +191,7 @@ fun DeckEditorRoute(
                         uiState.availableTags.forEach { tagSummary ->
                             FilterChip(
                                 selected = uiState.selectedTags.contains(tagSummary.tag),
+                                enabled = isEditorEnabled,
                                 onClick = {
                                     onToggleTag(tagSummary.tag)
                                 },
@@ -213,6 +248,7 @@ fun DeckEditorRoute(
                     }
                     Button(
                         onClick = onSave,
+                        enabled = isEditorEnabled,
                         modifier = Modifier.weight(1f)
                     ) {
                         Text(stringResource(R.string.settings_save))
@@ -228,6 +264,7 @@ fun DeckEditorRoute(
                 item {
                     OutlinedButton(
                         onClick = onDelete,
+                        enabled = isEditorEnabled,
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         Text(stringResource(R.string.settings_deck_editor_delete_button))

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorUiState.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummar
 
 data class DeckEditorUiState(
     val isLoading: Boolean,
+    val isDeckMissing: Boolean,
     val title: String,
     val isEditing: Boolean,
     val name: String,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckEditorViewModel.kt
@@ -7,8 +7,10 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.data.local.model.cards.DeckDraft
+import com.flashcardsopensourceapp.data.local.model.cards.DeckSummary
 import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
 import com.flashcardsopensourceapp.data.local.repository.DecksRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.feature.settings.R
@@ -18,9 +20,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 sealed interface DeckEditorSaveResult {
     data class Created(
@@ -33,54 +35,55 @@ sealed interface DeckEditorSaveResult {
 class DeckEditorViewModel(
     private val decksRepository: DecksRepository,
     workspaceRepository: WorkspaceRepository,
-    editingDeckId: String?,
+    private val editingDeckId: String?,
     private val strings: SettingsStringResolver
 ) : ViewModel() {
     private val inputState = MutableStateFlow(
-        value = DeckEditorUiState(
-            isLoading = true,
-            title = if (editingDeckId == null) {
-                strings.get(R.string.settings_deck_editor_new_title)
-            } else {
-                strings.get(R.string.settings_deck_editor_edit_title)
-            },
-            isEditing = editingDeckId != null,
+        value = DeckEditorInputState(
             name = "",
             selectedEffortLevels = emptyList(),
             selectedTags = emptyList(),
-            availableTags = emptyList(),
-            errorMessage = ""
+            errorMessage = "",
+            loadedEditingDeckId = null,
+            isEditingDeckMissing = false
         )
     )
 
+    init {
+        val deckId: String? = editingDeckId
+        if (deckId != null) {
+            viewModelScope.launch {
+                decksRepository.observeDeck(deckId = deckId).collect { deck ->
+                    inputState.update { currentState ->
+                        applyObservedEditingDeck(
+                            currentState = currentState,
+                            deck = deck
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     val uiState: StateFlow<DeckEditorUiState> = combine(
-        if (editingDeckId == null) {
-            flowOf(null)
-        } else {
-            decksRepository.observeDeck(deckId = editingDeckId)
-        },
         workspaceRepository.observeWorkspaceTagsSummary(),
         inputState
-    ) { deck, tagsSummary, currentState ->
-        currentState.copy(
-            isLoading = false,
+    ) { tagsSummary, currentState ->
+        toDeckEditorUiState(
+            inputState = currentState,
             availableTags = tagsSummary.tags,
-            name = if (currentState.name.isEmpty() && deck != null) deck.name else currentState.name,
-            selectedEffortLevels = if (currentState.selectedEffortLevels.isEmpty() && deck != null) {
-                deck.filterDefinition.effortLevels
-            } else {
-                currentState.selectedEffortLevels
-            },
-            selectedTags = if (currentState.selectedTags.isEmpty() && deck != null) {
-                deck.filterDefinition.tags
-            } else {
-                currentState.selectedTags
-            }
+            editingDeckId = editingDeckId,
+            strings = strings
         )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
-        initialValue = inputState.value
+        initialValue = toDeckEditorUiState(
+            inputState = inputState.value,
+            availableTags = emptyList(),
+            editingDeckId = editingDeckId,
+            strings = strings
+        )
     )
 
     fun updateName(name: String) {
@@ -116,6 +119,10 @@ class DeckEditorViewModel(
     suspend fun save(editingDeckId: String?): DeckEditorSaveResult? {
         val state = uiState.value
         val trimmedName = state.name.trim()
+
+        if (state.isDeckMissing) {
+            return null
+        }
 
         if (trimmedName.isEmpty()) {
             inputState.update { currentState ->
@@ -200,4 +207,69 @@ private fun toggleTagSelection(selectedTags: List<String>, tag: String): List<St
 
 private fun isDeckFilterEmpty(selectedEffortLevels: List<EffortLevel>, selectedTags: List<String>): Boolean {
     return selectedEffortLevels.isEmpty() && selectedTags.isEmpty()
+}
+
+private data class DeckEditorInputState(
+    val name: String,
+    val selectedEffortLevels: List<EffortLevel>,
+    val selectedTags: List<String>,
+    val errorMessage: String,
+    val loadedEditingDeckId: String?,
+    val isEditingDeckMissing: Boolean
+)
+
+private fun applyObservedEditingDeck(
+    currentState: DeckEditorInputState,
+    deck: DeckSummary?
+): DeckEditorInputState {
+    if (deck == null) {
+        return currentState.copy(isEditingDeckMissing = true)
+    }
+
+    if (currentState.loadedEditingDeckId == deck.deckId) {
+        return currentState.copy(isEditingDeckMissing = false)
+    }
+
+    return currentState.copy(
+        name = deck.name,
+        selectedEffortLevels = deck.filterDefinition.effortLevels,
+        selectedTags = deck.filterDefinition.tags,
+        loadedEditingDeckId = deck.deckId,
+        isEditingDeckMissing = false
+    )
+}
+
+private fun toDeckEditorUiState(
+    inputState: DeckEditorInputState,
+    availableTags: List<WorkspaceTagSummary>,
+    editingDeckId: String?,
+    strings: SettingsStringResolver
+): DeckEditorUiState {
+    return DeckEditorUiState(
+        isLoading = isDeckEditorLoading(
+            inputState = inputState,
+            editingDeckId = editingDeckId
+        ),
+        isDeckMissing = inputState.isEditingDeckMissing,
+        title = if (editingDeckId == null) {
+            strings.get(R.string.settings_deck_editor_new_title)
+        } else {
+            strings.get(R.string.settings_deck_editor_edit_title)
+        },
+        isEditing = editingDeckId != null,
+        name = inputState.name,
+        selectedEffortLevels = inputState.selectedEffortLevels,
+        selectedTags = inputState.selectedTags,
+        availableTags = availableTags,
+        errorMessage = inputState.errorMessage
+    )
+}
+
+private fun isDeckEditorLoading(
+    inputState: DeckEditorInputState,
+    editingDeckId: String?
+): Boolean {
+    return editingDeckId != null &&
+        inputState.loadedEditingDeckId == null &&
+        inputState.isEditingDeckMissing.not()
 }


### PR DESCRIPTION
## Summary
- initializes Android deck editor drafts from an existing deck exactly once
- preserves explicit empty effort/tag selections for validation
- handles missing deck editor routes with a visible not-found state and back action

## Validation
- git --no-pager diff --check
- rg static check for empty editor values used as deck initialization sentinels
- no Gradle run per repository instructions