### PR TITLE
[codex] Fix iOS progress summary merge

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
@@ -47,12 +47,42 @@ extension FlashcardsStore {
     func publishProgressSnapshot(scopeKey: ProgressScopeKey) throws {
         let timeZone = try progressTimeZone(identifier: scopeKey.timeZone)
         let calendar = makeProgressStoreCalendar(timeZone: timeZone)
-        let summaryScopeKey = progressSummaryScopeKey(seriesScopeKey: scopeKey)
         let reviewedAtClientSources = try self.loadProgressReviewedAtClientSources()
-        let localFallbackSummary = try makeProgressSummaryFromReviewedAtClients(
+        let renderedProgress = try self.makeProgressRenderedSummaryAndSeries(
+            scopeKey: scopeKey,
+            reviewedAtClientSources: reviewedAtClientSources
+        )
+
+        let snapshot = try makeProgressSnapshot(
+            summary: renderedProgress.renderedSummary.summary,
+            series: renderedProgress.renderedSeries.series,
+            scopeKey: scopeKey,
+            summarySourceState: renderedProgress.renderedSummary.sourceState,
+            seriesSourceState: renderedProgress.renderedSeries.sourceState,
+            calendar: calendar
+        )
+        self.applyProgressSnapshot(snapshot: snapshot)
+    }
+
+    private func makeProgressRenderedSummaryAndSeries(
+        scopeKey: ProgressScopeKey,
+        reviewedAtClientSources: ProgressReviewedAtClientSources
+    ) throws -> (
+        renderedSummary: ProgressRenderedSummary,
+        renderedSeries: ProgressRenderedSeries
+    ) {
+        let summaryScopeKey = progressSummaryScopeKey(seriesScopeKey: scopeKey)
+        let localFallbackActiveDates = try progressActiveDatesFromReviewedAtClients(
             reviewedAtClients: reviewedAtClientSources.canonicalReviewedAtClients,
+            timeZone: summaryScopeKey.timeZone
+        )
+        let localFallbackSummary = try makeProgressSummary(
+            reviewDates: localFallbackActiveDates,
             timeZone: summaryScopeKey.timeZone,
-            referenceLocalDate: scopeKey.to
+            generatedAt: progressReferenceDate(
+                localDate: scopeKey.to,
+                timeZoneIdentifier: summaryScopeKey.timeZone
+            )
         )
         let localFallbackSeries = try makeProgressSeriesFromReviewedAtClients(
             reviewedAtClients: reviewedAtClientSources.canonicalReviewedAtClients,
@@ -62,29 +92,29 @@ extension FlashcardsStore {
             reviewedAtClients: reviewedAtClientSources.pendingReviewedAtClients,
             requestRange: progressRequestRange(scopeKey: scopeKey)
         )
-        let renderedSummary = makeProgressRenderedSummary(
-            serverBase: self.progressSummaryServerBaseCache,
-            scopeKey: summaryScopeKey,
-            localFallbackSummary: localFallbackSummary,
-            pendingLocalOverlayState: reviewedAtClientSources.pendingLocalOverlayState
-        )
         let renderedSeries = try makeProgressRenderedSeries(
             serverBase: self.progressSeriesServerBaseCache,
             scopeKey: scopeKey,
             localFallbackSeries: localFallbackSeries,
-            pendingLocalOverlaySeries: pendingLocalOverlaySeries,
+            pendingLocalOverlaySeries: pendingLocalOverlaySeries
+        )
+        let renderedSummary = try makeProgressRenderedSummary(
+            serverBase: self.progressSummaryServerBaseCache,
+            scopeKey: summaryScopeKey,
+            localFallbackSummary: localFallbackSummary,
+            localFallbackActiveDates: localFallbackActiveDates,
+            renderedSeriesContext: try makeProgressRenderedSeriesSummaryContext(
+                serverBase: self.progressSeriesServerBaseCache,
+                scopeKey: scopeKey,
+                series: renderedSeries.series
+            ),
             pendingLocalOverlayState: reviewedAtClientSources.pendingLocalOverlayState
         )
 
-        let snapshot = try makeProgressSnapshot(
-            summary: renderedSummary.summary,
-            series: renderedSeries.series,
-            scopeKey: scopeKey,
-            summarySourceState: renderedSummary.sourceState,
-            seriesSourceState: renderedSeries.sourceState,
-            calendar: calendar
+        return (
+            renderedSummary: renderedSummary,
+            renderedSeries: renderedSeries
         )
-        self.applyProgressSnapshot(snapshot: snapshot)
     }
 
     func publishReviewScheduleSnapshot(scopeKey: ReviewScheduleScopeKey) throws {
@@ -204,22 +234,14 @@ extension FlashcardsStore {
     }
 
     func publishReviewProgressBadgeState(scopeKey: ProgressScopeKey) throws {
-        let summaryScopeKey = progressSummaryScopeKey(seriesScopeKey: scopeKey)
         let reviewedAtClientSources = try self.loadProgressReviewedAtClientSources()
-        let localFallbackSummary = try makeProgressSummaryFromReviewedAtClients(
-            reviewedAtClients: reviewedAtClientSources.canonicalReviewedAtClients,
-            timeZone: summaryScopeKey.timeZone,
-            referenceLocalDate: scopeKey.to
-        )
-        let renderedSummary = makeProgressRenderedSummary(
-            serverBase: self.progressSummaryServerBaseCache,
-            scopeKey: summaryScopeKey,
-            localFallbackSummary: localFallbackSummary,
-            pendingLocalOverlayState: reviewedAtClientSources.pendingLocalOverlayState
+        let renderedProgress = try self.makeProgressRenderedSummaryAndSeries(
+            scopeKey: scopeKey,
+            reviewedAtClientSources: reviewedAtClientSources
         )
 
         self.applyReviewProgressBadgeState(
-            badgeState: makeReviewProgressBadgeState(summary: renderedSummary.summary)
+            badgeState: makeReviewProgressBadgeState(summary: renderedProgress.renderedSummary.summary)
         )
     }
 

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
@@ -38,6 +38,13 @@ struct ProgressRenderedReviewSchedule: Hashable, Sendable {
     let sourceState: ProgressSourceState
 }
 
+struct ProgressRenderedSeriesSummaryContext: Hashable, Sendable {
+    let lowerBoundSummary: ProgressSummary
+    let activeDates: Set<String>
+    let activeDatesMissingFromServerBase: Set<String>
+    let serverBaseReviewHistoryWatermarks: [ProgressReviewHistoryWatermark]?
+}
+
 func progressSummaryScopeKey(seriesScopeKey: ProgressScopeKey) -> ProgressSummaryScopeKey {
     ProgressSummaryScopeKey(
         cloudState: seriesScopeKey.cloudState,
@@ -62,26 +69,45 @@ func makeProgressRenderedSummary(
     serverBase: PersistedProgressSummaryServerBase?,
     scopeKey: ProgressSummaryScopeKey,
     localFallbackSummary: ProgressSummary,
+    localFallbackActiveDates: Set<String>,
+    renderedSeriesContext: ProgressRenderedSeriesSummaryContext?,
     pendingLocalOverlayState: ProgressPendingLocalOverlayState
-) -> ProgressRenderedSummary {
-    guard let serverBaseSummary = serverBase?.serverBase.summary,
-          serverBase?.scopeKey == scopeKey else {
+) throws -> ProgressRenderedSummary {
+    guard let persistedServerBase = serverBase,
+          persistedServerBase.scopeKey == scopeKey else {
         return ProgressRenderedSummary(
             summary: localFallbackSummary,
             sourceState: .localOnly
         )
     }
 
+    let serverBaseSummary = persistedServerBase.serverBase.summary
+    let renderedSummary = try mergeProgressSummary(
+        serverBase: serverBaseSummary,
+        serverBaseReviewHistoryWatermarks: persistedServerBase.serverBase.reviewHistoryWatermarks,
+        localFallback: localFallbackSummary,
+        localFallbackActiveDates: localFallbackActiveDates,
+        renderedSeriesContext: renderedSeriesContext,
+        referenceLocalDate: scopeKey.referenceLocalDate
+    )
+
     switch pendingLocalOverlayState {
     case .present:
         return ProgressRenderedSummary(
-            summary: localFallbackSummary,
+            summary: renderedSummary,
             sourceState: .serverBaseWithPendingLocalOverlay
         )
     case .empty:
+        guard renderedSummary != serverBaseSummary else {
+            return ProgressRenderedSummary(
+                summary: serverBaseSummary,
+                sourceState: .serverBase
+            )
+        }
+
         return ProgressRenderedSummary(
-            summary: serverBaseSummary,
-            sourceState: .serverBase
+            summary: renderedSummary,
+            sourceState: .serverBaseWithPendingLocalOverlay
         )
     }
 }
@@ -90,8 +116,7 @@ func makeProgressRenderedSeries(
     serverBase: PersistedProgressSeriesServerBase?,
     scopeKey: ProgressScopeKey,
     localFallbackSeries: UserProgressSeries,
-    pendingLocalOverlaySeries: UserProgressSeries,
-    pendingLocalOverlayState: ProgressPendingLocalOverlayState
+    pendingLocalOverlaySeries: UserProgressSeries
 ) throws -> ProgressRenderedSeries {
     guard let serverBaseSeries = serverBase?.serverBase,
           serverBase?.scopeKey == scopeKey else {
@@ -101,12 +126,18 @@ func makeProgressRenderedSeries(
         )
     }
 
+    let renderedSeries = try mergeProgressSeries(
+        serverBase: serverBaseSeries,
+        pendingLocalOverlay: pendingLocalOverlaySeries,
+        localFallback: localFallbackSeries
+    )
+
     return ProgressRenderedSeries(
-        series: try mergeProgressSeries(
+        series: renderedSeries,
+        sourceState: progressSeriesSourceState(
             serverBase: serverBaseSeries,
-            pendingLocalOverlay: pendingLocalOverlaySeries
-        ),
-        sourceState: progressSeriesSourceState(pendingLocalOverlayState: pendingLocalOverlayState)
+            renderedSeries: renderedSeries
+        )
     )
 }
 
@@ -148,14 +179,349 @@ func makeProgressRenderedReviewSchedule(
 }
 
 private func progressSeriesSourceState(
-    pendingLocalOverlayState: ProgressPendingLocalOverlayState
+    serverBase: UserProgressSeries,
+    renderedSeries: UserProgressSeries
 ) -> ProgressSourceState {
-    switch pendingLocalOverlayState {
-    case .empty:
+    if serverBase.dailyReviews == renderedSeries.dailyReviews {
         return .serverBase
-    case .present:
-        return .serverBaseWithPendingLocalOverlay
     }
+
+    return .serverBaseWithPendingLocalOverlay
+}
+
+private func mergeProgressSummary(
+    serverBase: ProgressSummary,
+    serverBaseReviewHistoryWatermarks: [ProgressReviewHistoryWatermark],
+    localFallback: ProgressSummary,
+    localFallbackActiveDates: Set<String>,
+    renderedSeriesContext: ProgressRenderedSeriesSummaryContext?,
+    referenceLocalDate: String
+) throws -> ProgressSummary {
+    let renderedSeriesLowerBound = renderedSeriesContext?.lowerBoundSummary
+    let serverAndSeriesShareReviewHistoryBase = progressServerAndSeriesShareReviewHistoryBase(
+        serverBaseReviewHistoryWatermarks: serverBaseReviewHistoryWatermarks,
+        renderedSeriesContext: renderedSeriesContext
+    )
+    let serverActiveReviewDaysWithRenderedDelta = serverBase.activeReviewDays
+        + progressActiveReviewDayDelta(
+            activeReviewDayDeltaCandidates: progressActiveReviewDayDeltaCandidates(
+                renderedSeriesContext: renderedSeriesContext,
+                localFallbackActiveDates: localFallbackActiveDates,
+                serverBase: serverBase,
+                serverAndSeriesShareReviewHistoryBase: serverAndSeriesShareReviewHistoryBase
+            ),
+            serverBase: serverBase,
+            serverAndSeriesShareReviewHistoryBase: serverAndSeriesShareReviewHistoryBase,
+            referenceLocalDate: referenceLocalDate
+        )
+    let serverCurrentStreakDaysWithRenderedDelta = progressCurrentStreakDaysWithRenderedDelta(
+        serverBase: serverBase,
+        renderedSeriesActiveDates: renderedSeriesContext?.activeDates,
+        referenceLocalDate: referenceLocalDate
+    )
+
+    return ProgressSummary(
+        currentStreakDays: max(
+            serverCurrentStreakDaysWithRenderedDelta,
+            localFallback.currentStreakDays,
+            renderedSeriesLowerBound?.currentStreakDays ?? 0
+        ),
+        hasReviewedToday: serverBase.hasReviewedToday
+            || localFallback.hasReviewedToday
+            || (renderedSeriesLowerBound?.hasReviewedToday ?? false),
+        lastReviewedOn: maxProgressLocalDate(
+            left: maxProgressLocalDate(
+                left: serverBase.lastReviewedOn,
+                right: localFallback.lastReviewedOn
+            ),
+            right: renderedSeriesLowerBound?.lastReviewedOn
+        ),
+        activeReviewDays: max(
+            serverActiveReviewDaysWithRenderedDelta,
+            localFallback.activeReviewDays,
+            renderedSeriesLowerBound?.activeReviewDays ?? 0
+        )
+    )
+}
+
+private func progressServerAndSeriesShareReviewHistoryBase(
+    serverBaseReviewHistoryWatermarks: [ProgressReviewHistoryWatermark],
+    renderedSeriesContext: ProgressRenderedSeriesSummaryContext?
+) -> Bool {
+    guard let seriesBaseReviewHistoryWatermarks = renderedSeriesContext?.serverBaseReviewHistoryWatermarks else {
+        return false
+    }
+
+    return seriesBaseReviewHistoryWatermarks == serverBaseReviewHistoryWatermarks
+}
+
+private func progressActiveReviewDayDeltaCandidates(
+    renderedSeriesContext: ProgressRenderedSeriesSummaryContext?,
+    localFallbackActiveDates: Set<String>,
+    serverBase: ProgressSummary,
+    serverAndSeriesShareReviewHistoryBase: Bool
+) -> Set<String> {
+    let renderedSeriesCandidates: Set<String>
+    if let renderedSeriesContext {
+        if serverAndSeriesShareReviewHistoryBase {
+            renderedSeriesCandidates = renderedSeriesContext.activeDatesMissingFromServerBase
+        } else {
+            renderedSeriesCandidates = renderedSeriesContext.activeDates
+        }
+    } else {
+        renderedSeriesCandidates = []
+    }
+
+    return renderedSeriesCandidates.union(
+        progressLocalFallbackActiveReviewDayDeltaCandidates(
+            localFallbackActiveDates: localFallbackActiveDates,
+            serverBase: serverBase
+        )
+    )
+}
+
+private func progressLocalFallbackActiveReviewDayDeltaCandidates(
+    localFallbackActiveDates: Set<String>,
+    serverBase: ProgressSummary
+) -> Set<String> {
+    guard let lastReviewedOn = serverBase.lastReviewedOn else {
+        return localFallbackActiveDates
+    }
+
+    return Set(localFallbackActiveDates.filter { localDate in
+        localDate > lastReviewedOn
+    })
+}
+
+private func progressActiveReviewDayDelta(
+    activeReviewDayDeltaCandidates: Set<String>,
+    serverBase: ProgressSummary,
+    serverAndSeriesShareReviewHistoryBase: Bool,
+    referenceLocalDate: String
+) -> Int {
+    activeReviewDayDeltaCandidates.filter { localDate in
+        progressShouldApplyActiveReviewDayDelta(
+            localDate: localDate,
+            serverBase: serverBase,
+            serverAndSeriesShareReviewHistoryBase: serverAndSeriesShareReviewHistoryBase,
+            referenceLocalDate: referenceLocalDate
+        )
+    }.count
+}
+
+private func progressShouldApplyActiveReviewDayDelta(
+    localDate: String,
+    serverBase: ProgressSummary,
+    serverAndSeriesShareReviewHistoryBase: Bool,
+    referenceLocalDate: String
+) -> Bool {
+    if localDate == referenceLocalDate,
+       serverBase.hasReviewedToday {
+        return false
+    }
+
+    if serverAndSeriesShareReviewHistoryBase {
+        return true
+    }
+
+    guard let lastReviewedOn = serverBase.lastReviewedOn else {
+        return true
+    }
+
+    return localDate > lastReviewedOn
+}
+
+private func progressCurrentStreakDaysWithRenderedDelta(
+    serverBase: ProgressSummary,
+    renderedSeriesActiveDates: Set<String>?,
+    referenceLocalDate: String
+) -> Int {
+    guard serverBase.hasReviewedToday == false else {
+        return serverBase.currentStreakDays
+    }
+
+    guard serverBase.currentStreakDays > 0 else {
+        return serverBase.currentStreakDays
+    }
+
+    guard renderedSeriesActiveDates?.contains(referenceLocalDate) == true else {
+        return serverBase.currentStreakDays
+    }
+
+    return serverBase.currentStreakDays + 1
+}
+
+private func validateProgressSeriesMergeInputs(
+    serverBase: UserProgressSeries,
+    pendingLocalOverlay: UserProgressSeries,
+    localFallback: UserProgressSeries
+) throws {
+    guard
+        serverBase.timeZone == pendingLocalOverlay.timeZone,
+        serverBase.from == pendingLocalOverlay.from,
+        serverBase.to == pendingLocalOverlay.to,
+        serverBase.timeZone == localFallback.timeZone,
+        serverBase.from == localFallback.from,
+        serverBase.to == localFallback.to
+    else {
+        throw LocalStoreError.validation(
+            """
+            Progress merge inputs must share the same time range. \
+            serverBase=\(serverBase.timeZone) \(serverBase.from)...\(serverBase.to), \
+            pendingLocalOverlay=\(pendingLocalOverlay.timeZone) \(pendingLocalOverlay.from)...\(pendingLocalOverlay.to), \
+            localFallback=\(localFallback.timeZone) \(localFallback.from)...\(localFallback.to).
+            """
+        )
+    }
+}
+
+private func validateProgressSeriesPairInputs(
+    serverBase: UserProgressSeries,
+    renderedSeries: UserProgressSeries
+) throws {
+    guard
+        serverBase.timeZone == renderedSeries.timeZone,
+        serverBase.from == renderedSeries.from,
+        serverBase.to == renderedSeries.to
+    else {
+        throw LocalStoreError.validation(
+            """
+            Progress series comparison inputs must share the same time range. \
+            serverBase=\(serverBase.timeZone) \(serverBase.from)...\(serverBase.to), \
+            renderedSeries=\(renderedSeries.timeZone) \(renderedSeries.from)...\(renderedSeries.to).
+            """
+        )
+    }
+}
+
+private func progressCountsByLocalDate(
+    series: UserProgressSeries,
+    sourceName: String
+) throws -> [String: Int] {
+    var countsByLocalDate: [String: Int] = [:]
+    for progressDay in series.dailyReviews {
+        guard progressDay.reviewCount >= 0 else {
+            throw LocalStoreError.validation(
+                """
+                Progress merge \(sourceName) contained a negative review count. \
+                localDate=\(progressDay.date), reviewCount=\(progressDay.reviewCount).
+                """
+            )
+        }
+
+        guard countsByLocalDate.updateValue(progressDay.reviewCount, forKey: progressDay.date) == nil else {
+            throw LocalStoreError.validation(
+                "Progress merge \(sourceName) contained a duplicate local date. localDate=\(progressDay.date)."
+            )
+        }
+    }
+
+    return countsByLocalDate
+}
+
+private func validateProgressCountsInRange(
+    countsByLocalDate: [String: Int],
+    rangeLocalDates: Set<String>,
+    sourceName: String,
+    rangeDescription: String
+) throws {
+    for localDate in countsByLocalDate.keys where rangeLocalDates.contains(localDate) == false {
+        throw LocalStoreError.validation(
+            """
+            Progress merge \(sourceName) contained a local date outside the merge range. \
+            localDate=\(localDate), range=\(rangeDescription).
+            """
+        )
+    }
+}
+
+func makeProgressRenderedSeriesSummaryContext(
+    serverBase: PersistedProgressSeriesServerBase?,
+    scopeKey: ProgressScopeKey,
+    series: UserProgressSeries
+) throws -> ProgressRenderedSeriesSummaryContext {
+    let activeDates = try progressActiveDatesFromSeries(series: series)
+    let activeDatesMissingFromServerBase: Set<String>
+    let serverBaseReviewHistoryWatermarks: [ProgressReviewHistoryWatermark]?
+    if let serverBaseSeries = serverBase?.serverBase,
+       serverBase?.scopeKey == scopeKey {
+        activeDatesMissingFromServerBase = try progressActiveDatesMissingFromServerBase(
+            serverBase: serverBaseSeries,
+            renderedSeries: series
+        )
+        serverBaseReviewHistoryWatermarks = serverBaseSeries.reviewHistoryWatermarks
+    } else {
+        activeDatesMissingFromServerBase = []
+        serverBaseReviewHistoryWatermarks = nil
+    }
+
+    return ProgressRenderedSeriesSummaryContext(
+        lowerBoundSummary: try makeProgressSummaryLowerBoundFromSeries(series: series, activeDates: activeDates),
+        activeDates: activeDates,
+        activeDatesMissingFromServerBase: activeDatesMissingFromServerBase,
+        serverBaseReviewHistoryWatermarks: serverBaseReviewHistoryWatermarks
+    )
+}
+
+private func makeProgressSummaryLowerBoundFromSeries(
+    series: UserProgressSeries,
+    activeDates: Set<String>
+) throws -> ProgressSummary {
+    try makeProgressSummary(
+        reviewDates: activeDates,
+        timeZone: series.timeZone,
+        generatedAt: progressReferenceDate(
+            localDate: series.to,
+            timeZoneIdentifier: series.timeZone
+        )
+    )
+}
+
+private func progressActiveDatesFromSeries(series: UserProgressSeries) throws -> Set<String> {
+    let countsByLocalDate = try progressCountsByLocalDate(series: series, sourceName: "renderedSeries")
+    return Set(countsByLocalDate.compactMap { localDate, reviewCount in
+        reviewCount > 0 ? localDate : nil
+    })
+}
+
+private func progressActiveDatesMissingFromServerBase(
+    serverBase: UserProgressSeries,
+    renderedSeries: UserProgressSeries
+) throws -> Set<String> {
+    try validateProgressSeriesPairInputs(
+        serverBase: serverBase,
+        renderedSeries: renderedSeries
+    )
+
+    let serverCounts = try progressCountsByLocalDate(series: serverBase, sourceName: "serverBase")
+    let renderedCounts = try progressCountsByLocalDate(series: renderedSeries, sourceName: "renderedSeries")
+    let zeroFilledDays = try makeZeroFilledProgressDays(
+        requestRange: ProgressRequestRange(
+            timeZone: serverBase.timeZone,
+            from: serverBase.from,
+            to: serverBase.to
+        )
+    )
+    let rangeLocalDates = Set(zeroFilledDays.map(\.date))
+    let rangeDescription = "\(serverBase.from)...\(serverBase.to)"
+    try validateProgressCountsInRange(
+        countsByLocalDate: serverCounts,
+        rangeLocalDates: rangeLocalDates,
+        sourceName: "serverBase",
+        rangeDescription: rangeDescription
+    )
+    try validateProgressCountsInRange(
+        countsByLocalDate: renderedCounts,
+        rangeLocalDates: rangeLocalDates,
+        sourceName: "renderedSeries",
+        rangeDescription: rangeDescription
+    )
+
+    return Set(zeroFilledDays.compactMap { progressDay in
+        let serverCount = serverCounts[progressDay.date] ?? 0
+        let renderedCount = renderedCounts[progressDay.date] ?? 0
+        return renderedCount > 0 && serverCount == 0 ? progressDay.date : nil
+    })
 }
 
 func makeProgressSeriesFromReviewedAtClients(
@@ -198,23 +564,31 @@ func makeProgressSeriesFromReviewedAtClients(
     )
 }
 
-func makeProgressSummaryFromReviewedAtClients(
+func progressActiveDatesFromReviewedAtClients(
     reviewedAtClients: [String],
-    timeZone: String,
-    referenceLocalDate: String
-) throws -> ProgressSummary {
+    timeZone: String
+) throws -> Set<String> {
     let resolvedTimeZone = try progressTimeZone(identifier: timeZone)
     let calendar = makeProgressStoreCalendar(timeZone: resolvedTimeZone)
-    let reviewDates = try Set(reviewedAtClients.map { reviewedAtClient in
+    return try Set(reviewedAtClients.map { reviewedAtClient in
         guard let reviewedAtDate = parseIsoTimestamp(value: reviewedAtClient) else {
             throw LocalStoreError.validation("Progress reviewedAtClient timestamp is invalid: \(reviewedAtClient)")
         }
 
         return progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
     })
+}
 
+func makeProgressSummaryFromReviewedAtClients(
+    reviewedAtClients: [String],
+    timeZone: String,
+    referenceLocalDate: String
+) throws -> ProgressSummary {
     return try makeProgressSummary(
-        reviewDates: reviewDates,
+        reviewDates: progressActiveDatesFromReviewedAtClients(
+            reviewedAtClients: reviewedAtClients,
+            timeZone: timeZone
+        ),
         timeZone: timeZone,
         generatedAt: progressReferenceDate(
             localDate: referenceLocalDate,
@@ -225,23 +599,51 @@ func makeProgressSummaryFromReviewedAtClients(
 
 func mergeProgressSeries(
     serverBase: UserProgressSeries,
-    pendingLocalOverlay: UserProgressSeries
+    pendingLocalOverlay: UserProgressSeries,
+    localFallback: UserProgressSeries
 ) throws -> UserProgressSeries {
-    guard
-        serverBase.timeZone == pendingLocalOverlay.timeZone,
-        serverBase.from == pendingLocalOverlay.from,
-        serverBase.to == pendingLocalOverlay.to
-    else {
-        throw LocalStoreError.validation("Progress merge inputs must share the same time range")
-    }
+    try validateProgressSeriesMergeInputs(
+        serverBase: serverBase,
+        pendingLocalOverlay: pendingLocalOverlay,
+        localFallback: localFallback
+    )
 
-    let overlayCounts = Dictionary(uniqueKeysWithValues: pendingLocalOverlay.dailyReviews.map { progressDay in
-        (progressDay.date, progressDay.reviewCount)
-    })
-    let mergedDailyReviews = serverBase.dailyReviews.map { progressDay in
+    let serverCounts = try progressCountsByLocalDate(series: serverBase, sourceName: "serverBase")
+    let pendingCounts = try progressCountsByLocalDate(series: pendingLocalOverlay, sourceName: "pendingLocalOverlay")
+    let localFallbackCounts = try progressCountsByLocalDate(series: localFallback, sourceName: "localFallback")
+    let zeroFilledDays = try makeZeroFilledProgressDays(
+        requestRange: ProgressRequestRange(
+            timeZone: serverBase.timeZone,
+            from: serverBase.from,
+            to: serverBase.to
+        )
+    )
+    let rangeLocalDates = Set(zeroFilledDays.map(\.date))
+    let rangeDescription = "\(serverBase.from)...\(serverBase.to)"
+    try validateProgressCountsInRange(
+        countsByLocalDate: serverCounts,
+        rangeLocalDates: rangeLocalDates,
+        sourceName: "serverBase",
+        rangeDescription: rangeDescription
+    )
+    try validateProgressCountsInRange(
+        countsByLocalDate: pendingCounts,
+        rangeLocalDates: rangeLocalDates,
+        sourceName: "pendingLocalOverlay",
+        rangeDescription: rangeDescription
+    )
+    try validateProgressCountsInRange(
+        countsByLocalDate: localFallbackCounts,
+        rangeLocalDates: rangeLocalDates,
+        sourceName: "localFallback",
+        rangeDescription: rangeDescription
+    )
+    let mergedDailyReviews = zeroFilledDays.map { progressDay in
+        let serverOverlayCount = (serverCounts[progressDay.date] ?? 0) + (pendingCounts[progressDay.date] ?? 0)
+        let localFallbackCount = localFallbackCounts[progressDay.date] ?? 0
         ProgressDay(
             date: progressDay.date,
-            reviewCount: progressDay.reviewCount + (overlayCounts[progressDay.date] ?? 0)
+            reviewCount: max(serverOverlayCount, localFallbackCount)
         )
     }
 

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressBadgeRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressBadgeRefreshTests.swift
@@ -4,6 +4,137 @@ import XCTest
 
 final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
     @MainActor
+    func testRefreshReviewProgressBadgeKeepsLocalTodayReviewWhenServerSummaryIsStale() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-18",
+                hour: 9,
+                timeZoneIdentifier: requestRange.timeZone
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshReviewProgressBadgeIfNeeded(now: now)
+
+        XCTAssertNil(context.store.progressSnapshot)
+        XCTAssertEqual(
+            ReviewProgressBadgeState(
+                streakDays: 1,
+                hasReviewedToday: true,
+                isInteractive: true
+            ),
+            context.store.reviewProgressBadgeState
+        )
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressSeriesCallCount)
+    }
+
+    @MainActor
+    func testRefreshReviewProgressBadgeExtendsLongServerStreakWithLocalTodayReview() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-18",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-17": 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 200,
+                hasReviewedToday: false,
+                lastReviewedOn: "2026-04-17",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshReviewProgressBadgeIfNeeded(now: now)
+
+        XCTAssertNil(context.store.progressSnapshot)
+        XCTAssertEqual(
+            ReviewProgressBadgeState(
+                streakDays: 201,
+                hasReviewedToday: true,
+                isInteractive: true
+            ),
+            context.store.reviewProgressBadgeState
+        )
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressSeriesCallCount)
+    }
+
+    @MainActor
     func testRefreshReviewProgressBadgeIfNeededLoadsBadgeSummaryWithoutBuildingSnapshot() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressContextChangeTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressContextChangeTests.swift
@@ -49,7 +49,7 @@ final class ProgressContextChangeTests: ProgressStoreTestCase {
 
         let initialScopeKey = try XCTUnwrap(context.store.progressObservedScopeKey)
         let initialSnapshot = try XCTUnwrap(context.store.progressSnapshot)
-        XCTAssertEqual(1, initialSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(2, initialSnapshot.summary.activeReviewDays)
         XCTAssertEqual("2026-04-02", initialSnapshot.summary.lastReviewedOn)
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSeriesCallCount)
@@ -71,7 +71,7 @@ final class ProgressContextChangeTests: ProgressStoreTestCase {
         let updatedSnapshot = try XCTUnwrap(context.store.progressSnapshot)
         XCTAssertNotEqual(initialScopeKey, updatedScopeKey)
         XCTAssertNotEqual(initialScopeKey.workspaceMembershipKey, updatedScopeKey.workspaceMembershipKey)
-        XCTAssertEqual(2, updatedSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(3, updatedSnapshot.summary.activeReviewDays)
         XCTAssertEqual("2026-04-03", updatedSnapshot.summary.lastReviewedOn)
 
         await self.waitForProgressRefreshCallCounts(
@@ -395,7 +395,7 @@ final class ProgressContextChangeTests: ProgressStoreTestCase {
         await context.store.refreshProgressIfNeeded(now: now)
         let firstSnapshot = try XCTUnwrap(context.store.progressSnapshot)
         let firstScopeKey = try XCTUnwrap(context.store.progressObservedScopeKey)
-        XCTAssertEqual(2, firstSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(3, firstSnapshot.summary.activeReviewDays)
         XCTAssertEqual("2026-04-03", firstSnapshot.summary.lastReviewedOn)
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSeriesCallCount)

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSummarySeriesRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSummarySeriesRefreshTests.swift
@@ -4,6 +4,551 @@ import XCTest
 
 final class ProgressSummarySeriesRefreshTests: ProgressStoreTestCase {
     @MainActor
+    func testRefreshProgressIfNeededExtendsLongServerSummaryWhenRenderedSeriesAddsToday() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-18",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-17": 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 200,
+                hasReviewedToday: false,
+                lastReviewedOn: "2026-04-17",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(201, progressSnapshot.summary.currentStreakDays)
+        XCTAssertTrue(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-18", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(201, progressSnapshot.summary.activeReviewDays)
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededExtendsStaleSummaryActiveDaysWhenServerSeriesIsFresher() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-17": 1,
+                "2026-04-18": 1,
+            ],
+            generatedAt: "2026-04-18T12:00:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 200,
+                hasReviewedToday: false,
+                lastReviewedOn: "2026-04-17",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 41)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBase, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(201, progressSnapshot.summary.currentStreakDays)
+        XCTAssertTrue(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-18", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(201, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-17"))
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-18"))
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededExtendsActiveDaysForLocalDateOutsideRenderedSeriesRange() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2025-11-15",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 0,
+                hasReviewedToday: false,
+                lastReviewedOn: "2025-11-14",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBase, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(0, progressSnapshot.summary.currentStreakDays)
+        XCTAssertFalse(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2025-11-15", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(201, progressSnapshot.summary.activeReviewDays)
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededUsesRenderedSeriesLowerBoundWhenStaleServerSummaryAddsYesterday() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-17",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-16": 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 0,
+                hasReviewedToday: false,
+                lastReviewedOn: "2026-04-16",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(2, progressSnapshot.summary.currentStreakDays)
+        XCTAssertFalse(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-17", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(201, progressSnapshot.summary.activeReviewDays)
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededDoesNotDoubleApplyTodayWhenServerAlreadyIncludesToday() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-18",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-18": 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 200,
+                hasReviewedToday: true,
+                lastReviewedOn: "2026-04-18",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBase, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBase, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(200, progressSnapshot.summary.currentStreakDays)
+        XCTAssertTrue(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-18", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(200, progressSnapshot.summary.activeReviewDays)
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededDoesNotDoubleApplyPastDateWhenSummaryIsFresherThanSeries() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-17",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let staleServerSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:58:00.000Z"
+        )
+        let serverSeries = makeProgressSeries(
+            timeZone: staleServerSeries.timeZone,
+            from: staleServerSeries.from,
+            to: staleServerSeries.to,
+            dailyReviews: staleServerSeries.dailyReviews,
+            summary: staleServerSeries.summary,
+            generatedAt: staleServerSeries.generatedAt,
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 41)
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 1,
+                hasReviewedToday: false,
+                lastReviewedOn: "2026-04-17",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBase, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(1, progressSnapshot.summary.currentStreakDays)
+        XCTAssertFalse(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-17", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(200, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-17"))
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededMergesStaleServerSummaryWithLocalFallbackAfterPendingClears() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-17",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-18",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-16": 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: ["2026-04-16"],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.seriesSourceState)
+        XCTAssertFalse(progressSnapshot.isApproximate)
+        XCTAssertEqual(3, progressSnapshot.summary.currentStreakDays)
+        XCTAssertTrue(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-18", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(3, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-16"))
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-17"))
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-18"))
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressSeriesCallCount)
+    }
+
+    func testMergeProgressSeriesUsesLocalFallbackAsFloorWithoutDoubleCounting() throws {
+        let requestRange = ProgressSeriesLoadRequest(
+            apiBaseUrl: "",
+            authorizationHeader: "",
+            timeZone: "UTC",
+            from: "2026-04-15",
+            to: "2026-04-18"
+        )
+        let serverBase = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-16": 1,
+                "2026-04-17": 2,
+                "2026-04-18": 2,
+            ],
+            generatedAt: "2026-04-18T12:00:00.000Z"
+        )
+        let pendingLocalOverlay = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-17": 1
+            ],
+            generatedAt: "2026-04-18T12:00:00.000Z"
+        )
+        let localFallback = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-15": 1,
+                "2026-04-16": 1,
+                "2026-04-17": 2,
+                "2026-04-18": 1,
+            ],
+            generatedAt: "2026-04-18T12:00:00.000Z"
+        )
+
+        let mergedSeries = try mergeProgressSeries(
+            serverBase: serverBase,
+            pendingLocalOverlay: pendingLocalOverlay,
+            localFallback: localFallback
+        )
+        let mergedCountsByDate = Dictionary(uniqueKeysWithValues: mergedSeries.dailyReviews.map { progressDay in
+            (progressDay.date, progressDay.reviewCount)
+        })
+
+        XCTAssertEqual(1, mergedCountsByDate["2026-04-15"])
+        XCTAssertEqual(1, mergedCountsByDate["2026-04-16"])
+        XCTAssertEqual(3, mergedCountsByDate["2026-04-17"])
+        XCTAssertEqual(2, mergedCountsByDate["2026-04-18"])
+        XCTAssertEqual(serverBase.generatedAt, mergedSeries.generatedAt)
+        XCTAssertEqual(serverBase.reviewHistoryWatermarks, mergedSeries.reviewHistoryWatermarks)
+
+        let scopeKey = makeProgressScopeKeyForTests(
+            timeZone: requestRange.timeZone,
+            from: requestRange.from,
+            to: requestRange.to
+        )
+        let persistedServerBase = PersistedProgressSeriesServerBase(
+            scopeKey: scopeKey,
+            serverBase: serverBase,
+            storedAt: "2026-04-18T12:00:00.000Z"
+        )
+        let renderedOverlaySeries = try makeProgressRenderedSeries(
+            serverBase: persistedServerBase,
+            scopeKey: scopeKey,
+            localFallbackSeries: localFallback,
+            pendingLocalOverlaySeries: pendingLocalOverlay
+        )
+        let emptyPendingLocalOverlay = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T12:00:00.000Z"
+        )
+        let renderedServerSeries = try makeProgressRenderedSeries(
+            serverBase: persistedServerBase,
+            scopeKey: scopeKey,
+            localFallbackSeries: serverBase,
+            pendingLocalOverlaySeries: emptyPendingLocalOverlay
+        )
+
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, renderedOverlaySeries.sourceState)
+        XCTAssertEqual(.serverBase, renderedServerSeries.sourceState)
+    }
+
+    @MainActor
     func testRefreshProgressIfNeededMergesServerBaseWithPendingLocalOverlayWithoutSync() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
@@ -65,7 +610,7 @@ final class ProgressSummarySeriesRefreshTests: ProgressStoreTestCase {
         XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
         XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.seriesSourceState)
         XCTAssertFalse(progressSnapshot.isApproximate)
-        XCTAssertEqual(1, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(2, progressSnapshot.summary.activeReviewDays)
         XCTAssertFalse(progressSnapshot.summary.hasReviewedToday)
         XCTAssertEqual("2026-04-02", progressSnapshot.summary.lastReviewedOn)
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSyncCompletionTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSyncCompletionTests.swift
@@ -521,6 +521,96 @@ final class ProgressSyncCompletionTests: ProgressStoreTestCase {
     }
 
     @MainActor
+    func testHandleProgressSyncCompletionKeepsBadgeColoredWhenOutboxClearsBeforeServerSummaryCatchesUp() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-18",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let staleServerSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let staleServerSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: staleServerSummary,
+            serverSeries: staleServerSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        context.store.updateCurrentVisibleTab(tab: .review)
+        await context.store.refreshReviewProgressBadgeIfNeeded(now: now)
+
+        XCTAssertTrue(context.store.reviewProgressBadgeState.hasReviewedToday)
+        let initialSummaryCallCount = context.cloudSyncService.loadProgressSummaryCallCount
+        let initialSeriesCallCount = context.cloudSyncService.loadProgressSeriesCallCount
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+        context.cloudSyncService.serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T12:01:00.000Z"
+        )
+
+        await context.store.handleProgressSyncCompletion(
+            now: now,
+            syncResult: CloudSyncResult(
+                appliedPullChangeCount: 0,
+                reviewScheduleImpactingPullChangeCount: 0,
+                changedEntityTypes: [],
+                localIdRepairEntityTypes: [],
+                acknowledgedOperationCount: 1,
+                acknowledgedReviewEventOperationCount: 1,
+                acknowledgedReviewScheduleImpactingOperationCount: 0,
+                cleanedUpOperationCount: 0,
+                cleanedUpReviewEventOperationCount: 0,
+                cleanedUpReviewScheduleImpactingOperationCount: 0
+            )
+        )
+        await self.waitForProgressRefreshCallCounts(
+            cloudSyncService: context.cloudSyncService,
+            summaryCount: initialSummaryCallCount + 1,
+            seriesCount: initialSeriesCallCount
+        )
+
+        XCTAssertNil(context.store.progressSnapshot)
+        XCTAssertEqual(
+            ReviewProgressBadgeState(
+                streakDays: 1,
+                hasReviewedToday: true,
+                isInteractive: true
+            ),
+            context.store.reviewProgressBadgeState
+        )
+    }
+
+    @MainActor
     func testHandleProgressSyncCompletionRefreshesBadgeWithoutUpdatingSharedSnapshotWhenReviewIsVisible() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
@@ -668,7 +758,7 @@ final class ProgressSyncCompletionTests: ProgressStoreTestCase {
         XCTAssertEqual(initialSummaryCallCount, context.cloudSyncService.loadProgressSummaryCallCount)
         XCTAssertEqual(initialSeriesCallCount, context.cloudSyncService.loadProgressSeriesCallCount)
         let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
-        XCTAssertEqual(1, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(2, progressSnapshot.summary.activeReviewDays)
         XCTAssertEqual("2026-04-02", progressSnapshot.summary.lastReviewedOn)
     }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -39,6 +39,30 @@ func makeTestProgressRequestRange(
     )
 }
 
+func makeReviewedAtClientForTests(
+    localDate: String,
+    hour: Int,
+    timeZoneIdentifier: String
+) throws -> String {
+    guard let timeZone = TimeZone(identifier: timeZoneIdentifier) else {
+        throw LocalStoreError.validation("Test reviewed-at-client timezone is invalid: \(timeZoneIdentifier)")
+    }
+    guard (0..<24).contains(hour) else {
+        throw LocalStoreError.validation("Test reviewed-at-client hour is invalid: \(hour)")
+    }
+
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = timeZone
+    guard
+        let startOfDay = progressDateForTests(localDate: localDate, calendar: calendar),
+        let reviewedAt = calendar.date(byAdding: .hour, value: hour, to: startOfDay)
+    else {
+        throw LocalStoreError.validation("Test reviewed-at-client local date is invalid: \(localDate)")
+    }
+
+    return formatIsoTimestamp(date: reviewedAt)
+}
+
 func makeTestProgressSeries(
     requestRange: ProgressSeriesLoadRequest,
     reviewCountsByDate: [String: Int],

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
@@ -51,9 +51,11 @@ final class ProgressServerValidationRefreshTests: ProgressStoreTestCase {
         await context.store.refreshProgressIfNeeded(now: now)
 
         let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
-        XCTAssertEqual(.serverBase, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
         XCTAssertEqual(.localOnly, progressSnapshot.seriesSourceState)
         XCTAssertTrue(progressSnapshot.isApproximate)
+        XCTAssertEqual(2, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual("2026-04-02", progressSnapshot.summary.lastReviewedOn)
         XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-02"))
         XCTAssertNil(context.store.progressSeriesServerBaseCache)
         let persistedSeriesCacheKeys = context.userDefaults.dictionaryRepresentation().keys.filter { key in
@@ -118,9 +120,11 @@ final class ProgressServerValidationRefreshTests: ProgressStoreTestCase {
         await context.store.refreshProgressIfNeeded(now: now)
 
         let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
-        XCTAssertEqual(.serverBase, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
         XCTAssertEqual(.localOnly, progressSnapshot.seriesSourceState)
         XCTAssertTrue(progressSnapshot.isApproximate)
+        XCTAssertEqual(2, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual("2026-04-02", progressSnapshot.summary.lastReviewedOn)
         XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-02"))
         XCTAssertNil(context.store.progressSeriesServerBaseCache)
         let persistedSeriesCacheKeys = context.userDefaults.dictionaryRepresentation().keys.filter { key in


### PR DESCRIPTION
## Summary
- Route iOS progress screen and review badge through the same rendered summary/series path.
- Merge server summary with local all-time active dates and rendered series lower bounds.
- Add focused progress tests for stale server summaries, badge refresh, and active days outside the chart range.

## Validation
- `xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift apps/ios/Flashcards/FlashcardsTests/Progress/ProgressBadgeRefreshTests.swift apps/ios/Flashcards/FlashcardsTests/Progress/ProgressContextChangeTests.swift apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSummarySeriesRefreshTests.swift apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSyncCompletionTests.swift apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift`
- `git --no-pager diff --check HEAD~1..HEAD`

Simulator-backed iOS tests were not run because the repository requires explicit permission for simulator-backed runs.