### PR TITLE
[codex] Fix Android instrumentation test imports

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onNode
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickNode

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onNode
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick


### PR DESCRIPTION
## Summary

Remove invalid `androidx.compose.ui.test.onNode` imports from Android instrumentation test sources.

## Impact

This keeps the tests aligned with the existing `composeRule.onNode(...)` usage pattern and restores Kotlin compilation for the Android instrumentation test source set.

## Validation

- `git --no-pager diff --check`
- Reviewed the current working tree diff and related Android instrumentation test import patterns

Gradle was not run locally because this repository requires explicit approval for local `./gradlew` runs.