### PR TITLE
[codex] Remove Android Access review reminders duplicate

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccessNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccessNavGraph.kt
@@ -19,9 +19,6 @@ internal fun NavGraphBuilder.registerSettingsAccessNavGraph(
     ) {
         composable(route = SettingsAccessDestination.route) {
             AccessRoute(
-                onOpenNotifications = {
-                    navController.navigate(route = SettingsWorkspaceNotificationsDestination.route)
-                },
                 onOpenCapability = { capability ->
                     navController.navigate(
                         route = SettingsAccessDetailDestination.createRoute(capability = capability.name.lowercase())

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/access/AccessRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/access/AccessRoute.kt
@@ -25,7 +25,6 @@ import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
 
 @Composable
 fun AccessRoute(
-    onOpenNotifications: () -> Unit,
     onOpenCapability: (AccessCapability) -> Unit,
     onBack: () -> Unit
 ) {
@@ -66,26 +65,6 @@ fun AccessRoute(
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
             modifier = Modifier.fillMaxSize()
         ) {
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    ListItem(
-                        headlineContent = {
-                            Text(stringResource(R.string.settings_access_notifications_title))
-                        },
-                        supportingContent = {
-                            Text(stringResource(R.string.settings_access_notifications_summary))
-                        },
-                        leadingContent = {
-                            Icon(
-                                imageVector = Icons.Outlined.Info,
-                                contentDescription = null
-                            )
-                        },
-                        modifier = Modifier.clickable(onClick = onOpenNotifications)
-                    )
-                }
-            }
-
             items(capabilityStates, key = { item -> item.capability.name }) { item ->
                 Card(modifier = Modifier.fillMaxWidth()) {
                     ListItem(

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -213,8 +213,6 @@
     <string name="settings_account_danger_zone_delete_failed">Account deletion failed.</string>
 
     <string name="settings_access_title">Access</string>
-    <string name="settings_access_notifications_title">Notifications</string>
-    <string name="settings_access_notifications_summary">Review and strict reminder settings for this device</string>
     <string name="settings_access_status_label">Status</string>
     <string name="settings_access_usage_label">Usage</string>
     <string name="settings_access_status_allowed">Allowed</string>


### PR DESCRIPTION
## Summary
- remove the duplicate Review reminders entry from Android Settings > Access
- keep Access focused on Camera, Microphone, Photos, and Files
- remove the now-unused Access notification strings

## Validation
- git --no-pager diff --check
- rg "settings_access_notifications" apps/android

Android Gradle/instrumentation tests were not run locally because this repo requires explicit approval for Gradle runs.