### PR TITLE
[codex] Point account menu to settings root

### DIFF
--- a/apps/web/src/AccountMenu.tsx
+++ b/apps/web/src/AccountMenu.tsx
@@ -197,7 +197,7 @@ export function AccountMenu(props: Props): ReactElement {
           )}
           <div className="account-menu-separator" />
           <a className="account-menu-item account-menu-link" href={accountSettingsUrl}>
-            {t("accountMenu.accountSettings")}
+            {t("navigation.settings")}
           </a>
           <a className="account-menu-item account-menu-link" href={logoutUrl}>
             {t("accountMenu.logout")}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -523,7 +523,7 @@ export function AppShell(): ReactElement {
                 isBusy={isChoosingWorkspace}
                 isWorkspaceManagementLocked={isWorkspaceLocked}
                 workspaceManagementLockedMessage={workspaceManagementLockedMessage}
-                accountSettingsUrl={accountSettingsRoute}
+                accountSettingsUrl={settingsHubRoute}
                 logoutUrl={buildLogoutUrl()}
                 onSelectWorkspace={chooseWorkspace}
                 onCreateWorkspace={createWorkspace}


### PR DESCRIPTION
## Summary
- send the account menu settings entry to the unified /settings root
- reuse the existing localized Settings label in the account menu
- keep the legacy /settings/account route registered

## Validation
- npm ci
- npm run build
- git --no-pager diff --check