### PR TITLE
[codex] Fix web progress summary merge

### DIFF
--- a/apps/web/src/appData/progress/snapshots/progressSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSnapshots.ts
@@ -6,6 +6,7 @@ import type {
   ProgressReviewScheduleSnapshot,
   ProgressReviewScheduleSourceState,
   ProgressReviewHistoryWatermark,
+  ProgressRenderedSeriesSummaryContext,
   ProgressSeries,
   ProgressSeriesInput,
   ProgressSeriesSnapshot,
@@ -179,21 +180,6 @@ function mergeProgressSeriesWithOverlay(
   };
 }
 
-function isLocalDateAfter(
-  first: string | null,
-  second: string | null,
-): boolean {
-  if (first === null) {
-    return false;
-  }
-
-  if (second === null) {
-    return true;
-  }
-
-  return first > second;
-}
-
 function maxLocalDate(
   first: string | null,
   second: string | null,
@@ -209,37 +195,285 @@ function maxLocalDate(
   return first >= second ? first : second;
 }
 
+function createEmptyProgressSummary(): ProgressSummary {
+  return {
+    currentStreakDays: 0,
+    hasReviewedToday: false,
+    lastReviewedOn: null,
+    activeReviewDays: 0,
+  };
+}
+
+function sortLocalDates(localDates: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...localDates].sort((leftDate, rightDate) => leftDate.localeCompare(rightDate));
+}
+
+function uniqueSortedLocalDates(localDates: ReadonlyArray<string>): ReadonlyArray<string> {
+  return sortLocalDates([...new Set(localDates)]);
+}
+
+function activeDatesFromSeries(series: ProgressSeries): ReadonlyArray<string> {
+  return uniqueSortedLocalDates(
+    series.dailyReviews
+      .filter((day) => day.reviewCount > 0)
+      .map((day) => day.date),
+  );
+}
+
+function summaryLowerBoundFromActiveDates(
+  activeDates: ReadonlyArray<string>,
+  today: string,
+): ProgressSummary {
+  const sortedActiveDates = uniqueSortedLocalDates(activeDates);
+
+  if (sortedActiveDates.length === 0) {
+    return createEmptyProgressSummary();
+  }
+
+  const activeDateSet = new Set(sortedActiveDates);
+  const hasReviewedToday = activeDateSet.has(today);
+  let currentDate = hasReviewedToday ? today : shiftLocalDate(today, -1);
+  let currentStreakDays = 0;
+
+  while (activeDateSet.has(currentDate)) {
+    currentStreakDays += 1;
+    currentDate = shiftLocalDate(currentDate, -1);
+  }
+
+  return {
+    currentStreakDays,
+    hasReviewedToday,
+    lastReviewedOn: sortedActiveDates.at(-1) ?? null,
+    activeReviewDays: sortedActiveDates.length,
+  };
+}
+
+function validateProgressSeriesPairInputs(
+  serverBase: ProgressSeries,
+  renderedSeries: ProgressSeries,
+): void {
+  if (
+    serverBase.timeZone === renderedSeries.timeZone
+    && serverBase.from === renderedSeries.from
+    && serverBase.to === renderedSeries.to
+  ) {
+    return;
+  }
+
+  throw new Error(
+    `Progress series summary context inputs must share the same range. serverBase=${serverBase.timeZone} ${serverBase.from}...${serverBase.to}, renderedSeries=${renderedSeries.timeZone} ${renderedSeries.from}...${renderedSeries.to}.`,
+  );
+}
+
+function activeDatesMissingFromServerBase(
+  serverBase: ProgressSeries,
+  renderedSeries: ProgressSeries,
+): ReadonlyArray<string> {
+  validateProgressSeriesPairInputs(serverBase, renderedSeries);
+
+  const normalizedServerBase = normalizeProgressSeries(serverBase);
+  const normalizedRenderedSeries = normalizeProgressSeries(renderedSeries);
+  const serverReviewCounts = buildDailyReviewCountMap(normalizedServerBase.dailyReviews);
+
+  return normalizedRenderedSeries.dailyReviews
+    .filter((day) => day.reviewCount > 0 && (serverReviewCounts.get(day.date) ?? 0) === 0)
+    .map((day) => day.date);
+}
+
+export function createProgressRenderedSeriesSummaryContext(
+  serverBase: ProgressSeriesSnapshot | null,
+  renderedSeries: ProgressSeriesSnapshot | null,
+): ProgressRenderedSeriesSummaryContext | null {
+  if (renderedSeries === null) {
+    return null;
+  }
+
+  const activeDates = activeDatesFromSeries(renderedSeries);
+  const activeDatesMissingFromServerBaseResult = serverBase === null
+    ? []
+    : activeDatesMissingFromServerBase(serverBase, renderedSeries);
+
+  return {
+    lowerBoundSummary: summaryLowerBoundFromActiveDates(activeDates, renderedSeries.to),
+    activeDates,
+    activeDatesMissingFromServerBase: activeDatesMissingFromServerBaseResult,
+    serverBaseReviewHistoryWatermarks: serverBase?.reviewHistoryWatermarks ?? null,
+  };
+}
+
+function serverAndSeriesShareReviewHistoryBase(
+  serverBaseReviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark>,
+  renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null,
+): boolean {
+  const seriesBaseReviewHistoryWatermarks = renderedSeriesContext?.serverBaseReviewHistoryWatermarks;
+
+  if (seriesBaseReviewHistoryWatermarks === null || seriesBaseReviewHistoryWatermarks === undefined) {
+    return false;
+  }
+
+  return areProgressReviewHistoryWatermarksEqual(
+    serverBaseReviewHistoryWatermarks,
+    seriesBaseReviewHistoryWatermarks,
+  );
+}
+
+function localFallbackActiveReviewDayDeltaCandidates(
+  localFallbackActiveDates: ReadonlyArray<string>,
+  serverBase: ProgressSummary,
+): ReadonlyArray<string> {
+  const serverLastReviewedOn = serverBase.lastReviewedOn;
+
+  if (serverLastReviewedOn === null) {
+    return localFallbackActiveDates;
+  }
+
+  return localFallbackActiveDates.filter((localDate) => localDate > serverLastReviewedOn);
+}
+
+function activeReviewDayDeltaCandidates(
+  renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null,
+  localFallbackActiveDates: ReadonlyArray<string>,
+  serverBase: ProgressSummary,
+  hasSharedServerAndSeriesReviewHistoryBase: boolean,
+): ReadonlyArray<string> {
+  const renderedSeriesCandidates = renderedSeriesContext === null
+    ? []
+    : hasSharedServerAndSeriesReviewHistoryBase
+      ? renderedSeriesContext.activeDatesMissingFromServerBase
+      : renderedSeriesContext.activeDates;
+
+  return uniqueSortedLocalDates([
+    ...renderedSeriesCandidates,
+    ...localFallbackActiveReviewDayDeltaCandidates(localFallbackActiveDates, serverBase),
+  ]);
+}
+
+function shouldApplyActiveReviewDayDelta(
+  localDate: string,
+  serverBase: ProgressSummary,
+  hasSharedServerAndSeriesReviewHistoryBase: boolean,
+  referenceLocalDate: string,
+): boolean {
+  if (localDate === referenceLocalDate && serverBase.hasReviewedToday) {
+    return false;
+  }
+
+  if (hasSharedServerAndSeriesReviewHistoryBase) {
+    return true;
+  }
+
+  if (serverBase.lastReviewedOn === null) {
+    return true;
+  }
+
+  return localDate > serverBase.lastReviewedOn;
+}
+
+function activeReviewDayDelta(
+  deltaCandidates: ReadonlyArray<string>,
+  serverBase: ProgressSummary,
+  hasSharedServerAndSeriesReviewHistoryBase: boolean,
+  referenceLocalDate: string,
+): number {
+  return deltaCandidates.filter((localDate) => shouldApplyActiveReviewDayDelta(
+    localDate,
+    serverBase,
+    hasSharedServerAndSeriesReviewHistoryBase,
+    referenceLocalDate,
+  )).length;
+}
+
+function currentStreakDaysWithLocalDelta(
+  serverBase: ProgressSummary,
+  localFallbackActiveDates: ReadonlyArray<string>,
+  renderedSeriesActiveDates: ReadonlyArray<string>,
+  referenceLocalDate: string,
+): number {
+  if (serverBase.hasReviewedToday || serverBase.currentStreakDays === 0) {
+    return serverBase.currentStreakDays;
+  }
+
+  if (serverBase.lastReviewedOn === null) {
+    return serverBase.currentStreakDays;
+  }
+
+  const activeDateSet = new Set([
+    ...localFallbackActiveDates,
+    ...renderedSeriesActiveDates,
+  ]);
+  let currentDate = shiftLocalDate(serverBase.lastReviewedOn, 1);
+  let continuousLocalDelta = 0;
+
+  while (currentDate <= referenceLocalDate && activeDateSet.has(currentDate)) {
+    continuousLocalDelta += 1;
+    currentDate = shiftLocalDate(currentDate, 1);
+  }
+
+  return serverBase.currentStreakDays + continuousLocalDelta;
+}
+
 function hasProgressSummaryOverlay(
-  localFallback: ProgressSummarySnapshot,
+  mergedPayload: ProgressSummaryPayload,
   serverBase: ProgressSummarySnapshot,
 ): boolean {
-  return localFallback.summary.currentStreakDays > serverBase.summary.currentStreakDays
-    || (localFallback.summary.hasReviewedToday && serverBase.summary.hasReviewedToday === false)
-    || isLocalDateAfter(localFallback.summary.lastReviewedOn, serverBase.summary.lastReviewedOn)
-    || localFallback.summary.activeReviewDays > serverBase.summary.activeReviewDays;
+  return areProgressSummariesEqual(mergedPayload.summary, serverBase.summary) === false;
 }
 
 function mergeProgressSummary(
   serverBase: ProgressSummarySnapshot,
-  localFallback: ProgressSummarySnapshot,
+  localFallback: ProgressSummarySnapshot | null,
+  localFallbackActiveDates: ReadonlyArray<string>,
+  renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null,
+  referenceLocalDate: string,
 ): ProgressSummaryPayload {
+  const localFallbackSummary = localFallback?.summary ?? createEmptyProgressSummary();
+  const renderedSeriesLowerBound = renderedSeriesContext?.lowerBoundSummary;
+  const hasSharedServerAndSeriesReviewHistoryBase = serverAndSeriesShareReviewHistoryBase(
+    serverBase.reviewHistoryWatermarks,
+    renderedSeriesContext,
+  );
+  const serverActiveReviewDaysWithLocalDelta = serverBase.summary.activeReviewDays + activeReviewDayDelta(
+    activeReviewDayDeltaCandidates(
+      renderedSeriesContext,
+      localFallbackActiveDates,
+      serverBase.summary,
+      hasSharedServerAndSeriesReviewHistoryBase,
+    ),
+    serverBase.summary,
+    hasSharedServerAndSeriesReviewHistoryBase,
+    referenceLocalDate,
+  );
+  const serverCurrentStreakDaysWithLocalDelta = currentStreakDaysWithLocalDelta(
+    serverBase.summary,
+    localFallbackActiveDates,
+    renderedSeriesContext?.activeDates ?? [],
+    referenceLocalDate,
+  );
+
   return {
     timeZone: serverBase.timeZone,
     generatedAt: serverBase.generatedAt,
     reviewHistoryWatermarks: serverBase.reviewHistoryWatermarks,
     summary: {
       currentStreakDays: Math.max(
-        serverBase.summary.currentStreakDays,
-        localFallback.summary.currentStreakDays,
+        serverCurrentStreakDaysWithLocalDelta,
+        localFallbackSummary.currentStreakDays,
+        renderedSeriesLowerBound?.currentStreakDays ?? 0,
       ),
-      hasReviewedToday: serverBase.summary.hasReviewedToday || localFallback.summary.hasReviewedToday,
+      hasReviewedToday: serverBase.summary.hasReviewedToday
+        || localFallbackSummary.hasReviewedToday
+        || (renderedSeriesLowerBound?.hasReviewedToday ?? false),
       lastReviewedOn: maxLocalDate(
-        serverBase.summary.lastReviewedOn,
-        localFallback.summary.lastReviewedOn,
+        maxLocalDate(
+          serverBase.summary.lastReviewedOn,
+          localFallbackSummary.lastReviewedOn,
+        ),
+        renderedSeriesLowerBound?.lastReviewedOn ?? null,
       ),
       activeReviewDays: Math.max(
-        serverBase.summary.activeReviewDays,
-        localFallback.summary.activeReviewDays,
+        serverActiveReviewDaysWithLocalDelta,
+        localFallbackSummary.activeReviewDays,
+        renderedSeriesLowerBound?.activeReviewDays ?? 0,
       ),
     },
   };
@@ -268,17 +502,28 @@ function canRenderLocalReviewScheduleForServerBase(
 function buildRenderedSummary(
   serverBase: ProgressSummarySnapshot | null,
   localFallback: ProgressSummarySnapshot | null,
+  localFallbackActiveDates: ReadonlyArray<string>,
   hasPendingLocalReviews: boolean,
+  renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null,
+  referenceLocalDate: string | null,
   canRenderServerBase: boolean,
 ): ProgressSummarySnapshot | null {
   if (canRenderServerBase && serverBase !== null) {
-    if (hasPendingLocalReviews) {
-      return localFallback;
+    if (referenceLocalDate === null) {
+      throw new Error("Progress summary reference local date is required when rendering a server summary.");
     }
 
-    if (localFallback !== null && hasProgressSummaryOverlay(localFallback, serverBase)) {
+    const mergedPayload = mergeProgressSummary(
+      serverBase,
+      localFallback,
+      localFallbackActiveDates,
+      renderedSeriesContext,
+      referenceLocalDate,
+    );
+
+    if (hasPendingLocalReviews || hasProgressSummaryOverlay(mergedPayload, serverBase)) {
       return createProgressSummarySnapshot(
-        mergeProgressSummary(serverBase, localFallback),
+        mergedPayload,
         "server",
         true,
       );
@@ -482,6 +727,20 @@ function areProgressReviewHistoryWatermarksEqual(
   return true;
 }
 
+function areStringArraysEqual(left: ReadonlyArray<string>, right: ReadonlyArray<string>): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function areProgressSummaryPayloadsEqual(
   left: ProgressSummaryPayload | null,
   right: ProgressSummaryPayload | null,
@@ -515,6 +774,32 @@ function areProgressSummarySnapshotsEqual(
   return areProgressSummaryPayloadsEqual(left, right)
     && left.source === right.source
     && left.isApproximate === right.isApproximate;
+}
+
+function areProgressRenderedSeriesSummaryContextsEqual(
+  left: ProgressRenderedSeriesSummaryContext | null,
+  right: ProgressRenderedSeriesSummaryContext | null,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (left === null || right === null) {
+    return false;
+  }
+
+  const watermarksAreEqual = left.serverBaseReviewHistoryWatermarks === null
+    ? right.serverBaseReviewHistoryWatermarks === null
+    : right.serverBaseReviewHistoryWatermarks !== null
+      && areProgressReviewHistoryWatermarksEqual(
+        left.serverBaseReviewHistoryWatermarks,
+        right.serverBaseReviewHistoryWatermarks,
+      );
+
+  return areProgressSummariesEqual(left.lowerBoundSummary, right.lowerBoundSummary)
+    && areStringArraysEqual(left.activeDates, right.activeDates)
+    && areStringArraysEqual(left.activeDatesMissingFromServerBase, right.activeDatesMissingFromServerBase)
+    && watermarksAreEqual;
 }
 
 function areProgressSeriesEqual(left: ProgressSeries | null, right: ProgressSeries | null): boolean {
@@ -612,9 +897,12 @@ function areProgressSummarySourceStatesEqual(
   right: ProgressSummarySourceState,
 ): boolean {
   return left.scopeKey === right.scopeKey
+    && left.referenceLocalDate === right.referenceLocalDate
     && left.hasPendingLocalReviews === right.hasPendingLocalReviews
     && left.isLoading === right.isLoading
     && left.errorMessage === right.errorMessage
+    && areStringArraysEqual(left.localFallbackActiveDates, right.localFallbackActiveDates)
+    && areProgressRenderedSeriesSummaryContextsEqual(left.renderedSeriesContext, right.renderedSeriesContext)
     && areProgressSummarySnapshotsEqual(left.localFallback, right.localFallback)
     && areProgressSummarySnapshotsEqual(left.serverBase, right.serverBase)
     && areProgressSummarySnapshotsEqual(left.renderedSnapshot, right.renderedSnapshot);
@@ -660,9 +948,12 @@ export function areProgressSourceStatesEqual(left: ProgressSourceState, right: P
 export function createEmptyProgressSummarySourceState(): ProgressSummarySourceState {
   return {
     scopeKey: null,
+    referenceLocalDate: null,
     localFallback: null,
+    localFallbackActiveDates: [],
     serverBase: null,
     hasPendingLocalReviews: false,
+    renderedSeriesContext: null,
     renderedSnapshot: null,
     isLoading: false,
     errorMessage: "",
@@ -721,7 +1012,10 @@ export function createNextSummaryState(
     renderedSnapshot: buildRenderedSummary(
       nextStateWithoutRenderedSnapshot.serverBase,
       nextStateWithoutRenderedSnapshot.localFallback,
+      nextStateWithoutRenderedSnapshot.localFallbackActiveDates,
       nextStateWithoutRenderedSnapshot.hasPendingLocalReviews,
+      nextStateWithoutRenderedSnapshot.renderedSeriesContext,
+      nextStateWithoutRenderedSnapshot.referenceLocalDate,
       canRenderServerBase,
     ),
   };

--- a/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
@@ -143,9 +143,12 @@ describe("useProgressSource lifecycle", () => {
 
     expect(harness.getApi().progressSourceState.summary).toEqual({
       scopeKey: null,
+      referenceLocalDate: null,
       localFallback: null,
+      localFallbackActiveDates: [],
       serverBase: null,
       hasPendingLocalReviews: false,
+      renderedSeriesContext: null,
       renderedSnapshot: null,
       isLoading: false,
       errorMessage: "",

--- a/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
@@ -8,6 +8,7 @@ import {
   flushEffects,
   hasPendingProgressReviewEventsMock,
   linkedCloudSettings,
+  loadLocalProgressActiveDatesMock,
   loadLocalProgressDailyReviewsMock,
   loadLocalProgressSummaryMock,
   loadPendingProgressDailyReviewsMock,
@@ -88,7 +89,8 @@ describe("useProgressSource summary and series", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.serverBase?.source).toBe("server");
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("local_only");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(true);
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(8);
   });
 
@@ -167,6 +169,320 @@ describe("useProgressSource summary and series", () => {
     });
   });
 
+  it("extends a long server streak when local review history adds today", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: {
+        currentStreakDays: 200,
+        hasReviewedToday: false,
+        lastReviewedOn: "2026-04-19",
+        activeReviewDays: 200,
+      },
+    });
+    loadProgressSeriesMock.mockResolvedValue({
+      timeZone: currentSeriesInput.timeZone,
+      from: currentSeriesInput.from,
+      to: currentSeriesInput.to,
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      dailyReviews: [
+        {
+          date: "2026-04-19",
+          reviewCount: 1,
+        },
+      ],
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue({
+      currentStreakDays: 1,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 1,
+    });
+    loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-20"]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      {
+        date: "2026-04-20",
+        reviewCount: 1,
+      },
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(true);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
+      currentStreakDays: 201,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 201,
+    });
+  });
+
+  it("extends a long server streak through consecutive local active dates", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: {
+        currentStreakDays: 200,
+        hasReviewedToday: false,
+        lastReviewedOn: "2026-04-18",
+        activeReviewDays: 200,
+      },
+    });
+    loadProgressSeriesMock.mockResolvedValue({
+      timeZone: currentSeriesInput.timeZone,
+      from: currentSeriesInput.from,
+      to: currentSeriesInput.to,
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      dailyReviews: [
+        {
+          date: "2026-04-18",
+          reviewCount: 1,
+        },
+      ],
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue({
+      currentStreakDays: 2,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 2,
+    });
+    loadLocalProgressActiveDatesMock.mockResolvedValue([
+      "2026-04-19",
+      "2026-04-20",
+    ]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      {
+        date: "2026-04-19",
+        reviewCount: 1,
+      },
+      {
+        date: "2026-04-20",
+        reviewCount: 1,
+      },
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
+      currentStreakDays: 202,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 202,
+    });
+  });
+
+  it("adds local active dates after server last reviewed even outside the visible chart range", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: {
+        currentStreakDays: 0,
+        hasReviewedToday: false,
+        lastReviewedOn: "2025-11-15",
+        activeReviewDays: 200,
+      },
+    });
+    loadProgressSeriesMock.mockResolvedValue({
+      timeZone: currentSeriesInput.timeZone,
+      from: currentSeriesInput.from,
+      to: currentSeriesInput.to,
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      dailyReviews: [],
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue({
+      currentStreakDays: 0,
+      hasReviewedToday: false,
+      lastReviewedOn: "2025-11-16",
+      activeReviewDays: 1,
+    });
+    loadLocalProgressActiveDatesMock.mockResolvedValue(["2025-11-16"]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
+      currentStreakDays: 0,
+      hasReviewedToday: false,
+      lastReviewedOn: "2025-11-16",
+      activeReviewDays: 201,
+    });
+  });
+
+  it("does not double-count today when server summary already includes it", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: {
+        currentStreakDays: 200,
+        hasReviewedToday: true,
+        lastReviewedOn: "2026-04-20",
+        activeReviewDays: 200,
+      },
+    });
+    loadProgressSeriesMock.mockResolvedValue({
+      timeZone: currentSeriesInput.timeZone,
+      from: currentSeriesInput.from,
+      to: currentSeriesInput.to,
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      dailyReviews: [
+        {
+          date: "2026-04-20",
+          reviewCount: 1,
+        },
+      ],
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue({
+      currentStreakDays: 1,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 1,
+    });
+    loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-20"]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      {
+        date: "2026-04-20",
+        reviewCount: 1,
+      },
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(false);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
+      currentStreakDays: 200,
+      hasReviewedToday: true,
+      lastReviewedOn: "2026-04-20",
+      activeReviewDays: 200,
+    });
+  });
+
+  it("keeps disjoint visible server and local days consistent between chart and summary", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: {
+        currentStreakDays: 0,
+        hasReviewedToday: false,
+        lastReviewedOn: "2026-04-18",
+        activeReviewDays: 200,
+      },
+    });
+    loadProgressSeriesMock.mockResolvedValue({
+      timeZone: currentSeriesInput.timeZone,
+      from: currentSeriesInput.from,
+      to: currentSeriesInput.to,
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      dailyReviews: [
+        {
+          date: "2026-04-18",
+          reviewCount: 1,
+        },
+      ],
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue({
+      currentStreakDays: 1,
+      hasReviewedToday: false,
+      lastReviewedOn: "2026-04-19",
+      activeReviewDays: 1,
+    });
+    loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-19"]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      {
+        date: "2026-04-19",
+        reviewCount: 1,
+      },
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
+      currentStreakDays: 2,
+      hasReviewedToday: false,
+      lastReviewedOn: "2026-04-19",
+      activeReviewDays: 201,
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+      date: "2026-04-18",
+      reviewCount: 1,
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+      date: "2026-04-19",
+      reviewCount: 1,
+    });
+  });
+
   it("renders server series with pending local review overlay as approximate", async () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSeriesMock.mockResolvedValue(buildServerSeries(4, "2026-04-18T09:18:00.000Z"));
@@ -210,6 +526,7 @@ describe("useProgressSource summary and series", () => {
 
     expect(loadProgressSummaryMock).toHaveBeenCalledTimes(1);
     expect(loadLocalProgressSummaryMock).toHaveBeenCalledTimes(1);
+    expect(loadLocalProgressActiveDatesMock).toHaveBeenCalledTimes(1);
     expect(hasPendingProgressReviewEventsMock).toHaveBeenCalledTimes(1);
     expect(loadProgressSeriesMock).not.toHaveBeenCalled();
     expect(loadLocalProgressDailyReviewsMock).not.toHaveBeenCalled();

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -34,6 +34,7 @@ const progressSourceMocks = vi.hoisted(() => ({
   loadProgressSeriesMock: vi.fn<(input: Readonly<{ timeZone: string; from: string; to: string }>) => Promise<ProgressSeries>>(),
   loadProgressReviewScheduleMock: vi.fn<(input: Readonly<{ timeZone: string; today: string }>) => Promise<ProgressReviewSchedule>>(),
   hasPendingProgressReviewEventsMock: vi.fn<(workspaceIds: ReadonlyArray<string>) => Promise<boolean>>(),
+  loadLocalProgressActiveDatesMock: vi.fn<(workspaceIds: ReadonlyArray<string>, timeZone: string) => Promise<ReadonlyArray<string>>>(),
   loadLocalProgressSummaryMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; today: string }>) => Promise<ProgressSummary>>(),
   loadLocalProgressDailyReviewsMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; from: string; to: string }>) => Promise<ReadonlyArray<Readonly<{ date: string; reviewCount: number }>>>>(),
   loadPendingProgressDailyReviewsMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; from: string; to: string }>) => Promise<ReadonlyArray<Readonly<{ date: string; reviewCount: number }>>>>(),
@@ -52,6 +53,7 @@ const {
   loadProgressSeriesMock,
   loadProgressReviewScheduleMock,
   hasPendingProgressReviewEventsMock,
+  loadLocalProgressActiveDatesMock,
   loadLocalProgressSummaryMock,
   loadLocalProgressDailyReviewsMock,
   loadPendingProgressDailyReviewsMock,
@@ -87,6 +89,7 @@ vi.mock("../../../observability/webObservability", () => ({
 
 vi.mock("../../../localDb/progress/progress", () => ({
   hasPendingProgressReviewEvents: progressSourceMocks.hasPendingProgressReviewEventsMock,
+  loadLocalProgressActiveDates: progressSourceMocks.loadLocalProgressActiveDatesMock,
   loadLocalProgressSummary: progressSourceMocks.loadLocalProgressSummaryMock,
   loadLocalProgressDailyReviews: progressSourceMocks.loadLocalProgressDailyReviewsMock,
   loadPendingProgressDailyReviews: progressSourceMocks.loadPendingProgressDailyReviewsMock,
@@ -518,6 +521,7 @@ beforeEach(() => {
   loadProgressSeriesMock.mockReset();
   loadProgressReviewScheduleMock.mockReset();
   hasPendingProgressReviewEventsMock.mockReset();
+  loadLocalProgressActiveDatesMock.mockReset();
   loadLocalProgressSummaryMock.mockReset();
   loadLocalProgressDailyReviewsMock.mockReset();
   loadPendingProgressDailyReviewsMock.mockReset();
@@ -539,6 +543,7 @@ beforeEach(() => {
     lastReviewedOn: null,
     activeReviewDays: 0,
   });
+  loadLocalProgressActiveDatesMock.mockResolvedValue([]);
   loadLocalProgressDailyReviewsMock.mockResolvedValue([]);
   loadPendingProgressDailyReviewsMock.mockResolvedValue([]);
   loadLocalProgressReviewScheduleMock.mockResolvedValue(buildServerReviewSchedule(0, null));
@@ -568,6 +573,7 @@ export {
   hasCompleteLocalProgressReviewScheduleCoverageMock,
   hasPendingProgressReviewEventsMock,
   hasPendingProgressReviewScheduleCardChangesMock,
+  loadLocalProgressActiveDatesMock,
   loadLocalProgressDailyReviewsMock,
   loadLocalProgressReviewScheduleMock,
   loadLocalProgressSummaryMock,

--- a/apps/web/src/appData/progress/source/useProgressSource.ts
+++ b/apps/web/src/appData/progress/source/useProgressSource.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../observability/webObservability";
 import {
   hasPendingProgressReviewEvents,
+  loadLocalProgressActiveDates,
   loadLocalProgressDailyReviews,
   loadLocalProgressSummary,
   loadPendingProgressDailyReviews,
@@ -258,16 +259,20 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
     dispatch({
       type: "summary_scope_initialized",
       scopeKey: summaryScopeKey,
+      referenceLocalDate: summaryInput.today,
       serverBase: persistedSummary === null ? null : createProgressSummarySnapshot(persistedSummary, "server", false),
       canRenderServerBase: canLoadServerBaseRef.current,
     });
-  }, [canLoadServerBase, summaryScopeKey]);
+  }, [canLoadServerBase, summaryInput.today, summaryScopeKey]);
 
   useEffect(() => {
     currentSeriesScopeKeyRef.current = seriesScopeKey;
 
     if (seriesScopeKey === null) {
-      dispatch({ type: "series_scope_reset" });
+      dispatch({
+        type: "series_scope_reset",
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
       return;
     }
 
@@ -316,8 +321,9 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
 
     void Promise.all([
       loadLocalProgressSummary(accessibleWorkspaceIds, summaryInput),
+      loadLocalProgressActiveDates(accessibleWorkspaceIds, summaryInput.timeZone),
       hasPendingProgressReviewEvents(accessibleWorkspaceIds),
-    ]).then(([localSummary, hasPendingLocalReviews]) => {
+    ]).then(([localSummary, localFallbackActiveDates, hasPendingLocalReviews]) => {
       if (currentSummaryScopeKeyRef.current !== summaryScopeKey || summaryLocalLoadSequenceRef.current !== currentSequence) {
         return;
       }
@@ -331,6 +337,7 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
           reviewHistoryWatermarks: [],
           summary: localSummary,
         }, "local_only", true),
+        localFallbackActiveDates,
         hasPendingLocalReviews,
         canRenderServerBase: canLoadServerBaseRef.current,
       });

--- a/apps/web/src/appData/progress/state/progressReducer.ts
+++ b/apps/web/src/appData/progress/state/progressReducer.ts
@@ -3,8 +3,10 @@ import type {
   ProgressReviewScheduleSnapshot,
   ProgressScopeKey,
   ProgressSeriesSnapshot,
+  ProgressSeriesSourceState,
   ProgressSourceState,
   ProgressSummarySnapshot,
+  ProgressSummarySourceState,
 } from "../../../types";
 import {
   areProgressSourceStatesEqual,
@@ -12,6 +14,7 @@ import {
   createEmptyProgressSeriesSourceState,
   createEmptyProgressSourceState,
   createEmptyProgressSummarySourceState,
+  createProgressRenderedSeriesSummaryContext,
   createNextReviewScheduleState,
   createNextSeriesState,
   createNextSummaryState,
@@ -21,11 +24,12 @@ import {
 
 export type ProgressSourceAction =
   | Readonly<{ type: "summary_scope_reset" }>
-  | Readonly<{ type: "series_scope_reset" }>
+  | Readonly<{ type: "series_scope_reset"; canRenderServerBase: boolean }>
   | Readonly<{ type: "review_schedule_scope_reset" }>
   | Readonly<{
     type: "summary_scope_initialized";
     scopeKey: ProgressScopeKey;
+    referenceLocalDate: string;
     serverBase: ProgressSummarySnapshot | null;
     canRenderServerBase: boolean;
   }>
@@ -46,6 +50,7 @@ export type ProgressSourceAction =
     type: "summary_local_load_succeeded";
     scopeKey: ProgressScopeKey;
     localFallback: ProgressSummarySnapshot;
+    localFallbackActiveDates: ReadonlyArray<string>;
     hasPendingLocalReviews: boolean;
     canRenderServerBase: boolean;
   }>
@@ -137,6 +142,19 @@ export function createInitialProgressSourceState(): ProgressSourceState {
   return createEmptyProgressSourceState();
 }
 
+function createSummaryStateWithRenderedSeriesContext(
+  summaryState: ProgressSummarySourceState,
+  seriesState: ProgressSeriesSourceState,
+  canRenderServerBase: boolean,
+): ProgressSummarySourceState {
+  return createNextSummaryState(summaryState, {
+    renderedSeriesContext: createProgressRenderedSeriesSummaryContext(
+      seriesState.serverBase,
+      seriesState.renderedSnapshot,
+    ),
+  }, canRenderServerBase);
+}
+
 function reduceProgressSourceState(
   state: ProgressSourceState,
   action: ProgressSourceAction,
@@ -147,11 +165,18 @@ function reduceProgressSourceState(
         ...state,
         summary: createEmptyProgressSummarySourceState(),
       };
-    case "series_scope_reset":
+    case "series_scope_reset": {
+      const nextSeriesState = createEmptyProgressSeriesSourceState();
       return {
         ...state,
-        series: createEmptyProgressSeriesSourceState(),
+        summary: createSummaryStateWithRenderedSeriesContext(
+          state.summary,
+          nextSeriesState,
+          action.canRenderServerBase,
+        ),
+        series: nextSeriesState,
       };
+    }
     case "review_schedule_scope_reset":
       return {
         ...state,
@@ -162,25 +187,36 @@ function reduceProgressSourceState(
         ...state,
         summary: createNextSummaryState(state.summary, {
           scopeKey: action.scopeKey,
+          referenceLocalDate: action.referenceLocalDate,
           localFallback: null,
+          localFallbackActiveDates: [],
           serverBase: action.serverBase,
           hasPendingLocalReviews: false,
+          renderedSeriesContext: null,
           isLoading: true,
           errorMessage: "",
         }, action.canRenderServerBase),
       };
-    case "series_scope_initialized":
+    case "series_scope_initialized": {
+      const nextSeriesState = createNextSeriesState(state.series, {
+        scopeKey: action.scopeKey,
+        localFallback: null,
+        serverBase: action.serverBase,
+        pendingLocalOverlay: null,
+        isLoading: true,
+        errorMessage: "",
+      }, action.canRenderServerBase);
+
       return {
         ...state,
-        series: createNextSeriesState(state.series, {
-          scopeKey: action.scopeKey,
-          localFallback: null,
-          serverBase: action.serverBase,
-          pendingLocalOverlay: null,
-          isLoading: true,
-          errorMessage: "",
-        }, action.canRenderServerBase),
+        summary: createSummaryStateWithRenderedSeriesContext(
+          state.summary,
+          nextSeriesState,
+          action.canRenderServerBase,
+        ),
+        series: nextSeriesState,
       };
+    }
     case "review_schedule_scope_initialized":
       return {
         ...state,
@@ -210,6 +246,7 @@ function reduceProgressSourceState(
         summary: createNextSummaryState(state.summary, {
           scopeKey: action.scopeKey,
           localFallback: action.localFallback,
+          localFallbackActiveDates: action.localFallbackActiveDates,
           hasPendingLocalReviews: action.hasPendingLocalReviews,
           isLoading: false,
         }, action.canRenderServerBase),
@@ -224,40 +261,57 @@ function reduceProgressSourceState(
         summary: createNextSummaryState(state.summary, {
           scopeKey: action.scopeKey,
           localFallback: null,
+          localFallbackActiveDates: [],
           hasPendingLocalReviews: false,
           isLoading: false,
           errorMessage: action.errorMessage,
         }, action.canRenderServerBase),
       };
-    case "series_local_load_succeeded":
+    case "series_local_load_succeeded": {
       if (state.series.scopeKey !== action.scopeKey) {
         return state;
       }
 
+      const nextSeriesState = createNextSeriesState(state.series, {
+        scopeKey: action.scopeKey,
+        localFallback: action.localFallback,
+        pendingLocalOverlay: action.pendingLocalOverlay,
+        isLoading: false,
+      }, action.canRenderServerBase);
+
       return {
         ...state,
-        series: createNextSeriesState(state.series, {
-          scopeKey: action.scopeKey,
-          localFallback: action.localFallback,
-          pendingLocalOverlay: action.pendingLocalOverlay,
-          isLoading: false,
-        }, action.canRenderServerBase),
+        summary: createSummaryStateWithRenderedSeriesContext(
+          state.summary,
+          nextSeriesState,
+          action.canRenderServerBase,
+        ),
+        series: nextSeriesState,
       };
-    case "series_local_load_failed":
+    }
+    case "series_local_load_failed": {
       if (state.series.scopeKey !== action.scopeKey) {
         return state;
       }
 
+      const nextSeriesState = createNextSeriesState(state.series, {
+        scopeKey: action.scopeKey,
+        localFallback: null,
+        pendingLocalOverlay: null,
+        isLoading: false,
+        errorMessage: action.errorMessage,
+      }, action.canRenderServerBase);
+
       return {
         ...state,
-        series: createNextSeriesState(state.series, {
-          scopeKey: action.scopeKey,
-          localFallback: null,
-          pendingLocalOverlay: null,
-          isLoading: false,
-          errorMessage: action.errorMessage,
-        }, action.canRenderServerBase),
+        summary: createSummaryStateWithRenderedSeriesContext(
+          state.summary,
+          nextSeriesState,
+          action.canRenderServerBase,
+        ),
+        series: nextSeriesState,
       };
+    }
     case "review_schedule_local_load_succeeded":
       if (state.reviewSchedule.scopeKey !== action.scopeKey) {
         return state;
@@ -329,33 +383,49 @@ function reduceProgressSourceState(
           errorMessage: action.errorMessage,
         }, action.canRenderServerBase),
       };
-    case "series_server_load_succeeded":
+    case "series_server_load_succeeded": {
       if (state.series.scopeKey !== action.scopeKey) {
         return state;
       }
 
+      const nextSeriesState = createNextSeriesState(state.series, {
+        scopeKey: action.scopeKey,
+        serverBase: action.serverBase,
+        isLoading: false,
+        errorMessage: "",
+      }, action.canRenderServerBase);
+
       return {
         ...state,
-        series: createNextSeriesState(state.series, {
-          scopeKey: action.scopeKey,
-          serverBase: action.serverBase,
-          isLoading: false,
-          errorMessage: "",
-        }, action.canRenderServerBase),
+        summary: createSummaryStateWithRenderedSeriesContext(
+          state.summary,
+          nextSeriesState,
+          action.canRenderServerBase,
+        ),
+        series: nextSeriesState,
       };
-    case "series_server_load_failed":
+    }
+    case "series_server_load_failed": {
       if (state.series.scopeKey !== action.scopeKey) {
         return state;
       }
 
+      const nextSeriesState = createNextSeriesState(state.series, {
+        scopeKey: action.scopeKey,
+        isLoading: false,
+        errorMessage: action.errorMessage,
+      }, action.canRenderServerBase);
+
       return {
         ...state,
-        series: createNextSeriesState(state.series, {
-          scopeKey: action.scopeKey,
-          isLoading: false,
-          errorMessage: action.errorMessage,
-        }, action.canRenderServerBase),
+        summary: createSummaryStateWithRenderedSeriesContext(
+          state.summary,
+          nextSeriesState,
+          action.canRenderServerBase,
+        ),
+        series: nextSeriesState,
       };
+    }
     case "review_schedule_server_load_succeeded":
       if (state.reviewSchedule.scopeKey !== action.scopeKey) {
         return state;

--- a/apps/web/src/localDb/progress/progress.test.ts
+++ b/apps/web/src/localDb/progress/progress.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { clearWebSyncCache } from "../core/cache";
 import { putOutboxRecord } from "../sync/outbox";
 import {
+  loadLocalProgressActiveDates,
   loadLocalProgressDailyReviews,
   loadLocalProgressSummary,
   loadPendingProgressDailyReviews,
@@ -272,5 +273,55 @@ describe("localDb progress", () => {
       lastReviewedOn: "2025-01-08",
       activeReviewDays: 3,
     });
+  });
+
+  it("loads distinct all-time active local review dates for accessible workspaces", async () => {
+    await putReviewEvent({
+      reviewEventId: "active-date-review-1",
+      workspaceId,
+      cardId: "due-other",
+      replicaId: "device-1",
+      clientEventId: "active-date-client-event-1",
+      rating: 2,
+      reviewedAtClient: "2025-01-06T08:00:00.000Z",
+      reviewedAtServer: "2025-01-06T08:00:00.000Z",
+    });
+    await putReviewEvent({
+      reviewEventId: "active-date-review-2",
+      workspaceId,
+      cardId: "due-same-a",
+      replicaId: "device-1",
+      clientEventId: "active-date-client-event-2",
+      rating: 3,
+      reviewedAtClient: "2025-01-06T09:00:00.000Z",
+      reviewedAtServer: "2025-01-06T09:00:00.000Z",
+    });
+    await putReviewEvent({
+      reviewEventId: "active-date-review-3",
+      workspaceId: "workspace-2",
+      cardId: "card-2",
+      replicaId: "device-2",
+      clientEventId: "active-date-client-event-3",
+      rating: 1,
+      reviewedAtClient: "2025-01-08T10:00:00.000Z",
+      reviewedAtServer: "2025-01-08T10:00:00.000Z",
+    });
+    await putReviewEvent({
+      reviewEventId: "active-date-inaccessible-review",
+      workspaceId: "workspace-3",
+      cardId: "card-3",
+      replicaId: "device-3",
+      clientEventId: "active-date-inaccessible-client-event",
+      rating: 1,
+      reviewedAtClient: "2025-01-09T10:00:00.000Z",
+      reviewedAtServer: "2025-01-09T10:00:00.000Z",
+    });
+
+    const result = await loadLocalProgressActiveDates([workspaceId, "workspace-2"], "UTC");
+
+    expect(result).toEqual([
+      "2025-01-06",
+      "2025-01-08",
+    ]);
   });
 });

--- a/apps/web/src/localDb/progress/progress.ts
+++ b/apps/web/src/localDb/progress/progress.ts
@@ -52,14 +52,20 @@ function createEmptyProgressSummary(): ProgressSummary {
   };
 }
 
+function buildProgressActiveDates(
+  dailyReviewCounts: ReadonlyMap<string, number>,
+): ReadonlyArray<string> {
+  return [...dailyReviewCounts.entries()]
+    .filter(([, reviewCount]) => reviewCount > 0)
+    .map(([date]) => date)
+    .sort((leftDate, rightDate) => leftDate.localeCompare(rightDate));
+}
+
 function buildProgressSummary(
   today: string,
   dailyReviewCounts: ReadonlyMap<string, number>,
 ): ProgressSummary {
-  const reviewDates = [...dailyReviewCounts.entries()]
-    .filter(([, reviewCount]) => reviewCount > 0)
-    .map(([date]) => date)
-    .sort((leftDate, rightDate) => leftDate.localeCompare(rightDate));
+  const reviewDates = buildProgressActiveDates(dailyReviewCounts);
 
   if (reviewDates.length === 0) {
     return createEmptyProgressSummary();
@@ -209,6 +215,26 @@ export async function loadLocalProgressSummary(
     ).flat();
 
     return buildProgressSummary(input.today, buildMergedDailyReviewMap(progressDailyCounts));
+  });
+}
+
+export async function loadLocalProgressActiveDates(
+  workspaceIds: ReadonlyArray<string>,
+  timeZone: string,
+): Promise<ReadonlyArray<string>> {
+  if (workspaceIds.length === 0) {
+    return [];
+  }
+
+  return closeDatabaseAfter(async (database) => {
+    await ensureLocalProgressCacheReady(database, timeZone);
+    const progressDailyCounts = (
+      await Promise.all(
+        workspaceIds.map((workspaceId) => loadWorkspaceProgressDailyCounts(database, workspaceId, null)),
+      )
+    ).flat();
+
+    return buildProgressActiveDates(buildMergedDailyReviewMap(progressDailyCounts));
   });
 }
 

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -243,9 +243,12 @@ describe("ProgressScreen", () => {
       progressSourceState: {
         summary: {
           scopeKey: "progress::summary::UTC::2026-04-21",
+          referenceLocalDate: "2026-04-21",
           localFallback: null,
+          localFallbackActiveDates: [],
           serverBase: createProgressSummarySnapshot(),
           hasPendingLocalReviews: false,
+          renderedSeriesContext: null,
           renderedSnapshot: createProgressSummarySnapshot(),
           isLoading: false,
           errorMessage: "",
@@ -474,9 +477,12 @@ describe("ProgressScreen", () => {
       progressSourceState: {
         summary: {
           scopeKey: "progress::summary::UTC::2026-04-21",
+          referenceLocalDate: "2026-04-21",
           localFallback: null,
+          localFallbackActiveDates: [],
           serverBase: createProgressSummarySnapshot(),
           hasPendingLocalReviews: false,
+          renderedSeriesContext: null,
           renderedSnapshot: createProgressSummarySnapshot(),
           isLoading: false,
           errorMessage: "",

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -186,11 +186,21 @@ export type ProgressReviewScheduleSnapshot = ProgressReviewSchedule & Readonly<{
   isApproximate: boolean;
 }>;
 
+export type ProgressRenderedSeriesSummaryContext = Readonly<{
+  lowerBoundSummary: ProgressSummary;
+  activeDates: ReadonlyArray<string>;
+  activeDatesMissingFromServerBase: ReadonlyArray<string>;
+  serverBaseReviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> | null;
+}>;
+
 export type ProgressSummarySourceState = Readonly<{
   scopeKey: ProgressScopeKey | null;
+  referenceLocalDate: string | null;
   localFallback: ProgressSummarySnapshot | null;
+  localFallbackActiveDates: ReadonlyArray<string>;
   serverBase: ProgressSummarySnapshot | null;
   hasPendingLocalReviews: boolean;
+  renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null;
   renderedSnapshot: ProgressSummarySnapshot | null;
   isLoading: boolean;
   errorMessage: string;


### PR DESCRIPTION
## Summary

- Align web progress summary rendering with date-aware server/local merge behavior.

- Add all-time local active review dates and rendered-series lower-bound context for conservative summary overlays.
- Cover long streak extension, out-of-range local dates, double-count prevention, and local active-date loading.
## Validation
- npx vitest run src/appData/progress/source/progressSource.summarySeries.test.tsx src/localDb/progress/progress.test.ts

- npm run build

- git --no-pager diff --check


