### PR TITLE
[codex] Add review reaction preference API

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -46,6 +46,91 @@ paths:
     $ref: paths/api_agent_send-code.yaml
   /api/agent/verify-code:
     $ref: paths/api_agent_verify-code.yaml
+  /me:
+    get:
+      tags:
+        - bootstrap
+      summary: Load signed-in account context
+      description: >-
+        Returns the authenticated account profile, selected workspace id,
+        CSRF token for session callers, and server-owned account preferences.
+      security:
+        - BearerAuth: []
+        - GuestAuthorizationHeader: []
+        - SessionCookie: []
+      responses:
+        '200':
+          description: Account context
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeResponse'
+              example:
+                userId: user-1
+                selectedWorkspaceId: 50b5b928-7f04-4cc8-878d-6cd0e8b98474
+                authTransport: session
+                csrfToken: csrf-token
+                profile:
+                  email: kirill@example.com
+                  locale: en
+                  createdAt: '2026-03-07T10:40:54.589Z'
+                preferences:
+                  reviewReactionAnimationsEnabled: true
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /me/preferences:
+    patch:
+      tags:
+        - bootstrap
+      summary: Update signed-in account preferences
+      description: >-
+        Persists server-owned preferences on the account. Session callers must
+        send a valid X-CSRF-Token header. ApiKey authentication is rejected.
+      security:
+        - BearerAuth: []
+        - GuestAuthorizationHeader: []
+        - SessionCookie: []
+          CsrfTokenHeader: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountPreferences'
+            example:
+              reviewReactionAnimationsEnabled: false
+      responses:
+        '200':
+          description: Updated account preferences
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPreferencesResponse'
+              example:
+                preferences:
+                  reviewReactionAnimationsEnabled: false
+        '400':
+          description: Invalid preference payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden authentication transport or invalid session CSRF token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /agent/me:
     $ref: paths/agent_me.yaml
   /agent/workspaces:
@@ -58,3 +143,101 @@ components:
   securitySchemes:
     ApiKeyHeader:
       $ref: ./components/security-schemes/ApiKeyHeader.yaml
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: Cognito ID token
+    GuestAuthorizationHeader:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: Guest session token formatted as `Guest <token>`.
+    SessionCookie:
+      type: apiKey
+      in: cookie
+      name: session
+    CsrfTokenHeader:
+      type: apiKey
+      in: header
+      name: X-CSRF-Token
+  schemas:
+    AccountPreferences:
+      type: object
+      additionalProperties: false
+      required:
+        - reviewReactionAnimationsEnabled
+      properties:
+        reviewReactionAnimationsEnabled:
+          type: boolean
+          default: true
+    AccountPreferencesResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - preferences
+      properties:
+        preferences:
+          $ref: '#/components/schemas/AccountPreferences'
+    ErrorResponse:
+      type: object
+      additionalProperties: true
+      required:
+        - error
+      properties:
+        error:
+          type: string
+        requestId:
+          type:
+            - string
+            - 'null'
+        code:
+          type:
+            - string
+            - 'null'
+    MeResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - userId
+        - selectedWorkspaceId
+        - authTransport
+        - csrfToken
+        - profile
+        - preferences
+      properties:
+        userId:
+          type: string
+        selectedWorkspaceId:
+          anyOf:
+            - $ref: ./components/schemas/UuidString.yaml
+            - type: 'null'
+        authTransport:
+          type: string
+          enum:
+            - bearer
+            - guest
+            - session
+        csrfToken:
+          type:
+            - string
+            - 'null'
+        profile:
+          type: object
+          additionalProperties: false
+          required:
+            - email
+            - locale
+            - createdAt
+          properties:
+            email:
+              type:
+                - string
+                - 'null'
+              format: email
+            locale:
+              type: string
+            createdAt:
+              type: string
+              format: date-time
+        preferences:
+          $ref: '#/components/schemas/AccountPreferences'

--- a/apps/backend/src/auth/ensureUser.ts
+++ b/apps/backend/src/auth/ensureUser.ts
@@ -5,18 +5,24 @@
 import { transactionWithUserScope, type DatabaseExecutor } from "../database";
 import { ensureUserSelectedWorkspaceInExecutor } from "../workspaces";
 
+export type AccountPreferences = Readonly<{
+  reviewReactionAnimationsEnabled: boolean;
+}>;
+
 export type UserProfile = Readonly<{
   userId: string;
   selectedWorkspaceId: string | null;
   email: string | null;
   locale: string;
   createdAt: string;
+  preferences: AccountPreferences;
 }>;
 
 type UserSettingsRow = Readonly<{
   workspace_id: string | null;
   email: string | null;
   locale: string;
+  review_reaction_animations_enabled: boolean;
   created_at: Date | string;
 }>;
 
@@ -44,7 +50,12 @@ export async function ensureUserProfileInExecutor(
   );
 
   const existing = await executor.query<UserSettingsRow>(
-    "SELECT workspace_id, email, locale, created_at FROM org.user_settings WHERE user_id = $1 FOR UPDATE",
+    [
+      "SELECT workspace_id, email, locale, review_reaction_animations_enabled, created_at",
+      "FROM org.user_settings",
+      "WHERE user_id = $1",
+      "FOR UPDATE",
+    ].join(" "),
     [userId],
   );
 
@@ -65,6 +76,9 @@ export async function ensureUserProfileInExecutor(
     email: settings.email,
     locale: settings.locale,
     createdAt: toIsoString(settings.created_at),
+    preferences: {
+      reviewReactionAnimationsEnabled: settings.review_reaction_animations_enabled,
+    },
   };
 }
 

--- a/apps/backend/src/chat/tests/live/errors.test.ts
+++ b/apps/backend/src/chat/tests/live/errors.test.ts
@@ -134,6 +134,9 @@ test("handleLiveRequest prefers an explicit workspaceId for non-Live auth fallba
         email: null,
         locale: "en",
         createdAt: "2026-03-30T00:00:00.000Z",
+        preferences: {
+          reviewReactionAnimationsEnabled: true,
+        },
       }),
       verifyChatLiveAuthorizationHeaderFn: async () => {
         throw new Error("verifyChatLiveAuthorizationHeaderFn should not run for Bearer auth");

--- a/apps/backend/src/chat/tests/routes/contract.test.ts
+++ b/apps/backend/src/chat/tests/routes/contract.test.ts
@@ -41,6 +41,9 @@ function createRequestContext(): RequestContext {
     email: "user@example.com",
     locale: "en",
     userSettingsCreatedAt: "2026-03-30T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
     transport: "bearer",
     connectionId: null,
     guestSessionId: null,

--- a/apps/backend/src/chat/tests/routes/testSupport.ts
+++ b/apps/backend/src/chat/tests/routes/testSupport.ts
@@ -18,6 +18,9 @@ export function createRequestContext(): RequestContext {
     email: "user@example.com",
     locale: "en",
     userSettingsCreatedAt: "2026-03-30T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
     transport: "bearer",
     connectionId: null,
     guestSessionId: null,

--- a/apps/backend/src/chat/tests/routes/transcriptions.test.ts
+++ b/apps/backend/src/chat/tests/routes/transcriptions.test.ts
@@ -19,6 +19,9 @@ function createRequestContext(): RequestContext {
     email: "user@example.com",
     locale: "en",
     userSettingsCreatedAt: "2026-03-30T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
     transport: "bearer",
     connectionId: null,
     guestSessionId: null,

--- a/apps/backend/src/routes/feedback.test.ts
+++ b/apps/backend/src/routes/feedback.test.ts
@@ -62,6 +62,9 @@ function createRequestContext(transport: RequestContext["transport"]): RequestCo
     email: transport === "guest" ? null : "user@example.com",
     locale: "en",
     userSettingsCreatedAt: "2026-04-17T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
     transport,
     connectionId: transport === "api_key" ? "connection-1" : null,
     guestSessionId: transport === "guest" ? "guest-session-1" : null,

--- a/apps/backend/src/routes/sync.test.ts
+++ b/apps/backend/src/routes/sync.test.ts
@@ -29,6 +29,9 @@ function createRequestContextWithTransport(transport: RequestContext["transport"
     email: transport === "guest" ? null : "user@example.com",
     locale: "en",
     userSettingsCreatedAt: "2026-04-17T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
     transport,
     connectionId: null,
     guestSessionId: transport === "guest" ? "guest-session-1" : null,

--- a/apps/backend/src/routes/system.test.ts
+++ b/apps/backend/src/routes/system.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -13,16 +15,27 @@ import type {
 } from "../progress";
 import { createSystemRoutes } from "./system";
 import type { RequestContext } from "../server/requestContext";
+import type { AccountPreferences } from "../auth/ensureUser";
 
 type SystemTestAppOptions = Readonly<{
   transport: RequestContext["transport"];
+  enforceSessionCsrf?: boolean;
+  getAccountPreferencesFn?: () => AccountPreferences;
+  updateAccountPreferencesFn?: (userId: string, preferences: AccountPreferences) => Promise<AccountPreferences>;
   loadUserProgressReviewScheduleFn?: (args: ProgressReviewScheduleRequest) => Promise<ProgressReviewSchedule>;
   loadUserProgressSeriesFn?: (args: ProgressSeriesRequest) => Promise<ProgressSeries>;
   loadUserProgressSummaryFn?: (args: Readonly<{ userId: string; timeZone: string }>) => Promise<ProgressSummaryResponse>;
 }>;
 
+function createDefaultAccountPreferences(): AccountPreferences {
+  return {
+    reviewReactionAnimationsEnabled: true,
+  };
+}
+
 function createRequestContext(
   transport: RequestContext["transport"],
+  preferences: AccountPreferences,
 ): RequestContext {
   return {
     userId: "user-1",
@@ -31,6 +44,7 @@ function createRequestContext(
     email: "user@example.com",
     locale: "en",
     userSettingsCreatedAt: "2026-04-01T00:00:00.000Z",
+    preferences,
     transport,
     connectionId: transport === "api_key" ? "connection-1" : null,
     guestSessionId: transport === "guest" ? "guest-session-1" : null,
@@ -121,10 +135,25 @@ function createSystemTestApp(options: SystemTestAppOptions): Hono<AppEnv> {
   });
   app.route("/", createSystemRoutes({
     allowedOrigins: [],
-    loadRequestContextFromRequestFn: async () => ({
-      requestAuthInputs: {} as never,
-      requestContext: createRequestContext(options.transport),
-    }),
+    loadRequestContextFromRequestFn: async (request) => {
+      if (
+        options.enforceSessionCsrf === true
+        && options.transport === "session"
+        && request.headers.get("x-csrf-token") !== "valid-csrf-token"
+      ) {
+        throw new HttpError(403, "Invalid X-CSRF-Token header", "SESSION_CSRF_TOKEN_INVALID");
+      }
+
+      const preferences = options.getAccountPreferencesFn === undefined
+        ? createDefaultAccountPreferences()
+        : options.getAccountPreferencesFn();
+
+      return {
+        requestAuthInputs: {} as never,
+        requestContext: createRequestContext(options.transport, preferences),
+      };
+    },
+    updateAccountPreferencesFn: options.updateAccountPreferencesFn,
     loadUserProgressReviewScheduleFn: options.loadUserProgressReviewScheduleFn,
     loadUserProgressSeriesFn: options.loadUserProgressSeriesFn,
     loadUserProgressSummaryFn: options.loadUserProgressSummaryFn,
@@ -132,6 +161,149 @@ function createSystemTestApp(options: SystemTestAppOptions): Hono<AppEnv> {
 
   return app;
 }
+
+test("GET /me includes account preferences", async () => {
+  const app = createSystemTestApp({
+    transport: "session",
+    getAccountPreferencesFn: createDefaultAccountPreferences,
+  });
+  const response = await app.request("http://localhost/me");
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    userId: "user-1",
+    selectedWorkspaceId: "workspace-1",
+    authTransport: "session",
+    csrfToken: null,
+    profile: {
+      email: "user@example.com",
+      locale: "en",
+      createdAt: "2026-04-01T00:00:00.000Z",
+    },
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
+  });
+});
+
+test("review reaction animation preference migration defaults existing rows to true", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "../../db/migrations/0056_review_reaction_animation_preference.sql",
+  );
+  const migrationSql = readFileSync(migrationPath, "utf8");
+
+  assert.match(migrationSql, /ALTER TABLE org\.user_settings/);
+  assert.match(
+    migrationSql,
+    /ADD COLUMN review_reaction_animations_enabled BOOLEAN NOT NULL DEFAULT TRUE/,
+  );
+});
+
+test("PATCH /me/preferences persists false and GET /me returns the updated preference", async () => {
+  let persistedPreferences: AccountPreferences = createDefaultAccountPreferences();
+  const app = createSystemTestApp({
+    transport: "bearer",
+    getAccountPreferencesFn: () => persistedPreferences,
+    updateAccountPreferencesFn: async (userId, preferences) => {
+      assert.equal(userId, "user-1");
+      persistedPreferences = preferences;
+      return persistedPreferences;
+    },
+  });
+
+  const initialResponse = await app.request("http://localhost/me");
+  assert.equal(initialResponse.status, 200);
+  assert.deepEqual((await initialResponse.json() as Readonly<{ preferences: AccountPreferences }>).preferences, {
+    reviewReactionAnimationsEnabled: true,
+  });
+
+  const patchResponse = await app.request("http://localhost/me/preferences", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      reviewReactionAnimationsEnabled: false,
+    }),
+  });
+  assert.equal(patchResponse.status, 200);
+  assert.deepEqual(await patchResponse.json(), {
+    preferences: {
+      reviewReactionAnimationsEnabled: false,
+    },
+  });
+
+  const updatedResponse = await app.request("http://localhost/me");
+  assert.equal(updatedResponse.status, 200);
+  assert.deepEqual((await updatedResponse.json() as Readonly<{ preferences: AccountPreferences }>).preferences, {
+    reviewReactionAnimationsEnabled: false,
+  });
+});
+
+test("PATCH /me/preferences rejects session requests without valid CSRF", async () => {
+  let updateCalled = false;
+  const app = createSystemTestApp({
+    transport: "session",
+    enforceSessionCsrf: true,
+    updateAccountPreferencesFn: async (_userId, preferences) => {
+      updateCalled = true;
+      return preferences;
+    },
+  });
+  const response = await app.request("http://localhost/me/preferences", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      reviewReactionAnimationsEnabled: false,
+    }),
+  });
+
+  assert.equal(updateCalled, false);
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    error: "Invalid X-CSRF-Token header",
+    requestId: "request-1",
+    code: "SESSION_CSRF_TOKEN_INVALID",
+  });
+});
+
+test("PATCH /me/preferences rejects ApiKey authentication", async () => {
+  let updateCalled = false;
+  const app = createSystemTestApp({
+    transport: "api_key",
+    updateAccountPreferencesFn: async (_userId, preferences) => {
+      updateCalled = true;
+      return preferences;
+    },
+  });
+  const response = await app.request("http://localhost/me/preferences", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      reviewReactionAnimationsEnabled: false,
+    }),
+  });
+
+  assert.equal(updateCalled, false);
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    error: "This endpoint requires Guest, Bearer, or Session authentication",
+    requestId: "request-1",
+    code: "ACCOUNT_PREFERENCES_HUMAN_AUTH_REQUIRED",
+  });
+});
+
+test("API Gateway predeclares PATCH /me/preferences", () => {
+  const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(apiGatewaySource, /me\.addResource\("preferences"\)\.addMethod\("PATCH", integration\);/);
+});
 
 test("GET /me/progress/summary returns 200 for Session, Bearer, and Guest authentication", async () => {
   const transports: ReadonlyArray<RequestContext["transport"]> = [

--- a/apps/backend/src/routes/system.ts
+++ b/apps/backend/src/routes/system.ts
@@ -4,6 +4,7 @@ import { deleteAccountForAuthenticatedUser } from "../auth/accountDeletion";
 import { createAgentDiscoveryEnvelope } from "../agent/discovery";
 import { createAgentAccountEnvelope, shouldUseAgentSetupEnvelope } from "../agent/setup";
 import { HttpError } from "../shared/errors";
+import { queryWithUserScope } from "../database";
 import {
   loadUserProgressReviewSchedule,
   loadUserProgressSeries,
@@ -23,7 +24,7 @@ import {
   getSessionCsrfToken,
   toAuthRequest,
 } from "../auth/requestSecurity";
-import { expectRecord, parseJsonBody } from "../server/requestParsing";
+import { expectBoolean, expectRecord, parseJsonBody } from "../server/requestParsing";
 import { loadRequestContextFromRequest } from "../server/requestContext";
 import { createBackendFailureDetails } from "../server/logging";
 import {
@@ -34,6 +35,8 @@ import {
 } from "../observability/sentry";
 import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
 import type { AppEnv } from "../server/app";
+import type { AuthTransport } from "../auth";
+import type { AccountPreferences } from "../auth/ensureUser";
 
 type SystemRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
@@ -41,6 +44,7 @@ type SystemRoutesOptions = Readonly<{
   loadUserProgressReviewScheduleFn?: typeof loadUserProgressReviewSchedule;
   loadUserProgressSeriesFn?: typeof loadUserProgressSeries;
   loadUserProgressSummaryFn?: typeof loadUserProgressSummary;
+  updateAccountPreferencesFn?: UpdateAccountPreferencesFn;
 }>;
 
 type ProgressRequestedParameters = Readonly<{
@@ -49,11 +53,26 @@ type ProgressRequestedParameters = Readonly<{
   to: string | null;
 }>;
 
+type AccountPreferencesRow = Readonly<{
+  review_reaction_animations_enabled: boolean;
+}>;
+
+type UpdateAccountPreferencesFn = (
+  userId: string,
+  preferences: AccountPreferences,
+) => Promise<AccountPreferences>;
+
 function readRequestedProgressParameters(requestUrl: URL): ProgressRequestedParameters {
   return {
     timeZone: requestUrl.searchParams.get("timeZone"),
     from: requestUrl.searchParams.get("from"),
     to: requestUrl.searchParams.get("to"),
+  };
+}
+
+function mapAccountPreferencesRow(row: AccountPreferencesRow): AccountPreferences {
+  return {
+    reviewReactionAnimationsEnabled: row.review_reaction_animations_enabled,
   };
 }
 
@@ -65,6 +84,57 @@ function assertProgressHumanTransport(transport: string): void {
       "PROGRESS_HUMAN_AUTH_REQUIRED",
     );
   }
+}
+
+function assertAccountPreferencesHumanTransport(transport: AuthTransport): void {
+  if (transport !== "session" && transport !== "bearer" && transport !== "guest") {
+    throw new HttpError(
+      403,
+      "This endpoint requires Guest, Bearer, or Session authentication",
+      "ACCOUNT_PREFERENCES_HUMAN_AUTH_REQUIRED",
+    );
+  }
+}
+
+function parseAccountPreferencesInput(body: Record<string, unknown>): AccountPreferences {
+  const unexpectedKey = Object.keys(body).find((key) => key !== "reviewReactionAnimationsEnabled");
+  if (unexpectedKey !== undefined) {
+    throw new HttpError(
+      400,
+      `Unexpected preference field: ${unexpectedKey}`,
+      "ACCOUNT_PREFERENCES_FIELD_UNKNOWN",
+    );
+  }
+
+  return {
+    reviewReactionAnimationsEnabled: expectBoolean(
+      body.reviewReactionAnimationsEnabled,
+      "reviewReactionAnimationsEnabled",
+    ),
+  };
+}
+
+async function updateAccountPreferences(
+  userId: string,
+  preferences: AccountPreferences,
+): Promise<AccountPreferences> {
+  const result = await queryWithUserScope<AccountPreferencesRow>(
+    { userId },
+    [
+      "UPDATE org.user_settings",
+      "SET review_reaction_animations_enabled = $2",
+      "WHERE user_id = $1",
+      "RETURNING review_reaction_animations_enabled",
+    ].join(" "),
+    [userId, preferences.reviewReactionAnimationsEnabled],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Failed to update account preferences for user ${userId}`);
+  }
+
+  return mapAccountPreferencesRow(row);
 }
 
 function createSystemScope(
@@ -92,6 +162,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
   const loadUserProgressReviewScheduleFn = options.loadUserProgressReviewScheduleFn ?? loadUserProgressReviewSchedule;
   const loadUserProgressSeriesFn = options.loadUserProgressSeriesFn ?? loadUserProgressSeries;
   const loadUserProgressSummaryFn = options.loadUserProgressSummaryFn ?? loadUserProgressSummary;
+  const updateAccountPreferencesFn = options.updateAccountPreferencesFn ?? updateAccountPreferences;
 
   app.get("/", async (context) => context.json(createAgentDiscoveryEnvelope(context.req.url)));
   app.get("/agent", async (context) => context.json(createAgentDiscoveryEnvelope(context.req.url)));
@@ -128,6 +199,24 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         locale: requestContext.locale,
         createdAt: requestContext.userSettingsCreatedAt,
       },
+      preferences: requestContext.preferences,
+    });
+  });
+
+  app.patch("/me/preferences", async (context) => {
+    const { requestContext } = await loadRequestContextFromRequestFn(
+      context.req.raw,
+      options.allowedOrigins,
+    );
+
+    assertAccountPreferencesHumanTransport(requestContext.transport);
+
+    const body = expectRecord(await parseJsonBody(context.req.raw));
+    const preferencesInput = parseAccountPreferencesInput(body);
+    const preferences = await updateAccountPreferencesFn(requestContext.userId, preferencesInput);
+
+    return context.json({
+      preferences,
     });
   });
 

--- a/apps/backend/src/routes/workspaces.test.ts
+++ b/apps/backend/src/routes/workspaces.test.ts
@@ -25,6 +25,9 @@ function createRequestContext(): RequestContext {
     email: "user@example.com",
     locale: "en",
     userSettingsCreatedAt: "2026-04-17T00:00:00.000Z",
+    preferences: {
+      reviewReactionAnimationsEnabled: true,
+    },
     transport: "bearer",
     connectionId: null,
     guestSessionId: null,

--- a/apps/backend/src/server/requestContext.ts
+++ b/apps/backend/src/server/requestContext.ts
@@ -2,7 +2,7 @@ import { authenticateRequest, type AuthTransport } from "../auth";
 import type { GuestSessionPlatform } from "../guestAuth";
 import { isDeletedSubject } from "../auth/deletedSubjects";
 import { HttpError } from "../shared/errors";
-import { ensureUserProfile } from "../auth/ensureUser";
+import { ensureUserProfile, type AccountPreferences } from "../auth/ensureUser";
 import { assertUserHasWorkspaceAccess } from "../workspaces";
 import {
   enforceSessionCsrfProtection,
@@ -18,6 +18,7 @@ export type RequestContext = Readonly<{
   email: string | null;
   locale: string;
   userSettingsCreatedAt: string;
+  preferences: AccountPreferences;
   transport: AuthTransport;
   connectionId: string | null;
   guestSessionId: string | null;
@@ -86,6 +87,7 @@ export async function loadRequestContextWithDependencies(
     email: userProfile.email,
     locale: userProfile.locale,
     userSettingsCreatedAt: userProfile.createdAt,
+    preferences: userProfile.preferences,
     transport: auth.transport,
     connectionId: auth.connectionId,
     guestSessionId: auth.guestSessionId,

--- a/db/migrations/0056_review_reaction_animation_preference.sql
+++ b/db/migrations/0056_review_reaction_animation_preference.sql
@@ -1,0 +1,2 @@
+ALTER TABLE org.user_settings
+  ADD COLUMN review_reaction_animations_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -136,7 +136,7 @@ export const globalMetricsCorsPreflightOptions: apigw.CorsOptions = {
 function createBrowserCorsPreflightOptions(allowedOrigins: string[]): apigw.CorsOptions {
   return {
     allowOrigins: allowedOrigins,
-    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowMethods: ["GET", "POST", "PATCH", "OPTIONS"],
     allowHeaders: [...browserCorsAllowHeaders],
     allowCredentials: true,
   };
@@ -159,7 +159,7 @@ export function createGatewayErrorResponseHeaders(): GatewayErrorResponseHeaders
     "Access-Control-Allow-Origin": "method.request.header.Origin",
     "Vary": "'Origin'",
     "Access-Control-Allow-Headers": `'${browserCorsAllowHeaders.join(",")}'`,
-    "Access-Control-Allow-Methods": "'GET,POST,OPTIONS'",
+    "Access-Control-Allow-Methods": "'GET,POST,PATCH,OPTIONS'",
     "Access-Control-Allow-Credentials": "'true'",
     "Access-Control-Expose-Headers": `'${gatewayErrorCorsExposeHeaders.join(",")}'`,
   };
@@ -612,6 +612,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
 
   const me = restApi.root.addResource("me");
   me.addMethod("GET", integration);
+  me.addResource("preferences").addMethod("PATCH", integration);
   const meProgress = me.addResource("progress");
   meProgress.addResource("summary").addMethod("GET", integration);
   meProgress.addResource("review-schedule").addMethod("GET", integration);


### PR DESCRIPTION
## Summary
- add account-level review reaction animation preference storage
- return preferences from GET /me and add PATCH /me/preferences
- update API Gateway and OpenAPI contract
- add targeted backend route coverage

## Validation
- npm run lint --prefix apps/backend
- npm run bundle --prefix api
- node --test --import tsx src/routes/system.test.ts
- npm run lint --prefix api
- git --no-pager diff --check