### PR TITLE
Use dirty marker for review schedule cache

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -167,7 +167,7 @@ extension FlashcardsStore {
                 scopeKey: scopeKey,
                 summaryScopeKey: progressSummaryScopeKey(seriesScopeKey: scopeKey)
             )
-            self.markProgressReviewSchedulePendingLocalOverlay(scopeKey: scheduleScopeKey)
+            try self.markProgressReviewSchedulePendingLocalOverlay(scopeKey: scheduleScopeKey)
             try self.publishReviewProgressBadgeState(scopeKey: scopeKey)
             self.publishReviewScheduleSnapshotIsolatingErrors(
                 scopeKey: scheduleScopeKey
@@ -195,7 +195,7 @@ extension FlashcardsStore {
             let scopeKey = try self.prepareProgressScope(now: now)
             let scheduleScopeKey = reviewScheduleScopeKey(seriesScopeKey: scopeKey)
             self.progressReviewScheduleLocalRevision += 1
-            self.markProgressReviewSchedulePendingLocalOverlay(scopeKey: scheduleScopeKey)
+            try self.markProgressReviewSchedulePendingLocalOverlay(scopeKey: scheduleScopeKey)
             guard self.currentVisibleTab == .progress else {
                 return
             }
@@ -236,7 +236,10 @@ extension FlashcardsStore {
             if reviewProgressDataChanged {
                 self.invalidateProgressSummaryAndSeries(scopeKey: scopeKey, summaryScopeKey: summaryScopeKey)
                 if reviewScheduleDataChanged {
-                    self.invalidateProgressReviewSchedule(scopeKey: scheduleScopeKey)
+                    try self.markProgressReviewScheduleChangedAfterSync(
+                        scopeKey: scheduleScopeKey,
+                        syncResult: syncResult
+                    )
                 }
                 if isReviewVisible {
                     try self.publishReviewProgressBadgeState(scopeKey: scopeKey)
@@ -244,7 +247,10 @@ extension FlashcardsStore {
                     try self.publishProgressSnapshot(scopeKey: scopeKey)
                 }
             } else {
-                self.invalidateProgressReviewSchedule(scopeKey: scheduleScopeKey)
+                try self.markProgressReviewScheduleChangedAfterSync(
+                    scopeKey: scheduleScopeKey,
+                    syncResult: syncResult
+                )
             }
 
             if reviewScheduleDataChanged && isReviewVisible == false {
@@ -267,6 +273,20 @@ extension FlashcardsStore {
 
             self.replaceProgressErrorMessage(message: Flashcards.errorMessage(error: error))
         }
+    }
+
+    private func markProgressReviewScheduleChangedAfterSync(
+        scopeKey: ReviewScheduleScopeKey,
+        syncResult: CloudSyncResult
+    ) throws {
+        let didAcknowledgeLocalScheduleChange = syncResult.acknowledgedReviewScheduleImpactingOperationCount > 0
+            || syncResult.cleanedUpReviewScheduleImpactingOperationCount > 0
+        let didPullScheduleChange = syncResult.reviewScheduleImpactingPullChangeCount > 0
+        guard didAcknowledgeLocalScheduleChange || didPullScheduleChange else {
+            return
+        }
+
+        try self.markProgressReviewSchedulePendingLocalOverlay(scopeKey: scopeKey)
     }
 
     func prepareProgressForCurrentVisibleTab(now: Date) {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressRefresh.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressRefresh.swift
@@ -167,14 +167,15 @@ extension FlashcardsStore {
                 return
             }
 
-            let persistedServerBase = PersistedReviewScheduleServerBase(
+            let database = try requireLocalDatabase(database: self.database)
+            let workspaceIds = try self.loadCanonicalProgressWorkspaceIds(database: database)
+            try self.acceptFreshProgressReviewScheduleServerBase(
                 scopeKey: scopeKey,
-                serverBase: serverBase,
-                storedAt: nowIsoTimestamp()
+                serverBaseSchedule: serverBase,
+                storedAt: nowIsoTimestamp(),
+                database: database,
+                workspaceIds: workspaceIds
             )
-            try self.persistReviewScheduleServerBase(serverBase: persistedServerBase)
-            self.progressReviewScheduleServerBaseCache = persistedServerBase
-            self.progressReviewScheduleInvalidatedScopeKeys.remove(scopeKey)
             self.clearProgressReviewScheduleRefreshErrorMessage()
 
             guard let observedScopeKey = self.progressObservedScopeKey,
@@ -213,11 +214,24 @@ extension FlashcardsStore {
     }
 
     func shouldRefreshProgressReviewSchedule(scopeKey: ReviewScheduleScopeKey) -> Bool {
-        guard self.progressReviewScheduleServerBaseCache?.scopeKey == scopeKey else {
+        guard let cachedServerBase = self.progressReviewScheduleServerBaseCache,
+              cachedServerBase.scopeKey == scopeKey else {
             return true
         }
 
-        return self.progressReviewScheduleInvalidatedScopeKeys.contains(scopeKey)
+        if self.progressReviewScheduleInvalidatedScopeKeys.contains(scopeKey) {
+            return true
+        }
+        if cachedServerBase.requiresRefresh {
+            return true
+        }
+        if let reviewScheduleSnapshot = self.reviewScheduleSnapshot,
+           reviewScheduleSnapshot.scopeKey == scopeKey,
+           reviewScheduleSnapshot.sourceState == .serverBaseWithPendingLocalOverlay {
+            return true
+        }
+
+        return false
     }
 
     func activeProgressCloudSession(scopeKey: ProgressScopeKey) -> CloudLinkedSession? {
@@ -282,8 +296,19 @@ extension FlashcardsStore {
         self.updateProgressRefreshingState()
     }
 
-    func markProgressReviewSchedulePendingLocalOverlay(scopeKey: ReviewScheduleScopeKey) {
+    func markProgressReviewSchedulePendingLocalOverlay(scopeKey: ReviewScheduleScopeKey) throws {
         self.progressReviewScheduleInvalidatedScopeKeys.insert(scopeKey)
+        if let cachedServerBase = self.progressReviewScheduleServerBaseCache,
+           cachedServerBase.scopeKey == scopeKey {
+            let dirtyServerBase = PersistedReviewScheduleServerBase(
+                scopeKey: cachedServerBase.scopeKey,
+                serverBase: cachedServerBase.serverBase,
+                storedAt: cachedServerBase.storedAt,
+                requiresRefresh: true
+            )
+            try self.persistReviewScheduleServerBase(serverBase: dirtyServerBase)
+            self.progressReviewScheduleServerBaseCache = dirtyServerBase
+        }
         self.progressReviewScheduleRefreshToken += 1
         self.progressActiveReviewScheduleRefreshScopeKey = nil
         self.progressActiveReviewScheduleRefreshToken = nil

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
@@ -121,7 +121,7 @@ extension FlashcardsStore {
         if let serverBase = self.progressReviewScheduleServerBaseCache,
            serverBase.scopeKey == scopeKey {
             try self.publishReviewScheduleSnapshotFromServerBase(
-                serverBaseSchedule: serverBase.serverBase,
+                serverBase: serverBase,
                 scopeKey: scopeKey
             )
             return
@@ -155,67 +155,122 @@ extension FlashcardsStore {
     }
 
     private func publishReviewScheduleSnapshotFromServerBase(
-        serverBaseSchedule: UserReviewSchedule,
+        serverBase: PersistedReviewScheduleServerBase,
         scopeKey: ReviewScheduleScopeKey
     ) throws {
-        guard self.progressReviewScheduleInvalidatedScopeKeys.contains(scopeKey) else {
-            try self.publishReviewScheduleSnapshot(
-                schedule: serverBaseSchedule,
-                scopeKey: scopeKey,
-                sourceState: .serverBase
-            )
-            return
-        }
-
         let database = try requireLocalDatabase(database: self.database)
         let workspaceIds = try self.loadCanonicalProgressWorkspaceIds(database: database)
-        let pendingLocalOverlayState = try self.loadReviewSchedulePendingLocalOverlayState(
+        let renderedServerBase = try self.makeProgressReviewScheduleRenderedServerBase(
+            serverBase: serverBase,
+            database: database,
+            workspaceIds: workspaceIds
+        )
+        try self.publishReviewScheduleSnapshot(
+            schedule: renderedServerBase.renderedSchedule,
+            scopeKey: scopeKey,
+            sourceState: renderedServerBase.sourceState
+        )
+    }
+
+    func makeProgressReviewScheduleRenderedServerBase(
+        serverBase: PersistedReviewScheduleServerBase,
+        database: LocalDatabase,
+        workspaceIds: [String]
+    ) throws -> ProgressReviewScheduleRenderedServerBase {
+        let serverBaseSchedule = serverBase.serverBase
+        let pendingLocalOverlayState = try self.computeReviewSchedulePendingLocalOverlayState(
             database: database,
             workspaceIds: workspaceIds
         )
 
-        guard pendingLocalOverlayState == .present else {
-            try self.publishReviewScheduleSnapshot(
-                schedule: serverBaseSchedule,
-                scopeKey: scopeKey,
+        if pendingLocalOverlayState == .empty && serverBase.requiresRefresh == false {
+            return ProgressReviewScheduleRenderedServerBase(
+                renderedSchedule: serverBaseSchedule,
                 sourceState: .serverBase
             )
-            return
         }
 
-        let localFallbackCoverage = try self.loadReviewScheduleLocalCoverage(
+        let localEntry = try self.ensureProgressReviewScheduleLocalCacheEntry(
             database: database,
             workspaceIds: workspaceIds
         )
-        guard localFallbackCoverage == .userWide else {
-            try self.publishReviewScheduleSnapshot(
-                schedule: serverBaseSchedule,
-                scopeKey: scopeKey,
-                sourceState: .serverBaseWithPendingLocalOverlay
+
+        if pendingLocalOverlayState == .present {
+            return self.makeProgressReviewSchedulePendingOverlayRender(
+                serverBaseSchedule: serverBaseSchedule,
+                localEntry: localEntry
             )
-            return
         }
 
-        let localFallbackSchedule = try self.loadReviewScheduleLocalFallback(
+        return self.makeProgressReviewScheduleDirtyCacheRender(
+            serverBaseSchedule: serverBaseSchedule,
+            localEntry: localEntry
+        )
+    }
+
+    func acceptFreshProgressReviewScheduleServerBase(
+        scopeKey: ReviewScheduleScopeKey,
+        serverBaseSchedule: UserReviewSchedule,
+        storedAt: String,
+        database: LocalDatabase,
+        workspaceIds: [String]
+    ) throws {
+        let pendingLocalOverlayState = try self.computeReviewSchedulePendingLocalOverlayState(
             database: database,
             workspaceIds: workspaceIds
         )
-        let pendingLocalCardTotalDelta = try self.loadReviewSchedulePendingLocalCardTotalDelta(
-            database: database,
-            workspaceIds: workspaceIds
-        )
-        guard localFallbackSchedule.totalCards - pendingLocalCardTotalDelta == serverBaseSchedule.totalCards else {
-            try self.publishReviewScheduleSnapshot(
-                schedule: serverBaseSchedule,
-                scopeKey: scopeKey,
-                sourceState: .serverBaseWithPendingLocalOverlay
-            )
-            return
-        }
-
-        try self.publishReviewScheduleSnapshot(
-            schedule: localFallbackSchedule,
+        let requiresRefresh = pendingLocalOverlayState == .present
+        let persistedServerBase = PersistedReviewScheduleServerBase(
             scopeKey: scopeKey,
+            serverBase: serverBaseSchedule,
+            storedAt: storedAt,
+            requiresRefresh: requiresRefresh
+        )
+        try self.persistReviewScheduleServerBase(serverBase: persistedServerBase)
+        self.progressReviewScheduleServerBaseCache = persistedServerBase
+        if requiresRefresh {
+            self.progressReviewScheduleInvalidatedScopeKeys.insert(scopeKey)
+        } else {
+            self.progressReviewScheduleInvalidatedScopeKeys.remove(scopeKey)
+        }
+    }
+
+    private func makeProgressReviewScheduleDirtyCacheRender(
+        serverBaseSchedule: UserReviewSchedule,
+        localEntry: ProgressReviewScheduleLocalCacheEntry
+    ) -> ProgressReviewScheduleRenderedServerBase {
+        switch localEntry.localCoverage {
+        case .userWide:
+            return ProgressReviewScheduleRenderedServerBase(
+                renderedSchedule: localEntry.reviewSchedule,
+                sourceState: .serverBaseWithPendingLocalOverlay
+            )
+        case .partialOrUnknown:
+            return ProgressReviewScheduleRenderedServerBase(
+                renderedSchedule: serverBaseSchedule,
+                sourceState: .serverBaseWithPendingLocalOverlay
+            )
+        }
+    }
+
+    private func makeProgressReviewSchedulePendingOverlayRender(
+        serverBaseSchedule: UserReviewSchedule,
+        localEntry: ProgressReviewScheduleLocalCacheEntry
+    ) -> ProgressReviewScheduleRenderedServerBase {
+        guard canReplaceServerReviewScheduleForPendingLocalChange(
+            serverBaseSchedule: serverBaseSchedule,
+            localFallbackSchedule: localEntry.reviewSchedule,
+            localFallbackCoverage: localEntry.localCoverage,
+            pendingLocalCardTotalDelta: localEntry.pendingCardTotalDelta
+        ) else {
+            return ProgressReviewScheduleRenderedServerBase(
+                renderedSchedule: serverBaseSchedule,
+                sourceState: .serverBaseWithPendingLocalOverlay
+            )
+        }
+
+        return ProgressReviewScheduleRenderedServerBase(
+            renderedSchedule: localEntry.reviewSchedule,
             sourceState: .serverBaseWithPendingLocalOverlay
         )
     }
@@ -279,27 +334,7 @@ extension FlashcardsStore {
         ).sources
     }
 
-    private func loadReviewSchedulePendingLocalOverlayState(
-        database: LocalDatabase,
-        workspaceIds: [String]
-    ) throws -> ProgressPendingLocalOverlayState {
-        try self.ensureProgressReviewScheduleLocalCacheEntry(
-            database: database,
-            workspaceIds: workspaceIds
-        ).pendingOverlayState
-    }
-
-    private func loadReviewSchedulePendingLocalCardTotalDelta(
-        database: LocalDatabase,
-        workspaceIds: [String]
-    ) throws -> Int {
-        try self.ensureProgressReviewScheduleLocalCacheEntry(
-            database: database,
-            workspaceIds: workspaceIds
-        ).pendingCardTotalDelta
-    }
-
-    private func loadReviewScheduleLocalFallback(
+    func loadReviewScheduleLocalFallback(
         database: LocalDatabase,
         workspaceIds: [String]
     ) throws -> UserReviewSchedule {
@@ -307,16 +342,6 @@ extension FlashcardsStore {
             database: database,
             workspaceIds: workspaceIds
         ).reviewSchedule
-    }
-
-    private func loadReviewScheduleLocalCoverage(
-        database: LocalDatabase,
-        workspaceIds: [String]
-    ) throws -> ReviewScheduleLocalCoverage {
-        try self.ensureProgressReviewScheduleLocalCacheEntry(
-            database: database,
-            workspaceIds: workspaceIds
-        ).localCoverage
     }
 
     private func ensureProgressReviewedAtClientCacheEntry(
@@ -515,7 +540,7 @@ extension FlashcardsStore {
         )
     }
 
-    private func loadCanonicalProgressWorkspaceIds(database: LocalDatabase) throws -> [String] {
+    func loadCanonicalProgressWorkspaceIds(database: LocalDatabase) throws -> [String] {
         let workspaceIds = try database.workspaceSettingsStore.loadCachedWorkspaces().map(\.workspaceId)
         guard workspaceIds.isEmpty == false else {
             throw LocalStoreError.database("Progress requires at least one cached workspace")

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/ProgressLocalFallbackCaches.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/ProgressLocalFallbackCaches.swift
@@ -26,3 +26,8 @@ struct ProgressReviewScheduleLocalCacheEntry: Sendable {
     let pendingCardTotalDelta: Int
     let localCoverage: ReviewScheduleLocalCoverage
 }
+
+struct ProgressReviewScheduleRenderedServerBase: Sendable {
+    let renderedSchedule: UserReviewSchedule
+    let sourceState: ProgressSourceState
+}

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/ProgressServerBaseCache.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/ProgressServerBaseCache.swift
@@ -16,6 +16,36 @@ struct PersistedReviewScheduleServerBase: Codable, Hashable, Sendable {
     let scopeKey: ReviewScheduleScopeKey
     let serverBase: UserReviewSchedule
     let storedAt: String
+    let requiresRefresh: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case scopeKey
+        case serverBase
+        case storedAt
+        case requiresRefresh
+    }
+
+    init(
+        scopeKey: ReviewScheduleScopeKey,
+        serverBase: UserReviewSchedule,
+        storedAt: String,
+        requiresRefresh: Bool
+    ) {
+        self.scopeKey = scopeKey
+        self.serverBase = serverBase
+        self.storedAt = storedAt
+        self.requiresRefresh = requiresRefresh
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            scopeKey: try container.decode(ReviewScheduleScopeKey.self, forKey: .scopeKey),
+            serverBase: try container.decode(UserReviewSchedule.self, forKey: .serverBase),
+            storedAt: try container.decode(String.self, forKey: .storedAt),
+            requiresRefresh: try container.decodeIfPresent(Bool.self, forKey: .requiresRefresh) ?? false
+        )
+    }
 }
 
 private let progressSummaryServerBaseCacheUserDefaultsKeyPrefix: String = "progress-summary-server-base"

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
@@ -178,6 +178,19 @@ func makeProgressRenderedReviewSchedule(
     }
 }
 
+func canReplaceServerReviewScheduleForPendingLocalChange(
+    serverBaseSchedule: UserReviewSchedule,
+    localFallbackSchedule: UserReviewSchedule,
+    localFallbackCoverage: ReviewScheduleLocalCoverage,
+    pendingLocalCardTotalDelta: Int
+) -> Bool {
+    guard localFallbackCoverage == .userWide else {
+        return false
+    }
+
+    return localFallbackSchedule.totalCards - pendingLocalCardTotalDelta == serverBaseSchedule.totalCards
+}
+
 private func progressSeriesSourceState(
     serverBase: UserProgressSeries,
     renderedSeries: UserProgressSeries

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSyncCompletionTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSyncCompletionTests.swift
@@ -196,7 +196,67 @@ final class ProgressSyncCompletionTests: ProgressStoreTestCase {
         )
         let reviewScheduleSnapshot = try XCTUnwrap(context.store.reviewScheduleSnapshot)
         XCTAssertEqual(.serverBase, reviewScheduleSnapshot.sourceState)
+        XCTAssertFalse(reviewScheduleSnapshot.isApproximate)
         XCTAssertEqual(3, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+    }
+
+    @MainActor
+    func testHandleProgressSyncCompletionMarksReviewScheduleDirtyForMixedAckAndPullChanges() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let initialServerSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let initialServerSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: initialServerSummary,
+            serverSeries: initialServerSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+        let scopeKey = try XCTUnwrap(context.store.progressObservedScopeKey)
+        let scheduleScopeKey = reviewScheduleScopeKey(seriesScopeKey: scopeKey)
+        context.store.updateCurrentVisibleTab(tab: .cards)
+
+        await context.store.handleProgressSyncCompletion(
+            now: now,
+            syncResult: CloudSyncResult(
+                appliedPullChangeCount: 1,
+                reviewScheduleImpactingPullChangeCount: 1,
+                changedEntityTypes: [.card],
+                localIdRepairEntityTypes: [],
+                acknowledgedOperationCount: 1,
+                acknowledgedReviewEventOperationCount: 0,
+                acknowledgedReviewScheduleImpactingOperationCount: 1,
+                cleanedUpOperationCount: 0,
+                cleanedUpReviewEventOperationCount: 0,
+                cleanedUpReviewScheduleImpactingOperationCount: 0
+            )
+        )
+
+        XCTAssertTrue(context.store.progressReviewScheduleServerBaseCache?.requiresRefresh ?? false)
+        XCTAssertTrue(context.store.progressReviewScheduleInvalidatedScopeKeys.contains(scheduleScopeKey))
+        XCTAssertTrue(context.store.shouldRefreshProgressReviewSchedule(scopeKey: scheduleScopeKey))
     }
 
     @MainActor

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewSchedulePendingOverlayTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewSchedulePendingOverlayTests.swift
@@ -274,4 +274,579 @@ final class ProgressReviewSchedulePendingOverlayTests: ProgressStoreTestCase {
         XCTAssertEqual(4, reviewScheduleCount(snapshot: createSnapshot, key: .today))
         XCTAssertEqual(0, reviewScheduleCount(snapshot: createSnapshot, key: .new))
     }
+
+    @MainActor
+    func testPendingBucketOnlyMoveUsesCompleteLocalScheduleOverlay() async throws {
+        let fixture = try await self.makeReviewScheduleBucketMoveFixture(localCoverage: .userWide)
+        defer { fixture.context.tearDown() }
+
+        try self.applyPendingReviewScheduleBucketMove(fixture: fixture)
+
+        let reviewScheduleSnapshot = try XCTUnwrap(fixture.context.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, reviewScheduleSnapshot.sourceState)
+        XCTAssertTrue(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(1, reviewScheduleSnapshot.schedule.totalCards)
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+    }
+
+    @MainActor
+    func testAcknowledgedBucketOnlyMoveRendersDirtyLocalOverlayBeforeFreshServerResponse() async throws {
+        let fixture = try await self.makeReviewScheduleBucketMoveFixture(localCoverage: .userWide)
+        defer { fixture.context.tearDown() }
+
+        try self.applyPendingReviewScheduleBucketMove(fixture: fixture)
+        let scheduleRefreshCount = fixture.context.cloudSyncService.loadProgressReviewScheduleCallCount
+        try await self.acknowledgeReviewScheduleBucketMove(
+            fixture: fixture,
+            allowsImmediateRefresh: false
+        )
+
+        let reviewScheduleSnapshot = try XCTUnwrap(fixture.context.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, reviewScheduleSnapshot.sourceState)
+        XCTAssertTrue(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(1, reviewScheduleSnapshot.schedule.totalCards)
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+        XCTAssertEqual(scheduleRefreshCount, fixture.context.cloudSyncService.loadProgressReviewScheduleCallCount)
+        XCTAssertTrue(fixture.context.store.progressReviewScheduleServerBaseCache?.requiresRefresh ?? false)
+    }
+
+    @MainActor
+    func testReviewScheduleServerCatchUpClearsAcknowledgedLocalOverlay() async throws {
+        let fixture = try await self.makeReviewScheduleBucketMoveFixture(localCoverage: .userWide)
+        defer { fixture.context.tearDown() }
+
+        try self.applyPendingReviewScheduleBucketMove(fixture: fixture)
+        try await self.acknowledgeReviewScheduleBucketMove(
+            fixture: fixture,
+            allowsImmediateRefresh: false
+        )
+        fixture.context.cloudSyncService.serverReviewSchedule = makeTestReviewSchedule(
+            timeZone: fixture.requestRange.timeZone,
+            countsByBucketKey: [
+                .days1To7: 1
+            ],
+            generatedAt: "2026-04-18T12:02:00.000Z"
+        )
+
+        let activeSession = try XCTUnwrap(
+            fixture.context.store.activeProgressCloudSession(scopeKey: fixture.progressScopeKey)
+        )
+        await fixture.context.store.refreshProgressReviewScheduleServerBase(
+            scopeKey: fixture.scheduleScopeKey,
+            linkedSession: activeSession
+        )
+
+        let reviewScheduleSnapshot = try XCTUnwrap(fixture.context.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBase, reviewScheduleSnapshot.sourceState)
+        XCTAssertFalse(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(1, reviewScheduleSnapshot.schedule.totalCards)
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+        XCTAssertFalse(
+            fixture.context.store.progressReviewScheduleInvalidatedScopeKeys.contains(fixture.scheduleScopeKey)
+        )
+        XCTAssertFalse(fixture.context.store.progressReviewScheduleServerBaseCache?.requiresRefresh ?? true)
+    }
+
+    @MainActor
+    func testAcknowledgedBucketOnlyMoveKeepsServerOverlayWhenLocalCoverageIsPartial() async throws {
+        let fixture = try await self.makeReviewScheduleBucketMoveFixture(localCoverage: .partialOrUnknown)
+        defer { fixture.context.tearDown() }
+
+        try self.applyPendingReviewScheduleBucketMove(fixture: fixture)
+        try await self.acknowledgeReviewScheduleBucketMove(
+            fixture: fixture,
+            allowsImmediateRefresh: false
+        )
+
+        let reviewScheduleSnapshot = try XCTUnwrap(fixture.context.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, reviewScheduleSnapshot.sourceState)
+        XCTAssertTrue(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(1, reviewScheduleSnapshot.schedule.totalCards)
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+        XCTAssertTrue(fixture.context.store.progressReviewScheduleServerBaseCache?.requiresRefresh ?? false)
+    }
+
+    @MainActor
+    func testPersistedDirtyReviewScheduleCacheKeepsRefreshIntentAcrossRelaunch() async throws {
+        let fixture = try await self.makeReviewScheduleBucketMoveFixture(localCoverage: .userWide)
+        var relaunchedContext: ProgressStoreTestContext?
+        defer {
+            relaunchedContext?.tearDown()
+            fixture.context.tearDown()
+        }
+
+        try self.applyPendingReviewScheduleBucketMove(fixture: fixture)
+        try await self.acknowledgeReviewScheduleBucketMove(
+            fixture: fixture,
+            allowsImmediateRefresh: false
+        )
+        let dirtyPersistedServerBase = try XCTUnwrap(
+            fixture.context.store.loadPersistedReviewScheduleServerBase(scopeKey: fixture.scheduleScopeKey)
+        )
+        XCTAssertTrue(dirtyPersistedServerBase.requiresRefresh)
+        fixture.context.store.shutdownForTests()
+
+        let reloadedContext = try self.makeProgressStoreContext(
+            database: fixture.database,
+            workspaceId: fixture.workspaceId,
+            installationId: fixture.installationId,
+            serverSummary: fixture.serverSummary,
+            serverSeries: fixture.serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest,
+            suiteName: fixture.context.suiteName,
+            userDefaults: fixture.context.userDefaults
+        )
+        relaunchedContext = reloadedContext
+        reloadedContext.cloudSyncService.serverReviewSchedule = makeTestReviewSchedule(
+            timeZone: fixture.requestRange.timeZone,
+            countsByBucketKey: [
+                .today: 1
+            ],
+            generatedAt: "2026-04-18T12:02:00.000Z"
+        )
+
+        _ = try reloadedContext.store.prepareProgressSnapshot(now: fixture.now)
+
+        let reviewScheduleSnapshot = try XCTUnwrap(reloadedContext.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, reviewScheduleSnapshot.sourceState)
+        XCTAssertTrue(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(1, reviewScheduleSnapshot.schedule.totalCards)
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+
+        let scheduleRefreshCount = reloadedContext.cloudSyncService.loadProgressReviewScheduleCallCount
+        await reloadedContext.store.refreshProgressIfNeeded(now: fixture.now)
+
+        XCTAssertEqual(
+            scheduleRefreshCount + 1,
+            reloadedContext.cloudSyncService.loadProgressReviewScheduleCallCount
+        )
+    }
+
+    @MainActor
+    func testCleanReviewScheduleServerBaseRendersServerBaseWithoutCausalLocalChange() async throws {
+        let database = try self.makeDatabase()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let dueToday = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T08:00:00.000Z"))
+        let movedDueAt = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-21T08:00:00.000Z"))
+        let card = try self.addDueReviewScheduleCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            dueAt: dueToday
+        )
+        let setupOutboxEntries = try database.loadOutboxEntries(
+            workspaceId: workspace.workspaceId,
+            limit: Int.max
+        )
+        try database.deleteOutboxEntries(operationIds: setupOutboxEntries.map(\.operationId))
+        try database.setHasHydratedHotState(
+            workspaceId: workspace.workspaceId,
+            hasHydratedHotState: true
+        )
+        try self.moveReviewScheduleCardDueAt(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: card.cardId,
+            dueAt: movedDueAt
+        )
+
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+        let progressScopeKey = try context.store.prepareProgressScope(now: now)
+        let scheduleScopeKey = reviewScheduleScopeKey(seriesScopeKey: progressScopeKey)
+        let staleServerBase = PersistedReviewScheduleServerBase(
+            scopeKey: scheduleScopeKey,
+            serverBase: makeTestReviewSchedule(
+                timeZone: requestRange.timeZone,
+                countsByBucketKey: [
+                    .today: 1
+                ],
+                generatedAt: "2026-04-18T11:59:00.000Z"
+            ),
+            storedAt: "2026-04-18T11:59:00.000Z",
+            requiresRefresh: false
+        )
+        try context.store.persistReviewScheduleServerBase(serverBase: staleServerBase)
+        context.store.progressReviewScheduleServerBaseCache = context.store.loadPersistedReviewScheduleServerBase(
+            scopeKey: scheduleScopeKey
+        )
+
+        try context.store.publishReviewScheduleSnapshot(scopeKey: scheduleScopeKey)
+
+        let reviewScheduleSnapshot = try XCTUnwrap(context.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBase, reviewScheduleSnapshot.sourceState)
+        XCTAssertFalse(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+        XCTAssertFalse(context.store.progressReviewScheduleServerBaseCache?.requiresRefresh ?? true)
+        XCTAssertFalse(context.store.progressReviewScheduleInvalidatedScopeKeys.contains(scheduleScopeKey))
+    }
+
+    @MainActor
+    func testFreshDifferentServerResponseWithoutPendingLocalChangesWinsOverLocalFallback() async throws {
+        let database = try self.makeDatabase()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let dueToday = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T08:00:00.000Z"))
+        let movedDueAt = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-21T08:00:00.000Z"))
+        let card = try self.addDueReviewScheduleCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            dueAt: dueToday
+        )
+        let setupOutboxEntries = try database.loadOutboxEntries(
+            workspaceId: workspace.workspaceId,
+            limit: Int.max
+        )
+        try database.deleteOutboxEntries(operationIds: setupOutboxEntries.map(\.operationId))
+        try database.setHasHydratedHotState(
+            workspaceId: workspace.workspaceId,
+            hasHydratedHotState: true
+        )
+        try self.moveReviewScheduleCardDueAt(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: card.cardId,
+            dueAt: movedDueAt
+        )
+
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+        let progressScopeKey = try context.store.prepareProgressScope(now: now)
+        let scheduleScopeKey = reviewScheduleScopeKey(seriesScopeKey: progressScopeKey)
+        let dirtyServerBase = PersistedReviewScheduleServerBase(
+            scopeKey: scheduleScopeKey,
+            serverBase: makeTestReviewSchedule(
+                timeZone: requestRange.timeZone,
+                countsByBucketKey: [
+                    .today: 1
+                ],
+                generatedAt: "2026-04-18T11:59:00.000Z"
+            ),
+            storedAt: "2026-04-18T11:59:00.000Z",
+            requiresRefresh: true
+        )
+        try context.store.persistReviewScheduleServerBase(serverBase: dirtyServerBase)
+        context.store.progressReviewScheduleServerBaseCache = dirtyServerBase
+        context.store.progressReviewScheduleInvalidatedScopeKeys.insert(scheduleScopeKey)
+        context.cloudSyncService.serverReviewSchedule = makeTestReviewSchedule(
+            timeZone: requestRange.timeZone,
+            countsByBucketKey: [
+                .today: 1
+            ],
+            generatedAt: "2026-04-18T12:01:00.000Z"
+        )
+
+        let activeSession = try XCTUnwrap(context.store.activeProgressCloudSession(scopeKey: progressScopeKey))
+        await context.store.refreshProgressReviewScheduleServerBase(
+            scopeKey: scheduleScopeKey,
+            linkedSession: activeSession
+        )
+
+        let reviewScheduleSnapshot = try XCTUnwrap(context.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBase, reviewScheduleSnapshot.sourceState)
+        XCTAssertFalse(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+        XCTAssertFalse(context.store.progressReviewScheduleServerBaseCache?.requiresRefresh ?? true)
+        XCTAssertFalse(context.store.progressReviewScheduleInvalidatedScopeKeys.contains(scheduleScopeKey))
+    }
+
+    @MainActor
+    func testFirstReviewScheduleRefreshWithoutCacheKeepsPendingLocalOverlay() async throws {
+        let database = try self.makeDatabase()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let dueToday = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T08:00:00.000Z"))
+        let movedDueAt = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-21T08:00:00.000Z"))
+        let card = try self.addDueReviewScheduleCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            dueAt: dueToday
+        )
+        let setupOutboxEntries = try database.loadOutboxEntries(
+            workspaceId: workspace.workspaceId,
+            limit: Int.max
+        )
+        try database.deleteOutboxEntries(operationIds: setupOutboxEntries.map(\.operationId))
+        try database.setHasHydratedHotState(
+            workspaceId: workspace.workspaceId,
+            hasHydratedHotState: true
+        )
+
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+        context.cloudSyncService.serverReviewSchedule = makeTestReviewSchedule(
+            timeZone: requestRange.timeZone,
+            countsByBucketKey: [
+                .today: 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        context.store.updateCurrentVisibleTab(tab: .progress)
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: card.cardId,
+                rating: .good,
+                reviewedAtClient: formatIsoTimestamp(date: now)
+            )
+        )
+        try self.moveReviewScheduleCardDueAt(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            cardId: card.cardId,
+            dueAt: movedDueAt
+        )
+        context.store.handleReviewScheduleLocalCardStateDidChange(now: now)
+        XCTAssertNil(context.store.progressReviewScheduleServerBaseCache)
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let reviewScheduleSnapshot = try XCTUnwrap(context.store.reviewScheduleSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, reviewScheduleSnapshot.sourceState)
+        XCTAssertTrue(reviewScheduleSnapshot.isApproximate)
+        XCTAssertEqual(0, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
+        XCTAssertEqual(1, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .days1To7))
+        XCTAssertTrue(context.store.progressReviewScheduleServerBaseCache?.requiresRefresh ?? false)
+    }
+
+    @MainActor
+    private func makeReviewScheduleBucketMoveFixture(
+        localCoverage: ReviewScheduleLocalCoverage
+    ) async throws -> ReviewScheduleBucketMoveFixture {
+        let database = try self.makeDatabase()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let dueToday = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T08:00:00.000Z"))
+        let movedDueAt = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-21T08:00:00.000Z"))
+        let card = try self.addDueReviewScheduleCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            dueAt: dueToday
+        )
+        let setupOutboxEntries = try database.loadOutboxEntries(
+            workspaceId: workspace.workspaceId,
+            limit: Int.max
+        )
+        try database.deleteOutboxEntries(operationIds: setupOutboxEntries.map(\.operationId))
+        switch localCoverage {
+        case .userWide:
+            try database.setHasHydratedHotState(
+                workspaceId: workspace.workspaceId,
+                hasHydratedHotState: true
+            )
+        case .partialOrUnknown:
+            try database.setHasHydratedHotState(
+                workspaceId: workspace.workspaceId,
+                hasHydratedHotState: false
+            )
+        }
+
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: TimeZone.current,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        context.cloudSyncService.serverReviewSchedule = makeTestReviewSchedule(
+            timeZone: requestRange.timeZone,
+            countsByBucketKey: [
+                .today: 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+
+        await context.store.refreshProgressIfNeeded(now: now)
+        context.store.updateCurrentVisibleTab(tab: .progress)
+        let progressScopeKey = try XCTUnwrap(context.store.progressObservedScopeKey)
+        let scheduleScopeKey = reviewScheduleScopeKey(seriesScopeKey: progressScopeKey)
+
+        return ReviewScheduleBucketMoveFixture(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            now: now,
+            movedDueAt: movedDueAt,
+            requestRange: requestRange,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            progressScopeKey: progressScopeKey,
+            scheduleScopeKey: scheduleScopeKey,
+            context: context,
+            card: card
+        )
+    }
+
+    @MainActor
+    private func applyPendingReviewScheduleBucketMove(
+        fixture: ReviewScheduleBucketMoveFixture
+    ) throws {
+        _ = try fixture.database.submitReview(
+            workspaceId: fixture.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: fixture.card.cardId,
+                rating: .good,
+                reviewedAtClient: formatIsoTimestamp(date: fixture.now)
+            )
+        )
+        try self.moveReviewScheduleCardDueAt(
+            database: fixture.database,
+            workspaceId: fixture.workspaceId,
+            cardId: fixture.card.cardId,
+            dueAt: fixture.movedDueAt
+        )
+        fixture.context.store.handleReviewScheduleLocalCardStateDidChange(now: fixture.now)
+    }
+
+    @MainActor
+    private func acknowledgeReviewScheduleBucketMove(
+        fixture: ReviewScheduleBucketMoveFixture,
+        allowsImmediateRefresh: Bool
+    ) async throws {
+        let outboxEntries = try fixture.database.loadOutboxEntries(
+            workspaceId: fixture.workspaceId,
+            limit: Int.max
+        )
+        try fixture.database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+        if allowsImmediateRefresh == false {
+            fixture.context.store.updateCurrentVisibleTab(tab: .cards)
+        }
+
+        await fixture.context.store.handleProgressSyncCompletion(
+            now: fixture.now,
+            syncResult: CloudSyncResult(
+                appliedPullChangeCount: 0,
+                reviewScheduleImpactingPullChangeCount: 0,
+                changedEntityTypes: [],
+                localIdRepairEntityTypes: [],
+                acknowledgedOperationCount: outboxEntries.count,
+                acknowledgedReviewEventOperationCount: 1,
+                acknowledgedReviewScheduleImpactingOperationCount: 1,
+                cleanedUpOperationCount: 0,
+                cleanedUpReviewEventOperationCount: 0,
+                cleanedUpReviewScheduleImpactingOperationCount: 0
+            )
+        )
+        if allowsImmediateRefresh == false {
+            fixture.context.store.updateCurrentVisibleTab(tab: .progress)
+        }
+    }
+}
+
+private struct ReviewScheduleBucketMoveFixture {
+    let database: LocalDatabase
+    let workspaceId: String
+    let installationId: String
+    let now: Date
+    let movedDueAt: Date
+    let requestRange: ProgressSeriesLoadRequest
+    let serverSummary: UserProgressSummary
+    let serverSeries: UserProgressSeries
+    let progressScopeKey: ProgressScopeKey
+    let scheduleScopeKey: ReviewScheduleScopeKey
+    let context: ProgressStoreTestContext
+    let card: Card
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewScheduleRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewScheduleRefreshTests.swift
@@ -57,6 +57,13 @@ final class ProgressReviewScheduleRefreshTests: ProgressStoreTestCase {
         XCTAssertEqual(4, reviewScheduleSnapshot.schedule.totalCards)
         XCTAssertEqual(4, reviewScheduleCount(snapshot: reviewScheduleSnapshot, key: .today))
         XCTAssertEqual(1, context.cloudSyncService.loadProgressReviewScheduleCallCount)
+        XCTAssertFalse(
+            context.store.progressReviewScheduleInvalidatedScopeKeys.contains(reviewScheduleSnapshot.scopeKey)
+        )
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressReviewScheduleCallCount)
     }
 
     @MainActor
@@ -360,7 +367,7 @@ final class ProgressReviewScheduleRefreshTests: ProgressStoreTestCase {
     }
 
     @MainActor
-    func testReviewScheduleServerBaseRenderDoesNotLoadBrokenLocalFallbackWithoutPendingOverlay() async throws {
+    func testReviewScheduleServerBaseRenderDoesNotLoadBrokenLocalFallbackWithoutDirtyCacheOrPendingOverlay() async throws {
         let database = try self.makeDatabase()
         let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewScheduleTestHelpers.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewScheduleTestHelpers.swift
@@ -74,4 +74,26 @@ extension ProgressStoreTestCase {
             ]
         )
     }
+
+    func moveReviewScheduleCardDueAt(
+        database: LocalDatabase,
+        workspaceId: String,
+        cardId: String,
+        dueAt: Date
+    ) throws {
+        let dueAtText = formatIsoTimestamp(date: dueAt)
+        try database.core.execute(
+            sql: """
+            UPDATE cards
+            SET due_at = ?, due_at_millis = ?
+            WHERE workspace_id = ? AND card_id = ?
+            """,
+            values: [
+                .text(dueAtText),
+                .integer(epochMillis(date: dueAt)),
+                .text(workspaceId),
+                .text(cardId),
+            ]
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Replace iOS review-schedule accepted fingerprint state with a persisted dirty marker.
- Keep cached review-schedule rendering read-only and make fresh server responses the acceptance boundary.
- Cover pending overlay, relaunch, fresh server, and mixed sync result behavior in focused iOS tests.

## Validation
- git --no-pager diff --check origin/main...HEAD
- iOS xcodebuild was not run here because the local machine does not have an eligible iOS 26.5 destination/platform installed.