### PR TITLE
[codex] Fix Android local streak extension

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotCalculations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotCalculations.kt
@@ -437,6 +437,7 @@ internal fun mergeProgressSummary(
         )
     val serverCurrentStreakDaysWithRenderedDelta = progressCurrentStreakDaysWithRenderedDelta(
         serverBase = base,
+        localFallbackActiveDates = localFallbackActiveDates,
         renderedSeriesActiveDates = renderedSeriesContext?.activeDates,
         referenceLocalDate = referenceLocalDate
     )
@@ -680,6 +681,7 @@ private fun progressShouldApplyActiveReviewDayDelta(
 
 private fun progressCurrentStreakDaysWithRenderedDelta(
     serverBase: CloudProgressSummary,
+    localFallbackActiveDates: Set<String>,
     renderedSeriesActiveDates: Set<String>?,
     referenceLocalDate: String
 ): Int {
@@ -689,11 +691,18 @@ private fun progressCurrentStreakDaysWithRenderedDelta(
     if (serverBase.currentStreakDays <= 0) {
         return serverBase.currentStreakDays
     }
-    if (renderedSeriesActiveDates?.contains(referenceLocalDate) != true) {
-        return serverBase.currentStreakDays
+    val lastReviewedOn = serverBase.lastReviewedOn ?: return serverBase.currentStreakDays
+    val referenceDate: LocalDate = parseLocalDate(rawDate = referenceLocalDate)
+    val activeDates: Set<String> = localFallbackActiveDates + (renderedSeriesActiveDates ?: emptySet())
+    var currentDate: LocalDate = parseLocalDate(rawDate = lastReviewedOn).plusDays(1L)
+    var localDelta: Int = 0
+
+    while (currentDate <= referenceDate && activeDates.contains(currentDate.toString())) {
+        localDelta += 1
+        currentDate = currentDate.plusDays(1L)
     }
 
-    return serverBase.currentStreakDays + 1
+    return serverBase.currentStreakDays + localDelta
 }
 
 private fun validateProgressSeriesMergeInputs(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
@@ -198,6 +198,151 @@ class ProgressSummarySnapshotTest {
     }
 
     @Test
+    fun longServerStreakExtendsThroughConsecutiveLocalDates() {
+        val summaryScopeKey = createProgressSummaryScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-20"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val seriesScopeKey = createProgressSeriesScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-20"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val localDayCounts = listOf(
+            createProgressLocalDayCount(
+                workspaceId = "workspace-1",
+                localDate = "2026-04-19",
+                reviewCount = 1
+            ),
+            createProgressLocalDayCount(
+                workspaceId = "workspace-1",
+                localDate = "2026-04-20",
+                reviewCount = 1
+            )
+        )
+        val localFallback = createLocalFallbackSummary(
+            scopeKey = summaryScopeKey,
+            localDayCounts = localDayCounts,
+            workspaceIds = listOf("workspace-1"),
+            today = LocalDate.parse("2026-04-20")
+        )
+        val serverWatermarks = createWatermarks(reviewSequenceId = 42L)
+        val serverSeries = createSeries(
+            scopeKey = seriesScopeKey,
+            reviewCountsByDate = mapOf("2026-04-18" to 1),
+            reviewHistoryWatermarks = serverWatermarks
+        )
+        val localFallbackSeries = createLocalFallbackSeries(
+            scopeKey = seriesScopeKey,
+            localDayCounts = localDayCounts,
+            workspaceIds = listOf("workspace-1")
+        )
+        val renderedSeriesContext = createRenderedSeriesContext(
+            scopeKey = seriesScopeKey,
+            serverBase = serverSeries,
+            localFallback = localFallbackSeries,
+            pendingLocalOverlay = createPendingLocalOverlaySeries(
+                scopeKey = seriesScopeKey,
+                pendingReviewLocalDates = emptyList(),
+                workspaceIds = listOf("workspace-1")
+            )
+        )
+        val serverBase = CloudProgressSummary(
+            currentStreakDays = 200,
+            hasReviewedToday = false,
+            lastReviewedOn = "2026-04-18",
+            activeReviewDays = 200,
+            reviewHistoryWatermarks = serverWatermarks
+        )
+
+        val snapshot = createProgressSummarySnapshot(
+            scopeKey = summaryScopeKey,
+            localFallback = localFallback,
+            localFallbackActiveDates = setOf("2026-04-19", "2026-04-20"),
+            serverBase = serverBase,
+            renderedSeriesContext = renderedSeriesContext,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(202, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
+        assertEquals("2026-04-20", snapshot.renderedSummary.lastReviewedOn)
+        assertEquals(202, snapshot.renderedSummary.activeReviewDays)
+    }
+
+    @Test
+    fun longServerStreakExtendsToYesterdayWhenTodayHasNoReview() {
+        val summaryScopeKey = createProgressSummaryScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-20"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val seriesScopeKey = createProgressSeriesScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-20"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val localDayCounts = listOf(
+            createProgressLocalDayCount(
+                workspaceId = "workspace-1",
+                localDate = "2026-04-19",
+                reviewCount = 1
+            )
+        )
+        val localFallback = createLocalFallbackSummary(
+            scopeKey = summaryScopeKey,
+            localDayCounts = localDayCounts,
+            workspaceIds = listOf("workspace-1"),
+            today = LocalDate.parse("2026-04-20")
+        )
+        val serverWatermarks = createWatermarks(reviewSequenceId = 42L)
+        val serverSeries = createSeries(
+            scopeKey = seriesScopeKey,
+            reviewCountsByDate = mapOf("2026-04-18" to 1),
+            reviewHistoryWatermarks = serverWatermarks
+        )
+        val localFallbackSeries = createLocalFallbackSeries(
+            scopeKey = seriesScopeKey,
+            localDayCounts = localDayCounts,
+            workspaceIds = listOf("workspace-1")
+        )
+        val renderedSeriesContext = createRenderedSeriesContext(
+            scopeKey = seriesScopeKey,
+            serverBase = serverSeries,
+            localFallback = localFallbackSeries,
+            pendingLocalOverlay = createPendingLocalOverlaySeries(
+                scopeKey = seriesScopeKey,
+                pendingReviewLocalDates = emptyList(),
+                workspaceIds = listOf("workspace-1")
+            )
+        )
+        val serverBase = CloudProgressSummary(
+            currentStreakDays = 200,
+            hasReviewedToday = false,
+            lastReviewedOn = "2026-04-18",
+            activeReviewDays = 200,
+            reviewHistoryWatermarks = serverWatermarks
+        )
+
+        val snapshot = createProgressSummarySnapshot(
+            scopeKey = summaryScopeKey,
+            localFallback = localFallback,
+            localFallbackActiveDates = setOf("2026-04-19"),
+            serverBase = serverBase,
+            renderedSeriesContext = renderedSeriesContext,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(201, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(false, snapshot.renderedSummary.hasReviewedToday)
+        assertEquals("2026-04-19", snapshot.renderedSummary.lastReviewedOn)
+        assertEquals(201, snapshot.renderedSummary.activeReviewDays)
+    }
+
+    @Test
     fun localActiveDateOutsideVisibleChartRangeExtendsActiveDays() {
         val summaryScopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),


### PR DESCRIPTION
## Summary

Fix Android progress summary merging so a stale server streak extends through every consecutive local active review date after the server frontier, instead of adding at most one day.

## Impact

Android rendered progress summaries now match the expected offline/local overlay behavior for multi-day local streak continuation and for a streak that remains current through yesterday when today has no review.

## Validation

- `git --no-pager diff --check`
- `git --no-pager diff --cached --check`

Gradle was not run locally because repository instructions require explicit approval for local Gradle runs.