### PR TITLE
[codex] Fix iOS local streak extension

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
@@ -227,8 +227,9 @@ private func mergeProgressSummary(
             serverAndSeriesShareReviewHistoryBase: serverAndSeriesShareReviewHistoryBase,
             referenceLocalDate: referenceLocalDate
         )
-    let serverCurrentStreakDaysWithRenderedDelta = progressCurrentStreakDaysWithRenderedDelta(
+    let serverCurrentStreakDaysWithRenderedDelta = try progressCurrentStreakDaysWithRenderedDelta(
         serverBase: serverBase,
+        localFallbackActiveDates: localFallbackActiveDates,
         renderedSeriesActiveDates: renderedSeriesContext?.activeDates,
         referenceLocalDate: referenceLocalDate
     )
@@ -346,9 +347,10 @@ private func progressShouldApplyActiveReviewDayDelta(
 
 private func progressCurrentStreakDaysWithRenderedDelta(
     serverBase: ProgressSummary,
+    localFallbackActiveDates: Set<String>,
     renderedSeriesActiveDates: Set<String>?,
     referenceLocalDate: String
-) -> Int {
+) throws -> Int {
     guard serverBase.hasReviewedToday == false else {
         return serverBase.currentStreakDays
     }
@@ -357,11 +359,20 @@ private func progressCurrentStreakDaysWithRenderedDelta(
         return serverBase.currentStreakDays
     }
 
-    guard renderedSeriesActiveDates?.contains(referenceLocalDate) == true else {
+    guard let lastReviewedOn = serverBase.lastReviewedOn else {
         return serverBase.currentStreakDays
     }
 
-    return serverBase.currentStreakDays + 1
+    let activeDates = localFallbackActiveDates.union(renderedSeriesActiveDates ?? Set<String>())
+    var currentDate = try progressShiftLocalDateForStore(value: lastReviewedOn, offsetDays: 1)
+    var localDelta = 0
+
+    while currentDate <= referenceLocalDate, activeDates.contains(currentDate) {
+        localDelta += 1
+        currentDate = try progressShiftLocalDateForStore(value: currentDate, offsetDays: 1)
+    }
+
+    return serverBase.currentStreakDays + localDelta
 }
 
 private func validateProgressSeriesMergeInputs(

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSummarySeriesRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSummarySeriesRefreshTests.swift
@@ -69,6 +69,151 @@ final class ProgressSummarySeriesRefreshTests: ProgressStoreTestCase {
     }
 
     @MainActor
+    func testRefreshProgressIfNeededExtendsLongServerSummaryThroughConsecutiveLocalDates() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-17",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-18",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-18T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-16": 1
+            ],
+            generatedAt: "2026-04-18T11:59:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 200,
+                hasReviewedToday: false,
+                lastReviewedOn: "2026-04-16",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-18T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(202, progressSnapshot.summary.currentStreakDays)
+        XCTAssertTrue(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-18", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(202, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-16"))
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-17"))
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-18"))
+    }
+
+    @MainActor
+    func testRefreshProgressIfNeededExtendsLongServerSummaryThroughYesterdayWhenTodayIsInactive() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: try makeReviewedAtClientForTests(
+                localDate: "2026-04-19",
+                hour: 9,
+                timeZoneIdentifier: timeZone.identifier
+            )
+        )
+        let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
+        try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-04-20T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                "2026-04-18": 1
+            ],
+            generatedAt: "2026-04-20T11:59:00.000Z"
+        )
+        let serverSummary = UserProgressSummary(
+            timeZone: requestRange.timeZone,
+            summary: ProgressSummary(
+                currentStreakDays: 200,
+                hasReviewedToday: false,
+                lastReviewedOn: "2026-04-18",
+                activeReviewDays: 200
+            ),
+            generatedAt: "2026-04-20T11:59:00.000Z",
+            reviewHistoryWatermarks: makeTestProgressReviewHistoryWatermarks(reviewSequenceId: 42)
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .guest
+        )
+        defer { context.tearDown() }
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.summarySourceState)
+        XCTAssertEqual(.serverBaseWithPendingLocalOverlay, progressSnapshot.seriesSourceState)
+        XCTAssertEqual(201, progressSnapshot.summary.currentStreakDays)
+        XCTAssertFalse(progressSnapshot.summary.hasReviewedToday)
+        XCTAssertEqual("2026-04-19", progressSnapshot.summary.lastReviewedOn)
+        XCTAssertEqual(201, progressSnapshot.summary.activeReviewDays)
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-18"))
+        XCTAssertEqual(1, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-19"))
+        XCTAssertEqual(0, progressReviewCount(snapshot: progressSnapshot, localDate: "2026-04-20"))
+    }
+
+    @MainActor
     func testRefreshProgressIfNeededExtendsStaleSummaryActiveDaysWhenServerSeriesIsFresher() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()


### PR DESCRIPTION
## Summary

- Extend iOS progress summary streak merging across every consecutive local active date after the stale server frontier.
- Add iOS progress refresh coverage for multi-day local streak extension and yesterday-only local activity.

## Validation

- `xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSummarySeriesRefreshTests.swift`
- `git --no-pager diff --check`

Simulator-backed iOS tests were not run because the repository requires explicit approval for those runs.