### PR TITLE
Fix iOS progress series merge compile error

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressAggregation.swift
@@ -662,10 +662,10 @@ func mergeProgressSeries(
         sourceName: "localFallback",
         rangeDescription: rangeDescription
     )
-    let mergedDailyReviews = zeroFilledDays.map { progressDay in
+    let mergedDailyReviews: [ProgressDay] = zeroFilledDays.map { progressDay in
         let serverOverlayCount = (serverCounts[progressDay.date] ?? 0) + (pendingCounts[progressDay.date] ?? 0)
         let localFallbackCount = localFallbackCounts[progressDay.date] ?? 0
-        ProgressDay(
+        return ProgressDay(
             date: progressDay.date,
             reviewCount: max(serverOverlayCount, localFallbackCount)
         )


### PR DESCRIPTION
## Summary

- Fix iOS progress series merge compilation by returning ProgressDay from the multi-statement map closure.
- Keep the merged daily review collection explicitly typed as [ProgressDay].

## Validation

- git --no-pager diff --check
- Full local iOS build was not run because the local machine has low disk space and local Xcode destination/platform setup issues.
