### PR TITLE
[codex] Fix Android settings CI compile

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatLiveRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatLiveRemoteService.kt
@@ -243,12 +243,7 @@ class AiChatLiveRemoteService private constructor(
 
                 val requestId = readAiChatRequestIdHeader(response = response)
                 try {
-                    val responseBody = response.body ?: throw AiChatLiveStreamException(
-                        message = "AI live attach returned a successful response without an event stream body.",
-                        requestId = requestId,
-                        code = "ai_live_stream_body_missing",
-                        cause = IllegalStateException("AI live stream response body is missing.")
-                    )
+                    val responseBody = response.body
                     var currentEventType: String? = null
                     val dataLines = mutableListOf<String>()
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/network/OkHttpCoroutine.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/network/OkHttpCoroutine.kt
@@ -13,9 +13,9 @@ internal suspend fun Call.awaitOkHttpResponse(): Response {
             cancel()
         }
         enqueue(object : Callback {
-            override fun onFailure(call: Call, error: IOException) {
+            override fun onFailure(call: Call, e: IOException) {
                 if (continuation.isActive) {
-                    continuation.resumeWithException(error)
+                    continuation.resumeWithException(e)
                 }
             }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -239,9 +239,6 @@ class CloudGuestSessionCoordinator(
             require(createSessionIfMissing) {
                 "Guest AI session is unavailable."
             }
-            if (activeRecoveryState != null) {
-                throw CloudCredentialRecoveryRequiredException(recoveryState = activeRecoveryState)
-            }
             // A missing stored session here means we already crossed a full
             // local identity reset boundary such as logout or account deletion.
             // The recreated guest session must therefore be treated as a brand

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsViewModel.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.launch
 
 class SettingsViewModel(
     workspaceRepository: WorkspaceRepository,
-    cloudAccountRepository: CloudAccountRepository,
+    private val cloudAccountRepository: CloudAccountRepository,
     private val autoSyncEventRepository: AutoSyncEventRepository,
     private val messageController: TransientMessageController,
     testModeStore: TestModeStore,


### PR DESCRIPTION
## Summary

Fix the Android Release compile failure from the latest main run by storing `cloudAccountRepository` as a `SettingsViewModel` property.

Also clean up the Kotlin warnings surfaced in the same CI log:

- remove an unreachable OkHttp response-body null branch
- align the OkHttp callback failure parameter name with the interface
- remove a duplicate unreachable recovery-state check

## Validation

- `git diff --check`

Gradle was not run locally because this repository requires explicit approval before local `./gradlew` runs.