### PR TITLE
[codex] Fix Android settings route test import

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.fetchSemanticsNode
 import androidx.compose.ui.test.hasScrollToNodeAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText


### PR DESCRIPTION
## Summary

Fix the Android instrumentation test compilation failure surfaced after PR #423 by removing an invalid `fetchSemanticsNode` import from `SettingsRootRouteTest`.

`fetchSemanticsNode()` is used as a member on `SemanticsNodeInteraction` elsewhere in the Android tests, so this import is unnecessary and does not exist in the configured Compose test API.

## Validation

- `git diff --check`

Gradle was not run locally because this repository requires explicit approval before local `./gradlew` runs.