### PR TITLE
[codex] Reorder review reminder settings

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
@@ -8,8 +8,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationMode
 import com.flashcardsopensourceapp.feature.settings.R
@@ -82,19 +85,6 @@ fun ReviewNotificationsRoute(
                 Card(modifier = Modifier.fillMaxWidth()) {
                     ListItem(
                         headlineContent = {
-                            Text(stringResource(R.string.settings_notifications_this_device_title))
-                        },
-                        supportingContent = {
-                            Text(stringResource(R.string.settings_notifications_this_device_body))
-                        }
-                    )
-                }
-            }
-
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    ListItem(
-                        headlineContent = {
                             Text(stringResource(R.string.settings_notifications_permission_title))
                         },
                         supportingContent = {
@@ -130,6 +120,155 @@ fun ReviewNotificationsRoute(
 
             item {
                 Card(modifier = Modifier.fillMaxWidth()) {
+                    Column {
+                        ListItem(
+                            headlineContent = {
+                                Text(stringResource(R.string.settings_notifications_reminders_title))
+                            },
+                            supportingContent = {
+                                Text(stringResource(R.string.settings_notifications_reminders_body))
+                            },
+                            trailingContent = {
+                                Switch(
+                                    checked = uiState.settings.isEnabled,
+                                    onCheckedChange = onUpdateEnabled
+                                )
+                            }
+                        )
+
+                        if (uiState.settings.selectedMode == ReviewNotificationMode.DAILY) {
+                            ReviewNotificationModeSelector(
+                                selectedMode = uiState.settings.selectedMode,
+                                onUpdateMode = onUpdateMode
+                            )
+
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_daily_title))
+                                },
+                                supportingContent = {
+                                    Text(
+                                        stringResource(
+                                            R.string.settings_notifications_daily_example,
+                                            formatTimeLabel(
+                                                context = context,
+                                                hour = uiState.settings.daily.hour,
+                                                minute = uiState.settings.daily.minute
+                                            )
+                                        )
+                                    )
+                                },
+                                trailingContent = {
+                                    TimeValueStepper(
+                                        hour = uiState.settings.daily.hour,
+                                        minute = uiState.settings.daily.minute,
+                                        onValueChange = onUpdateDailyTime
+                                    )
+                                }
+                            )
+                        } else {
+                            ReviewNotificationModeSelector(
+                                selectedMode = uiState.settings.selectedMode,
+                                onUpdateMode = onUpdateMode
+                            )
+
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_inactivity_title))
+                                },
+                                supportingContent = {
+                                    Text(
+                                        stringResource(
+                                            R.string.settings_notifications_inactivity_example,
+                                            formatTimeLabel(
+                                                context = context,
+                                                hour = uiState.settings.inactivity.windowStartHour,
+                                                minute = uiState.settings.inactivity.windowStartMinute
+                                            ),
+                                            formatTimeLabel(
+                                                context = context,
+                                                hour = uiState.settings.inactivity.windowEndHour,
+                                                minute = uiState.settings.inactivity.windowEndMinute
+                                            ),
+                                            idleMinutesLabel(minutes = uiState.settings.inactivity.idleMinutes),
+                                            idleMinutesLabel(minutes = uiState.settings.inactivity.idleMinutes)
+                                        )
+                                    )
+                                }
+                            )
+
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_from_title))
+                                },
+                                trailingContent = {
+                                    TimeValueStepper(
+                                        hour = uiState.settings.inactivity.windowStartHour,
+                                        minute = uiState.settings.inactivity.windowStartMinute,
+                                        onValueChange = onUpdateInactivityWindowStart
+                                    )
+                                }
+                            )
+
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_to_title))
+                                },
+                                trailingContent = {
+                                    TimeValueStepper(
+                                        hour = uiState.settings.inactivity.windowEndHour,
+                                        minute = uiState.settings.inactivity.windowEndMinute,
+                                        onValueChange = onUpdateInactivityWindowEnd
+                                    )
+                                }
+                            )
+
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_remind_after_title))
+                                },
+                                trailingContent = {
+                                    SingleChoiceSegmentedButtonRow {
+                                        listOf(60, 120, 180).forEachIndexed { index, value ->
+                                            SegmentedButton(
+                                                selected = uiState.settings.inactivity.idleMinutes == value,
+                                                onClick = {
+                                                    onUpdateIdleMinutes(value)
+                                                },
+                                                shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
+                                                    index = index,
+                                                    count = 3
+                                                ),
+                                                label = {
+                                                    Text(idleMinutesLabel(minutes = value))
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            )
+                        }
+
+                        ListItem(
+                            headlineContent = {
+                                Text(stringResource(R.string.settings_notifications_show_app_icon_badge_title))
+                            },
+                            supportingContent = {
+                                Text(stringResource(R.string.settings_notifications_show_app_icon_badge_body))
+                            },
+                            trailingContent = {
+                                Switch(
+                                    checked = uiState.settings.showAppIconBadge,
+                                    onCheckedChange = onUpdateShowAppIconBadge
+                                )
+                            }
+                        )
+                    }
+                }
+            }
+
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
                     ListItem(
                         headlineContent = {
                             Text(stringResource(R.string.settings_notifications_strict_reminders_title))
@@ -155,191 +294,50 @@ fun ReviewNotificationsRoute(
                 Card(modifier = Modifier.fillMaxWidth()) {
                     ListItem(
                         headlineContent = {
-                            Text(stringResource(R.string.settings_notifications_reminders_title))
+                            Text(stringResource(R.string.settings_notifications_this_device_title))
                         },
                         supportingContent = {
-                            Text(stringResource(R.string.settings_notifications_reminders_body))
-                        },
-                        trailingContent = {
-                            Switch(
-                                checked = uiState.settings.isEnabled,
-                                onCheckedChange = onUpdateEnabled
-                            )
+                            Text(stringResource(R.string.settings_notifications_this_device_body))
                         }
                     )
                 }
             }
+        }
+    }
+}
 
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    ListItem(
-                        headlineContent = {
-                            Text(stringResource(R.string.settings_notifications_show_app_icon_badge_title))
-                        },
-                        supportingContent = {
-                            Text(stringResource(R.string.settings_notifications_show_app_icon_badge_body))
-                        },
-                        trailingContent = {
-                            Switch(
-                                checked = uiState.settings.showAppIconBadge,
-                                onCheckedChange = onUpdateShowAppIconBadge
-                            )
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReviewNotificationModeSelector(
+    selectedMode: ReviewNotificationMode,
+    onUpdateMode: (ReviewNotificationMode) -> Unit
+) {
+    SingleChoiceSegmentedButtonRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        val modes = listOf(ReviewNotificationMode.DAILY, ReviewNotificationMode.INACTIVITY)
+        modes.forEachIndexed { index, mode ->
+            SegmentedButton(
+                selected = selectedMode == mode,
+                onClick = {
+                    onUpdateMode(mode)
+                },
+                shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
+                    index = index,
+                    count = modes.size
+                ),
+                label = {
+                    Text(
+                        if (mode == ReviewNotificationMode.DAILY) {
+                            stringResource(R.string.settings_notifications_mode_daily)
+                        } else {
+                            stringResource(R.string.settings_notifications_mode_inactivity)
                         }
                     )
                 }
-            }
-
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                        val modes = listOf(ReviewNotificationMode.DAILY, ReviewNotificationMode.INACTIVITY)
-                        modes.forEachIndexed { index, mode ->
-                            SegmentedButton(
-                                selected = uiState.settings.selectedMode == mode,
-                                onClick = {
-                                    onUpdateMode(mode)
-                                },
-                                shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
-                                    index = index,
-                                    count = modes.size
-                                ),
-                                label = {
-                                    Text(
-                                        if (mode == ReviewNotificationMode.DAILY) {
-                                            stringResource(R.string.settings_notifications_mode_daily)
-                                        } else {
-                                            stringResource(R.string.settings_notifications_mode_inactivity)
-                                        }
-                                    )
-                                }
-                            )
-                        }
-                    }
-                }
-            }
-
-            if (uiState.settings.selectedMode == ReviewNotificationMode.DAILY) {
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_daily_title))
-                            },
-                            supportingContent = {
-                                Text(
-                                    stringResource(
-                                        R.string.settings_notifications_daily_example,
-                                        formatTimeLabel(
-                                            context = context,
-                                            hour = uiState.settings.daily.hour,
-                                            minute = uiState.settings.daily.minute
-                                        )
-                                    )
-                                )
-                            },
-                            trailingContent = {
-                                TimeValueStepper(
-                                    hour = uiState.settings.daily.hour,
-                                    minute = uiState.settings.daily.minute,
-                                    onValueChange = onUpdateDailyTime
-                                )
-                            }
-                        )
-                    }
-                }
-            } else {
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_inactivity_title))
-                            },
-                            supportingContent = {
-                                Text(
-                                    stringResource(
-                                        R.string.settings_notifications_inactivity_example,
-                                        formatTimeLabel(
-                                            context = context,
-                                            hour = uiState.settings.inactivity.windowStartHour,
-                                            minute = uiState.settings.inactivity.windowStartMinute
-                                        ),
-                                        formatTimeLabel(
-                                            context = context,
-                                            hour = uiState.settings.inactivity.windowEndHour,
-                                            minute = uiState.settings.inactivity.windowEndMinute
-                                        ),
-                                        idleMinutesLabel(minutes = uiState.settings.inactivity.idleMinutes),
-                                        idleMinutesLabel(minutes = uiState.settings.inactivity.idleMinutes)
-                                    )
-                                )
-                            }
-                        )
-                    }
-                }
-
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_from_title))
-                            },
-                            trailingContent = {
-                                TimeValueStepper(
-                                    hour = uiState.settings.inactivity.windowStartHour,
-                                    minute = uiState.settings.inactivity.windowStartMinute,
-                                    onValueChange = onUpdateInactivityWindowStart
-                                )
-                            }
-                        )
-                    }
-                }
-
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_to_title))
-                            },
-                            trailingContent = {
-                                TimeValueStepper(
-                                    hour = uiState.settings.inactivity.windowEndHour,
-                                    minute = uiState.settings.inactivity.windowEndMinute,
-                                    onValueChange = onUpdateInactivityWindowEnd
-                                )
-                            }
-                        )
-                    }
-                }
-
-                item {
-                    Card(modifier = Modifier.fillMaxWidth()) {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_remind_after_title))
-                            },
-                            trailingContent = {
-                                SingleChoiceSegmentedButtonRow {
-                                    listOf(60, 120, 180).forEachIndexed { index, value ->
-                                        SegmentedButton(
-                                            selected = uiState.settings.inactivity.idleMinutes == value,
-                                            onClick = {
-                                                onUpdateIdleMinutes(value)
-                                            },
-                                            shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
-                                                index = index,
-                                                count = 3
-                                            ),
-                                            label = {
-                                                Text(idleMinutesLabel(minutes = value))
-                                            }
-                                        )
-                                    }
-                                }
-                            }
-                        )
-                    }
-                }
-            }
+            )
         }
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Notifications/ReviewNotificationsSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Notifications/ReviewNotificationsSettingsView.swift
@@ -14,16 +14,6 @@ struct ReviewNotificationsSettingsView: View {
                 }
             }
 
-            Section {
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.description",
-                        "Workspace review reminders and strict reminders stay enabled inside Flashcards by default. Delivery still depends on the system notification permission. Study notifications contain cards only and never marketing messages."
-                    )
-                )
-                    .foregroundStyle(.secondary)
-            }
-
             Section(aiSettingsLocalized("settings.notifications.section.permission", "Permission")) {
                 LabeledContent(aiSettingsLocalized("settings.access.detail.status", "Status")) {
                     Text(localizedReviewNotificationPermissionStatusTitle(self.permissionStatus))
@@ -54,77 +44,12 @@ struct ReviewNotificationsSettingsView: View {
                         }
                     )
                 )
-
-                Picker(
-                    aiSettingsLocalized("settings.notifications.mode", "Mode"),
-                    selection: Binding(
-                        get: {
-                            store.reviewNotificationsSettings.selectedMode
-                        },
-                        set: { selectedMode in
-                            store.updateReviewNotificationsMode(selectedMode: selectedMode)
-                        }
-                    )
-                ) {
-                    ForEach(ReviewNotificationMode.allCases) { mode in
-                        Text(localizedReviewNotificationModeTitle(mode)).tag(mode)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Toggle(
-                    aiSettingsLocalized("settings.notifications.appIconBadge.toggle", "Show app icon badge"),
-                    isOn: Binding(
-                        get: {
-                            store.reviewNotificationsSettings.showAppIconBadge
-                        },
-                        set: { isEnabled in
-                            store.updateReviewNotificationsAppIconBadgeEnabled(isEnabled: isEnabled)
-                        }
-                    )
-                )
-
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.appIconBadge.description",
-                        "When a review reminder fires and you haven't reviewed any card yet today, a red 1 appears on the app icon. The badge clears as soon as you review a card or open the app."
-                    )
-                )
-                    .foregroundStyle(.secondary)
-            }
-
-            Section(aiSettingsLocalized("settings.notifications.section.strictReminders", "Strict reminders")) {
-                Toggle(
-                    aiSettingsLocalized("settings.notifications.enableStrictReminders", "Enable strict reminders"),
-                    isOn: Binding(
-                        get: {
-                            store.strictRemindersSettings.isEnabled
-                        },
-                        set: { isEnabled in
-                            store.updateStrictRemindersEnabled(isEnabled: isEnabled)
-                        }
-                    )
-                )
-
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.strictReminders.description",
-                        "If you have not reviewed anywhere in the app on a local day, Flashcards reminds you 4, 3, and 2 hours before that day ends."
-                    )
-                )
-                    .foregroundStyle(.secondary)
-
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.strictReminders.deviceNote",
-                        "Strict reminders are app-level, apply only to this device, and remain internally enabled even if system notification permission is off."
-                    )
-                )
-                    .foregroundStyle(.secondary)
             }
 
             if store.reviewNotificationsSettings.selectedMode == .daily {
                 Section(aiSettingsLocalized("settings.notifications.section.dailyReminder", "Daily Reminder")) {
+                    self.reviewNotificationModePicker
+
                     Text(aiSettingsLocalized("settings.notifications.dailyExample", "Example: send one card every day at the selected local time."))
                         .foregroundStyle(.secondary)
 
@@ -147,9 +72,13 @@ struct ReviewNotificationsSettingsView: View {
                         ),
                         displayedComponents: [.hourAndMinute]
                     )
+
+                    self.appIconBadgeToggle
                 }
             } else {
                 Section(aiSettingsLocalized("settings.notifications.section.inactivityReminder", "Inactivity Reminder")) {
+                    self.reviewNotificationModePicker
+
                     Text(
                         aiSettingsLocalized(
                             "settings.notifications.inactivityExample",
@@ -225,13 +154,98 @@ struct ReviewNotificationsSettingsView: View {
                             Text(formatIdleMinutes(minutes: minutes)).tag(minutes)
                         }
                     }
+
+                    self.appIconBadgeToggle
                 }
+            }
+
+            Section(aiSettingsLocalized("settings.notifications.section.strictReminders", "Strict reminders")) {
+                Toggle(
+                    aiSettingsLocalized("settings.notifications.enableStrictReminders", "Enable strict reminders"),
+                    isOn: Binding(
+                        get: {
+                            store.strictRemindersSettings.isEnabled
+                        },
+                        set: { isEnabled in
+                            store.updateStrictRemindersEnabled(isEnabled: isEnabled)
+                        }
+                    )
+                )
+
+                Text(
+                    aiSettingsLocalized(
+                        "settings.notifications.strictReminders.description",
+                        "If you have not reviewed anywhere in the app on a local day, Flashcards reminds you 4, 3, and 2 hours before that day ends."
+                    )
+                )
+                    .foregroundStyle(.secondary)
+
+                Text(
+                    aiSettingsLocalized(
+                        "settings.notifications.strictReminders.deviceNote",
+                        "Strict reminders are app-level, apply only to this device, and remain internally enabled even if system notification permission is off."
+                    )
+                )
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Text(
+                    aiSettingsLocalized(
+                        "settings.notifications.description",
+                        "Workspace review reminders and strict reminders stay enabled inside Flashcards by default. Delivery still depends on the system notification permission. Study notifications contain cards only and never marketing messages."
+                    )
+                )
+                    .foregroundStyle(.secondary)
             }
         }
         .listStyle(.insetGrouped)
         .navigationTitle(aiSettingsLocalized("settings.notifications.title", "Notifications"))
         .task(id: store.workspace?.workspaceId) {
             await self.refreshPermissionStatus()
+        }
+    }
+
+    private var reviewNotificationModePicker: some View {
+        Picker(
+            aiSettingsLocalized("settings.notifications.mode", "Mode"),
+            selection: Binding(
+                get: {
+                    store.reviewNotificationsSettings.selectedMode
+                },
+                set: { selectedMode in
+                    store.updateReviewNotificationsMode(selectedMode: selectedMode)
+                }
+            )
+        ) {
+            ForEach(ReviewNotificationMode.allCases) { mode in
+                Text(localizedReviewNotificationModeTitle(mode)).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var appIconBadgeToggle: some View {
+        Group {
+            Toggle(
+                aiSettingsLocalized("settings.notifications.appIconBadge.toggle", "Show app icon badge"),
+                isOn: Binding(
+                    get: {
+                        store.reviewNotificationsSettings.showAppIconBadge
+                    },
+                    set: { isEnabled in
+                        store.updateReviewNotificationsAppIconBadgeEnabled(isEnabled: isEnabled)
+                    }
+                )
+            )
+
+            Text(
+                aiSettingsLocalized(
+                    "settings.notifications.appIconBadge.description",
+                    "When a review reminder fires and you haven't reviewed any card yet today, a red 1 appears on the app icon. The badge clears as soon as you review a card or open the app."
+                )
+            )
+                .foregroundStyle(.secondary)
         }
     }
 


### PR DESCRIPTION
## Summary
- reorder mobile Review Reminders settings so permission appears first
- move Daily/Inactivity mode selection into the dynamic reminder details area
- keep web notification settings informational-only

## Validation
- git --no-pager diff --check
- swiftc -parse apps/ios/Flashcards/Flashcards/Settings/Workspace/Notifications/ReviewNotificationsSettingsView.swift

Android Gradle and iOS simulator tests were not run because the repository requires explicit approval for those local runs.