### PR TITLE
[codex] Stabilize Android Test Lab UI flows

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -21,8 +21,13 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.flashcardsopensourceapp.app.R as AppR
+import com.flashcardsopensourceapp.app.navigation.AiDestination
+import com.flashcardsopensourceapp.app.navigation.CardsDestination
+import com.flashcardsopensourceapp.app.navigation.ReviewDestination
+import com.flashcardsopensourceapp.app.navigation.SettingsDestination
 import com.flashcardsopensourceapp.app.support.AppStateResetRule
+import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
+import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.feature.ai.R as AiFeatureR
 import com.flashcardsopensourceapp.feature.ai.aiComposerMessageFieldTag
 import com.flashcardsopensourceapp.feature.ai.aiConversationLoadingTag
@@ -39,6 +44,7 @@ import com.flashcardsopensourceapp.feature.review.reviewFilterButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateGoodButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewShowAnswerButtonTag
 import com.flashcardsopensourceapp.feature.settings.R as SettingsR
+import com.flashcardsopensourceapp.feature.settings.deck.deckCardRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsAccessRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsAccountStatusRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsAgentConnectionsRowTag
@@ -47,6 +53,7 @@ import com.flashcardsopensourceapp.feature.settings.settingsDecksRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsDeleteAccountRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsDeviceDiagnosticsRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsExportRowTag
+import com.flashcardsopensourceapp.feature.settings.settingsRootScreenTag
 import com.flashcardsopensourceapp.feature.settings.settingsSchedulingRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsTagsRowTag
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerApplyButtonTag
@@ -56,9 +63,12 @@ import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerMaximumIn
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerRelearningStepsFieldTag
 import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerSaveButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceNameTag
+import com.flashcardsopensourceapp.feature.settings.workspace.export.workspaceExportCsvButtonTag
+import com.flashcardsopensourceapp.feature.settings.workspace.export.workspaceExportScreenTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagCardsCountTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagRowTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagsSearchFieldTag
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -71,6 +81,7 @@ import org.junit.runner.RunWith
 class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     companion object {
         private const val uiTimeoutMillis: Long = 20_000L
+        private const val settingsBackStackPopLimit: Int = 6
         private const val emptyCardsMessage: String = "No cards yet. Tap the add button to create the first card."
     }
 
@@ -179,6 +190,7 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
 
         openAiTabAndAssertConsentGate()
         acceptAiConsentAndWaitForConversationComposer()
+        waitForAiConversationReady()
 
         focusAiComposerAndWaitUntilFocused()
         assertTrue(
@@ -261,30 +273,19 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         waitForCardsEmptyState()
         createCardsForWorkspaceSettingsFlows()
 
+        val deckTitle: String = "Storage deck"
+        val matchingCardFrontText: String = "SQLite note"
+        val matchingCardId: String = requireCardId(frontText = matchingCardFrontText)
+
         openSettingsRow(rowTag = settingsDecksRowTag)
 
         composeRule.onNodeWithContentDescription(settingsString(SettingsR.string.settings_decks_add_content_description)).performClick()
-        composeRule.onNodeWithText(settingsString(SettingsR.string.settings_deck_editor_name_label)).performTextInput("Storage deck")
+        composeRule.onNodeWithText(settingsString(SettingsR.string.settings_deck_editor_name_label)).performTextInput(deckTitle)
         composeRule.onNodeWithText("storage (1)").performClick()
         composeRule.onNodeWithText(settingsString(SettingsR.string.settings_save)).performClick()
 
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodes(
-                matcher = hasText("Storage deck").and(other = hasClickAction())
-            ).fetchSemanticsNodes().isNotEmpty()
-        }
-
-        composeRule.onNode(
-            matcher = hasText("Storage deck").and(other = hasClickAction())
-        ).performClick()
-        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodes(
-                matcher = hasText("SQLite note").and(other = hasClickAction())
-            ).fetchSemanticsNodes().isNotEmpty()
-        }
-        composeRule.onNode(
-            matcher = hasText("SQLite note").and(other = hasClickAction())
-        ).performClick()
+        waitForTagToExist(tag = deckCardRowTag(cardId = matchingCardId))
+        composeRule.onNodeWithTag(testTag = deckCardRowTag(cardId = matchingCardId)).performClick()
         composeRule.onNodeWithText("Edit card").fetchSemanticsNode()
         composeRule.onNodeWithText("Stored locally.").fetchSemanticsNode()
     }
@@ -400,6 +401,8 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         waitForCardsEmptyState()
 
         openSettingsRow(rowTag = settingsExportRowTag)
+        waitForTagToExist(tag = workspaceExportScreenTag)
+        waitForTagToExist(tag = workspaceExportCsvButtonTag)
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_title))
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_summary))
     }
@@ -533,7 +536,8 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
 
     private fun waitUntilComposerIsNotFocused() {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            aiComposerFocusStateOrNull() == false
+            countNodesWithTagInAnySemanticsTree(tag = aiComposerMessageFieldTag) > 0 &&
+                aiComposerFocusStateOrNull() == false
         }
     }
 
@@ -653,6 +657,23 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         }
     }
 
+    private fun requireCardId(frontText: String): String {
+        val application = composeRule.activity.application as FlashcardsApplication
+        val cards: List<CardSummary> = runBlocking {
+            application.appGraph.cardsRepository.observeCards(
+                searchQuery = "",
+                filter = CardFilter(tags = emptyList(), effort = emptyList())
+            ).first()
+        }
+        val matchingCards: List<CardSummary> = cards.filter { card ->
+            card.frontText == frontText
+        }
+        require(matchingCards.size == 1) {
+            "Expected exactly one test card with front text '$frontText' but found ${matchingCards.size}."
+        }
+        return matchingCards.single().cardId
+    }
+
     private fun createCardsForWorkspaceSettingsFlows() {
         createCard(
             frontText = "SQLite note",
@@ -675,21 +696,15 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     private fun openCardsTab() {
-        composeRule.onNode(
-            matcher = hasText("Cards").and(other = hasClickAction())
-        ).performClick()
+        openTopLevelDestination(destinationTag = CardsDestination.testTag)
     }
 
     private fun openReviewTab() {
-        composeRule.onNode(
-            matcher = hasText("Review").and(other = hasClickAction())
-        ).performClick()
+        openTopLevelDestination(destinationTag = ReviewDestination.testTag)
     }
 
     private fun openAiTab() {
-        composeRule.onNode(
-            matcher = hasText("AI").and(other = hasClickAction())
-        ).performClick()
+        openTopLevelDestination(destinationTag = AiDestination.testTag)
     }
 
     private fun openCardFilter() {
@@ -704,8 +719,43 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     private fun openSettingsTab() {
+        openTopLevelDestination(destinationTag = SettingsDestination.testTag)
+        waitForSettingsRoot()
+    }
+
+    private fun openTopLevelDestination(destinationTag: String) {
+        composeRule.onNodeWithTag(testTag = destinationTag).performClick()
+    }
+
+    private fun waitForSettingsRoot() {
+        repeat(settingsBackStackPopLimit) {
+            composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+                isSettingsRootVisible() || isSettingsBackButtonVisible()
+            }
+            if (isSettingsRootVisible()) {
+                return
+            }
+            tapSettingsBackButton()
+            composeRule.waitForIdle()
+        }
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            isSettingsRootVisible()
+        }
+    }
+
+    private fun isSettingsRootVisible(): Boolean {
+        return composeRule.onAllNodesWithTag(testTag = settingsRootScreenTag).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    private fun isSettingsBackButtonVisible(): Boolean {
+        return composeRule.onAllNodes(
+            matcher = hasContentDescription(settingsString(SettingsR.string.settings_back_content_description)).and(other = hasClickAction())
+        ).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    private fun tapSettingsBackButton() {
         composeRule.onNode(
-            matcher = hasText(appString(AppR.string.top_level_settings)).and(other = hasClickAction())
+            matcher = hasContentDescription(settingsString(SettingsR.string.settings_back_content_description)).and(other = hasClickAction())
         ).performClick()
     }
 
@@ -719,13 +769,9 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
 
     private fun tapVisibleBackButton() {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodes(
-                matcher = hasContentDescription(settingsString(SettingsR.string.settings_back_content_description)).and(other = hasClickAction())
-            ).fetchSemanticsNodes().isNotEmpty()
+            isSettingsBackButtonVisible()
         }
-        composeRule.onNode(
-            matcher = hasContentDescription(settingsString(SettingsR.string.settings_back_content_description)).and(other = hasClickAction())
-        ).performClick()
+        tapSettingsBackButton()
     }
 
     private fun openSettingsRow(rowTag: String) {
@@ -734,9 +780,13 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
             matcher = hasTestTag(rowTag)
         )
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithTag(rowTag).fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodes(
+                matcher = hasTestTag(rowTag).and(other = hasClickAction())
+            ).fetchSemanticsNodes().isNotEmpty()
         }
-        composeRule.onNodeWithTag(rowTag).performClick()
+        composeRule.onNode(
+            matcher = hasTestTag(rowTag).and(other = hasClickAction())
+        ).performClick()
     }
 
     private fun scrollToText(text: String) {
@@ -749,8 +799,10 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         }
     }
 
-    private fun appString(@StringRes resId: Int): String {
-        return composeRule.activity.getString(resId)
+    private fun waitForTagToExist(tag: String) {
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(testTag = tag).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 
     private fun aiString(@StringRes resId: Int): String {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -105,7 +105,9 @@ fun SettingsRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = settingsRootScreenTag)
         ) {
             item {
                 SectionTitle(text = stringResource(R.string.settings_section_account))

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreenTags.kt
@@ -20,6 +20,7 @@ const val settingsDeviceDiagnosticsRowTag: String = "settings_row_device_diagnos
 const val settingsResetStudyProgressRowTag: String = "settings_row_reset_study_progress"
 const val settingsDeleteCurrentWorkspaceRowTag: String = "settings_row_delete_current_workspace"
 const val settingsDeleteAccountRowTag: String = "settings_row_delete_account"
+const val settingsRootScreenTag: String = "settings_root_screen"
 const val settingsTestRowTag: String = "settings_row_test"
 const val testSettingsScreenTag: String = "test_settings_screen"
 const val testSettingsAnimationsRowTag: String = "test_settings_animations_row"

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckScreenComponents.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/deck/DeckScreenComponents.kt
@@ -10,12 +10,21 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.feature.settings.R
+
+fun deckRowTag(deckTargetId: String): String {
+    return "settings_deck_row:$deckTargetId"
+}
+
+fun deckCardRowTag(cardId: String): String {
+    return "settings_deck_card_row:$cardId"
+}
 
 @Composable
 internal fun DeckRow(
@@ -25,6 +34,7 @@ internal fun DeckRow(
     Card(
         modifier = Modifier
             .fillMaxWidth()
+            .testTag(tag = deckRowTag(deckTargetId = deckEntry.target.id))
             .clickable {
                 onOpenDeck(deckEntry.target)
             }
@@ -79,6 +89,7 @@ internal fun DeckCardRow(
     Card(
         modifier = Modifier
             .fillMaxWidth()
+            .testTag(tag = deckCardRowTag(cardId = card.cardId))
             .clickable {
                 onOpenCard(card.cardId)
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/export/WorkspaceExportRoute.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -34,6 +35,9 @@ import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
 import java.time.LocalDate
 import kotlinx.coroutines.launch
+
+const val workspaceExportScreenTag: String = "workspace_export_screen"
+const val workspaceExportCsvButtonTag: String = "workspace_export_csv_button"
 
 @Composable
 fun WorkspaceExportRoute(
@@ -85,7 +89,9 @@ fun WorkspaceExportRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = workspaceExportScreenTag)
         ) {
             item {
                 Card(modifier = Modifier.fillMaxWidth()) {
@@ -144,7 +150,9 @@ fun WorkspaceExportRoute(
                         }
                     },
                     enabled = uiState.isExporting.not(),
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(tag = workspaceExportCsvButtonTag)
                 ) {
                     Text(
                         if (uiState.isExporting) {


### PR DESCRIPTION
## Summary
- Add stable Compose test tags for Settings root, workspace export, and deck rows/cards.
- Update Android instrumentation flows to use test tags and restored Settings root navigation.
- Keep the deck test aligned with the actual post-save detail navigation and ID-based card row tags.

## Validation
- git diff --check
- Android Gradle/instrumentation tests were not run because repo instructions require explicit approval before running ./gradlew.