### PR TITLE
[codex] Open review from settings tags

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -422,6 +422,11 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
             WorkspaceTagsRoute(
                 uiState = uiState,
                 onSearchQueryChange = workspaceTagsViewModel::updateSearchQuery,
+                onOpenTagReview = { tag ->
+                    appGraph.appHandoffCoordinator.requestReviewFilter(
+                        reviewFilter = ReviewFilter.Tag(tag = tag)
+                    )
+                },
                 onBack = {
                     navController.popBackStack()
                 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/tags/WorkspaceTagsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/tags/WorkspaceTagsRoute.kt
@@ -44,6 +44,7 @@ fun workspaceTagCardsCountTag(tag: String): String {
 fun WorkspaceTagsRoute(
     uiState: WorkspaceTagsUiState,
     onSearchQueryChange: (String) -> Unit,
+    onOpenTagReview: (String) -> Unit,
     onBack: () -> Unit
 ) {
     Scaffold(
@@ -102,6 +103,9 @@ fun WorkspaceTagsRoute(
             } else {
                 items(uiState.tags, key = { tag -> tag.tag }) { tagSummary ->
                     Card(
+                        onClick = {
+                            onOpenTagReview(tagSummary.tag)
+                        },
                         modifier = Modifier
                             .fillMaxWidth()
                             .testTag(tag = workspaceTagRowTag(tag = tagSummary.tag))

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Tags/TagsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Tags/TagsScreen.swift
@@ -10,6 +10,7 @@ private func formatCardsCount(_ cardsCount: Int) -> String {
 
 struct TagsScreen: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
+    @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     @State private var tagsSummary: WorkspaceTagsSummary = WorkspaceTagsSummary(tags: [], totalCards: 0)
@@ -59,17 +60,23 @@ struct TagsScreen: View {
                     )
                 } else {
                     ForEach(self.filteredTags, id: \.tag) { tagSummary in
-                        HStack(spacing: 12) {
-                            Label(tagSummary.tag, systemImage: "tag")
-                                .foregroundStyle(.primary)
+                        Button {
+                            self.openReview(tag: tagSummary.tag)
+                        } label: {
+                            HStack(spacing: 12) {
+                                Label(tagSummary.tag, systemImage: "tag")
+                                    .foregroundStyle(.primary)
 
-                            Spacer()
+                                Spacer()
 
-                            Text(formatCardsCount(tagSummary.cardsCount))
-                                .font(.subheadline.monospacedDigit())
-                                .foregroundStyle(.secondary)
+                                Text(formatCardsCount(tagSummary.cardsCount))
+                                    .font(.subheadline.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
                         }
+                        .buttonStyle(.plain)
                         .padding(.vertical, 4)
+                        .accessibilityLabel("\(aiSettingsLocalized("settings.workspace.decks.openReview", "Open review")): \(tagSummary.tag)")
                     }
                 }
             }
@@ -132,6 +139,11 @@ struct TagsScreen: View {
 
         self.isLoading = false
     }
+
+    private func openReview(tag: String) {
+        store.selectReviewFilter(reviewFilter: .tag(tag: tag))
+        navigation.selectTab(.review)
+    }
 }
 
 private func workspaceTagSummariesMatchingSearchText(
@@ -152,5 +164,6 @@ private func workspaceTagSummariesMatchingSearchText(
     NavigationStack {
         TagsScreen()
             .environment(FlashcardsStore())
+            .environment(AppNavigationModel())
     }
 }

--- a/apps/web/src/screens/settings/workspace/TagsScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/TagsScreen.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAppData } from "../../../appData";
 import { useI18n } from "../../../i18n";
 import { loadWorkspaceTagsSummary } from "../../../localDb/cards/workspace";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
-import type { WorkspaceTagsSummary } from "../../../types";
+import { reviewRoute } from "../../../routes";
+import type { ReviewFilter, WorkspaceTagsSummary } from "../../../types";
 
 const emptyTagsSummary: WorkspaceTagsSummary = {
   tags: [],
@@ -11,8 +13,9 @@ const emptyTagsSummary: WorkspaceTagsSummary = {
 };
 
 export function TagsScreen(): ReactElement {
-  const { activeWorkspace, cloudSettings, localReadVersion, refreshLocalData, session } = useAppData();
+  const { activeWorkspace, cloudSettings, localReadVersion, openReview, refreshLocalData, session } = useAppData();
   const { t, formatCount, formatNumber } = useI18n();
+  const navigate = useNavigate();
   const [tagsSummary, setTagsSummary] = useState<WorkspaceTagsSummary>(emptyTagsSummary);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [errorMessage, setErrorMessage] = useState<string>("");
@@ -77,6 +80,16 @@ export function TagsScreen(): ReactElement {
     };
   }, [activeWorkspace, localReadVersion]);
 
+  function handleOpenTagReview(tag: string): void {
+    const reviewFilter: ReviewFilter = {
+      kind: "tag",
+      tag,
+    };
+
+    openReview(reviewFilter);
+    navigate(reviewRoute);
+  }
+
   if (isLoading) {
     return (
       <main className="container">
@@ -119,7 +132,13 @@ export function TagsScreen(): ReactElement {
           {tagsSummary.tags.length === 0 ? (
             <div className="content-card">{t("tagsScreen.empty")}</div>
           ) : tagsSummary.tags.map((tagSummary) => (
-            <article key={tagSummary.tag} className="content-card tags-summary-card">
+            <button
+              key={tagSummary.tag}
+              className="content-card tags-summary-card tags-summary-card-button"
+              type="button"
+              onClick={() => handleOpenTagReview(tagSummary.tag)}
+              aria-label={`${t("deckDetail.actions.openReview")}: ${tagSummary.tag}`}
+            >
               <div className="tags-summary-card-head">
                 <strong className="panel-subtitle">{tagSummary.tag}</strong>
                 <span className="badge">{formatCount(tagSummary.cardsCount, {
@@ -127,7 +146,7 @@ export function TagsScreen(): ReactElement {
                   other: t("common.countLabels.card.other"),
                 })}</span>
               </div>
-            </article>
+            </button>
           ))}
         </div>
 

--- a/apps/web/src/styles/features/tags.css
+++ b/apps/web/src/styles/features/tags.css
@@ -208,6 +208,23 @@
   gap: 10px;
 }
 
+.tags-summary-card-button {
+  width: 100%;
+  color: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+.tags-summary-card-button:hover {
+  border-color: rgba(196, 75, 45, 0.34);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.tags-summary-card-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
 .tags-summary-card-head,
 .tags-total-card-head {
   display: flex;


### PR DESCRIPTION
## Summary
- make settings tag rows/cards open Review with that tag filter selected across web, iOS, and Android
- reuse the existing review-filter handoff/navigation patterns for each client

## Validation
- npm run build in apps/web
- git --no-pager diff --check

Android Gradle and iOS simulator-backed checks were not run because this repository requires explicit permission for those heavy local runs.