### PR TITLE
Clarify mobile language settings

### DIFF
--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -95,9 +95,9 @@
     <string name="settings_account_preferences_refresh_failed">Could not refresh account preferences.</string>
     <string name="settings_language_title">Language</string>
     <string name="settings_language_summary">Android system and per-app language settings</string>
-    <string name="settings_language_body">Android controls the app language through system and per-app language settings. Change the Android system language or this app\'s language setting, then return to Flashcards.</string>
+    <string name="settings_language_body">This opens Android\'s language setting for Flashcards. To change every app on this device, use Android Settings > System > Languages.</string>
     <string name="settings_language_supported_languages_title">Supported languages</string>
-    <string name="settings_language_open_android_settings">Open Android language settings</string>
+    <string name="settings_language_open_android_settings">Open app language settings</string>
     <string name="settings_decks_summary">Manage decks in this workspace</string>
     <string name="settings_tags_summary">Browse tags used by workspace cards</string>
     <string name="settings_scheduling_title">Scheduling / FSRS</string>

--- a/apps/ios/Flashcards/Flashcards/Settings/LanguageSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/LanguageSettingsView.swift
@@ -53,13 +53,13 @@ struct LanguageSettingsView: View {
                 Text(
                     aiSettingsLocalized(
                         "settings.language.systemDescription",
-                        "iOS controls the app language. Change the system language or the app-specific language in iOS Settings."
+                        "iOS controls the app language. In iOS Settings, open Flashcards and use Preferred Language. If Preferred Language is not shown, add another language in Settings > General > Language & Region first."
                     )
                 )
                     .foregroundStyle(.secondary)
                     .accessibilityIdentifier(UITestIdentifier.languageSettingsSystemText)
 
-                Button(aiSettingsLocalized("common.openSettings", "Open Settings")) {
+                Button(aiSettingsLocalized("settings.language.action.openAppSettings", "Open Flashcards settings")) {
                     openApplicationSettings()
                 }
             }

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "رسوم المراجعة المتحركة";
 "settings.reviewAnimations.toggle" = "إظهار الرسوم المتحركة بعد تقييم بطاقة";
 "settings.language.title" = "اللغة";
-"settings.language.systemDescription" = "يتحكم iOS في لغة التطبيق. غيّر لغة النظام أو لغة التطبيق المحددة من إعدادات iOS.";
+"settings.language.systemDescription" = "يتحكم iOS في لغة التطبيق. في إعدادات iOS، افتح Flashcards واستخدم اللغة المفضلة. إذا لم تظهر اللغة المفضلة، فأضف لغة أخرى أولاً من الإعدادات > عام > اللغة والمنطقة.";
+"settings.language.action.openAppSettings" = "افتح إعدادات Flashcards";
 "settings.language.section.supportedLanguages" = "اللغات المدعومة";
 "settings.language.supported.english" = "الإنجليزية";
 "settings.language.supported.arabic" = "العربية";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "Wiederholungsanimationen";
 "settings.reviewAnimations.toggle" = "Animationen nach dem Bewerten einer Karte anzeigen";
 "settings.language.title" = "Sprache";
-"settings.language.systemDescription" = "iOS steuert die App-Sprache. Ändern Sie die Systemsprache oder die app-spezifische Sprache in den iOS-Einstellungen.";
+"settings.language.systemDescription" = "iOS steuert die App-Sprache. Öffne in den iOS-Einstellungen Flashcards und verwende Bevorzugte Sprache. Wenn Bevorzugte Sprache nicht angezeigt wird, füge zuerst unter Einstellungen > Allgemein > Sprache & Region eine weitere Sprache hinzu.";
+"settings.language.action.openAppSettings" = "Einstellungen für Flashcards öffnen";
 "settings.language.section.supportedLanguages" = "Unterstützte Sprachen";
 "settings.language.supported.english" = "Englisch";
 "settings.language.supported.arabic" = "Arabisch";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "Animaciones de repaso";
 "settings.reviewAnimations.toggle" = "Mostrar animaciones despues de valorar una tarjeta";
 "settings.language.title" = "Idioma";
-"settings.language.systemDescription" = "iOS controla el idioma de la app. Cambia el idioma del sistema o el idioma especifico de la app en Ajustes de iOS.";
+"settings.language.systemDescription" = "iOS controla el idioma de la app. En Ajustes de iOS, abre Flashcards y usa Idioma preferido. Si Idioma preferido no aparece, primero añade otro idioma en Ajustes > General > Idioma y región.";
+"settings.language.action.openAppSettings" = "Abrir ajustes de Flashcards";
 "settings.language.section.supportedLanguages" = "Idiomas compatibles";
 "settings.language.supported.english" = "Ingles";
 "settings.language.supported.arabic" = "Arabe";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "Animaciones de repaso";
 "settings.reviewAnimations.toggle" = "Mostrar animaciones despues de valorar una tarjeta";
 "settings.language.title" = "Idioma";
-"settings.language.systemDescription" = "iOS controla el idioma de la app. Cambia el idioma del sistema o el idioma especifico de la app en Ajustes de iOS.";
+"settings.language.systemDescription" = "iOS controla el idioma de la app. En Ajustes de iOS, abre Flashcards y usa Idioma preferido. Si Idioma preferido no aparece, primero agrega otro idioma en Ajustes > General > Idioma y región.";
+"settings.language.action.openAppSettings" = "Abrir ajustes de Flashcards";
 "settings.language.section.supportedLanguages" = "Idiomas compatibles";
 "settings.language.supported.english" = "Ingles";
 "settings.language.supported.arabic" = "Arabe";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "समीक्षा एनिमेशन";
 "settings.reviewAnimations.toggle" = "कार्ड को रेट करने के बाद एनिमेशन दिखाएं";
 "settings.language.title" = "भाषा";
-"settings.language.systemDescription" = "iOS ऐप की भाषा नियंत्रित करता है। सिस्टम भाषा या ऐप-विशिष्ट भाषा iOS सेटिंग्स में बदलें।";
+"settings.language.systemDescription" = "iOS ऐप की भाषा नियंत्रित करता है। iOS सेटिंग्स में Flashcards खोलें और पसंदीदा भाषा इस्तेमाल करें। अगर पसंदीदा भाषा दिखाई नहीं देती, तो पहले सेटिंग्स > सामान्य > भाषा और क्षेत्र में कोई दूसरी भाषा जोड़ें।";
+"settings.language.action.openAppSettings" = "Flashcards सेटिंग्स खोलें";
 "settings.language.section.supportedLanguages" = "समर्थित भाषाएं";
 "settings.language.supported.english" = "अंग्रेज़ी";
 "settings.language.supported.arabic" = "अरबी";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "復習アニメーション";
 "settings.reviewAnimations.toggle" = "カード評価後にアニメーションを表示";
 "settings.language.title" = "言語";
-"settings.language.systemDescription" = "iOS がアプリの言語を管理します。システム言語またはアプリ固有の言語は iOS の設定で変更してください。";
+"settings.language.systemDescription" = "iOS がアプリの言語を管理します。iOS の「設定」で Flashcards を開き、「優先する言語」を使用してください。「優先する言語」が表示されない場合は、先に「設定」>「一般」>「言語と地域」で別の言語を追加してください。";
+"settings.language.action.openAppSettings" = "Flashcards の設定を開く";
 "settings.language.section.supportedLanguages" = "対応言語";
 "settings.language.supported.english" = "英語";
 "settings.language.supported.arabic" = "アラビア語";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "Анимации повторения";
 "settings.reviewAnimations.toggle" = "Показывать анимации после оценки карточки";
 "settings.language.title" = "Язык";
-"settings.language.systemDescription" = "iOS управляет языком приложения. Измените системный язык или язык приложения в Настройках iOS.";
+"settings.language.systemDescription" = "iOS управляет языком приложения. В настройках iOS откройте Flashcards и используйте «Предпочитаемый язык». Если «Предпочитаемый язык» не отображается, сначала добавьте другой язык в «Настройки» > «Основные» > «Язык и регион».";
+"settings.language.action.openAppSettings" = "Открыть настройки Flashcards";
 "settings.language.section.supportedLanguages" = "Поддерживаемые языки";
 "settings.language.supported.english" = "Английский";
 "settings.language.supported.arabic" = "Арабский";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -169,7 +169,8 @@
 "settings.reviewAnimations.title" = "复习动画";
 "settings.reviewAnimations.toggle" = "给卡片评分后显示动画";
 "settings.language.title" = "语言";
-"settings.language.systemDescription" = "iOS 控制 App 语言。请在 iOS 设置中更改系统语言或 App 专用语言。";
+"settings.language.systemDescription" = "iOS 控制 App 语言。在 iOS 设置中打开 Flashcards，并使用“首选语言”。如果没有显示“首选语言”，请先在“设置”>“通用”>“语言与地区”中添加另一种语言。";
+"settings.language.action.openAppSettings" = "打开 Flashcards 设置";
 "settings.language.section.supportedLanguages" = "支持的语言";
 "settings.language.supported.english" = "英语";
 "settings.language.supported.arabic" = "阿拉伯语";


### PR DESCRIPTION
## Summary
- Clarify iOS language settings guidance and app-settings button copy.
- Add the new iOS language-settings action key across supported app locales.
- Clarify Android language settings copy while keeping the existing per-app language intent.

## Validation
- plutil -lint for edited iOS AISettings.strings files and Info.plist
- xmllint --noout for Android settings strings.xml
- git diff --check