### PR TITLE
Fix Android settings smoke selectors

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -4,6 +4,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasScrollToNodeAction
@@ -400,8 +401,7 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     fun workspaceExportShowsCsvActionFromEmptyState() {
         waitForCardsEmptyState()
 
-        openSettingsRow(rowTag = settingsExportRowTag)
-        waitForTagToExist(tag = workspaceExportScreenTag)
+        openSettingsRow(rowTag = settingsExportRowTag, destinationTag = workspaceExportScreenTag)
         waitForTagToExist(tag = workspaceExportCsvButtonTag)
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_title))
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_summary))
@@ -776,16 +776,22 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
 
     private fun openSettingsRow(rowTag: String) {
         openSettingsTab()
+        val rowMatcher = hasTestTag(rowTag).and(other = hasClickAction())
+
         composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
-            .performScrollToNode(matcher = hasTestTag(rowTag))
+            .performScrollToNode(matcher = rowMatcher)
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodes(
-                matcher = hasTestTag(rowTag).and(other = hasClickAction())
-            ).fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodes(matcher = rowMatcher).fetchSemanticsNodes().isNotEmpty()
         }
-        composeRule.onNode(
-            matcher = hasTestTag(rowTag).and(other = hasClickAction())
-        ).performClick()
+        composeRule.onNode(matcher = rowMatcher).performScrollTo()
+        composeRule.onNode(matcher = rowMatcher).assertIsDisplayed()
+        composeRule.onNode(matcher = rowMatcher).performClick()
+        composeRule.waitForIdle()
+    }
+
+    private fun openSettingsRow(rowTag: String, destinationTag: String) {
+        openSettingsRow(rowTag = rowTag)
+        waitForTagToExist(tag = destinationTag)
     }
 
     private fun scrollToText(text: String) {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -3,11 +3,12 @@
 package com.flashcardsopensourceapp.app.livesmoke.flows
 
 import androidx.compose.ui.test.hasClickAction
-import androidx.compose.ui.test.hasScrollToNodeAction
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickNode
@@ -18,6 +19,14 @@ import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTagToExist
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTextToExist
 import com.flashcardsopensourceapp.app.livesmoke.support.LiveSmokeContext
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
+import com.flashcardsopensourceapp.feature.settings.access.accessSettingsScreenTag
+import com.flashcardsopensourceapp.feature.settings.account.accountStatusScreenTag
+import com.flashcardsopensourceapp.feature.settings.device.deviceDiagnosticsScreenTag
+import com.flashcardsopensourceapp.feature.settings.language.languageSettingsScreenTag
+import com.flashcardsopensourceapp.feature.settings.language.languageSettingsSupportedLanguagesSectionTag
+import com.flashcardsopensourceapp.feature.settings.review.reviewNotificationsScreenTag
+import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerSettingsScreenTag
+import com.flashcardsopensourceapp.feature.settings.server.serverSettingsScreenTag
 import com.flashcardsopensourceapp.feature.settings.settingsAccessRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsAccountStatusRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsAgentConnectionsRowTag
@@ -33,10 +42,12 @@ import com.flashcardsopensourceapp.feature.settings.settingsLegalRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsOpenSourceRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsResetStudyProgressRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsReviewRemindersRowTag
+import com.flashcardsopensourceapp.feature.settings.settingsRootScreenTag
 import com.flashcardsopensourceapp.feature.settings.settingsSchedulingRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsServerRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsSupportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsTagsRowTag
+import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceListTag
 
 internal fun LiveSmokeContext.openCardsTab() {
     clickNode(
@@ -68,13 +79,24 @@ internal fun LiveSmokeContext.openSettingsTab() {
 
 internal fun LiveSmokeContext.openSettingsRow(rowTag: String, rowLabel: String) {
     openSettingsTab()
-    composeRule.onNode(hasScrollToNodeAction()).performScrollToNode(matcher = hasTestTag(rowTag))
+    composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
+        .performScrollToNode(matcher = hasTestTag(rowTag).and(other = hasClickAction()))
     waitForTagToExist(
         tag = rowTag,
         timeoutMillis = internalUiTimeoutMillis,
         context = "while waiting for settings row '$rowLabel'"
     )
+    composeRule.onNodeWithTag(testTag = rowTag).performScrollTo()
     clickTag(tag = rowTag, label = rowLabel)
+}
+
+internal fun LiveSmokeContext.openSettingsRow(rowTag: String, rowLabel: String, destinationTag: String) {
+    openSettingsRow(rowTag = rowTag, rowLabel = rowLabel)
+    waitForTagToExist(
+        tag = destinationTag,
+        timeoutMillis = internalUiTimeoutMillis,
+        context = "while waiting for settings detail '$rowLabel'"
+    )
 }
 
 internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
@@ -85,7 +107,8 @@ internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
         "Support",
         "Advanced"
     ).forEach { sectionTitle ->
-        composeRule.onNode(hasScrollToNodeAction()).performScrollToNode(matcher = hasText(sectionTitle))
+        composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
+            .performScrollToNode(matcher = hasText(sectionTitle))
         waitForTextToExist(
             text = sectionTitle,
             substring = false,
@@ -117,7 +140,8 @@ internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
     ).forEach { row ->
         val rowTag = row.first
         val rowLabel = row.second
-        composeRule.onNode(hasScrollToNodeAction()).performScrollToNode(matcher = hasTestTag(rowTag))
+        composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
+            .performScrollToNode(matcher = hasTestTag(rowTag).and(other = hasClickAction()))
         waitForTagToExist(
             tag = rowTag,
             timeoutMillis = internalUiTimeoutMillis,
@@ -131,67 +155,56 @@ internal fun LiveSmokeContext.openSettingsInformationArchitectureDetails() {
         SettingsDetailProbe(
             rowTag = settingsAccountStatusRowTag,
             rowLabel = "Account status",
-            expectedText = "Cloud status"
+            destinationTag = accountStatusScreenTag
         ),
         SettingsDetailProbe(
             rowTag = settingsCurrentWorkspaceRowTag,
             rowLabel = "Workspace",
-            expectedText = "Cloud status"
+            destinationTag = currentWorkspaceListTag
         ),
         SettingsDetailProbe(
             rowTag = settingsReviewRemindersRowTag,
             rowLabel = "Review reminders",
-            expectedText = "Workspace review reminders"
+            destinationTag = reviewNotificationsScreenTag
         ),
         SettingsDetailProbe(
             rowTag = settingsLanguageRowTag,
             rowLabel = "Language",
-            expectedText = "Android controls the app language"
+            destinationTag = languageSettingsScreenTag
         ),
         SettingsDetailProbe(
             rowTag = settingsAccessRowTag,
             rowLabel = "Access",
-            expectedText = "Camera"
+            destinationTag = accessSettingsScreenTag
         ),
         SettingsDetailProbe(
             rowTag = settingsSchedulingRowTag,
             rowLabel = "Scheduling / FSRS",
-            expectedText = "Desired retention"
+            destinationTag = schedulerSettingsScreenTag
         ),
         SettingsDetailProbe(
             rowTag = settingsServerRowTag,
             rowLabel = "Server",
-            expectedText = "Current server"
+            destinationTag = serverSettingsScreenTag
         ),
         SettingsDetailProbe(
             rowTag = settingsDeviceDiagnosticsRowTag,
             rowLabel = "Device",
-            expectedText = "Workspace ID"
+            destinationTag = deviceDiagnosticsScreenTag
         )
     ).forEach { probe ->
-        openSettingsRow(rowTag = probe.rowTag, rowLabel = probe.rowLabel)
-        composeRule.onNode(hasScrollToNodeAction()).performScrollToNode(
-            matcher = hasText(probe.expectedText, substring = true)
-        )
-        waitForTextToExist(
-            text = probe.expectedText,
-            substring = true,
-            timeoutMillis = internalUiTimeoutMillis,
-            context = "while verifying ${probe.rowLabel} detail"
+        openSettingsRow(
+            rowTag = probe.rowTag,
+            rowLabel = probe.rowLabel,
+            destinationTag = probe.destinationTag
         )
         if (probe.rowTag == settingsLanguageRowTag) {
-            composeRule.onNode(hasScrollToNodeAction()).performScrollToNode(matcher = hasText("Supported languages"))
-            waitForTextToExist(
-                text = "Supported languages",
-                substring = false,
+            composeRule.onNodeWithTag(testTag = languageSettingsScreenTag)
+                .performScrollToNode(matcher = hasTestTag(languageSettingsSupportedLanguagesSectionTag))
+            waitForTagToExist(
+                tag = languageSettingsSupportedLanguagesSectionTag,
                 timeoutMillis = internalUiTimeoutMillis,
-                context = "while verifying Language supported languages title"
-            )
-            waitForTextToExist(
-                text = "English",
-                substring = true,
-                timeoutMillis = internalUiTimeoutMillis,
-                context = "while verifying Language supported languages list"
+                context = "while verifying Language supported languages section"
             )
         }
         tapBackIcon()
@@ -213,5 +226,5 @@ internal fun LiveSmokeContext.updateCardText(fieldTitle: String, value: String) 
 private data class SettingsDetailProbe(
     val rowTag: String,
     val rowLabel: String,
-    val expectedText: String
+    val destinationTag: String
 )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/access/AccessRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/access/AccessRoute.kt
@@ -16,12 +16,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
+
+const val accessSettingsScreenTag: String = "access_settings_screen"
 
 @Composable
 fun AccessRoute(
@@ -63,7 +66,9 @@ fun AccessRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = accessSettingsScreenTag)
         ) {
             items(capabilityStates, key = { item -> item.capability.name }) { item ->
                 Card(modifier = Modifier.fillMaxWidth()) {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusRoute.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DeviceInfoCard
@@ -26,6 +27,8 @@ import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
+
+const val accountStatusScreenTag: String = "account_status_screen"
 
 @Composable
 fun AccountStatusRoute(
@@ -45,7 +48,9 @@ fun AccountStatusRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = accountStatusScreenTag)
         ) {
             if (uiState.syncBlockedMessage != null) {
                 item {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/device/DeviceDiagnosticsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/device/DeviceDiagnosticsRoute.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DeviceInfoCard
@@ -19,6 +20,8 @@ import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
+
+const val deviceDiagnosticsScreenTag: String = "device_diagnostics_screen"
 
 @Composable
 fun DeviceDiagnosticsRoute(
@@ -34,7 +37,9 @@ fun DeviceDiagnosticsRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = deviceDiagnosticsScreenTag)
         ) {
             item {
                 DeviceInfoCard(

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/language/LanguageSettingsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/language/LanguageSettingsRoute.kt
@@ -12,12 +12,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
+
+const val languageSettingsScreenTag: String = "language_settings_screen"
+const val languageSettingsSupportedLanguagesSectionTag: String = "language_settings_supported_languages_section"
 
 @Composable
 fun LanguageSettingsRoute(
@@ -33,7 +37,9 @@ fun LanguageSettingsRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = languageSettingsScreenTag)
         ) {
             item {
                 Card(modifier = Modifier.fillMaxWidth()) {
@@ -60,7 +66,11 @@ fun LanguageSettingsRoute(
             }
 
             item {
-                Card(modifier = Modifier.fillMaxWidth()) {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(tag = languageSettingsSupportedLanguagesSectionTag)
+                ) {
                     Column(
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier.padding(20.dp)

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -38,6 +39,8 @@ import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+
+const val reviewNotificationsScreenTag: String = "review_notifications_screen"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,7 +82,9 @@ fun ReviewNotificationsRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = reviewNotificationsScreenTag)
         ) {
             item {
                 Card(modifier = Modifier.fillMaxWidth()) {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/scheduler/SchedulerScreenTags.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/scheduler/SchedulerScreenTags.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.feature.settings.scheduler
 
+const val schedulerSettingsScreenTag: String = "scheduler_settings_screen"
 const val schedulerDesiredRetentionFieldTag: String = "scheduler_desired_retention_field"
 const val schedulerLearningStepsFieldTag: String = "scheduler_learning_steps_field"
 const val schedulerRelearningStepsFieldTag: String = "scheduler_relearning_steps_field"

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/scheduler/SchedulerSettingsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/scheduler/SchedulerSettingsRoute.kt
@@ -49,7 +49,9 @@ fun SchedulerSettingsRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = schedulerSettingsScreenTag)
         ) {
             item {
                 Card(modifier = Modifier.fillMaxWidth()) {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/server/ServerSettingsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/server/ServerSettingsRoute.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DeviceInfoCard
@@ -20,6 +21,8 @@ import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
+
+const val serverSettingsScreenTag: String = "server_settings_screen"
 
 @Composable
 fun ServerSettingsRoute(
@@ -38,7 +41,9 @@ fun ServerSettingsRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = serverSettingsScreenTag)
         ) {
             item {
                 DeviceInfoCard(


### PR DESCRIPTION
## Summary
- add stable Settings detail screen test tags for Android smoke navigation
- make Settings row helpers scroll within the Settings root and wait for destination tags
- replace fragile Language detail text checks with screen and section tags

## Validation
- git --no-pager diff --check
- Gradle/instrumentation not run locally per repository rule requiring explicit approval