### PR TITLE
Stabilize Android settings row clicks

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -783,9 +783,9 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             composeRule.onAllNodes(matcher = rowMatcher).fetchSemanticsNodes().isNotEmpty()
         }
-        composeRule.onNode(matcher = rowMatcher).performScrollTo()
-        composeRule.onNode(matcher = rowMatcher).assertIsDisplayed()
-        composeRule.onNode(matcher = rowMatcher).performClick()
+        composeRule.onNodeWithTag(testTag = rowTag).performScrollTo()
+        composeRule.onNodeWithTag(testTag = rowTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(testTag = rowTag).performClick()
         composeRule.waitForIdle()
     }
 
@@ -806,7 +806,7 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
 
     private fun waitForTagToExist(tag: String) {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
-            composeRule.onAllNodesWithTag(testTag = tag).fetchSemanticsNodes().isNotEmpty()
+            countNodesWithTagInAnySemanticsTree(tag = tag) > 0
         }
     }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -338,15 +338,17 @@ private fun SettingsRootRow(
         }
     }
 
-    Card(modifier = Modifier.fillMaxWidth()) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(tag = testTag)
+            .clickable(onClick = onClick)
+    ) {
         ListItem(
             headlineContent = {
                 Text(title)
             },
-            supportingContent = supportingContent,
-            modifier = Modifier
-                .testTag(tag = testTag)
-                .clickable(onClick = onClick)
+            supportingContent = supportingContent
         )
     }
 }


### PR DESCRIPTION
## Summary
- make Settings root rows expose one stable tagged click target
- make the Android instrumentation helper click the tagged row node directly
- wait for destination tags across merged and unmerged semantics trees

## Validation
- git --no-pager diff --check
- git --no-pager diff --cached --check
- Gradle/instrumentation not run locally per repository rule requiring explicit approval