### PR TITLE
Stabilize workspace export smoke navigation

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -26,6 +26,7 @@ import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
 import com.flashcardsopensourceapp.app.navigation.ReviewDestination
 import com.flashcardsopensourceapp.app.navigation.SettingsDestination
+import com.flashcardsopensourceapp.app.navigation.SettingsNavigationTarget
 import com.flashcardsopensourceapp.app.support.AppStateResetRule
 import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
@@ -53,7 +54,6 @@ import com.flashcardsopensourceapp.feature.settings.settingsCurrentWorkspaceRowT
 import com.flashcardsopensourceapp.feature.settings.settingsDecksRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsDeleteAccountRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsDeviceDiagnosticsRowTag
-import com.flashcardsopensourceapp.feature.settings.settingsExportRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsRootScreenTag
 import com.flashcardsopensourceapp.feature.settings.settingsSchedulingRowTag
 import com.flashcardsopensourceapp.feature.settings.settingsTagsRowTag
@@ -66,6 +66,8 @@ import com.flashcardsopensourceapp.feature.settings.scheduler.schedulerSaveButto
 import com.flashcardsopensourceapp.feature.settings.workspace.current.currentWorkspaceNameTag
 import com.flashcardsopensourceapp.feature.settings.workspace.export.workspaceExportCsvButtonTag
 import com.flashcardsopensourceapp.feature.settings.workspace.export.workspaceExportScreenTag
+import com.flashcardsopensourceapp.feature.settings.workspace.settings.workspaceSettingsExportRowTag
+import com.flashcardsopensourceapp.feature.settings.workspace.settings.workspaceSettingsScreenTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagCardsCountTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagRowTag
 import com.flashcardsopensourceapp.feature.settings.workspace.tags.workspaceTagsSearchFieldTag
@@ -401,7 +403,11 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
     fun workspaceExportShowsCsvActionFromEmptyState() {
         waitForCardsEmptyState()
 
-        openSettingsRow(rowTag = settingsExportRowTag, destinationTag = workspaceExportScreenTag)
+        openWorkspaceSettings()
+        openWorkspaceSettingsRow(
+            rowTag = workspaceSettingsExportRowTag,
+            destinationTag = workspaceExportScreenTag
+        )
         waitForTagToExist(tag = workspaceExportCsvButtonTag)
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_title))
         waitForTextToExist(text = settingsString(SettingsR.string.settings_export_csv_summary))
@@ -776,9 +782,34 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
 
     private fun openSettingsRow(rowTag: String) {
         openSettingsTab()
+        openScrollableRow(containerTag = settingsRootScreenTag, rowTag = rowTag)
+    }
+
+    private fun openSettingsRow(rowTag: String, destinationTag: String) {
+        openSettingsRow(rowTag = rowTag)
+        waitForTagToExist(tag = destinationTag)
+    }
+
+    private fun openWorkspaceSettings() {
+        val application = composeRule.activity.application as FlashcardsApplication
+
+        composeRule.runOnIdle {
+            application.appGraph.appHandoffCoordinator.requestSettingsNavigation(
+                target = SettingsNavigationTarget.WORKSPACE
+            )
+        }
+        waitForTagToExist(tag = workspaceSettingsScreenTag)
+    }
+
+    private fun openWorkspaceSettingsRow(rowTag: String, destinationTag: String) {
+        openScrollableRow(containerTag = workspaceSettingsScreenTag, rowTag = rowTag)
+        waitForTagToExist(tag = destinationTag)
+    }
+
+    private fun openScrollableRow(containerTag: String, rowTag: String) {
         val rowMatcher = hasTestTag(rowTag).and(other = hasClickAction())
 
-        composeRule.onNodeWithTag(testTag = settingsRootScreenTag)
+        composeRule.onNodeWithTag(testTag = containerTag)
             .performScrollToNode(matcher = rowMatcher)
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             composeRule.onAllNodes(matcher = rowMatcher).fetchSemanticsNodes().isNotEmpty()
@@ -786,11 +817,6 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.onNode(matcher = rowMatcher).assertIsDisplayed()
         composeRule.onNode(matcher = rowMatcher).performClick()
         composeRule.waitForIdle()
-    }
-
-    private fun openSettingsRow(rowTag: String, destinationTag: String) {
-        openSettingsRow(rowTag = rowTag)
-        waitForTagToExist(tag = destinationTag)
     }
 
     private fun scrollToText(text: String) {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsRoute.kt
@@ -51,6 +51,8 @@ const val workspaceSettingsResetProgressPreviewBodyTag: String =
     "workspace_settings_reset_progress_preview_body"
 const val workspaceSettingsResetProgressPreviewButtonTag: String =
     "workspace_settings_reset_progress_preview_button"
+const val workspaceSettingsScreenTag: String = "workspace_settings_screen"
+const val workspaceSettingsExportRowTag: String = "workspace_settings_export_row"
 
 @Composable
 fun WorkspaceSettingsRoute(
@@ -80,7 +82,9 @@ fun WorkspaceSettingsRoute(
         LazyColumn(
             contentPadding = settingsScreenContentPadding(innerPadding = innerPadding),
             verticalArrangement = Arrangement.spacedBy(settingsScreenCardSpacing),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
+                .testTag(tag = workspaceSettingsScreenTag)
         ) {
             if (uiState.errorMessage.isNotEmpty()) {
                 item {
@@ -209,15 +213,19 @@ fun WorkspaceSettingsRoute(
             }
 
             item {
-                Card(modifier = Modifier.fillMaxWidth()) {
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(tag = workspaceSettingsExportRowTag)
+                        .clickable(onClick = onOpenExport)
+                ) {
                     ListItem(
                         headlineContent = {
                             Text(stringResource(R.string.settings_workspace_export_title))
                         },
                         supportingContent = {
                             Text(uiState.exportSummary)
-                        },
-                        modifier = Modifier.clickable(onClick = onOpenExport)
+                        }
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- add stable workspace settings screen/export row test tags
- route the workspace export smoke test through the existing settings handoff
- reuse a scoped scroll helper for tagged rows

## Validation
- git --no-pager diff --check
- Gradle not run locally per repository guidance