### PR TITLE
[codex] Fix destructive confirmation phrase wrapping

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/DestructiveConfirmationPhraseText.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/DestructiveConfirmationPhraseText.kt
@@ -1,0 +1,75 @@
+package com.flashcardsopensourceapp.feature.settings
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+private const val confirmationPhraseLongTokenBreakThreshold: Int = 24
+private const val confirmationPhraseBreakOpportunity: String = "\u200B"
+
+@Composable
+fun DestructiveConfirmationPhraseText(text: String, testTag: String, modifier: Modifier) {
+    val originalText: AnnotatedString = AnnotatedString(text)
+
+    Text(
+        text = confirmationPhraseDisplayText(text = text),
+        style = MaterialTheme.typography.bodyMedium,
+        fontWeight = FontWeight.SemiBold,
+        softWrap = true,
+        maxLines = Int.MAX_VALUE,
+        overflow = TextOverflow.Visible,
+        modifier = modifier
+            .fillMaxWidth()
+            .clearAndSetSemantics {
+                this.text = originalText
+                this.testTag = testTag
+            }
+    )
+}
+
+private fun confirmationPhraseDisplayText(text: String): String {
+    val result: StringBuilder = StringBuilder()
+    val token: StringBuilder = StringBuilder()
+
+    text.forEach { character: Char ->
+        if (confirmationPhraseIsWhitespace(character = character)) {
+            result.append(confirmationPhraseDisplayToken(token = token.toString()))
+            token.clear()
+            result.append(character)
+        } else {
+            token.append(character)
+        }
+    }
+
+    result.append(confirmationPhraseDisplayToken(token = token.toString()))
+    return result.toString()
+}
+
+private fun confirmationPhraseDisplayToken(token: String): String {
+    if (token.length <= confirmationPhraseLongTokenBreakThreshold) {
+        return token
+    }
+    if (confirmationPhraseIsAsciiToken(token = token) == false) {
+        return token
+    }
+
+    return token
+        .map { character: Char -> character.toString() }
+        .joinToString(separator = confirmationPhraseBreakOpportunity)
+}
+
+private fun confirmationPhraseIsAsciiToken(token: String): Boolean {
+    return token.all { character: Char -> character.code <= 0x7F }
+}
+
+private fun confirmationPhraseIsWhitespace(character: Char): Boolean {
+    return character.isWhitespace()
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneRoute.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -20,12 +23,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DestructiveActionState
+import com.flashcardsopensourceapp.feature.settings.DestructiveConfirmationPhraseText
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.accountDeletionConfirmationText
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
+
+const val accountDangerZoneConfirmationPhraseTag: String = "account_danger_zone_confirmation_phrase"
 
 @Composable
 fun AccountDangerZoneRoute(
@@ -148,7 +154,12 @@ fun AccountDangerZoneRoute(
                 Text(stringResource(R.string.settings_account_danger_zone_dialog_title))
             },
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier
+                        .heightIn(max = 420.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     Text(
                         text = stringResource(R.string.settings_account_danger_zone_dialog_warning),
                         color = MaterialTheme.colorScheme.error
@@ -162,9 +173,10 @@ fun AccountDangerZoneRoute(
                             color = MaterialTheme.colorScheme.error
                         )
                     }
-                    Text(
+                    DestructiveConfirmationPhraseText(
                         text = accountDeletionConfirmationText(strings = strings),
-                        style = MaterialTheme.typography.bodyMedium
+                        testTag = accountDangerZoneConfirmationPhraseTag,
+                        modifier = Modifier
                     )
                     OutlinedTextField(
                         value = uiState.confirmationText,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/delete/DeleteCurrentWorkspaceRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/delete/DeleteCurrentWorkspaceRoute.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -18,9 +21,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DestructiveActionState
+import com.flashcardsopensourceapp.feature.settings.DestructiveConfirmationPhraseText
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
@@ -212,7 +215,12 @@ fun DeleteCurrentWorkspaceRoute(
                 )
             },
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier
+                        .heightIn(max = 420.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     Text(
                         text = stringResource(R.string.settings_workspace_delete_dialog_warning),
                         color = MaterialTheme.colorScheme.error
@@ -229,11 +237,10 @@ fun DeleteCurrentWorkspaceRoute(
                             modifier = Modifier.testTag(tag = workspaceOverviewDeleteConfirmationErrorTag)
                         )
                     }
-                    Text(
+                    DestructiveConfirmationPhraseText(
                         text = uiState.deletePreview.confirmationText,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.testTag(tag = workspaceOverviewDeleteConfirmationPhraseTag)
+                        testTag = workspaceOverviewDeleteConfirmationPhraseTag,
+                        modifier = Modifier
                     )
                     OutlinedTextField(
                         value = uiState.deleteConfirmationText,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/overview/WorkspaceOverviewRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/overview/WorkspaceOverviewRoute.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -20,9 +23,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DestructiveActionState
+import com.flashcardsopensourceapp.feature.settings.DestructiveConfirmationPhraseText
 import com.flashcardsopensourceapp.feature.settings.OverviewRow
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
@@ -304,7 +307,12 @@ fun WorkspaceOverviewRoute(
                 )
             },
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier
+                        .heightIn(max = 420.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     Text(
                         text = stringResource(R.string.settings_workspace_delete_dialog_warning),
                         color = MaterialTheme.colorScheme.error
@@ -321,11 +329,10 @@ fun WorkspaceOverviewRoute(
                             modifier = Modifier.testTag(tag = workspaceOverviewDeleteConfirmationErrorTag)
                         )
                     }
-                    Text(
+                    DestructiveConfirmationPhraseText(
                         text = uiState.deletePreview.confirmationText,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        modifier = Modifier.testTag(tag = workspaceOverviewDeleteConfirmationPhraseTag)
+                        testTag = workspaceOverviewDeleteConfirmationPhraseTag,
+                        modifier = Modifier
                     )
                     OutlinedTextField(
                         value = uiState.deleteConfirmationText,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/reset/ResetStudyProgressRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/reset/ResetStudyProgressRoute.kt
@@ -4,8 +4,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -22,6 +25,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DestructiveActionState
+import com.flashcardsopensourceapp.feature.settings.DestructiveConfirmationPhraseText
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
@@ -177,7 +181,12 @@ fun ResetStudyProgressRoute(
                 )
             },
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier
+                        .heightIn(max = 420.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     Text(
                         text = stringResource(R.string.settings_workspace_reset_dialog_body),
                         color = MaterialTheme.colorScheme.error
@@ -189,9 +198,10 @@ fun ResetStudyProgressRoute(
                             modifier = Modifier.testTag(tag = workspaceSettingsResetProgressDialogErrorTag)
                         )
                     }
-                    Text(
+                    DestructiveConfirmationPhraseText(
                         text = confirmationPhrase,
-                        modifier = Modifier.testTag(tag = workspaceSettingsResetProgressConfirmationPhraseTag)
+                        testTag = workspaceSettingsResetProgressConfirmationPhraseTag,
+                        modifier = Modifier
                     )
                     OutlinedTextField(
                         value = uiState.resetConfirmationText,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/workspace/settings/WorkspaceSettingsRoute.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -25,6 +28,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DestructiveActionState
+import com.flashcardsopensourceapp.feature.settings.DestructiveConfirmationPhraseText
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
@@ -308,7 +312,12 @@ fun WorkspaceSettingsRoute(
                 )
             },
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier
+                        .heightIn(max = 420.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
                     Text(
                         text = stringResource(R.string.settings_workspace_reset_dialog_body),
                         color = MaterialTheme.colorScheme.error
@@ -320,9 +329,10 @@ fun WorkspaceSettingsRoute(
                             modifier = Modifier.testTag(tag = workspaceSettingsResetProgressDialogErrorTag)
                         )
                     }
-                    Text(
+                    DestructiveConfirmationPhraseText(
                         text = confirmationPhrase,
-                        modifier = Modifier.testTag(tag = workspaceSettingsResetProgressConfirmationPhraseTag)
+                        testTag = workspaceSettingsResetProgressConfirmationPhraseTag,
+                        modifier = Modifier
                     )
                     OutlinedTextField(
                         value = uiState.resetConfirmationText,

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/DeleteAccountConfirmationView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/DeleteAccountConfirmationView.swift
@@ -12,45 +12,45 @@ struct DeleteAccountConfirmationView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 20) {
-                Text(
-                    aiSettingsLocalized(
-                        "settings.account.deleteConfirmation.warning",
-                        "Warning! This action is permanent. You will lose all your data forever, and we will not be able to restore it."
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Text(
+                        aiSettingsLocalized(
+                            "settings.account.deleteConfirmation.warning",
+                            "Warning! This action is permanent. You will lose all your data forever, and we will not be able to restore it."
+                        )
                     )
-                )
-                    .foregroundStyle(.red)
-                    .font(.headline)
+                        .foregroundStyle(.red)
+                        .font(.headline)
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(aiSettingsLocalized("common.typePhraseToContinue", "Type this phrase exactly to continue:"))
-                        .foregroundStyle(.secondary)
-                    Text(accountDeletionConfirmationText)
-                        .font(.body.monospaced())
-                }
-
-                TextField(aiSettingsLocalized("settings.account.deleteConfirmation.placeholder", "delete my account"), text: self.$confirmationText)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled(true)
-                    .keyboardType(.asciiCapable)
-                    .textFieldStyle(.roundedBorder)
-                    .submitLabel(.done)
-                    .focused(self.$isConfirmationFieldFocused)
-                    .onSubmit {
-                        self.isConfirmationFieldFocused = false
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(aiSettingsLocalized("common.typePhraseToContinue", "Type this phrase exactly to continue:"))
+                            .foregroundStyle(.secondary)
+                        ConfirmationPhraseText(text: accountDeletionConfirmationText)
                     }
 
-                Spacer()
+                    TextField(aiSettingsLocalized("settings.account.deleteConfirmation.placeholder", "delete my account"), text: self.$confirmationText)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                        .keyboardType(.asciiCapable)
+                        .textFieldStyle(.roundedBorder)
+                        .submitLabel(.done)
+                        .focused(self.$isConfirmationFieldFocused)
+                        .onSubmit {
+                            self.isConfirmationFieldFocused = false
+                        }
 
-                Button(aiSettingsLocalized("settings.account.dangerZone.deleteAccount", "Delete my account"), role: .destructive) {
-                    store.beginAccountDeletion()
-                    dismiss()
+                    Button(aiSettingsLocalized("settings.account.dangerZone.deleteAccount", "Delete my account"), role: .destructive) {
+                        store.beginAccountDeletion()
+                        dismiss()
+                    }
+                    .buttonStyle(.glassProminent)
+                    .tint(.red)
+                    .disabled(self.isDeleteEnabled == false)
                 }
-                .buttonStyle(.glassProminent)
-                .tint(.red)
-                .disabled(self.isDeleteEnabled == false)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(24)
             }
-            .padding(24)
             .navigationTitle(aiSettingsLocalized("settings.account.deleteConfirmation.title", "Delete account"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/apps/ios/Flashcards/Flashcards/Settings/ConfirmationPhraseText.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/ConfirmationPhraseText.swift
@@ -1,0 +1,60 @@
+import Foundation
+import SwiftUI
+
+private let confirmationPhraseLongTokenBreakThreshold: Int = 24
+private let confirmationPhraseBreakOpportunity: String = "\u{200B}"
+
+struct ConfirmationPhraseText: View {
+    let text: String
+
+    var body: some View {
+        Text(confirmationPhraseDisplayText(text: self.text))
+            .font(.body.monospaced())
+            .lineLimit(nil)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityLabel(self.text)
+    }
+}
+
+private func confirmationPhraseDisplayText(text: String) -> String {
+    var result: String = ""
+    var token: String = ""
+
+    for character in text {
+        if confirmationPhraseIsWhitespace(character: character) {
+            result += confirmationPhraseDisplayToken(token: token)
+            token = ""
+            result.append(character)
+        } else {
+            token.append(character)
+        }
+    }
+
+    result += confirmationPhraseDisplayToken(token: token)
+    return result
+}
+
+private func confirmationPhraseDisplayToken(token: String) -> String {
+    if token.count <= confirmationPhraseLongTokenBreakThreshold {
+        return token
+    }
+    if confirmationPhraseIsAsciiToken(token: token) == false {
+        return token
+    }
+
+    return token.map { String($0) }.joined(separator: confirmationPhraseBreakOpportunity)
+}
+
+private func confirmationPhraseIsAsciiToken(token: String) -> Bool {
+    token.unicodeScalars.allSatisfy { scalar in
+        scalar.isASCII
+    }
+}
+
+private func confirmationPhraseIsWhitespace(character: Character) -> Bool {
+    character.unicodeScalars.allSatisfy { scalar in
+        CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/DangerZone/DeleteWorkspaceConfirmationView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/DangerZone/DeleteWorkspaceConfirmationView.swift
@@ -17,70 +17,70 @@ struct DeleteWorkspaceConfirmationView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 20) {
-                Text(
-                    aiSettingsLocalizedFormat(
-                        "settings.workspace.deleteConfirmation.warning",
-                        "Warning! This action is permanent. It will delete %d active cards from %@.",
-                        self.preview.activeCardCount,
-                        self.preview.workspaceName
-                    )
-                )
-                    .foregroundStyle(.red)
-                    .font(.headline)
-
-                if self.preview.isLastAccessibleWorkspace {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
                     Text(
-                        aiSettingsLocalized(
-                            "settings.workspace.deleteConfirmation.lastWorkspace",
-                            "A new empty Personal workspace will be created immediately after deletion."
+                        aiSettingsLocalizedFormat(
+                            "settings.workspace.deleteConfirmation.warning",
+                            "Warning! This action is permanent. It will delete %d active cards from %@.",
+                            self.preview.activeCardCount,
+                            self.preview.workspaceName
                         )
                     )
-                        .foregroundStyle(.secondary)
-                }
+                        .foregroundStyle(.red)
+                        .font(.headline)
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(aiSettingsLocalized("common.typePhraseToContinue", "Type this phrase exactly to continue:"))
-                        .foregroundStyle(.secondary)
-                    Text(self.preview.confirmationText)
-                        .font(.body.monospaced())
-                        .accessibilityIdentifier(UITestIdentifier.deleteWorkspaceConfirmationPhrase)
-                }
-
-                TextField(aiSettingsLocalized("settings.workspace.deleteConfirmation.placeholder", "delete workspace"), text: self.$confirmationText)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled(true)
-                    .keyboardType(.asciiCapable)
-                    .textFieldStyle(.roundedBorder)
-                    .submitLabel(.done)
-                    .focused(self.$isConfirmationFieldFocused)
-                    .onSubmit {
-                        self.isConfirmationFieldFocused = false
+                    if self.preview.isLastAccessibleWorkspace {
+                        Text(
+                            aiSettingsLocalized(
+                                "settings.workspace.deleteConfirmation.lastWorkspace",
+                                "A new empty Personal workspace will be created immediately after deletion."
+                            )
+                        )
+                            .foregroundStyle(.secondary)
                     }
-                    .accessibilityIdentifier(UITestIdentifier.deleteWorkspaceConfirmationField)
 
-                if self.errorMessage.isEmpty == false {
-                    CopyableErrorMessageView(message: self.errorMessage)
-                }
-
-                Spacer()
-
-                Button(
-                    self.isDeleting
-                        ? aiSettingsLocalized("settings.workspace.deleteConfirmation.deleting", "Deleting...")
-                        : aiSettingsLocalized("settings.workspace.overview.deleteWorkspace", "Delete workspace"),
-                    role: .destructive
-                ) {
-                    Task {
-                        await self.deleteWorkspace()
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(aiSettingsLocalized("common.typePhraseToContinue", "Type this phrase exactly to continue:"))
+                            .foregroundStyle(.secondary)
+                        ConfirmationPhraseText(text: self.preview.confirmationText)
+                            .accessibilityIdentifier(UITestIdentifier.deleteWorkspaceConfirmationPhrase)
                     }
+
+                    TextField(aiSettingsLocalized("settings.workspace.deleteConfirmation.placeholder", "delete workspace"), text: self.$confirmationText)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled(true)
+                        .keyboardType(.asciiCapable)
+                        .textFieldStyle(.roundedBorder)
+                        .submitLabel(.done)
+                        .focused(self.$isConfirmationFieldFocused)
+                        .onSubmit {
+                            self.isConfirmationFieldFocused = false
+                        }
+                        .accessibilityIdentifier(UITestIdentifier.deleteWorkspaceConfirmationField)
+
+                    if self.errorMessage.isEmpty == false {
+                        CopyableErrorMessageView(message: self.errorMessage)
+                    }
+
+                    Button(
+                        self.isDeleting
+                            ? aiSettingsLocalized("settings.workspace.deleteConfirmation.deleting", "Deleting...")
+                            : aiSettingsLocalized("settings.workspace.overview.deleteWorkspace", "Delete workspace"),
+                        role: .destructive
+                    ) {
+                        Task {
+                            await self.deleteWorkspace()
+                        }
+                    }
+                    .buttonStyle(.glassProminent)
+                    .tint(.red)
+                    .disabled(self.isDeleteEnabled == false)
+                    .accessibilityIdentifier(UITestIdentifier.deleteWorkspaceConfirmationButton)
                 }
-                .buttonStyle(.glassProminent)
-                .tint(.red)
-                .disabled(self.isDeleteEnabled == false)
-                .accessibilityIdentifier(UITestIdentifier.deleteWorkspaceConfirmationButton)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(24)
             }
-            .padding(24)
             .navigationTitle(aiSettingsLocalized("settings.workspace.deleteConfirmation.title", "Delete workspace"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/DangerZone/ResetWorkspaceProgressConfirmationView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/DangerZone/ResetWorkspaceProgressConfirmationView.swift
@@ -22,14 +22,17 @@ struct ResetWorkspaceProgressConfirmationView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: 20) {
-                if let preview {
-                    self.previewContent(preview: preview)
-                } else {
-                    self.confirmationContent()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    if let preview {
+                        self.previewContent(preview: preview)
+                    } else {
+                        self.confirmationContent()
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(24)
             }
-            .padding(24)
             .navigationTitle(
                 self.preview == nil
                     ? aiSettingsLocalized("settings.workspace.resetAllProgress", "Reset all progress")
@@ -75,8 +78,7 @@ struct ResetWorkspaceProgressConfirmationView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(aiSettingsLocalized("common.typePhraseToContinue", "Type this phrase exactly to continue:"))
                 .foregroundStyle(.secondary)
-            Text(workspaceResetProgressConfirmationText)
-                .font(.body.monospaced())
+            ConfirmationPhraseText(text: workspaceResetProgressConfirmationText)
                 .accessibilityIdentifier(UITestIdentifier.resetWorkspaceProgressConfirmationPhrase)
         }
 
@@ -111,8 +113,6 @@ struct ResetWorkspaceProgressConfirmationView: View {
             Text(aiSettingsLocalized("settings.workspace.resetConfirmation.loadingPreview", "Loading reset preview..."))
                 .foregroundStyle(.secondary)
         }
-
-        Spacer()
 
         Button(
             self.isLoadingPreview
@@ -165,8 +165,6 @@ struct ResetWorkspaceProgressConfirmationView: View {
             Text(aiSettingsLocalized("settings.workspace.resetConfirmation.resetting", "Resetting progress..."))
                 .foregroundStyle(.secondary)
         }
-
-        Spacer()
 
         Button(
             self.isResetting

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -294,14 +294,17 @@
   display: grid;
   place-items: center;
   padding: 20px;
+  overflow-y: auto;
   background: rgba(9, 10, 15, 0.8);
   backdrop-filter: blur(10px);
 }
 
 .settings-delete-dialog {
   width: min(100%, 520px);
+  max-height: calc(100vh - 40px);
   display: grid;
   gap: 18px;
+  overflow-y: auto;
 }
 
 .settings-delete-warning {
@@ -310,8 +313,13 @@
 
 .settings-delete-phrase {
   margin: 0;
+  min-width: 0;
+  max-width: 100%;
   user-select: none;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .settings-workspace-picker {


### PR DESCRIPTION
## Summary
- Make dangerous confirmation phrase text wrap safely on web, iOS, and Android.
- Add shared iOS and Android phrase text helpers that preserve the original confirmation text for accessibility/test readers.
- Make destructive confirmation dialogs scrollable so long text remains reachable on small screens.

## Validation
- `git --no-pager diff --cached --check`
- Review of Android/iOS smoke readers for exact confirmation phrase text and tag behavior.