### PR TITLE
[codex] Fix API Gateway CORS test

### DIFF
--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -117,7 +117,7 @@ test("default API Gateway generated errors expose supported request id headers",
   const responseParameters = {
     "gatewayresponse.header.Access-Control-Allow-Credentials": "'true'",
     "gatewayresponse.header.Access-Control-Allow-Headers": `'${allowHeaders}'`,
-    "gatewayresponse.header.Access-Control-Allow-Methods": "'GET,POST,OPTIONS'",
+    "gatewayresponse.header.Access-Control-Allow-Methods": "'GET,POST,PATCH,OPTIONS'",
     "gatewayresponse.header.Access-Control-Allow-Origin": "method.request.header.Origin",
     "gatewayresponse.header.Access-Control-Expose-Headers": "'x-request-id,x-amzn-requestid,x-amz-apigw-id'",
     "gatewayresponse.header.Vary": "'Origin'",


### PR DESCRIPTION
## Summary
- Align the API Gateway generated error CORS test with the current PATCH-enabled methods list.

## Validation
- npm run test --prefix infra/aws