### PR TITLE
[codex] Add iOS settings account attention badges

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -57,6 +57,12 @@ struct RootTabView: View {
         )
     }
 
+    private var settingsAttentionSummary: SettingsAttentionSummary {
+        makeSettingsAttentionSummary(
+            issues: makeSettingsAttentionIssues(cloudState: store.cloudSettings?.cloudState)
+        )
+    }
+
     private var guestSignInAfterReviewPromptPresentation: Binding<Bool> {
         Binding<Bool>(
             get: {
@@ -523,6 +529,7 @@ struct RootTabView: View {
             )
             .accessibilityIdentifier(UITestIdentifier.rootTabSettingsItem)
         }
+        .badge(self.settingsAttentionSummary.settingsTabCount)
         .tag(AppTab.settings)
     }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
@@ -37,6 +37,12 @@ struct AccountStatusView: View {
     @State private var isCloudSignInPresented: Bool = false
     @State private var isLogoutConfirmationPresented: Bool = false
 
+    private var settingsAttentionSummary: SettingsAttentionSummary {
+        makeSettingsAttentionSummary(
+            issues: makeSettingsAttentionIssues(cloudState: store.cloudSettings?.cloudState)
+        )
+    }
+
     var body: some View {
         List {
             if screenErrorMessage.isEmpty == false {
@@ -97,11 +103,13 @@ struct AccountStatusView: View {
                         Button(aiSettingsLocalized("settings.account.status.signIn", "Sign in or sign up")) {
                             self.isCloudSignInPresented = true
                         }
+                        .badge(self.settingsAttentionSummary.accountStatusPrimaryActionCount)
                         .accessibilityIdentifier(UITestIdentifier.accountStatusSignInButton)
                     case .guest:
                         Button(aiSettingsLocalized("settings.account.status.signIn", "Sign in or sign up")) {
                             self.isCloudSignInPresented = true
                         }
+                        .badge(self.settingsAttentionSummary.accountStatusPrimaryActionCount)
                         .accessibilityIdentifier(UITestIdentifier.accountStatusSignInButton)
                     case .linked:
                         Button(aiSettingsLocalized("settings.account.status.syncNow", "Sync now")) {

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsAttentionSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsAttentionSupport.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+enum SettingsAttentionIssue: Hashable, Sendable {
+    case accountNotLinked
+}
+
+enum SettingsAttentionTarget: Hashable, Sendable {
+    case settingsTab
+    case accountStatusRow
+    case accountStatusPrimaryAction
+}
+
+struct SettingsAttentionSummary: Equatable, Sendable {
+    let settingsTabCount: Int
+    let accountStatusRowCount: Int
+    let accountStatusPrimaryActionCount: Int
+}
+
+func makeSettingsAttentionIssues(cloudState: CloudAccountState?) -> [SettingsAttentionIssue] {
+    switch cloudState {
+    case .linked:
+        return []
+    case nil, .disconnected, .linkingReady, .guest:
+        return [.accountNotLinked]
+    }
+}
+
+func makeSettingsAttentionSummary(issues: [SettingsAttentionIssue]) -> SettingsAttentionSummary {
+    SettingsAttentionSummary(
+        settingsTabCount: makeSettingsAttentionTargetCount(
+            issues: issues,
+            target: .settingsTab
+        ),
+        accountStatusRowCount: makeSettingsAttentionTargetCount(
+            issues: issues,
+            target: .accountStatusRow
+        ),
+        accountStatusPrimaryActionCount: makeSettingsAttentionTargetCount(
+            issues: issues,
+            target: .accountStatusPrimaryAction
+        )
+    )
+}
+
+private func makeSettingsAttentionTargetCount(
+    issues: [SettingsAttentionIssue],
+    target: SettingsAttentionTarget
+) -> Int {
+    issues.reduce(0) { count, issue in
+        count + (settingsAttentionTargets(issue: issue).contains(target) ? 1 : 0)
+    }
+}
+
+private func settingsAttentionTargets(issue: SettingsAttentionIssue) -> [SettingsAttentionTarget] {
+    switch issue {
+    case .accountNotLinked:
+        return [.settingsTab, .accountStatusRow, .accountStatusPrimaryAction]
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -23,6 +23,12 @@ struct SettingsView: View {
         store.workspace?.name ?? aiSettingsLocalized("common.unavailable", "Unavailable")
     }
 
+    private var settingsAttentionSummary: SettingsAttentionSummary {
+        makeSettingsAttentionSummary(
+            issues: makeSettingsAttentionIssues(cloudState: store.cloudSettings?.cloudState)
+        )
+    }
+
     var body: some View {
         List {
             if store.globalErrorMessage.isEmpty == false {
@@ -39,6 +45,7 @@ struct SettingsView: View {
                         systemImage: "person.crop.circle"
                     )
                 }
+                .badge(self.settingsAttentionSummary.accountStatusRowCount)
                 .accessibilityIdentifier(UITestIdentifier.settingsAccountStatusRow)
 
                 NavigationLink(value: SettingsNavigationDestination.currentWorkspace) {


### PR DESCRIPTION
## Summary
- Add reusable iOS settings attention support for not-fully-linked account states.
- Show native SwiftUI badges on the Settings tab, the Settings Account Status row, and Account Status sign-in actions.

## Validation
- xcrun swiftc -parse on the touched Swift files.
- xcrun swift checks for the account-state count behavior and SwiftUI badge usage.
- Full xcodebuild build was not completed because local Sentry package artifact extraction exhausted disk space; generated artifacts were removed.
- Simulator-backed tests were not run per repository instructions.