### PR TITLE
[codex] Add Android settings attention badges

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountStatusRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountStatusRouteTest.kt
@@ -39,6 +39,7 @@ class AccountStatusRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isLinkingReady = false,
                         isSyncBlocked = true,
                         syncBlockedMessage = "Cloud sync is blocked for this installation.",
+                        accountStatusPrimaryActionAttentionCount = 0,
                         showLogoutConfirmation = false,
                         errorMessage = "",
                         isSubmitting = false

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsRootRouteTest.kt
@@ -192,6 +192,7 @@ class SettingsRootRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         storageLabel = "Room + SQLite",
                         syncStatusText = "Local",
                         accountStatusTitle = "Not signed in",
+                        accountStatusAttentionCount = 0,
                         reviewReactionAnimationsEnabled = true,
                         canManageAccountPreferences = canManageAccountPreferences,
                         isTestModeEnabled = isTestModeEnabled

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -84,6 +84,10 @@ import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncSource
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.review.reaction.rememberReviewReactionLottieConfigurationStore
+import com.flashcardsopensourceapp.feature.settings.SettingsAttentionBadge
+import com.flashcardsopensourceapp.feature.settings.SettingsAttentionSummary
+import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionIssues
+import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionSummary
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -246,6 +250,9 @@ fun FlashcardsApp(
         val canRefreshCloudAccountContext = shouldRefreshCloudAccountContext(
             cloudState = cloudSettings.cloudState,
             accountDeletionState = accountDeletionState
+        )
+        val settingsAttentionSummary: SettingsAttentionSummary = makeSettingsAttentionSummary(
+            issues = makeSettingsAttentionIssues(cloudState = cloudSettings.cloudState)
         )
         val currentCanRunImmediateAutoSync by rememberUpdatedState(newValue = canRunImmediateAutoSync)
         val currentCanRefreshCloudAccountContext by rememberUpdatedState(newValue = canRefreshCloudAccountContext)
@@ -454,6 +461,15 @@ fun FlashcardsApp(
             layoutType = navigationSuiteType,
             navigationSuiteItems = {
                 topLevelDestinations.forEach { destination ->
+                    val settingsBadge: (@Composable () -> Unit)? =
+                        if (destination == SettingsDestination && settingsAttentionSummary.settingsTabCount > 0) {
+                            {
+                                SettingsAttentionBadge(count = settingsAttentionSummary.settingsTabCount)
+                            }
+                        } else {
+                            null
+                        }
+
                     item(
                         selected = currentDestination.route == destination.route,
                         onClick = {
@@ -490,7 +506,8 @@ fun FlashcardsApp(
                         },
                         label = {
                             Text(stringResource(destination.labelResId))
-                        }
+                        },
+                        badge = settingsBadge
                     )
                 }
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsAttentionBadge.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsAttentionBadge.kt
@@ -1,0 +1,12 @@
+package com.flashcardsopensourceapp.feature.settings
+
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun SettingsAttentionBadge(count: Int) {
+    Badge {
+        Text(text = count.toString())
+    }
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsAttentionSupport.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsAttentionSupport.kt
@@ -1,0 +1,34 @@
+package com.flashcardsopensourceapp.feature.settings
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+
+enum class SettingsAttentionIssue {
+    ACCOUNT_NOT_LINKED
+}
+
+data class SettingsAttentionSummary(
+    val settingsTabCount: Int,
+    val accountStatusRowCount: Int,
+    val accountStatusPrimaryActionCount: Int
+)
+
+fun makeSettingsAttentionIssues(cloudState: CloudAccountState): List<SettingsAttentionIssue> {
+    return when (cloudState) {
+        CloudAccountState.DISCONNECTED,
+        CloudAccountState.LINKING_READY,
+        CloudAccountState.GUEST -> listOf(SettingsAttentionIssue.ACCOUNT_NOT_LINKED)
+        CloudAccountState.LINKED -> emptyList()
+    }
+}
+
+fun makeSettingsAttentionSummary(issues: List<SettingsAttentionIssue>): SettingsAttentionSummary {
+    val accountNotLinkedCount: Int = issues.count { issue ->
+        issue == SettingsAttentionIssue.ACCOUNT_NOT_LINKED
+    }
+
+    return SettingsAttentionSummary(
+        settingsTabCount = issues.size,
+        accountStatusRowCount = accountNotLinkedCount,
+        accountStatusPrimaryActionCount = accountNotLinkedCount
+    )
+}

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -121,6 +121,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_account_status_title),
                     summary = uiState.accountStatusTitle,
+                    attentionCount = uiState.accountStatusAttentionCount,
                     testTag = settingsAccountStatusRowTag,
                     onClick = onOpenAccountStatus
                 )
@@ -130,6 +131,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_root_current_workspace_title),
                     summary = uiState.currentWorkspaceName,
+                    attentionCount = null,
                     testTag = settingsCurrentWorkspaceRowTag,
                     onClick = onOpenCurrentWorkspace
                 )
@@ -146,6 +148,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_review_reminders_title),
                     summary = stringResource(R.string.settings_review_reminders_summary),
+                    attentionCount = null,
                     testTag = settingsReviewRemindersRowTag,
                     onClick = onOpenReviewReminders
                 )
@@ -160,6 +163,7 @@ fun SettingsRoute(
                         } else {
                             stringResource(R.string.settings_common_off)
                         },
+                        attentionCount = null,
                         testTag = settingsReviewAnimationsRowTag,
                         onClick = onOpenReviewAnimations
                     )
@@ -170,6 +174,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_language_title),
                     summary = stringResource(R.string.settings_language_summary),
+                    attentionCount = null,
                     testTag = settingsLanguageRowTag,
                     onClick = onOpenLanguage
                 )
@@ -179,6 +184,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_root_access_title),
                     summary = stringResource(R.string.settings_root_access_summary),
+                    attentionCount = null,
                     testTag = settingsAccessRowTag,
                     onClick = onOpenAccess
                 )
@@ -188,6 +194,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_workspace_decks_title),
                     summary = stringResource(R.string.settings_decks_summary),
+                    attentionCount = null,
                     testTag = settingsDecksRowTag,
                     onClick = onOpenDecks
                 )
@@ -197,6 +204,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_workspace_tags_title),
                     summary = stringResource(R.string.settings_tags_summary),
+                    attentionCount = null,
                     testTag = settingsTagsRowTag,
                     onClick = onOpenTags
                 )
@@ -206,6 +214,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_workspace_export_title),
                     summary = stringResource(R.string.settings_export_csv_summary),
+                    attentionCount = null,
                     testTag = settingsExportRowTag,
                     onClick = onOpenExport
                 )
@@ -222,6 +231,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_root_feedback_title),
                     summary = stringResource(R.string.settings_root_feedback_summary),
+                    attentionCount = null,
                     testTag = settingsFeedbackRowTag,
                     onClick = onOpenFeedback
                 )
@@ -231,6 +241,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_account_support_title),
                     summary = null,
+                    attentionCount = null,
                     testTag = settingsSupportRowTag,
                     onClick = onOpenSupport
                 )
@@ -240,6 +251,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_account_legal_title),
                     summary = null,
+                    attentionCount = null,
                     testTag = settingsLegalRowTag,
                     onClick = onOpenLegal
                 )
@@ -249,6 +261,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_account_open_source_title),
                     summary = stringResource(R.string.settings_account_open_source_summary),
+                    attentionCount = null,
                     testTag = settingsOpenSourceRowTag,
                     onClick = onOpenOpenSource
                 )
@@ -265,6 +278,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_scheduling_title),
                     summary = stringResource(R.string.settings_scheduling_summary),
+                    attentionCount = null,
                     testTag = settingsSchedulingRowTag,
                     onClick = onOpenScheduling
                 )
@@ -274,6 +288,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_account_agent_connections_title),
                     summary = stringResource(R.string.settings_account_agent_connections_summary),
+                    attentionCount = null,
                     testTag = settingsAgentConnectionsRowTag,
                     onClick = onOpenAgentConnections
                 )
@@ -283,6 +298,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_server_title),
                     summary = stringResource(R.string.settings_server_summary),
+                    attentionCount = null,
                     testTag = settingsServerRowTag,
                     onClick = onOpenServer
                 )
@@ -292,6 +308,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_device_diagnostics_title),
                     summary = null,
+                    attentionCount = null,
                     testTag = settingsDeviceDiagnosticsRowTag,
                     onClick = onOpenDeviceDiagnostics
                 )
@@ -301,6 +318,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_reset_study_progress_title),
                     summary = stringResource(R.string.settings_workspace_reset_body),
+                    attentionCount = null,
                     testTag = settingsResetStudyProgressRowTag,
                     onClick = onOpenResetStudyProgress
                 )
@@ -310,6 +328,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_delete_current_workspace_title),
                     summary = stringResource(R.string.settings_workspace_delete_body),
+                    attentionCount = null,
                     testTag = settingsDeleteCurrentWorkspaceRowTag,
                     onClick = onOpenDeleteCurrentWorkspace
                 )
@@ -319,6 +338,7 @@ fun SettingsRoute(
                 SettingsRootRow(
                     title = stringResource(R.string.settings_account_danger_zone_dialog_title),
                     summary = stringResource(R.string.settings_account_danger_zone_body),
+                    attentionCount = null,
                     testTag = settingsDeleteAccountRowTag,
                     onClick = onOpenDeleteAccount
                 )
@@ -329,6 +349,7 @@ fun SettingsRoute(
                     SettingsRootRow(
                         title = stringResource(R.string.settings_root_test_title),
                         summary = stringResource(R.string.settings_root_test_summary),
+                        attentionCount = null,
                         testTag = settingsTestRowTag,
                         onClick = onOpenTest
                     )
@@ -349,12 +370,22 @@ private fun SettingsRootSectionTitle(title: String, testTag: String) {
 private fun SettingsRootRow(
     title: String,
     summary: String?,
+    attentionCount: Int?,
     testTag: String,
     onClick: () -> Unit
 ) {
     val supportingContent: (@Composable () -> Unit)? = summary?.let { rowSummary ->
         {
             Text(rowSummary)
+        }
+    }
+    val positiveAttentionCount: Int? = attentionCount?.takeIf { count -> count > 0 }
+    val trailingContent: (@Composable () -> Unit)? = if (positiveAttentionCount == null) {
+        null
+    } else {
+        val badgeCount: Int = positiveAttentionCount
+        {
+            SettingsAttentionBadge(count = badgeCount)
         }
     }
 
@@ -368,7 +399,8 @@ private fun SettingsRootRow(
             headlineContent = {
                 Text(title)
             },
-            supportingContent = supportingContent
+            supportingContent = supportingContent,
+            trailingContent = trailingContent
         )
     }
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsUiState.kt
@@ -8,6 +8,7 @@ data class SettingsUiState(
     val storageLabel: String,
     val syncStatusText: String,
     val accountStatusTitle: String,
+    val accountStatusAttentionCount: Int,
     val reviewReactionAnimationsEnabled: Boolean,
     val canManageAccountPreferences: Boolean,
     val isTestModeEnabled: Boolean

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsViewModel.kt
@@ -51,6 +51,10 @@ class SettingsViewModel(
         cloudAccountRepository.observeAccountPreferences(),
         testModeStore.observeIsEnabled()
     ) { metadata, cloudSettings, accountPreferences, isTestModeEnabled ->
+        val attentionSummary: SettingsAttentionSummary = makeSettingsAttentionSummary(
+            issues = makeSettingsAttentionIssues(cloudState = cloudSettings.cloudState)
+        )
+
         SettingsUiState(
             currentWorkspaceName = strings.resolveWorkspaceName(workspaceName = metadata.currentWorkspaceName),
             workspaceName = strings.resolveWorkspaceName(workspaceName = metadata.workspaceName),
@@ -64,6 +68,7 @@ class SettingsViewModel(
                 CloudAccountState.GUEST -> strings.get(R.string.settings_cloud_status_guest_ai)
                 CloudAccountState.LINKED -> cloudSettings.linkedEmail ?: strings.get(R.string.settings_cloud_status_linked)
             },
+            accountStatusAttentionCount = attentionSummary.accountStatusRowCount,
             reviewReactionAnimationsEnabled = accountPreferences.reviewReactionAnimationsEnabled,
             canManageAccountPreferences = canManageAccountPreferences(cloudState = cloudSettings.cloudState),
             isTestModeEnabled = isTestModeEnabled
@@ -79,6 +84,7 @@ class SettingsViewModel(
             storageLabel = strings.get(R.string.settings_device_storage_room_sqlite),
             syncStatusText = strings.get(R.string.settings_loading),
             accountStatusTitle = strings.get(R.string.settings_loading),
+            accountStatusAttentionCount = 1,
             reviewReactionAnimationsEnabled = true,
             canManageAccountPreferences = false,
             isTestModeEnabled = false

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusRoute.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.LockOpen
@@ -24,6 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.settings.DeviceInfoCard
 import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsAttentionBadge
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
 import com.flashcardsopensourceapp.feature.settings.settingsScreenCardSpacing
 import com.flashcardsopensourceapp.feature.settings.settingsScreenContentPadding
@@ -150,6 +153,10 @@ fun AccountStatusRoute(
                                         else -> stringResource(R.string.settings_account_status_sign_in_button)
                                     }
                                 )
+                                if (uiState.accountStatusPrimaryActionAttentionCount > 0) {
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    SettingsAttentionBadge(count = uiState.accountStatusPrimaryActionAttentionCount)
+                                }
                             }
                         }
                         if (uiState.isLinked) {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusUiState.kt
@@ -12,6 +12,7 @@ data class AccountStatusUiState(
     val isLinkingReady: Boolean,
     val isSyncBlocked: Boolean,
     val syncBlockedMessage: String?,
+    val accountStatusPrimaryActionAttentionCount: Int,
     val showLogoutConfirmation: Boolean,
     val errorMessage: String,
     val isSubmitting: Boolean

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountStatusViewModel.kt
@@ -13,10 +13,13 @@ import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.SyncRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
 import com.flashcardsopensourceapp.feature.settings.R
+import com.flashcardsopensourceapp.feature.settings.SettingsAttentionSummary
 import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
 import com.flashcardsopensourceapp.feature.settings.cloud.displayCloudAccountStateTitle
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
 import com.flashcardsopensourceapp.feature.settings.formatTimestampLabel
+import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionIssues
+import com.flashcardsopensourceapp.feature.settings.makeSettingsAttentionSummary
 import com.flashcardsopensourceapp.feature.settings.resolveAppMetadataSyncStatusText
 import com.flashcardsopensourceapp.feature.settings.resolveWorkspaceName
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -53,6 +56,10 @@ class AccountStatusViewModel(
         syncRepository.observeSyncStatus(),
         draftState
     ) { metadata, cloudSettings, syncStatus, draft ->
+        val attentionSummary: SettingsAttentionSummary = makeSettingsAttentionSummary(
+            issues = makeSettingsAttentionIssues(cloudState = cloudSettings.cloudState)
+        )
+
         AccountStatusUiState(
             workspaceName = strings.resolveWorkspaceName(workspaceName = metadata.workspaceName),
             cloudStatusTitle = displayCloudAccountStateTitle(
@@ -79,6 +86,10 @@ class AccountStatusViewModel(
             isLinkingReady = cloudSettings.cloudState == CloudAccountState.LINKING_READY,
             isSyncBlocked = syncStatus.status is SyncStatus.Blocked,
             syncBlockedMessage = (syncStatus.status as? SyncStatus.Blocked)?.message,
+            accountStatusPrimaryActionAttentionCount = accountStatusPrimaryActionAttentionCount(
+                cloudState = cloudSettings.cloudState,
+                attentionSummary = attentionSummary
+            ),
             showLogoutConfirmation = draft.showLogoutConfirmation,
             errorMessage = draft.errorMessage,
             isSubmitting = draft.isSubmitting
@@ -98,6 +109,7 @@ class AccountStatusViewModel(
             isLinkingReady = false,
             isSyncBlocked = false,
             syncBlockedMessage = null,
+            accountStatusPrimaryActionAttentionCount = 1,
             showLogoutConfirmation = false,
             errorMessage = "",
             isSubmitting = false
@@ -158,6 +170,17 @@ class AccountStatusViewModel(
             }
         }
     }
+}
+
+private fun accountStatusPrimaryActionAttentionCount(
+    cloudState: CloudAccountState,
+    attentionSummary: SettingsAttentionSummary
+): Int {
+    if (cloudState == CloudAccountState.LINKING_READY) {
+        return 0
+    }
+
+    return attentionSummary.accountStatusPrimaryActionCount
 }
 
 fun createAccountStatusViewModelFactory(


### PR DESCRIPTION
## Summary
- add shared Android settings attention issue and summary logic
- show Material 3 badges on the Settings navigation item, Settings Account Status row, and Account Status primary sign-in action
- update route fixtures for the new UI state fields

## Validation
- reviewed the current diff
- did not run ./gradlew locally because this repository requires explicit approval for local Gradle runs