### PR TITLE
[codex] Fix Android settings destination import

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -59,6 +59,7 @@ import com.flashcardsopensourceapp.app.navigation.AppNotificationTapHandoffReque
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
 import com.flashcardsopensourceapp.app.navigation.ReviewDestination
+import com.flashcardsopensourceapp.app.navigation.SettingsDestination
 import com.flashcardsopensourceapp.app.navigation.TopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.currentVisibleAppScreen
 import com.flashcardsopensourceapp.app.navigation.currentTopLevelDestination


### PR DESCRIPTION
## Summary
- import the Android top-level Settings destination in `FlashcardsApp.kt`
- restore compilation for the Settings navigation badge path

## Validation
- `git --no-pager diff --check`
- Android Gradle checks were not run because this repository requires explicit approval before local Gradle runs