### PR TITLE
[codex] Group web card screens

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -61,8 +61,8 @@ import {
 } from "./routes";
 import { isWorkspaceManagementLocked } from "./workspaceManagement";
 import { TestModeProvider, useTestMode } from "./testMode";
-import { CardFormScreen } from "./screens/cards/CardFormScreen";
-import { CardsScreen } from "./screens/cards/CardsScreen";
+import { CardFormScreen } from "./screens/cards/form/CardFormScreen";
+import { CardsScreen } from "./screens/cards/list/CardsScreen";
 import { ProgressScreen } from "./screens/progress/ProgressScreen";
 import { ReviewScreen } from "./screens/review/ReviewScreen";
 

--- a/apps/web/src/screens/cards/form/CardForm.tsx
+++ b/apps/web/src/screens/cards/form/CardForm.tsx
@@ -1,8 +1,8 @@
 import { type ChangeEvent, type ReactElement } from "react";
-import { useI18n } from "../../i18n";
+import { useI18n } from "../../../i18n";
 import { CardFormTagsField } from "./CardFormTagsField";
-import type { Card, EffortLevel, TagSuggestion } from "../../types";
-import { formatEffortLevelLabel, formatNullableDateTime } from "../shared/featureFormatting";
+import type { Card, EffortLevel, TagSuggestion } from "../../../types";
+import { formatEffortLevelLabel, formatNullableDateTime } from "../../shared/featureFormatting";
 
 export type CardFormState = Readonly<{
   frontText: string;

--- a/apps/web/src/screens/cards/form/CardFormScreen.tsx
+++ b/apps/web/src/screens/cards/form/CardFormScreen.tsx
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { useAppData } from "../../appData";
-import { useAiCardHandoff } from "../../chat/handoff/useAiCardHandoff";
-import { useI18n } from "../../i18n";
+import { useAppData } from "../../../appData";
+import { useAiCardHandoff } from "../../../chat/handoff/useAiCardHandoff";
+import { useI18n } from "../../../i18n";
 import { CardFormFields, isCardFormStateDirty, toCardFormState, type CardFormState } from "./CardForm";
-import type { Card, CreateCardInput, TagSuggestion, UpdateCardInput } from "../../types";
-import { loadCardById } from "../../localDb/cards/cards";
-import { loadWorkspaceTagsSummary } from "../../localDb/cards/workspace";
-import { captureAppOperationError } from "../../observability/appOperationObservation";
-import { cardsRoute } from "../../routes";
+import type { Card, CreateCardInput, TagSuggestion, UpdateCardInput } from "../../../types";
+import { loadCardById } from "../../../localDb/cards/cards";
+import { loadWorkspaceTagsSummary } from "../../../localDb/cards/workspace";
+import { captureAppOperationError } from "../../../observability/appOperationObservation";
+import { cardsRoute } from "../../../routes";
 
 function toTagSuggestions(tags: Awaited<ReturnType<typeof loadWorkspaceTagsSummary>>["tags"]): ReadonlyArray<TagSuggestion> {
   return tags.map((tagSummary) => ({

--- a/apps/web/src/screens/cards/form/CardFormTagsField.tsx
+++ b/apps/web/src/screens/cards/form/CardFormTagsField.tsx
@@ -8,9 +8,9 @@ import {
   type ReactElement,
 } from "react";
 import { createPortal } from "react-dom";
-import { useI18n } from "../../i18n";
-import type { TagSuggestion } from "../../types";
-import { areSameTags, CardTagsInput, CardTagsValue, type CardTagsInputHandle } from "./CardTagsInput";
+import { useI18n } from "../../../i18n";
+import type { TagSuggestion } from "../../../types";
+import { areSameTags, CardTagsInput, CardTagsValue, type CardTagsInputHandle } from "../CardTagsInput";
 
 type OverlayRect = Readonly<{
   top: number;

--- a/apps/web/src/screens/cards/list/CardsScreen.tsx
+++ b/apps/web/src/screens/cards/list/CardsScreen.tsx
@@ -1,21 +1,21 @@
 import { useEffect, useRef, useState, type ReactElement } from "react";
 import { Link } from "react-router-dom";
-import { useAppData } from "../../appData";
-import { getCardFilterActiveDimensionCount, normalizeCardFilter } from "../../cardFilters";
-import { EFFORT_LEVELS } from "../../deckFilters";
-import { useI18n } from "../../i18n";
-import { CardTagsInput, type CardTagsInputHandle } from "./CardTagsInput";
+import { useAppData } from "../../../appData";
+import { getCardFilterActiveDimensionCount, normalizeCardFilter } from "../../../cardFilters";
+import { EFFORT_LEVELS } from "../../../deckFilters";
+import { useI18n } from "../../../i18n";
+import { CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
 import { EditableCardEffortCell, EditableCardTagsCell, EditableCardTextCell } from "./CardsTableEditors";
-import { queryLocalCardsPage } from "../../localDb/cards/cards";
-import { loadWorkspaceTagsSummary } from "../../localDb/cards/workspace";
-import { captureAppOperationError } from "../../observability/appOperationObservation";
-import type { Card, CardFilter, CardQuerySort, CardQuerySortDirection, CardQuerySortKey, QueryCardsPage, TagSuggestion, UpdateCardInput } from "../../types";
+import { queryLocalCardsPage } from "../../../localDb/cards/cards";
+import { loadWorkspaceTagsSummary } from "../../../localDb/cards/workspace";
+import { captureAppOperationError } from "../../../observability/appOperationObservation";
+import type { Card, CardFilter, CardQuerySort, CardQuerySortDirection, CardQuerySortKey, QueryCardsPage, TagSuggestion, UpdateCardInput } from "../../../types";
 import {
   buildCardsLoadingRowPreview,
   readCardsLoadingSnapshot,
   writeCardsLoadingSnapshot,
-} from "../shared/loadingSnapshots";
-import { formatCardFilterSummary, formatEffortLevelLabel, formatNullableDateTime, formatTagSummary } from "../shared/featureFormatting";
+} from "../../shared/loadingSnapshots";
+import { formatCardFilterSummary, formatEffortLevelLabel, formatNullableDateTime, formatTagSummary } from "../../shared/featureFormatting";
 
 type CardsQueryState = Readonly<{
   items: ReadonlyArray<Card>;

--- a/apps/web/src/screens/cards/list/CardsTableEditors.tsx
+++ b/apps/web/src/screens/cards/list/CardsTableEditors.tsx
@@ -11,10 +11,10 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
-import { useI18n } from "../../i18n";
-import type { EffortLevel, TagSuggestion } from "../../types";
-import { areSameTags, CardTagsInput, type CardTagsInputHandle } from "./CardTagsInput";
-import { formatEffortLevelLabel } from "../shared/featureFormatting";
+import { useI18n } from "../../../i18n";
+import type { EffortLevel, TagSuggestion } from "../../../types";
+import { areSameTags, CardTagsInput, type CardTagsInputHandle } from "../CardTagsInput";
+import { formatEffortLevelLabel } from "../../shared/featureFormatting";
 
 type OverlayRect = Readonly<{
   top: number;

--- a/apps/web/src/screens/review/components/ReviewEditorModal.tsx
+++ b/apps/web/src/screens/review/components/ReviewEditorModal.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from "react";
 import { useI18n } from "../../../i18n";
-import { CardFormFields, type CardFormState } from "../../cards/CardForm";
+import { CardFormFields, type CardFormState } from "../../cards/form/CardForm";
 import type { Card, TagSuggestion } from "../../../types";
 
 export type ReviewEditorModalProps = Readonly<{

--- a/apps/web/src/screens/review/components/useReviewCardEditor.ts
+++ b/apps/web/src/screens/review/components/useReviewCardEditor.ts
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { TranslationKey } from "../../../i18n";
 import { captureAppOperationError } from "../../../observability/appOperationObservation";
-import { toCardFormState, type CardFormState } from "../../cards/CardForm";
+import { toCardFormState, type CardFormState } from "../../cards/form/CardForm";
 import type { Card } from "../../../types";
 
 type UseReviewCardEditorParams = Readonly<{

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -35,7 +35,7 @@ import { normalizeCaughtError } from "../../observability/webObservability";
 import { useAiCardHandoff } from "../../chat/handoff/useAiCardHandoff";
 import { useTransientMessage } from "../../useTransientMessage";
 import type { Card, FeedbackPromptEventType, FeedbackSubmissionRequest } from "../../types";
-import { isCardFormStateDirty } from "../cards/CardForm";
+import { isCardFormStateDirty } from "../cards/form/CardForm";
 import type { ReviewEditorModalProps } from "./components/ReviewEditorModal";
 import type { ReviewPaneProps } from "./components/ReviewPane";
 import type { ReviewQueuePanelProps } from "./components/ReviewQueuePanel";

--- a/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
+++ b/apps/web/src/screens/settings/workspace/decks/DeckFormScreen.tsx
@@ -4,7 +4,7 @@ import { useAppData } from "../../../../appData";
 import { ALL_CARDS_DECK_SLUG, buildDeckFilterDefinition, EFFORT_LEVELS } from "../../../../deckFilters";
 import { useI18n } from "../../../../i18n";
 import { buildSettingsDeckDetailRoute, settingsDecksRoute } from "../../../../routes";
-import { CardFormTagsField } from "../../../cards/CardFormTagsField";
+import { CardFormTagsField } from "../../../cards/form/CardFormTagsField";
 import { loadWorkspaceTagsSummary } from "../../../../localDb/cards/workspace";
 import { captureAppOperationError } from "../../../../observability/appOperationObservation";
 import type { EffortLevel, TagSuggestion, UpdateDeckInput } from "../../../../types";


### PR DESCRIPTION
## Summary

- Move the web cards list screen and inline table editors into `screens/cards/list/`.
- Move the web card create/edit form files into `screens/cards/form/`.
- Keep `CardTagsInput.tsx` shared at the cards folder root and update import consumers.

## Validation

- `npm run build` from `apps/web`
