### PR TITLE
[codex] Group backend sync and workspace routes

### DIFF
--- a/apps/backend/src/routes/sync/bootstrapDetails.ts
+++ b/apps/backend/src/routes/sync/bootstrapDetails.ts
@@ -1,0 +1,89 @@
+import {
+  type SyncBootstrapInput,
+  type SyncBootstrapPullResult,
+  type SyncBootstrapPushResult,
+} from "../../sync";
+import type { SyncBootstrapDetails } from "../../observability/sentry";
+
+export function buildSyncBootstrapPullDetails(
+  input: Extract<SyncBootstrapInput, Readonly<{ mode: "pull" }>>,
+  result: SyncBootstrapPullResult,
+  durationMs: number,
+): SyncBootstrapDetails {
+  return {
+    statusCode: 200,
+    durationMs,
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    mode: input.mode,
+    cursorPresent: input.cursor !== null,
+    limit: input.limit,
+    entriesCount: result.entries.length,
+    appliedEntriesCount: null,
+    hasMore: result.hasMore,
+    nextCursorPresent: result.nextCursor !== null,
+    bootstrapHotChangeId: result.bootstrapHotChangeId,
+    remoteIsEmpty: result.remoteIsEmpty,
+  };
+}
+
+export function buildSyncBootstrapPushDetails(
+  input: Extract<SyncBootstrapInput, Readonly<{ mode: "push" }>>,
+  result: SyncBootstrapPushResult,
+  durationMs: number,
+): SyncBootstrapDetails {
+  return {
+    statusCode: 200,
+    durationMs,
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    mode: input.mode,
+    cursorPresent: null,
+    limit: null,
+    entriesCount: input.entries.length,
+    appliedEntriesCount: result.appliedEntriesCount,
+    hasMore: null,
+    nextCursorPresent: null,
+    bootstrapHotChangeId: result.bootstrapHotChangeId,
+    remoteIsEmpty: null,
+  };
+}
+
+export function buildSyncBootstrapDetails(
+  input: SyncBootstrapInput,
+  result: SyncBootstrapPullResult | SyncBootstrapPushResult,
+  durationMs: number,
+): SyncBootstrapDetails {
+  if (input.mode === "pull" && result.mode === "pull") {
+    return buildSyncBootstrapPullDetails(input, result, durationMs);
+  }
+
+  if (input.mode === "push" && result.mode === "push") {
+    return buildSyncBootstrapPushDetails(input, result, durationMs);
+  }
+
+  throw new Error(`Sync bootstrap result mode mismatch: input=${input.mode} result=${result.mode}`);
+}
+
+export function getSyncBootstrapFailureInputDetails(
+  input: SyncBootstrapInput,
+  durationMs: number,
+): Omit<SyncBootstrapDetails, "statusCode"> {
+  return {
+    durationMs,
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    mode: input.mode,
+    cursorPresent: input.mode === "pull" ? input.cursor !== null : null,
+    limit: input.mode === "pull" ? input.limit : null,
+    entriesCount: input.mode === "push" ? input.entries.length : null,
+    appliedEntriesCount: null,
+    hasMore: null,
+    nextCursorPresent: null,
+    bootstrapHotChangeId: null,
+    remoteIsEmpty: null,
+  };
+}

--- a/apps/backend/src/routes/sync/conflictDetails.ts
+++ b/apps/backend/src/routes/sync/conflictDetails.ts
@@ -1,0 +1,41 @@
+import { HttpError } from "../../shared/errors";
+import type { BackendSyncConflictDetails } from "../../observability/sentry";
+
+export function getSyncConflictLogContext(error: HttpError | unknown): BackendSyncConflictDetails {
+  if (!(error instanceof HttpError)) {
+    return emptySyncConflictDetails();
+  }
+
+  const syncConflict = error.details?.syncConflict;
+  if (syncConflict === undefined) {
+    return emptySyncConflictDetails();
+  }
+
+  return {
+    syncConflictPhase: syncConflict.phase,
+    syncConflictEntityType: syncConflict.entityType,
+    syncConflictEntityId: syncConflict.entityId,
+    conflictingWorkspaceId: syncConflict.conflictingWorkspaceId,
+    constraint: syncConflict.constraint,
+    sqlState: syncConflict.sqlState,
+    table: syncConflict.table,
+    entryIndex: syncConflict.entryIndex ?? null,
+    reviewEventIndex: syncConflict.reviewEventIndex ?? null,
+    syncConflictRecoverable: syncConflict.recoverable,
+  };
+}
+
+export function emptySyncConflictDetails(): BackendSyncConflictDetails {
+  return {
+    syncConflictPhase: null,
+    syncConflictEntityType: null,
+    syncConflictEntityId: null,
+    conflictingWorkspaceId: null,
+    constraint: null,
+    sqlState: null,
+    table: null,
+    entryIndex: null,
+    reviewEventIndex: null,
+    syncConflictRecoverable: null,
+  };
+}

--- a/apps/backend/src/routes/sync/guestPlatform.ts
+++ b/apps/backend/src/routes/sync/guestPlatform.ts
@@ -1,0 +1,51 @@
+import { bindGuestSessionPlatform, type GuestSessionPlatform } from "../../guestAuth";
+import type { RequestContext } from "../../server/requestContext";
+import { HttpError } from "../../shared/errors";
+
+export type SyncClientPlatform = "ios" | "android" | "web";
+
+export function toGuestSessionPlatform(platform: SyncClientPlatform): GuestSessionPlatform | null {
+  if (platform === "ios" || platform === "android") {
+    return platform;
+  }
+
+  return null;
+}
+
+export async function requireSupportedSyncPlatformForTransport(
+  requestContext: RequestContext,
+  platform: SyncClientPlatform,
+  bindGuestSessionPlatformFn: typeof bindGuestSessionPlatform,
+): Promise<void> {
+  if (requestContext.transport !== "guest") {
+    return;
+  }
+
+  const guestPlatform = toGuestSessionPlatform(platform);
+  if (guestPlatform === null) {
+    throw new HttpError(
+      403,
+      "Guest web sync is not supported. Sign in before syncing from the web app.",
+      "GUEST_WEB_SYNC_UNSUPPORTED",
+    );
+  }
+
+  if (requestContext.guestSessionId === null) {
+    throw new Error("Guest sync request context is missing guestSessionId");
+  }
+
+  if (requestContext.guestPlatform === null) {
+    // Pre-1.7.0 iOS/Android guest sessions are unbound at creation time.
+    // Bind them on first native sync, then remove this path after those versions are no longer supported.
+    await bindGuestSessionPlatformFn(requestContext.guestSessionId, guestPlatform);
+    return;
+  }
+
+  if (requestContext.guestPlatform !== guestPlatform) {
+    throw new HttpError(
+      403,
+      "Guest session platform does not match this sync request. Create a new guest session for this device.",
+      "GUEST_SESSION_PLATFORM_MISMATCH",
+    );
+  }
+}

--- a/apps/backend/src/routes/sync/index.test.ts
+++ b/apps/backend/src/routes/sync/index.test.ts
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import type { AppEnv } from "../server/app";
-import { HttpError } from "../shared/errors";
-import { isTransientDatabaseError } from "../database/transient";
-import type { RequestContext } from "../server/requestContext";
-import type { GuestSessionPlatform } from "../guestAuth";
-import { createSyncRoutes } from "./sync";
+import type { AppEnv } from "../../server/app";
+import { HttpError } from "../../shared/errors";
+import { isTransientDatabaseError } from "../../database/transient";
+import type { RequestContext } from "../../server/requestContext";
+import type { GuestSessionPlatform } from "../../guestAuth";
+import { createSyncRoutes } from "./index";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 

--- a/apps/backend/src/routes/sync/index.ts
+++ b/apps/backend/src/routes/sync/index.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import { HttpError } from "../shared/errors";
 import {
   parseSyncBootstrapInput,
   parseSyncPullInput,
@@ -11,40 +10,43 @@ import {
   processSyncPush,
   processSyncReviewHistoryImport,
   processSyncReviewHistoryPull,
-  type SyncBootstrapInput,
-  type SyncBootstrapPullResult,
-  type SyncBootstrapPushResult,
   type SyncPullInput,
   type SyncPullResult,
   type SyncReviewHistoryPullInput,
   type SyncReviewHistoryPullResult,
-} from "../sync";
+} from "../../sync";
 import {
   assertUserHasWorkspaceAccess,
-} from "../workspaces";
-import { bindGuestSessionPlatform, type GuestSessionPlatform } from "../guestAuth";
+} from "../../workspaces";
+import { bindGuestSessionPlatform } from "../../guestAuth";
 import {
   loadRequestContextFromRequest,
   parseWorkspaceIdParam,
   type RequestContext,
-} from "../server/requestContext";
-import { parseJsonBody } from "../server/requestParsing";
+} from "../../server/requestContext";
+import { parseJsonBody } from "../../server/requestParsing";
 import {
   createBackendFailureDetails,
-} from "../server/logging";
-import { withTransientDatabaseRetry } from "../database/transient";
+} from "../../server/logging";
+import { withTransientDatabaseRetry } from "../../database/transient";
 import {
   addBackendBreadcrumb,
-  createBackendObservationScope,
   normalizeCaughtError,
-  type BackendObservationScope,
-  type BackendSyncConflictDetails,
-  type SyncBootstrapDetails,
-  type SyncPullDetails,
-  type SyncReviewHistoryPullDetails,
-} from "../observability/sentry";
-import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
-import type { AppEnv } from "../server/app";
+} from "../../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../../observability/reporting";
+import type { AppEnv } from "../../server/app";
+import {
+  buildSyncBootstrapDetails,
+  getSyncBootstrapFailureInputDetails,
+} from "./bootstrapDetails";
+import { getSyncConflictLogContext } from "./conflictDetails";
+import { requireSupportedSyncPlatformForTransport } from "./guestPlatform";
+import {
+  createSyncScope,
+  getRequestContextUserId,
+  getSyncPullInputDetails,
+  getSyncReviewHistoryPullInputDetails,
+} from "./observation";
 
 type SyncRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
@@ -56,8 +58,6 @@ type SyncRoutesOptions = Readonly<{
   withTransientDatabaseRetryFn?: typeof withTransientDatabaseRetry;
   bindGuestSessionPlatformFn?: typeof bindGuestSessionPlatform;
 }>;
-
-type SyncClientPlatform = "ios" | "android" | "web";
 
 type SyncPullRouteState = Readonly<{
   requestContext: RequestContext;
@@ -72,238 +72,6 @@ type SyncReviewHistoryPullRouteState = Readonly<{
   input: SyncReviewHistoryPullInput;
   result: SyncReviewHistoryPullResult;
 }>;
-
-function getRequestContextUserId(requestContext: RequestContext | null): string | null {
-  return requestContext === null ? null : requestContext.userId;
-}
-
-function getSyncPullInputDetails(
-  input: SyncPullInput | null,
-): Pick<SyncPullDetails, "installationId" | "platform" | "appVersion" | "afterHotChangeId"> {
-  if (input === null) {
-    return {
-      installationId: null,
-      platform: null,
-      appVersion: null,
-      afterHotChangeId: null,
-    };
-  }
-
-  return {
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-    afterHotChangeId: input.afterHotChangeId,
-  };
-}
-
-function getSyncReviewHistoryPullInputDetails(
-  input: SyncReviewHistoryPullInput | null,
-): Pick<SyncReviewHistoryPullDetails, "installationId" | "platform" | "appVersion" | "afterReviewSequenceId"> {
-  if (input === null) {
-    return {
-      installationId: null,
-      platform: null,
-      appVersion: null,
-      afterReviewSequenceId: null,
-    };
-  }
-
-  return {
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-    afterReviewSequenceId: input.afterReviewSequenceId,
-  };
-}
-
-function buildSyncBootstrapPullDetails(
-  input: Extract<SyncBootstrapInput, Readonly<{ mode: "pull" }>>,
-  result: SyncBootstrapPullResult,
-  durationMs: number,
-): SyncBootstrapDetails {
-  return {
-    statusCode: 200,
-    durationMs,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-    mode: input.mode,
-    cursorPresent: input.cursor !== null,
-    limit: input.limit,
-    entriesCount: result.entries.length,
-    appliedEntriesCount: null,
-    hasMore: result.hasMore,
-    nextCursorPresent: result.nextCursor !== null,
-    bootstrapHotChangeId: result.bootstrapHotChangeId,
-    remoteIsEmpty: result.remoteIsEmpty,
-  };
-}
-
-function buildSyncBootstrapPushDetails(
-  input: Extract<SyncBootstrapInput, Readonly<{ mode: "push" }>>,
-  result: SyncBootstrapPushResult,
-  durationMs: number,
-): SyncBootstrapDetails {
-  return {
-    statusCode: 200,
-    durationMs,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-    mode: input.mode,
-    cursorPresent: null,
-    limit: null,
-    entriesCount: input.entries.length,
-    appliedEntriesCount: result.appliedEntriesCount,
-    hasMore: null,
-    nextCursorPresent: null,
-    bootstrapHotChangeId: result.bootstrapHotChangeId,
-    remoteIsEmpty: null,
-  };
-}
-
-function buildSyncBootstrapDetails(
-  input: SyncBootstrapInput,
-  result: SyncBootstrapPullResult | SyncBootstrapPushResult,
-  durationMs: number,
-): SyncBootstrapDetails {
-  if (input.mode === "pull" && result.mode === "pull") {
-    return buildSyncBootstrapPullDetails(input, result, durationMs);
-  }
-
-  if (input.mode === "push" && result.mode === "push") {
-    return buildSyncBootstrapPushDetails(input, result, durationMs);
-  }
-
-  throw new Error(`Sync bootstrap result mode mismatch: input=${input.mode} result=${result.mode}`);
-}
-
-function getSyncBootstrapFailureInputDetails(
-  input: SyncBootstrapInput,
-  durationMs: number,
-): Omit<SyncBootstrapDetails, "statusCode"> {
-  return {
-    durationMs,
-    installationId: input.installationId,
-    platform: input.platform,
-    appVersion: input.appVersion ?? null,
-    mode: input.mode,
-    cursorPresent: input.mode === "pull" ? input.cursor !== null : null,
-    limit: input.mode === "pull" ? input.limit : null,
-    entriesCount: input.mode === "push" ? input.entries.length : null,
-    appliedEntriesCount: null,
-    hasMore: null,
-    nextCursorPresent: null,
-    bootstrapHotChangeId: null,
-    remoteIsEmpty: null,
-  };
-}
-
-function getSyncConflictLogContext(error: HttpError | unknown): BackendSyncConflictDetails {
-  if (!(error instanceof HttpError)) {
-    return emptySyncConflictDetails();
-  }
-
-  const syncConflict = error.details?.syncConflict;
-  if (syncConflict === undefined) {
-    return emptySyncConflictDetails();
-  }
-
-  return {
-    syncConflictPhase: syncConflict.phase,
-    syncConflictEntityType: syncConflict.entityType,
-    syncConflictEntityId: syncConflict.entityId,
-    conflictingWorkspaceId: syncConflict.conflictingWorkspaceId,
-    constraint: syncConflict.constraint,
-    sqlState: syncConflict.sqlState,
-    table: syncConflict.table,
-    entryIndex: syncConflict.entryIndex ?? null,
-    reviewEventIndex: syncConflict.reviewEventIndex ?? null,
-    syncConflictRecoverable: syncConflict.recoverable,
-  };
-}
-
-function emptySyncConflictDetails(): BackendSyncConflictDetails {
-  return {
-    syncConflictPhase: null,
-    syncConflictEntityType: null,
-    syncConflictEntityId: null,
-    conflictingWorkspaceId: null,
-    constraint: null,
-    sqlState: null,
-    table: null,
-    entryIndex: null,
-    reviewEventIndex: null,
-    syncConflictRecoverable: null,
-  };
-}
-
-function createSyncScope(
-  requestId: string,
-  route: string,
-  method: string,
-  userId: string | null,
-  workspaceId: string | null,
-): BackendObservationScope {
-  return createBackendObservationScope(
-    "backend-api",
-    requestId,
-    route,
-    method,
-    userId,
-    workspaceId,
-    null,
-    null,
-    null,
-  );
-}
-
-function toGuestSessionPlatform(platform: SyncClientPlatform): GuestSessionPlatform | null {
-  if (platform === "ios" || platform === "android") {
-    return platform;
-  }
-
-  return null;
-}
-
-async function requireSupportedSyncPlatformForTransport(
-  requestContext: RequestContext,
-  platform: SyncClientPlatform,
-  bindGuestSessionPlatformFn: typeof bindGuestSessionPlatform,
-): Promise<void> {
-  if (requestContext.transport !== "guest") {
-    return;
-  }
-
-  const guestPlatform = toGuestSessionPlatform(platform);
-  if (guestPlatform === null) {
-    throw new HttpError(
-      403,
-      "Guest web sync is not supported. Sign in before syncing from the web app.",
-      "GUEST_WEB_SYNC_UNSUPPORTED",
-    );
-  }
-
-  if (requestContext.guestSessionId === null) {
-    throw new Error("Guest sync request context is missing guestSessionId");
-  }
-
-  if (requestContext.guestPlatform === null) {
-    // Pre-1.7.0 iOS/Android guest sessions are unbound at creation time.
-    // Bind them on first native sync, then remove this path after those versions are no longer supported.
-    await bindGuestSessionPlatformFn(requestContext.guestSessionId, guestPlatform);
-    return;
-  }
-
-  if (requestContext.guestPlatform !== guestPlatform) {
-    throw new HttpError(
-      403,
-      "Guest session platform does not match this sync request. Create a new guest session for this device.",
-      "GUEST_SESSION_PLATFORM_MISMATCH",
-    );
-  }
-}
 
 export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();

--- a/apps/backend/src/routes/sync/observation.ts
+++ b/apps/backend/src/routes/sync/observation.ts
@@ -1,0 +1,75 @@
+import {
+  createBackendObservationScope,
+  type BackendObservationScope,
+  type SyncPullDetails,
+  type SyncReviewHistoryPullDetails,
+} from "../../observability/sentry";
+import type { RequestContext } from "../../server/requestContext";
+import {
+  type SyncPullInput,
+  type SyncReviewHistoryPullInput,
+} from "../../sync";
+
+export function getRequestContextUserId(requestContext: RequestContext | null): string | null {
+  return requestContext === null ? null : requestContext.userId;
+}
+
+export function getSyncPullInputDetails(
+  input: SyncPullInput | null,
+): Pick<SyncPullDetails, "installationId" | "platform" | "appVersion" | "afterHotChangeId"> {
+  if (input === null) {
+    return {
+      installationId: null,
+      platform: null,
+      appVersion: null,
+      afterHotChangeId: null,
+    };
+  }
+
+  return {
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    afterHotChangeId: input.afterHotChangeId,
+  };
+}
+
+export function getSyncReviewHistoryPullInputDetails(
+  input: SyncReviewHistoryPullInput | null,
+): Pick<SyncReviewHistoryPullDetails, "installationId" | "platform" | "appVersion" | "afterReviewSequenceId"> {
+  if (input === null) {
+    return {
+      installationId: null,
+      platform: null,
+      appVersion: null,
+      afterReviewSequenceId: null,
+    };
+  }
+
+  return {
+    installationId: input.installationId,
+    platform: input.platform,
+    appVersion: input.appVersion ?? null,
+    afterReviewSequenceId: input.afterReviewSequenceId,
+  };
+}
+
+export function createSyncScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string | null,
+  workspaceId: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+  );
+}

--- a/apps/backend/src/routes/workspaces/connectionAccess.ts
+++ b/apps/backend/src/routes/workspaces/connectionAccess.ts
@@ -1,0 +1,25 @@
+import type { AuthTransport } from "../../auth";
+import { HttpError } from "../../shared/errors";
+
+export function parseConnectionId(value: string | undefined): string {
+  if (value === undefined) {
+    throw new HttpError(400, "connectionId is required", "AGENT_API_KEY_ID_REQUIRED");
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") {
+    throw new HttpError(400, "connectionId must not be empty", "AGENT_API_KEY_ID_INVALID");
+  }
+
+  return trimmedValue;
+}
+
+export function requireHumanManagedConnectionAccess(transport: AuthTransport): void {
+  if (transport === "api_key") {
+    throw new HttpError(403, "Agent connections must be managed from a human session", "AGENT_API_KEY_HUMAN_SESSION_REQUIRED");
+  }
+
+  if (transport === "guest") {
+    throw new HttpError(403, "Sign in with an account before managing workspaces or agent connections.", "ACCOUNT_SIGN_IN_REQUIRED");
+  }
+}

--- a/apps/backend/src/routes/workspaces/cursor.ts
+++ b/apps/backend/src/routes/workspaces/cursor.ts
@@ -1,0 +1,14 @@
+import { parseOptionalCursorQuery, parseRequiredPageLimit } from "../../shared/pagination";
+
+export type CursorQueryParams = Readonly<{
+  cursor: string | null;
+  limit: number;
+}>;
+
+export function parseCursorQueryParams(request: Request): CursorQueryParams {
+  const url = new URL(request.url);
+  return {
+    cursor: parseOptionalCursorQuery(url.searchParams.get("cursor") ?? undefined, "cursor"),
+    limit: parseRequiredPageLimit(url.searchParams.get("limit") ?? undefined, "limit", 100),
+  };
+}

--- a/apps/backend/src/routes/workspaces/index.test.ts
+++ b/apps/backend/src/routes/workspaces/index.test.ts
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
-import type { AppEnv } from "../server/app";
-import { isTransientDatabaseError } from "../database/transient";
-import { HttpError } from "../shared/errors";
-import type { RequestContext } from "../server/requestContext";
-import type { WorkspaceSummary } from "../workspaces";
-import { createWorkspaceRoutes } from "./workspaces";
+import type { AppEnv } from "../../server/app";
+import { isTransientDatabaseError } from "../../database/transient";
+import { HttpError } from "../../shared/errors";
+import type { RequestContext } from "../../server/requestContext";
+import type { WorkspaceSummary } from "../../workspaces";
+import { createWorkspaceRoutes } from "./index";
 
 const workspaceId = "11111111-1111-4111-8111-111111111111";
 

--- a/apps/backend/src/routes/workspaces/index.ts
+++ b/apps/backend/src/routes/workspaces/index.ts
@@ -1,18 +1,16 @@
 import { Hono } from "hono";
-import type { AuthTransport } from "../auth";
 import {
   createAgentConnectionListEnvelope,
   createAgentConnectionRevokeEnvelope,
   createAgentWorkspaceReadyEnvelope,
   createAgentWorkspacesEnvelope,
   shouldUseAgentSetupEnvelope,
-} from "../agent/setup";
+} from "../../agent/setup";
 import {
   type AgentApiKeyConnection,
   listAgentApiKeyConnectionsPageForUser,
   revokeAgentApiKeyConnectionForUser,
-} from "../agent/apiKeys";
-import { parseOptionalCursorQuery, parseRequiredPageLimit } from "../shared/pagination";
+} from "../../agent/apiKeys";
 import {
   listUserWorkspacesPageForSelectedWorkspace,
   renameWorkspaceForUser,
@@ -23,39 +21,40 @@ import {
   type ResetWorkspaceProgressResult,
   type WorkspaceResetProgressPreview,
   type WorkspaceSummary,
-} from "../workspaces";
+} from "../../workspaces";
 import {
   createWorkspaceForApiKeyConnectionWithObservationScope,
   createWorkspaceForUserWithObservationScope,
-} from "../workspaces/create";
+} from "../../workspaces/create";
 import {
   deleteWorkspaceForUserWithObservationScope,
   loadWorkspaceDeletePreviewForUserWithObservationScope,
   loadWorkspaceResetProgressPreviewForUserWithObservationScope,
   resetWorkspaceProgressForUserWithObservationScope,
-} from "../workspaces/management";
-import { HttpError } from "../shared/errors";
+} from "../../workspaces/management";
+import { HttpError } from "../../shared/errors";
 import {
   loadRequestContextFromRequest,
   parseWorkspaceIdParam,
   requireAgentConnectionId,
   type RequestContext,
-} from "../server/requestContext";
+} from "../../server/requestContext";
 import {
   expectNonEmptyString,
   expectRecord,
   parseJsonBody,
-} from "../server/requestParsing";
-import { createBackendFailureDetails } from "../server/logging";
-import { withTransientDatabaseRetry } from "../database/transient";
+} from "../../server/requestParsing";
+import { createBackendFailureDetails } from "../../server/logging";
+import { withTransientDatabaseRetry } from "../../database/transient";
 import {
   addBackendBreadcrumb,
-  createBackendObservationScope,
   normalizeCaughtError,
-  type BackendObservationScope,
-} from "../observability/sentry";
-import { reportBackendExceptionOrBreadcrumb } from "../observability/reporting";
-import type { AppEnv } from "../server/app";
+} from "../../observability/sentry";
+import { reportBackendExceptionOrBreadcrumb } from "../../observability/reporting";
+import type { AppEnv } from "../../server/app";
+import { parseConnectionId, requireHumanManagedConnectionAccess } from "./connectionAccess";
+import { parseCursorQueryParams } from "./cursor";
+import { createWorkspaceRouteScope, getRequestContextUserId } from "./observation";
 
 type WorkspaceRoutesOptions = Readonly<{
   allowedOrigins: ReadonlyArray<string>;
@@ -63,11 +62,6 @@ type WorkspaceRoutesOptions = Readonly<{
   createWorkspaceForApiKeyConnectionWithObservationScopeFn?: typeof createWorkspaceForApiKeyConnectionWithObservationScope;
   createWorkspaceForUserWithObservationScopeFn?: typeof createWorkspaceForUserWithObservationScope;
   withTransientDatabaseRetryFn?: typeof withTransientDatabaseRetry;
-}>;
-
-type CursorQueryParams = Readonly<{
-  cursor: string | null;
-  limit: number;
 }>;
 
 type WorkspacesPageResponse = Readonly<{
@@ -91,38 +85,6 @@ type WorkspaceCreateRouteState = Readonly<{
   requestContext: RequestContext;
   workspace: WorkspaceSummary;
 }>;
-
-function getRequestContextUserId(requestContext: RequestContext | null): string | null {
-  return requestContext === null ? null : requestContext.userId;
-}
-
-function parseCursorQueryParams(request: Request): CursorQueryParams {
-  const url = new URL(request.url);
-  return {
-    cursor: parseOptionalCursorQuery(url.searchParams.get("cursor") ?? undefined, "cursor"),
-    limit: parseRequiredPageLimit(url.searchParams.get("limit") ?? undefined, "limit", 100),
-  };
-}
-
-function createWorkspaceRouteScope(
-  requestId: string,
-  route: string,
-  method: string,
-  userId: string | null,
-  workspaceId: string | null,
-): BackendObservationScope {
-  return createBackendObservationScope(
-    "backend-api",
-    requestId,
-    route,
-    method,
-    userId,
-    workspaceId,
-    null,
-    null,
-    null,
-  );
-}
 
 export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
@@ -542,27 +504,4 @@ export function createWorkspaceRoutes(options: WorkspaceRoutesOptions): Hono<App
   });
 
   return app;
-}
-
-function parseConnectionId(value: string | undefined): string {
-  if (value === undefined) {
-    throw new HttpError(400, "connectionId is required", "AGENT_API_KEY_ID_REQUIRED");
-  }
-
-  const trimmedValue = value.trim();
-  if (trimmedValue === "") {
-    throw new HttpError(400, "connectionId must not be empty", "AGENT_API_KEY_ID_INVALID");
-  }
-
-  return trimmedValue;
-}
-
-function requireHumanManagedConnectionAccess(transport: AuthTransport): void {
-  if (transport === "api_key") {
-    throw new HttpError(403, "Agent connections must be managed from a human session", "AGENT_API_KEY_HUMAN_SESSION_REQUIRED");
-  }
-
-  if (transport === "guest") {
-    throw new HttpError(403, "Sign in with an account before managing workspaces or agent connections.", "ACCOUNT_SIGN_IN_REQUIRED");
-  }
 }

--- a/apps/backend/src/routes/workspaces/observation.ts
+++ b/apps/backend/src/routes/workspaces/observation.ts
@@ -1,0 +1,29 @@
+import {
+  createBackendObservationScope,
+  type BackendObservationScope,
+} from "../../observability/sentry";
+import type { RequestContext } from "../../server/requestContext";
+
+export function getRequestContextUserId(requestContext: RequestContext | null): string | null {
+  return requestContext === null ? null : requestContext.userId;
+}
+
+export function createWorkspaceRouteScope(
+  requestId: string,
+  route: string,
+  method: string,
+  userId: string | null,
+  workspaceId: string | null,
+): BackendObservationScope {
+  return createBackendObservationScope(
+    "backend-api",
+    requestId,
+    route,
+    method,
+    userId,
+    workspaceId,
+    null,
+    null,
+    null,
+  );
+}

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -15,11 +15,11 @@ import { createAgentRoutes } from "../routes/agent";
 import { createCardsRoutes } from "../routes/cards";
 import { createFeedbackRoutes } from "../routes/feedback";
 import { createGlobalSnapshotRoutes, globalSnapshotPath } from "../routes/globalSnapshot";
-import { createSyncRoutes } from "../routes/sync";
+import { createSyncRoutes } from "../routes/sync/index";
 import { createSystemRoutes } from "../routes/system";
 import { createAdminRoutes } from "../routes/admin";
 import { createGuestAuthRoutes } from "../routes/guestAuth";
-import { createWorkspaceRoutes } from "../routes/workspaces";
+import { createWorkspaceRoutes } from "../routes/workspaces/index";
 import {
   createAgentConnectionManagementErrorEnvelope,
   createAgentSetupErrorEnvelope,


### PR DESCRIPTION
## Summary

- Move the backend sync route workflow into `routes/sync/` with helper modules for bootstrap details, conflict details, guest platform checks, and observation fields.
- Move the backend workspace route workflow into `routes/workspaces/` with helper modules for cursor parsing, connection access checks, and observation fields.
- Update the backend app route imports and moved test imports to use the new entrypoints.

## Validation

- `npm run lint`
- `npm run test` (`365` tests)
