### PR TITLE
[codex] Fix Android navigation back stack owners

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -43,6 +43,7 @@ import com.flashcardsopensourceapp.feature.review.reviewEmptyStateContentTag
 import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag
 import com.flashcardsopensourceapp.feature.review.reviewFilterButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateGoodButtonTag
+import com.flashcardsopensourceapp.feature.review.reviewQueueButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewShowAnswerButtonTag
 import com.flashcardsopensourceapp.feature.settings.R as SettingsR
 import com.flashcardsopensourceapp.feature.settings.deck.deckCardRowTag
@@ -267,6 +268,55 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
             composeRule.onAllNodesWithText("Updated Android card").fetchSemanticsNodes().isEmpty()
         }
         composeRule.onNodeWithText(emptyCardsMessage).fetchSemanticsNode()
+    }
+
+    @Test
+    fun nestedNavigationChildRoutesSurviveActivityRecreation() {
+        waitForCardsEmptyState()
+        createCard(
+            frontText = "Restorable navigation card",
+            backText = "Back text survives navigation recreation.",
+            tags = emptyList()
+        )
+
+        composeRule.onNodeWithText("Restorable navigation card").performClick()
+        composeRule.onNodeWithTag(cardEditorFrontSummaryCardTag).performScrollTo()
+        composeRule.onNodeWithTag(cardEditorFrontSummaryCardTag).performClick()
+        waitForTagToExist(tag = cardEditorFrontTextFieldTag)
+        recreateActivity()
+        waitForTagToExist(tag = cardEditorFrontTextFieldTag)
+        composeRule.onNodeWithTag(cardEditorFrontTextFieldTag).performTextReplacement("Restored navigation card")
+        tapVisibleBackButton()
+
+        composeRule.onNodeWithText("Tags").performClick()
+        waitForTextToExist(text = "Add a tag")
+        recreateActivity()
+        waitForTextToExist(text = "Add a tag")
+        composeRule.onNodeWithText("Add a tag").performTextInput("restored")
+        composeRule.onNodeWithText("Add tag").performClick()
+        tapVisibleBackButton()
+
+        scrollToText(text = "Save")
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodes(
+                matcher = hasClickAction().and(other = hasText("Save"))
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.onNode(
+            matcher = hasClickAction().and(other = hasText("Save"))
+        ).performClick()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithText("Search cards").fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithText("Restored navigation card").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        openReviewTabAndWaitForCard()
+        composeRule.onNodeWithTag(reviewQueueButtonTag).performClick()
+        waitForReviewPreviewCard(frontText = "Restored navigation card")
+        recreateActivity()
+        waitForReviewPreviewCard(frontText = "Restored navigation card")
+        tapVisibleBackButton()
+        waitForTagToExist(tag = reviewShowAnswerButtonTag)
     }
 
     @Test
@@ -703,8 +753,28 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         openTopLevelDestination(destinationTag = ReviewDestination.testTag)
     }
 
+    private fun openReviewTabAndWaitForCard() {
+        openReviewTab()
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(reviewQueueButtonTag).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(reviewShowAnswerButtonTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun waitForReviewPreviewCard(frontText: String) {
+        composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
+            composeRule.onAllNodesWithTag(reviewShowAnswerButtonTag).fetchSemanticsNodes().isEmpty() &&
+                composeRule.onAllNodesWithText(frontText).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
     private fun openAiTab() {
         openTopLevelDestination(destinationTag = AiDestination.testTag)
+    }
+
+    private fun recreateActivity() {
+        composeRule.activityRule.scenario.recreate()
+        composeRule.waitForIdle()
     }
 
     private fun openCardFilter() {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavHost.kt
@@ -13,6 +13,7 @@ import com.flashcardsopensourceapp.app.navigation.ai.registerAiNavGraph
 import com.flashcardsopensourceapp.app.navigation.cards.registerCardsNavGraph
 import com.flashcardsopensourceapp.app.navigation.progress.registerProgressNavGraph
 import com.flashcardsopensourceapp.app.navigation.review.ReviewPreviewDestination
+import com.flashcardsopensourceapp.app.navigation.review.ReviewRootGraph
 import com.flashcardsopensourceapp.app.navigation.review.registerReviewNavGraph
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsCurrentWorkspaceDestination
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsWorkspaceDeleteCurrentDestination
@@ -85,7 +86,7 @@ fun AppNavHost(
 
     NavHost(
         navController = navController,
-        startDestination = ReviewDestination.route
+        startDestination = ReviewRootGraph.route
     ) {
         registerReviewNavGraph(
             appGraph = appGraph,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavigationSupport.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavigationSupport.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
-import com.flashcardsopensourceapp.app.navigation.cards.CardEditorDestination
+import com.flashcardsopensourceapp.app.navigation.cards.CardEditorGraph
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsWorkspaceDecksDestination
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsWorkspaceTagsDestination
 
@@ -24,7 +24,7 @@ internal fun navigateToCardEditor(
     navController: NavHostController,
     cardId: String?
 ) {
-    navController.navigate(route = CardEditorDestination.createRoute(cardId = cardId ?: "new")) {
+    navController.navigate(route = CardEditorGraph.createRoute(cardId = cardId ?: "new")) {
         launchSingleTop = true
     }
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.AiDestination
@@ -32,202 +33,216 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
     navController: NavHostController,
     coroutineScope: CoroutineScope
 ) {
-    composable(
-        route = CardEditorDestination.routePattern,
-        arguments = listOf(navArgument(name = CardEditorDestination.routeArgument) {
+    navigation(
+        startDestination = CardEditorDestination.routePattern,
+        route = CardEditorGraph.routePattern,
+        arguments = listOf(navArgument(name = CardEditorGraph.routeArgument) {
             type = NavType.StringType
         })
-    ) { backStackEntry ->
-        val editingArgument = requireNotNull(backStackEntry.arguments?.getString(CardEditorDestination.routeArgument)) {
-            "Card editor route requires cardId."
-        }
-        val editingCardId = resolveEditingCardId(editingArgument = editingArgument)
-        val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
-            factory = createCardEditorViewModelFactory(
-                cardsRepository = appGraph.cardsRepository,
-                workspaceRepository = appGraph.workspaceRepository,
-                editingCardId = editingCardId
+    ) {
+        composable(
+            route = CardEditorDestination.routePattern,
+            arguments = listOf(navArgument(name = CardEditorDestination.routeArgument) {
+                type = NavType.StringType
+            })
+        ) { backStackEntry ->
+            val editingArgument = requireNotNull(backStackEntry.arguments?.getString(CardEditorDestination.routeArgument)) {
+                "Card editor route requires cardId."
+            }
+            val editingCardId = resolveEditingCardId(editingArgument = editingArgument)
+            val editorBackStackEntry = rememberRouteBackStackEntry(
+                navController = navController,
+                currentBackStackEntry = backStackEntry,
+                route = CardEditorGraph.createRoute(cardId = editingArgument)
             )
-        )
-        val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
-
-        CardEditorRoute(
-            uiState = uiState,
-            onOpenFrontTextEditor = {
-                navController.navigate(
-                    route = CardEditorTextDestination.createRoute(
-                        cardId = editingArgument,
-                        field = "front"
-                    )
+            val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
+                viewModelStoreOwner = editorBackStackEntry,
+                factory = createCardEditorViewModelFactory(
+                    cardsRepository = appGraph.cardsRepository,
+                    workspaceRepository = appGraph.workspaceRepository,
+                    editingCardId = editingCardId
                 )
-            },
-            onOpenBackTextEditor = {
-                navController.navigate(
-                    route = CardEditorTextDestination.createRoute(
-                        cardId = editingArgument,
-                        field = "back"
-                    )
-                )
-            },
-            onOpenTagsEditor = {
-                navController.navigate(route = CardEditorTagsDestination.createRoute(cardId = editingArgument))
-            },
-            onEditWithAi = if (editingCardId == null) {
-                null
-            } else {
-                {
-                    val handoffCardId = requireNotNull(editingCardId)
-                    coroutineScope.launch {
-                        val savedCardDraft = editorViewModel.save(editingCardId = handoffCardId)
-                        if (savedCardDraft == null) {
-                            return@launch
-                        }
+            )
+            val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
 
-                        appGraph.appHandoffCoordinator.requestAiCardHandoff(
-                            cardId = handoffCardId,
-                            frontText = savedCardDraft.frontText,
-                            backText = savedCardDraft.backText,
-                            tags = savedCardDraft.tags,
-                            effortLevel = savedCardDraft.effortLevel
+            CardEditorRoute(
+                uiState = uiState,
+                onOpenFrontTextEditor = {
+                    navController.navigate(
+                        route = CardEditorTextDestination.createRoute(
+                            cardId = editingArgument,
+                            field = "front"
                         )
-                        navigateToTopLevelDestination(
-                            navController = navController,
-                            destination = AiDestination
+                    )
+                },
+                onOpenBackTextEditor = {
+                    navController.navigate(
+                        route = CardEditorTextDestination.createRoute(
+                            cardId = editingArgument,
+                            field = "back"
                         )
-                    }
-                }
-            },
-            onRemoveTag = editorViewModel::removeTag,
-            onEffortLevelChange = editorViewModel::updateEffortLevel,
-            onSave = {
-                coroutineScope.launch {
-                    val didSave = editorViewModel.save(editingCardId = editingCardId)
-                    if (didSave != null) {
-                        withContext(Dispatchers.Main.immediate) {
-                            navController.popBackStack()
+                    )
+                },
+                onOpenTagsEditor = {
+                    navController.navigate(route = CardEditorTagsDestination.createRoute(cardId = editingArgument))
+                },
+                onEditWithAi = if (editingCardId == null) {
+                    null
+                } else {
+                    {
+                        val handoffCardId = requireNotNull(editingCardId)
+                        coroutineScope.launch {
+                            val savedCardDraft = editorViewModel.save(editingCardId = handoffCardId)
+                            if (savedCardDraft == null) {
+                                return@launch
+                            }
+
+                            appGraph.appHandoffCoordinator.requestAiCardHandoff(
+                                cardId = handoffCardId,
+                                frontText = savedCardDraft.frontText,
+                                backText = savedCardDraft.backText,
+                                tags = savedCardDraft.tags,
+                                effortLevel = savedCardDraft.effortLevel
+                            )
+                            navigateToTopLevelDestination(
+                                navController = navController,
+                                destination = AiDestination
+                            )
                         }
                     }
-                }
-            },
-            onDelete = if (editingCardId == null) {
-                null
-            } else {
-                {
+                },
+                onRemoveTag = editorViewModel::removeTag,
+                onEffortLevelChange = editorViewModel::updateEffortLevel,
+                onSave = {
                     coroutineScope.launch {
-                        val didDelete = editorViewModel.delete(editingCardId = editingCardId)
-                        if (didDelete) {
+                        val didSave = editorViewModel.save(editingCardId = editingCardId)
+                        if (didSave != null) {
                             withContext(Dispatchers.Main.immediate) {
                                 navController.popBackStack()
                             }
                         }
                     }
+                },
+                onDelete = if (editingCardId == null) {
+                    null
+                } else {
+                    {
+                        coroutineScope.launch {
+                            val didDelete = editorViewModel.delete(editingCardId = editingCardId)
+                            if (didDelete) {
+                                withContext(Dispatchers.Main.immediate) {
+                                    navController.popBackStack()
+                                }
+                            }
+                        }
+                    }
+                },
+                onBack = {
+                    navController.popBackStack()
                 }
-            },
-            onBack = {
-                navController.popBackStack()
-            }
-        )
-    }
-
-    composable(
-        route = CardEditorTextDestination.routePattern,
-        arguments = listOf(
-            navArgument(name = CardEditorTextDestination.cardIdArgument) {
-                type = NavType.StringType
-            },
-            navArgument(name = CardEditorTextDestination.fieldArgument) {
-                type = NavType.StringType
-            }
-        )
-    ) { backStackEntry ->
-        val editingArgument = requireNotNull(
-            backStackEntry.arguments?.getString(CardEditorTextDestination.cardIdArgument)
-        ) {
-            "Card text editor route requires cardId."
-        }
-        val field = requireNotNull(
-            backStackEntry.arguments?.getString(CardEditorTextDestination.fieldArgument)
-        ) {
-            "Card text editor route requires field."
-        }
-        val editorBackStackEntry = rememberRouteBackStackEntry(
-            navController = navController,
-            currentBackStackEntry = backStackEntry,
-            route = CardEditorDestination.createRoute(cardId = editingArgument)
-        )
-        val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
-            viewModelStoreOwner = editorBackStackEntry,
-            factory = createCardEditorViewModelFactory(
-                cardsRepository = appGraph.cardsRepository,
-                workspaceRepository = appGraph.workspaceRepository,
-                editingCardId = resolveEditingCardId(editingArgument = editingArgument)
             )
-        )
-        val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
-
-        CardTextEditorRoute(
-            title = if (field == "front") {
-                stringResource(id = CardsR.string.cards_front_title)
-            } else {
-                stringResource(id = CardsR.string.cards_back_title)
-            },
-            supportingText = if (field == "front") {
-                stringResource(id = CardsR.string.cards_front_supporting_text)
-            } else {
-                stringResource(id = CardsR.string.cards_back_supporting_text)
-            },
-            text = if (field == "front") uiState.frontText else uiState.backText,
-            textFieldTag = if (field == "front") {
-                cardEditorFrontTextFieldTag
-            } else {
-                cardEditorBackTextFieldTag
-            },
-            onTextChange = if (field == "front") {
-                editorViewModel::updateFrontText
-            } else {
-                editorViewModel::updateBackText
-            },
-            onBack = {
-                navController.popBackStack()
-            }
-        )
-    }
-
-    composable(
-        route = CardEditorTagsDestination.routePattern,
-        arguments = listOf(navArgument(name = CardEditorTagsDestination.routeArgument) {
-            type = NavType.StringType
-        })
-    ) { backStackEntry ->
-        val editingArgument = requireNotNull(
-            backStackEntry.arguments?.getString(CardEditorTagsDestination.routeArgument)
-        ) {
-            "Card tags route requires cardId."
         }
-        val editorBackStackEntry = rememberRouteBackStackEntry(
-            navController = navController,
-            currentBackStackEntry = backStackEntry,
-            route = CardEditorDestination.createRoute(cardId = editingArgument)
-        )
-        val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
-            viewModelStoreOwner = editorBackStackEntry,
-            factory = createCardEditorViewModelFactory(
-                cardsRepository = appGraph.cardsRepository,
-                workspaceRepository = appGraph.workspaceRepository,
-                editingCardId = resolveEditingCardId(editingArgument = editingArgument)
-            )
-        )
-        val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
 
-        CardTagsRoute(
-            uiState = uiState,
-            onToggleSuggestedTag = editorViewModel::toggleTag,
-            onAddTag = editorViewModel::addTag,
-            onRemoveTag = editorViewModel::removeTag,
-            onBack = {
-                navController.popBackStack()
+        composable(
+            route = CardEditorTextDestination.routePattern,
+            arguments = listOf(
+                navArgument(name = CardEditorTextDestination.cardIdArgument) {
+                    type = NavType.StringType
+                },
+                navArgument(name = CardEditorTextDestination.fieldArgument) {
+                    type = NavType.StringType
+                }
+            )
+        ) { backStackEntry ->
+            val editingArgument = requireNotNull(
+                backStackEntry.arguments?.getString(CardEditorTextDestination.cardIdArgument)
+            ) {
+                "Card text editor route requires cardId."
             }
-        )
+            val field = requireNotNull(
+                backStackEntry.arguments?.getString(CardEditorTextDestination.fieldArgument)
+            ) {
+                "Card text editor route requires field."
+            }
+            val editorBackStackEntry = rememberRouteBackStackEntry(
+                navController = navController,
+                currentBackStackEntry = backStackEntry,
+                route = CardEditorGraph.createRoute(cardId = editingArgument)
+            )
+            val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
+                viewModelStoreOwner = editorBackStackEntry,
+                factory = createCardEditorViewModelFactory(
+                    cardsRepository = appGraph.cardsRepository,
+                    workspaceRepository = appGraph.workspaceRepository,
+                    editingCardId = resolveEditingCardId(editingArgument = editingArgument)
+                )
+            )
+            val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
+
+            CardTextEditorRoute(
+                title = if (field == "front") {
+                    stringResource(id = CardsR.string.cards_front_title)
+                } else {
+                    stringResource(id = CardsR.string.cards_back_title)
+                },
+                supportingText = if (field == "front") {
+                    stringResource(id = CardsR.string.cards_front_supporting_text)
+                } else {
+                    stringResource(id = CardsR.string.cards_back_supporting_text)
+                },
+                text = if (field == "front") uiState.frontText else uiState.backText,
+                textFieldTag = if (field == "front") {
+                    cardEditorFrontTextFieldTag
+                } else {
+                    cardEditorBackTextFieldTag
+                },
+                onTextChange = if (field == "front") {
+                    editorViewModel::updateFrontText
+                } else {
+                    editorViewModel::updateBackText
+                },
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
+
+        composable(
+            route = CardEditorTagsDestination.routePattern,
+            arguments = listOf(navArgument(name = CardEditorTagsDestination.routeArgument) {
+                type = NavType.StringType
+            })
+        ) { backStackEntry ->
+            val editingArgument = requireNotNull(
+                backStackEntry.arguments?.getString(CardEditorTagsDestination.routeArgument)
+            ) {
+                "Card tags route requires cardId."
+            }
+            val editorBackStackEntry = rememberRouteBackStackEntry(
+                navController = navController,
+                currentBackStackEntry = backStackEntry,
+                route = CardEditorGraph.createRoute(cardId = editingArgument)
+            )
+            val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
+                viewModelStoreOwner = editorBackStackEntry,
+                factory = createCardEditorViewModelFactory(
+                    cardsRepository = appGraph.cardsRepository,
+                    workspaceRepository = appGraph.workspaceRepository,
+                    editingCardId = resolveEditingCardId(editingArgument = editingArgument)
+                )
+            )
+            val uiState by editorViewModel.uiState.collectAsStateWithLifecycle()
+
+            CardTagsRoute(
+                uiState = uiState,
+                onToggleSuggestedTag = editorViewModel::toggleTag,
+                onAddTag = editorViewModel::addTag,
+                onRemoveTag = editorViewModel::removeTag,
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
     }
 }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsDestinations.kt
@@ -1,7 +1,17 @@
 package com.flashcardsopensourceapp.app.navigation.cards
 
-data object CardEditorDestination {
+internal data object CardEditorGraph {
     const val routePrefix: String = "cards/editor"
+    const val routeArgument: String = "cardId"
+    const val routePattern: String = "$routePrefix/{$routeArgument}"
+
+    fun createRoute(cardId: String): String {
+        return "$routePrefix/$cardId"
+    }
+}
+
+data object CardEditorDestination {
+    const val routePrefix: String = "cards/editor/overview"
     const val routeArgument: String = "cardId"
     const val routePattern: String = "$routePrefix/{$routeArgument}"
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewDestinations.kt
@@ -1,5 +1,9 @@
 package com.flashcardsopensourceapp.app.navigation.review
 
+internal data object ReviewRootGraph {
+    const val route: String = "review/root"
+}
+
 data object ReviewPreviewDestination {
     const val route: String = "review/preview"
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.navigation
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.ProgressDestination
@@ -47,201 +48,222 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
         )
     }
 
-    composable(route = ReviewDestination.route) {
-        val context = LocalContext.current
-        val activity = context as? ComponentActivity
-        val notificationPermissionLauncher = rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.RequestPermission()
-        ) { isGranted ->
-            if (isGranted) {
-                handleNotificationPermissionGranted()
+    navigation(
+        startDestination = ReviewDestination.route,
+        route = ReviewRootGraph.route
+    ) {
+        composable(route = ReviewDestination.route) { backStackEntry ->
+            val context = LocalContext.current
+            val activity = context as? ComponentActivity
+            val notificationPermissionLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.RequestPermission()
+            ) { isGranted ->
+                if (isGranted) {
+                    handleNotificationPermissionGranted()
+                }
             }
-        }
-        val reviewViewModel = viewModel<com.flashcardsopensourceapp.feature.review.ReviewViewModel>(
-            factory = createReviewViewModelFactory(
-                reviewRepository = appGraph.reviewRepository,
-                progressRepository = appGraph.progressRepository,
-                autoSyncEventRepository = appGraph.autoSyncEventRepository,
-                messageController = appGraph.appMessageBus,
-                reviewNotificationsStore = appGraph.reviewNotificationsStore,
-                shouldShowNotificationPermissionPrePrompt = {
-                    hasNotificationPermission(context = context).not()
-                },
-                onReviewNotificationsChanged = { trigger ->
-                    appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
-                        trigger = trigger,
-                        nowMillis = System.currentTimeMillis()
-                    )
-                },
-                onSuccessfulReviewRecorded = { reviewedAtMillis ->
-                    appGraph.strictRemindersManager.recordSuccessfulReview(
-                        reviewedAtMillis = reviewedAtMillis,
-                        nowMillis = System.currentTimeMillis()
-                    )
-                    appGraph.guestSignInAfterReviewPromptController.requestReevaluation()
-                },
-                onStoreReviewOpportunity = {
-                    val currentActivity = appGraph.storeReviewActivityProvider.currentActivity()
-                    if (currentActivity == null) {
-                        false
-                    } else {
-                        appGraph.storeReviewRequestManager.requestStoreReviewIfEligible(
-                            activity = currentActivity
+            val reviewBackStackEntry = rememberRouteBackStackEntry(
+                navController = navController,
+                currentBackStackEntry = backStackEntry,
+                route = ReviewRootGraph.route
+            )
+            val reviewViewModel = viewModel<com.flashcardsopensourceapp.feature.review.ReviewViewModel>(
+                viewModelStoreOwner = reviewBackStackEntry,
+                factory = createReviewViewModelFactory(
+                    reviewRepository = appGraph.reviewRepository,
+                    progressRepository = appGraph.progressRepository,
+                    autoSyncEventRepository = appGraph.autoSyncEventRepository,
+                    messageController = appGraph.appMessageBus,
+                    reviewNotificationsStore = appGraph.reviewNotificationsStore,
+                    shouldShowNotificationPermissionPrePrompt = {
+                        hasNotificationPermission(context = context).not()
+                    },
+                    onReviewNotificationsChanged = { trigger ->
+                        appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
+                            trigger = trigger,
+                            nowMillis = System.currentTimeMillis()
                         )
+                    },
+                    onSuccessfulReviewRecorded = { reviewedAtMillis ->
+                        appGraph.strictRemindersManager.recordSuccessfulReview(
+                            reviewedAtMillis = reviewedAtMillis,
+                            nowMillis = System.currentTimeMillis()
+                        )
+                        appGraph.guestSignInAfterReviewPromptController.requestReevaluation()
+                    },
+                    onStoreReviewOpportunity = {
+                        val currentActivity = appGraph.storeReviewActivityProvider.currentActivity()
+                        if (currentActivity == null) {
+                            false
+                        } else {
+                            appGraph.storeReviewRequestManager.requestStoreReviewIfEligible(
+                                activity = currentActivity
+                            )
+                        }
+                    },
+                    onAutomaticFeedbackPromptCandidate = {
+                        appGraph.feedbackPromptController.requestAutomaticReevaluation()
+                    },
+                    onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
+                    reviewPreferencesStore = appGraph.reviewPreferencesStore,
+                    visibleAppScreenRepository = appGraph.visibleAppScreenController,
+                    workspaceRepository = appGraph.workspaceRepository
+                )
+            )
+            val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
+            val accountPreferences by appGraph.cloudAccountRepository.observeAccountPreferences().collectAsStateWithLifecycle(
+                initialValue = defaultAccountPreferences()
+            )
+            val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
+
+            LaunchedEffect(reviewFilterRequest?.requestId, uiState) {
+                val request = reviewFilterRequest ?: return@LaunchedEffect
+                val didSelectFilter = reviewViewModel.selectFilterForHandoff(reviewFilter = request.reviewFilter)
+                if (didSelectFilter) {
+                    appGraph.appHandoffCoordinator.consumeReviewFilter(requestId = request.requestId)
+                }
+            }
+
+            ReviewRoute(
+                uiState = uiState,
+                reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
+                reviewReactionAnimationsEnabled = accountPreferences.reviewReactionAnimationsEnabled,
+                onSelectFilter = reviewViewModel::selectFilter,
+                onOpenPreview = {
+                    navController.navigate(route = ReviewPreviewDestination.route)
+                },
+                onOpenCurrentCard = { cardId ->
+                    appGraph.appHandoffCoordinator.requestCardEditor(cardId = cardId)
+                },
+                onOpenCurrentCardWithAi = { cardId, frontText, backText, tags, effortLevel ->
+                    AiChatDiagnosticsLogger.info(
+                        event = "review_ai_handoff_requested",
+                        fields = listOf(
+                            "cardId" to cardId,
+                            "frontText" to frontText,
+                            "backTextLength" to backText.length.toString(),
+                            "tagsCount" to tags.size.toString(),
+                            "effortLevel" to effortLevel.name
+                        )
+                    )
+                    appGraph.appHandoffCoordinator.requestAiCardHandoff(
+                        cardId = cardId,
+                        frontText = frontText,
+                        backText = backText,
+                        tags = tags,
+                        effortLevel = effortLevel
+                    )
+                    navigateToTopLevelDestination(
+                        navController = navController,
+                        destination = AiDestination
+                    )
+                },
+                onOpenDeckManagement = {
+                    appGraph.appHandoffCoordinator.requestSettingsNavigation(
+                        target = SettingsNavigationTarget.WORKSPACE_DECKS
+                    )
+                },
+                onCreateCard = {
+                    appGraph.appHandoffCoordinator.requestCardEditor(cardId = null)
+                },
+                onCreateCardWithAi = {
+                    appGraph.appHandoffCoordinator.requestAiEntryPrefill(prefill = com.flashcardsopensourceapp.feature.ai.AiEntryPrefill.CREATE_CARD)
+                    navigateToTopLevelDestination(
+                        navController = navController,
+                        destination = AiDestination
+                    )
+                },
+                onSwitchToAllCards = {
+                    reviewViewModel.selectFilter(reviewFilter = ReviewFilter.AllCards)
+                },
+                onRevealAnswer = reviewViewModel::revealAnswer,
+                onRateAgain = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.AGAIN) },
+                onRateHard = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.HARD) },
+                onRateGood = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.GOOD) },
+                onRateEasy = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.EASY) },
+                onDismissHardAnswerReminder = reviewViewModel::dismissHardAnswerReminder,
+                onDismissErrorMessage = reviewViewModel::dismissErrorMessage,
+                onDismissNotificationPermissionPrompt = reviewViewModel::dismissNotificationPermissionPrompt,
+                onContinueNotificationPermissionPrompt = {
+                    reviewViewModel.continueNotificationPermissionPrompt()
+                    if (activity != null) {
+                        notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                     }
                 },
-                onAutomaticFeedbackPromptCandidate = {
-                    appGraph.feedbackPromptController.requestAutomaticReevaluation()
+                onOpenProgress = {
+                    navigateToTopLevelDestination(
+                        navController = navController,
+                        destination = ProgressDestination
+                    )
                 },
-                onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
-                reviewPreferencesStore = appGraph.reviewPreferencesStore,
-                visibleAppScreenRepository = appGraph.visibleAppScreenController,
-                workspaceRepository = appGraph.workspaceRepository
+                onScreenVisible = reviewViewModel::onScreenVisible
             )
-        )
-        val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
-        val accountPreferences by appGraph.cloudAccountRepository.observeAccountPreferences().collectAsStateWithLifecycle(
-            initialValue = defaultAccountPreferences()
-        )
-        val reviewFilterRequest by appGraph.appHandoffCoordinator.observeReviewFilter().collectAsStateWithLifecycle()
-
-        LaunchedEffect(reviewFilterRequest?.requestId, uiState) {
-            val request = reviewFilterRequest ?: return@LaunchedEffect
-            val didSelectFilter = reviewViewModel.selectFilterForHandoff(reviewFilter = request.reviewFilter)
-            if (didSelectFilter) {
-                appGraph.appHandoffCoordinator.consumeReviewFilter(requestId = request.requestId)
-            }
         }
 
-        ReviewRoute(
-            uiState = uiState,
-            reviewReactionLottieConfigurationStore = reviewReactionLottieConfigurationStore,
-            reviewReactionAnimationsEnabled = accountPreferences.reviewReactionAnimationsEnabled,
-            onSelectFilter = reviewViewModel::selectFilter,
-            onOpenPreview = {
-                navController.navigate(route = ReviewPreviewDestination.route)
-            },
-            onOpenCurrentCard = { cardId ->
-                appGraph.appHandoffCoordinator.requestCardEditor(cardId = cardId)
-            },
-            onOpenCurrentCardWithAi = { cardId, frontText, backText, tags, effortLevel ->
-                AiChatDiagnosticsLogger.info(
-                    event = "review_ai_handoff_requested",
-                    fields = listOf(
-                        "cardId" to cardId,
-                        "frontText" to frontText,
-                        "backTextLength" to backText.length.toString(),
-                        "tagsCount" to tags.size.toString(),
-                        "effortLevel" to effortLevel.name
-                    )
-                )
-                appGraph.appHandoffCoordinator.requestAiCardHandoff(
-                    cardId = cardId,
-                    frontText = frontText,
-                    backText = backText,
-                    tags = tags,
-                    effortLevel = effortLevel
-                )
-                navigateToTopLevelDestination(
-                    navController = navController,
-                    destination = AiDestination
-                )
-            },
-            onOpenDeckManagement = {
-                appGraph.appHandoffCoordinator.requestSettingsNavigation(
-                    target = SettingsNavigationTarget.WORKSPACE_DECKS
-                )
-            },
-            onCreateCard = {
-                appGraph.appHandoffCoordinator.requestCardEditor(cardId = null)
-            },
-            onCreateCardWithAi = {
-                appGraph.appHandoffCoordinator.requestAiEntryPrefill(prefill = com.flashcardsopensourceapp.feature.ai.AiEntryPrefill.CREATE_CARD)
-                navigateToTopLevelDestination(
-                    navController = navController,
-                    destination = AiDestination
-                )
-            },
-            onSwitchToAllCards = {
-                reviewViewModel.selectFilter(reviewFilter = ReviewFilter.AllCards)
-            },
-            onRevealAnswer = reviewViewModel::revealAnswer,
-            onRateAgain = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.AGAIN) },
-            onRateHard = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.HARD) },
-            onRateGood = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.GOOD) },
-            onRateEasy = { reviewViewModel.rateCard(rating = com.flashcardsopensourceapp.data.local.model.review.ReviewRating.EASY) },
-            onDismissHardAnswerReminder = reviewViewModel::dismissHardAnswerReminder,
-            onDismissErrorMessage = reviewViewModel::dismissErrorMessage,
-            onDismissNotificationPermissionPrompt = reviewViewModel::dismissNotificationPermissionPrompt,
-            onContinueNotificationPermissionPrompt = {
-                reviewViewModel.continueNotificationPermissionPrompt()
-                if (activity != null) {
-                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                }
-            },
-            onOpenProgress = {
-                navigateToTopLevelDestination(
-                    navController = navController,
-                    destination = ProgressDestination
-                )
-            },
-            onScreenVisible = reviewViewModel::onScreenVisible
-        )
-    }
-
-    composable(route = ReviewPreviewDestination.route) { backStackEntry ->
-        val reviewBackStackEntry = rememberRouteBackStackEntry(
-            navController = navController,
-            currentBackStackEntry = backStackEntry,
-            route = ReviewDestination.route
-        )
-        val reviewViewModel = viewModel<com.flashcardsopensourceapp.feature.review.ReviewViewModel>(
-            viewModelStoreOwner = reviewBackStackEntry,
-            factory = createReviewViewModelFactory(
-                reviewRepository = appGraph.reviewRepository,
-                progressRepository = appGraph.progressRepository,
-                autoSyncEventRepository = appGraph.autoSyncEventRepository,
-                messageController = appGraph.appMessageBus,
-                reviewNotificationsStore = appGraph.reviewNotificationsStore,
-                shouldShowNotificationPermissionPrePrompt = {
-                    false
-                },
-                onReviewNotificationsChanged = { trigger ->
-                    appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
-                        trigger = trigger,
-                        nowMillis = System.currentTimeMillis()
-                    )
-                },
-                onSuccessfulReviewRecorded = { reviewedAtMillis ->
-                    appGraph.strictRemindersManager.recordSuccessfulReview(
-                        reviewedAtMillis = reviewedAtMillis,
-                        nowMillis = System.currentTimeMillis()
-                    )
-                    appGraph.guestSignInAfterReviewPromptController.requestReevaluation()
-                },
-                onStoreReviewOpportunity = {
-                    false
-                },
-                onAutomaticFeedbackPromptCandidate = {},
-                onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
-                reviewPreferencesStore = appGraph.reviewPreferencesStore,
-                visibleAppScreenRepository = appGraph.visibleAppScreenController,
-                workspaceRepository = appGraph.workspaceRepository
+        composable(route = ReviewPreviewDestination.route) { backStackEntry ->
+            val context = LocalContext.current
+            val reviewBackStackEntry = rememberRouteBackStackEntry(
+                navController = navController,
+                currentBackStackEntry = backStackEntry,
+                route = ReviewRootGraph.route
             )
-        )
-        val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
+            val reviewViewModel = viewModel<com.flashcardsopensourceapp.feature.review.ReviewViewModel>(
+                viewModelStoreOwner = reviewBackStackEntry,
+                factory = createReviewViewModelFactory(
+                    reviewRepository = appGraph.reviewRepository,
+                    progressRepository = appGraph.progressRepository,
+                    autoSyncEventRepository = appGraph.autoSyncEventRepository,
+                    messageController = appGraph.appMessageBus,
+                    reviewNotificationsStore = appGraph.reviewNotificationsStore,
+                    shouldShowNotificationPermissionPrePrompt = {
+                        hasNotificationPermission(context = context).not()
+                    },
+                    onReviewNotificationsChanged = { trigger ->
+                        appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
+                            trigger = trigger,
+                            nowMillis = System.currentTimeMillis()
+                        )
+                    },
+                    onSuccessfulReviewRecorded = { reviewedAtMillis ->
+                        appGraph.strictRemindersManager.recordSuccessfulReview(
+                            reviewedAtMillis = reviewedAtMillis,
+                            nowMillis = System.currentTimeMillis()
+                        )
+                        appGraph.guestSignInAfterReviewPromptController.requestReevaluation()
+                    },
+                    onStoreReviewOpportunity = {
+                        val currentActivity = appGraph.storeReviewActivityProvider.currentActivity()
+                        if (currentActivity == null) {
+                            false
+                        } else {
+                            appGraph.storeReviewRequestManager.requestStoreReviewIfEligible(
+                                activity = currentActivity
+                            )
+                        }
+                    },
+                    onAutomaticFeedbackPromptCandidate = {
+                        appGraph.feedbackPromptController.requestAutomaticReevaluation()
+                    },
+                    onNotificationPermissionGranted = ::handleNotificationPermissionGranted,
+                    reviewPreferencesStore = appGraph.reviewPreferencesStore,
+                    visibleAppScreenRepository = appGraph.visibleAppScreenController,
+                    workspaceRepository = appGraph.workspaceRepository
+                )
+            )
+            val uiState by reviewViewModel.uiState.collectAsStateWithLifecycle()
 
-        ReviewPreviewRoute(
-            uiState = uiState,
-            onStartPreview = reviewViewModel::startPreview,
-            onLoadNextPreviewPageIfNeeded = reviewViewModel::loadNextPreviewPageIfNeeded,
-            onRetryPreview = reviewViewModel::retryPreview,
-            onOpenCard = { cardId ->
-                appGraph.appHandoffCoordinator.requestCardEditor(cardId = cardId)
-            },
-            onBack = {
-                navController.popBackStack()
-            }
-        )
+            ReviewPreviewRoute(
+                uiState = uiState,
+                onStartPreview = reviewViewModel::startPreview,
+                onLoadNextPreviewPageIfNeeded = reviewViewModel::loadNextPreviewPageIfNeeded,
+                onRetryPreview = reviewViewModel::retryPreview,
+                onOpenCard = { cardId ->
+                    appGraph.appHandoffCoordinator.requestCardEditor(cardId = cardId)
+                },
+                onBack = {
+                    navController.popBackStack()
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add real parent navigation graphs for the Android card editor and review preview flows
- make shared card editor and review ViewModels use graph-owned back stack entries instead of sibling destination entries
- add an instrumentation regression covering recreation on card text editor, card tags editor, and review preview

## Validation
- `git --no-pager diff --check --cached`
- Gradle was not run locally per repository policy; narrow follow-up command from `apps/android/`: `./gradlew --no-daemon :app:connectedDebugAndroidTest`