### PR TITLE
[codex] Refresh Android review preview on open

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
@@ -28,8 +28,8 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.activity.getString(resourceId)
 
     @Test
-    fun loadingStateStartsPreviewWithoutShowingEmptyOrErrorState() {
-        var startPreviewCalls = 0
+    fun loadingStateEnsuresPreviewStartedWithoutShowingEmptyOrErrorState() {
+        var ensurePreviewStartedCalls = 0
         val emptyTitle = reviewString(ReviewStringResources.string.review_preview_empty_title)
 
         composeRule.setContent {
@@ -63,8 +63,8 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isNotificationPermissionPromptVisible = false,
                         isHardAnswerReminderVisible = false
                     ),
-                    onStartPreview = {
-                        startPreviewCalls += 1
+                    onEnsurePreviewStarted = {
+                        ensurePreviewStartedCalls += 1
                     },
                     onLoadNextPreviewPageIfNeeded = {},
                     onRetryPreview = {},
@@ -75,7 +75,7 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         }
 
         composeRule.waitUntil(timeoutMillis = 5_000L) {
-            startPreviewCalls == 1
+            ensurePreviewStartedCalls == 1
         }
         composeRule.onNodeWithText("All cards").assertIsDisplayed()
         assertEquals(
@@ -86,7 +86,7 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
             0,
             composeRule.onAllNodesWithText("Queue couldn't be loaded").fetchSemanticsNodes().size
         )
-        assertEquals(1, startPreviewCalls)
+        assertEquals(1, ensurePreviewStartedCalls)
     }
 
     @Test
@@ -125,7 +125,7 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isNotificationPermissionPromptVisible = false,
                         isHardAnswerReminderVisible = false
                     ),
-                    onStartPreview = {},
+                    onEnsurePreviewStarted = {},
                     onLoadNextPreviewPageIfNeeded = {},
                     onRetryPreview = {},
                     onOpenCard = {},
@@ -173,7 +173,7 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isNotificationPermissionPromptVisible = false,
                         isHardAnswerReminderVisible = false
                     ),
-                    onStartPreview = {},
+                    onEnsurePreviewStarted = {},
                     onLoadNextPreviewPageIfNeeded = {},
                     onRetryPreview = {
                         retryCalls += 1

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
@@ -145,7 +145,7 @@ class RtlLayoutTest : FirebaseAppInstrumentationTimeoutTest() {
                     isNotificationPermissionPromptVisible = false,
                     isHardAnswerReminderVisible = false
                 ),
-                onStartPreview = {},
+                onEnsurePreviewStarted = {},
                 onLoadNextPreviewPageIfNeeded = { _ -> },
                 onRetryPreview = {},
                 onOpenCard = { _ -> },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -130,6 +130,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                 reviewReactionAnimationsEnabled = accountPreferences.reviewReactionAnimationsEnabled,
                 onSelectFilter = reviewViewModel::selectFilter,
                 onOpenPreview = {
+                    reviewViewModel.refreshPreview()
                     navController.navigate(route = ReviewPreviewDestination.route)
                 },
                 onOpenCurrentCard = { cardId ->
@@ -254,7 +255,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
 
             ReviewPreviewRoute(
                 uiState = uiState,
-                onStartPreview = reviewViewModel::startPreview,
+                onEnsurePreviewStarted = reviewViewModel::ensurePreviewStarted,
                 onLoadNextPreviewPageIfNeeded = reviewViewModel::loadNextPreviewPageIfNeeded,
                 onRetryPreview = reviewViewModel::retryPreview,
                 onOpenCard = { cardId ->

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewViewModel.kt
@@ -240,14 +240,18 @@ class ReviewViewModel(
         onNotificationPermissionGranted()
     }
 
-    fun startPreview() {
+    fun refreshPreview() {
+        draftState.update(::applyStartReviewPreview)
+        loadPreviewPage(offset = 0, replaceCards = true)
+    }
+
+    fun ensurePreviewStarted() {
         val currentState = draftState.value
-        if (shouldStartReviewPreview(state = currentState).not()) {
+        if (shouldEnsureReviewPreviewStarted(state = currentState).not()) {
             return
         }
 
-        draftState.update(::applyStartReviewPreview)
-        loadPreviewPage(offset = 0, replaceCards = true)
+        refreshPreview()
     }
 
     fun loadNextPreviewPageIfNeeded(itemCardId: String) {
@@ -269,7 +273,7 @@ class ReviewViewModel(
     }
 
     fun retryPreview() {
-        startPreview()
+        refreshPreview()
     }
 
     fun rateCard(rating: ReviewRating) {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/preview/ReviewPreviewPaging.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/preview/ReviewPreviewPaging.kt
@@ -4,8 +4,10 @@ import com.flashcardsopensourceapp.data.local.model.review.ReviewTimelinePage
 
 internal const val reviewPreviewPageSize: Int = 20
 
-internal fun shouldStartReviewPreview(state: ReviewDraftState): Boolean {
-    return state.isPreviewLoading.not()
+internal fun shouldEnsureReviewPreviewStarted(state: ReviewDraftState): Boolean {
+    return state.isPreviewLoading.not() &&
+        state.previewCards.isEmpty() &&
+        state.previewErrorMessage.isEmpty()
 }
 
 internal fun applyStartReviewPreview(state: ReviewDraftState): ReviewDraftState {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/preview/ReviewPreviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/preview/ReviewPreviewRoute.kt
@@ -28,14 +28,14 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun ReviewPreviewRoute(
     uiState: ReviewUiState,
-    onStartPreview: () -> Unit,
+    onEnsurePreviewStarted: () -> Unit,
     onLoadNextPreviewPageIfNeeded: (String) -> Unit,
     onRetryPreview: () -> Unit,
     onOpenCard: (String) -> Unit,
     onBack: () -> Unit
 ) {
     LaunchedEffect(Unit) {
-        onStartPreview()
+        onEnsurePreviewStarted()
     }
 
     Scaffold(


### PR DESCRIPTION
## Summary
- refresh the Android review preview before navigating from the review screen
- keep the preview route as an idempotent ensure-start entry point
- update instrumentation callers for the renamed preview callback

## Validation
- `rg` found no remaining stale `onStartPreview` references
- `git diff --check` passed
- Gradle was not run per repository policy