### PR TITLE
[codex] Harden Android settings row scroll tests

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/MainActivityTest.kt
@@ -862,6 +862,7 @@ class MainActivityTest : FirebaseAppInstrumentationTimeoutTest() {
         composeRule.waitUntil(timeoutMillis = uiTimeoutMillis) {
             composeRule.onAllNodes(matcher = rowMatcher).fetchSemanticsNodes().isNotEmpty()
         }
+        composeRule.onNode(matcher = rowMatcher).performScrollTo()
         composeRule.onNode(matcher = rowMatcher).assertIsDisplayed()
         composeRule.onNode(matcher = rowMatcher).performClick()
         composeRule.waitForIdle()

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTextReplacement
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickNode
@@ -89,6 +90,7 @@ internal fun LiveSmokeContext.openSettingsRow(rowTag: String, rowLabel: String) 
         timeoutMillis = internalUiTimeoutMillis,
         context = "while waiting for settings row '$rowLabel'"
     )
+    composeRule.onNodeWithTag(testTag = rowTag).performScrollTo()
     clickNode(matcher = rowMatcher, label = rowLabel)
 }
 


### PR DESCRIPTION
## Summary
- Ensure settings row helpers scroll the target row itself before asserting and clicking.
- Apply the same hardening to the live smoke settings navigation helper.

## Root cause
Firebase Test Lab showed the Export row flow could land the settings list below the target row after performScrollToNode, so the destination screen was never opened.

## Validation
- git diff --cached --check before commit
- inspected Firebase Test Lab matrix matrix-2ujbc0xdasi3e and downloaded artifacts
- local Gradle not run because this repository requires explicit permission for ./gradlew