### PR TITLE
[codex] Fix Android Test Lab smoke failures

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/diagnostics/LiveSmokeDiagnostics.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/diagnostics/LiveSmokeDiagnostics.kt
@@ -1,6 +1,5 @@
 package com.flashcardsopensourceapp.app.livesmoke.diagnostics
 
-import android.os.ParcelFileDescriptor
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
@@ -16,7 +15,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
@@ -27,8 +25,7 @@ import com.flashcardsopensourceapp.app.livesmoke.support.systemDialogAlertTitleR
 import com.flashcardsopensourceapp.app.livesmoke.support.systemDialogCloseAppButtonResourceId
 import com.flashcardsopensourceapp.app.livesmoke.support.systemDialogWaitButtonResourceId
 import com.flashcardsopensourceapp.app.livesmoke.support.deleteCurrentWorkspaceErrorMessageOrNull
-import java.io.BufferedReader
-import java.io.InputStreamReader
+import java.io.ByteArrayOutputStream
 import java.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -97,10 +94,11 @@ private fun formatSemanticsNode(node: SemanticsNode, depth: Int): String {
 }
 
 private fun LiveSmokeContext.captureWindowHierarchy(): String {
-    val dumpPath: String = "/sdcard/Download/flashcards-live-smoke-window-hierarchy.xml"
     return try {
-        val command: String = "uiautomator dump $dumpPath >/dev/null 2>&1 && cat $dumpPath"
-        runShellCommand(command = command).ifBlank { "<empty window hierarchy dump>" }
+        val outputStream = ByteArrayOutputStream()
+        device.dumpWindowHierarchy(outputStream)
+        String(outputStream.toByteArray(), Charsets.UTF_8)
+            .ifBlank { "<empty window hierarchy dump>" }
     } catch (error: Throwable) {
         "<window hierarchy capture failed: ${error.message}>"
     }
@@ -394,15 +392,6 @@ internal fun LiveSmokeContext.dismissExternalSystemDialogIfPresent(): String? {
 
 internal fun LiveSmokeContext.currentBlockingSystemDialogSummaryOrNull(): String? {
     return device.currentBlockingSystemDialogSummaryOrNull()
-}
-
-private fun runShellCommand(command: String): String {
-    val shellOutput = InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(command)
-    ParcelFileDescriptor.AutoCloseInputStream(shellOutput).use { inputStream ->
-        BufferedReader(InputStreamReader(inputStream)).use { reader ->
-            return reader.readText()
-        }
-    }
 }
 
 internal fun LiveSmokeContext.scrollToText(text: String) {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeAuthFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeAuthFlows.kt
@@ -29,41 +29,71 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
 private const val linkedSignInTimeoutMillis: Long = 120_000L
+private const val sendCodeAttemptLimit: Int = 3
+private const val sendCodeAttemptTimeoutMillis: Long = 120_000L
 private const val cloudPostAuthLinkingWorkspaceTitle: String = "Linking workspace"
 private const val cloudPostAuthSyncingWorkspaceTitle: String = "Syncing workspace"
 private const val cloudPostAuthGuestUpgradeTitle: String = "Upgrading guest account"
 private const val cloudPostAuthRetryButtonText: String = "Retry"
 private const val accountStatusSyncNowButtonText: String = "Sync now"
+private const val cloudSignInSendCodeTransportFailedText: String =
+    "We could not confirm that the code was sent. Check your connection and try again."
+private const val cloudSignInSendCodeFailedText: String = "Could not send the sign-in code."
+
+private enum class CloudSignInSendCodeOutcome {
+    READY,
+    SEND_CODE_FAILED
+}
 
 internal fun LiveSmokeContext.signInWithReviewAccount(reviewEmail: String) {
     openSettingsRow(rowTag = settingsAccountStatusRowTag, rowLabel = "Account status")
     clickText(text = "Sign in or sign up", substring = false)
     composeRule.onNodeWithTag(cloudSignInEmailFieldTag).performTextInput(reviewEmail)
-    clickTag(tag = cloudSignInSendCodeButtonTag, label = "Send code")
+    sendReviewAccountCodeWithRetries()
 
-    waitForCloudSignInSurface()
     completeCloudPostAuthWorkspaceSelectionIfNeeded()
     waitForLinkedAccountStatusAfterSignIn()
     tapBackIcon()
     tapBackIcon()
 }
 
-private fun LiveSmokeContext.waitForCloudSignInSurface() {
+private fun LiveSmokeContext.sendReviewAccountCodeWithRetries() {
+    var attemptNumber: Int = 1
+    while (attemptNumber <= sendCodeAttemptLimit) {
+        clickTag(tag = cloudSignInSendCodeButtonTag, label = "Send code")
+        when (waitForCloudSignInSendCodeOutcome()) {
+            CloudSignInSendCodeOutcome.READY -> return
+            CloudSignInSendCodeOutcome.SEND_CODE_FAILED -> {
+                if (attemptNumber < sendCodeAttemptLimit) {
+                    System.err.println(
+                        "event=android_live_smoke_send_code_retry level=warning " +
+                            "attempt=$attemptNumber maxAttempts=$sendCodeAttemptLimit"
+                    )
+                }
+            }
+        }
+        attemptNumber += 1
+    }
+
+    throw AssertionError(
+        "Sign-in send-code failed after $sendCodeAttemptLimit attempts. " +
+            "CloudSettings=${currentCloudSettingsSummary()} " +
+            "CurrentWorkspace=${currentWorkspaceSummaryOrNull()} " +
+            "SystemDialog=${currentBlockingSystemDialogSummaryOrNull()}"
+    )
+}
+
+private fun LiveSmokeContext.waitForCloudSignInSendCodeOutcome(): CloudSignInSendCodeOutcome {
     try {
         waitUntilWithMitigation(
-            timeoutMillis = linkedSignInTimeoutMillis,
-            context = "while waiting for sign-in to reach account status or post-auth sync"
+            timeoutMillis = sendCodeAttemptTimeoutMillis,
+            context = "while waiting for sign-in send-code outcome"
         ) {
-            hasVisibleText(text = accountStatusSyncNowButtonText, substring = false) ||
-                hasVisibleText(text = cloudSyncChooserPrompt, substring = false) ||
-                hasVisibleText(text = cloudPostAuthLinkingWorkspaceTitle, substring = false) ||
-                hasVisibleText(text = cloudPostAuthSyncingWorkspaceTitle, substring = false) ||
-                hasVisibleText(text = cloudPostAuthGuestUpgradeTitle, substring = false) ||
-                hasVisibleText(text = cloudPostAuthRetryButtonText, substring = false)
+            isCloudSignInReadySurfaceVisible() || isCloudSignInSendCodeErrorVisible()
         }
     } catch (error: Throwable) {
         throw AssertionError(
-            "Sign-in did not reach account status or post-auth sync. " +
+            "Sign-in send-code did not reach a terminal outcome. " +
                 "CloudSettings=${currentCloudSettingsSummary()} " +
                 "CurrentWorkspace=${currentWorkspaceSummaryOrNull()} " +
                 "VisibleRows=${captureVisibleWorkspaceRows(rowTag = cloudPostAuthWorkspaceRowTag)} " +
@@ -71,6 +101,26 @@ private fun LiveSmokeContext.waitForCloudSignInSurface() {
             error
         )
     }
+
+    return if (isCloudSignInReadySurfaceVisible()) {
+        CloudSignInSendCodeOutcome.READY
+    } else {
+        CloudSignInSendCodeOutcome.SEND_CODE_FAILED
+    }
+}
+
+private fun LiveSmokeContext.isCloudSignInReadySurfaceVisible(): Boolean {
+    return hasVisibleText(text = accountStatusSyncNowButtonText, substring = false) ||
+        hasVisibleText(text = cloudSyncChooserPrompt, substring = false) ||
+        hasVisibleText(text = cloudPostAuthLinkingWorkspaceTitle, substring = false) ||
+        hasVisibleText(text = cloudPostAuthSyncingWorkspaceTitle, substring = false) ||
+        hasVisibleText(text = cloudPostAuthGuestUpgradeTitle, substring = false) ||
+        hasVisibleText(text = cloudPostAuthRetryButtonText, substring = false)
+}
+
+private fun LiveSmokeContext.isCloudSignInSendCodeErrorVisible(): Boolean {
+    return hasVisibleText(text = cloudSignInSendCodeTransportFailedText, substring = false) ||
+        hasVisibleText(text = cloudSignInSendCodeFailedText, substring = false)
 }
 
 private fun LiveSmokeContext.completeCloudPostAuthWorkspaceSelectionIfNeeded() {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
@@ -61,6 +61,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
+private const val linkedWorkspaceMutationTimeoutMillis: Long = 120_000L
+
 private enum class DeletePreviewResolution {
     PREVIEW_READY,
     ERROR_VISIBLE
@@ -102,15 +104,17 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
     clickTag(tag = currentWorkspaceCreateButtonTag, label = "Create new workspace")
     val createdWorkspaceSelection: LinkedWorkspaceSelectionSnapshot = waitForLinkedWorkspaceSelectionToChange(
         previousWorkspaceId = selectedWorkspaceIdBeforeCreate,
-        timeoutMillis = externalUiTimeoutMillis,
+        timeoutMillis = linkedWorkspaceMutationTimeoutMillis,
         context = "after creating a linked workspace"
     )
     waitForSelectedWorkspaceSummaryToChange(
         beforeSummary = selectedWorkspaceSummaryBeforeCreate,
         context = "after creating a linked workspace",
-        timeoutMillis = externalUiTimeoutMillis
+        timeoutMillis = linkedWorkspaceMutationTimeoutMillis
     )
-    waitForCurrentWorkspaceOperationToFinish()
+    waitForCurrentWorkspaceOperationToFinish(
+        timeoutMillis = linkedWorkspaceMutationTimeoutMillis
+    )
     waitForCurrentWorkspaceRenameReady(
         expectedWorkspaceName = workspaceName,
         requireExpectedWorkspaceName = false,
@@ -118,10 +122,13 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
     )
     composeRule.onNodeWithTag(currentWorkspaceNameFieldTag).performTextReplacement(workspaceName)
     clickTag(tag = currentWorkspaceSaveNameButtonTag, label = "Save workspace name")
-    waitForCurrentWorkspaceRenameOutcome(expectedWorkspaceName = workspaceName)
+    waitForCurrentWorkspaceRenameOutcome(
+        expectedWorkspaceName = workspaceName,
+        timeoutMillis = linkedWorkspaceMutationTimeoutMillis
+    )
     val renamedWorkspaceSelection: LinkedWorkspaceSelectionSnapshot = waitForLinkedWorkspaceName(
         expectedWorkspaceName = workspaceName,
-        timeoutMillis = externalUiTimeoutMillis,
+        timeoutMillis = linkedWorkspaceMutationTimeoutMillis,
         context = "after renaming the linked workspace"
     )
     tapBackIcon()
@@ -379,11 +386,11 @@ private fun LiveSmokeContext.tapDeleteWorkspaceConfirmation(workspaceName: Strin
     }
 }
 
-private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToFinish() {
-    waitForCurrentWorkspaceOperationToLeaveSwitchingState()
+private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToFinish(timeoutMillis: Long) {
+    waitForCurrentWorkspaceOperationToLeaveSwitchingState(timeoutMillis = timeoutMillis)
     try {
         waitUntilWithMitigation(
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = timeoutMillis,
             context = "while waiting for current workspace operation to finish"
         ) {
             currentWorkspaceOperationMessageOrNull() == null &&
@@ -402,10 +409,12 @@ private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToFinish() {
     }
 }
 
-private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToLeaveSwitchingState() {
+private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToLeaveSwitchingState(
+    timeoutMillis: Long
+) {
     try {
         waitUntilWithMitigation(
-            timeoutMillis = internalUiTimeoutMillis,
+            timeoutMillis = timeoutMillis,
             context = "while waiting for current workspace operation to leave switching"
         ) {
             currentWorkspaceOperationMessageOrNull()
@@ -425,10 +434,13 @@ private fun LiveSmokeContext.waitForCurrentWorkspaceOperationToLeaveSwitchingSta
     }
 }
 
-private fun LiveSmokeContext.waitForCurrentWorkspaceRenameOutcome(expectedWorkspaceName: String) {
+private fun LiveSmokeContext.waitForCurrentWorkspaceRenameOutcome(
+    expectedWorkspaceName: String,
+    timeoutMillis: Long
+) {
     try {
         waitUntilWithMitigation(
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = timeoutMillis,
             context = "while waiting for workspace rename to persist"
         ) {
             currentWorkspaceNameFieldValueOrNull() == expectedWorkspaceName &&

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsScreen.kt
@@ -69,7 +69,13 @@ internal fun SettingsScreenScaffold(
             )
         }
     ) { innerPadding ->
-        content(innerPadding)
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues = innerPadding)
+        ) {
+            content(PaddingValues(all = 0.dp))
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- keep settings screens below the top app bar so Compose scroll actions do not hide target rows under chrome
- capture live-smoke window hierarchy through the existing UiDevice instead of spawning a nested uiautomator shell command
- add bounded retry for Android live-smoke sign-in code send failures
- use a scoped longer timeout for linked workspace create/rename/switch cloud mutations

## Validation
- git diff --check
- Gradle was not run locally because this repository requires explicit approval for local ./gradlew runs

## Root cause
Firebase Test Lab exposed three independent issues: settings rows could be scrolled beneath the top app bar, diagnostic shell dumps could conflict with the active UiAutomation service, and live-smoke cloud operations needed explicit handling for external latency or transient send-code transport failures.