### PR TITLE
Split Android cards feature packages

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardEditorNavGraph.kt
@@ -14,13 +14,14 @@ import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.AiDestination
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.rememberRouteBackStackEntry
-import com.flashcardsopensourceapp.feature.cards.CardEditorRoute
-import com.flashcardsopensourceapp.feature.cards.CardTagsRoute
-import com.flashcardsopensourceapp.feature.cards.CardTextEditorRoute
 import com.flashcardsopensourceapp.feature.cards.R as CardsR
 import com.flashcardsopensourceapp.feature.cards.cardEditorBackTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.cardEditorFrontTextFieldTag
 import com.flashcardsopensourceapp.feature.cards.createCardEditorViewModelFactory
+import com.flashcardsopensourceapp.feature.cards.editor.CardEditorRoute
+import com.flashcardsopensourceapp.feature.cards.editor.CardEditorViewModel
+import com.flashcardsopensourceapp.feature.cards.editor.CardTagsRoute
+import com.flashcardsopensourceapp.feature.cards.editor.CardTextEditorRoute
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -55,7 +56,7 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 currentBackStackEntry = backStackEntry,
                 route = CardEditorGraph.createRoute(cardId = editingArgument)
             )
-            val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
+            val editorViewModel = viewModel<CardEditorViewModel>(
                 viewModelStoreOwner = editorBackStackEntry,
                 factory = createCardEditorViewModelFactory(
                     cardsRepository = appGraph.cardsRepository,
@@ -169,7 +170,7 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 currentBackStackEntry = backStackEntry,
                 route = CardEditorGraph.createRoute(cardId = editingArgument)
             )
-            val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
+            val editorViewModel = viewModel<CardEditorViewModel>(
                 viewModelStoreOwner = editorBackStackEntry,
                 factory = createCardEditorViewModelFactory(
                     cardsRepository = appGraph.cardsRepository,
@@ -223,7 +224,7 @@ internal fun NavGraphBuilder.registerCardEditorNavGraph(
                 currentBackStackEntry = backStackEntry,
                 route = CardEditorGraph.createRoute(cardId = editingArgument)
             )
-            val editorViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardEditorViewModel>(
+            val editorViewModel = viewModel<CardEditorViewModel>(
                 viewModelStoreOwner = editorBackStackEntry,
                 factory = createCardEditorViewModelFactory(
                     cardsRepository = appGraph.cardsRepository,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/cards/CardsRootNavGraph.kt
@@ -8,8 +8,9 @@ import androidx.navigation.compose.composable
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.CardsDestination
 import com.flashcardsopensourceapp.app.navigation.SettingsNavigationTarget
-import com.flashcardsopensourceapp.feature.cards.CardsRoute
 import com.flashcardsopensourceapp.feature.cards.createCardsViewModelFactory
+import com.flashcardsopensourceapp.feature.cards.list.CardsRoute
+import com.flashcardsopensourceapp.feature.cards.list.CardsViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -18,7 +19,7 @@ internal fun NavGraphBuilder.registerCardsRootDestination(
     coroutineScope: CoroutineScope
 ) {
     composable(route = CardsDestination.route) {
-        val cardsViewModel = viewModel<com.flashcardsopensourceapp.feature.cards.CardsViewModel>(
+        val cardsViewModel = viewModel<CardsViewModel>(
             factory = createCardsViewModelFactory(
                 cardsRepository = appGraph.cardsRepository,
                 workspaceRepository = appGraph.workspaceRepository,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsTestTags.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsTestTags.kt
@@ -1,0 +1,21 @@
+package com.flashcardsopensourceapp.feature.cards
+
+import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+
+const val cardsCardRowTag: String = "cards_card_row"
+const val cardsCardFrontTextTag: String = "cards_card_front_text"
+const val cardsSearchFieldTag: String = "cards_search_field"
+const val cardsEmptyStateTag: String = "cards_empty_state"
+const val cardsAddCardButtonTag: String = "cards_add_card_button"
+const val cardEditorFrontSummaryCardTag: String = "card_editor_front_summary_card"
+const val cardEditorBackSummaryCardTag: String = "card_editor_back_summary_card"
+const val cardEditorTagsSummaryCardTag: String = "card_editor_tags_summary_card"
+const val cardEditorSaveButtonTag: String = "card_editor_save_button"
+const val cardEditorFrontTextFieldTag: String = "card_editor_front_text_field"
+const val cardEditorBackTextFieldTag: String = "card_editor_back_text_field"
+const val cardTagsInputFieldTag: String = "card_tags_input_field"
+const val cardTagsAddButtonTag: String = "card_tags_add_button"
+
+fun cardEditorEffortLevelTag(effortLevel: EffortLevel): String {
+    return "card_editor_effort_${effortLevel.name.lowercase()}"
+}

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsViewModelFactories.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/CardsViewModelFactories.kt
@@ -1,0 +1,58 @@
+package com.flashcardsopensourceapp.feature.cards
+
+import android.app.Application
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.flashcardsopensourceapp.core.ui.TransientMessageController
+import com.flashcardsopensourceapp.core.ui.VisibleAppScreenRepository
+import com.flashcardsopensourceapp.data.local.repository.CardsRepository
+import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
+import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncEventRepository
+import com.flashcardsopensourceapp.feature.cards.editor.CardEditorViewModel
+import com.flashcardsopensourceapp.feature.cards.list.CardsViewModel
+
+fun createCardsViewModelFactory(
+    cardsRepository: CardsRepository,
+    workspaceRepository: WorkspaceRepository,
+    autoSyncEventRepository: AutoSyncEventRepository,
+    messageController: TransientMessageController,
+    visibleAppScreenRepository: VisibleAppScreenRepository
+): ViewModelProvider.Factory {
+    return viewModelFactory {
+        initializer {
+            val application = requireApplication()
+            CardsViewModel(
+                cardsRepository = cardsRepository,
+                autoSyncEventRepository = autoSyncEventRepository,
+                messageController = messageController,
+                visibleAppScreenRepository = visibleAppScreenRepository,
+                workspaceRepository = workspaceRepository,
+                textProvider = cardsTextProvider(context = application)
+            )
+        }
+    }
+}
+
+fun createCardEditorViewModelFactory(
+    cardsRepository: CardsRepository,
+    workspaceRepository: WorkspaceRepository,
+    editingCardId: String?
+): ViewModelProvider.Factory {
+    return viewModelFactory {
+        initializer {
+            val application = requireApplication()
+            CardEditorViewModel(
+                cardsRepository = cardsRepository,
+                workspaceRepository = workspaceRepository,
+                editingCardId = editingCardId,
+                textProvider = cardsTextProvider(context = application)
+            )
+        }
+    }
+}
+
+private fun CreationExtras.requireApplication(): Application {
+    return checkNotNull(this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
+}

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorComponents.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorComponents.kt
@@ -1,0 +1,47 @@
+package com.flashcardsopensourceapp.feature.cards.editor
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Card
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun NavigationSummaryCard(
+    modifier: Modifier,
+    title: String,
+    summary: String,
+    supportingText: String,
+    icon: @Composable () -> Unit,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+    ) {
+        ListItem(
+            headlineContent = {
+                Text(title)
+            },
+            supportingContent = {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Text(summary)
+                    Text(
+                        text = supportingText,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            },
+            leadingContent = icon
+        )
+    }
+}

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorDraft.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorDraft.kt
@@ -1,0 +1,23 @@
+package com.flashcardsopensourceapp.feature.cards.editor
+
+import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
+import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+
+internal fun buildCardEditorDraft(
+    frontText: String,
+    backText: String,
+    selectedTags: List<String>,
+    effortLevel: EffortLevel,
+    referenceTags: List<String>
+): CardDraft {
+    return CardDraft(
+        frontText = frontText.trim(),
+        backText = backText.trim(),
+        tags = normalizeTags(
+            values = selectedTags,
+            referenceTags = referenceTags
+        ),
+        effortLevel = effortLevel
+    )
+}

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.editor
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,6 +36,15 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+import com.flashcardsopensourceapp.feature.cards.R
+import com.flashcardsopensourceapp.feature.cards.cardEditorBackSummaryCardTag
+import com.flashcardsopensourceapp.feature.cards.cardEditorEffortLevelTag
+import com.flashcardsopensourceapp.feature.cards.cardEditorFrontSummaryCardTag
+import com.flashcardsopensourceapp.feature.cards.cardEditorSaveButtonTag
+import com.flashcardsopensourceapp.feature.cards.cardEditorTagsSummaryCardTag
+import com.flashcardsopensourceapp.feature.cards.formatCardsEffortLevelTitle
+import com.flashcardsopensourceapp.feature.cards.formatCardsTagSelectionSummary
+import com.flashcardsopensourceapp.feature.cards.formatCardsTextPreview
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorUiState.kt
@@ -1,17 +1,7 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.editor
 
-import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
-import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
-
-data class CardsUiState(
-    val isLoading: Boolean,
-    val searchQuery: String,
-    val activeFilter: CardFilter,
-    val availableTagSuggestions: List<WorkspaceTagSummary>,
-    val cards: List<CardSummary>
-)
 
 data class CardEditorUiState(
     val isLoading: Boolean,

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorViewModel.kt
@@ -1,209 +1,24 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.editor
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.viewmodel.CreationExtras
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
-import com.flashcardsopensourceapp.core.ui.TransientMessageController
-import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
-import com.flashcardsopensourceapp.core.ui.VisibleAppScreenRepository
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
-import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
-import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
-import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncCompletion
-import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncEvent
-import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncEventRepository
-import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncOutcome
-import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncRequest
 import com.flashcardsopensourceapp.data.local.repository.CardsRepository
 import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.flashcardsopensourceapp.feature.cards.CardsTextProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-
-@OptIn(ExperimentalCoroutinesApi::class)
-class CardsViewModel(
-    private val cardsRepository: CardsRepository,
-    private val autoSyncEventRepository: AutoSyncEventRepository,
-    private val messageController: TransientMessageController,
-    visibleAppScreenRepository: VisibleAppScreenRepository,
-    workspaceRepository: WorkspaceRepository,
-    private val textProvider: CardsTextProvider
-) : ViewModel() {
-    private val searchQuery = MutableStateFlow(value = "")
-    private val activeFilter = MutableStateFlow(
-        value = CardFilter(
-            tags = emptyList(),
-            effort = emptyList()
-        )
-    )
-
-    private val cardsFlow = combine(
-        searchQuery,
-        activeFilter
-    ) { query, filter ->
-        query to filter
-    }.flatMapLatest { (query, filter) ->
-        cardsRepository.observeCards(
-            searchQuery = query,
-            filter = filter
-        )
-    }
-    private val visibleAppScreenState = visibleAppScreenRepository.observeVisibleAppScreen().stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
-        initialValue = VisibleAppScreen.OTHER
-    )
-    private var pendingAutoSyncRequestId: String? = null
-    private var cardsSignatureAtAutoSyncStart: CardsVisibleSignature? = null
-    private var lastVisibleAutoSyncChangeSignature: CardsVisibleSignature? = null
-
-    val uiState: StateFlow<CardsUiState> = combine(
-        cardsFlow,
-        workspaceRepository.observeWorkspaceTagsSummary(),
-        searchQuery,
-        activeFilter
-    ) { cards, tagsSummary, query, filter ->
-        CardsUiState(
-            isLoading = false,
-            searchQuery = query,
-            activeFilter = filter,
-            availableTagSuggestions = tagsSummary.tags,
-            cards = cards
-        )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
-        initialValue = CardsUiState(
-            isLoading = true,
-            searchQuery = "",
-            activeFilter = CardFilter(tags = emptyList(), effort = emptyList()),
-            availableTagSuggestions = emptyList(),
-            cards = emptyList()
-        )
-    )
-
-    init {
-        observeAutoSyncDrivenCardsChanges()
-    }
-
-    fun updateSearchQuery(query: String) {
-        searchQuery.value = query
-    }
-
-    fun applyFilter(filter: CardFilter) {
-        activeFilter.value = filter
-    }
-
-    fun clearFilter() {
-        activeFilter.value = CardFilter(
-            tags = emptyList(),
-            effort = emptyList()
-        )
-    }
-
-    private fun observeAutoSyncDrivenCardsChanges() {
-        viewModelScope.launch {
-            autoSyncEventRepository.observeAutoSyncEvents().collect { event ->
-                when (event) {
-                    is AutoSyncEvent.Requested -> {
-                        handleAutoSyncRequested(request = event.request)
-                    }
-
-                    is AutoSyncEvent.Completed -> {
-                        handleAutoSyncCompleted(completion = event.completion)
-                    }
-                }
-            }
-        }
-    }
-
-    private fun handleAutoSyncRequested(request: AutoSyncRequest) {
-        if (request.allowsVisibleChangeMessage.not()) {
-            return
-        }
-        if (visibleAppScreenState.value != VisibleAppScreen.CARDS) {
-            return
-        }
-
-        pendingAutoSyncRequestId = request.requestId
-        cardsSignatureAtAutoSyncStart = buildCardsVisibleSignature(uiState = uiState.value)
-    }
-
-    private fun handleAutoSyncCompleted(completion: AutoSyncCompletion) {
-        if (completion.request.requestId != pendingAutoSyncRequestId) {
-            return
-        }
-
-        pendingAutoSyncRequestId = null
-        val cardsSignatureBeforeSync = cardsSignatureAtAutoSyncStart
-        cardsSignatureAtAutoSyncStart = null
-
-        if (completion.outcome !is AutoSyncOutcome.Succeeded) {
-            return
-        }
-        if (completion.request.allowsVisibleChangeMessage.not()) {
-            return
-        }
-        if (visibleAppScreenState.value != VisibleAppScreen.CARDS) {
-            return
-        }
-
-        val currentCardsSignature = buildCardsVisibleSignature(uiState = uiState.value)
-        if (cardsSignatureBeforeSync == null || cardsSignatureBeforeSync == currentCardsSignature) {
-            return
-        }
-        if (currentCardsSignature == lastVisibleAutoSyncChangeSignature) {
-            return
-        }
-
-        lastVisibleAutoSyncChangeSignature = currentCardsSignature
-        messageController.showMessage(message = textProvider.cardsUpdatedOnAnotherDeviceMessage)
-    }
-}
-
-private data class VisibleCardSignature(
-    val cardId: String,
-    val frontText: String,
-    val effortLevel: EffortLevel,
-    val tags: List<String>,
-    val dueAtMillis: Long?
-)
-
-private data class CardsVisibleSignature(
-    val searchQuery: String,
-    val activeFilter: CardFilter,
-    val cards: List<VisibleCardSignature>
-)
-
-private fun buildCardsVisibleSignature(uiState: CardsUiState): CardsVisibleSignature {
-    return CardsVisibleSignature(
-        searchQuery = uiState.searchQuery,
-        activeFilter = uiState.activeFilter,
-        cards = uiState.cards.map { card ->
-            VisibleCardSignature(
-                cardId = card.cardId,
-                frontText = card.frontText,
-                effortLevel = card.effortLevel,
-                tags = card.tags,
-                dueAtMillis = card.dueAtMillis
-            )
-        }
-    )
-}
 
 private data class CardEditorDraftState(
     val frontText: String,
@@ -468,46 +283,6 @@ class CardEditorViewModel(
     }
 }
 
-fun createCardsViewModelFactory(
-    cardsRepository: CardsRepository,
-    workspaceRepository: WorkspaceRepository,
-    autoSyncEventRepository: AutoSyncEventRepository,
-    messageController: TransientMessageController,
-    visibleAppScreenRepository: VisibleAppScreenRepository
-): ViewModelProvider.Factory {
-    return viewModelFactory {
-        initializer {
-            val application = requireApplication()
-            CardsViewModel(
-                cardsRepository = cardsRepository,
-                autoSyncEventRepository = autoSyncEventRepository,
-                messageController = messageController,
-                visibleAppScreenRepository = visibleAppScreenRepository,
-                workspaceRepository = workspaceRepository,
-                textProvider = cardsTextProvider(context = application)
-            )
-        }
-    }
-}
-
-fun createCardEditorViewModelFactory(
-    cardsRepository: CardsRepository,
-    workspaceRepository: WorkspaceRepository,
-    editingCardId: String?
-): ViewModelProvider.Factory {
-    return viewModelFactory {
-        initializer {
-            val application = requireApplication()
-            CardEditorViewModel(
-                cardsRepository = cardsRepository,
-                workspaceRepository = workspaceRepository,
-                editingCardId = editingCardId,
-                textProvider = cardsTextProvider(context = application)
-            )
-        }
-    }
-}
-
 private data class CardEditorValidationResult(
     val isValid: Boolean,
     val frontTextErrorMessage: String,
@@ -539,10 +314,6 @@ private fun validateCardEditorInput(
     )
 }
 
-private fun CreationExtras.requireApplication(): android.app.Application {
-    return checkNotNull(this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
-}
-
 private fun toggleTagSelection(selectedTags: List<String>, tag: String): List<String> {
     if (selectedTags.contains(tag)) {
         return selectedTags.filter { value ->
@@ -551,22 +322,4 @@ private fun toggleTagSelection(selectedTags: List<String>, tag: String): List<St
     }
 
     return selectedTags + tag
-}
-
-internal fun buildCardEditorDraft(
-    frontText: String,
-    backText: String,
-    selectedTags: List<String>,
-    effortLevel: EffortLevel,
-    referenceTags: List<String>
-): CardDraft {
-    return CardDraft(
-        frontText = frontText.trim(),
-        backText = backText.trim(),
-        tags = normalizeTags(
-            values = selectedTags,
-            referenceTags = referenceTags
-        ),
-        effortLevel = effortLevel
-    )
 }

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTagsRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTagsRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.editor
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -20,11 +20,11 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.InputChip
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -38,6 +38,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTagKey
+import com.flashcardsopensourceapp.feature.cards.R
+import com.flashcardsopensourceapp.feature.cards.cardTagsAddButtonTag
+import com.flashcardsopensourceapp.feature.cards.cardTagsInputFieldTag
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/editor/CardTextEditorRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.editor
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.flashcardsopensourceapp.feature.cards.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsListComponents.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsListComponents.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.list
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -39,27 +39,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import com.flashcardsopensourceapp.data.local.model.cards.buildCardFilter
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
-import com.flashcardsopensourceapp.data.local.model.cards.buildCardFilter
-
-const val cardsCardRowTag: String = "cards_card_row"
-const val cardsCardFrontTextTag: String = "cards_card_front_text"
-const val cardsSearchFieldTag: String = "cards_search_field"
-const val cardsEmptyStateTag: String = "cards_empty_state"
-const val cardsAddCardButtonTag: String = "cards_add_card_button"
-const val cardEditorFrontSummaryCardTag: String = "card_editor_front_summary_card"
-const val cardEditorBackSummaryCardTag: String = "card_editor_back_summary_card"
-const val cardEditorTagsSummaryCardTag: String = "card_editor_tags_summary_card"
-const val cardEditorSaveButtonTag: String = "card_editor_save_button"
-const val cardEditorFrontTextFieldTag: String = "card_editor_front_text_field"
-const val cardEditorBackTextFieldTag: String = "card_editor_back_text_field"
-const val cardTagsInputFieldTag: String = "card_tags_input_field"
-const val cardTagsAddButtonTag: String = "card_tags_add_button"
-
-fun cardEditorEffortLevelTag(effortLevel: EffortLevel): String {
-    return "card_editor_effort_${effortLevel.name.lowercase()}"
-}
+import com.flashcardsopensourceapp.feature.cards.R
+import com.flashcardsopensourceapp.feature.cards.cardsCardFrontTextTag
+import com.flashcardsopensourceapp.feature.cards.cardsCardRowTag
+import com.flashcardsopensourceapp.feature.cards.formatCardsEffortLevelTitle
+import com.flashcardsopensourceapp.feature.cards.formatCardsMetadataSummary
 
 @Composable
 internal fun CardRow(
@@ -303,40 +290,6 @@ internal fun CardsFilterSheet(
                 }
             }
         }
-    }
-}
-
-@Composable
-internal fun NavigationSummaryCard(
-    modifier: Modifier,
-    title: String,
-    summary: String,
-    supportingText: String,
-    icon: @Composable () -> Unit,
-    onClick: () -> Unit
-) {
-    Card(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-    ) {
-        ListItem(
-            headlineContent = {
-                Text(title)
-            },
-            supportingContent = {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(6.dp)
-                ) {
-                    Text(summary)
-                    Text(
-                        text = supportingText,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            },
-            leadingContent = icon
-        )
     }
 }
 

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsRoute.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsRoute.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.list
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -41,6 +41,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
 import com.flashcardsopensourceapp.data.local.model.cards.cardFilterActiveDimensionCount
+import com.flashcardsopensourceapp.feature.cards.R
+import com.flashcardsopensourceapp.feature.cards.cardsAddCardButtonTag
+import com.flashcardsopensourceapp.feature.cards.cardsEmptyStateTag
+import com.flashcardsopensourceapp.feature.cards.cardsSearchFieldTag
+import com.flashcardsopensourceapp.feature.cards.formatCardsFilterSummary
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsUiState.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsUiState.kt
@@ -1,0 +1,13 @@
+package com.flashcardsopensourceapp.feature.cards.list
+
+import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
+import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import com.flashcardsopensourceapp.data.local.model.workspace.WorkspaceTagSummary
+
+data class CardsUiState(
+    val isLoading: Boolean,
+    val searchQuery: String,
+    val activeFilter: CardFilter,
+    val availableTagSuggestions: List<WorkspaceTagSummary>,
+    val cards: List<CardSummary>
+)

--- a/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsViewModel.kt
+++ b/apps/android/feature/cards/src/main/java/com/flashcardsopensourceapp/feature/cards/list/CardsViewModel.kt
@@ -1,0 +1,197 @@
+package com.flashcardsopensourceapp.feature.cards.list
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.flashcardsopensourceapp.core.ui.TransientMessageController
+import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
+import com.flashcardsopensourceapp.core.ui.VisibleAppScreenRepository
+import com.flashcardsopensourceapp.data.local.model.cards.CardFilter
+import com.flashcardsopensourceapp.data.local.model.cards.CardSummary
+import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
+import com.flashcardsopensourceapp.data.local.repository.CardsRepository
+import com.flashcardsopensourceapp.data.local.repository.WorkspaceRepository
+import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncCompletion
+import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncEvent
+import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncEventRepository
+import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncOutcome
+import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncRequest
+import com.flashcardsopensourceapp.feature.cards.CardsTextProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CardsViewModel(
+    private val cardsRepository: CardsRepository,
+    private val autoSyncEventRepository: AutoSyncEventRepository,
+    private val messageController: TransientMessageController,
+    visibleAppScreenRepository: VisibleAppScreenRepository,
+    workspaceRepository: WorkspaceRepository,
+    private val textProvider: CardsTextProvider
+) : ViewModel() {
+    private val searchQuery = MutableStateFlow(value = "")
+    private val activeFilter = MutableStateFlow(
+        value = CardFilter(
+            tags = emptyList(),
+            effort = emptyList()
+        )
+    )
+
+    private val cardsFlow = combine(
+        searchQuery,
+        activeFilter
+    ) { query, filter ->
+        query to filter
+    }.flatMapLatest { (query, filter) ->
+        cardsRepository.observeCards(
+            searchQuery = query,
+            filter = filter
+        )
+    }
+    private val visibleAppScreenState = visibleAppScreenRepository.observeVisibleAppScreen().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = VisibleAppScreen.OTHER
+    )
+    private var pendingAutoSyncRequestId: String? = null
+    private var cardsSignatureAtAutoSyncStart: CardsVisibleSignature? = null
+    private var lastVisibleAutoSyncChangeSignature: CardsVisibleSignature? = null
+
+    val uiState: StateFlow<CardsUiState> = combine(
+        cardsFlow,
+        workspaceRepository.observeWorkspaceTagsSummary(),
+        searchQuery,
+        activeFilter
+    ) { cards, tagsSummary, query, filter ->
+        CardsUiState(
+            isLoading = false,
+            searchQuery = query,
+            activeFilter = filter,
+            availableTagSuggestions = tagsSummary.tags,
+            cards = cards
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000L),
+        initialValue = CardsUiState(
+            isLoading = true,
+            searchQuery = "",
+            activeFilter = CardFilter(tags = emptyList(), effort = emptyList()),
+            availableTagSuggestions = emptyList(),
+            cards = emptyList()
+        )
+    )
+
+    init {
+        observeAutoSyncDrivenCardsChanges()
+    }
+
+    fun updateSearchQuery(query: String) {
+        searchQuery.value = query
+    }
+
+    fun applyFilter(filter: CardFilter) {
+        activeFilter.value = filter
+    }
+
+    fun clearFilter() {
+        activeFilter.value = CardFilter(
+            tags = emptyList(),
+            effort = emptyList()
+        )
+    }
+
+    private fun observeAutoSyncDrivenCardsChanges() {
+        viewModelScope.launch {
+            autoSyncEventRepository.observeAutoSyncEvents().collect { event ->
+                when (event) {
+                    is AutoSyncEvent.Requested -> {
+                        handleAutoSyncRequested(request = event.request)
+                    }
+
+                    is AutoSyncEvent.Completed -> {
+                        handleAutoSyncCompleted(completion = event.completion)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun handleAutoSyncRequested(request: AutoSyncRequest) {
+        if (request.allowsVisibleChangeMessage.not()) {
+            return
+        }
+        if (visibleAppScreenState.value != VisibleAppScreen.CARDS) {
+            return
+        }
+
+        pendingAutoSyncRequestId = request.requestId
+        cardsSignatureAtAutoSyncStart = buildCardsVisibleSignature(uiState = uiState.value)
+    }
+
+    private fun handleAutoSyncCompleted(completion: AutoSyncCompletion) {
+        if (completion.request.requestId != pendingAutoSyncRequestId) {
+            return
+        }
+
+        pendingAutoSyncRequestId = null
+        val cardsSignatureBeforeSync = cardsSignatureAtAutoSyncStart
+        cardsSignatureAtAutoSyncStart = null
+
+        if (completion.outcome !is AutoSyncOutcome.Succeeded) {
+            return
+        }
+        if (completion.request.allowsVisibleChangeMessage.not()) {
+            return
+        }
+        if (visibleAppScreenState.value != VisibleAppScreen.CARDS) {
+            return
+        }
+
+        val currentCardsSignature = buildCardsVisibleSignature(uiState = uiState.value)
+        if (cardsSignatureBeforeSync == null || cardsSignatureBeforeSync == currentCardsSignature) {
+            return
+        }
+        if (currentCardsSignature == lastVisibleAutoSyncChangeSignature) {
+            return
+        }
+
+        lastVisibleAutoSyncChangeSignature = currentCardsSignature
+        messageController.showMessage(message = textProvider.cardsUpdatedOnAnotherDeviceMessage)
+    }
+}
+
+private data class VisibleCardSignature(
+    val cardId: String,
+    val frontText: String,
+    val effortLevel: EffortLevel,
+    val tags: List<String>,
+    val dueAtMillis: Long?
+)
+
+private data class CardsVisibleSignature(
+    val searchQuery: String,
+    val activeFilter: CardFilter,
+    val cards: List<VisibleCardSignature>
+)
+
+private fun buildCardsVisibleSignature(uiState: CardsUiState): CardsVisibleSignature {
+    return CardsVisibleSignature(
+        searchQuery = uiState.searchQuery,
+        activeFilter = uiState.activeFilter,
+        cards = uiState.cards.map { card ->
+            VisibleCardSignature(
+                cardId = card.cardId,
+                frontText = card.frontText,
+                effortLevel = card.effortLevel,
+                tags = card.tags,
+                dueAtMillis = card.dueAtMillis
+            )
+        }
+    )
+}

--- a/apps/android/feature/cards/src/test/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorDraftSnapshotTest.kt
+++ b/apps/android/feature/cards/src/test/java/com/flashcardsopensourceapp/feature/cards/editor/CardEditorDraftSnapshotTest.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.cards
+package com.flashcardsopensourceapp.feature.cards.editor
 
 import com.flashcardsopensourceapp.data.local.model.cards.CardDraft
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel


### PR DESCRIPTION
## Summary
- Split the Android Cards feature into list and editor packages.
- Keep shared strings, public test tags, and ViewModel factories in the root cards package.
- Update app navigation imports and move the focused editor draft test with the pure draft helper.

## Validation
- git --no-pager diff --check
- Source searches for stale root-package route/ViewModel references
- Gradle not run locally per repository instruction requiring explicit approval
