### PR TITLE
[codex] Fix Android core compile SDK mismatch

### DIFF
--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "9.2.1"
 kotlin = "2.3.21"
 ksp = "2.3.9"
-coreKtx = "1.19.0"
+coreKtx = "1.18.0"
 splashscreen = "1.2.0"
 activityCompose = "1.13.0"
 lifecycle = "2.10.0"


### PR DESCRIPTION
## Summary

- Pin AndroidX Core KTX back to 1.18.0.
- Keep the Android dependency catalog aligned with the current compileSdk 36 baseline.

## Root cause

AndroidX Core/Core KTX 1.19.0 requires compileSdk 37, while this repository currently builds Android with compileSdk 36. That caused Android Release to fail at :app:checkDebugAarMetadata.

## Validation

- git --no-pager diff --check
- Did not run local Gradle because repository instructions require explicit permission for ./gradlew runs.
