### PR TITLE
Stop inactive notification reconciliation on iOS

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -236,7 +236,7 @@ struct FlashcardsApp: App {
                         store.triggerCloudAccountContextRefreshIfActive(surfacesGlobalErrorMessage: false)
                         store.reconcileReviewNotifications(trigger: .appActive, now: now)
                         store.reconcileStrictReminders(trigger: .appActive, now: now)
-                    } else if nextPhase == .background || nextPhase == .inactive {
+                    } else if nextPhase == .background {
                         store.reconcileReviewNotifications(trigger: .appBackground, now: Date())
                         store.reconcileStrictReminders(trigger: .appBackground, now: Date())
                     }


### PR DESCRIPTION
## Summary

- Stop iOS notification reconciliation from running during transient `.inactive` scene phases.
- Keep review reminder and strict reminder reconciliation on `.active` resume and `.background` transitions.

## Impact

Temporary inactive transitions such as permission prompts, app switcher handoff, and foreground/background handoff no longer remove and re-add notification requests.

## Validation

- `xcrun --sdk iphoneos swiftc -parse -target arm64-apple-ios26.0 apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift`

Simulator-backed iOS tests were not run.