### PR TITLE
[codex] Move Android notification background reconcile to stop

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -371,6 +371,9 @@ fun FlashcardsApp(
 
                     Lifecycle.Event.ON_PAUSE -> {
                         isAppResumed = false
+                    }
+
+                    Lifecycle.Event.ON_STOP -> {
                         appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
                             trigger = ReviewNotificationsReconcileTrigger.APP_BACKGROUND,
                             nowMillis = System.currentTimeMillis()


### PR DESCRIPTION
## Summary

- Move Android background notification reconciliation from `Lifecycle.Event.ON_PAUSE` to `Lifecycle.Event.ON_STOP`.
- Keep `ON_PAUSE` responsible for clearing the resumed state only.
- Leave resume sync, account refresh, progress refresh, and navigation behavior unchanged.

## Validation

- `git --no-pager diff --check`
- Review-only pass found no P0-P4 diff-related issues.

`./gradlew` was not run per repository instruction.