### PR TITLE
[codex] Await Android reminder work scheduling

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
@@ -12,6 +12,7 @@ import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import androidx.work.await
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
@@ -286,7 +287,7 @@ class ReviewNotificationsManager(
         return tag.startsWith(reviewReminderNotificationTagPrefix)
     }
 
-    private fun enqueuePayload(
+    private suspend fun enqueuePayload(
         payload: ScheduledReviewNotificationPayload,
         nowMillis: Long
     ) {
@@ -312,11 +313,11 @@ class ReviewNotificationsManager(
             payload.requestId,
             ExistingWorkPolicy.REPLACE,
             request
-        )
+        ).await()
     }
 
-    private fun clearCurrentWorkspaceReviewScheduling(workspaceId: String) {
-        workManager.cancelAllWorkByTag(reviewNotificationWorkTag)
+    private suspend fun clearCurrentWorkspaceReviewScheduling(workspaceId: String) {
+        workManager.cancelAllWorkByTag(reviewNotificationWorkTag).await()
         reviewNotificationsStore.saveScheduledPayloads(workspaceId = workspaceId, payloads = emptyList())
     }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManager.kt
@@ -9,6 +9,7 @@ import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
+import androidx.work.await
 import com.flashcardsopensourceapp.data.local.database.review.ReviewLogDao
 import com.flashcardsopensourceapp.data.local.notifications.ScheduledStrictReminderPayload
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
@@ -38,8 +39,8 @@ const val strictReminderWorkTag: String = "strict-reminder-notification"
 interface StrictRemindersScheduler {
     fun hasNotificationPermission(): Boolean
     fun clearDeliveredNotifications()
-    fun clearScheduledReminders()
-    fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long)
+    suspend fun clearScheduledReminders()
+    suspend fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long)
 }
 
 private sealed interface StrictRemindersCommand {
@@ -88,11 +89,11 @@ class AndroidStrictRemindersScheduler(
         }
     }
 
-    override fun clearScheduledReminders() {
-        workManager.cancelAllWorkByTag(strictReminderWorkTag)
+    override suspend fun clearScheduledReminders() {
+        workManager.cancelAllWorkByTag(strictReminderWorkTag).await()
     }
 
-    override fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long) {
+    override suspend fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long) {
         val delayMillis = maxOf(1L, payload.scheduledAtMillis - nowMillis)
         val inputData = Data.Builder()
             .putString(strictReminderRequestIdDataKey, payload.requestId)
@@ -113,7 +114,7 @@ class AndroidStrictRemindersScheduler(
             payload.requestId,
             ExistingWorkPolicy.REPLACE,
             request
-        )
+        ).await()
     }
 
     private fun isStrictReminderNotification(notification: StatusBarNotification): Boolean {
@@ -334,7 +335,7 @@ class StrictRemindersManager(
         strictRemindersStore.saveScheduledStrictReminderPayloads(payloads = payloads)
     }
 
-    private fun clearIdentityStateNow() {
+    private suspend fun clearIdentityStateNow() {
         scheduler.clearDeliveredNotifications()
         scheduler.clearScheduledReminders()
         strictRemindersStore.clearStrictRemindersIdentityState()

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -282,12 +282,12 @@ private class FakeStrictRemindersScheduler(
         clearDeliveredInvocationCount += 1
     }
 
-    override fun clearScheduledReminders() {
+    override suspend fun clearScheduledReminders() {
         clearScheduledInvocationCount += 1
         scheduledPayloads.clear()
     }
 
-    override fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long) {
+    override suspend fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long) {
         scheduledPayloads.add(payload)
     }
 }


### PR DESCRIPTION
## Summary

- await WorkManager cancellation before clearing persisted Android reminder payloads
- await WorkManager enqueue operations before persisting review and strict reminder scheduled payloads
- update the strict reminders scheduler test fake for the suspend scheduler contract

## Validation

- `git --no-pager diff --check`
- `git --no-pager diff --cached --check`

Gradle tests were not run because local `./gradlew` runs require explicit approval for this repository.