### PR TITLE
[codex] Add iOS notification scheduling diagnostics

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -222,6 +222,41 @@ struct NotificationTapDroppedWarning: Sendable, Hashable {
     let detailSummary: String?
 }
 
+struct AppNotificationPendingRequestBreakdown: Sendable, Hashable {
+    let totalCount: Int
+    let reviewCount: Int
+    let strictCount: Int
+    let otherCount: Int
+}
+
+struct NotificationScheduledAtMillisRange: Sendable, Hashable {
+    let firstScheduledAtMillis: Int64?
+    let lastScheduledAtMillis: Int64?
+}
+
+struct NotificationSchedulingDelaySecondsRange: Sendable, Hashable {
+    let minDelaySeconds: Int?
+    let maxDelaySeconds: Int?
+}
+
+struct DelayedNotificationSchedulingReadback: Sendable, Hashable {
+    let pending: AppNotificationPendingRequestBreakdown
+    let recovered: Bool
+}
+
+struct NotificationSchedulingDiagnostics: Sendable, Hashable {
+    let trigger: String
+    let pendingBefore: AppNotificationPendingRequestBreakdown
+    let pendingAfter: AppNotificationPendingRequestBreakdown
+    let permissionStatusBefore: String
+    let permissionStatusAfter: String
+    let appStateBeforeAdd: String
+    let appStateAfterReadback: String
+    let scheduledAtMillisRange: NotificationScheduledAtMillisRange
+    let delaySecondsRange: NotificationSchedulingDelaySecondsRange
+    let delayedReadback: DelayedNotificationSchedulingReadback?
+}
+
 struct NotificationSchedulingFailureWarning: Sendable, Hashable {
     let action: String
     let scope: IOSObservationScope
@@ -236,6 +271,7 @@ struct NotificationSchedulingFailureWarning: Sendable, Hashable {
     let errorDomain: String?
     let errorCode: Int?
     let messageSummary: String?
+    let diagnostics: NotificationSchedulingDiagnostics
 }
 
 struct CloudRetryWarning: Sendable, Hashable {

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -261,6 +261,7 @@ extension SentryObservabilityAdapter {
             )
         case .notificationSchedulingFailed(let warning):
             let context: [String: Any] = [
+                "trigger": warning.diagnostics.trigger,
                 "notification_kind": warning.notificationKind,
                 "workspace_id": warning.workspaceId ?? "",
                 "notification_request_id": warning.requestId ?? "",
@@ -269,12 +270,33 @@ extension SentryObservabilityAdapter {
                 "accepted_count": String(warning.acceptedCount),
                 "pending_before_count": String(warning.pendingBeforeCount),
                 "pending_after_count": String(warning.pendingAfterCount),
+                "pending_before_total_count": String(warning.diagnostics.pendingBefore.totalCount),
+                "pending_before_review_count": String(warning.diagnostics.pendingBefore.reviewCount),
+                "pending_before_strict_count": String(warning.diagnostics.pendingBefore.strictCount),
+                "pending_before_other_count": String(warning.diagnostics.pendingBefore.otherCount),
+                "pending_after_total_count": String(warning.diagnostics.pendingAfter.totalCount),
+                "pending_after_review_count": String(warning.diagnostics.pendingAfter.reviewCount),
+                "pending_after_strict_count": String(warning.diagnostics.pendingAfter.strictCount),
+                "pending_after_other_count": String(warning.diagnostics.pendingAfter.otherCount),
+                "permission_status_before": warning.diagnostics.permissionStatusBefore,
+                "permission_status_after": warning.diagnostics.permissionStatusAfter,
+                "app_state_before_add": warning.diagnostics.appStateBeforeAdd,
+                "app_state_after_readback": warning.diagnostics.appStateAfterReadback,
+                "first_scheduled_at_millis": warning.diagnostics.scheduledAtMillisRange.firstScheduledAtMillis.map { value in String(value) } ?? "",
+                "last_scheduled_at_millis": warning.diagnostics.scheduledAtMillisRange.lastScheduledAtMillis.map { value in String(value) } ?? "",
+                "min_delay_seconds": warning.diagnostics.delaySecondsRange.minDelaySeconds.map { value in String(value) } ?? "",
+                "max_delay_seconds": warning.diagnostics.delaySecondsRange.maxDelaySeconds.map { value in String(value) } ?? "",
+                "delayed_pending_total_count": warning.diagnostics.delayedReadback.map { readback in String(readback.pending.totalCount) } ?? "",
+                "delayed_pending_review_count": warning.diagnostics.delayedReadback.map { readback in String(readback.pending.reviewCount) } ?? "",
+                "delayed_pending_strict_count": warning.diagnostics.delayedReadback.map { readback in String(readback.pending.strictCount) } ?? "",
+                "delayed_pending_other_count": warning.diagnostics.delayedReadback.map { readback in String(readback.pending.otherCount) } ?? "",
+                "delayed_readback_recovered": warning.diagnostics.delayedReadback.map { readback in String(describing: readback.recovered) } ?? "",
                 "error_domain": warning.errorDomain ?? "",
                 "error_code": warning.errorCode.map { errorCode in String(errorCode) } ?? "",
                 "message_summary": warning.messageSummary ?? ""
             ]
             return ObservationPayload(
-                message: "iOS notification scheduling warning: \(warning.action)",
+                message: "iOS notification scheduling diagnostics: \(warning.action)",
                 action: warning.action,
                 scope: warning.scope,
                 statusCode: nil,

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -397,8 +397,10 @@ extension FlashcardsStore {
         }
 
         let payloads = loadResult.payloads
-        let pendingBeforeRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
-        let pendingBeforeCount = pendingBeforeRequestIdentifiers.count
+        let pendingBeforeRequestIdentifiers: [String] = await pendingAppNotificationRequestIdentifiers(center: center)
+        let permissionStatusBeforeAdd: ReviewNotificationPermissionStatus =
+            await resolveReviewNotificationPermissionStatus()
+        let appStateBeforeAdd: String = currentAppNotificationApplicationStateDiagnosticValue()
         var addFailure: Error?
         var failedRequestId: String?
 
@@ -441,16 +443,59 @@ extension FlashcardsStore {
             return
         }
 
-        let pendingAfterRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
+        let pendingAfterRequestIdentifiers: [String] = await pendingAppNotificationRequestIdentifiers(center: center)
         guard self.reviewNotificationsRescheduleGeneration == generation else {
             return
         }
         guard Task.isCancelled == false else {
             return
         }
-        let acceptedPayloads = acceptedReviewNotificationPayloads(
+        let permissionStatusAfterReadback: ReviewNotificationPermissionStatus =
+            await resolveReviewNotificationPermissionStatus()
+        guard self.reviewNotificationsRescheduleGeneration == generation else {
+            return
+        }
+        guard Task.isCancelled == false else {
+            return
+        }
+        let appStateAfterReadback: String = currentAppNotificationApplicationStateDiagnosticValue()
+        let acceptedPayloads: [ScheduledReviewNotificationPayload] = acceptedReviewNotificationPayloads(
             payloads: payloads,
             pendingRequestIdentifiers: pendingAfterRequestIdentifiers
+        )
+        let hasReadbackMismatch: Bool = addFailure == nil && acceptedPayloads.count != payloads.count
+        var delayedReadback: DelayedNotificationSchedulingReadback?
+        if hasReadbackMismatch {
+            do {
+                delayedReadback = try await delayedNotificationSchedulingReadback(
+                    center: center,
+                    plannedRequestIdentifiers: payloads.map(\.requestId),
+                    delayNanoseconds: notificationSchedulingDelayedReadbackNanoseconds
+                )
+            } catch {
+                return
+            }
+            guard self.reviewNotificationsRescheduleGeneration == generation else {
+                return
+            }
+            guard Task.isCancelled == false else {
+                return
+            }
+        }
+        let diagnostics: NotificationSchedulingDiagnostics = makeNotificationSchedulingDiagnostics(
+            trigger: trigger.diagnosticValue,
+            scheduledAtMillisRange: reviewNotificationScheduledAtMillisRange(payloads: payloads),
+            delaySecondsRange: reviewNotificationSchedulingDelaySecondsRange(
+                payloads: payloads,
+                now: now
+            ),
+            pendingBeforeRequestIdentifiers: pendingBeforeRequestIdentifiers,
+            pendingAfterRequestIdentifiers: pendingAfterRequestIdentifiers,
+            permissionStatusBefore: permissionStatusBeforeAdd,
+            permissionStatusAfter: permissionStatusAfterReadback,
+            appStateBeforeAdd: appStateBeforeAdd,
+            appStateAfterReadback: appStateAfterReadback,
+            delayedReadback: delayedReadback
         )
         if let addFailure {
             FlashcardsObservability.captureWarning(
@@ -474,14 +519,13 @@ extension FlashcardsStore {
                         stage: "add",
                         plannedCount: payloads.count,
                         acceptedCount: acceptedPayloads.count,
-                        pendingBeforeCount: pendingBeforeCount,
-                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        diagnostics: diagnostics,
                         error: addFailure,
                         messageSummary: nil
                     )
                 )
             )
-        } else if acceptedPayloads.count != payloads.count {
+        } else if hasReadbackMismatch {
             FlashcardsObservability.captureWarning(
                 .notificationSchedulingFailed(
                     makeNotificationSchedulingFailureWarning(
@@ -503,8 +547,7 @@ extension FlashcardsStore {
                         stage: "readback",
                         plannedCount: payloads.count,
                         acceptedCount: acceptedPayloads.count,
-                        pendingBeforeCount: pendingBeforeCount,
-                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        diagnostics: diagnostics,
                         error: nil,
                         messageSummary: "Notification Center accepted fewer review reminders than planned"
                     )

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsSupport.swift
@@ -7,6 +7,7 @@ let defaultDailyReminderHour: Int = 10
 let defaultDailyReminderMinute: Int = 0
 let dailyReminderSchedulingHorizonDays: Int = 7
 let appNotificationPendingRequestsLimit: Int = 64
+let notificationSchedulingDelayedReadbackNanoseconds: UInt64 = 350_000_000
 let defaultInactivityReminderWindowEndHour: Int = 19
 let defaultInactivityReminderWindowEndMinute: Int = 0
 let reviewNotificationFallbackBodyText: String = String(
@@ -69,6 +70,25 @@ enum ReviewNotificationsReconcileTrigger: Hashable, Sendable {
             return true
         case .appBackground, .settingsChanged, .permissionChanged, .filterChanged, .workspaceChanged:
             return false
+        }
+    }
+
+    var diagnosticValue: String {
+        switch self {
+        case .appActive:
+            return "app_active"
+        case .appBackground:
+            return "app_background"
+        case .settingsChanged:
+            return "settings_changed"
+        case .permissionChanged:
+            return "permission_changed"
+        case .reviewRecorded:
+            return "review_recorded"
+        case .filterChanged:
+            return "filter_changed"
+        case .workspaceChanged:
+            return "workspace_changed"
         }
     }
 }
@@ -463,6 +483,96 @@ func filterReviewNotificationRequestIdentifiers(identifiers: [String]) -> [Strin
     identifiers.filter(isReviewNotificationRequestIdentifier)
 }
 
+func appNotificationPendingRequestBreakdown(
+    identifiers: [String]
+) -> AppNotificationPendingRequestBreakdown {
+    let reviewCount: Int = identifiers.filter(isReviewNotificationRequestIdentifier).count
+    let strictCount: Int = identifiers.filter(isStrictReminderRequestIdentifier).count
+    return AppNotificationPendingRequestBreakdown(
+        totalCount: identifiers.count,
+        reviewCount: reviewCount,
+        strictCount: strictCount,
+        otherCount: identifiers.count - reviewCount - strictCount
+    )
+}
+
+func notificationScheduledAtMillisRange(
+    scheduledAtMillisValues: [Int64]
+) -> NotificationScheduledAtMillisRange {
+    NotificationScheduledAtMillisRange(
+        firstScheduledAtMillis: scheduledAtMillisValues.min(),
+        lastScheduledAtMillis: scheduledAtMillisValues.max()
+    )
+}
+
+func reviewNotificationScheduledAtMillisRange(
+    payloads: [ScheduledReviewNotificationPayload]
+) -> NotificationScheduledAtMillisRange {
+    notificationScheduledAtMillisRange(
+        scheduledAtMillisValues: payloads.map(\.scheduledAtMillis)
+    )
+}
+
+func notificationSchedulingDelaySecondsRange(
+    scheduledAtMillisValues: [Int64],
+    now: Date
+) -> NotificationSchedulingDelaySecondsRange {
+    let delaySecondsValues: [Int] = scheduledAtMillisValues.map { scheduledAtMillis in
+        let rawDelaySeconds: TimeInterval = TimeInterval(scheduledAtMillis) / 1_000 - now.timeIntervalSince1970
+        return max(1, Int(rawDelaySeconds.rounded(.up)))
+    }
+
+    return NotificationSchedulingDelaySecondsRange(
+        minDelaySeconds: delaySecondsValues.min(),
+        maxDelaySeconds: delaySecondsValues.max()
+    )
+}
+
+func reviewNotificationSchedulingDelaySecondsRange(
+    payloads: [ScheduledReviewNotificationPayload],
+    now: Date
+) -> NotificationSchedulingDelaySecondsRange {
+    notificationSchedulingDelaySecondsRange(
+        scheduledAtMillisValues: payloads.map(\.scheduledAtMillis),
+        now: now
+    )
+}
+
+func reviewNotificationPermissionStatusDiagnosticValue(
+    status: ReviewNotificationPermissionStatus
+) -> String {
+    switch status {
+    case .allowed:
+        return "allowed"
+    case .notRequested:
+        return "not_requested"
+    case .blocked:
+        return "blocked"
+    }
+}
+
+func appNotificationApplicationStateDiagnosticValue(
+    applicationState: UIApplication.State
+) -> String {
+    switch applicationState {
+    case .active:
+        return "active"
+    case .inactive:
+        return "inactive"
+    case .background:
+        return "background"
+    @unknown default:
+        return "unknown"
+    }
+}
+
+@MainActor
+func currentAppNotificationApplicationStateDiagnosticValue() -> String {
+    appNotificationApplicationStateDiagnosticValue(
+        applicationState: UIApplication.shared.applicationState
+    )
+}
+
 func pendingAppNotificationRequestIdentifiers(
     center: UNUserNotificationCenter
 ) async -> [String] {
@@ -838,6 +948,66 @@ func appNotificationTapType(request: AppNotificationTapRequest) -> String {
     }
 }
 
+func makeDelayedNotificationSchedulingReadback(
+    pendingRequestIdentifiers: [String],
+    plannedRequestIdentifiers: [String]
+) -> DelayedNotificationSchedulingReadback {
+    let pendingRequestIdentifierSet: Set<String> = Set(pendingRequestIdentifiers)
+    return DelayedNotificationSchedulingReadback(
+        pending: appNotificationPendingRequestBreakdown(identifiers: pendingRequestIdentifiers),
+        recovered: plannedRequestIdentifiers.allSatisfy { requestIdentifier in
+            pendingRequestIdentifierSet.contains(requestIdentifier)
+        }
+    )
+}
+
+func delayedNotificationSchedulingReadback(
+    center: UNUserNotificationCenter,
+    plannedRequestIdentifiers: [String],
+    delayNanoseconds: UInt64
+) async throws -> DelayedNotificationSchedulingReadback {
+    try await Task.sleep(nanoseconds: delayNanoseconds)
+    let pendingRequestIdentifiers: [String] = await pendingAppNotificationRequestIdentifiers(center: center)
+    return makeDelayedNotificationSchedulingReadback(
+        pendingRequestIdentifiers: pendingRequestIdentifiers,
+        plannedRequestIdentifiers: plannedRequestIdentifiers
+    )
+}
+
+func makeNotificationSchedulingDiagnostics(
+    trigger: String,
+    scheduledAtMillisRange: NotificationScheduledAtMillisRange,
+    delaySecondsRange: NotificationSchedulingDelaySecondsRange,
+    pendingBeforeRequestIdentifiers: [String],
+    pendingAfterRequestIdentifiers: [String],
+    permissionStatusBefore: ReviewNotificationPermissionStatus,
+    permissionStatusAfter: ReviewNotificationPermissionStatus,
+    appStateBeforeAdd: String,
+    appStateAfterReadback: String,
+    delayedReadback: DelayedNotificationSchedulingReadback?
+) -> NotificationSchedulingDiagnostics {
+    NotificationSchedulingDiagnostics(
+        trigger: trigger,
+        pendingBefore: appNotificationPendingRequestBreakdown(
+            identifiers: pendingBeforeRequestIdentifiers
+        ),
+        pendingAfter: appNotificationPendingRequestBreakdown(
+            identifiers: pendingAfterRequestIdentifiers
+        ),
+        permissionStatusBefore: reviewNotificationPermissionStatusDiagnosticValue(
+            status: permissionStatusBefore
+        ),
+        permissionStatusAfter: reviewNotificationPermissionStatusDiagnosticValue(
+            status: permissionStatusAfter
+        ),
+        appStateBeforeAdd: appStateBeforeAdd,
+        appStateAfterReadback: appStateAfterReadback,
+        scheduledAtMillisRange: scheduledAtMillisRange,
+        delaySecondsRange: delaySecondsRange,
+        delayedReadback: delayedReadback
+    )
+}
+
 func makeNotificationSchedulingFailureWarning(
     action: String,
     scope: IOSObservationScope,
@@ -847,8 +1017,7 @@ func makeNotificationSchedulingFailureWarning(
     stage: String,
     plannedCount: Int,
     acceptedCount: Int,
-    pendingBeforeCount: Int,
-    pendingAfterCount: Int,
+    diagnostics: NotificationSchedulingDiagnostics,
     error: Error?,
     messageSummary: String?
 ) -> NotificationSchedulingFailureWarning {
@@ -870,11 +1039,12 @@ func makeNotificationSchedulingFailureWarning(
         stage: stage,
         plannedCount: plannedCount,
         acceptedCount: acceptedCount,
-        pendingBeforeCount: pendingBeforeCount,
-        pendingAfterCount: pendingAfterCount,
+        pendingBeforeCount: diagnostics.pendingBefore.totalCount,
+        pendingAfterCount: diagnostics.pendingAfter.totalCount,
         errorDomain: safeErrorDomain,
         errorCode: nsError?.code,
-        messageSummary: error.map { value in Flashcards.errorMessage(error: value) } ?? messageSummary
+        messageSummary: error.map { value in Flashcards.errorMessage(error: value) } ?? messageSummary,
+        diagnostics: diagnostics
     )
 }
 

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
@@ -221,8 +221,10 @@ extension FlashcardsStore {
         }
 
         let notificationScope = loadStrictReminderNotificationScope(userDefaults: self.userDefaults)
-        let pendingBeforeRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
-        let pendingBeforeCount = pendingBeforeRequestIdentifiers.count
+        let pendingBeforeRequestIdentifiers: [String] = await pendingAppNotificationRequestIdentifiers(center: center)
+        let permissionStatusBeforeAdd: ReviewNotificationPermissionStatus =
+            await resolveReviewNotificationPermissionStatus()
+        let appStateBeforeAdd: String = currentAppNotificationApplicationStateDiagnosticValue()
         var addFailure: Error?
         var failedRequestId: String?
         for payload in payloads {
@@ -254,13 +256,50 @@ extension FlashcardsStore {
             return
         }
 
-        let pendingAfterRequestIdentifiers = await pendingAppNotificationRequestIdentifiers(center: center)
+        let pendingAfterRequestIdentifiers: [String] = await pendingAppNotificationRequestIdentifiers(center: center)
         guard Task.isCancelled == false else {
             return
         }
-        let acceptedPayloads = acceptedStrictReminderPayloads(
+        let permissionStatusAfterReadback: ReviewNotificationPermissionStatus =
+            await resolveReviewNotificationPermissionStatus()
+        guard Task.isCancelled == false else {
+            return
+        }
+        let appStateAfterReadback: String = currentAppNotificationApplicationStateDiagnosticValue()
+        let acceptedPayloads: [ScheduledStrictReminderPayload] = acceptedStrictReminderPayloads(
             payloads: payloads,
             pendingRequestIdentifiers: pendingAfterRequestIdentifiers
+        )
+        let hasReadbackMismatch: Bool = addFailure == nil && acceptedPayloads.count != payloads.count
+        var delayedReadback: DelayedNotificationSchedulingReadback?
+        if hasReadbackMismatch {
+            do {
+                delayedReadback = try await delayedNotificationSchedulingReadback(
+                    center: center,
+                    plannedRequestIdentifiers: payloads.map(\.requestId),
+                    delayNanoseconds: notificationSchedulingDelayedReadbackNanoseconds
+                )
+            } catch {
+                return
+            }
+            guard Task.isCancelled == false else {
+                return
+            }
+        }
+        let diagnostics: NotificationSchedulingDiagnostics = makeNotificationSchedulingDiagnostics(
+            trigger: strictRemindersReconcileTriggerDiagnosticValue(triggers: request.triggers),
+            scheduledAtMillisRange: strictReminderScheduledAtMillisRange(payloads: payloads),
+            delaySecondsRange: strictReminderSchedulingDelaySecondsRange(
+                payloads: payloads,
+                now: request.now
+            ),
+            pendingBeforeRequestIdentifiers: pendingBeforeRequestIdentifiers,
+            pendingAfterRequestIdentifiers: pendingAfterRequestIdentifiers,
+            permissionStatusBefore: permissionStatusBeforeAdd,
+            permissionStatusAfter: permissionStatusAfterReadback,
+            appStateBeforeAdd: appStateBeforeAdd,
+            appStateAfterReadback: appStateAfterReadback,
+            delayedReadback: delayedReadback
         )
         if let addFailure {
             FlashcardsObservability.captureWarning(
@@ -284,14 +323,13 @@ extension FlashcardsStore {
                         stage: "add",
                         plannedCount: payloads.count,
                         acceptedCount: acceptedPayloads.count,
-                        pendingBeforeCount: pendingBeforeCount,
-                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        diagnostics: diagnostics,
                         error: addFailure,
                         messageSummary: nil
                     )
                 )
             )
-        } else if acceptedPayloads.count != payloads.count {
+        } else if hasReadbackMismatch {
             FlashcardsObservability.captureWarning(
                 .notificationSchedulingFailed(
                     makeNotificationSchedulingFailureWarning(
@@ -313,8 +351,7 @@ extension FlashcardsStore {
                         stage: "readback",
                         plannedCount: payloads.count,
                         acceptedCount: acceptedPayloads.count,
-                        pendingBeforeCount: pendingBeforeCount,
-                        pendingAfterCount: pendingAfterRequestIdentifiers.count,
+                        diagnostics: diagnostics,
                         error: nil,
                         messageSummary: "Notification Center accepted fewer strict reminders than planned"
                     )

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
@@ -71,6 +71,25 @@ enum StrictRemindersReconcileTrigger: Hashable, Sendable {
             return false
         }
     }
+
+    var diagnosticValue: String {
+        switch self {
+        case .appActive:
+            return "app_active"
+        case .appBackground:
+            return "app_background"
+        case .settingsChanged:
+            return "settings_changed"
+        case .permissionChanged:
+            return "permission_changed"
+        case .reviewRecorded:
+            return "review_recorded"
+        case .reviewHistoryImported:
+            return "review_history_imported"
+        case .workspaceChanged:
+            return "workspace_changed"
+        }
+    }
 }
 
 struct ScheduledStrictReminderPayload: Codable, Hashable, Sendable, Identifiable {
@@ -102,6 +121,7 @@ struct StrictReminderCompletedDayResolution: Sendable {
 
 struct StrictRemindersReconcileRequest: Equatable, Sendable {
     let now: Date
+    let triggers: [StrictRemindersReconcileTrigger]
     let shouldClearDeliveredStrictReminders: Bool
 }
 
@@ -117,8 +137,30 @@ func makeStrictRemindersReconcileRequest(
 ) -> StrictRemindersReconcileRequest {
     StrictRemindersReconcileRequest(
         now: now,
+        triggers: [trigger],
         shouldClearDeliveredStrictReminders: trigger.shouldClearDeliveredStrictReminders
     )
+}
+
+func mergeStrictRemindersReconcileTriggers(
+    pendingTriggers: [StrictRemindersReconcileTrigger],
+    nextTriggers: [StrictRemindersReconcileTrigger]
+) -> [StrictRemindersReconcileTrigger] {
+    var mergedTriggers: [StrictRemindersReconcileTrigger] = []
+    for trigger in pendingTriggers + nextTriggers where mergedTriggers.contains(trigger) == false {
+        mergedTriggers.append(trigger)
+    }
+    return mergedTriggers
+}
+
+func strictRemindersReconcileTriggerDiagnosticValue(
+    triggers: [StrictRemindersReconcileTrigger]
+) -> String {
+    let triggerValues: [String] = triggers.map(\.diagnosticValue)
+    guard triggerValues.isEmpty == false else {
+        return "unknown"
+    }
+    return triggerValues.joined(separator: "+")
 }
 
 func mergeStrictRemindersReconcileRequests(
@@ -131,6 +173,10 @@ func mergeStrictRemindersReconcileRequests(
 
     return StrictRemindersReconcileRequest(
         now: max(pendingRequest.now, nextRequest.now),
+        triggers: mergeStrictRemindersReconcileTriggers(
+            pendingTriggers: pendingRequest.triggers,
+            nextTriggers: nextRequest.triggers
+        ),
         shouldClearDeliveredStrictReminders: pendingRequest.shouldClearDeliveredStrictReminders
             || nextRequest.shouldClearDeliveredStrictReminders
     )
@@ -365,6 +411,24 @@ func acceptedStrictReminderPayloads(
     return payloads.filter { payload in
         pendingRequestIdentifierSet.contains(payload.requestId)
     }
+}
+
+func strictReminderScheduledAtMillisRange(
+    payloads: [ScheduledStrictReminderPayload]
+) -> NotificationScheduledAtMillisRange {
+    notificationScheduledAtMillisRange(
+        scheduledAtMillisValues: payloads.map(\.scheduledAtMillis)
+    )
+}
+
+func strictReminderSchedulingDelaySecondsRange(
+    payloads: [ScheduledStrictReminderPayload],
+    now: Date
+) -> NotificationSchedulingDelaySecondsRange {
+    notificationSchedulingDelaySecondsRange(
+        scheduledAtMillisValues: payloads.map(\.scheduledAtMillis),
+        now: now
+    )
 }
 
 func pendingStrictReminderRequestIdentifiers(

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/ReviewNotificationsSupportTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/ReviewNotificationsSupportTests.swift
@@ -195,6 +195,7 @@ final class ReviewNotificationsSupportTests: XCTestCase {
             makeStrictRemindersReconcileRequest(trigger: .appActive, now: now),
             StrictRemindersReconcileRequest(
                 now: now,
+                triggers: [.appActive],
                 shouldClearDeliveredStrictReminders: true
             )
         )
@@ -202,6 +203,7 @@ final class ReviewNotificationsSupportTests: XCTestCase {
             makeStrictRemindersReconcileRequest(trigger: .reviewRecorded, now: now),
             StrictRemindersReconcileRequest(
                 now: now,
+                triggers: [.reviewRecorded],
                 shouldClearDeliveredStrictReminders: false
             )
         )
@@ -215,10 +217,12 @@ final class ReviewNotificationsSupportTests: XCTestCase {
         let mergedRequest = mergeStrictRemindersReconcileRequests(
             pendingRequest: StrictRemindersReconcileRequest(
                 now: earlierNow,
+                triggers: [.appActive],
                 shouldClearDeliveredStrictReminders: true
             ),
             nextRequest: StrictRemindersReconcileRequest(
                 now: laterNow,
+                triggers: [.reviewRecorded],
                 shouldClearDeliveredStrictReminders: false
             )
         )
@@ -227,8 +231,13 @@ final class ReviewNotificationsSupportTests: XCTestCase {
             mergedRequest,
             StrictRemindersReconcileRequest(
                 now: laterNow,
+                triggers: [.appActive, .reviewRecorded],
                 shouldClearDeliveredStrictReminders: true
             )
+        )
+        XCTAssertEqual(
+            strictRemindersReconcileTriggerDiagnosticValue(triggers: mergedRequest.triggers),
+            "app_active+review_recorded"
         )
     }
 
@@ -739,6 +748,38 @@ final class ReviewNotificationsSupportTests: XCTestCase {
                 "review-notification::workspace-2::inactivity::2026-04-03-12-00"
             ]
         )
+    }
+
+    func testAppNotificationPendingRequestBreakdownClassifiesReviewStrictAndOtherRequests() {
+        let breakdown: AppNotificationPendingRequestBreakdown = appNotificationPendingRequestBreakdown(
+            identifiers: [
+                "review-notification::workspace-1::daily::2026-04-03-10-00",
+                "strict-reminder::4h::2026-04-03-20-00",
+                "external-notification::news",
+                "strict-reminder::2h::2026-04-04-22-00",
+                "review-notification::workspace-2::inactivity::2026-04-03-12-00"
+            ]
+        )
+
+        XCTAssertEqual(breakdown.totalCount, 5)
+        XCTAssertEqual(breakdown.reviewCount, 2)
+        XCTAssertEqual(breakdown.strictCount, 2)
+        XCTAssertEqual(breakdown.otherCount, 1)
+    }
+
+    func testNotificationSchedulingDelaySecondsRangeRoundsUpAndFloorsAtOneSecond() {
+        let now: Date = Date(timeIntervalSince1970: 1_000)
+        let range: NotificationSchedulingDelaySecondsRange = notificationSchedulingDelaySecondsRange(
+            scheduledAtMillisValues: [
+                999_000,
+                1_060_000,
+                1_360_500
+            ],
+            now: now
+        )
+
+        XCTAssertEqual(range.minDelaySeconds, 1)
+        XCTAssertEqual(range.maxDelaySeconds, 361)
     }
 
     func testAcceptedNotificationPayloadFiltersKeepOnlyPendingReadbackIdentifiers() throws {


### PR DESCRIPTION
## Summary
- enrich iOS notification scheduling warnings with trigger, permission, app state, pending-request breakdown, schedule range, and delay diagnostics
- add diagnostic-only delayed readback evidence for review and strict reminder readback mismatches
- add focused helper coverage for pending request classification and delay range calculation

## Validation
- git diff --check
- xcrun swiftc -parse for touched Swift files
- full non-simulator xcodebuild was attempted earlier but package artifact extraction was blocked by local disk space