### PR TITLE
[codex] Add Android notification work limits

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
@@ -23,6 +24,16 @@
         <meta-data
             android:name="io.sentry.auto-init"
             android:value="false" />
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
 
         <activity
             android:name=".MainActivity"

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApplication.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApplication.kt
@@ -1,12 +1,14 @@
 package com.flashcardsopensourceapp.app
 
 import android.app.Application
+import androidx.work.Configuration
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.di.AppStartupState
 import com.flashcardsopensourceapp.app.navigation.AppNotificationTapHandoffRequest
 import com.flashcardsopensourceapp.app.notifications.AppNotificationTapRequest
 import com.flashcardsopensourceapp.app.observability.AndroidObservabilityStartup
 import com.flashcardsopensourceapp.app.observability.startAndroidObservability
+import com.flashcardsopensourceapp.data.local.notifications.appNotificationWorkLimit
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,7 +19,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 
-class FlashcardsApplication : Application() {
+class FlashcardsApplication : Application(), Configuration.Provider {
     private val appGraphResetMutex = Mutex()
     private val appGraphLock = Any()
     private val nextAppNotificationTapRequestId = AtomicLong(0L)
@@ -38,6 +40,11 @@ class FlashcardsApplication : Application() {
 
     val appNotificationTapState: StateFlow<AppNotificationTapHandoffRequest?>
         get() = appNotificationTapStateMutable.asStateFlow()
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setMaxSchedulerLimit(appNotificationWorkLimit)
+            .build()
 
     private var appGraphHolder: AppGraph? = null
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -196,7 +196,8 @@ class AppGraph(
         database = database,
         preferencesStore = cloudPreferencesStore,
         reviewPreferencesStore = reviewPreferencesStore,
-        reviewNotificationsStore = reviewNotificationsStore
+        reviewNotificationsStore = reviewNotificationsStore,
+        strictRemindersStore = strictRemindersStore
     )
     val strictRemindersManager = StrictRemindersManager(
         strictRemindersStore = strictRemindersStore,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsWorkspaceNavGraph.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -37,6 +38,8 @@ import com.flashcardsopensourceapp.feature.settings.workspace.tags.createWorkspa
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
@@ -71,22 +74,47 @@ internal fun NavGraphBuilder.registerSettingsWorkspaceNavGraph(
     }
 
     composable(route = SettingsWorkspaceNotificationsDestination.route) {
+        val notificationSchedulingMutex = remember { Mutex() }
         val reviewNotificationsViewModel = viewModel<com.flashcardsopensourceapp.feature.settings.review.ReviewNotificationsViewModel>(
             factory = createReviewNotificationsViewModelFactory(
                 workspaceRepository = appGraph.workspaceRepository,
                 reviewNotificationsStore = appGraph.reviewNotificationsStore,
                 strictRemindersStore = appGraph.strictRemindersStore,
                 onReviewSettingsChanged = {
-                    appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotifications(
-                        trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
-                        nowMillis = System.currentTimeMillis()
-                    )
+                    coroutineScope.launch {
+                        notificationSchedulingMutex.withLock {
+                            appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
+                                trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
+                                nowMillis = System.currentTimeMillis()
+                            )
+                        }
+                    }
                 },
-                onStrictRemindersSettingsChanged = {
-                    appGraph.strictRemindersManager.reconcileStrictReminders(
-                        trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
-                        nowMillis = System.currentTimeMillis()
-                    )
+                onStrictRemindersSettingsChanged = { isEnabled ->
+                    coroutineScope.launch {
+                        notificationSchedulingMutex.withLock {
+                            val nowMillis = System.currentTimeMillis()
+                            if (isEnabled) {
+                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
+                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
+                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                            } else {
+                                appGraph.strictRemindersManager.reconcileStrictRemindersAndWait(
+                                    trigger = StrictRemindersReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                                appGraph.reviewNotificationsManager.reconcileCurrentWorkspaceReviewNotificationsAndWait(
+                                    trigger = ReviewNotificationsReconcileTrigger.SETTINGS_CHANGED,
+                                    nowMillis = nowMillis
+                                )
+                            }
+                        }
+                    }
                 },
                 onAppIconBadgeDisabled = {
                     appGraph.reviewNotificationsManager.clearDeliveredReviewReminderNotifications()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
@@ -27,11 +27,13 @@ import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationMo
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsReconcileTrigger
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
 import com.flashcardsopensourceapp.data.local.notifications.ScheduledReviewNotificationPayload
+import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersStore
 import com.flashcardsopensourceapp.data.local.notifications.buildFallbackDailyReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.buildFallbackInactivityReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.buildDailyReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.buildInactivityReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.makePersistedReviewFilter
+import com.flashcardsopensourceapp.data.local.notifications.reviewNotificationWorkLimit
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.loadCurrentWorkspaceOrNull
 import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
 import com.flashcardsopensourceapp.feature.review.reviewTextProvider
@@ -39,6 +41,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import java.time.ZoneId
@@ -56,7 +59,8 @@ class ReviewNotificationsManager(
     private val database: AppDatabase,
     private val preferencesStore: CloudPreferencesStore,
     private val reviewPreferencesStore: ReviewPreferencesStore,
-    private val reviewNotificationsStore: ReviewNotificationsStore
+    private val reviewNotificationsStore: ReviewNotificationsStore,
+    private val strictRemindersStore: StrictRemindersStore
 ) {
     private val workManager: WorkManager = WorkManager.getInstance(context)
     private val scopeJob = SupervisorJob()
@@ -84,6 +88,29 @@ class ReviewNotificationsManager(
                 nowMillis = nowMillis,
                 generation = generation
             )
+            if (isLatestReconcileGeneration(generation = generation)) {
+                activeReconcileJob = null
+            }
+        }
+    }
+
+    suspend fun reconcileCurrentWorkspaceReviewNotificationsAndWait(
+        trigger: ReviewNotificationsReconcileTrigger,
+        nowMillis: Long
+    ) {
+        val generation = reconcileGeneration.incrementAndGet()
+        activeReconcileJob?.cancelAndJoin()
+        val reconcileJob = scope.async {
+            reconcileCurrentWorkspaceReviewNotifications(
+                trigger = trigger,
+                nowMillis = nowMillis,
+                generation = generation
+            )
+        }
+        activeReconcileJob = reconcileJob
+        try {
+            reconcileJob.await()
+        } finally {
             if (isLatestReconcileGeneration(generation = generation)) {
                 activeReconcileJob = null
             }
@@ -163,6 +190,9 @@ class ReviewNotificationsManager(
         )
 
         val zoneId = ZoneId.systemDefault()
+        val workLimit: Int = reviewNotificationWorkLimit(
+            strictRemindersSettings = strictRemindersStore.loadStrictRemindersSettings()
+        )
         val payloads = if (currentCard != null) {
             when (settings.selectedMode) {
                 ReviewNotificationMode.DAILY -> buildDailyReminderPayloads(
@@ -170,7 +200,8 @@ class ReviewNotificationsManager(
                     currentCard = currentCard,
                     nowMillis = nowMillis,
                     zoneId = zoneId,
-                    settings = settings.daily
+                    settings = settings.daily,
+                    workLimit = workLimit
                 )
 
                 ReviewNotificationMode.INACTIVITY -> {
@@ -185,7 +216,8 @@ class ReviewNotificationsManager(
                         nowMillis = nowMillis,
                         lastActiveAtMillis = lastActiveAtMillis,
                         zoneId = zoneId,
-                        settings = settings.inactivity
+                        settings = settings.inactivity,
+                        workLimit = workLimit
                     )
                 }
             }
@@ -199,7 +231,8 @@ class ReviewNotificationsManager(
                     fallbackFrontText = fallbackFrontText,
                     nowMillis = nowMillis,
                     zoneId = zoneId,
-                    settings = settings.daily
+                    settings = settings.daily,
+                    workLimit = workLimit
                 )
 
                 ReviewNotificationMode.INACTIVITY -> {
@@ -215,7 +248,8 @@ class ReviewNotificationsManager(
                         nowMillis = nowMillis,
                         lastActiveAtMillis = lastActiveAtMillis,
                         zoneId = zoneId,
-                        settings = settings.inactivity
+                        settings = settings.inactivity,
+                        workLimit = workLimit
                     )
                 }
             }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManager.kt
@@ -46,7 +46,8 @@ interface StrictRemindersScheduler {
 private sealed interface StrictRemindersCommand {
     data class Reconcile(
         val trigger: StrictRemindersReconcileTrigger,
-        val nowMillis: Long
+        val nowMillis: Long,
+        val completion: CompletableDeferred<Unit>?
     ) : StrictRemindersCommand
 
     data class RecordSuccessfulReview(
@@ -153,9 +154,25 @@ class StrictRemindersManager(
         enqueueCommandIfOpen(
             command = StrictRemindersCommand.Reconcile(
                 trigger = trigger,
-                nowMillis = nowMillis
+                nowMillis = nowMillis,
+                completion = null
             )
         )
+    }
+
+    suspend fun reconcileStrictRemindersAndWait(
+        trigger: StrictRemindersReconcileTrigger,
+        nowMillis: Long
+    ) {
+        val completion = CompletableDeferred<Unit>()
+        enqueueRequiredCommand(
+            command = StrictRemindersCommand.Reconcile(
+                trigger = trigger,
+                nowMillis = nowMillis,
+                completion = completion
+            )
+        )
+        completion.await()
     }
 
     fun recordSuccessfulReview(
@@ -204,10 +221,12 @@ class StrictRemindersManager(
     private suspend fun processCommand(command: StrictRemindersCommand) {
         when (command) {
             is StrictRemindersCommand.Reconcile -> {
-                reconcileStrictRemindersNow(
-                    trigger = command.trigger,
-                    nowMillis = command.nowMillis
-                )
+                runCompletableCommand(completion = command.completion) {
+                    reconcileStrictRemindersNow(
+                        trigger = command.trigger,
+                        nowMillis = command.nowMillis
+                    )
+                }
             }
 
             is StrictRemindersCommand.RecordSuccessfulReview -> {
@@ -237,15 +256,24 @@ class StrictRemindersManager(
             }
 
             is StrictRemindersCommand.ClearIdentityState -> {
-                runCatching {
+                runCompletableCommand(completion = command.completion) {
                     clearIdentityStateNow()
-                }.onSuccess {
-                    command.completion.complete(Unit)
-                }.onFailure { error ->
-                    command.completion.completeExceptionally(error)
-                    throw error
                 }
             }
+        }
+    }
+
+    private suspend fun runCompletableCommand(
+        completion: CompletableDeferred<Unit>?,
+        action: suspend () -> Unit
+    ) {
+        runCatching {
+            action()
+        }.onSuccess {
+            completion?.complete(Unit)
+        }.onFailure { error ->
+            completion?.completeExceptionally(error)
+            throw error
         }
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
@@ -15,6 +15,9 @@ const val reviewNotificationPermissionPromptThreshold: Int = 6
 const val defaultDailyReminderHour: Int = 10
 const val defaultDailyReminderMinute: Int = 0
 const val dailyReminderSchedulingHorizonDays: Int = 7
+const val appNotificationWorkLimit: Int = 50
+const val reviewNotificationWorkLimitWhenStrictRemindersEnabled: Int =
+    appNotificationWorkLimit - strictReminderWorkLimit
 const val defaultInactivityReminderWindowEndHour: Int = 19
 const val defaultInactivityReminderWindowEndMinute: Int = 0
 
@@ -117,6 +120,14 @@ fun defaultNotificationPermissionPromptState(): NotificationPermissionPromptStat
         hasRequestedSystemPermission = false,
         hasDismissedPrePrompt = false
     )
+}
+
+fun reviewNotificationWorkLimit(strictRemindersSettings: StrictRemindersSettings): Int {
+    if (strictRemindersSettings.isEnabled.not()) {
+        return appNotificationWorkLimit
+    }
+
+    return reviewNotificationWorkLimitWhenStrictRemindersEnabled
 }
 
 interface ReviewNotificationsStore {
@@ -391,7 +402,8 @@ fun buildDailyReminderPayloads(
     currentCard: CurrentReviewNotificationCard,
     nowMillis: Long,
     zoneId: ZoneId,
-    settings: DailyReviewNotificationsSettings
+    settings: DailyReviewNotificationsSettings,
+    workLimit: Int
 ): List<ScheduledReviewNotificationPayload> {
     val scheduledAtDateTimes = buildDailyReminderScheduledAtDateTimes(
         nowMillis = nowMillis,
@@ -404,7 +416,8 @@ fun buildDailyReminderPayloads(
         cardId = currentCard.cardId,
         frontText = currentCard.frontText,
         scheduledAtDateTimes = scheduledAtDateTimes,
-        mode = ReviewNotificationMode.DAILY
+        mode = ReviewNotificationMode.DAILY,
+        workLimit = workLimit
     )
 }
 
@@ -414,7 +427,8 @@ fun buildFallbackDailyReminderPayloads(
     fallbackFrontText: String,
     nowMillis: Long,
     zoneId: ZoneId,
-    settings: DailyReviewNotificationsSettings
+    settings: DailyReviewNotificationsSettings,
+    workLimit: Int
 ): List<ScheduledReviewNotificationPayload> {
     val scheduledAtDateTimes = buildDailyReminderScheduledAtDateTimes(
         nowMillis = nowMillis,
@@ -427,7 +441,8 @@ fun buildFallbackDailyReminderPayloads(
         cardId = null,
         frontText = fallbackFrontText,
         scheduledAtDateTimes = scheduledAtDateTimes,
-        mode = ReviewNotificationMode.DAILY
+        mode = ReviewNotificationMode.DAILY,
+        workLimit = workLimit
     )
 }
 
@@ -482,7 +497,8 @@ fun buildInactivityReminderPayloads(
     nowMillis: Long,
     lastActiveAtMillis: Long,
     zoneId: ZoneId,
-    settings: InactivityReviewNotificationsSettings
+    settings: InactivityReviewNotificationsSettings,
+    workLimit: Int
 ): List<ScheduledReviewNotificationPayload> {
     val scheduledAtMillisList = buildInactivityReminderTimestampMillisList(
         settings = settings,
@@ -503,7 +519,8 @@ fun buildInactivityReminderPayloads(
         cardId = currentCard.cardId,
         frontText = currentCard.frontText,
         scheduledAtDateTimes = scheduledAtDateTimes,
-        mode = ReviewNotificationMode.INACTIVITY
+        mode = ReviewNotificationMode.INACTIVITY,
+        workLimit = workLimit
     )
 }
 
@@ -514,7 +531,8 @@ fun buildFallbackInactivityReminderPayloads(
     nowMillis: Long,
     lastActiveAtMillis: Long,
     zoneId: ZoneId,
-    settings: InactivityReviewNotificationsSettings
+    settings: InactivityReviewNotificationsSettings,
+    workLimit: Int
 ): List<ScheduledReviewNotificationPayload> {
     val scheduledAtMillisList = buildInactivityReminderTimestampMillisList(
         settings = settings,
@@ -535,7 +553,8 @@ fun buildFallbackInactivityReminderPayloads(
         cardId = null,
         frontText = fallbackFrontText,
         scheduledAtDateTimes = scheduledAtDateTimes,
-        mode = ReviewNotificationMode.INACTIVITY
+        mode = ReviewNotificationMode.INACTIVITY,
+        workLimit = workLimit
     )
 }
 
@@ -649,8 +668,13 @@ private fun buildScheduledReviewNotificationPayloads(
     cardId: String?,
     frontText: String,
     scheduledAtDateTimes: List<ZonedDateTime>,
-    mode: ReviewNotificationMode
+    mode: ReviewNotificationMode,
+    workLimit: Int
 ): List<ScheduledReviewNotificationPayload> {
+    require(workLimit >= 0) {
+        "Review notification work limit must be non-negative. workLimit=$workLimit"
+    }
+
     return scheduledAtDateTimes.map { scheduledAtDateTime ->
         ScheduledReviewNotificationPayload(
             workspaceId = workspaceId,
@@ -664,7 +688,9 @@ private fun buildScheduledReviewNotificationPayloads(
                 suffix = makeNotificationRequestSuffix(scheduledAtDateTime = scheduledAtDateTime)
             )
         )
-    }
+    }.sortedBy { payload ->
+        payload.scheduledAtMillis
+    }.take(workLimit)
 }
 
 private val notificationRequestIdDateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm")

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/StrictReminders.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/StrictReminders.kt
@@ -6,6 +6,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 const val strictReminderSchedulingMaxDayOffset: Int = 7
+const val strictReminderWorkLimit: Int = 24
 
 enum class StrictReminderTimeOffset(
     val rawValue: String,
@@ -130,7 +131,9 @@ suspend fun buildStrictReminderPayloads(
             zoneId = zoneId,
             isLocalDateCompleted = isLocalDateCompleted
         )
-    }
+    }.sortedBy { payload ->
+        payload.scheduledAtMillis
+    }.take(strictReminderWorkLimit)
 }
 
 fun makeStrictReminderRequestId(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStoreTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStoreTest.kt
@@ -25,6 +25,30 @@ class ReviewNotificationsStoreTest {
     }
 
     @Test
+    fun reviewNotificationWorkLimitReservesStrictReminderCapacityWhenEnabled() {
+        assertEquals(
+            appNotificationWorkLimit - strictReminderWorkLimit,
+            reviewNotificationWorkLimitWhenStrictRemindersEnabled
+        )
+        assertEquals(
+            reviewNotificationWorkLimitWhenStrictRemindersEnabled,
+            reviewNotificationWorkLimit(
+                strictRemindersSettings = StrictRemindersSettings(isEnabled = true)
+            )
+        )
+    }
+
+    @Test
+    fun reviewNotificationWorkLimitUsesFullLimitWhenStrictRemindersDisabled() {
+        assertEquals(
+            appNotificationWorkLimit,
+            reviewNotificationWorkLimit(
+                strictRemindersSettings = StrictRemindersSettings(isEnabled = false)
+            )
+        )
+    }
+
+    @Test
     fun dailyReminderFallbackPayloadsUseGenericBodyTextAndNullCardId() {
         val zoneId = ZoneId.of("UTC")
         val payloads = buildFallbackDailyReminderPayloads(
@@ -41,7 +65,8 @@ class ReviewNotificationsStoreTest {
             settings = DailyReviewNotificationsSettings(
                 hour = 10,
                 minute = 0
-            )
+            ),
+            workLimit = appNotificationWorkLimit
         )
 
         assertEquals(fallbackFrontText, payloads.first().frontText)
@@ -79,7 +104,8 @@ class ReviewNotificationsStoreTest {
                 windowEndHour = 19,
                 windowEndMinute = 0,
                 idleMinutes = 120
-            )
+            ),
+            workLimit = appNotificationWorkLimit
         )
 
         assertEquals(
@@ -95,6 +121,42 @@ class ReviewNotificationsStoreTest {
                 "2026-04-04T18:00:00Z"
             ),
             payloads.take(9).map { payload ->
+                formatTimestampMillis(
+                    value = payload.scheduledAtMillis,
+                    zoneId = zoneId
+                )
+            }
+        )
+    }
+
+    @Test
+    fun inactivityReminderPayloadsStayWithinPassedWorkLimit() {
+        val zoneId = ZoneId.of("UTC")
+        val workLimit: Int = 3
+        val payloads = buildInactivityReminderPayloads(
+            workspaceId = "workspace-1",
+            currentCard = makeCurrentCard(cardId = "card-a", frontText = "Front A"),
+            nowMillis = parseTimestampMillis(value = "2026-04-03T10:01:00Z"),
+            lastActiveAtMillis = parseTimestampMillis(value = "2026-04-03T10:00:00Z"),
+            zoneId = zoneId,
+            settings = InactivityReviewNotificationsSettings(
+                windowStartHour = 10,
+                windowStartMinute = 0,
+                windowEndHour = 19,
+                windowEndMinute = 0,
+                idleMinutes = 1
+            ),
+            workLimit = workLimit
+        )
+
+        assertEquals(workLimit, payloads.size)
+        assertEquals(
+            listOf(
+                "2026-04-03T10:02:00Z",
+                "2026-04-03T10:03:00Z",
+                "2026-04-03T10:04:00Z"
+            ),
+            payloads.map { payload ->
                 formatTimestampMillis(
                     value = payload.scheduledAtMillis,
                     zoneId = zoneId
@@ -124,7 +186,8 @@ class ReviewNotificationsStoreTest {
                 windowEndHour = 19,
                 windowEndMinute = 0,
                 idleMinutes = 120
-            )
+            ),
+            workLimit = appNotificationWorkLimit
         )
 
         assertEquals(fallbackFrontText, payloads.first().frontText)
@@ -162,7 +225,8 @@ class ReviewNotificationsStoreTest {
                 windowEndHour = 19,
                 windowEndMinute = 0,
                 idleMinutes = 120
-            )
+            ),
+            workLimit = appNotificationWorkLimit
         )
 
         assertEquals(
@@ -218,7 +282,8 @@ class ReviewNotificationsStoreTest {
                 windowEndHour = 19,
                 windowEndMinute = 0,
                 idleMinutes = 120
-            )
+            ),
+            workLimit = appNotificationWorkLimit
         ).take(2)
 
         assertEquals(listOf("card-a", "card-a"), originalPayloads.map { it.cardId })
@@ -239,6 +304,18 @@ class ReviewNotificationsStoreTest {
         )
         assertEquals("effort", persistedFilter.kind)
         assertEquals(EffortLevel.MEDIUM.name, persistedFilter.effortLevel)
+    }
+
+    @Test
+    fun strictReminderPayloadsStayWithinWorkLimit() = runBlocking {
+        val payloads = buildStrictReminderPayloads(
+            nowMillis = parseTimestampMillis(value = "2026-04-03T09:00:00Z"),
+            zoneId = ZoneId.of("UTC"),
+            isLocalDateCompleted = { _ -> false }
+        )
+
+        assertEquals(strictReminderWorkLimit, payloads.size)
+        assertTrue(payloads.size <= appNotificationWorkLimit)
     }
 
     @Test

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsViewModel.kt
@@ -24,7 +24,7 @@ class ReviewNotificationsViewModel(
     private val reviewNotificationsStore: ReviewNotificationsStore,
     private val strictRemindersStore: StrictRemindersStore,
     private val onReviewSettingsChanged: () -> Unit,
-    private val onStrictRemindersSettingsChanged: () -> Unit,
+    private val onStrictRemindersSettingsChanged: (Boolean) -> Unit,
     private val onAppIconBadgeDisabled: () -> Unit
 ) : ViewModel() {
     private val refreshVersion = MutableStateFlow(value = 0)
@@ -119,7 +119,7 @@ class ReviewNotificationsViewModel(
         val nextSettings = StrictRemindersSettings(isEnabled = isEnabled)
         strictRemindersStore.saveStrictRemindersSettings(settings = nextSettings)
         refreshVersion.update { version -> version + 1 }
-        onStrictRemindersSettingsChanged()
+        onStrictRemindersSettingsChanged(isEnabled)
     }
 
     fun markSystemPermissionRequested() {
@@ -148,7 +148,7 @@ fun createReviewNotificationsViewModelFactory(
     reviewNotificationsStore: ReviewNotificationsStore,
     strictRemindersStore: StrictRemindersStore,
     onReviewSettingsChanged: () -> Unit,
-    onStrictRemindersSettingsChanged: () -> Unit,
+    onStrictRemindersSettingsChanged: (Boolean) -> Unit,
     onAppIconBadgeDisabled: () -> Unit
 ): ViewModelProvider.Factory {
     return viewModelFactory {


### PR DESCRIPTION
## Summary
- add explicit Android WorkManager notification limits for review and strict reminders
- cap review inactivity/daily and strict reminder payload scheduling by shared work budget
- configure WorkManager max scheduler limit and reconcile strict/review settings changes in an awaited order

## Validation
- git --no-pager diff --check
- Gradle not run per repository instruction requiring explicit approval