### PR TITLE
[codex] Add Android reminder diagnostics

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -197,13 +197,19 @@ class AppGraph(
         preferencesStore = cloudPreferencesStore,
         reviewPreferencesStore = reviewPreferencesStore,
         reviewNotificationsStore = reviewNotificationsStore,
-        strictRemindersStore = strictRemindersStore
+        strictRemindersStore = strictRemindersStore,
+        observability = observability,
+        appVersion = appPackageInfo.versionName,
+        versionCode = appPackageInfo.longVersionCode.toInt()
     )
     val strictRemindersManager = StrictRemindersManager(
         strictRemindersStore = strictRemindersStore,
         reviewLogDao = database.reviewLogDao(),
         scheduler = strictRemindersScheduler,
-        zoneIdProvider = ZoneId::systemDefault
+        zoneIdProvider = ZoneId::systemDefault,
+        observability = observability,
+        appVersion = appPackageInfo.versionName,
+        versionCode = appPackageInfo.longVersionCode.toInt()
     )
     val storeReviewRequestManager = StoreReviewRequestManager(
         context = context,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationWorkDiagnostics.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationWorkDiagnostics.kt
@@ -1,0 +1,171 @@
+package com.flashcardsopensourceapp.app.notifications
+
+import android.content.Context
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.await
+import com.flashcardsopensourceapp.app.FlashcardsApplication
+import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
+import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
+import com.flashcardsopensourceapp.core.observability.AndroidWorkInfoStateCounts
+import com.flashcardsopensourceapp.data.local.notifications.appNotificationWorkLimit
+import com.flashcardsopensourceapp.data.local.notifications.strictReminderWorkLimit
+import java.util.concurrent.TimeUnit
+
+internal const val reviewReminderNotificationKind: String = "reviewReminder"
+internal const val strictReminderNotificationKind: String = "strictReminder"
+
+internal data class NotificationExpectedWorkInfoReadback(
+    val stateCounts: AndroidWorkInfoStateCounts,
+    val expectedWorkNameCount: Int,
+    val missingExpectedWorkNameCount: Int
+)
+
+internal data class NotificationDelayRange(
+    val firstScheduledAtMillis: Long?,
+    val lastScheduledAtMillis: Long?,
+    val minDelaySeconds: Long?,
+    val maxDelaySeconds: Long?
+)
+
+internal suspend fun loadWorkInfoStateCountsByTag(
+    workManager: WorkManager,
+    workTag: String
+): AndroidWorkInfoStateCounts {
+    return countWorkInfoStates(workInfos = workManager.getWorkInfosByTag(workTag).await())
+}
+
+internal suspend fun loadExpectedWorkInfoReadback(
+    workManager: WorkManager,
+    expectedUniqueWorkNames: List<String>
+): NotificationExpectedWorkInfoReadback {
+    val distinctWorkNames: List<String> = expectedUniqueWorkNames.distinct()
+    val workInfosByName: List<List<WorkInfo>> = distinctWorkNames.map { workName ->
+        workManager.getWorkInfosForUniqueWork(workName).await()
+    }
+    val missingExpectedWorkNameCount = workInfosByName.count { workInfos ->
+        workInfos.isEmpty()
+    }
+
+    return NotificationExpectedWorkInfoReadback(
+        stateCounts = countWorkInfoStates(workInfos = workInfosByName.flatten()),
+        expectedWorkNameCount = distinctWorkNames.size,
+        missingExpectedWorkNameCount = missingExpectedWorkNameCount
+    )
+}
+
+internal fun countWorkInfoStates(workInfos: List<WorkInfo>): AndroidWorkInfoStateCounts {
+    val groupedCounts: Map<WorkInfo.State, Int> = workInfos.groupingBy { workInfo ->
+        workInfo.state
+    }.eachCount()
+
+    return AndroidWorkInfoStateCounts(
+        enqueued = groupedCounts[WorkInfo.State.ENQUEUED] ?: 0,
+        running = groupedCounts[WorkInfo.State.RUNNING] ?: 0,
+        blocked = groupedCounts[WorkInfo.State.BLOCKED] ?: 0,
+        cancelled = groupedCounts[WorkInfo.State.CANCELLED] ?: 0,
+        failed = groupedCounts[WorkInfo.State.FAILED] ?: 0,
+        succeeded = groupedCounts[WorkInfo.State.SUCCEEDED] ?: 0
+    )
+}
+
+internal fun calculateNotificationDelayRange(
+    scheduledAtMillisValues: List<Long>,
+    nowMillis: Long
+): NotificationDelayRange {
+    if (scheduledAtMillisValues.isEmpty()) {
+        return NotificationDelayRange(
+            firstScheduledAtMillis = null,
+            lastScheduledAtMillis = null,
+            minDelaySeconds = null,
+            maxDelaySeconds = null
+        )
+    }
+
+    val sortedScheduledAtMillisValues: List<Long> = scheduledAtMillisValues.sorted()
+    val delaySecondsValues: List<Long> = sortedScheduledAtMillisValues.map { scheduledAtMillis ->
+        TimeUnit.MILLISECONDS.toSeconds(maxOf(0L, scheduledAtMillis - nowMillis))
+    }
+
+    return NotificationDelayRange(
+        firstScheduledAtMillis = sortedScheduledAtMillisValues.first(),
+        lastScheduledAtMillis = sortedScheduledAtMillisValues.last(),
+        minDelaySeconds = delaySecondsValues.minOrNull(),
+        maxDelaySeconds = delaySecondsValues.maxOrNull()
+    )
+}
+
+internal fun emptyNotificationDelayRange(): NotificationDelayRange {
+    return NotificationDelayRange(
+        firstScheduledAtMillis = null,
+        lastScheduledAtMillis = null,
+        minDelaySeconds = null,
+        maxDelaySeconds = null
+    )
+}
+
+internal fun hasMissingExpectedWorkNames(readback: NotificationExpectedWorkInfoReadback): Boolean {
+    return readback.expectedWorkNameCount > 0 && readback.missingExpectedWorkNameCount > 0
+}
+
+internal fun hasOnlyCancelledOrFailedExpectedWork(readback: NotificationExpectedWorkInfoReadback): Boolean {
+    val counts: AndroidWorkInfoStateCounts = readback.stateCounts
+    val observedWorkCount: Int = counts.enqueued +
+        counts.running +
+        counts.blocked +
+        counts.cancelled +
+        counts.failed +
+        counts.succeeded
+    val failedOrCancelledCount: Int = counts.cancelled + counts.failed
+
+    return observedWorkCount > 0 && failedOrCancelledCount == observedWorkCount
+}
+
+internal fun addNotificationWorkerBreadcrumb(
+    applicationContext: Context,
+    notificationKind: String,
+    stage: String,
+    requestId: String?,
+    workspaceId: String?,
+    permissionAllowed: Boolean,
+    workTag: String,
+    workLimit: Int?
+) {
+    val appGraph: AppGraph = (applicationContext as? FlashcardsApplication)?.appGraphOrNull ?: return
+    appGraph.observability.addBreadcrumb(
+        event = AndroidBreadcrumbEvent.NotificationSchedulingBreadcrumb(
+            diagnostic = AndroidNotificationSchedulingDiagnostic(
+                notificationKind = notificationKind,
+                stage = stage,
+                trigger = "work_manager",
+                requestId = requestId,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed,
+                plannedCount = null,
+                workLimit = workLimit,
+                appNotificationWorkLimit = appNotificationWorkLimit,
+                strictReminderWorkLimit = strictReminderWorkLimit,
+                strictRemindersEnabled = null,
+                plannedCountEqualsWorkLimit = null,
+                storedScheduledCountBefore = null,
+                storedScheduledCountAfter = null,
+                workTag = workTag,
+                tagWorkStateCounts = null,
+                expectedWorkStateCounts = null,
+                expectedWorkNameCount = null,
+                missingExpectedWorkNameCount = null,
+                firstScheduledAtMillis = null,
+                lastScheduledAtMillis = null,
+                minDelaySeconds = null,
+                maxDelaySeconds = null,
+                generation = null,
+                managerClosed = null,
+                enqueueRejected = null
+            ),
+            appVersion = appGraph.appPackageInfo.versionName,
+            clientVersion = appGraph.appPackageInfo.versionName,
+            versionCode = appGraph.appPackageInfo.longVersionCode.toInt()
+        )
+    )
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationWorker.kt
@@ -12,16 +12,35 @@ class ReviewNotificationWorker(
     params: WorkerParameters
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
-        if (hasNotificationPermission(context = applicationContext).not()) {
+        val requestId = inputData.getString(reviewNotificationRequestIdDataKey)
+        val workspaceId = inputData.getString(reviewNotificationWorkspaceIdDataKey)
+        val permissionAllowed: Boolean = hasNotificationPermission(context = applicationContext)
+        addWorkerBreadcrumb(
+            stage = "worker_start",
+            requestId = requestId,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed
+        )
+        if (permissionAllowed.not()) {
+            addWorkerBreadcrumb(
+                stage = "worker_permission_blocked",
+                requestId = requestId,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed
+            )
             return Result.success()
         }
 
         val frontText = inputData.getString(reviewNotificationFrontTextDataKey)
-            ?: return Result.failure()
-        val requestId = inputData.getString(reviewNotificationRequestIdDataKey)
-            ?: return Result.failure()
-        val workspaceId = inputData.getString(reviewNotificationWorkspaceIdDataKey)
-            ?: return Result.failure()
+        if (frontText == null || requestId == null || workspaceId == null) {
+            addWorkerBreadcrumb(
+                stage = "worker_invalid_input_failure",
+                requestId = requestId,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed
+            )
+            return Result.failure()
+        }
 
         // Read live so a toggle-off after schedule time wins immediately, even if a
         // worker is already mid-flight.
@@ -33,6 +52,12 @@ class ReviewNotificationWorker(
             frontText = frontText,
             requestId = requestId,
             showAppIconBadge = showAppIconBadge
+        )
+        addWorkerBreadcrumb(
+            stage = "worker_notification_posted",
+            requestId = requestId,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed
         )
         return Result.success()
     }
@@ -46,5 +71,23 @@ class ReviewNotificationWorker(
         }
         // Cold-start fallback: the worker can fire before Application.onCreate has published the graph.
         return SharedPreferencesReviewNotificationsStore(context = applicationContext)
+    }
+
+    private fun addWorkerBreadcrumb(
+        stage: String,
+        requestId: String?,
+        workspaceId: String?,
+        permissionAllowed: Boolean
+    ) {
+        addNotificationWorkerBreadcrumb(
+            applicationContext = applicationContext,
+            notificationKind = reviewReminderNotificationKind,
+            stage = stage,
+            requestId = requestId,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed,
+            workTag = reviewNotificationWorkTag,
+            workLimit = null
+        )
     }
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManager.kt
@@ -13,6 +13,11 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.await
+import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
+import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidWorkInfoStateCounts
+import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.CardEntity
@@ -28,12 +33,14 @@ import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsR
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
 import com.flashcardsopensourceapp.data.local.notifications.ScheduledReviewNotificationPayload
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersStore
+import com.flashcardsopensourceapp.data.local.notifications.appNotificationWorkLimit
 import com.flashcardsopensourceapp.data.local.notifications.buildFallbackDailyReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.buildFallbackInactivityReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.buildDailyReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.buildInactivityReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.makePersistedReviewFilter
 import com.flashcardsopensourceapp.data.local.notifications.reviewNotificationWorkLimit
+import com.flashcardsopensourceapp.data.local.notifications.strictReminderWorkLimit
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.loadCurrentWorkspaceOrNull
 import com.flashcardsopensourceapp.data.local.review.ReviewPreferencesStore
 import com.flashcardsopensourceapp.feature.review.reviewTextProvider
@@ -60,7 +67,10 @@ class ReviewNotificationsManager(
     private val preferencesStore: CloudPreferencesStore,
     private val reviewPreferencesStore: ReviewPreferencesStore,
     private val reviewNotificationsStore: ReviewNotificationsStore,
-    private val strictRemindersStore: StrictRemindersStore
+    private val strictRemindersStore: StrictRemindersStore,
+    private val observability: AppObservability,
+    private val appVersion: String?,
+    private val versionCode: Int?
 ) {
     private val workManager: WorkManager = WorkManager.getInstance(context)
     private val scopeJob = SupervisorJob()
@@ -143,21 +153,79 @@ class ReviewNotificationsManager(
             return
         }
 
-        clearCurrentWorkspaceReviewScheduling(workspaceId = workspace.workspaceId)
+        val workspaceId: String = workspace.workspaceId
+        val strictRemindersSettings = strictRemindersStore.loadStrictRemindersSettings()
+        val strictRemindersEnabled: Boolean = strictRemindersSettings.isEnabled
+        val workLimit: Int = reviewNotificationWorkLimit(strictRemindersSettings = strictRemindersSettings)
+        val permissionAllowed: Boolean = hasNotificationPermission(context = context)
+        val storedScheduledCountBefore: Int = reviewNotificationsStore.loadScheduledPayloads(
+            workspaceId = workspaceId
+        ).size
+        emitReviewSchedulingBreadcrumb(
+            diagnostic = makeReviewSchedulingDiagnostic(
+                stage = "reconcile_start",
+                trigger = trigger,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed,
+                plannedCount = null,
+                workLimit = workLimit,
+                strictRemindersEnabled = strictRemindersEnabled,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                storedScheduledCountAfter = null,
+                tagWorkStateCounts = null,
+                expectedWorkReadback = null,
+                delayRange = emptyNotificationDelayRange(),
+                generation = generation
+            )
+        )
 
-        val settings = reviewNotificationsStore.loadSettings(workspaceId = workspace.workspaceId)
+        clearCurrentWorkspaceReviewScheduling(workspaceId = workspaceId)
+        emitReviewSchedulingBreadcrumb(
+            diagnostic = makeReviewSchedulingDiagnostic(
+                stage = "after_cancel",
+                trigger = trigger,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed,
+                plannedCount = null,
+                workLimit = workLimit,
+                strictRemindersEnabled = strictRemindersEnabled,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                storedScheduledCountAfter = reviewNotificationsStore.loadScheduledPayloads(workspaceId = workspaceId).size,
+                tagWorkStateCounts = loadWorkInfoStateCountsByTag(
+                    workManager = workManager,
+                    workTag = reviewNotificationWorkTag
+                ),
+                expectedWorkReadback = null,
+                delayRange = emptyNotificationDelayRange(),
+                generation = generation
+            )
+        )
+
+        val settings = reviewNotificationsStore.loadSettings(workspaceId = workspaceId)
         if (settings.isEnabled.not()) {
-            reviewNotificationsStore.saveScheduledPayloads(
-                workspaceId = workspace.workspaceId,
-                payloads = emptyList()
+            saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(
+                stage = "settings_disabled",
+                trigger = trigger,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed,
+                workLimit = workLimit,
+                strictRemindersEnabled = strictRemindersEnabled,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                generation = generation
             )
             return
         }
-        if (hasNotificationPermission(context = context).not()) {
+        if (permissionAllowed.not()) {
             // Keep the internal setting enabled; Android permission alone gates delivery.
-            reviewNotificationsStore.saveScheduledPayloads(
-                workspaceId = workspace.workspaceId,
-                payloads = emptyList()
+            saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(
+                stage = "permission_blocked",
+                trigger = trigger,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed,
+                workLimit = workLimit,
+                strictRemindersEnabled = strictRemindersEnabled,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                generation = generation
             )
             return
         }
@@ -166,37 +234,40 @@ class ReviewNotificationsManager(
         }
 
         val selectedReviewFilter = reviewPreferencesStore.loadSelectedReviewFilter(
-            workspaceId = workspace.workspaceId
+            workspaceId = workspaceId
         )
         val reviewNotificationFilterPlan = loadReviewNotificationFilterPlan(
-            workspaceId = workspace.workspaceId,
+            workspaceId = workspaceId,
             selectedReviewFilter = selectedReviewFilter
         )
         val resolvedReviewFilter = when (reviewNotificationFilterPlan) {
             is ReviewNotificationFilterPlan.Schedule -> reviewNotificationFilterPlan.reviewFilter
             ReviewNotificationFilterPlan.SuppressScheduledPayloads -> {
-                reviewNotificationsStore.saveScheduledPayloads(
-                    workspaceId = workspace.workspaceId,
-                    payloads = emptyList()
+                saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(
+                    stage = "filter_suppressed",
+                    trigger = trigger,
+                    workspaceId = workspaceId,
+                    permissionAllowed = permissionAllowed,
+                    workLimit = workLimit,
+                    strictRemindersEnabled = strictRemindersEnabled,
+                    storedScheduledCountBefore = storedScheduledCountBefore,
+                    generation = generation
                 )
                 return
             }
         }
 
         val currentCard = loadCurrentReviewNotificationCard(
-            workspaceId = workspace.workspaceId,
+            workspaceId = workspaceId,
             reviewFilter = resolvedReviewFilter,
             nowMillis = nowMillis
         )
 
         val zoneId = ZoneId.systemDefault()
-        val workLimit: Int = reviewNotificationWorkLimit(
-            strictRemindersSettings = strictRemindersStore.loadStrictRemindersSettings()
-        )
         val payloads = if (currentCard != null) {
             when (settings.selectedMode) {
                 ReviewNotificationMode.DAILY -> buildDailyReminderPayloads(
-                    workspaceId = workspace.workspaceId,
+                    workspaceId = workspaceId,
                     currentCard = currentCard,
                     nowMillis = nowMillis,
                     zoneId = zoneId,
@@ -206,12 +277,18 @@ class ReviewNotificationsManager(
 
                 ReviewNotificationMode.INACTIVITY -> {
                     val lastActiveAtMillis = reviewNotificationsStore.loadLastActiveAtMillis()
-                        ?: return reviewNotificationsStore.saveScheduledPayloads(
-                            workspaceId = workspace.workspaceId,
-                            payloads = emptyList()
+                        ?: return saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(
+                            stage = "missing_last_active",
+                            trigger = trigger,
+                            workspaceId = workspaceId,
+                            permissionAllowed = permissionAllowed,
+                            workLimit = workLimit,
+                            strictRemindersEnabled = strictRemindersEnabled,
+                            storedScheduledCountBefore = storedScheduledCountBefore,
+                            generation = generation
                         )
                     buildInactivityReminderPayloads(
-                        workspaceId = workspace.workspaceId,
+                        workspaceId = workspaceId,
                         currentCard = currentCard,
                         nowMillis = nowMillis,
                         lastActiveAtMillis = lastActiveAtMillis,
@@ -226,7 +303,7 @@ class ReviewNotificationsManager(
             val fallbackFrontText = reviewTextProvider(context = context).notificationFallbackFrontText
             when (settings.selectedMode) {
                 ReviewNotificationMode.DAILY -> buildFallbackDailyReminderPayloads(
-                    workspaceId = workspace.workspaceId,
+                    workspaceId = workspaceId,
                     reviewFilter = persistedReviewFilter,
                     fallbackFrontText = fallbackFrontText,
                     nowMillis = nowMillis,
@@ -237,12 +314,18 @@ class ReviewNotificationsManager(
 
                 ReviewNotificationMode.INACTIVITY -> {
                     val lastActiveAtMillis = reviewNotificationsStore.loadLastActiveAtMillis()
-                        ?: return reviewNotificationsStore.saveScheduledPayloads(
-                            workspaceId = workspace.workspaceId,
-                            payloads = emptyList()
+                        ?: return saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(
+                            stage = "missing_last_active",
+                            trigger = trigger,
+                            workspaceId = workspaceId,
+                            permissionAllowed = permissionAllowed,
+                            workLimit = workLimit,
+                            strictRemindersEnabled = strictRemindersEnabled,
+                            storedScheduledCountBefore = storedScheduledCountBefore,
+                            generation = generation
                         )
                     buildFallbackInactivityReminderPayloads(
-                        workspaceId = workspace.workspaceId,
+                        workspaceId = workspaceId,
                         reviewFilter = persistedReviewFilter,
                         fallbackFrontText = fallbackFrontText,
                         nowMillis = nowMillis,
@@ -268,8 +351,45 @@ class ReviewNotificationsManager(
             return
         }
         reviewNotificationsStore.saveScheduledPayloads(
-            workspaceId = workspace.workspaceId,
+            workspaceId = workspaceId,
             payloads = payloads
+        )
+        val expectedWorkReadback: NotificationExpectedWorkInfoReadback = loadExpectedWorkInfoReadback(
+            workManager = workManager,
+            expectedUniqueWorkNames = payloads.map { payload ->
+                payload.requestId
+            }
+        )
+        val tagWorkStateCounts: AndroidWorkInfoStateCounts = loadWorkInfoStateCountsByTag(
+            workManager = workManager,
+            workTag = reviewNotificationWorkTag
+        )
+        val delayRange: NotificationDelayRange = calculateNotificationDelayRange(
+            scheduledAtMillisValues = payloads.map { payload ->
+                payload.scheduledAtMillis
+            },
+            nowMillis = nowMillis
+        )
+        val afterEnqueueDiagnostic: AndroidNotificationSchedulingDiagnostic = makeReviewSchedulingDiagnostic(
+            stage = "after_enqueue",
+            trigger = trigger,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed,
+            plannedCount = payloads.size,
+            workLimit = workLimit,
+            strictRemindersEnabled = strictRemindersEnabled,
+            storedScheduledCountBefore = storedScheduledCountBefore,
+            storedScheduledCountAfter = reviewNotificationsStore.loadScheduledPayloads(workspaceId = workspaceId).size,
+            tagWorkStateCounts = tagWorkStateCounts,
+            expectedWorkReadback = expectedWorkReadback,
+            delayRange = delayRange,
+            generation = generation
+        )
+        emitReviewSchedulingBreadcrumb(diagnostic = afterEnqueueDiagnostic)
+        emitReviewSchedulingWarningIfNeeded(
+            diagnostic = afterEnqueueDiagnostic,
+            plannedCount = payloads.size,
+            expectedWorkReadback = expectedWorkReadback
         )
     }
 
@@ -353,6 +473,127 @@ class ReviewNotificationsManager(
     private suspend fun clearCurrentWorkspaceReviewScheduling(workspaceId: String) {
         workManager.cancelAllWorkByTag(reviewNotificationWorkTag).await()
         reviewNotificationsStore.saveScheduledPayloads(workspaceId = workspaceId, payloads = emptyList())
+    }
+
+    private suspend fun saveEmptyReviewSchedulingAndEmitSkippedDiagnostic(
+        stage: String,
+        trigger: ReviewNotificationsReconcileTrigger,
+        workspaceId: String,
+        permissionAllowed: Boolean,
+        workLimit: Int,
+        strictRemindersEnabled: Boolean,
+        storedScheduledCountBefore: Int,
+        generation: Long
+    ) {
+        reviewNotificationsStore.saveScheduledPayloads(
+            workspaceId = workspaceId,
+            payloads = emptyList()
+        )
+        emitReviewSchedulingBreadcrumb(
+            diagnostic = makeReviewSchedulingDiagnostic(
+                stage = stage,
+                trigger = trigger,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed,
+                plannedCount = 0,
+                workLimit = workLimit,
+                strictRemindersEnabled = strictRemindersEnabled,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                storedScheduledCountAfter = reviewNotificationsStore.loadScheduledPayloads(workspaceId = workspaceId).size,
+                tagWorkStateCounts = loadWorkInfoStateCountsByTag(
+                    workManager = workManager,
+                    workTag = reviewNotificationWorkTag
+                ),
+                expectedWorkReadback = null,
+                delayRange = emptyNotificationDelayRange(),
+                generation = generation
+            )
+        )
+    }
+
+    private fun makeReviewSchedulingDiagnostic(
+        stage: String,
+        trigger: ReviewNotificationsReconcileTrigger,
+        workspaceId: String,
+        permissionAllowed: Boolean,
+        plannedCount: Int?,
+        workLimit: Int,
+        strictRemindersEnabled: Boolean,
+        storedScheduledCountBefore: Int?,
+        storedScheduledCountAfter: Int?,
+        tagWorkStateCounts: AndroidWorkInfoStateCounts?,
+        expectedWorkReadback: NotificationExpectedWorkInfoReadback?,
+        delayRange: NotificationDelayRange,
+        generation: Long
+    ): AndroidNotificationSchedulingDiagnostic {
+        return AndroidNotificationSchedulingDiagnostic(
+            notificationKind = reviewReminderNotificationKind,
+            stage = stage,
+            trigger = trigger.name.lowercase(),
+            requestId = null,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed,
+            plannedCount = plannedCount,
+            workLimit = workLimit,
+            appNotificationWorkLimit = appNotificationWorkLimit,
+            strictReminderWorkLimit = strictReminderWorkLimit,
+            strictRemindersEnabled = strictRemindersEnabled,
+            plannedCountEqualsWorkLimit = plannedCount?.let { count ->
+                count == workLimit
+            },
+            storedScheduledCountBefore = storedScheduledCountBefore,
+            storedScheduledCountAfter = storedScheduledCountAfter,
+            workTag = reviewNotificationWorkTag,
+            tagWorkStateCounts = tagWorkStateCounts,
+            expectedWorkStateCounts = expectedWorkReadback?.stateCounts,
+            expectedWorkNameCount = expectedWorkReadback?.expectedWorkNameCount,
+            missingExpectedWorkNameCount = expectedWorkReadback?.missingExpectedWorkNameCount,
+            firstScheduledAtMillis = delayRange.firstScheduledAtMillis,
+            lastScheduledAtMillis = delayRange.lastScheduledAtMillis,
+            minDelaySeconds = delayRange.minDelaySeconds,
+            maxDelaySeconds = delayRange.maxDelaySeconds,
+            generation = generation,
+            managerClosed = null,
+            enqueueRejected = null
+        )
+    }
+
+    private fun emitReviewSchedulingBreadcrumb(diagnostic: AndroidNotificationSchedulingDiagnostic) {
+        observability.addBreadcrumb(
+            event = AndroidBreadcrumbEvent.NotificationSchedulingBreadcrumb(
+                diagnostic = diagnostic,
+                appVersion = appVersion,
+                clientVersion = appVersion,
+                versionCode = versionCode
+            )
+        )
+    }
+
+    private fun emitReviewSchedulingWarningIfNeeded(
+        diagnostic: AndroidNotificationSchedulingDiagnostic,
+        plannedCount: Int,
+        expectedWorkReadback: NotificationExpectedWorkInfoReadback
+    ) {
+        if (plannedCount == 0) {
+            return
+        }
+
+        val warningReason: String = when {
+            hasMissingExpectedWorkNames(readback = expectedWorkReadback) -> "expected_work_missing"
+            hasOnlyCancelledOrFailedExpectedWork(readback = expectedWorkReadback) -> {
+                "expected_work_cancelled_or_failed"
+            }
+            else -> return
+        }
+        observability.captureWarning(
+            event = AndroidWarningIssueEvent.NotificationSchedulingWarning(
+                diagnostic = diagnostic,
+                warningReason = warningReason,
+                appVersion = appVersion,
+                clientVersion = appVersion,
+                versionCode = versionCode
+            )
+        )
     }
 
     private suspend fun loadCurrentReviewNotificationCard(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictReminderWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictReminderWorker.kt
@@ -4,24 +4,47 @@ import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.flashcardsopensourceapp.data.local.notifications.StrictReminderTimeOffset
+import com.flashcardsopensourceapp.data.local.notifications.strictReminderWorkLimit
 
 class StrictReminderWorker(
     appContext: Context,
     params: WorkerParameters
 ) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
-        if (hasNotificationPermission(context = applicationContext).not()) {
+        val requestId = inputData.getString(strictReminderRequestIdDataKey)
+        val permissionAllowed: Boolean = hasNotificationPermission(context = applicationContext)
+        addWorkerBreadcrumb(
+            stage = "worker_start",
+            requestId = requestId,
+            permissionAllowed = permissionAllowed
+        )
+        if (permissionAllowed.not()) {
+            addWorkerBreadcrumb(
+                stage = "worker_permission_blocked",
+                requestId = requestId,
+                permissionAllowed = permissionAllowed
+            )
             return Result.success()
         }
 
-        val requestId = inputData.getString(strictReminderRequestIdDataKey)
-            ?: return Result.failure()
         val rawTimeOffset = inputData.getString(strictReminderTimeOffsetDataKey)
-            ?: return Result.failure()
+        if (requestId == null || rawTimeOffset == null) {
+            addWorkerBreadcrumb(
+                stage = "worker_invalid_input_failure",
+                requestId = requestId,
+                permissionAllowed = permissionAllowed
+            )
+            return Result.failure()
+        }
 
         val timeOffset = try {
             StrictReminderTimeOffset.fromRawValue(rawValue = rawTimeOffset)
         } catch (_: IllegalArgumentException) {
+            addWorkerBreadcrumb(
+                stage = "worker_invalid_input_failure",
+                requestId = requestId,
+                permissionAllowed = permissionAllowed
+            )
             return Result.failure()
         }
 
@@ -30,6 +53,28 @@ class StrictReminderWorker(
             timeOffset = timeOffset,
             requestId = requestId
         )
+        addWorkerBreadcrumb(
+            stage = "worker_notification_posted",
+            requestId = requestId,
+            permissionAllowed = permissionAllowed
+        )
         return Result.success()
+    }
+
+    private fun addWorkerBreadcrumb(
+        stage: String,
+        requestId: String?,
+        permissionAllowed: Boolean
+    ) {
+        addNotificationWorkerBreadcrumb(
+            applicationContext = applicationContext,
+            notificationKind = strictReminderNotificationKind,
+            stage = stage,
+            requestId = requestId,
+            workspaceId = null,
+            permissionAllowed = permissionAllowed,
+            workTag = strictReminderWorkTag,
+            workLimit = strictReminderWorkLimit
+        )
     }
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManager.kt
@@ -10,15 +10,22 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.await
+import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
+import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidWorkInfoStateCounts
+import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.data.local.database.review.ReviewLogDao
 import com.flashcardsopensourceapp.data.local.notifications.ScheduledStrictReminderPayload
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersStore
+import com.flashcardsopensourceapp.data.local.notifications.appNotificationWorkLimit
 import com.flashcardsopensourceapp.data.local.notifications.buildStrictReminderLocalDateWindow
 import com.flashcardsopensourceapp.data.local.notifications.buildStrictReminderPayloads
 import com.flashcardsopensourceapp.data.local.notifications.isStrictReminderLocalDateCompleted
 import com.flashcardsopensourceapp.data.local.notifications.mergeStrictReminderCompletedReviewAtMillis
 import com.flashcardsopensourceapp.data.local.notifications.resolveStrictReminderCompletedReviewAtMillis
+import com.flashcardsopensourceapp.data.local.notifications.strictReminderWorkLimit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CompletableDeferred
@@ -41,6 +48,8 @@ interface StrictRemindersScheduler {
     fun clearDeliveredNotifications()
     suspend fun clearScheduledReminders()
     suspend fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long)
+    suspend fun loadScheduledWorkStateCounts(): AndroidWorkInfoStateCounts
+    suspend fun loadExpectedWorkReadback(requestIds: List<String>): NotificationExpectedWorkInfoReadback
 }
 
 private sealed interface StrictRemindersCommand {
@@ -118,6 +127,22 @@ class AndroidStrictRemindersScheduler(
         ).await()
     }
 
+    override suspend fun loadScheduledWorkStateCounts(): AndroidWorkInfoStateCounts {
+        return loadWorkInfoStateCountsByTag(
+            workManager = workManager,
+            workTag = strictReminderWorkTag
+        )
+    }
+
+    override suspend fun loadExpectedWorkReadback(
+        requestIds: List<String>
+    ): NotificationExpectedWorkInfoReadback {
+        return loadExpectedWorkInfoReadback(
+            workManager = workManager,
+            expectedUniqueWorkNames = requestIds
+        )
+    }
+
     private fun isStrictReminderNotification(notification: StatusBarNotification): Boolean {
         if (notification.packageName != context.packageName) {
             return false
@@ -135,7 +160,10 @@ class StrictRemindersManager(
     private val strictRemindersStore: StrictRemindersStore,
     private val reviewLogDao: ReviewLogDao,
     private val scheduler: StrictRemindersScheduler,
-    private val zoneIdProvider: () -> ZoneId
+    private val zoneIdProvider: () -> ZoneId,
+    private val observability: AppObservability,
+    private val appVersion: String?,
+    private val versionCode: Int?
 ) {
     private val scopeJob = SupervisorJob()
     private val scope = CoroutineScope(scopeJob + Dispatchers.Default)
@@ -281,6 +309,8 @@ class StrictRemindersManager(
         if (tryEnqueueCommand(command = command)) {
             return
         }
+
+        emitStrictReminderCommandRejectedWarning(command = command)
     }
 
     private fun enqueueRequiredCommand(command: StrictRemindersCommand) {
@@ -288,6 +318,7 @@ class StrictRemindersManager(
             return
         }
 
+        emitStrictReminderCommandRejectedWarning(command = command)
         throw closedManagerException(cause = null)
     }
 
@@ -323,16 +354,64 @@ class StrictRemindersManager(
         trigger: StrictRemindersReconcileTrigger,
         nowMillis: Long
     ) {
+        val storedScheduledCountBefore: Int = strictRemindersStore.loadScheduledStrictReminderPayloads().size
+        val settings = strictRemindersStore.loadStrictRemindersSettings()
+        val permissionAllowed: Boolean = scheduler.hasNotificationPermission()
+        emitStrictReminderSchedulingBreadcrumb(
+            diagnostic = makeStrictReminderSchedulingDiagnostic(
+                stage = "reconcile_start",
+                trigger = trigger.name.lowercase(),
+                permissionAllowed = permissionAllowed,
+                plannedCount = null,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                storedScheduledCountAfter = null,
+                tagWorkStateCounts = null,
+                expectedWorkReadback = null,
+                delayRange = emptyNotificationDelayRange(),
+                managerClosed = false,
+                enqueueRejected = false
+            )
+        )
+
         if (trigger.shouldClearDeliveredStrictReminders) {
             scheduler.clearDeliveredNotifications()
         }
 
         scheduler.clearScheduledReminders()
         strictRemindersStore.saveScheduledStrictReminderPayloads(payloads = emptyList())
+        emitStrictReminderSchedulingBreadcrumb(
+            diagnostic = makeStrictReminderSchedulingDiagnostic(
+                stage = "after_cancel",
+                trigger = trigger.name.lowercase(),
+                permissionAllowed = permissionAllowed,
+                plannedCount = null,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                storedScheduledCountAfter = strictRemindersStore.loadScheduledStrictReminderPayloads().size,
+                tagWorkStateCounts = scheduler.loadScheduledWorkStateCounts(),
+                expectedWorkReadback = null,
+                delayRange = emptyNotificationDelayRange(),
+                managerClosed = false,
+                enqueueRejected = false
+            )
+        )
 
-        val settings = strictRemindersStore.loadStrictRemindersSettings()
-        if (settings.isEnabled.not() || scheduler.hasNotificationPermission().not()) {
+        if (settings.isEnabled.not()) {
+            saveEmptyStrictReminderSchedulingAndEmitSkippedDiagnostic(
+                stage = "settings_disabled",
+                trigger = trigger,
+                permissionAllowed = permissionAllowed,
+                storedScheduledCountBefore = storedScheduledCountBefore
+            )
+            return
+        }
+        if (permissionAllowed.not()) {
             // Keep the internal setting enabled; Android permission alone gates delivery.
+            saveEmptyStrictReminderSchedulingAndEmitSkippedDiagnostic(
+                stage = "permission_blocked",
+                trigger = trigger,
+                permissionAllowed = permissionAllowed,
+                storedScheduledCountBefore = storedScheduledCountBefore
+            )
             return
         }
 
@@ -361,6 +440,177 @@ class StrictRemindersManager(
         }
 
         strictRemindersStore.saveScheduledStrictReminderPayloads(payloads = payloads)
+        val expectedWorkReadback: NotificationExpectedWorkInfoReadback = scheduler.loadExpectedWorkReadback(
+            requestIds = payloads.map { payload ->
+                payload.requestId
+            }
+        )
+        val delayRange: NotificationDelayRange = calculateNotificationDelayRange(
+            scheduledAtMillisValues = payloads.map { payload ->
+                payload.scheduledAtMillis
+            },
+            nowMillis = nowMillis
+        )
+        val afterEnqueueDiagnostic: AndroidNotificationSchedulingDiagnostic = makeStrictReminderSchedulingDiagnostic(
+            stage = "after_enqueue",
+            trigger = trigger.name.lowercase(),
+            permissionAllowed = permissionAllowed,
+            plannedCount = payloads.size,
+            storedScheduledCountBefore = storedScheduledCountBefore,
+            storedScheduledCountAfter = strictRemindersStore.loadScheduledStrictReminderPayloads().size,
+            tagWorkStateCounts = scheduler.loadScheduledWorkStateCounts(),
+            expectedWorkReadback = expectedWorkReadback,
+            delayRange = delayRange,
+            managerClosed = false,
+            enqueueRejected = false
+        )
+        emitStrictReminderSchedulingBreadcrumb(diagnostic = afterEnqueueDiagnostic)
+        emitStrictReminderSchedulingWarningIfNeeded(
+            diagnostic = afterEnqueueDiagnostic,
+            plannedCount = payloads.size,
+            expectedWorkReadback = expectedWorkReadback
+        )
+    }
+
+    private suspend fun saveEmptyStrictReminderSchedulingAndEmitSkippedDiagnostic(
+        stage: String,
+        trigger: StrictRemindersReconcileTrigger,
+        permissionAllowed: Boolean,
+        storedScheduledCountBefore: Int
+    ) {
+        strictRemindersStore.saveScheduledStrictReminderPayloads(payloads = emptyList())
+        emitStrictReminderSchedulingBreadcrumb(
+            diagnostic = makeStrictReminderSchedulingDiagnostic(
+                stage = stage,
+                trigger = trigger.name.lowercase(),
+                permissionAllowed = permissionAllowed,
+                plannedCount = 0,
+                storedScheduledCountBefore = storedScheduledCountBefore,
+                storedScheduledCountAfter = strictRemindersStore.loadScheduledStrictReminderPayloads().size,
+                tagWorkStateCounts = scheduler.loadScheduledWorkStateCounts(),
+                expectedWorkReadback = null,
+                delayRange = emptyNotificationDelayRange(),
+                managerClosed = false,
+                enqueueRejected = false
+            )
+        )
+    }
+
+    private fun makeStrictReminderSchedulingDiagnostic(
+        stage: String,
+        trigger: String,
+        permissionAllowed: Boolean?,
+        plannedCount: Int?,
+        storedScheduledCountBefore: Int?,
+        storedScheduledCountAfter: Int?,
+        tagWorkStateCounts: AndroidWorkInfoStateCounts?,
+        expectedWorkReadback: NotificationExpectedWorkInfoReadback?,
+        delayRange: NotificationDelayRange,
+        managerClosed: Boolean?,
+        enqueueRejected: Boolean?
+    ): AndroidNotificationSchedulingDiagnostic {
+        return AndroidNotificationSchedulingDiagnostic(
+            notificationKind = strictReminderNotificationKind,
+            stage = stage,
+            trigger = trigger,
+            requestId = null,
+            workspaceId = null,
+            permissionAllowed = permissionAllowed,
+            plannedCount = plannedCount,
+            workLimit = strictReminderWorkLimit,
+            appNotificationWorkLimit = appNotificationWorkLimit,
+            strictReminderWorkLimit = strictReminderWorkLimit,
+            strictRemindersEnabled = null,
+            plannedCountEqualsWorkLimit = plannedCount?.let { count ->
+                count == strictReminderWorkLimit
+            },
+            storedScheduledCountBefore = storedScheduledCountBefore,
+            storedScheduledCountAfter = storedScheduledCountAfter,
+            workTag = strictReminderWorkTag,
+            tagWorkStateCounts = tagWorkStateCounts,
+            expectedWorkStateCounts = expectedWorkReadback?.stateCounts,
+            expectedWorkNameCount = expectedWorkReadback?.expectedWorkNameCount,
+            missingExpectedWorkNameCount = expectedWorkReadback?.missingExpectedWorkNameCount,
+            firstScheduledAtMillis = delayRange.firstScheduledAtMillis,
+            lastScheduledAtMillis = delayRange.lastScheduledAtMillis,
+            minDelaySeconds = delayRange.minDelaySeconds,
+            maxDelaySeconds = delayRange.maxDelaySeconds,
+            generation = null,
+            managerClosed = managerClosed,
+            enqueueRejected = enqueueRejected
+        )
+    }
+
+    private fun emitStrictReminderSchedulingBreadcrumb(diagnostic: AndroidNotificationSchedulingDiagnostic) {
+        observability.addBreadcrumb(
+            event = AndroidBreadcrumbEvent.NotificationSchedulingBreadcrumb(
+                diagnostic = diagnostic,
+                appVersion = appVersion,
+                clientVersion = appVersion,
+                versionCode = versionCode
+            )
+        )
+    }
+
+    private fun emitStrictReminderSchedulingWarningIfNeeded(
+        diagnostic: AndroidNotificationSchedulingDiagnostic,
+        plannedCount: Int,
+        expectedWorkReadback: NotificationExpectedWorkInfoReadback
+    ) {
+        if (plannedCount == 0) {
+            return
+        }
+
+        val warningReason: String = when {
+            hasMissingExpectedWorkNames(readback = expectedWorkReadback) -> "expected_work_missing"
+            hasOnlyCancelledOrFailedExpectedWork(readback = expectedWorkReadback) -> {
+                "expected_work_cancelled_or_failed"
+            }
+            else -> return
+        }
+        observability.captureWarning(
+            event = AndroidWarningIssueEvent.NotificationSchedulingWarning(
+                diagnostic = diagnostic,
+                warningReason = warningReason,
+                appVersion = appVersion,
+                clientVersion = appVersion,
+                versionCode = versionCode
+            )
+        )
+    }
+
+    private fun emitStrictReminderCommandRejectedWarning(command: StrictRemindersCommand) {
+        val diagnostic = makeStrictReminderSchedulingDiagnostic(
+            stage = "command_enqueue_rejected",
+            trigger = strictReminderCommandTrigger(command = command),
+            permissionAllowed = null,
+            plannedCount = null,
+            storedScheduledCountBefore = null,
+            storedScheduledCountAfter = null,
+            tagWorkStateCounts = null,
+            expectedWorkReadback = null,
+            delayRange = emptyNotificationDelayRange(),
+            managerClosed = isClosed.get(),
+            enqueueRejected = true
+        )
+        observability.captureWarning(
+            event = AndroidWarningIssueEvent.NotificationSchedulingWarning(
+                diagnostic = diagnostic,
+                warningReason = "command_enqueue_rejected",
+                appVersion = appVersion,
+                clientVersion = appVersion,
+                versionCode = versionCode
+            )
+        )
+    }
+
+    private fun strictReminderCommandTrigger(command: StrictRemindersCommand): String {
+        return when (command) {
+            is StrictRemindersCommand.Reconcile -> command.trigger.name.lowercase()
+            is StrictRemindersCommand.RecordSuccessfulReview -> "record_successful_review"
+            is StrictRemindersCommand.RecordImportedReviewHistory -> "record_imported_review_history"
+            is StrictRemindersCommand.ClearIdentityState -> "clear_identity_state"
+        }
     }
 
     private suspend fun clearIdentityStateNow() {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
@@ -3,9 +3,11 @@ package com.flashcardsopensourceapp.app.observability
 import android.util.Log
 import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
 import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
 import com.flashcardsopensourceapp.core.observability.AndroidObservationEvent
 import com.flashcardsopensourceapp.core.observability.AndroidObservationTags
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidWorkInfoStateCounts
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
 import io.sentry.Breadcrumb
@@ -195,6 +197,15 @@ private fun addBreadcrumbData(
                 )
             )
         }
+        is AndroidBreadcrumbEvent.NotificationSchedulingBreadcrumb -> {
+            breadcrumb.setData(
+                "notifications",
+                notificationSchedulingContext(
+                    diagnostic = event.diagnostic,
+                    warningReason = null
+                )
+            )
+        }
     }
 }
 
@@ -212,7 +223,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 stage = sanitizeSentryContextValue(fieldName = "stage", value = event.stage)
             ),
             ai = null,
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidWarningIssueEvent.HttpUnexpectedClientError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -226,7 +238,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 stage = sanitizeSentryContextValue(fieldName = "stage", value = event.stage)
             ),
             ai = null,
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidWarningIssueEvent.AiRemoteError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -258,7 +271,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 cardPartCount = null,
                 message = null
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidWarningIssueEvent.AiLifecycleWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -289,7 +303,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidWarningIssueEvent.AiSendWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -320,7 +335,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidWarningIssueEvent.AiBootstrapWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -351,7 +367,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidWarningIssueEvent.ProgressRefreshWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -363,7 +380,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 progressAction = sanitizeSentryContextValue(fieldName = "refreshAction", value = event.refreshAction),
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
-            )
+            ),
+            notifications = null
         )
         is AndroidWarningIssueEvent.ProgressRepositoryWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -375,7 +393,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 progressAction = sanitizeSentryContextValue(fieldName = "repositoryAction", value = event.repositoryAction),
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
-            )
+            ),
+            notifications = null
         )
         is AndroidWarningIssueEvent.AiRuntimeWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -406,7 +425,19 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
+        )
+        is AndroidWarningIssueEvent.NotificationSchedulingWarning -> SentryAndroidObservationContext(
+            feature = event.feature.tagValue,
+            action = event.action.tagValue,
+            http = null,
+            ai = null,
+            progress = null,
+            notifications = notificationSchedulingContext(
+                diagnostic = event.diagnostic,
+                warningReason = event.warningReason
+            )
         )
     }
 }
@@ -418,14 +449,16 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             action = event.action.tagValue,
             http = null,
             ai = null,
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidExceptionIssueEvent.AppStartupException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
             action = event.action.tagValue,
             http = null,
             ai = null,
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidExceptionIssueEvent.AiStreamCrash -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -456,7 +489,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 cardPartCount = null,
                 message = null
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidExceptionIssueEvent.AiLifecycleError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -487,7 +521,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidExceptionIssueEvent.AiSendError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -518,7 +553,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidExceptionIssueEvent.AiBootstrapError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -549,7 +585,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
         is AndroidExceptionIssueEvent.ProgressRefreshException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -561,7 +598,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 progressAction = sanitizeSentryContextValue(fieldName = "refreshAction", value = event.refreshAction),
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
-            )
+            ),
+            notifications = null
         )
         is AndroidExceptionIssueEvent.ProgressRepositoryException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -573,7 +611,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 progressAction = sanitizeSentryContextValue(fieldName = "repositoryAction", value = event.repositoryAction),
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
-            )
+            ),
+            notifications = null
         )
         is AndroidExceptionIssueEvent.AiRuntimeException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -604,7 +643,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 cardPartCount = null,
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
-            progress = null
+            progress = null,
+            notifications = null
         )
     }
 }
@@ -627,6 +667,59 @@ private fun aiObservationHttpContext(
         statusCode = statusCode,
         code = sanitizeSentryContextValue(fieldName = "code", value = code),
         stage = sanitizeSentryContextValue(fieldName = "stage", value = stage)
+    )
+}
+
+private fun notificationSchedulingContext(
+    diagnostic: AndroidNotificationSchedulingDiagnostic,
+    warningReason: String?
+): SentryNotificationSchedulingContext {
+    return SentryNotificationSchedulingContext(
+        notificationKind = sanitizeSentryContextValue(
+            fieldName = "notificationKind",
+            value = diagnostic.notificationKind
+        ),
+        stage = sanitizeSentryContextValue(fieldName = "stage", value = diagnostic.stage),
+        trigger = sanitizeSentryContextValue(fieldName = "trigger", value = diagnostic.trigger),
+        requestId = sanitizeSentryIdentifier(value = diagnostic.requestId),
+        workspaceId = sanitizeSentryIdentifier(value = diagnostic.workspaceId),
+        permissionAllowed = diagnostic.permissionAllowed,
+        plannedCount = diagnostic.plannedCount,
+        workLimit = diagnostic.workLimit,
+        appNotificationWorkLimit = diagnostic.appNotificationWorkLimit,
+        strictReminderWorkLimit = diagnostic.strictReminderWorkLimit,
+        strictRemindersEnabled = diagnostic.strictRemindersEnabled,
+        plannedCountEqualsWorkLimit = diagnostic.plannedCountEqualsWorkLimit,
+        storedScheduledCountBefore = diagnostic.storedScheduledCountBefore,
+        storedScheduledCountAfter = diagnostic.storedScheduledCountAfter,
+        workTag = sanitizeSentryContextValue(fieldName = "workTag", value = diagnostic.workTag),
+        tagWorkStateCounts = sentryWorkInfoStateCounts(counts = diagnostic.tagWorkStateCounts),
+        expectedWorkStateCounts = sentryWorkInfoStateCounts(counts = diagnostic.expectedWorkStateCounts),
+        expectedWorkNameCount = diagnostic.expectedWorkNameCount,
+        missingExpectedWorkNameCount = diagnostic.missingExpectedWorkNameCount,
+        firstScheduledAtMillis = diagnostic.firstScheduledAtMillis,
+        lastScheduledAtMillis = diagnostic.lastScheduledAtMillis,
+        minDelaySeconds = diagnostic.minDelaySeconds,
+        maxDelaySeconds = diagnostic.maxDelaySeconds,
+        generation = diagnostic.generation,
+        managerClosed = diagnostic.managerClosed,
+        enqueueRejected = diagnostic.enqueueRejected,
+        warningReason = sanitizeSentryContextValue(fieldName = "warningReason", value = warningReason)
+    )
+}
+
+private fun sentryWorkInfoStateCounts(counts: AndroidWorkInfoStateCounts?): SentryWorkInfoStateCounts? {
+    if (counts == null) {
+        return null
+    }
+
+    return SentryWorkInfoStateCounts(
+        enqueued = counts.enqueued,
+        running = counts.running,
+        blocked = counts.blocked,
+        cancelled = counts.cancelled,
+        failed = counts.failed,
+        succeeded = counts.succeeded
     )
 }
 
@@ -740,6 +833,7 @@ private fun warningIssueGroupKey(event: AndroidWarningIssueEvent): String? {
         is AndroidWarningIssueEvent.ProgressRefreshWarning -> event.refreshAction
         is AndroidWarningIssueEvent.ProgressRepositoryWarning -> event.repositoryAction
         is AndroidWarningIssueEvent.AiRuntimeWarning -> event.name.tagValue
+        is AndroidWarningIssueEvent.NotificationSchedulingWarning -> event.diagnostic.notificationKind
     }
     return sanitizeSentryTagValue(fieldName = "warningGroup", value = rawGroupKey)
 }
@@ -764,7 +858,8 @@ private data class SentryAndroidObservationContext(
     val action: String,
     val http: SentryHttpContext?,
     val ai: SentryAiContext?,
-    val progress: SentryProgressContext?
+    val progress: SentryProgressContext?,
+    val notifications: SentryNotificationSchedulingContext?
 )
 
 private data class SentryHttpContext(
@@ -801,4 +896,43 @@ private data class SentryProgressContext(
     val progressAction: String?,
     val scopeId: String?,
     val source: String?
+)
+
+private data class SentryNotificationSchedulingContext(
+    val notificationKind: String?,
+    val stage: String?,
+    val trigger: String?,
+    val requestId: String?,
+    val workspaceId: String?,
+    val permissionAllowed: Boolean?,
+    val plannedCount: Int?,
+    val workLimit: Int?,
+    val appNotificationWorkLimit: Int?,
+    val strictReminderWorkLimit: Int?,
+    val strictRemindersEnabled: Boolean?,
+    val plannedCountEqualsWorkLimit: Boolean?,
+    val storedScheduledCountBefore: Int?,
+    val storedScheduledCountAfter: Int?,
+    val workTag: String?,
+    val tagWorkStateCounts: SentryWorkInfoStateCounts?,
+    val expectedWorkStateCounts: SentryWorkInfoStateCounts?,
+    val expectedWorkNameCount: Int?,
+    val missingExpectedWorkNameCount: Int?,
+    val firstScheduledAtMillis: Long?,
+    val lastScheduledAtMillis: Long?,
+    val minDelaySeconds: Long?,
+    val maxDelaySeconds: Long?,
+    val generation: Long?,
+    val managerClosed: Boolean?,
+    val enqueueRejected: Boolean?,
+    val warningReason: String?
+)
+
+private data class SentryWorkInfoStateCounts(
+    val enqueued: Int,
+    val running: Int,
+    val blocked: Int,
+    val cancelled: Int,
+    val failed: Int,
+    val succeeded: Int
 )

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -1,6 +1,12 @@
 package com.flashcardsopensourceapp.app.notifications
 
 import com.flashcardsopensourceapp.data.local.database.review.ReviewLogDao
+import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
+import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidWorkInfoStateCounts
+import com.flashcardsopensourceapp.core.observability.AppObservability
+import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.notifications.ScheduledStrictReminderPayload
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
@@ -31,7 +37,10 @@ class StrictRemindersManagerTest {
             strictRemindersStore = store,
             reviewLogDao = FakeReviewLogDao(hasReviewLogsBetween = false),
             scheduler = scheduler,
-            zoneIdProvider = { zoneId }
+            zoneIdProvider = { zoneId },
+            observability = FakeAppObservability(),
+            appVersion = testAppVersion,
+            versionCode = testVersionCode
         )
 
         try {
@@ -69,7 +78,10 @@ class StrictRemindersManagerTest {
             strictRemindersStore = store,
             reviewLogDao = FakeReviewLogDao(hasReviewLogsBetween = true),
             scheduler = scheduler,
-            zoneIdProvider = { zoneId }
+            zoneIdProvider = { zoneId },
+            observability = FakeAppObservability(),
+            appVersion = testAppVersion,
+            versionCode = testVersionCode
         )
 
         try {
@@ -121,7 +133,10 @@ class StrictRemindersManagerTest {
             strictRemindersStore = store,
             reviewLogDao = FakeReviewLogDao(hasReviewLogsBetween = false),
             scheduler = scheduler,
-            zoneIdProvider = { zoneId }
+            zoneIdProvider = { zoneId },
+            observability = FakeAppObservability(),
+            appVersion = testAppVersion,
+            versionCode = testVersionCode
         )
 
         try {
@@ -172,7 +187,10 @@ class StrictRemindersManagerTest {
             strictRemindersStore = store,
             reviewLogDao = FakeReviewLogDao(hasReviewLogsBetween = false),
             scheduler = scheduler,
-            zoneIdProvider = { zoneId }
+            zoneIdProvider = { zoneId },
+            observability = FakeAppObservability(),
+            appVersion = testAppVersion,
+            versionCode = testVersionCode
         )
 
         try {
@@ -197,7 +215,10 @@ class StrictRemindersManagerTest {
             strictRemindersStore = store,
             reviewLogDao = FakeReviewLogDao(hasReviewLogsBetween = false),
             scheduler = scheduler,
-            zoneIdProvider = { zoneId }
+            zoneIdProvider = { zoneId },
+            observability = FakeAppObservability(),
+            appVersion = testAppVersion,
+            versionCode = testVersionCode
         )
 
         manager.close()
@@ -290,6 +311,59 @@ private class FakeStrictRemindersScheduler(
     override suspend fun scheduleReminder(payload: ScheduledStrictReminderPayload, nowMillis: Long) {
         scheduledPayloads.add(payload)
     }
+
+    override suspend fun loadScheduledWorkStateCounts(): AndroidWorkInfoStateCounts {
+        return AndroidWorkInfoStateCounts(
+            enqueued = scheduledPayloads.size,
+            running = 0,
+            blocked = 0,
+            cancelled = 0,
+            failed = 0,
+            succeeded = 0
+        )
+    }
+
+    override suspend fun loadExpectedWorkReadback(
+        requestIds: List<String>
+    ): NotificationExpectedWorkInfoReadback {
+        val scheduledRequestIds: Set<String> = scheduledPayloads.map { payload ->
+            payload.requestId
+        }.toSet()
+        val expectedRequestIds: List<String> = requestIds.distinct()
+        val missingExpectedWorkNameCount: Int = expectedRequestIds.count { requestId ->
+            scheduledRequestIds.contains(requestId).not()
+        }
+
+        return NotificationExpectedWorkInfoReadback(
+            stateCounts = AndroidWorkInfoStateCounts(
+                enqueued = expectedRequestIds.size - missingExpectedWorkNameCount,
+                running = 0,
+                blocked = 0,
+                cancelled = 0,
+                failed = 0,
+                succeeded = 0
+            ),
+            expectedWorkNameCount = expectedRequestIds.size,
+            missingExpectedWorkNameCount = missingExpectedWorkNameCount
+        )
+    }
+}
+
+private class FakeAppObservability : AppObservability {
+    override fun setCloudIdentity(identity: CloudObservationIdentity) {
+    }
+
+    override fun clearCloudIdentity() {
+    }
+
+    override fun addBreadcrumb(event: AndroidBreadcrumbEvent) {
+    }
+
+    override fun captureWarning(event: AndroidWarningIssueEvent) {
+    }
+
+    override fun captureException(event: AndroidExceptionIssueEvent) {
+    }
 }
 
 private class FakeReviewLogDao(
@@ -379,3 +453,6 @@ private suspend fun awaitUntil(predicate: () -> Boolean) {
 private fun parseTimestampMillis(value: String): Long {
     return Instant.parse(value).toEpochMilli()
 }
+
+private const val testAppVersion: String = "1.9.0"
+private const val testVersionCode: Int = 1

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app.observability
 
 import com.flashcardsopensourceapp.core.observability.AndroidObservationFeature
+import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -145,6 +146,41 @@ class SentryAppObservabilityTest {
                 clientVersion = testAppVersion,
                 versionCode = testVersionCode
             )
+        val notificationWarning: AndroidWarningIssueEvent.NotificationSchedulingWarning =
+            AndroidWarningIssueEvent.NotificationSchedulingWarning(
+                diagnostic = AndroidNotificationSchedulingDiagnostic(
+                    notificationKind = "reviewReminder",
+                    stage = "after_enqueue",
+                    trigger = "app_background",
+                    requestId = null,
+                    workspaceId = "workspace-1",
+                    permissionAllowed = true,
+                    plannedCount = 26,
+                    workLimit = 26,
+                    appNotificationWorkLimit = 50,
+                    strictReminderWorkLimit = 24,
+                    strictRemindersEnabled = true,
+                    plannedCountEqualsWorkLimit = true,
+                    storedScheduledCountBefore = 3,
+                    storedScheduledCountAfter = 26,
+                    workTag = "review-notification",
+                    tagWorkStateCounts = null,
+                    expectedWorkStateCounts = null,
+                    expectedWorkNameCount = 26,
+                    missingExpectedWorkNameCount = 26,
+                    firstScheduledAtMillis = 1_000L,
+                    lastScheduledAtMillis = 2_000L,
+                    minDelaySeconds = 1L,
+                    maxDelaySeconds = 2L,
+                    generation = 7L,
+                    managerClosed = null,
+                    enqueueRejected = null
+                ),
+                warningReason = "expected_work_missing",
+                appVersion = testAppVersion,
+                clientVersion = testAppVersion,
+                versionCode = testVersionCode
+            )
 
         assertEquals(
             listOf(
@@ -167,6 +203,17 @@ class SentryAppObservabilityTest {
                 "413"
             ),
             warningIssueFingerprint(event = httpWarning)
+        )
+        assertEquals(
+            listOf(
+                "android",
+                "notifications",
+                "notification_scheduling_warning",
+                "reviewReminder",
+                "expected_work_missing",
+                "no_status"
+            ),
+            warningIssueFingerprint(event = notificationWarning)
         )
     }
 }

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
@@ -8,7 +8,8 @@ enum class AndroidObservationFeature(
     BACKEND(tagValue = "backend"),
     AUTH(tagValue = "auth"),
     AI(tagValue = "ai"),
-    PROGRESS(tagValue = "progress")
+    PROGRESS(tagValue = "progress"),
+    NOTIFICATIONS(tagValue = "notifications")
 }
 
 enum class AndroidObservationAction(
@@ -35,7 +36,9 @@ enum class AndroidObservationAction(
     PROGRESS_REFRESH_WARNING(tagValue = "progress_refresh_warning"),
     PROGRESS_REFRESH_EXCEPTION(tagValue = "progress_refresh_exception"),
     PROGRESS_REPOSITORY_WARNING(tagValue = "progress_repository_warning"),
-    PROGRESS_REPOSITORY_EXCEPTION(tagValue = "progress_repository_exception")
+    PROGRESS_REPOSITORY_EXCEPTION(tagValue = "progress_repository_exception"),
+    NOTIFICATION_SCHEDULING_BREADCRUMB(tagValue = "notification_scheduling_breadcrumb"),
+    NOTIFICATION_SCHEDULING_WARNING(tagValue = "notification_scheduling_warning")
 }
 
 enum class AndroidAiObservationName(
@@ -70,6 +73,44 @@ data class AndroidObservationTags(
     val appVersion: String?,
     val clientVersion: String?,
     val versionCode: Int?
+)
+
+data class AndroidWorkInfoStateCounts(
+    val enqueued: Int,
+    val running: Int,
+    val blocked: Int,
+    val cancelled: Int,
+    val failed: Int,
+    val succeeded: Int
+)
+
+data class AndroidNotificationSchedulingDiagnostic(
+    val notificationKind: String,
+    val stage: String,
+    val trigger: String?,
+    val requestId: String?,
+    val workspaceId: String?,
+    val permissionAllowed: Boolean?,
+    val plannedCount: Int?,
+    val workLimit: Int?,
+    val appNotificationWorkLimit: Int?,
+    val strictReminderWorkLimit: Int?,
+    val strictRemindersEnabled: Boolean?,
+    val plannedCountEqualsWorkLimit: Boolean?,
+    val storedScheduledCountBefore: Int?,
+    val storedScheduledCountAfter: Int?,
+    val workTag: String?,
+    val tagWorkStateCounts: AndroidWorkInfoStateCounts?,
+    val expectedWorkStateCounts: AndroidWorkInfoStateCounts?,
+    val expectedWorkNameCount: Int?,
+    val missingExpectedWorkNameCount: Int?,
+    val firstScheduledAtMillis: Long?,
+    val lastScheduledAtMillis: Long?,
+    val minDelaySeconds: Long?,
+    val maxDelaySeconds: Long?,
+    val generation: Long?,
+    val managerClosed: Boolean?,
+    val enqueueRejected: Boolean?
 )
 
 sealed interface AndroidObservationEvent {
@@ -169,6 +210,26 @@ sealed interface AndroidBreadcrumbEvent : AndroidObservationEvent {
             requestId = null,
             statusCode = null,
             code = name.tagValue,
+            appVersion = appVersion,
+            clientVersion = clientVersion,
+            versionCode = versionCode
+        )
+    }
+
+    data class NotificationSchedulingBreadcrumb(
+        val diagnostic: AndroidNotificationSchedulingDiagnostic,
+        val appVersion: String?,
+        val clientVersion: String?,
+        val versionCode: Int?
+    ) : AndroidBreadcrumbEvent {
+        override val feature: AndroidObservationFeature = AndroidObservationFeature.NOTIFICATIONS
+        override val action: AndroidObservationAction = AndroidObservationAction.NOTIFICATION_SCHEDULING_BREADCRUMB
+        override val tags: AndroidObservationTags = AndroidObservationTags(
+            userId = null,
+            workspaceId = diagnostic.workspaceId,
+            requestId = diagnostic.requestId,
+            statusCode = null,
+            code = diagnostic.stage,
             appVersion = appVersion,
             clientVersion = clientVersion,
             versionCode = versionCode
@@ -415,6 +476,27 @@ sealed interface AndroidWarningIssueEvent : AndroidObservationEvent {
             requestId = requestId,
             statusCode = statusCode,
             code = code ?: name.tagValue,
+            appVersion = appVersion,
+            clientVersion = clientVersion,
+            versionCode = versionCode
+        )
+    }
+
+    data class NotificationSchedulingWarning(
+        val diagnostic: AndroidNotificationSchedulingDiagnostic,
+        val warningReason: String,
+        val appVersion: String?,
+        val clientVersion: String?,
+        val versionCode: Int?
+    ) : AndroidWarningIssueEvent {
+        override val feature: AndroidObservationFeature = AndroidObservationFeature.NOTIFICATIONS
+        override val action: AndroidObservationAction = AndroidObservationAction.NOTIFICATION_SCHEDULING_WARNING
+        override val tags: AndroidObservationTags = AndroidObservationTags(
+            userId = null,
+            workspaceId = diagnostic.workspaceId,
+            requestId = diagnostic.requestId,
+            statusCode = null,
+            code = warningReason,
             appVersion = appVersion,
             clientVersion = clientVersion,
             versionCode = versionCode


### PR DESCRIPTION
## Summary
- add typed Android notification scheduling diagnostics to the existing observability contract
- emit review and strict reminder WorkManager scheduling readbacks and warnings
- add worker breadcrumbs for notification execution outcomes

## Validation
- git --no-pager diff --check
- diff-focused review of changed observability and notification paths
- Gradle not run per repository instruction requiring explicit approval
