### PR TITLE
Fix web progress timezone fallback to derive a fixed-offset zone

### DIFF
--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -566,7 +566,8 @@ export type SyncLocalDbRecoveryFailedWarningDetails = SyncBootstrapTimingDetails
 export type ProgressTimezoneInvalidWarningDetails = Readonly<{
   eventName: "progress_timezone_invalid";
   observedTimeZone: string | null;
-  fallbackTimeZone: "UTC";
+  observedOffsetMinutes: number | null;
+  fallbackTimeZone: string;
   errorName: string;
 }>;
 

--- a/apps/web/src/progress/progressDates.test.ts
+++ b/apps/web/src/progress/progressDates.test.ts
@@ -52,6 +52,10 @@ function mockBrowserTimeZone(timeZone: string): void {
   });
 }
 
+function mockBrowserUtcOffset(offsetMinutes: number): void {
+  vi.spyOn(Date.prototype, "getTimezoneOffset").mockReturnValue(offsetMinutes);
+}
+
 function readCapturedWarning(callIndex: number): WebWarningEvent {
   const event = observabilityMocks.captureWebWarningMock.mock.calls[callIndex]?.[0] as WebWarningEvent | undefined;
   if (event === undefined) {
@@ -78,8 +82,20 @@ describe("progress date context", () => {
     observabilityMocks.captureWebWarningMock.mockReset();
   });
 
-  it("falls back to UTC when the browser timezone is invalid", async () => {
+  it("falls back to the browser offset zone when the timezone is invalid", async () => {
     mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserUtcOffset(180);
+    const { buildProgressDateContext } = await loadProgressDatesModule();
+
+    expect(buildProgressDateContext(new Date("2026-06-08T01:00:00.000Z"))).toEqual({
+      timeZone: "Etc/GMT+3",
+      today: "2026-06-07",
+    });
+  });
+
+  it("falls back to UTC when the browser offset is not a whole hour", async () => {
+    mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserUtcOffset(-330);
     const { buildProgressDateContext } = await loadProgressDatesModule();
 
     expect(buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"))).toEqual({
@@ -90,6 +106,7 @@ describe("progress date context", () => {
 
   it("emits progress_timezone_invalid for the first invalid timezone", async () => {
     mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserUtcOffset(180);
     const { buildProgressDateContext } = await loadProgressDatesModule();
 
     buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
@@ -100,7 +117,8 @@ describe("progress date context", () => {
       details: {
         eventName: "progress_timezone_invalid",
         observedTimeZone: "Etc/Unknown",
-        fallbackTimeZone: "UTC",
+        observedOffsetMinutes: 180,
+        fallbackTimeZone: "Etc/GMT+3",
         errorName: "RangeError",
       },
     }));
@@ -108,6 +126,7 @@ describe("progress date context", () => {
 
   it("does not emit a second invalid timezone warning within the throttle window after reload", async () => {
     mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserUtcOffset(180);
     const firstModule = await loadProgressDatesModule();
     firstModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
 
@@ -124,6 +143,7 @@ describe("progress date context", () => {
 
   it("emits a new first warning after localStorage is cleared across reloads", async () => {
     mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserUtcOffset(180);
     const firstModule = await loadProgressDatesModule();
     firstModule.buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));
 
@@ -141,6 +161,7 @@ describe("progress date context", () => {
   it("includes installationId in the warning scope when localStorage is available", async () => {
     window.localStorage.setItem(INSTALLATION_ID_STORAGE_KEY, "installation-1");
     mockBrowserTimeZone("Etc/Unknown");
+    mockBrowserUtcOffset(180);
     const { buildProgressDateContext } = await loadProgressDatesModule();
 
     buildProgressDateContext(new Date("2026-06-04T12:00:00.000Z"));

--- a/apps/web/src/progress/progressDates.ts
+++ b/apps/web/src/progress/progressDates.ts
@@ -211,6 +211,8 @@ function writeProgressTimezoneWarningHistory(
 function observeInvalidProgressTimeZone(
   observedTimeZone: string | null,
   errorName: string,
+  observedOffsetMinutes: number | null,
+  fallbackTimeZone: string,
 ): void {
   const warningKey = `${observedTimeZone ?? "null"}:${errorName}`;
   if (observedInvalidProgressTimeZoneWarnings.has(warningKey)) {
@@ -235,7 +237,8 @@ function observeInvalidProgressTimeZone(
     details: {
       eventName: "progress_timezone_invalid",
       observedTimeZone,
-      fallbackTimeZone: fallbackProgressTimeZone,
+      observedOffsetMinutes,
+      fallbackTimeZone,
       errorName,
     },
   });
@@ -261,6 +264,61 @@ function assertUsableTimeZone(timeZone: string): void {
   formatter.formatToParts(new Date(0));
 }
 
+function readBrowserUtcOffsetMinutes(): number | null {
+  const offsetMinutes = new Date().getTimezoneOffset();
+  return Number.isFinite(offsetMinutes) ? offsetMinutes : null;
+}
+
+function deriveFixedOffsetProgressTimeZone(offsetMinutes: number): string | null {
+  // Date.getTimezoneOffset() reports minutes behind UTC (UTC-3 -> +180), and the
+  // IANA Etc/GMT zones invert the sign the same way (Etc/GMT+3 == UTC-3), so the
+  // sign carries over directly. Only whole-hour offsets map to an Etc/GMT zone.
+  if (offsetMinutes % 60 !== 0) {
+    return null;
+  }
+
+  const offsetHours = offsetMinutes / 60;
+  if (offsetHours === 0) {
+    return fallbackProgressTimeZone;
+  }
+
+  return offsetHours > 0 ? `Etc/GMT+${offsetHours}` : `Etc/GMT${offsetHours}`;
+}
+
+function resolveFallbackProgressTimeZone(offsetMinutes: number | null): string {
+  if (offsetMinutes === null) {
+    return fallbackProgressTimeZone;
+  }
+
+  const fixedOffsetTimeZone = deriveFixedOffsetProgressTimeZone(offsetMinutes);
+  if (fixedOffsetTimeZone === null) {
+    return fallbackProgressTimeZone;
+  }
+
+  try {
+    assertUsableTimeZone(fixedOffsetTimeZone);
+  } catch {
+    return fallbackProgressTimeZone;
+  }
+
+  return fixedOffsetTimeZone;
+}
+
+function fallBackFromInvalidProgressTimeZone(
+  observedTimeZone: string | null,
+  errorName: string,
+): string {
+  const observedOffsetMinutes = readBrowserUtcOffsetMinutes();
+  const fallbackTimeZone = resolveFallbackProgressTimeZone(observedOffsetMinutes);
+  observeInvalidProgressTimeZone(
+    observedTimeZone,
+    errorName,
+    observedOffsetMinutes,
+    fallbackTimeZone,
+  );
+  return fallbackTimeZone;
+}
+
 function getBrowserTimeZone(): string {
   let timeZone: string | null = null;
   try {
@@ -269,20 +327,17 @@ function getBrowserTimeZone(): string {
       ? observedTimeZone
       : null;
   } catch (error) {
-    observeInvalidProgressTimeZone(null, readErrorName(error));
-    return fallbackProgressTimeZone;
+    return fallBackFromInvalidProgressTimeZone(null, readErrorName(error));
   }
 
   if (timeZone === null) {
-    observeInvalidProgressTimeZone(null, "Error");
-    return fallbackProgressTimeZone;
+    return fallBackFromInvalidProgressTimeZone(null, "Error");
   }
 
   try {
     assertUsableTimeZone(timeZone);
   } catch (error) {
-    observeInvalidProgressTimeZone(timeZone, readErrorName(error));
-    return fallbackProgressTimeZone;
+    return fallBackFromInvalidProgressTimeZone(timeZone, readErrorName(error));
   }
 
   return timeZone;


### PR DESCRIPTION
## Problem

The web progress feature reads the browser IANA timezone to compute the user's local "today" and sends that zone to the backend, which buckets review events into local days using the same zone (streaks, "reviewed today", and the due-today/tomorrow schedule).

On some setups (notably Windows + Chrome) the browser reports `Etc/Unknown` instead of a real zone. That value throws when used for date formatting, so the code fell back to `"UTC"`. For any non-UTC user this silently shifts the day boundary by their offset — e.g. a Buenos Aires (UTC−3) user's day rolls over at 21:00 local, breaking streaks and "today" counts. No error surfaces; the numbers are just quietly wrong. This is the source of the `web.progress_timezone_invalid` warnings in Sentry.

## Change

When the named zone is unusable, derive a fixed-offset IANA zone from `Date.getTimezoneOffset()`, which the browser reports reliably even when it can't name the zone:

- `+180` min (UTC−3) → `Etc/GMT+3` → correct local date.
- Validated with the existing `assertUsableTimeZone` before use.
- The same single string is used for both the client `today` and the `timeZone` sent to the backend, so client and server stay consistent by construction.
- Falls back to `"UTC"` only for sub-hour offsets (e.g. UTC+5:30) or when the offset is unavailable — identical to prior behavior for those.

No backend change needed: it already accepts `Etc/GMT±N` (validates via `Intl.DateTimeFormat`, buckets via Postgres `timezone()`). iOS/Android are unaffected — they always have a valid system zone.

The `progress_timezone_invalid` warning now also carries `observedOffsetMinutes` and the chosen `fallbackTimeZone` for better triage.

## Limitation

`Etc/GMT±N` is a fixed offset and does not track DST, so for the already-broken-zone subset the computed "today" can be off by an hour near midnight during part of the year. Still strictly better than always-UTC, and not solvable from a single offset sample.

## Tests

`apps/web/src/progress/progressDates.test.ts` updated to cover the offset-derived zone, the sub-hour UTC fallback, and the enriched warning. The browser offset is mocked so assertions are deterministic regardless of the host machine timezone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
