### PR TITLE
fix(android/ai): stop reporting offline AI warm-up timeouts as Sentry warnings

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapRetryPolicy.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapRetryPolicy.kt
@@ -43,7 +43,7 @@ internal fun isRetryableBootstrapFailure(error: Exception): Boolean {
     if (cloudRemoteError != null) {
         return shouldRetryHttpStatus(statusCode = cloudRemoteError.statusCode)
     }
-    return error is IOException && isLikelyTransientBootstrapIoException(error = error)
+    return error is IOException && isLikelyTransientNetworkIoException(error = error)
 }
 
 internal fun nextBootstrapRetryDelayMillis(retryCount: Int): Long {
@@ -69,7 +69,7 @@ private fun findCloudRemoteCause(error: Throwable): CloudRemoteException? {
     return null
 }
 
-private fun isLikelyTransientBootstrapIoException(error: IOException): Boolean {
+internal fun isLikelyTransientNetworkIoException(error: IOException): Boolean {
     if (error is MalformedURLException || error is ProtocolException) {
         return false
     }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiChatObservability.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiChatObservability.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.data.local.ai.remote.isAiChatAttachmentUnsupp
 import com.flashcardsopensourceapp.data.local.ai.remote.isAiChatRequestTooLargeRemoteError
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatContentPart
 import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.AiChatBootstrapBlockedException
+import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.isLikelyTransientNetworkIoException
 import java.io.IOException
 
 internal data class AiChatContentPartCounts(
@@ -274,7 +275,11 @@ internal fun aiChatFailureIssueDisposition(error: Exception): AiChatFailureIssue
         return AiChatFailureIssueDisposition.NONE
     }
     if (error is IOException) {
-        return AiChatFailureIssueDisposition.WARNING
+        return if (isLikelyTransientNetworkIoException(error = error)) {
+            AiChatFailureIssueDisposition.NONE
+        } else {
+            AiChatFailureIssueDisposition.WARNING
+        }
     }
     if (error is AiChatBootstrapBlockedException) {
         return AiChatFailureIssueDisposition.WARNING


### PR DESCRIPTION
## What & why
Transient network `IOException`s (socket timeout, no connectivity) during AI session warm-up — and other AI chat failure paths — were classified as `WARNING` and sent to Sentry. For expected offline behavior this is pure noise (e.g. `ai_lifecycle_warning / warm_up_failed`).

## Change
Reuses the existing transient-network predicate from the bootstrap retry policy (now `internal`, renamed `isLikelyTransientNetworkIoException`) inside the shared `aiChatFailureIssueDisposition` classifier:
- Transient network `IOException` → `NONE` (no Sentry warning).
- Genuine/unexpected IO (cert, protocol, malformed) → still `WARNING`.

Telemetry-only: user-facing state, retry flags, and local diagnostics are untouched. Because the classifier is the shared chokepoint, this applies uniformly across all AI chat coordinators (warm-up, send, bootstrap, session).

## Scope
2 files, +8/-3. No public API or cross-client contract change. No tests reference the changed symbols.

## Testing
Telemetry classification change; validated by review of all four classifier consumers. Optional manual smoke: airplane mode → open AI screen (triggers warm-up) → no `warm_up_failed` warning in Sentry, UI behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)