### PR TITLE
fix(web): prevent unhandled rejections from background IndexedDB sync ops

### DIFF
--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -30,6 +30,9 @@ import {
   normalizeCaughtError,
 } from "../../../observability/webObservability";
 import {
+  captureAppOperationError,
+} from "../../../observability/appOperationObservation";
+import {
   getErrorMessage,
   nowIso,
 } from "../../domain";
@@ -109,6 +112,16 @@ function createSyncRunId(): string {
   }
 
   return `sync-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+// Background sync is fire-and-forget from effects and mutations. Failures are
+// already observed (observeSyncFailure) and surfaced (reportSyncError) inside
+// runSyncForWorkspace before it rethrows for awaited callers, so here we attach
+// a no-op catch only to keep the fire-and-forget promise from surfacing as a
+// context-less unhandled rejection (for example "Failed to open IndexedDB" when
+// the browser blocks local storage).
+function runSyncInBackground(syncTask: Promise<void>): void {
+  void syncTask.catch((): void => undefined);
 }
 
 export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
@@ -398,7 +411,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
           const needsResync = needsResyncWorkspaceIdsRef.current.has(workspaceId);
           needsResyncWorkspaceIdsRef.current.delete(workspaceId);
           if (needsResync && discardedSyncWorkspaceIdsRef.current.has(workspaceId) === false) {
-            void runSyncForWorkspace(workspace);
+            runSyncInBackground(runSyncForWorkspace(workspace));
           }
         }
       }
@@ -443,8 +456,17 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       return;
     }
 
-    void refreshLocalMetadata(activeWorkspace.workspaceId);
-    void runSyncForWorkspace(activeWorkspace);
+    void refreshLocalMetadata(activeWorkspace.workspaceId).catch((error: unknown): void => {
+      captureAppOperationError(error, {
+        feature: "sync",
+        operation: "refresh_local_metadata",
+        userId: session.userId,
+        workspaceId: activeWorkspace.workspaceId,
+        installationId: null,
+        entityId: null,
+      });
+    });
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
   }, [activeWorkspace, refreshLocalMetadata, runSyncForWorkspace, session, sessionLoadState, sessionVerificationState]);
 
   const refreshLocalData = useCallback(async function refreshLocalData(): Promise<void> {
@@ -507,7 +529,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
-    void runSyncForWorkspace(activeWorkspace);
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
@@ -522,7 +544,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       clientUpdatedAt: nowIso(),
     }));
     bumpLocalReadVersion();
-    void runSyncForWorkspace(activeWorkspace);
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.deck;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
@@ -541,7 +563,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
-    void runSyncForWorkspace(activeWorkspace);
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
@@ -557,7 +579,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       clientUpdatedAt: nowIso(),
     }));
     bumpLocalReadVersion();
-    void runSyncForWorkspace(activeWorkspace);
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.deck;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
@@ -575,7 +597,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     if (mutationResult.didChangeReviewSchedule) {
       invalidateLocalReviewSchedule();
     }
-    void runSyncForWorkspace(activeWorkspace);
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
@@ -590,7 +612,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       clientUpdatedAt: nowIso(),
     }));
     bumpLocalReadVersion();
-    void runSyncForWorkspace(activeWorkspace);
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.deck;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 
@@ -611,7 +633,7 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
     bumpLocalReadVersion();
     invalidateLocalProgress();
     invalidateLocalReviewSchedule();
-    void runSyncForWorkspace(activeWorkspace);
+    runSyncInBackground(runSyncForWorkspace(activeWorkspace));
     return mutationResult.card;
   }, [activeWorkspace, activeWorkspaceId, bumpLocalReadVersion, runLocalWorkspaceMutation, runSyncForWorkspace]);
 

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -301,7 +301,8 @@ export type WebAppOperation =
   | "workspace_settings_load"
   | "workspace_reset_preview_load"
   | "workspace_reset_execute"
-  | "workspace_export";
+  | "workspace_export"
+  | "refresh_local_metadata";
 
 export type WebAppOperationFailureDetails = Readonly<{
   operation: WebAppOperation;


### PR DESCRIPTION
## What

Background (fire-and-forget) workspace sync and local-metadata reads in the web sync engine opened IndexedDB without a rejection handler. When `indexedDB.open()` fails (browser-blocked local storage, private mode, corruption, quota), the rejection became a context-less `onunhandledrejection` in Sentry (observed on `/review`).

## Change

- New module-level `runSyncInBackground(syncTask)` helper in `useSyncEngine.ts`; all 9 fire-and-forget `runSyncForWorkspace(...)` calls go through it. Errors are already observed (`observeSyncFailure`) and surfaced (`reportSyncError`) inside the sync task before it rethrows for awaited callers, so awaited callers (`runSync`, `refreshLocalData`, `seedLinkedWorkspace`, internal re-sync) are unchanged — the helper only suppresses the duplicate unhandled rejection.
- The fire-and-forget `refreshLocalMetadata(...)` now `.catch`es and reports via `captureAppOperationError` (feature `sync`, operation `refresh_local_metadata`), which was previously unobserved.
- Adds `"refresh_local_metadata"` to the `WebAppOperation` union.

## Validation

- `apps/web` `npx tsc -b` passes (exit 0). No ESLint config in repo.
- No behavior change for awaited callers; the visible `/review` error path is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)