### PR TITLE
Disable Sentry below minSdk to drop out-of-contract crash noise

### DIFF
--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -110,6 +110,10 @@ if (isReleaseTaskRequested) {
     }
 }
 
+// Single source for defaultConfig.minSdk, also surfaced to runtime via BuildConfig so
+// observability can skip telemetry from below-minSdk (out-of-contract) devices.
+val androidMinSdk: Int = 34
+
 fun toBuildConfigString(value: String): String {
     return "\"${value.replace("\\", "\\\\").replace("\"", "\\\"")}\""
 }
@@ -135,12 +139,13 @@ android {
 
     defaultConfig {
         applicationId = "com.flashcardsopensourceapp.app"
-        minSdk = 34
+        minSdk = androidMinSdk
         targetSdk = 36
         versionCode = androidVersionCode ?: 1
         versionName = "1.9.0"
         testInstrumentationRunner = "com.flashcardsopensourceapp.app.FlashcardsAndroidTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
+        buildConfigField("int", "ANDROID_MIN_SDK", androidMinSdk.toString())
         buildConfigField("String", "ANDROID_SENTRY_DSN", toBuildConfigString(androidSentryDsn))
         buildConfigField(
             "String",

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidObservabilityStartup.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidObservabilityStartup.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app.observability
 
 import android.app.Application
+import android.os.Build
 import com.flashcardsopensourceapp.app.BuildConfig
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.data.local.network.TracePropagationTarget
@@ -36,12 +37,19 @@ data class AndroidObservabilityStartup(
 
 fun startAndroidObservability(application: Application): AndroidObservabilityStartup {
     val sentryDsn = BuildConfig.ANDROID_SENTRY_DSN.trim()
-    val isSentryEnabled = sentryDsn.isNotBlank()
-    SentryAndroid.init(application) { options ->
-        configureSentryOptions(
-            options = options,
-            sentryDsn = sentryDsn
-        )
+    // Run Sentry only on devices at or above the declared minSdk. Reports from lower API levels
+    // come from out-of-contract devices (emulators, cloud test farms, spoofed or sideloaded
+    // installs) where the latest-only codepath is expected to fail and only pollute crash-free
+    // metrics. Sentry recommends skipping init entirely to fully disable the SDK; that also stops
+    // native (NDK) and ANR capture, which a beforeSend filter cannot reach.
+    val isSentryEnabled = sentryDsn.isNotBlank() && isDeviceAtOrAboveMinimumSupportedSdk()
+    if (isSentryEnabled) {
+        SentryAndroid.init(application) { options ->
+            configureSentryOptions(
+                options = options,
+                sentryDsn = sentryDsn
+            )
+        }
     }
 
     return AndroidObservabilityStartup(
@@ -58,11 +66,6 @@ private fun configureSentryOptions(
     options: io.sentry.android.core.SentryAndroidOptions,
     sentryDsn: String
 ) {
-    if (sentryDsn.isBlank()) {
-        options.isEnabled = false
-        return
-    }
-
     options.dsn = sentryDsn
     options.release = "${BuildConfig.APPLICATION_ID}@${BuildConfig.VERSION_NAME}+${BuildConfig.VERSION_CODE}"
     options.dist = BuildConfig.VERSION_CODE.toString()
@@ -81,6 +84,10 @@ private fun configureSentryOptions(
     options.setBeforeBreadcrumb { breadcrumb, _ ->
         sanitizeSentryBreadcrumb(breadcrumb = breadcrumb)
     }
+}
+
+private fun isDeviceAtOrAboveMinimumSupportedSdk(): Boolean {
+    return Build.VERSION.SDK_INT >= BuildConfig.ANDROID_MIN_SDK
 }
 
 private fun sentryEnvironment(): String {


### PR DESCRIPTION
## Problem
Fatal `NoSuchMethodError` crashes were reported from devices on **Android 11 (API 30)** — below the app's declared `minSdk = 34`. The startup path calls `PackageManager.PackageInfoFlags.of(0L)` (API 33+), which does not exist on older runtimes, so the app dies in `Application.onCreate`. Such installs come from out-of-contract devices (emulators, cloud test farms, spoofed/sideloaded installs); real Play installs (API ≥ 34) are unaffected, but these reports pollute crash-free metrics.

## Fix
- Gate Sentry init on `Build.VERSION.SDK_INT >= BuildConfig.ANDROID_MIN_SDK` and **skip `SentryAndroid.init` entirely** on below-minSdk devices. Manifest `io.sentry.auto-init` is already `false`, so this fully disables the SDK — including native (NDK) and ANR capture that a `beforeSend` filter cannot reach.
- Single-source the threshold: `defaultConfig.minSdk` and the new `BuildConfig.ANDROID_MIN_SDK` both derive from one `val androidMinSdk = 34`, so they cannot drift.
- Remove the now-unreachable blank-DSN guard in `configureSentryOptions` (its precondition is guaranteed by the caller).

No backward-compat code added (per `apps/android/README.md`); supported devices (API ≥ 34, DSN present) behave exactly as before.

## Test
Not run locally (Gradle runs are gated in this repo); compile/lint validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)