### PR TITLE
Window chat history to model context budget and clarify context-length error

### DIFF
--- a/apps/backend/src/chat/config.ts
+++ b/apps/backend/src/chat/config.ts
@@ -13,6 +13,18 @@ export const CHAT_PROVIDER_LABEL = "OpenAI" as const;
 export const CHAT_MODEL_REASONING_LABEL = `${CHAT_MODEL_REASONING_EFFORT.slice(0, 1).toUpperCase()}${CHAT_MODEL_REASONING_EFFORT.slice(1)}` as const;
 export const CHAT_MODEL_BADGE_LABEL = `${CHAT_MODEL_LABEL} · ${CHAT_MODEL_REASONING_LABEL}` as const;
 
+/**
+ * Maximum estimated token size of replayed chat history sent to the model.
+ *
+ * gpt-5.4 exposes a standard 272K-token context window (the ~1M window is an
+ * experimental opt-in we do not enable). We keep replayed history well under
+ * that so the system prompt, the current turn, within-run tool-call/reasoning
+ * growth, and model output always fit. Full history stays in storage; only the
+ * provider input is windowed. Token sizes are estimated from character length,
+ * so this is a conservative cap rather than an exact token count.
+ */
+export const CHAT_HISTORY_REPLAY_TOKEN_BUDGET = 150_000 as const;
+
 export type ChatRuntimeModelId =
   | typeof CHAT_MODEL_ID
   | typeof CHAT_LOW_COST_MODEL_ID;

--- a/apps/backend/src/chat/openai/loop/input.ts
+++ b/apps/backend/src/chat/openai/loop/input.ts
@@ -5,6 +5,7 @@
 import type OpenAI from "openai";
 import type { ContentPart, FileContentPart, ImageContentPart } from "../../types";
 import { buildSystemInstructions } from "../../shared";
+import { CHAT_HISTORY_REPLAY_TOKEN_BUDGET } from "../../config";
 import { buildCardContextXml } from "../../cardContext";
 import {
   validateChatFileAttachmentContent,
@@ -139,6 +140,84 @@ async function buildUserInputMessage(
   };
 }
 
+const HISTORY_CHARS_PER_TOKEN = 4;
+const HISTORY_ATTACHMENT_TOKEN_ESTIMATE = 1_500;
+
+function estimateTextTokens(text: string): number {
+  return Math.ceil(text.length / HISTORY_CHARS_PER_TOKEN);
+}
+
+function estimateContentPartTokens(part: ContentPart): number {
+  if (part.type === "text") {
+    return estimateTextTokens(part.text);
+  }
+
+  if (part.type === "image" || part.type === "file") {
+    return HISTORY_ATTACHMENT_TOKEN_ESTIMATE;
+  }
+
+  if (part.type === "card") {
+    return estimateTextTokens(`${part.frontText}${part.backText}${part.tags.join(" ")}`);
+  }
+
+  if (part.type === "tool_call") {
+    return estimateTextTokens(`${part.name}${part.input ?? ""}${part.output ?? ""}`);
+  }
+
+  return estimateTextTokens(part.summary);
+}
+
+/**
+ * Estimates the provider token cost of one persisted message, mirroring how
+ * the input builder replays it: user messages cost their content, assistant
+ * messages cost their stored OpenAI replay items.
+ */
+function estimateMessageTokens(message: ServerChatMessage): number {
+  if (message.role === "assistant") {
+    return message.openaiItems === undefined
+      ? 0
+      : estimateTextTokens(stringifyJson(message.openaiItems));
+  }
+
+  return message.content.reduce(
+    (total, part) => total + estimateContentPartTokens(part),
+    0,
+  );
+}
+
+/**
+ * Caps replayed history to a token budget by dropping the oldest messages.
+ *
+ * Only the provider input is windowed; full history stays in storage and in the
+ * client UI. The kept window always starts at a user-message boundary so an
+ * assistant turn's reasoning/tool-call replay items are never sent without the
+ * originating user turn. Returns the input unchanged when it already fits.
+ */
+function windowHistoryToTokenBudget(
+  history: ReadonlyArray<ServerChatMessage>,
+  budgetTokens: number,
+): ReadonlyArray<ServerChatMessage> {
+  let runningTokens = 0;
+  let keepFrom = history.length;
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    runningTokens += estimateMessageTokens(history[index]);
+    if (runningTokens > budgetTokens) {
+      break;
+    }
+    keepFrom = index;
+  }
+
+  if (keepFrom === 0) {
+    return history;
+  }
+
+  while (keepFrom < history.length && history[keepFrom].role !== "user") {
+    keepFrom += 1;
+  }
+
+  return history.slice(keepFrom);
+}
+
 /**
  * Builds the complete OpenAI Responses input array for one backend-owned chat run.
  */
@@ -154,7 +233,8 @@ export async function buildChatCompletionInput(
   }];
 
   const normalizedHistory = normalizeHistoryMessages(localMessages, turnInput);
-  for (const message of normalizedHistory) {
+  const windowedHistory = windowHistoryToTokenBudget(normalizedHistory, CHAT_HISTORY_REPLAY_TOKEN_BUDGET);
+  for (const message of windowedHistory) {
     if (message.role === "assistant") {
       input.push(...buildAssistantHistoryItems(message));
       continue;

--- a/apps/backend/src/chat/runtime/providerErrors.ts
+++ b/apps/backend/src/chat/runtime/providerErrors.ts
@@ -19,6 +19,7 @@ const PROVIDER_AUTH_ERROR_MESSAGE = "The AI service could not authenticate the r
 const PROVIDER_RATE_LIMITED_ERROR_MESSAGE = "The AI service is rate limited right now. Please try again in a few minutes.";
 const PROVIDER_UNAVAILABLE_ERROR_MESSAGE = "The AI service is temporarily unavailable. Please try again soon.";
 const PROVIDER_ABORT_ERROR_MESSAGE = "The AI request was interrupted. Please try again.";
+const PROVIDER_CONTEXT_LENGTH_ERROR_MESSAGE = "This conversation has grown too long for the AI to continue. Please start a new chat to keep going.";
 
 type SafeProviderErrorDetails = Pick<
   ChatWorkerLifecycleDetails,
@@ -104,6 +105,10 @@ export function createPublicTerminalErrorMessage(error: unknown): string {
 
   if (isChatAttachmentUnsupportedTypeError(error) || providerErrorCode === "invalid_file") {
     return chatAttachmentUnsupportedTypeMessage;
+  }
+
+  if (providerErrorCode === "context_length_exceeded") {
+    return PROVIDER_CONTEXT_LENGTH_ERROR_MESSAGE;
   }
 
   if (category === "provider_auth") {


### PR DESCRIPTION
## What
- Window replayed chat history to a token budget (`CHAT_HISTORY_REPLAY_TOKEN_BUDGET`, 150K est. tokens) before building the OpenAI Responses input, dropping the oldest messages at a user-message boundary so long conversations no longer fail with `context_length_exceeded`. Full history stays in storage/UI; only the model input is windowed, and it is a no-op when history already fits.
- Map OpenAI `context_length_exceeded` to a clear, actionable terminal error message for the residual single-oversized-message case.

## Notes
- Backend-only; no public signature/contract change (`buildChatCompletionInput` unchanged, sole caller is the OpenAI loop).
- Verified locally: `tsc --noEmit` clean; `input.test.ts` 5/5; `loop.test.ts` 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)