### PR TITLE
Add backend public review activity facts and immutable review authorship

### DIFF
--- a/apps/backend/src/cards/reviews.ts
+++ b/apps/backend/src/cards/reviews.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
 import { transactionWithWorkspaceScope, type DatabaseExecutor } from "../database";
+import {
+  createCurrentUserPublicProfileResolver,
+  recordQualifiedReviewActivityFactInExecutor,
+  type CurrentUserPublicProfileResolver,
+} from "../community/reviewActivityFacts";
 import { HttpError } from "../shared/errors";
 import {
   computeReviewSchedule,
@@ -79,12 +84,13 @@ export async function appendReviewEventSnapshotInExecutor(
   workspaceId: string,
   reviewEvent: ReviewEvent,
   operationId: string,
+  resolveReviewedBy: CurrentUserPublicProfileResolver,
 ): Promise<ReviewEventAppendResult> {
   const insertResult = await executor.query<ReviewHistoryRow>(
     [
       "INSERT INTO content.review_events",
-      "(review_event_id, workspace_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server)",
-      "VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, now()))",
+      "(review_event_id, workspace_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server, reviewed_by_user_id)",
+      "VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, now()), security.current_user_id())",
       "ON CONFLICT DO NOTHING",
       "RETURNING review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server",
     ].join(" "),
@@ -103,6 +109,18 @@ export async function appendReviewEventSnapshotInExecutor(
   const insertedRow = insertResult.rows[0];
   if (insertedRow !== undefined) {
     const insertedReviewEvent = mapReviewHistoryItem(insertedRow);
+    // Project the new review event into the public activity fact layer in the same
+    // transaction. Authorship and the opaque identity derive from the authenticated
+    // request scope, so every review-write path (direct review, sync push, review
+    // history import, guest merge) records the fact for the right user. The resolver
+    // is invoked only here, on a real insert, and memoizes across a batch.
+    const reviewedBy = await resolveReviewedBy();
+    await recordQualifiedReviewActivityFactInExecutor(executor, reviewedBy, {
+      reviewEventId: insertedReviewEvent.reviewEventId,
+      rating: insertedReviewEvent.rating,
+      reviewedAtClient: insertedReviewEvent.reviewedAtClient,
+      reviewedAtServer: insertedReviewEvent.reviewedAtServer,
+    });
 
     return {
       reviewEvent: insertedReviewEvent,
@@ -191,6 +209,7 @@ export async function submitReview(
         reviewedAtServer: new Date().toISOString(),
       },
       normalizedMetadata.lastOperationId,
+      createCurrentUserPublicProfileResolver(executor),
     );
 
     const updatedCardResult = await executor.query<CardRow>(

--- a/apps/backend/src/community/publicProfiles.ts
+++ b/apps/backend/src/community/publicProfiles.ts
@@ -123,12 +123,10 @@ function createAnonymousDisplayName(
   return createDisplayName(prefix, adjective, noun, wordPools.separator);
 }
 
-async function readPublicProfileForUserInExecutor(
+async function readPublicProfileRowForUserInExecutor(
   executor: DatabaseExecutor,
   userId: string,
-  localeHint: string,
-  dependencies: PublicProfileServiceDependencies,
-): Promise<PublicProfile | null> {
+): Promise<PublicProfileRow | null> {
   const result = await executor.query<PublicProfileRow>(
     [
       "SELECT public_profile_id, leaderboard_participation_enabled",
@@ -139,17 +137,14 @@ async function readPublicProfileForUserInExecutor(
     [userId],
   );
 
-  const row = result.rows[0];
-  return row === undefined ? null : mapPublicProfileRow(row, localeHint, dependencies);
+  return result.rows[0] ?? null;
 }
 
-async function insertPublicProfileCandidateInExecutor(
+async function insertPublicProfileCandidateRowInExecutor(
   executor: DatabaseExecutor,
   userId: string,
   publicProfileId: string,
-  localeHint: string,
-  dependencies: PublicProfileServiceDependencies,
-): Promise<PublicProfile | null> {
+): Promise<PublicProfileRow | null> {
   const result = await executor.query<PublicProfileRow>(
     [
       "WITH inserted_profile AS (",
@@ -171,8 +166,39 @@ async function insertPublicProfileCandidateInExecutor(
     [userId, publicProfileId],
   );
 
-  const row = result.rows[0];
-  return row === undefined ? null : mapPublicProfileRow(row, localeHint, dependencies);
+  return result.rows[0] ?? null;
+}
+
+async function ensurePublicProfileRowForUserInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  dependencies: PublicProfileServiceDependencies,
+): Promise<PublicProfileRow> {
+  assertValidCreateAttemptLimit(dependencies.maxCreateAttempts);
+
+  const existingRow = await readPublicProfileRowForUserInExecutor(executor, userId);
+  if (existingRow !== null) {
+    return existingRow;
+  }
+
+  for (let attempt = 1; attempt <= dependencies.maxCreateAttempts; attempt += 1) {
+    const row = await insertPublicProfileCandidateRowInExecutor(executor, userId, dependencies.randomUuidFn());
+    if (row !== null) {
+      return row;
+    }
+  }
+
+  throw new PublicProfileIdCollisionLimitError(dependencies.maxCreateAttempts);
+}
+
+async function readPublicProfileForUserInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  localeHint: string,
+  dependencies: PublicProfileServiceDependencies,
+): Promise<PublicProfile | null> {
+  const row = await readPublicProfileRowForUserInExecutor(executor, userId);
+  return row === null ? null : mapPublicProfileRow(row, localeHint, dependencies);
 }
 
 async function ensurePublicProfileForUserInExecutorWithDependencies(
@@ -181,27 +207,8 @@ async function ensurePublicProfileForUserInExecutorWithDependencies(
   localeHint: string,
   dependencies: PublicProfileServiceDependencies,
 ): Promise<PublicProfile> {
-  assertValidCreateAttemptLimit(dependencies.maxCreateAttempts);
-
-  const existingProfile = await readPublicProfileForUserInExecutor(executor, userId, localeHint, dependencies);
-  if (existingProfile !== null) {
-    return existingProfile;
-  }
-
-  for (let attempt = 1; attempt <= dependencies.maxCreateAttempts; attempt += 1) {
-    const profile = await insertPublicProfileCandidateInExecutor(
-      executor,
-      userId,
-      dependencies.randomUuidFn(),
-      localeHint,
-      dependencies,
-    );
-    if (profile !== null) {
-      return profile;
-    }
-  }
-
-  throw new PublicProfileIdCollisionLimitError(dependencies.maxCreateAttempts);
+  const row = await ensurePublicProfileRowForUserInExecutor(executor, userId, dependencies);
+  return mapPublicProfileRow(row, localeHint, dependencies);
 }
 
 export async function ensurePublicProfileForUserWithDependencies(
@@ -216,6 +223,60 @@ export async function ensurePublicProfileForUserWithDependencies(
 
 export async function ensurePublicProfileForUser(userId: string, localeHint: string): Promise<PublicProfile> {
   return ensurePublicProfileForUserWithDependencies(userId, localeHint, defaultPublicProfileServiceDependencies);
+}
+
+export class PublicProfileMissingUserScopeError extends Error {
+  readonly name = "PublicProfileMissingUserScopeError";
+
+  constructor() {
+    super("No authenticated user scope is set for the current public profile operation.");
+  }
+}
+
+export type CurrentUserPublicProfileId = Readonly<{
+  userId: string;
+  publicProfileId: string;
+}>;
+
+async function selectCurrentUserIdInExecutor(executor: DatabaseExecutor): Promise<string> {
+  const result = await executor.query<Readonly<{ user_id: string | null }>>(
+    "SELECT security.current_user_id() AS user_id",
+    [],
+  );
+
+  const userId = result.rows[0]?.user_id ?? null;
+  if (userId === null || userId === "") {
+    throw new PublicProfileMissingUserScopeError();
+  }
+
+  return userId;
+}
+
+/**
+ * Ensures and returns the stable public_profile_id for the currently scoped user
+ * without computing or storing any display name. Same-transaction fact writes use
+ * this so authorship and the opaque identity are captured from the authenticated
+ * request scope, never from mutable replica labels.
+ */
+export async function ensurePublicProfileIdForCurrentUserInExecutorWithDependencies(
+  executor: DatabaseExecutor,
+  dependencies: PublicProfileServiceDependencies,
+): Promise<CurrentUserPublicProfileId> {
+  const userId = await selectCurrentUserIdInExecutor(executor);
+  const row = await ensurePublicProfileRowForUserInExecutor(executor, userId, dependencies);
+  return {
+    userId,
+    publicProfileId: row.public_profile_id,
+  };
+}
+
+export async function ensurePublicProfileIdForCurrentUserInExecutor(
+  executor: DatabaseExecutor,
+): Promise<CurrentUserPublicProfileId> {
+  return ensurePublicProfileIdForCurrentUserInExecutorWithDependencies(
+    executor,
+    defaultPublicProfileServiceDependencies,
+  );
 }
 
 export async function readPublicProfileForUserWithDependencies(

--- a/apps/backend/src/community/reviewActivityFacts.test.ts
+++ b/apps/backend/src/community/reviewActivityFacts.test.ts
@@ -1,0 +1,299 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import {
+  QUALIFIED_REVIEWS_METRIC_VERSION,
+  classifyQualifiedReviewActivity,
+  createCurrentUserPublicProfileResolver,
+  recordQualifiedReviewActivityFactInExecutor,
+} from "./reviewActivityFacts";
+
+type QueryResultRow = pg.QueryResultRow;
+
+type StoredFact = Readonly<{
+  reviewEventId: string;
+  metricVersion: string;
+  publicProfileId: string;
+  reviewedByUserId: string | null;
+  rating: number;
+  reviewedAtClient: string;
+  reviewedAtServer: string;
+  isCountable: boolean;
+  exclusionReason: string | null;
+}>;
+
+type MutableFactStoreState = {
+  currentUserId: string;
+  currentUserIdQueryCount: number;
+  profilesByUserId: Map<string, string>;
+  insertedProfileIds: Array<string>;
+  facts: Array<StoredFact>;
+};
+
+function createQueryResult<Row extends QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createFactStoreState(currentUserId: string): MutableFactStoreState {
+  return {
+    currentUserId,
+    currentUserIdQueryCount: 0,
+    profilesByUserId: new Map<string, string>(),
+    insertedProfileIds: [],
+    facts: [],
+  };
+}
+
+function readStringParam(params: ReadonlyArray<SqlValue>, index: number, label: string): string {
+  const value = params[index];
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string.`);
+  }
+
+  return value;
+}
+
+function readNumberParam(params: ReadonlyArray<SqlValue>, index: number, label: string): number {
+  const value = params[index];
+  if (typeof value !== "number") {
+    throw new Error(`${label} must be a number.`);
+  }
+
+  return value;
+}
+
+function readBooleanParam(params: ReadonlyArray<SqlValue>, index: number, label: string): boolean {
+  const value = params[index];
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean.`);
+  }
+
+  return value;
+}
+
+function readNullableStringParam(params: ReadonlyArray<SqlValue>, index: number, label: string): string | null {
+  const value = params[index];
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string or null.`);
+  }
+
+  return value;
+}
+
+function createFactExecutor(state: MutableFactStoreState): DatabaseExecutor {
+  return {
+    async query<Row extends QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      if (text === "SELECT security.current_user_id() AS user_id") {
+        state.currentUserIdQueryCount += 1;
+        return createQueryResult([{ user_id: state.currentUserId }]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.startsWith("SELECT public_profile_id, leaderboard_participation_enabled")
+        && text.includes("FROM community.public_profiles")
+        && text.includes("WHERE user_id = $1")
+      ) {
+        const userId = readStringParam(params, 0, "userId");
+        const publicProfileId = state.profilesByUserId.get(userId);
+        const rows = publicProfileId === undefined
+          ? []
+          : [{ public_profile_id: publicProfileId, leaderboard_participation_enabled: true }];
+        return createQueryResult(rows) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.startsWith("WITH inserted_profile AS")) {
+        const userId = readStringParam(params, 0, "userId");
+        const publicProfileId = readStringParam(params, 1, "publicProfileId");
+        const existing = state.profilesByUserId.get(userId);
+        if (existing !== undefined) {
+          return createQueryResult([
+            { public_profile_id: existing, leaderboard_participation_enabled: true },
+          ]) as unknown as pg.QueryResult<Row>;
+        }
+
+        state.profilesByUserId.set(userId, publicProfileId);
+        state.insertedProfileIds.push(publicProfileId);
+        return createQueryResult([
+          { public_profile_id: publicProfileId, leaderboard_participation_enabled: true },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.startsWith("INSERT INTO community.public_review_activity_facts")
+        && text.includes("ON CONFLICT (review_event_id, metric_version) DO NOTHING")
+      ) {
+        const reviewEventId = readStringParam(params, 0, "reviewEventId");
+        const metricVersion = readStringParam(params, 1, "metricVersion");
+        const alreadyStored = state.facts.some(
+          (fact) => fact.reviewEventId === reviewEventId && fact.metricVersion === metricVersion,
+        );
+        if (alreadyStored) {
+          return createQueryResult([]) as unknown as pg.QueryResult<Row>;
+        }
+
+        state.facts.push({
+          reviewEventId,
+          metricVersion,
+          publicProfileId: readStringParam(params, 2, "publicProfileId"),
+          reviewedByUserId: readNullableStringParam(params, 3, "reviewedByUserId"),
+          rating: readNumberParam(params, 4, "rating"),
+          reviewedAtClient: readStringParam(params, 5, "reviewedAtClient"),
+          reviewedAtServer: readStringParam(params, 6, "reviewedAtServer"),
+          isCountable: readBooleanParam(params, 7, "isCountable"),
+          exclusionReason: readNullableStringParam(params, 8, "exclusionReason"),
+        });
+        return createQueryResult([]) as unknown as pg.QueryResult<Row>;
+      }
+
+      throw new Error(`Unexpected review activity fact query: ${text}`);
+    },
+  };
+}
+
+const PROFILE_USER_1 = { userId: "user-1", publicProfileId: "profile-1" } as const;
+
+test("classifyQualifiedReviewActivity excludes rating 0 as again", () => {
+  assert.deepEqual(classifyQualifiedReviewActivity(0), {
+    metricVersion: QUALIFIED_REVIEWS_METRIC_VERSION,
+    isCountable: false,
+    exclusionReason: "again",
+  });
+});
+
+test("classifyQualifiedReviewActivity counts ratings 1, 2, and 3", () => {
+  for (const rating of [1, 2, 3]) {
+    assert.deepEqual(classifyQualifiedReviewActivity(rating), {
+      metricVersion: QUALIFIED_REVIEWS_METRIC_VERSION,
+      isCountable: true,
+      exclusionReason: null,
+    });
+  }
+});
+
+test("recordQualifiedReviewActivityFactInExecutor creates a countable fact for a good rating", async () => {
+  const state = createFactStoreState("user-1");
+  const executor = createFactExecutor(state);
+
+  await recordQualifiedReviewActivityFactInExecutor(executor, PROFILE_USER_1, {
+    reviewEventId: "review-1",
+    rating: 2,
+    reviewedAtClient: "2026-06-10T10:00:00.000Z",
+    reviewedAtServer: "2026-06-10T10:00:01.000Z",
+  });
+
+  assert.deepEqual(state.facts, [{
+    reviewEventId: "review-1",
+    metricVersion: "qualified_reviews_v1",
+    publicProfileId: "profile-1",
+    reviewedByUserId: "user-1",
+    rating: 2,
+    reviewedAtClient: "2026-06-10T10:00:00.000Z",
+    reviewedAtServer: "2026-06-10T10:00:01.000Z",
+    isCountable: true,
+    exclusionReason: null,
+  }]);
+});
+
+test("recordQualifiedReviewActivityFactInExecutor records an again rating as not countable", async () => {
+  const state = createFactStoreState("user-1");
+  const executor = createFactExecutor(state);
+
+  await recordQualifiedReviewActivityFactInExecutor(executor, PROFILE_USER_1, {
+    reviewEventId: "review-again",
+    rating: 0,
+    reviewedAtClient: "2026-06-10T10:00:00.000Z",
+    reviewedAtServer: "2026-06-10T10:00:01.000Z",
+  });
+
+  const fact = state.facts[0];
+  assert.equal(fact?.isCountable, false);
+  assert.equal(fact?.exclusionReason, "again");
+  assert.equal(fact?.reviewedByUserId, "user-1");
+});
+
+test("recordQualifiedReviewActivityFactInExecutor stays idempotent for a replayed review event", async () => {
+  const state = createFactStoreState("user-1");
+  const executor = createFactExecutor(state);
+
+  const input = {
+    reviewEventId: "review-replay",
+    rating: 1,
+    reviewedAtClient: "2026-06-10T10:00:00.000Z",
+    reviewedAtServer: "2026-06-10T10:00:01.000Z",
+  } as const;
+  await recordQualifiedReviewActivityFactInExecutor(executor, PROFILE_USER_1, input);
+  await recordQualifiedReviewActivityFactInExecutor(executor, PROFILE_USER_1, input);
+
+  assert.equal(state.facts.length, 1);
+});
+
+test("createCurrentUserPublicProfileResolver ensures the scoped profile once and memoizes", async () => {
+  const state = createFactStoreState("user-without-profile");
+  const executor = createFactExecutor(state);
+  const resolveReviewedBy = createCurrentUserPublicProfileResolver(executor);
+
+  const first = await resolveReviewedBy();
+  const second = await resolveReviewedBy();
+
+  assert.equal(first.userId, "user-without-profile");
+  assert.equal(state.insertedProfileIds.length, 1);
+  assert.equal(first.publicProfileId, state.insertedProfileIds[0]);
+  assert.deepEqual(second, first);
+  // The second call is served from the memo, so the scope/profile is resolved once.
+  assert.equal(state.currentUserIdQueryCount, 1);
+});
+
+test("0058 migration adds immutable authorship and the public review activity fact layer", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "../../db/migrations/0058_public_review_activity_facts.sql",
+  );
+  const migrationSql = readFileSync(migrationPath, "utf8");
+
+  assert.match(
+    migrationSql,
+    /ALTER TABLE content\.review_events\s+ADD COLUMN IF NOT EXISTS reviewed_by_user_id TEXT\s+REFERENCES org\.user_settings\(user_id\) ON DELETE SET NULL/,
+  );
+  assert.match(migrationSql, /FROM sync\.workspace_replicas AS workspace_replicas/);
+  assert.match(migrationSql, /SET reviewed_by_user_id = workspace_replicas\.user_id/);
+
+  assert.match(migrationSql, /CREATE TABLE IF NOT EXISTS community\.public_review_activity_facts/);
+  assert.match(migrationSql, /review_event_id\s+UUID\s+NOT NULL REFERENCES content\.review_events\(review_event_id\) ON DELETE CASCADE/);
+  assert.match(migrationSql, /public_profile_id\s+UUID\s+NOT NULL REFERENCES community\.public_profiles\(public_profile_id\) ON DELETE CASCADE/);
+  assert.match(migrationSql, /reviewed_by_user_id TEXT\s+REFERENCES org\.user_settings\(user_id\) ON DELETE SET NULL/);
+  assert.match(migrationSql, /PRIMARY KEY \(review_event_id, metric_version\)/);
+
+  assert.match(migrationSql, /idx_public_review_activity_facts_metric_countable_client_time\s+ON community\.public_review_activity_facts\(metric_version, is_countable, reviewed_at_client\)/);
+  assert.match(migrationSql, /idx_public_review_activity_facts_profile_metric_countable_client_time\s+ON community\.public_review_activity_facts\(public_profile_id, metric_version, is_countable, reviewed_at_client\)/);
+  assert.match(migrationSql, /idx_public_review_activity_facts_user_metric_client_time\s+ON community\.public_review_activity_facts\(reviewed_by_user_id, metric_version, reviewed_at_client\)/);
+
+  assert.match(migrationSql, /'qualified_reviews_v1'/);
+  assert.match(migrationSql, /\(review_events\.rating <> 0\)/);
+  assert.match(migrationSql, /CASE WHEN review_events\.rating = 0 THEN 'again' ELSE NULL END/);
+
+  assert.match(migrationSql, /ALTER TABLE community\.public_review_activity_facts ENABLE ROW LEVEL SECURITY/);
+  assert.match(migrationSql, /CREATE POLICY public_review_activity_facts_self_insert_runtime/);
+  assert.match(migrationSql, /WITH CHECK \(reviewed_by_user_id = security\.current_user_id\(\)\)/);
+  assert.match(migrationSql, /GRANT INSERT \(/);
+
+  // Display names are never stored in the fact layer; they stay derived at read time.
+  assert.equal(migrationSql.includes("display_name"), false);
+  // Facts are immutable, so there is no inert updated_at column.
+  assert.equal(migrationSql.includes("updated_at"), false);
+});

--- a/apps/backend/src/community/reviewActivityFacts.ts
+++ b/apps/backend/src/community/reviewActivityFacts.ts
@@ -1,0 +1,118 @@
+import { type DatabaseExecutor } from "../database";
+import {
+  ensurePublicProfileIdForCurrentUserInExecutor,
+  type CurrentUserPublicProfileId,
+} from "./publicProfiles";
+
+/**
+ * Reusable public review activity fact layer.
+ *
+ * Each raw review event projects into one immutable fact row per metric version
+ * in community.public_review_activity_facts. Display names are never stored here;
+ * they stay derived at read time from the public profile id and request locale.
+ */
+
+export const QUALIFIED_REVIEWS_METRIC_VERSION = "qualified_reviews_v1";
+
+export const REVIEW_ACTIVITY_EXCLUSION_REASON_AGAIN = "again";
+
+export type ReviewActivityFactClassification = Readonly<{
+  metricVersion: string;
+  isCountable: boolean;
+  exclusionReason: string | null;
+}>;
+
+export type ReviewActivityFactInput = Readonly<{
+  reviewEventId: string;
+  rating: number;
+  reviewedAtClient: string;
+  reviewedAtServer: string;
+}>;
+
+/**
+ * Classifies one review event for the qualified_reviews_v1 metric.
+ *
+ * A review counts unless its rating is 0 (again). The `<1s` answer guard is not
+ * implemented yet; it will arrive later as a new exclusion reason and/or a new
+ * metric version without changing this contract.
+ */
+export function classifyQualifiedReviewActivity(rating: number): ReviewActivityFactClassification {
+  if (rating === 0) {
+    return {
+      metricVersion: QUALIFIED_REVIEWS_METRIC_VERSION,
+      isCountable: false,
+      exclusionReason: REVIEW_ACTIVITY_EXCLUSION_REASON_AGAIN,
+    };
+  }
+
+  return {
+    metricVersion: QUALIFIED_REVIEWS_METRIC_VERSION,
+    isCountable: true,
+    exclusionReason: null,
+  };
+}
+
+async function upsertReviewActivityFactRowInExecutor(
+  executor: DatabaseExecutor,
+  profile: CurrentUserPublicProfileId,
+  input: ReviewActivityFactInput,
+  classification: ReviewActivityFactClassification,
+): Promise<void> {
+  await executor.query(
+    [
+      "INSERT INTO community.public_review_activity_facts",
+      "(review_event_id, metric_version, public_profile_id, reviewed_by_user_id, rating,",
+      "reviewed_at_client, reviewed_at_server, is_countable, exclusion_reason)",
+      "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+      "ON CONFLICT (review_event_id, metric_version) DO NOTHING",
+    ].join(" "),
+    [
+      input.reviewEventId,
+      classification.metricVersion,
+      profile.publicProfileId,
+      profile.userId,
+      input.rating,
+      input.reviewedAtClient,
+      input.reviewedAtServer,
+      classification.isCountable,
+      classification.exclusionReason,
+    ],
+  );
+}
+
+export type CurrentUserPublicProfileResolver = () => Promise<CurrentUserPublicProfileId>;
+
+/**
+ * Resolves and memoizes the scoped user's public profile id once per executor, so a
+ * batch of review writes (sync push, review-history import, guest merge) ensures the
+ * profile a single time instead of once per event. Resolution stays lazy: callers
+ * invoke it only when a review event is actually stored, so a batch with no stored
+ * review event never creates a public profile.
+ */
+export function createCurrentUserPublicProfileResolver(
+  executor: DatabaseExecutor,
+): CurrentUserPublicProfileResolver {
+  let resolvedProfile: Promise<CurrentUserPublicProfileId> | null = null;
+  return () => {
+    if (resolvedProfile === null) {
+      resolvedProfile = ensurePublicProfileIdForCurrentUserInExecutor(executor);
+    }
+
+    return resolvedProfile;
+  };
+}
+
+/**
+ * Records the qualified_reviews_v1 fact for one newly written review event in the
+ * same transaction as the review event write, owned by the already-resolved public
+ * profile of the authenticated author. Idempotent: replaying the same review event
+ * never duplicates or recounts a fact.
+ */
+export async function recordQualifiedReviewActivityFactInExecutor(
+  executor: DatabaseExecutor,
+  reviewedBy: CurrentUserPublicProfileId,
+  input: ReviewActivityFactInput,
+): Promise<void> {
+  const classification = classifyQualifiedReviewActivity(input.rating);
+  await upsertReviewActivityFactRowInExecutor(executor, reviewedBy, input, classification);
+}

--- a/apps/backend/src/guestAuth/merge/index.ts
+++ b/apps/backend/src/guestAuth/merge/index.ts
@@ -7,6 +7,7 @@ import {
   type CardSnapshotInput,
   type ReviewEvent,
 } from "../../cards";
+import { createCurrentUserPublicProfileResolver } from "../../community/reviewActivityFacts";
 import {
   applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
@@ -613,6 +614,8 @@ async function mergeReviewEventsIntoTargetInExecutor(
     userId: targetUserId,
     workspaceId: targetWorkspaceId,
   });
+  // Re-inserted events are owned by the target; resolve its public profile once.
+  const resolveReviewedBy = createCurrentUserPublicProfileResolver(executor);
 
   for (const reviewEvent of reviewEvents) {
     if (!mergedCardIds.has(reviewEvent.cardId)) {
@@ -650,6 +653,7 @@ async function mergeReviewEventsIntoTargetInExecutor(
           targetWorkspaceId,
           createReviewEventSnapshot(targetWorkspaceId, reviewEvent, targetReplicaId),
           reviewEvent.reviewEventId,
+          resolveReviewedBy,
         );
         if (result.reviewEvent.reviewEventId === reviewEvent.reviewEventId) {
           return true;

--- a/apps/backend/src/guestAuth/tests/communityActivityFacts.test.ts
+++ b/apps/backend/src/guestAuth/tests/communityActivityFacts.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { completeGuestUpgradeInExecutor } from "..";
+import {
+  createGuestUpgradeExecutor,
+  createMergeState,
+  DROPPED_ENTITIES_UNSUPPORTED,
+} from "../../guestAuthTestHarness";
+
+test("completeGuestUpgradeInExecutor reattaches guest review activity facts to the linked account", async () => {
+  const guestToken = "guest-token-activity-facts";
+  const guestUserId = "guest-user-activity-facts";
+  const guestWorkspaceId = "guest-workspace-activity-facts";
+  const targetUserId = "linked-user-activity-facts";
+  const targetWorkspaceId = "target-workspace-activity-facts";
+  const guestReplicaId = "guest-replica-activity-facts";
+  const installationId = "installation-activity-facts";
+  const targetSubject = "cognito-subject-activity-facts";
+  const cardId = "aaaa1111-1111-4111-8111-111111111111";
+  const reviewEventId = "bbbb2222-2222-4222-8222-222222222222";
+
+  const state = createMergeState({
+    guestToken,
+    guestSessionId: "guest-session-activity-facts",
+    guestUserId,
+    guestWorkspaceId,
+    targetSubject,
+    targetUserId,
+    targetWorkspaceId,
+    guestReplicaId,
+    installationId,
+    guestSchedulerUpdatedAt: "2026-04-02T14:00:00.000Z",
+    targetSchedulerUpdatedAt: "2026-04-02T14:05:00.000Z",
+  });
+  state.cards.push({
+    card_id: cardId,
+    workspace_id: guestWorkspaceId,
+    front_text: "Guest front",
+    back_text: "Guest back",
+    tags: ["guest"],
+    effort_level: "fast",
+    due_at: null,
+    created_at: "2026-04-02T14:00:02.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-04-02T14:00:03.000Z",
+    last_modified_by_replica_id: guestReplicaId,
+    last_operation_id: "guest-card-op",
+    updated_at: "2026-04-02T14:00:03.000Z",
+    deleted_at: null,
+  });
+  state.reviewEvents.push({
+    review_event_id: reviewEventId,
+    workspace_id: guestWorkspaceId,
+    card_id: cardId,
+    replica_id: guestReplicaId,
+    client_event_id: "guest-client-event-activity-facts",
+    rating: 2,
+    reviewed_at_client: "2026-04-02T14:00:04.000Z",
+    reviewed_at_server: "2026-04-02T14:00:04.000Z",
+  });
+  // The guest already had a stable opaque identity and an activity fact for the
+  // review before linking, pointing at the throwaway guest public profile.
+  state.publicProfiles.push({
+    user_id: guestUserId,
+    public_profile_id: "guest-public-profile-id",
+    leaderboard_participation_enabled: true,
+  });
+  state.publicReviewActivityFacts.push({
+    review_event_id: reviewEventId,
+    metric_version: "qualified_reviews_v1",
+    public_profile_id: "guest-public-profile-id",
+    reviewed_by_user_id: guestUserId,
+    rating: 2,
+    reviewed_at_client: "2026-04-02T14:00:04.000Z",
+    reviewed_at_server: "2026-04-02T14:00:04.000Z",
+    is_countable: true,
+    exclusion_reason: null,
+  });
+
+  const executor = createGuestUpgradeExecutor(state);
+  const result = await completeGuestUpgradeInExecutor(
+    executor,
+    guestToken,
+    targetSubject,
+    { type: "existing", workspaceId: targetWorkspaceId },
+    DROPPED_ENTITIES_UNSUPPORTED,
+  );
+
+  assert.equal(result.outcome, "fresh_completion");
+  assert.equal(result.targetUserId, targetUserId);
+
+  // The rewritten review event carries immutable authorship for the linked account.
+  const targetReviewEvent = state.reviewEvents.find(
+    (reviewEvent) => reviewEvent.workspace_id === targetWorkspaceId && reviewEvent.review_event_id === reviewEventId,
+  );
+  assert.ok(targetReviewEvent);
+  assert.equal(targetReviewEvent?.reviewed_by_user_id, targetUserId);
+
+  const targetProfile = state.publicProfiles.find((profile) => profile.user_id === targetUserId);
+  assert.ok(targetProfile, "the linked account has a public profile after upgrade");
+  // The guest's stable opaque identity is preserved and now belongs to the linked
+  // account (transferred ahead of the merge), not replaced by a throwaway new one.
+  assert.equal(targetProfile?.public_profile_id, "guest-public-profile-id");
+  assert.equal(state.publicProfiles.some((profile) => profile.user_id === guestUserId), false);
+
+  const factsForReview = state.publicReviewActivityFacts.filter(
+    (fact) => fact.review_event_id === reviewEventId,
+  );
+  assert.equal(factsForReview.length, 1);
+  const fact = factsForReview[0];
+  assert.equal(fact?.metric_version, "qualified_reviews_v1");
+  assert.equal(fact?.reviewed_by_user_id, targetUserId);
+  // The fact is reattached to the preserved community identity, now owned by the account.
+  assert.equal(fact?.public_profile_id, "guest-public-profile-id");
+  assert.equal(fact?.is_countable, true);
+  assert.equal(fact?.exclusion_reason, null);
+});

--- a/apps/backend/src/guestAuth/tests/replay.test.ts
+++ b/apps/backend/src/guestAuth/tests/replay.test.ts
@@ -267,6 +267,7 @@ test("completeGuestUpgradeInExecutor rejects a replay from a different subject",
     feedbackPromptEvents: [],
     feedbackSubmissions: [],
     publicProfiles: [],
+    publicReviewActivityFacts: [],
   };
 
   const executor = createGuestUpgradeExecutor(state);
@@ -322,6 +323,7 @@ test("completeGuestUpgradeInExecutor rejects a revoked guest session without rep
     feedbackPromptEvents: [],
     feedbackSubmissions: [],
     publicProfiles: [],
+    publicReviewActivityFacts: [],
   };
 
   const executor = createGuestUpgradeExecutor(state);

--- a/apps/backend/src/guestAuth/upgrade/index.ts
+++ b/apps/backend/src/guestAuth/upgrade/index.ts
@@ -503,6 +503,16 @@ export async function completeGuestUpgradeInExecutor(
     selection,
   );
 
+  // Move the guest community identity onto the target before the merge below. The
+  // merge re-records public activity facts under the target scope, so the guest public
+  // profile must already belong to the target; otherwise the fact write would mint a
+  // throwaway target profile and discard the guest's stable identity.
+  await transferGuestPublicProfileInExecutor(
+    executor,
+    guestSession.userId,
+    guestUpgradeResolution.targetUserId,
+  );
+
   // Phase 8: merge already-synced guest cloud state into the destination workspace.
   const guestUpgradeMerge = await mergeGuestWorkspaceIntoTargetInExecutor(
     executor,
@@ -533,18 +543,14 @@ export async function completeGuestUpgradeInExecutor(
     guestUpgradeResolution.targetWorkspaceId,
   );
 
-  // Phase 11: transfer guest-owned support and community data before deleting source rows.
+  // Phase 11: transfer remaining guest-owned support data before deleting source rows.
+  // The guest community profile was already transferred ahead of the merge above.
   await transferGuestFeedbackInExecutor(
     executor,
     guestSession.userId,
     guestUpgradeResolution.guestWorkspaceId,
     guestUpgradeResolution.targetUserId,
     guestUpgradeResolution.targetWorkspaceId,
-  );
-  await transferGuestPublicProfileInExecutor(
-    executor,
-    guestSession.userId,
-    guestUpgradeResolution.targetUserId,
   );
 
   // Phase 12: revoke and delete guest source rows.

--- a/apps/backend/src/guestAuthTestHarness/executor.ts
+++ b/apps/backend/src/guestAuthTestHarness/executor.ts
@@ -10,6 +10,8 @@ import {
   type GuestUpgradeExecutorParam,
   type GuestUpgradeHandlerContext,
   type MutableState,
+  type PublicProfileState,
+  type PublicReviewActivityFactState,
 } from "./models";
 import { createQueryResult } from "./queryResult";
 
@@ -126,6 +128,93 @@ function handleCommunityProfileExecutorQuery<Row extends pg.QueryResultRow>(
   return createQueryResult<Row>([]);
 }
 
+function toPublicProfileRow<Row extends pg.QueryResultRow>(profile: PublicProfileState): Row {
+  return {
+    public_profile_id: profile.public_profile_id,
+    leaderboard_participation_enabled: profile.leaderboard_participation_enabled,
+  } as unknown as Row;
+}
+
+function handleCommunityActivityExecutorQuery<Row extends pg.QueryResultRow>(
+  context: GuestUpgradeHandlerContext,
+  text: string,
+  params: ReadonlyArray<GuestUpgradeExecutorParam>,
+): pg.QueryResult<Row> | null {
+  const { state } = context;
+
+  if (text === "SELECT security.current_user_id() AS user_id") {
+    return createQueryResult<Row>([{ user_id: state.currentUserId } as unknown as Row]);
+  }
+
+  if (
+    text.startsWith("SELECT public_profile_id, leaderboard_participation_enabled")
+    && text.includes("FROM community.public_profiles")
+    && text.includes("WHERE user_id = $1")
+  ) {
+    const userId = typeof params[0] === "string" ? params[0] : null;
+    const profile = state.publicProfiles.find((entry) => entry.user_id === userId);
+    return createQueryResult<Row>(profile === undefined ? [] : [toPublicProfileRow<Row>(profile)]);
+  }
+
+  if (
+    text.startsWith("WITH inserted_profile AS")
+    && text.includes("INSERT INTO community.public_profiles")
+  ) {
+    const userId = typeof params[0] === "string" ? params[0] : null;
+    const publicProfileId = typeof params[1] === "string" ? params[1] : null;
+    if (userId === null || publicProfileId === null) {
+      return createQueryResult<Row>([]);
+    }
+
+    const existingProfile = state.publicProfiles.find((entry) => entry.user_id === userId);
+    if (existingProfile !== undefined) {
+      return createQueryResult<Row>([toPublicProfileRow<Row>(existingProfile)]);
+    }
+
+    if (state.publicProfiles.some((entry) => entry.public_profile_id === publicProfileId)) {
+      return createQueryResult<Row>([]);
+    }
+
+    const insertedProfile: PublicProfileState = {
+      user_id: userId,
+      public_profile_id: publicProfileId,
+      leaderboard_participation_enabled: true,
+    };
+    state.publicProfiles.push(insertedProfile);
+    return createQueryResult<Row>([toPublicProfileRow<Row>(insertedProfile)]);
+  }
+
+  if (
+    text.startsWith("INSERT INTO community.public_review_activity_facts")
+    && text.includes("ON CONFLICT (review_event_id, metric_version) DO NOTHING")
+  ) {
+    const reviewEventId = String(params[0]);
+    const metricVersion = String(params[1]);
+    const alreadyStored = state.publicReviewActivityFacts.some(
+      (fact) => fact.review_event_id === reviewEventId && fact.metric_version === metricVersion,
+    );
+    if (alreadyStored) {
+      return createQueryResult<Row>([]);
+    }
+
+    const insertedFact: PublicReviewActivityFactState = {
+      review_event_id: reviewEventId,
+      metric_version: metricVersion,
+      public_profile_id: String(params[2]),
+      reviewed_by_user_id: params[3] === null ? null : String(params[3]),
+      rating: Number(params[4]),
+      reviewed_at_client: String(params[5]),
+      reviewed_at_server: String(params[6]),
+      is_countable: Boolean(params[7]),
+      exclusion_reason: params[8] === null ? null : String(params[8]),
+    };
+    state.publicReviewActivityFacts.push(insertedFact);
+    return createQueryResult<Row>([]);
+  }
+
+  return null;
+}
+
 function handleSchemaExecutorQuery<Row extends pg.QueryResultRow>(
   text: string,
 ): pg.QueryResult<Row> | null {
@@ -215,6 +304,11 @@ export function createGuestUpgradeExecutor(state: MutableState): DatabaseExecuto
       const communityProfileResult = handleCommunityProfileExecutorQuery<Row>(context, text, params);
       if (communityProfileResult !== null) {
         return communityProfileResult;
+      }
+
+      const communityActivityResult = handleCommunityActivityExecutorQuery<Row>(context, text, params);
+      if (communityActivityResult !== null) {
+        return communityActivityResult;
       }
 
       throw new Error(`Unexpected query: ${text}`);

--- a/apps/backend/src/guestAuthTestHarness/fixtures.ts
+++ b/apps/backend/src/guestAuthTestHarness/fixtures.ts
@@ -174,6 +174,7 @@ export function createMergeState(params: Readonly<{
     feedbackPromptEvents: [],
     feedbackSubmissions: [],
     publicProfiles: [],
+    publicReviewActivityFacts: [],
   };
 }
 

--- a/apps/backend/src/guestAuthTestHarness/handlers/content.ts
+++ b/apps/backend/src/guestAuthTestHarness/handlers/content.ts
@@ -103,7 +103,17 @@ export function handleContentExecutorQuery<Row extends pg.QueryResultRow>(
   ) {
     const workspaceId = String(params[0]);
     if (text.includes("content.review_events")) {
+      // Mirror the public_review_activity_facts.review_event_id ON DELETE CASCADE so
+      // facts for deleted review events do not survive (matches the real schema).
+      const deletedReviewEventIds = new Set(
+        state.reviewEvents
+          .filter((reviewEvent) => reviewEvent.workspace_id === workspaceId)
+          .map((reviewEvent) => reviewEvent.review_event_id),
+      );
       state.reviewEvents = state.reviewEvents.filter((reviewEvent) => reviewEvent.workspace_id !== workspaceId);
+      state.publicReviewActivityFacts = state.publicReviewActivityFacts.filter(
+        (fact) => !deletedReviewEventIds.has(fact.review_event_id),
+      );
     } else if (text.includes("content.decks")) {
       state.decks = state.decks.filter((deck) => deck.workspace_id !== workspaceId);
     } else {
@@ -272,6 +282,8 @@ export function handleContentExecutorQuery<Row extends pg.QueryResultRow>(
       rating: Number(params[5]),
       reviewed_at_client: String(params[6]),
       reviewed_at_server: String(params[7]),
+      // VALUES (..., security.current_user_id()) — immutable authorship from the scope.
+      reviewed_by_user_id: typeof state.currentUserId === "string" ? state.currentUserId : null,
     };
     state.reviewEvents.push(insertedReviewEvent);
     return createQueryResult<Row>([createReviewEventQueryRow(insertedReviewEvent) as unknown as Row]);

--- a/apps/backend/src/guestAuthTestHarness/index.ts
+++ b/apps/backend/src/guestAuthTestHarness/index.ts
@@ -21,6 +21,8 @@ export {
   type HotChangeState,
   type InstallationState,
   type MutableState,
+  type PublicProfileState,
+  type PublicReviewActivityFactState,
   type ReviewEventClientEventDedupMergeFixture,
   type ReviewEventState,
   type UserSettingsState,

--- a/apps/backend/src/guestAuthTestHarness/models.ts
+++ b/apps/backend/src/guestAuthTestHarness/models.ts
@@ -94,6 +94,9 @@ export type ReviewEventState = Readonly<{
   rating: number;
   reviewed_at_client: string;
   reviewed_at_server: string;
+  // Immutable authorship. Optional because seeded historical fixtures may predate it;
+  // new harness inserts populate it from the request scope, like the real backend.
+  reviewed_by_user_id?: string | null;
 }>;
 
 export type WorkspaceMembershipRole = "owner" | "member";
@@ -147,6 +150,18 @@ export type PublicProfileState = Readonly<{
   leaderboard_participation_enabled: boolean;
 }>;
 
+export type PublicReviewActivityFactState = Readonly<{
+  review_event_id: string;
+  metric_version: string;
+  public_profile_id: string;
+  reviewed_by_user_id: string | null;
+  rating: number;
+  reviewed_at_client: string;
+  reviewed_at_server: string;
+  is_countable: boolean;
+  exclusion_reason: string | null;
+}>;
+
 export type MutableState = {
   currentUserId: string | null;
   currentWorkspaceId: string | null;
@@ -168,6 +183,7 @@ export type MutableState = {
   feedbackPromptEvents: Array<FeedbackPromptEventState>;
   feedbackSubmissions: Array<FeedbackSubmissionState>;
   publicProfiles: Array<PublicProfileState>;
+  publicReviewActivityFacts: Array<PublicReviewActivityFactState>;
 };
 
 export type ReviewEventClientEventDedupMergeFixture = Readonly<{

--- a/apps/backend/src/sync/replication/push.ts
+++ b/apps/backend/src/sync/replication/push.ts
@@ -3,6 +3,10 @@ import {
   upsertCardSnapshotInExecutor,
 } from "../../cards";
 import {
+  createCurrentUserPublicProfileResolver,
+  type CurrentUserPublicProfileResolver,
+} from "../../community/reviewActivityFacts";
+import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
 } from "../../database";
@@ -93,6 +97,7 @@ export async function processOperationInExecutor(
   workspaceId: string,
   replicaId: string,
   operation: SyncPushOperation,
+  resolveReviewedBy: CurrentUserPublicProfileResolver,
 ): Promise<SyncPushOperationResult> {
   let resultingHotChangeId: number | null = null;
   let status: SyncPushOperationResult["status"] = "applied";
@@ -214,6 +219,9 @@ export async function processOperationInExecutor(
       };
     }
 
+    // appendReviewEventSnapshotInExecutor stamps immutable reviewed_by_user_id from
+    // the authenticated syncing user (the request scope, not mutable replica labels)
+    // and upserts the public activity fact in this same operation transaction.
     const mutation = await appendReviewEventSnapshotInExecutor(
       executor,
       workspaceId,
@@ -228,6 +236,7 @@ export async function processOperationInExecutor(
         reviewedAtServer: new Date().toISOString(),
       },
       operation.operationId,
+      resolveReviewedBy,
     );
     status = mutation.applied ? "applied" : "ignored";
     resultingHotChangeId = null;
@@ -258,6 +267,9 @@ export async function processSyncPushOperationsInExecutor(
     replicaId,
     operations.map((operation) => operation.operationId),
   );
+  // Resolve the syncing user's public profile at most once for the whole push batch;
+  // the resolver stays lazy, so a push with no applied review event never creates one.
+  const resolveReviewedBy = createCurrentUserPublicProfileResolver(executor);
   const results: Array<SyncPushOperationResult> = [];
 
   for (const operation of operations) {
@@ -274,7 +286,7 @@ export async function processSyncPushOperationsInExecutor(
       continue;
     }
 
-    results.push(await processOperationInExecutor(executor, workspaceId, replicaId, operation));
+    results.push(await processOperationInExecutor(executor, workspaceId, replicaId, operation, resolveReviewedBy));
   }
 
   return results;

--- a/apps/backend/src/sync/replication/reviewHistory.ts
+++ b/apps/backend/src/sync/replication/reviewHistory.ts
@@ -1,4 +1,5 @@
 import { appendReviewEventSnapshotInExecutor } from "../../cards";
+import { createCurrentUserPublicProfileResolver } from "../../community/reviewActivityFacts";
 import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
@@ -72,6 +73,8 @@ export async function processSyncReviewHistoryImportInExecutor(
 ): Promise<SyncReviewHistoryImportResult> {
   let importedCount = 0;
   let duplicateCount = 0;
+  // Resolve the importing user's public profile at most once for the whole import.
+  const resolveReviewedBy = createCurrentUserPublicProfileResolver(executor);
 
   for (const [reviewEventIndex, reviewEvent] of input.reviewEvents.entries()) {
     try {
@@ -89,6 +92,7 @@ export async function processSyncReviewHistoryImportInExecutor(
           reviewedAtServer: reviewEvent.reviewedAtServer,
         },
         reviewEvent.reviewEventId,
+        resolveReviewedBy,
       );
 
       if (mutation.applied) {

--- a/db/migrations/0058_public_review_activity_facts.sql
+++ b/db/migrations/0058_public_review_activity_facts.sql
@@ -1,0 +1,148 @@
+-- Migration status: Current / canonical.
+-- Introduces: immutable review authorship on raw review events and the reusable
+--   public review activity fact layer (metric qualified_reviews_v1).
+-- Current guidance: facts are derived backend-internal projections of review
+--   events. Display names are never stored here; they stay derived at read time
+--   from community.public_profiles.public_profile_id and request locale.
+-- See also: db/migrations/0057_community_public_profiles.sql, docs/architecture.md.
+
+-- 1. Immutable review authorship on raw review events.
+ALTER TABLE content.review_events
+  ADD COLUMN IF NOT EXISTS reviewed_by_user_id TEXT
+    REFERENCES org.user_settings(user_id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN content.review_events.reviewed_by_user_id IS
+  'Immutable authenticated user who recorded the review event. New writes always set it from the authenticated request scope; nullable only because historical rows can be unresolvable.';
+
+-- Backfill historical authorship from the current replica owner. workspace_replicas.user_id
+-- is the only available historical signal and is used only for this backfill; new writes never
+-- infer authorship from mutable replica labels.
+UPDATE content.review_events AS review_events
+SET reviewed_by_user_id = workspace_replicas.user_id
+FROM sync.workspace_replicas AS workspace_replicas
+WHERE workspace_replicas.replica_id = review_events.replica_id
+  AND review_events.reviewed_by_user_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM org.user_settings AS user_settings
+    WHERE user_settings.user_id = workspace_replicas.user_id
+  );
+
+-- 2. Reusable public review activity fact table.
+CREATE TABLE IF NOT EXISTS community.public_review_activity_facts (
+  review_event_id     UUID        NOT NULL REFERENCES content.review_events(review_event_id) ON DELETE CASCADE,
+  metric_version      TEXT        NOT NULL,
+  public_profile_id   UUID        NOT NULL REFERENCES community.public_profiles(public_profile_id) ON DELETE CASCADE,
+  reviewed_by_user_id TEXT        REFERENCES org.user_settings(user_id) ON DELETE SET NULL,
+  rating              INTEGER     NOT NULL,
+  reviewed_at_client  TIMESTAMPTZ NOT NULL,
+  reviewed_at_server  TIMESTAMPTZ NOT NULL,
+  is_countable        BOOLEAN     NOT NULL,
+  exclusion_reason    TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (review_event_id, metric_version)
+);
+
+COMMENT ON TABLE community.public_review_activity_facts IS
+  'One immutable activity fact per (review event, metric version). Reusable projection for community activity reads. Never stores display names; those derive at read time from public_profile_id and locale.';
+COMMENT ON COLUMN community.public_review_activity_facts.metric_version IS
+  'Metric classification version. qualified_reviews_v1 counts every rating except again. New exclusion rules (for example a <1s answer guard) arrive as new exclusion reasons and/or metric versions.';
+COMMENT ON COLUMN community.public_review_activity_facts.public_profile_id IS
+  'Opaque community identity that owns this activity fact. Joins to community.public_profiles for read-time display-name derivation.';
+COMMENT ON COLUMN community.public_review_activity_facts.reviewed_by_user_id IS
+  'Authenticated author copied from content.review_events.reviewed_by_user_id at write time. Nullable only for unresolvable historical rows.';
+COMMENT ON COLUMN community.public_review_activity_facts.is_countable IS
+  'Whether this fact counts toward the metric. For qualified_reviews_v1 this is (rating <> 0).';
+COMMENT ON COLUMN community.public_review_activity_facts.exclusion_reason IS
+  'Why a fact is not countable. For qualified_reviews_v1: again for rating 0, NULL for ratings 1, 2, 3.';
+
+CREATE INDEX IF NOT EXISTS idx_public_review_activity_facts_metric_countable_client_time
+  ON community.public_review_activity_facts(metric_version, is_countable, reviewed_at_client);
+CREATE INDEX IF NOT EXISTS idx_public_review_activity_facts_profile_metric_countable_client_time
+  ON community.public_review_activity_facts(public_profile_id, metric_version, is_countable, reviewed_at_client);
+CREATE INDEX IF NOT EXISTS idx_public_review_activity_facts_user_metric_client_time
+  ON community.public_review_activity_facts(reviewed_by_user_id, metric_version, reviewed_at_client);
+
+ALTER TABLE community.public_review_activity_facts ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT (
+  review_event_id,
+  metric_version,
+  public_profile_id,
+  reviewed_by_user_id,
+  rating,
+  reviewed_at_client,
+  reviewed_at_server,
+  is_countable,
+  exclusion_reason,
+  created_at
+) ON TABLE community.public_review_activity_facts TO backend_app;
+GRANT INSERT (
+  review_event_id,
+  metric_version,
+  public_profile_id,
+  reviewed_by_user_id,
+  rating,
+  reviewed_at_client,
+  reviewed_at_server,
+  is_countable,
+  exclusion_reason
+) ON TABLE community.public_review_activity_facts TO backend_app;
+
+DROP POLICY IF EXISTS public_review_activity_facts_self_select_runtime ON community.public_review_activity_facts;
+CREATE POLICY public_review_activity_facts_self_select_runtime
+  ON community.public_review_activity_facts
+  FOR SELECT
+  TO backend_app
+  USING (reviewed_by_user_id = security.current_user_id());
+
+DROP POLICY IF EXISTS public_review_activity_facts_self_insert_runtime ON community.public_review_activity_facts;
+CREATE POLICY public_review_activity_facts_self_insert_runtime
+  ON community.public_review_activity_facts
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (reviewed_by_user_id = security.current_user_id());
+
+-- 3. Backfill facts for resolvable historical review events.
+-- First ensure every historical reviewer has a stable opaque public profile so the
+-- fact join below always resolves a public_profile_id.
+INSERT INTO community.public_profiles (user_id, public_profile_id)
+SELECT reviewer_user_ids.reviewed_by_user_id, gen_random_uuid()
+FROM (
+  SELECT DISTINCT review_events.reviewed_by_user_id
+  FROM content.review_events AS review_events
+  WHERE review_events.reviewed_by_user_id IS NOT NULL
+) AS reviewer_user_ids
+WHERE EXISTS (
+    SELECT 1
+    FROM org.user_settings AS user_settings
+    WHERE user_settings.user_id = reviewer_user_ids.reviewed_by_user_id
+  )
+ON CONFLICT (user_id) DO NOTHING;
+
+INSERT INTO community.public_review_activity_facts (
+  review_event_id,
+  metric_version,
+  public_profile_id,
+  reviewed_by_user_id,
+  rating,
+  reviewed_at_client,
+  reviewed_at_server,
+  is_countable,
+  exclusion_reason
+)
+SELECT
+  review_events.review_event_id,
+  'qualified_reviews_v1',
+  public_profiles.public_profile_id,
+  review_events.reviewed_by_user_id,
+  review_events.rating,
+  review_events.reviewed_at_client,
+  review_events.reviewed_at_server,
+  (review_events.rating <> 0),
+  CASE WHEN review_events.rating = 0 THEN 'again' ELSE NULL END
+FROM content.review_events AS review_events
+JOIN community.public_profiles AS public_profiles
+  ON public_profiles.user_id = review_events.reviewed_by_user_id
+WHERE review_events.reviewed_by_user_id IS NOT NULL
+ON CONFLICT (review_event_id, metric_version) DO NOTHING;


### PR DESCRIPTION
## Summary
- Migration `0058`: adds immutable `content.review_events.reviewed_by_user_id` (backfilled from `sync.workspace_replicas`) and the reusable `community.public_review_activity_facts` table (metric `qualified_reviews_v1` — countable unless rating 0/again) with indexes, RLS, grants, and SQL backfill.
- Records one fact per review event in the same transaction as the review write, across all write paths (direct review, sync push, review-history import, guest merge), using a lazy memoized per-batch public-profile resolver (profile ensured once per batch; never created for batches that store no review).
- Reorders the guest upgrade so the community-profile transfer runs before the merge, preserving the guest's stable `public_profile_id` on the linked account.
- No client-facing contract change: `reviewed_by_user_id` is backend-internal and the fact layer is additive.

## Test plan
- `npm test --prefix apps/backend` — 394/394 pass (fact classification/idempotency/resolver tests + guest-upgrade fact-preservation test).
- `npm run lint --prefix apps/backend` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)