### PR TITLE
Fix Android startup NoSuchMethodError on out-of-contract devices

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavigationSupport.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppNavigationSupport.kt
@@ -1,7 +1,6 @@
 package com.flashcardsopensourceapp.app.navigation
 
 import android.content.Context
-import android.content.pm.PackageManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.navigation.NavBackStackEntry
@@ -66,11 +65,13 @@ internal data class AppPackageInfo(
     val longVersionCode: Long
 )
 
+@Suppress("DEPRECATION")
 internal fun loadPackageInfo(context: Context): AppPackageInfo {
-    val packageInfo = context.packageManager.getPackageInfo(
-        context.packageName,
-        PackageManager.PackageInfoFlags.of(0L)
-    )
+    // Use the overloads available since API 1 on purpose: some out-of-contract devices
+    // (emulators, test farms, spoofed installs) report a higher Build.VERSION.SDK_INT than
+    // their real framework, so SDK_INT-gated newer APIs (PackageInfoFlags API 33,
+    // PackageInfo.longVersionCode API 28) link-fail there with NoSuchMethodError.
+    val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
     val versionName = packageInfo.versionName?.trim().orEmpty()
     require(versionName.isNotEmpty()) {
         "Android package versionName is missing from PackageInfo."
@@ -78,6 +79,6 @@ internal fun loadPackageInfo(context: Context): AppPackageInfo {
 
     return AppPackageInfo(
         versionName = versionName,
-        longVersionCode = packageInfo.longVersionCode
+        longVersionCode = packageInfo.versionCode.toLong()
     )
 }


### PR DESCRIPTION
## Summary
`loadPackageInfo` (Android startup) read package info via the API-33 `PackageManager.PackageInfoFlags.of(...)` overload and the API-28 `PackageInfo.longVersionCode` field. Out-of-contract devices (emulators, test farms, spoofed installs) can report a higher `Build.VERSION.SDK_INT` than their real framework, so those calls link-fail with `NoSuchMethodError` at app startup — and a `SDK_INT` guard cannot help, because the device misreports `SDK_INT` itself.

This reads `versionName` and `versionCode` through the `getPackageInfo(String, Int)` overload and the `PackageInfo.versionCode` field, both available since API 1, so there is no newer symbol that can be missing at runtime.

## Why this is safe
- `AppPackageInfo.longVersionCode` stays `Long`; every consumer reads it via `.toInt()`/`.toString()` and is unaffected.
- No `versionCodeMajor` is set and this app's `versionCode` is a positive `Int`, so `versionCode.toLong()` equals `longVersionCode` exactly.
- Behavior identical on in-contract devices (`minSdk = 34`); it only removes the crash on spoofed sub-framework environments.

## Verification
- No local `./gradlew` run (repo policy); CI `Android Release` validates build/lint.
- `getPackageInfo`/`PackageInfoFlags` exists at only this one site in the Android tree, and no caller breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)