### PR TITLE
Silence self-healing local-DB recovery telemetry

### DIFF
--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -341,7 +341,9 @@ describe("sync lifecycle observation", () => {
   it("does not warn when an empty local database has no restore history", async () => {
     await runWorkspaceRemoteSync(createRemoteSyncInput());
 
-    expect(findCapturedWarning("sync_local_db_missing")).toBeNull();
+    expect(observabilityMocks.addWebBreadcrumbMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "sync_local_db_missing" }),
+    );
   });
 
   it("uses separate page sizes for bootstrap and incremental pulls", async () => {
@@ -373,7 +375,7 @@ describe("sync lifecycle observation", () => {
     );
   });
 
-  it("deduplicates slow warnings for successful local database recovery", async () => {
+  it("emits recovery breadcrumbs and suppresses the slow warning for successful local database recovery", async () => {
     const clock = installMutableDateNow(0);
     const persistentStorageMock = installPersistentStorageMockWithClock(clock, 0, 7, 0);
     apiMocks.bootstrapPullSyncStateMock.mockImplementation(async () => {
@@ -404,7 +406,7 @@ describe("sync lifecycle observation", () => {
       },
     });
 
-    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledWith(expect.objectContaining({
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
       action: "sync_local_db_missing",
       details: expect.objectContaining({
         eventName: "sync_local_db_missing",
@@ -435,7 +437,7 @@ describe("sync lifecycle observation", () => {
         indexedDbDatabaseUpgraded: false,
       }),
     }));
-    expect(observabilityMocks.captureWebWarningMock).toHaveBeenCalledWith(expect.objectContaining({
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
       action: "sync_local_db_recovery_succeeded",
       details: expect.objectContaining({
         eventName: "sync_local_db_recovery_succeeded",
@@ -545,7 +547,9 @@ describe("sync lifecycle observation", () => {
     await runWorkspaceRemoteSync(createRemoteSyncInput());
 
     expect(apiMocks.bootstrapPullSyncStateMock).not.toHaveBeenCalled();
-    expect(findCapturedWarning("sync_local_db_missing")).toBeNull();
+    expect(observabilityMocks.addWebBreadcrumbMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "sync_local_db_missing" }),
+    );
     expect(loadSyncRestoreHistoryEntry({
       userId: "user-1",
       workspaceId: "workspace-1",

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.ts
@@ -164,11 +164,17 @@ export function observeSlowHotBootstrap(input: HotBootstrapSlowObservationInput)
   });
 }
 
+// Expected, self-healing condition: the browser evicted the best-effort local
+// IndexedDB cache and we are about to transparently re-hydrate from the backend
+// (the source of truth). Emitted as a silent breadcrumb, not a warning, so it never
+// raises a Sentry issue on its own — it only adds context to a later capture. See
+// bootstrapHotState for the full rationale; a failed re-hydration is reported as a
+// warning by observeLocalDbRecoveryFailed.
 export function observeLocalDbMissing(input: LocalDbMissingObservationInput): void {
   const indexedDbOpenLifecycleFields = buildIndexedDbOpenLifecycleObservationFields(
     input.indexedDbOpenLifecycleSnapshot,
   );
-  captureWebWarning({
+  addWebBreadcrumb({
     action: "sync_local_db_missing",
     scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
     details: {
@@ -216,13 +222,16 @@ function persistentStorageStateOrNull(state: PersistentStorageState | null): Per
   return state ?? nullPersistentStorageState();
 }
 
+// Successful transparent re-hydration after the browser evicted the local cache.
+// Like observeLocalDbMissing, this is a silent breadcrumb (no Sentry issue): the app
+// behaved exactly as designed, so it must not raise a warning.
 export function observeLocalDbRecoverySucceeded(input: LocalDbRecoveryObservationInput): void {
   const persistentStorageStateBefore = persistentStorageStateOrNull(input.persistentStorageStateBefore);
   const persistentStorageStateAfter = persistentStorageStateOrNull(input.persistentStorageStateAfter);
   const indexedDbOpenLifecycleFields = buildIndexedDbOpenLifecycleObservationFields(
     input.indexedDbOpenLifecycleSnapshot,
   );
-  captureWebWarning({
+  addWebBreadcrumb({
     action: "sync_local_db_recovery_succeeded",
     scope: buildSyncObservationScope(input.userId, input.workspaceId, input.installationId),
     details: {
@@ -270,6 +279,9 @@ export function observeLocalDbRecoverySucceeded(input: LocalDbRecoveryObservatio
   });
 }
 
+// Real problem: re-hydrating the evicted local cache from the backend failed, so the
+// user is left without their data. Unlike the missing/succeeded breadcrumbs above,
+// this stays a warning so it surfaces as a Sentry issue.
 export function observeLocalDbRecoveryFailed(input: LocalDbRecoveryFailedObservationInput): void {
   const persistentStorageStateBefore = persistentStorageStateOrNull(input.persistentStorageStateBefore);
   const persistentStorageStateAfter = persistentStorageStateOrNull(input.persistentStorageStateAfter);

--- a/apps/web/src/appData/sync/remote/bootstrapHotState.ts
+++ b/apps/web/src/appData/sync/remote/bootstrapHotState.ts
@@ -189,6 +189,14 @@ export async function bootstrapHotState(input: WorkspaceRemoteSyncInput): Promis
     bootstrapPageDurationMs,
   });
   let recoveryFailurePhase: SyncLocalDbRecoveryFailurePhase = "pre_bootstrap_storage_read";
+  // The local IndexedDB is a best-effort cache, never a source of truth. Browsers can
+  // evict it at any time — storage pressure, a denied navigator.storage.persist()
+  // grant, or the user clearing site data — so finding it empty while restore history
+  // shows it once held data is an expected condition, not a failure. The backend is the
+  // source of truth and the loop below transparently re-hydrates the full hot state
+  // from it. Because this path self-heals, the "missing" and "recovered" signals are
+  // emitted as silent breadcrumbs (no Sentry issue); only a failed re-hydration (catch
+  // block) escalates to a warning.
   const isLocalDbRecovery = syncStateBefore === null
     && localCardCountBefore === 0
     && restoreHistoryBefore !== null;

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -189,6 +189,16 @@ export type WebBreadcrumbEvent =
     action: "indexed_db_operation";
     scope: WebObservationScope;
     details: IndexedDbOperationBreadcrumbDetails;
+  }>
+  | Readonly<{
+    action: "sync_local_db_missing";
+    scope: WebObservationScope;
+    details: SyncLocalDbMissingBreadcrumbDetails;
+  }>
+  | Readonly<{
+    action: "sync_local_db_recovery_succeeded";
+    scope: WebObservationScope;
+    details: SyncLocalDbRecoverySucceededBreadcrumbDetails;
   }>;
 
 export type ApiContractFailureDetails = Readonly<{
@@ -427,7 +437,12 @@ export type SyncRestoreWarningDetails = SyncBootstrapTimingDetails & Readonly<{
   remoteIsEmpty: boolean | null;
 }>;
 
-export type SyncLocalDbMissingWarningDetails = Readonly<{
+// Local IndexedDB is a best-effort cache the browser may evict at any time, so
+// detecting it missing and re-hydrating from the backend (the source of truth) is
+// expected, self-healing behavior — not an error. These details are therefore
+// carried as a silent breadcrumb (see WebBreadcrumbEvent), never a warning. Only
+// sync_local_db_recovery_failed escalates to a warning.
+export type SyncLocalDbMissingBreadcrumbDetails = Readonly<{
   eventName: "sync_local_db_missing";
   syncRunId: string;
   workspaceId: string;
@@ -459,7 +474,9 @@ export type SyncLocalDbMissingWarningDetails = Readonly<{
   indexedDbDatabaseUpgraded: boolean | null;
 }>;
 
-export type SyncLocalDbRecoverySucceededWarningDetails = SyncBootstrapTimingDetails & Readonly<{
+// Successful self-healing recovery — emitted as a silent breadcrumb, not a warning
+// (see SyncLocalDbMissingBreadcrumbDetails for the rationale).
+export type SyncLocalDbRecoverySucceededBreadcrumbDetails = SyncBootstrapTimingDetails & Readonly<{
   eventName: "sync_local_db_recovery_succeeded";
   syncRunId: string;
   workspaceId: string;
@@ -587,16 +604,6 @@ export type WebWarningEvent =
     action: "sync_restore_slow";
     scope: WebObservationScope;
     details: SyncRestoreWarningDetails;
-  }>
-  | Readonly<{
-    action: "sync_local_db_missing";
-    scope: WebObservationScope;
-    details: SyncLocalDbMissingWarningDetails;
-  }>
-  | Readonly<{
-    action: "sync_local_db_recovery_succeeded";
-    scope: WebObservationScope;
-    details: SyncLocalDbRecoverySucceededWarningDetails;
   }>
   | Readonly<{
     action: "sync_local_db_recovery_failed";


### PR DESCRIPTION
## What

Local IndexedDB is a best-effort cache the browser can evict at any time (storage pressure, a denied `navigator.storage.persist()` grant, or the user clearing site data). Finding it empty and transparently re-hydrating from the backend (the source of truth) is expected, self-healing behavior — not an error.

## Change

- `sync_local_db_missing` and `sync_local_db_recovery_succeeded` now emit as **silent breadcrumbs** instead of Sentry warnings, so the normal self-heal path stops creating Sentry issues while still attaching full context to any later capture.
- `sync_local_db_recovery_failed` stays a **warning** — a failed re-hydration is a real problem and must still surface.
- Detail types moved from the warning union to the breadcrumb union; rationale documented in code comments.
- Tests updated to assert the new breadcrumb contract.

## Validation

- `tsc --noEmit` passes for `apps/web`.
- `vitest` was not run in this environment (Node major-version mismatch when loading `vite.config.ts`); the test edits use assertion patterns already established in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)