### PR TITLE
Add compact Progress leaderboard read API

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -219,6 +219,84 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /me/progress/leaderboard:
+    get:
+      tags:
+        - bootstrap
+      summary: Load the compact community Progress leaderboard
+      description: >-
+        Returns all five leaderboard windows in one payload for the Progress tab,
+        each with viewer-perspective ranks, the per-viewer tie rule, and the
+        server-computed compact rows so every client renders the same list.
+        Guests receive status linked_account_required and opted-out users receive
+        participation_disabled, both with no other users' rows. ApiKey
+        authentication is rejected. Only opaque public profile ids and
+        locale-derived anonymous display names are returned; internal user ids and
+        raw review timestamps are never exposed.
+      security:
+        - BearerAuth: []
+        - GuestAuthorizationHeader: []
+        - SessionCookie: []
+      responses:
+        '200':
+          description: Compact community leaderboard
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProgressLeaderboardResponse'
+              example:
+                status: ready
+                metric:
+                  metricVersion: qualified_reviews_v1
+                  title: Qualified reviews
+                  description: Hard, Good, and Easy reviews count toward your rank. Again does not.
+                defaultWindowKey: last_24_hours
+                windows:
+                  - windowKey: last_24_hours
+                    snapshotId: 0cc86d10-18cb-4d64-a2f2-a5fd960b45b2
+                    snapshotGeneratedAt: '2026-06-10T14:00:05.000Z'
+                    asOfServerHour: '2026-06-10T14:00:00.000Z'
+                    nextRefreshAfter: '2026-06-10T15:00:00.000Z'
+                    participantCount: 128
+                    viewer:
+                      publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
+                      displayName: You
+                      rank: 42
+                      qualifiedReviewCount: 7
+                    rows:
+                      - kind: top
+                        publicProfileId: a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d
+                        anonymousDisplayName: Silver Bright Harbor
+                        qualifiedReviewCount: 51
+                        rank: 1
+                      - kind: gap
+                      - kind: neighbor
+                        publicProfileId: b2c3d4e5-6f70-4b9c-8d1e-2f3a4b5c6d7e
+                        anonymousDisplayName: Amber Calm Meadow
+                        qualifiedReviewCount: 8
+                        rank: 41
+                      - kind: viewer
+                        publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
+                        anonymousDisplayName: Jade Swift River
+                        qualifiedReviewCount: 7
+                        rank: 42
+                      - kind: neighbor
+                        publicProfileId: c3d4e5f6-7081-4c0d-9e2f-3a4b5c6d7e8f
+                        anonymousDisplayName: Coral Keen Valley
+                        qualifiedReviewCount: 7
+                        rank: 43
+        '403':
+          description: Forbidden authentication transport
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /agent/me:
     $ref: paths/agent_me.yaml
   /agent/workspaces:
@@ -293,6 +371,158 @@ components:
           type: boolean
         linkedAccountRequiredForLeaderboard:
           type: boolean
+    LeaderboardWindowKey:
+      type: string
+      enum:
+        - last_24_hours
+        - last_3_days
+        - last_7_days
+        - last_30_days
+        - all_time
+    ProgressLeaderboardMetric:
+      type: object
+      additionalProperties: false
+      required:
+        - metricVersion
+        - title
+        - description
+      properties:
+        metricVersion:
+          type: string
+          enum:
+            - qualified_reviews_v1
+        title:
+          type: string
+        description:
+          type: string
+          description: Communicates that Hard, Good, and Easy reviews count while Again does not.
+    ProgressLeaderboardViewer:
+      type: object
+      additionalProperties: false
+      required:
+        - publicProfileId
+        - displayName
+        - rank
+        - qualifiedReviewCount
+      properties:
+        publicProfileId:
+          $ref: ./components/schemas/UuidString.yaml
+        displayName:
+          type: string
+          enum:
+            - You
+          description: Always "You"; clients render the viewer row using the row kind.
+        rank:
+          type: integer
+          minimum: 1
+        qualifiedReviewCount:
+          type: integer
+          minimum: 0
+    ProgressLeaderboardParticipantRow:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - publicProfileId
+        - anonymousDisplayName
+        - qualifiedReviewCount
+        - rank
+      properties:
+        kind:
+          type: string
+          enum:
+            - top
+            - neighbor
+            - viewer
+        publicProfileId:
+          $ref: ./components/schemas/UuidString.yaml
+        anonymousDisplayName:
+          type: string
+          description: Locale-aware anonymous display label derived from the public profile id.
+        qualifiedReviewCount:
+          type: integer
+          minimum: 0
+        rank:
+          type: integer
+          minimum: 1
+    ProgressLeaderboardGapRow:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          enum:
+            - gap
+    ProgressLeaderboardRow:
+      oneOf:
+        - $ref: '#/components/schemas/ProgressLeaderboardParticipantRow'
+        - $ref: '#/components/schemas/ProgressLeaderboardGapRow'
+    ProgressLeaderboardWindow:
+      type: object
+      additionalProperties: false
+      required:
+        - windowKey
+        - snapshotId
+        - snapshotGeneratedAt
+        - asOfServerHour
+        - nextRefreshAfter
+        - participantCount
+        - viewer
+        - rows
+      properties:
+        windowKey:
+          $ref: '#/components/schemas/LeaderboardWindowKey'
+        snapshotId:
+          $ref: ./components/schemas/UuidString.yaml
+        snapshotGeneratedAt:
+          type: string
+          format: date-time
+        asOfServerHour:
+          type: string
+          format: date-time
+        nextRefreshAfter:
+          type: string
+          format: date-time
+        participantCount:
+          type: integer
+          minimum: 0
+          description: >-
+            Size of the viewer-perspective ranking. Always includes the viewer
+            (with count 0 when absent from the snapshot), so the viewer rank is
+            never greater than this value.
+        viewer:
+          $ref: '#/components/schemas/ProgressLeaderboardViewer'
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProgressLeaderboardRow'
+    ProgressLeaderboardResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - metric
+        - defaultWindowKey
+        - windows
+      properties:
+        status:
+          type: string
+          enum:
+            - ready
+            - linked_account_required
+            - participation_disabled
+            - snapshot_unavailable
+        metric:
+          $ref: '#/components/schemas/ProgressLeaderboardMetric'
+        defaultWindowKey:
+          $ref: '#/components/schemas/LeaderboardWindowKey'
+        windows:
+          type: array
+          description: Empty unless status is ready; otherwise one item per leaderboard window.
+          items:
+            $ref: '#/components/schemas/ProgressLeaderboardWindow'
     ErrorResponse:
       type: object
       additionalProperties: true

--- a/apps/backend/src/community/leaderboardWindows.ts
+++ b/apps/backend/src/community/leaderboardWindows.ts
@@ -84,6 +84,47 @@ export function assertLeaderboardWindowKey(windowKey: string): LeaderboardWindow
 }
 
 /**
+ * Window a client preselects when none is requested. The compact Progress-tab
+ * leaderboard returns every window in one payload, but the default selected
+ * window is never `all_time`: a viewer with stale or no recent activity still
+ * lands on a bounded window so one fresh review can visibly move their rank.
+ */
+export const DEFAULT_COMPACT_LEADERBOARD_WINDOW_KEY: LeaderboardWindowKey = "last_24_hours";
+
+/**
+ * Resolves which window a client preselects from how long ago the viewer's
+ * latest countable review happened. Each bounded window's `lowerBoundHours`
+ * doubles as that window's inclusive upper edge for selection (24h, 72h, 168h,
+ * 720h); anything older clamps to the longest bounded window (`last_30_days`)
+ * and a viewer with no countable review falls back to {@link
+ * DEFAULT_COMPACT_LEADERBOARD_WINDOW_KEY}. `all_time` is never selected so a
+ * fresh review is always visible in the preselected window.
+ */
+export function resolveDefaultLeaderboardWindowKey(
+  elapsedHoursSinceLatestCountableReview: number | null,
+): LeaderboardWindowKey {
+  if (elapsedHoursSinceLatestCountableReview === null) {
+    return DEFAULT_COMPACT_LEADERBOARD_WINDOW_KEY;
+  }
+
+  // LEADERBOARD_WINDOWS is ordered shortest-first with all_time last, so the last
+  // bounded window seen becomes the clamp target for reviews older than 30 days.
+  let longestBoundedWindowKey: LeaderboardWindowKey = DEFAULT_COMPACT_LEADERBOARD_WINDOW_KEY;
+  for (const window of LEADERBOARD_WINDOWS) {
+    if (window.lowerBoundHours === null) {
+      continue;
+    }
+
+    longestBoundedWindowKey = window.windowKey;
+    if (elapsedHoursSinceLatestCountableReview <= window.lowerBoundHours) {
+      return window.windowKey;
+    }
+  }
+
+  return longestBoundedWindowKey;
+}
+
+/**
  * Truncates a wall-clock instant to the start of its UTC hour, matching the SQL
  * `date_trunc('hour', now())` semantics used for `as_of_server_hour`.
  */

--- a/apps/backend/src/community/progressLeaderboard.test.ts
+++ b/apps/backend/src/community/progressLeaderboard.test.ts
@@ -1,0 +1,526 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import {
+  LEADERBOARD_WINDOW_KEYS,
+  resolveDefaultLeaderboardWindowKey,
+} from "./leaderboardWindows";
+import {
+  loadProgressLeaderboard,
+  loadProgressLeaderboardInExecutor,
+  type ProgressLeaderboard,
+  type ProgressLeaderboardParticipantRow,
+  type ProgressLeaderboardRow,
+} from "./progressLeaderboard";
+
+type QueryResultRow = pg.QueryResultRow;
+
+type SnapshotHeaderRow = Readonly<{
+  window_key: string;
+  snapshot_id: string;
+  generated_at: Date;
+  as_of_server_hour: Date;
+}>;
+
+type SnapshotEntryRow = Readonly<{
+  public_profile_id: string;
+  qualified_review_count: number;
+  base_sort_position: number;
+}>;
+
+type ViewerProfileFixture = Readonly<{
+  publicProfileId: string;
+  leaderboardParticipationEnabled: boolean;
+}>;
+
+type LeaderboardExecutorFixture = Readonly<{
+  viewerUserId: string;
+  viewerProfile: ViewerProfileFixture;
+  latestReviewedAtClient: Date | null;
+  headers: ReadonlyArray<SnapshotHeaderRow>;
+  entriesBySnapshotId: Readonly<Record<string, ReadonlyArray<SnapshotEntryRow>>>;
+}>;
+
+type RecordedQuery = Readonly<{ text: string; params: ReadonlyArray<SqlValue> }>;
+
+const VIEWER_USER_ID = "user-viewer";
+const VIEWER_PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
+const AS_OF_SERVER_HOUR = new Date("2026-06-10T14:00:00.000Z");
+const SNAPSHOT_GENERATED_AT = new Date("2026-06-10T14:00:05.000Z");
+const EXPECTED_AS_OF_ISO = "2026-06-10T14:00:00.000Z";
+const EXPECTED_GENERATED_AT_ISO = "2026-06-10T14:00:05.000Z";
+const EXPECTED_NEXT_REFRESH_ISO = "2026-06-10T15:00:00.000Z";
+const NOW = new Date("2026-06-10T14:30:00.000Z");
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
+
+function createQueryResult<Row extends QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function snapshotIdForWindow(windowKey: string): string {
+  return `snapshot-${windowKey}`;
+}
+
+function createReadyHeaders(): ReadonlyArray<SnapshotHeaderRow> {
+  return LEADERBOARD_WINDOW_KEYS.map((windowKey) => ({
+    window_key: windowKey,
+    snapshot_id: snapshotIdForWindow(windowKey),
+    generated_at: SNAPSHOT_GENERATED_AT,
+    as_of_server_hour: AS_OF_SERVER_HOUR,
+  }));
+}
+
+function createEntriesForWindow(
+  windowKey: string,
+  entries: ReadonlyArray<SnapshotEntryRow>,
+): Readonly<Record<string, ReadonlyArray<SnapshotEntryRow>>> {
+  return { [snapshotIdForWindow(windowKey)]: entries };
+}
+
+function isStringArray(value: SqlValue | undefined): value is ReadonlyArray<string> {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+/**
+ * In-memory fake of the request-scoped executor exercised by the leaderboard read.
+ * It reproduces the scope handshake, the viewer profile read, the viewer's latest
+ * countable review, the latest-snapshot-per-window header read, and the entry read,
+ * and throws on any query the loader is not expected to issue so privacy
+ * short-circuits (guest, opt-out, missing snapshots) are observable.
+ */
+function createLeaderboardExecutor(
+  fixture: LeaderboardExecutorFixture,
+): Readonly<{ executor: DatabaseExecutor; recordedQueries: ReadonlyArray<RecordedQuery> }> {
+  const recordedQueries: Array<RecordedQuery> = [];
+  let scopedUserId: string | null = null;
+
+  const executor: DatabaseExecutor = {
+    async query<Row extends QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+
+      if (text.includes("set_config('app.user_id', $1, true)")) {
+        scopedUserId = typeof params[0] === "string" ? params[0] : null;
+        return createQueryResult<QueryResultRow>([]) as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("security.current_user_id() AS user_id")) {
+        if (scopedUserId !== fixture.viewerUserId) {
+          throw new Error("current_user_id read requires the viewer user scope");
+        }
+
+        return createQueryResult([{ user_id: fixture.viewerUserId }]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.includes("FROM community.public_profiles")
+        && text.includes("leaderboard_participation_enabled")
+        && text.includes("WHERE user_id = $1")
+        && !text.includes("INSERT")
+      ) {
+        if (scopedUserId !== fixture.viewerUserId) {
+          throw new Error("public profile read requires the viewer user scope");
+        }
+
+        return createQueryResult([
+          {
+            public_profile_id: fixture.viewerProfile.publicProfileId,
+            leaderboard_participation_enabled: fixture.viewerProfile.leaderboardParticipationEnabled,
+          },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("INSERT INTO community.public_profiles")) {
+        throw new Error("viewer profile was pre-seeded; no insert expected");
+      }
+
+      if (text.includes("MAX(facts.reviewed_at_client)")) {
+        return createQueryResult([
+          { latest_reviewed_at_client: fixture.latestReviewedAtClient },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.includes("FROM community.leaderboard_snapshots")
+        && text.includes("DISTINCT ON (snapshots.window_key)")
+      ) {
+        return createQueryResult(fixture.headers) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("FROM community.leaderboard_snapshot_entries")) {
+        const snapshotIds = params[0];
+        if (!isStringArray(snapshotIds)) {
+          throw new Error("entry read requires a snapshot id array parameter");
+        }
+
+        const rows = snapshotIds.flatMap((snapshotId) =>
+          (fixture.entriesBySnapshotId[snapshotId] ?? []).map((entry) => ({
+            snapshot_id: snapshotId,
+            public_profile_id: entry.public_profile_id,
+            qualified_review_count: entry.qualified_review_count,
+            base_sort_position: entry.base_sort_position,
+          })),
+        );
+
+        return createQueryResult(rows) as unknown as pg.QueryResult<Row>;
+      }
+
+      throw new Error(`Unexpected leaderboard read query: ${text}`);
+    },
+  };
+
+  return { executor, recordedQueries };
+}
+
+function findWindow(leaderboard: ProgressLeaderboard, windowKey: string) {
+  const window = leaderboard.windows.find((candidate) => candidate.windowKey === windowKey);
+  if (window === undefined) {
+    throw new Error(`Missing window ${windowKey} in leaderboard response`);
+  }
+
+  return window;
+}
+
+function participantRows(
+  rows: ReadonlyArray<ProgressLeaderboardRow>,
+): ReadonlyArray<ProgressLeaderboardParticipantRow> {
+  return rows.filter((row): row is ProgressLeaderboardParticipantRow => row.kind !== "gap");
+}
+
+function includesQuery(recordedQueries: ReadonlyArray<RecordedQuery>, substring: string): boolean {
+  return recordedQueries.some((query) => query.text.includes(substring));
+}
+
+test("resolveDefaultLeaderboardWindowKey maps elapsed hours to a bounded window and never all_time", () => {
+  assert.equal(resolveDefaultLeaderboardWindowKey(null), "last_24_hours");
+  assert.equal(resolveDefaultLeaderboardWindowKey(0), "last_24_hours");
+  assert.equal(resolveDefaultLeaderboardWindowKey(24), "last_24_hours");
+  assert.equal(resolveDefaultLeaderboardWindowKey(24.5), "last_3_days");
+  assert.equal(resolveDefaultLeaderboardWindowKey(72), "last_3_days");
+  assert.equal(resolveDefaultLeaderboardWindowKey(100), "last_7_days");
+  assert.equal(resolveDefaultLeaderboardWindowKey(168), "last_7_days");
+  assert.equal(resolveDefaultLeaderboardWindowKey(200), "last_30_days");
+  assert.equal(resolveDefaultLeaderboardWindowKey(720), "last_30_days");
+  // Older than 30 days clamps to last_30_days, never all_time.
+  assert.equal(resolveDefaultLeaderboardWindowKey(5000), "last_30_days");
+});
+
+test("guest viewers receive linked_account_required with no rows and no database access", async () => {
+  const leaderboard = await loadProgressLeaderboard({
+    userId: VIEWER_USER_ID,
+    transport: "guest",
+    localeHint: "en",
+  });
+
+  assert.equal(leaderboard.status, "linked_account_required");
+  assert.deepEqual(leaderboard.windows, []);
+  assert.equal(leaderboard.defaultWindowKey, "last_24_hours");
+  assert.equal(leaderboard.metric.metricVersion, "qualified_reviews_v1");
+});
+
+test("opted-out viewers receive participation_disabled without reading any other user rows", async () => {
+  const { executor, recordedQueries } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: false },
+    latestReviewedAtClient: null,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: {},
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  assert.equal(leaderboard.status, "participation_disabled");
+  assert.deepEqual(leaderboard.windows, []);
+  assert.equal(includesQuery(recordedQueries, "community.leaderboard_snapshots"), false);
+  assert.equal(includesQuery(recordedQueries, "community.leaderboard_snapshot_entries"), false);
+});
+
+test("missing snapshots yield snapshot_unavailable without reading entries", async () => {
+  const { executor, recordedQueries } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    headers: [],
+    entriesBySnapshotId: {},
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "bearer", localeHint: "en" },
+    NOW,
+  );
+
+  assert.equal(leaderboard.status, "snapshot_unavailable");
+  assert.deepEqual(leaderboard.windows, []);
+  assert.equal(includesQuery(recordedQueries, "community.leaderboard_snapshot_entries"), false);
+});
+
+test("ready response defaults to the window of the viewer's latest countable review", async () => {
+  // 100 hours before NOW falls inside the 7-day window but outside the 3-day window.
+  const latestReviewedAtClient = new Date(NOW.getTime() - 100 * MILLISECONDS_PER_HOUR);
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_7_days", [
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 9, base_sort_position: 1 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  assert.equal(leaderboard.status, "ready");
+  assert.equal(leaderboard.defaultWindowKey, "last_7_days");
+  assert.equal(leaderboard.windows.length, LEADERBOARD_WINDOW_KEYS.length);
+  const window = findWindow(leaderboard, "last_7_days");
+  assert.equal(window.snapshotGeneratedAt, EXPECTED_GENERATED_AT_ISO);
+  assert.equal(window.asOfServerHour, EXPECTED_AS_OF_ISO);
+  assert.equal(window.nextRefreshAfter, EXPECTED_NEXT_REFRESH_ISO);
+  assert.equal(window.viewer.qualifiedReviewCount, 9);
+  assert.equal(window.viewer.rank, 1);
+});
+
+test("a zero-count viewer defaults to last_24_hours and still appears ranked last with zero", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: "00000000-0000-4000-8000-0000000000b1", qualified_review_count: 5, base_sort_position: 1 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000b2", qualified_review_count: 3, base_sort_position: 2 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  assert.equal(leaderboard.status, "ready");
+  assert.equal(leaderboard.defaultWindowKey, "last_24_hours");
+  const window = findWindow(leaderboard, "last_24_hours");
+  assert.equal(window.participantCount, 3);
+  assert.equal(window.viewer.qualifiedReviewCount, 0);
+  assert.equal(window.viewer.rank, 3);
+  const viewerRow = participantRows(window.rows).find((row) => row.kind === "viewer");
+  assert.notEqual(viewerRow, undefined);
+  assert.equal(viewerRow?.qualifiedReviewCount, 0);
+  assert.equal(viewerRow?.rank, 3);
+  assert.equal(viewerRow?.publicProfileId, VIEWER_PROFILE_ID);
+});
+
+test("equal counts rank the viewer below other users with the same count", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: "00000000-0000-4000-8000-0000000000c1", qualified_review_count: 5, base_sort_position: 1 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000c2", qualified_review_count: 5, base_sort_position: 2 },
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 5, base_sort_position: 3 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000c4", qualified_review_count: 3, base_sort_position: 4 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  // Viewer ties three users at count 5 but is placed below the two other equal-count users.
+  assert.equal(window.viewer.rank, 3);
+  assert.equal(window.viewer.qualifiedReviewCount, 5);
+  const rows = participantRows(window.rows);
+  assert.deepEqual(
+    rows.map((row) => ({ kind: row.kind, rank: row.rank, count: row.qualifiedReviewCount })),
+    [
+      { kind: "top", rank: 1, count: 5 },
+      { kind: "top", rank: 2, count: 5 },
+      { kind: "viewer", rank: 3, count: 5 },
+      { kind: "neighbor", rank: 4, count: 3 },
+    ],
+  );
+});
+
+test("compact rows show the top three, a single gap, and the viewer with its neighbors", async () => {
+  const otherEntries: ReadonlyArray<SnapshotEntryRow> = [
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d1", qualified_review_count: 100, base_sort_position: 1 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d2", qualified_review_count: 90, base_sort_position: 2 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d3", qualified_review_count: 80, base_sort_position: 3 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d4", qualified_review_count: 70, base_sort_position: 4 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d5", qualified_review_count: 60, base_sort_position: 5 },
+    { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 55, base_sort_position: 6 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d7", qualified_review_count: 50, base_sort_position: 7 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d8", qualified_review_count: 40, base_sort_position: 8 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000d9", qualified_review_count: 30, base_sort_position: 9 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000da", qualified_review_count: 20, base_sort_position: 10 },
+  ];
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", otherEntries),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  assert.equal(window.participantCount, 10);
+  assert.equal(window.viewer.rank, 6);
+
+  const kindsAndRanks = window.rows.map((row) => (row.kind === "gap" ? "gap" : `${row.kind}:${row.rank}`));
+  assert.deepEqual(kindsAndRanks, [
+    "top:1",
+    "top:2",
+    "top:3",
+    "gap",
+    "neighbor:5",
+    "viewer:6",
+    "neighbor:7",
+  ]);
+
+  // The top three rows always precede the single gap row.
+  assert.equal(window.rows[0]?.kind, "top");
+  assert.equal(window.rows[3]?.kind, "gap");
+  assert.equal(window.rows.filter((row) => row.kind === "gap").length, 1);
+});
+
+test("a viewer near the top produces contiguous rows with no gap", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: "00000000-0000-4000-8000-0000000000e1", qualified_review_count: 30, base_sort_position: 1 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000e2", qualified_review_count: 20, base_sort_position: 2 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000e3", qualified_review_count: 15, base_sort_position: 3 },
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 10, base_sort_position: 4 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000e5", qualified_review_count: 5, base_sort_position: 5 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  assert.equal(window.viewer.rank, 4);
+  assert.equal(window.rows.some((row) => row.kind === "gap"), false);
+  assert.deepEqual(
+    window.rows.map((row) => (row.kind === "gap" ? "gap" : `${row.kind}:${row.rank}`)),
+    ["top:1", "top:2", "top:3", "viewer:4", "neighbor:5"],
+  );
+});
+
+test("anonymous names change with locale while ids, counts, and ranks stay stable", async () => {
+  const entries = createEntriesForWindow("last_24_hours", [
+    { public_profile_id: "00000000-0000-4000-8000-0000000000f1", qualified_review_count: 9, base_sort_position: 1 },
+    { public_profile_id: "00000000-0000-4000-8000-0000000000f2", qualified_review_count: 4, base_sort_position: 2 },
+    { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 1, base_sort_position: 3 },
+  ]);
+  const buildFixture = (): LeaderboardExecutorFixture => ({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: entries,
+  });
+
+  const englishLeaderboard = await loadProgressLeaderboardInExecutor(
+    createLeaderboardExecutor(buildFixture()).executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+  const russianLeaderboard = await loadProgressLeaderboardInExecutor(
+    createLeaderboardExecutor(buildFixture()).executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "ru" },
+    NOW,
+  );
+
+  const englishWindow = findWindow(englishLeaderboard, "last_24_hours");
+  const russianWindow = findWindow(russianLeaderboard, "last_24_hours");
+  const englishRows = participantRows(englishWindow.rows);
+  const russianRows = participantRows(russianWindow.rows);
+
+  assert.deepEqual(
+    englishRows.map((row) => ({ id: row.publicProfileId, count: row.qualifiedReviewCount, rank: row.rank })),
+    russianRows.map((row) => ({ id: row.publicProfileId, count: row.qualifiedReviewCount, rank: row.rank })),
+  );
+  const englishTopName = englishRows[0]?.anonymousDisplayName ?? "";
+  const russianTopName = russianRows[0]?.anonymousDisplayName ?? "";
+  assert.notEqual(englishTopName, "");
+  assert.notEqual(russianTopName, "");
+  assert.notEqual(englishTopName, russianTopName);
+  // Metric copy is localized too, but the metric version key stays stable.
+  assert.equal(englishLeaderboard.metric.metricVersion, russianLeaderboard.metric.metricVersion);
+  assert.notEqual(englishLeaderboard.metric.title, russianLeaderboard.metric.title);
+});
+
+test("ready response serializes only public fields, never internal identifiers", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: new Date(NOW.getTime() - 2 * MILLISECONDS_PER_HOUR),
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: "00000000-0000-4000-8000-000000000aa1", qualified_review_count: 7, base_sort_position: 1 },
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 2, base_sort_position: 2 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+  const serialized = JSON.stringify(leaderboard);
+
+  assert.equal(serialized.includes("publicProfileId"), true);
+  assert.equal(serialized.includes("anonymousDisplayName"), true);
+  assert.equal(serialized.includes("qualifiedReviewCount"), true);
+  for (const internalField of [
+    VIEWER_USER_ID,
+    "user_id",
+    "userId",
+    "reviewed_by",
+    "reviewedBy",
+    "base_sort",
+    "baseSort",
+    "reviewed_at",
+    "reviewedAt",
+    "email",
+  ]) {
+    assert.equal(serialized.includes(internalField), false, `serialized payload must not include ${internalField}`);
+  }
+});

--- a/apps/backend/src/community/progressLeaderboard.ts
+++ b/apps/backend/src/community/progressLeaderboard.ts
@@ -1,0 +1,599 @@
+import {
+  applyUserDatabaseScopeInExecutor,
+  type DatabaseExecutor,
+} from "../database";
+import { unsafeTransaction } from "../database/unsafe";
+import type { AuthTransport } from "../auth";
+import {
+  createAnonymousDisplayName,
+  ensurePublicProfileForCurrentUserInExecutor,
+} from "./publicProfiles";
+import {
+  getAnonymousDisplayNameWordPools,
+  resolveAnonymousDisplayNameLocale,
+  type AnonymousDisplayNameLocale,
+} from "./anonymousDisplayNames";
+import {
+  DEFAULT_COMPACT_LEADERBOARD_WINDOW_KEY,
+  LEADERBOARD_SNAPSHOT_METRIC_VERSION,
+  LEADERBOARD_WINDOW_KEYS,
+  assertLeaderboardWindowKey,
+  isLeaderboardWindowKey,
+  resolveDefaultLeaderboardWindowKey,
+  truncateToServerHour,
+  type LeaderboardWindowKey,
+} from "./leaderboardWindows";
+
+/**
+ * Client-facing compact Progress-tab leaderboard read.
+ *
+ * The hourly job (see leaderboardSnapshots.ts) writes tie-neutral base orderings
+ * into community.leaderboard_snapshots / _entries. This module is the read side:
+ * it derives the viewer-perspective ranking, the per-viewer tie rule, the compact
+ * row window, and the locale-derived anonymous names at read time, and returns
+ * every window in one payload so a client never makes one request per segment.
+ *
+ * Privacy contract: only opaque public_profile_ids and derived display names ever
+ * leave this module. Internal user ids, raw review timestamps, and the snapshot
+ * base_sort_position are never serialized. Guests and opted-out users receive an
+ * explicit status with no other users' rows.
+ */
+
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
+
+const PROGRESS_LEADERBOARD_VIEWER_DISPLAY_NAME = "You" as const;
+
+export const PROGRESS_LEADERBOARD_STATUSES = [
+  "ready",
+  "linked_account_required",
+  "participation_disabled",
+  "snapshot_unavailable",
+] as const;
+
+export type ProgressLeaderboardStatus = (typeof PROGRESS_LEADERBOARD_STATUSES)[number];
+
+export const PROGRESS_LEADERBOARD_ROW_KINDS = [
+  "top",
+  "neighbor",
+  "viewer",
+  "gap",
+] as const;
+
+export type ProgressLeaderboardRowKind = (typeof PROGRESS_LEADERBOARD_ROW_KINDS)[number];
+
+export type ProgressLeaderboardMetric = Readonly<{
+  metricVersion: typeof LEADERBOARD_SNAPSHOT_METRIC_VERSION;
+  title: string;
+  description: string;
+}>;
+
+export type ProgressLeaderboardViewer = Readonly<{
+  publicProfileId: string;
+  displayName: typeof PROGRESS_LEADERBOARD_VIEWER_DISPLAY_NAME;
+  rank: number;
+  qualifiedReviewCount: number;
+}>;
+
+export type ProgressLeaderboardParticipantRow = Readonly<{
+  kind: "top" | "neighbor" | "viewer";
+  publicProfileId: string;
+  anonymousDisplayName: string;
+  qualifiedReviewCount: number;
+  rank: number;
+}>;
+
+export type ProgressLeaderboardGapRow = Readonly<{
+  kind: "gap";
+}>;
+
+export type ProgressLeaderboardRow = ProgressLeaderboardParticipantRow | ProgressLeaderboardGapRow;
+
+export type ProgressLeaderboardWindow = Readonly<{
+  windowKey: LeaderboardWindowKey;
+  snapshotId: string;
+  snapshotGeneratedAt: string;
+  asOfServerHour: string;
+  nextRefreshAfter: string;
+  participantCount: number;
+  viewer: ProgressLeaderboardViewer;
+  rows: ReadonlyArray<ProgressLeaderboardRow>;
+}>;
+
+export type ProgressLeaderboard = Readonly<{
+  status: ProgressLeaderboardStatus;
+  metric: ProgressLeaderboardMetric;
+  defaultWindowKey: LeaderboardWindowKey;
+  windows: ReadonlyArray<ProgressLeaderboardWindow>;
+}>;
+
+export type ProgressLeaderboardRequest = Readonly<{
+  userId: string;
+  transport: AuthTransport;
+  localeHint: string;
+}>;
+
+type ProgressLeaderboardMetricCopy = Readonly<{
+  title: string;
+  description: string;
+}>;
+
+// Localized metric copy mirrors the anonymous-display-name locale set so the whole
+// payload (names plus metric text) stays consistent for the resolved locale.
+const PROGRESS_LEADERBOARD_METRIC_COPY_BY_LOCALE: Readonly<
+  Record<AnonymousDisplayNameLocale, ProgressLeaderboardMetricCopy>
+> = {
+  en: {
+    title: "Qualified reviews",
+    description: "Hard, Good, and Easy reviews count toward your rank. Again does not.",
+  },
+  ar: {
+    title: "المراجعات المحتسبة",
+    description: "تُحتسب مراجعات صعب وجيد وسهل في ترتيبك، أما مرة أخرى فلا تُحتسب.",
+  },
+  "zh-Hans": {
+    title: "有效复习",
+    description: "“困难”“良好”“简单”计入排名，“重来”不计入。",
+  },
+  de: {
+    title: "Gewertete Wiederholungen",
+    description: "Schwer, Gut und Leicht zählen für deinen Rang. Nochmal zählt nicht.",
+  },
+  hi: {
+    title: "मान्य समीक्षाएँ",
+    description: "कठिन, अच्छा और आसान समीक्षाएँ आपकी रैंक में गिनी जाती हैं। फिर से नहीं गिना जाता।",
+  },
+  ja: {
+    title: "有効な復習",
+    description: "「難しい」「普通」「簡単」はランクに加算されます。「もう一度」は加算されません。",
+  },
+  ru: {
+    title: "Зачтённые повторения",
+    description: "«Трудно», «Хорошо» и «Легко» учитываются в рейтинге. «Снова» не учитывается.",
+  },
+  "es-MX": {
+    title: "Repasos válidos",
+    description: "Los repasos Difícil, Bien y Fácil cuentan para tu posición. Otra vez no cuenta.",
+  },
+  "es-ES": {
+    title: "Repasos válidos",
+    description: "Los repasos Difícil, Bien y Fácil cuentan para tu posición. Otra vez no cuenta.",
+  },
+};
+
+type LeaderboardSnapshotEntry = Readonly<{
+  publicProfileId: string;
+  qualifiedReviewCount: number;
+  baseSortPosition: number;
+}>;
+
+type LeaderboardSnapshotHeader = Readonly<{
+  windowKey: LeaderboardWindowKey;
+  snapshotId: string;
+  generatedAt: string;
+  asOfServerHour: string;
+}>;
+
+type RankedParticipant = Readonly<{
+  publicProfileId: string;
+  qualifiedReviewCount: number;
+  rank: number;
+  isViewer: boolean;
+}>;
+
+type ViewerPerspectiveRanking = Readonly<{
+  ranked: ReadonlyArray<RankedParticipant>;
+  viewerRank: number;
+  viewerCount: number;
+}>;
+
+type LeaderboardSnapshotHeaderRow = Readonly<{
+  window_key: string;
+  snapshot_id: string;
+  generated_at: Date | string;
+  as_of_server_hour: Date | string;
+}>;
+
+type LeaderboardSnapshotEntryRow = Readonly<{
+  snapshot_id: string;
+  public_profile_id: string;
+  qualified_review_count: number | string;
+  base_sort_position: number | string;
+}>;
+
+type ViewerLatestReviewRow = Readonly<{
+  latest_reviewed_at_client: Date | string | null;
+}>;
+
+function resolveProgressLeaderboardMetric(localeHint: string): ProgressLeaderboardMetric {
+  const copy = PROGRESS_LEADERBOARD_METRIC_COPY_BY_LOCALE[resolveAnonymousDisplayNameLocale(localeHint)];
+  return {
+    metricVersion: LEADERBOARD_SNAPSHOT_METRIC_VERSION,
+    title: copy.title,
+    description: copy.description,
+  };
+}
+
+function buildNonReadyProgressLeaderboard(
+  status: ProgressLeaderboardStatus,
+  localeHint: string,
+): ProgressLeaderboard {
+  return {
+    status,
+    metric: resolveProgressLeaderboardMetric(localeHint),
+    defaultWindowKey: DEFAULT_COMPACT_LEADERBOARD_WINDOW_KEY,
+    windows: [],
+  };
+}
+
+function assertProgressLeaderboardReadTransport(transport: AuthTransport): void {
+  // session/bearer are the production human transports; "none" is the local
+  // AUTH_MODE=none development stand-in for a signed-in user. Guests are handled
+  // by the public wrapper before any read and api_key is rejected by the route.
+  if (transport !== "session" && transport !== "bearer" && transport !== "none") {
+    throw new Error(
+      `Progress leaderboard read requires a signed-in human transport, received ${transport}.`,
+    );
+  }
+}
+
+function normalizeTimestamp(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid leaderboard snapshot timestamp: ${String(value)}`);
+  }
+
+  return date.toISOString();
+}
+
+function normalizeNonNegativeInteger(value: number | string, field: string): number {
+  const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid non-negative integer for ${field}: ${String(value)}`);
+  }
+
+  return parsed;
+}
+
+function computeNextRefreshAfter(now: Date): string {
+  // Snapshots regenerate at the top of every hour (cron 0 * * * ? *). Anchoring on
+  // the next hour boundary from now (rather than the snapshot's server hour) keeps
+  // this hint in the future even if the hourly job lags and serves an older
+  // snapshot; in healthy operation it equals as_of_server_hour + 1h.
+  return new Date(truncateToServerHour(now).getTime() + MILLISECONDS_PER_HOUR).toISOString();
+}
+
+function computeElapsedHoursSinceReview(
+  latestReviewedAtClient: string | null,
+  now: Date,
+): number | null {
+  if (latestReviewedAtClient === null) {
+    return null;
+  }
+
+  return (now.getTime() - Date.parse(latestReviewedAtClient)) / MILLISECONDS_PER_HOUR;
+}
+
+/**
+ * Where the viewer slots into the count-descending list of other participants.
+ * Equal-count users rank above the viewer (the per-viewer tie rule), so the viewer
+ * is placed before the first other participant with a strictly lower count.
+ */
+function findViewerInsertionIndex(
+  others: ReadonlyArray<LeaderboardSnapshotEntry>,
+  viewerCount: number,
+): number {
+  const index = others.findIndex((entry) => entry.qualifiedReviewCount < viewerCount);
+  return index === -1 ? others.length : index;
+}
+
+/**
+ * Builds the full viewer-perspective ranking for one window. Higher count ranks
+ * above lower count; for equal counts the viewer is placed below other users
+ * (so one more review visibly moves them up) while other equal-count users keep
+ * the tie-neutral snapshot order (base_sort_position ascending). The viewer is
+ * always included, with count 0 when absent from the snapshot.
+ */
+function buildViewerPerspectiveRanking(
+  entries: ReadonlyArray<LeaderboardSnapshotEntry>,
+  viewerPublicProfileId: string,
+): ViewerPerspectiveRanking {
+  const viewerEntry = entries.find((entry) => entry.publicProfileId === viewerPublicProfileId) ?? null;
+  const viewerCount = viewerEntry === null ? 0 : viewerEntry.qualifiedReviewCount;
+  const others = entries
+    .filter((entry) => entry.publicProfileId !== viewerPublicProfileId)
+    .sort((left, right) => left.baseSortPosition - right.baseSortPosition);
+
+  const viewerInsertionIndex = findViewerInsertionIndex(others, viewerCount);
+  const ordered: Array<Readonly<{ publicProfileId: string; qualifiedReviewCount: number; isViewer: boolean }>> = [];
+  others.forEach((entry, index) => {
+    if (index === viewerInsertionIndex) {
+      ordered.push({ publicProfileId: viewerPublicProfileId, qualifiedReviewCount: viewerCount, isViewer: true });
+    }
+
+    ordered.push({
+      publicProfileId: entry.publicProfileId,
+      qualifiedReviewCount: entry.qualifiedReviewCount,
+      isViewer: false,
+    });
+  });
+  if (viewerInsertionIndex === others.length) {
+    ordered.push({ publicProfileId: viewerPublicProfileId, qualifiedReviewCount: viewerCount, isViewer: true });
+  }
+
+  const ranked: ReadonlyArray<RankedParticipant> = ordered.map((participant, index) => ({
+    ...participant,
+    rank: index + 1,
+  }));
+  const viewerRank = ranked.find((participant) => participant.isViewer)?.rank ?? ranked.length;
+
+  return { ranked, viewerRank, viewerCount };
+}
+
+function buildParticipantRow(
+  participant: RankedParticipant,
+  topRowCount: number,
+  resolveName: (publicProfileId: string) => string,
+): ProgressLeaderboardParticipantRow {
+  const kind: "top" | "neighbor" | "viewer" = participant.isViewer
+    ? "viewer"
+    : participant.rank <= topRowCount
+      ? "top"
+      : "neighbor";
+
+  return {
+    kind,
+    publicProfileId: participant.publicProfileId,
+    anonymousDisplayName: resolveName(participant.publicProfileId),
+    qualifiedReviewCount: participant.qualifiedReviewCount,
+    rank: participant.rank,
+  };
+}
+
+/**
+ * Selects the compact rows server-side so every client renders the same list:
+ * the top three rows (when that many participants exist), the row before the
+ * viewer, the viewer, and the row after the viewer. Overlapping groups are
+ * de-duplicated by rank and a single gap row is inserted only when hidden ranks
+ * sit between the top block and the viewer-neighbor block.
+ */
+function buildCompactRows(
+  ranked: ReadonlyArray<RankedParticipant>,
+  viewerRank: number,
+  resolveName: (publicProfileId: string) => string,
+): ReadonlyArray<ProgressLeaderboardRow> {
+  const total = ranked.length;
+  const topRowCount = Math.min(3, total);
+
+  const shownRanks = new Set<number>();
+  for (let rank = 1; rank <= topRowCount; rank += 1) {
+    shownRanks.add(rank);
+  }
+  for (const candidate of [viewerRank - 1, viewerRank, viewerRank + 1]) {
+    if (candidate >= 1 && candidate <= total) {
+      shownRanks.add(candidate);
+    }
+  }
+
+  const orderedRanks = [...shownRanks].sort((left, right) => left - right);
+  const rows: Array<ProgressLeaderboardRow> = [];
+  let previousRank = 0;
+  for (const rank of orderedRanks) {
+    if (previousRank !== 0 && rank > previousRank + 1) {
+      rows.push({ kind: "gap" });
+    }
+
+    const participant = ranked[rank - 1];
+    if (participant === undefined) {
+      throw new Error(`Missing ranked participant for rank ${rank}.`);
+    }
+
+    rows.push(buildParticipantRow(participant, topRowCount, resolveName));
+    previousRank = rank;
+  }
+
+  return rows;
+}
+
+function buildLeaderboardWindow(
+  header: LeaderboardSnapshotHeader,
+  entries: ReadonlyArray<LeaderboardSnapshotEntry>,
+  viewerPublicProfileId: string,
+  resolveName: (publicProfileId: string) => string,
+  now: Date,
+): ProgressLeaderboardWindow {
+  const ranking = buildViewerPerspectiveRanking(entries, viewerPublicProfileId);
+
+  return {
+    windowKey: header.windowKey,
+    snapshotId: header.snapshotId,
+    snapshotGeneratedAt: header.generatedAt,
+    asOfServerHour: header.asOfServerHour,
+    nextRefreshAfter: computeNextRefreshAfter(now),
+    // Size of the viewer-perspective ranking, which always includes the viewer
+    // (count 0 when absent from the snapshot). This keeps viewer rank <=
+    // participantCount, so clients can safely render "rank X of N".
+    participantCount: ranking.ranked.length,
+    viewer: {
+      publicProfileId: viewerPublicProfileId,
+      displayName: PROGRESS_LEADERBOARD_VIEWER_DISPLAY_NAME,
+      rank: ranking.viewerRank,
+      qualifiedReviewCount: ranking.viewerCount,
+    },
+    rows: buildCompactRows(ranking.ranked, ranking.viewerRank, resolveName),
+  };
+}
+
+async function readViewerLatestCountableReviewInExecutor(
+  executor: DatabaseExecutor,
+): Promise<string | null> {
+  const result = await executor.query<ViewerLatestReviewRow>(
+    [
+      "SELECT MAX(facts.reviewed_at_client) AS latest_reviewed_at_client",
+      "FROM community.public_review_activity_facts AS facts",
+      "WHERE facts.metric_version = $1",
+      "AND facts.is_countable = TRUE",
+    ].join(" "),
+    [LEADERBOARD_SNAPSHOT_METRIC_VERSION],
+  );
+
+  const value = result.rows[0]?.latest_reviewed_at_client ?? null;
+  return value === null ? null : normalizeTimestamp(value);
+}
+
+async function readLatestLeaderboardSnapshotHeadersInExecutor(
+  executor: DatabaseExecutor,
+): Promise<ReadonlyArray<LeaderboardSnapshotHeader>> {
+  const result = await executor.query<LeaderboardSnapshotHeaderRow>(
+    [
+      "SELECT DISTINCT ON (snapshots.window_key)",
+      "snapshots.window_key AS window_key,",
+      "snapshots.snapshot_id::text AS snapshot_id,",
+      "snapshots.generated_at AS generated_at,",
+      "snapshots.as_of_server_hour AS as_of_server_hour",
+      "FROM community.leaderboard_snapshots AS snapshots",
+      "WHERE snapshots.metric_version = $1",
+      "ORDER BY snapshots.window_key, snapshots.as_of_server_hour DESC",
+    ].join(" "),
+    [LEADERBOARD_SNAPSHOT_METRIC_VERSION],
+  );
+
+  return result.rows
+    .filter((row) => isLeaderboardWindowKey(row.window_key))
+    .map((row) => ({
+      windowKey: assertLeaderboardWindowKey(row.window_key),
+      snapshotId: row.snapshot_id,
+      generatedAt: normalizeTimestamp(row.generated_at),
+      asOfServerHour: normalizeTimestamp(row.as_of_server_hour),
+    }));
+}
+
+async function readLeaderboardSnapshotEntriesInExecutor(
+  executor: DatabaseExecutor,
+  snapshotIds: ReadonlyArray<string>,
+): Promise<ReadonlyMap<string, ReadonlyArray<LeaderboardSnapshotEntry>>> {
+  const entriesBySnapshotId = new Map<string, Array<LeaderboardSnapshotEntry>>();
+  if (snapshotIds.length === 0) {
+    return entriesBySnapshotId;
+  }
+
+  const result = await executor.query<LeaderboardSnapshotEntryRow>(
+    [
+      "SELECT",
+      "entries.snapshot_id::text AS snapshot_id,",
+      "entries.public_profile_id::text AS public_profile_id,",
+      "entries.qualified_review_count AS qualified_review_count,",
+      "entries.base_sort_position AS base_sort_position",
+      "FROM community.leaderboard_snapshot_entries AS entries",
+      "WHERE entries.snapshot_id = ANY($1::uuid[])",
+      "ORDER BY entries.snapshot_id, entries.base_sort_position ASC",
+    ].join(" "),
+    [snapshotIds],
+  );
+
+  for (const row of result.rows) {
+    const list = entriesBySnapshotId.get(row.snapshot_id) ?? [];
+    list.push({
+      publicProfileId: row.public_profile_id,
+      qualifiedReviewCount: normalizeNonNegativeInteger(row.qualified_review_count, "qualified_review_count"),
+      baseSortPosition: normalizeNonNegativeInteger(row.base_sort_position, "base_sort_position"),
+    });
+    entriesBySnapshotId.set(row.snapshot_id, list);
+  }
+
+  return entriesBySnapshotId;
+}
+
+function indexSnapshotHeadersByWindowKey(
+  headers: ReadonlyArray<LeaderboardSnapshotHeader>,
+): ReadonlyMap<LeaderboardWindowKey, LeaderboardSnapshotHeader> {
+  const headersByWindowKey = new Map<LeaderboardWindowKey, LeaderboardSnapshotHeader>();
+  for (const header of headers) {
+    headersByWindowKey.set(header.windowKey, header);
+  }
+
+  return headersByWindowKey;
+}
+
+function collectCompleteSnapshotHeaders(
+  headersByWindowKey: ReadonlyMap<LeaderboardWindowKey, LeaderboardSnapshotHeader>,
+): ReadonlyArray<LeaderboardSnapshotHeader> | null {
+  const orderedHeaders: Array<LeaderboardSnapshotHeader> = [];
+  for (const windowKey of LEADERBOARD_WINDOW_KEYS) {
+    const header = headersByWindowKey.get(windowKey);
+    if (header === undefined) {
+      return null;
+    }
+
+    orderedHeaders.push(header);
+  }
+
+  return orderedHeaders;
+}
+
+export async function loadProgressLeaderboardInExecutor(
+  executor: DatabaseExecutor,
+  request: ProgressLeaderboardRequest,
+  now: Date,
+): Promise<ProgressLeaderboard> {
+  assertProgressLeaderboardReadTransport(request.transport);
+
+  const metric = resolveProgressLeaderboardMetric(request.localeHint);
+  await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
+
+  const viewerProfile = await ensurePublicProfileForCurrentUserInExecutor(executor);
+  if (!viewerProfile.leaderboardParticipationEnabled) {
+    return buildNonReadyProgressLeaderboard("participation_disabled", request.localeHint);
+  }
+
+  const snapshotHeaders = await readLatestLeaderboardSnapshotHeadersInExecutor(executor);
+  const completeHeaders = collectCompleteSnapshotHeaders(indexSnapshotHeadersByWindowKey(snapshotHeaders));
+  if (completeHeaders === null) {
+    return buildNonReadyProgressLeaderboard("snapshot_unavailable", request.localeHint);
+  }
+
+  const latestReviewedAtClient = await readViewerLatestCountableReviewInExecutor(executor);
+  const defaultWindowKey = resolveDefaultLeaderboardWindowKey(
+    computeElapsedHoursSinceReview(latestReviewedAtClient, now),
+  );
+
+  const entriesBySnapshotId = await readLeaderboardSnapshotEntriesInExecutor(
+    executor,
+    completeHeaders.map((header) => header.snapshotId),
+  );
+  const wordPools = getAnonymousDisplayNameWordPools(request.localeHint);
+  const resolveName = (publicProfileId: string): string => createAnonymousDisplayName(publicProfileId, wordPools);
+
+  const windows = completeHeaders.map((header) => buildLeaderboardWindow(
+    header,
+    entriesBySnapshotId.get(header.snapshotId) ?? [],
+    viewerProfile.publicProfileId,
+    resolveName,
+    now,
+  ));
+
+  return {
+    status: "ready",
+    metric,
+    defaultWindowKey,
+    windows,
+  };
+}
+
+export async function loadProgressLeaderboard(
+  request: ProgressLeaderboardRequest,
+): Promise<ProgressLeaderboard> {
+  if (request.transport === "guest") {
+    // Guests get the linked-account-required state with no rows and never open a
+    // transaction, since they are excluded from leaderboard participation.
+    return buildNonReadyProgressLeaderboard("linked_account_required", request.localeHint);
+  }
+
+  // Default (READ COMMITTED) isolation: this read also ensures the viewer's public
+  // profile, an idempotent INSERT ... ON CONFLICT DO NOTHING that READ COMMITTED
+  // absorbs without a serialization error, matching how /me/community/profile
+  // ensures profiles. The leaderboard data is hourly snapshots whose entries are
+  // replaced atomically, so it needs no stronger cross-statement isolation.
+  return unsafeTransaction(
+    async (executor) => loadProgressLeaderboardInExecutor(executor, request, new Date()),
+  );
+}

--- a/apps/backend/src/community/publicProfiles.ts
+++ b/apps/backend/src/community/publicProfiles.ts
@@ -112,7 +112,13 @@ function readDeterministicPoolValue(
   return readPoolValue(pool, poolName, hash.readUInt32BE(offset) % pool.length);
 }
 
-function createAnonymousDisplayName(
+/**
+ * Derives the deterministic locale-aware anonymous display name for a public
+ * profile id. Exported so cross-user community reads (for example the Progress
+ * leaderboard) render the exact same names as `/me/community/profile` from the
+ * same word-pool logic, resolving the pools once per request.
+ */
+export function createAnonymousDisplayName(
   publicProfileId: string,
   wordPools: AnonymousDisplayNameWordPools,
 ): string {
@@ -274,6 +280,40 @@ export async function ensurePublicProfileIdForCurrentUserInExecutor(
   executor: DatabaseExecutor,
 ): Promise<CurrentUserPublicProfileId> {
   return ensurePublicProfileIdForCurrentUserInExecutorWithDependencies(
+    executor,
+    defaultPublicProfileServiceDependencies,
+  );
+}
+
+export type CurrentUserPublicProfile = Readonly<{
+  userId: string;
+  publicProfileId: string;
+  leaderboardParticipationEnabled: boolean;
+}>;
+
+/**
+ * Ensures and returns the scoped user's stable public profile together with the
+ * leaderboard participation preference, without computing a display name. The
+ * Progress leaderboard read needs both the opaque viewer identity and the opt-out
+ * flag in the same scoped transaction before deciding whether to expose any rows.
+ */
+export async function ensurePublicProfileForCurrentUserInExecutorWithDependencies(
+  executor: DatabaseExecutor,
+  dependencies: PublicProfileServiceDependencies,
+): Promise<CurrentUserPublicProfile> {
+  const userId = await selectCurrentUserIdInExecutor(executor);
+  const row = await ensurePublicProfileRowForUserInExecutor(executor, userId, dependencies);
+  return {
+    userId,
+    publicProfileId: row.public_profile_id,
+    leaderboardParticipationEnabled: row.leaderboard_participation_enabled,
+  };
+}
+
+export async function ensurePublicProfileForCurrentUserInExecutor(
+  executor: DatabaseExecutor,
+): Promise<CurrentUserPublicProfile> {
+  return ensurePublicProfileForCurrentUserInExecutorWithDependencies(
     executor,
     defaultPublicProfileServiceDependencies,
   );

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -167,6 +167,15 @@ export type ProgressSeriesDetails = Readonly<{
   generatedAt: string | null;
 }>;
 
+export type ProgressLeaderboardDetails = Readonly<{
+  statusCode: number;
+  authTransport: string;
+  status: string | null;
+  metricVersion: string | null;
+  defaultWindowKey: string | null;
+  windowCount: number | null;
+}>;
+
 export type AccountDeleteDetails = Readonly<{
   statusCode: number;
   transport: string;
@@ -612,6 +621,8 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"me_progress_review_schedule_error", FailureDetailsFor<ProgressReviewScheduleDetails>>
   | EventByAction<"me_progress_series", ProgressSeriesDetails>
   | EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>>
+  | EventByAction<"me_progress_leaderboard", ProgressLeaderboardDetails>
+  | EventByAction<"me_progress_leaderboard_error", FailureDetailsFor<ProgressLeaderboardDetails>>
   | EventByAction<"account_delete", AccountDeleteDetails>
   | EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>>
   | EventByAction<"feedback_state", FeedbackStateDetails>
@@ -724,6 +735,7 @@ export type BackendExceptionEvent =
   | (EventByAction<"me_progress_summary_error", FailureDetailsFor<ProgressSummaryDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"me_progress_review_schedule_error", FailureDetailsFor<ProgressReviewScheduleDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>> & Readonly<{ error: Error }>)
+  | (EventByAction<"me_progress_leaderboard_error", FailureDetailsFor<ProgressLeaderboardDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"feedback_state_error", FailureDetailsFor<FeedbackStateDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"feedback_prompt_event_error", FailureDetailsFor<FeedbackPromptEventDetails>> & Readonly<{ error: Error }>)

--- a/apps/backend/src/progress/index.test.ts
+++ b/apps/backend/src/progress/index.test.ts
@@ -6,6 +6,8 @@ import type pg from "pg";
 import { HttpError } from "../shared/errors";
 import { loadOpenApiDocument } from "../shared/openapi";
 import {
+  loadProgressLeaderboard,
+  loadProgressLeaderboardInExecutor,
   loadUserProgressReviewScheduleInExecutor,
   loadUserProgressSeriesInExecutor,
   loadUserProgressSummaryInExecutor,
@@ -1030,4 +1032,33 @@ test("published contract excludes progress endpoints while the API Gateway resou
   assert.match(apiGatewaySource, /meProgress\.addResource\("summary"\)\.addMethod\("GET", integration\);/);
   assert.match(apiGatewaySource, /meProgress\.addResource\("review-schedule"\)\.addMethod\("GET", integration\);/);
   assert.match(apiGatewaySource, /meProgress\.addResource\("series"\)\.addMethod\("GET", integration\);/);
+});
+
+test("progress barrel re-exports the community leaderboard loaders", async () => {
+  assert.equal(typeof loadProgressLeaderboardInExecutor, "function");
+
+  // The re-export resolves to the real loader: a guest returns the linked-account
+  // state without opening a transaction, so this runs offline.
+  const guestLeaderboard = await loadProgressLeaderboard({
+    userId: "user-guest",
+    transport: "guest",
+    localeHint: "en",
+  });
+
+  assert.equal(guestLeaderboard.status, "linked_account_required");
+  assert.deepEqual(guestLeaderboard.windows, []);
+});
+
+test("published contract documents the progress leaderboard and the API Gateway predeclares it", () => {
+  const openApiDocument = loadOpenApiDocument() as Readonly<{
+    paths?: Readonly<Record<string, unknown>>;
+  }>;
+  assert.notEqual(openApiDocument.paths?.["/me/progress/leaderboard"], undefined);
+
+  const apiGatewayPath = path.resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
+  const apiGatewaySource = fs.readFileSync(apiGatewayPath, "utf8");
+  assert.match(
+    apiGatewaySource,
+    /meProgress\.addResource\("leaderboard"\)\.addMethod\("GET", integration\);/,
+  );
 });

--- a/apps/backend/src/progress/index.ts
+++ b/apps/backend/src/progress/index.ts
@@ -8,6 +8,16 @@ import { unsafeRepeatableReadTransaction } from "../database/unsafe";
 import { HttpError } from "../shared/errors";
 import { listUserWorkspaceIdsInExecutor } from "../workspaces/queries";
 
+// The compact Progress-tab community leaderboard lives in the community module
+// (next to the snapshot writer) but is re-exported here so every /me/progress/*
+// loader is imported from one place by the route layer.
+export {
+  loadProgressLeaderboard,
+  loadProgressLeaderboardInExecutor,
+  type ProgressLeaderboard,
+  type ProgressLeaderboardRequest,
+} from "../community/progressLeaderboard";
+
 export type ProgressSummaryInput = Readonly<{
   timeZone: string;
 }>;

--- a/apps/backend/src/routes/system.test.ts
+++ b/apps/backend/src/routes/system.test.ts
@@ -7,6 +7,8 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { AppEnv } from "../server/app";
 import { HttpError } from "../shared/errors";
 import type {
+  ProgressLeaderboard,
+  ProgressLeaderboardRequest,
   ProgressReviewSchedule,
   ProgressReviewScheduleRequest,
   ProgressSeries,
@@ -34,6 +36,7 @@ type SystemTestAppOptions = Readonly<{
   loadUserProgressReviewScheduleFn?: (args: ProgressReviewScheduleRequest) => Promise<ProgressReviewSchedule>;
   loadUserProgressSeriesFn?: (args: ProgressSeriesRequest) => Promise<ProgressSeries>;
   loadUserProgressSummaryFn?: (args: Readonly<{ userId: string; timeZone: string }>) => Promise<ProgressSummaryResponse>;
+  loadProgressLeaderboardFn?: (args: ProgressLeaderboardRequest) => Promise<ProgressLeaderboard>;
 }>;
 
 function createDefaultAccountPreferences(): AccountPreferences {
@@ -128,6 +131,50 @@ function createProgressReviewSchedule(): ProgressReviewSchedule {
   };
 }
 
+function createProgressLeaderboard(): ProgressLeaderboard {
+  return {
+    status: "ready",
+    metric: {
+      metricVersion: "qualified_reviews_v1",
+      title: "Qualified reviews",
+      description: "Hard, Good, and Easy reviews count toward your rank. Again does not.",
+    },
+    defaultWindowKey: "last_24_hours",
+    windows: [
+      {
+        windowKey: "last_24_hours",
+        snapshotId: "0cc86d10-18cb-4d64-a2f2-a5fd960b45b2",
+        snapshotGeneratedAt: "2026-06-10T14:00:05.000Z",
+        asOfServerHour: "2026-06-10T14:00:00.000Z",
+        nextRefreshAfter: "2026-06-10T15:00:00.000Z",
+        participantCount: 2,
+        viewer: {
+          publicProfileId: "5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f",
+          displayName: "You",
+          rank: 2,
+          qualifiedReviewCount: 3,
+        },
+        rows: [
+          {
+            kind: "top",
+            publicProfileId: "a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d",
+            anonymousDisplayName: "Silver Bright Harbor",
+            qualifiedReviewCount: 5,
+            rank: 1,
+          },
+          {
+            kind: "viewer",
+            publicProfileId: "5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f",
+            anonymousDisplayName: "Jade Swift River",
+            qualifiedReviewCount: 3,
+            rank: 2,
+          },
+        ],
+      },
+    ],
+  };
+}
+
 function createSystemTestApp(options: SystemTestAppOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   app.use("*", async (context, next) => {
@@ -177,6 +224,7 @@ function createSystemTestApp(options: SystemTestAppOptions): Hono<AppEnv> {
     loadUserProgressReviewScheduleFn: options.loadUserProgressReviewScheduleFn,
     loadUserProgressSeriesFn: options.loadUserProgressSeriesFn,
     loadUserProgressSummaryFn: options.loadUserProgressSummaryFn,
+    loadProgressLeaderboardFn: options.loadProgressLeaderboardFn,
   }));
 
   return app;
@@ -640,6 +688,101 @@ test("progress endpoints reject ApiKey authentication", async () => {
       requestId: "request-1",
       code: "PROGRESS_HUMAN_AUTH_REQUIRED",
     });
+  }
+});
+
+test("GET /me/progress/leaderboard returns the leaderboard for Session and Bearer", async () => {
+  const transports: ReadonlyArray<RequestContext["transport"]> = ["session", "bearer"];
+
+  for (const transport of transports) {
+    const app = createSystemTestApp({
+      transport,
+      locale: "es-MX",
+      loadProgressLeaderboardFn: async ({ userId, transport: requestTransport, localeHint }) => {
+        assert.equal(userId, "user-1");
+        assert.equal(requestTransport, transport);
+        assert.equal(localeHint, "es-MX");
+        return createProgressLeaderboard();
+      },
+    });
+    const response = await app.request("http://localhost/me/progress/leaderboard");
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), createProgressLeaderboard());
+  }
+});
+
+test("GET /me/progress/leaderboard returns linked_account_required for Guest", async () => {
+  const app = createSystemTestApp({ transport: "guest" });
+  const response = await app.request("http://localhost/me/progress/leaderboard");
+  const payload = await response.json() as ProgressLeaderboard;
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.status, "linked_account_required");
+  assert.deepEqual(payload.windows, []);
+  assert.equal(payload.defaultWindowKey, "last_24_hours");
+  assert.equal(payload.metric.metricVersion, "qualified_reviews_v1");
+});
+
+test("GET /me/progress/leaderboard rejects ApiKey authentication", async () => {
+  let called = false;
+  const app = createSystemTestApp({
+    transport: "api_key",
+    loadProgressLeaderboardFn: async () => {
+      called = true;
+      return createProgressLeaderboard();
+    },
+  });
+  const response = await app.request("http://localhost/me/progress/leaderboard");
+
+  assert.equal(called, false);
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    error: "This endpoint requires Guest, Bearer, or Session authentication",
+    requestId: "request-1",
+    code: "PROGRESS_HUMAN_AUTH_REQUIRED",
+  });
+});
+
+test("API Gateway predeclares /me/progress/leaderboard", () => {
+  const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(
+    apiGatewaySource,
+    /meProgress\.addResource\("leaderboard"\)\.addMethod\("GET", integration\);/,
+  );
+});
+
+test("published OpenAPI documents the progress leaderboard without internal ids", () => {
+  const openApiDocument = loadOpenApiDocument() as Readonly<{
+    paths?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
+    components?: Readonly<{ schemas?: Readonly<Record<string, unknown>> }>;
+  }>;
+  const leaderboardPath = openApiDocument.paths?.["/me/progress/leaderboard"];
+  const schemas = openApiDocument.components?.schemas ?? {};
+  const leaderboardSchemas = Object.fromEntries(
+    Object.entries(schemas).filter(([name]) => name.startsWith("ProgressLeaderboard") || name === "LeaderboardWindowKey"),
+  );
+  const serializedSchemas = JSON.stringify(leaderboardSchemas);
+
+  assert.notEqual(leaderboardPath?.get, undefined);
+  assert.notEqual(schemas.ProgressLeaderboardResponse, undefined);
+  for (const expectedField of [
+    "status",
+    "defaultWindowKey",
+    "metricVersion",
+    "anonymousDisplayName",
+    "publicProfileId",
+    "qualifiedReviewCount",
+    "rank",
+    "nextRefreshAfter",
+    "participantCount",
+  ]) {
+    assert.equal(serializedSchemas.includes(expectedField), true, `OpenAPI must document ${expectedField}`);
+  }
+  for (const internalField of ["userId", "baseSort", "reviewed_by", "reviewedBy", "email"]) {
+    assert.equal(serializedSchemas.includes(internalField), false, `OpenAPI must not expose ${internalField}`);
   }
 });
 

--- a/apps/backend/src/routes/system.ts
+++ b/apps/backend/src/routes/system.ts
@@ -11,12 +11,14 @@ import {
 import { HttpError } from "../shared/errors";
 import { queryWithUserScope } from "../database";
 import {
+  loadProgressLeaderboard,
   loadUserProgressReviewSchedule,
   loadUserProgressSeries,
   loadUserProgressSummary,
   parseProgressReviewScheduleInputFromRequest,
   parseProgressSeriesInputFromRequest,
   parseProgressSummaryInputFromRequest,
+  type ProgressLeaderboard,
   type ProgressReviewSchedule,
   type ProgressSeries,
   type ProgressSummaryResponse,
@@ -49,6 +51,7 @@ type SystemRoutesOptions = Readonly<{
   loadUserProgressReviewScheduleFn?: typeof loadUserProgressReviewSchedule;
   loadUserProgressSeriesFn?: typeof loadUserProgressSeries;
   loadUserProgressSummaryFn?: typeof loadUserProgressSummary;
+  loadProgressLeaderboardFn?: typeof loadProgressLeaderboard;
   updateAccountPreferencesFn?: UpdateAccountPreferencesFn;
   ensurePublicProfileForUserFn?: EnsurePublicProfileForUserFn;
   updateLeaderboardParticipationFn?: UpdateLeaderboardParticipationFn;
@@ -221,6 +224,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
   const loadUserProgressReviewScheduleFn = options.loadUserProgressReviewScheduleFn ?? loadUserProgressReviewSchedule;
   const loadUserProgressSeriesFn = options.loadUserProgressSeriesFn ?? loadUserProgressSeries;
   const loadUserProgressSummaryFn = options.loadUserProgressSummaryFn ?? loadUserProgressSummary;
+  const loadProgressLeaderboardFn = options.loadProgressLeaderboardFn ?? loadProgressLeaderboard;
   const updateAccountPreferencesFn = options.updateAccountPreferencesFn ?? updateAccountPreferences;
   const ensurePublicProfileForUserFn = options.ensurePublicProfileForUserFn ?? ensurePublicProfileForUser;
   const updateLeaderboardParticipationFn = options.updateLeaderboardParticipationFn ?? updateLeaderboardParticipation;
@@ -471,6 +475,55 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
         error,
         { action: "me_progress_series_error", error: normalizeCaughtError(error), scope, details },
         { action: "me_progress_series_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.get("/me/progress/leaderboard", async (context) => {
+    const { requestContext } = await loadRequestContextFromRequestFn(
+      context.req.raw,
+      options.allowedOrigins,
+    );
+    const requestId = context.get("requestId");
+
+    try {
+      assertProgressHumanTransport(requestContext.transport);
+
+      const leaderboard = await loadProgressLeaderboardFn({
+        userId: requestContext.userId,
+        transport: requestContext.transport,
+        localeHint: requestContext.locale,
+      });
+
+      addBackendBreadcrumb({
+        action: "me_progress_leaderboard",
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        details: {
+          statusCode: 200,
+          authTransport: requestContext.transport,
+          status: leaderboard.status,
+          metricVersion: leaderboard.metric.metricVersion,
+          defaultWindowKey: leaderboard.defaultWindowKey,
+          windowCount: leaderboard.windows.length,
+        },
+      });
+
+      return context.json(leaderboard satisfies ProgressLeaderboard);
+    } catch (error) {
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const details = {
+        authTransport: requestContext.transport,
+        status: null,
+        metricVersion: null,
+        defaultWindowKey: null,
+        windowCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "me_progress_leaderboard_error", error: normalizeCaughtError(error), scope, details },
+        { action: "me_progress_leaderboard_error", scope, details },
       );
       throw error;
     }

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -24,6 +24,16 @@ test("API Gateway predeclares /me/community/profile", () => {
   assert.match(apiGatewaySource, /meCommunityProfile\.addMethod\("PATCH", integration\);/);
 });
 
+test("API Gateway predeclares /me/progress/leaderboard", () => {
+  const apiGatewayPath = resolve(process.cwd(), "lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(
+    apiGatewaySource,
+    /meProgress\.addResource\("leaderboard"\)\.addMethod\("GET", integration\);/,
+  );
+});
+
 test("global snapshot API Gateway mock preflight allows content type and Sentry trace headers", () => {
   const stack = new cdk.Stack();
   const restApi = new apigw.RestApi(stack, "Api");

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -620,6 +620,7 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   meProgress.addResource("summary").addMethod("GET", integration);
   meProgress.addResource("review-schedule").addMethod("GET", integration);
   meProgress.addResource("series").addMethod("GET", integration);
+  meProgress.addResource("leaderboard").addMethod("GET", integration);
   me.addResource("delete").addMethod("POST", integration);
 
   const feedback = restApi.root.addResource("feedback");


### PR DESCRIPTION
## Summary
Adds the client-facing compact Progress-tab leaderboard read API: `GET /me/progress/leaderboard`, returning all five leaderboard windows in one response.

- Viewer-perspective ranks with the per-viewer tie rule (equal counts place the viewer below other equal-count users), computed server-side so every client renders the same list.
- Compact rows: top three, an optional single gap, and the viewer with its immediate neighbors.
- Statuses: `ready`, `linked_account_required` (guests), `participation_disabled` (opted-out — no other users' rows), `snapshot_unavailable`.
- Default window follows the viewer's latest countable review and never defaults to `all_time`.
- Locale-derived anonymous names (same logic as `/me/community/profile`); no internal ids or raw review timestamps are exposed.
- Stable freshness fields (`snapshotId`, `snapshotGeneratedAt`, `asOfServerHour`, `nextRefreshAfter`) for offline caching.
- API key transport is rejected; session/bearer/guest only.

## Wiring
Route in `routes/system.ts`, loader re-exported via `progress/index.ts`, the OpenAPI contract, the API Gateway resource, and the observability action registry are all updated together.

## Testing
- `npm test --prefix apps/backend` — all passing, including new focused tests for ranking, the tie rule, compact rows/gap, locale-stable names, the status states, and no-internal-id serialization.
- `tsc --noEmit` clean; OpenAPI bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)