### PR TITLE
Harden web bootstrap cleanup, caching, and stale-bundle recovery

### DIFF
--- a/apps/web/src/accountDeletion.test.ts
+++ b/apps/web/src/accountDeletion.test.ts
@@ -84,14 +84,34 @@ function expectLocalBrowserStateCleared(): void {
   expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
 }
 
-function mockBlockedDeleteDatabase(): ReturnType<typeof vi.spyOn> {
-  return vi.spyOn(indexedDB, "deleteDatabase").mockImplementation(() => {
-    const request = {} as IDBOpenDBRequest;
-    queueMicrotask(() => {
-      request.onblocked?.(new Event("blocked"));
-    });
-    return request;
+function createMockOpenDbRequest(fire: (request: IDBOpenDBRequest) => void): IDBOpenDBRequest {
+  const request = {} as IDBOpenDBRequest;
+  queueMicrotask(() => {
+    fire(request);
   });
+  return request;
+}
+
+function mockBlockedThenSuccessfulDeleteDatabase(): void {
+  vi.spyOn(indexedDB, "deleteDatabase").mockImplementation(() => createMockOpenDbRequest((request) => {
+    request.onblocked?.(new Event("blocked"));
+    queueMicrotask(() => {
+      request.onsuccess?.(new Event("success"));
+    });
+  }));
+}
+
+function mockFailingDeleteDatabase(): void {
+  vi.spyOn(indexedDB, "deleteDatabase").mockImplementation(() => createMockOpenDbRequest((request) => {
+    request.onerror?.(new Event("error"));
+  }));
+}
+
+function mockUnavailableIndexedDbOpen(): void {
+  vi.spyOn(indexedDB, "open").mockImplementation(() => createMockOpenDbRequest((request) => {
+    Object.assign(request, { error: new DOMException("IndexedDB unavailable", "UnknownError") });
+    request.onerror?.(new Event("error"));
+  }));
 }
 
 beforeEach(async () => {
@@ -113,11 +133,51 @@ afterEach(async () => {
 });
 
 describe("account deletion local cleanup helpers", () => {
-  it("keeps the reauth guard when IndexedDB cleanup is blocked", async () => {
+  it("completes cleanup when the database delete is blocked before succeeding", async () => {
     seedLocalBrowserState();
-    mockBlockedDeleteDatabase();
+    await putCloudSettings(seededCloudSettings);
+    mockBlockedThenSuccessfulDeleteDatabase();
 
-    await expect(clearAllLocalBrowserData("logout_marker")).rejects.toThrow("Failed to delete IndexedDB: delete request was blocked");
+    await expect(clearAllLocalBrowserData("logout_marker")).resolves.toBeUndefined();
+
+    expectLocalBrowserStateCleared();
+    await expect(loadCloudSettings()).resolves.toBeNull();
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "local_browser_data_cleanup",
+      details: expect.objectContaining({
+        eventName: "local_browser_data_cleanup_succeeded",
+        reason: "logout_marker",
+        indexedDbCleared: true,
+        localStorageCleared: true,
+      }),
+    }));
+  });
+
+  it("completes cleanup when the database delete fails after stores were wiped", async () => {
+    seedLocalBrowserState();
+    await putCloudSettings(seededCloudSettings);
+    mockFailingDeleteDatabase();
+
+    await expect(clearAllLocalBrowserData("logout_marker")).resolves.toBeUndefined();
+
+    expectLocalBrowserStateCleared();
+    await expect(loadCloudSettings()).resolves.toBeNull();
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "indexed_db_operation",
+      details: expect.objectContaining({
+        eventName: "indexed_db_delete_lifecycle",
+        indexedDbDeleteOutcome: "delete_error",
+      }),
+    }));
+  });
+
+  it("keeps the reauth guard when the database cannot be wiped or deleted", async () => {
+    seedLocalBrowserState();
+    await putCloudSettings(seededCloudSettings);
+    mockUnavailableIndexedDbOpen();
+    mockFailingDeleteDatabase();
+
+    await expect(clearAllLocalBrowserData("logout_marker")).rejects.toThrow("Failed to open IndexedDB");
     expect(window.localStorage.getItem("flashcards-warm-start-snapshot")).toBeNull();
     expect(window.localStorage.getItem("flashcards-chat-drafts::workspace-1")).toBeNull();
     expect(window.localStorage.getItem(SYNC_RESTORE_HISTORY_STORAGE_KEY)).toBeNull();
@@ -126,6 +186,13 @@ describe("account deletion local cleanup helpers", () => {
     expect(isBrowserReauthRequired()).toBe(true);
     expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
     expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
+    expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+      action: "local_browser_data_cleanup",
+      details: expect.objectContaining({
+        eventName: "local_browser_data_cleanup_failed",
+        errorName: "UnknownError",
+      }),
+    }));
   });
 
   it("clears reauth markers and IndexedDB only during explicit local data cleanup", async () => {

--- a/apps/web/src/accountDeletion.ts
+++ b/apps/web/src/accountDeletion.ts
@@ -119,6 +119,15 @@ function normalizeCleanupError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+function readCleanupErrorName(error: Error): string {
+  const metadata = error as Readonly<{ indexedDbErrorName?: unknown }>;
+  if (typeof metadata.indexedDbErrorName === "string" && metadata.indexedDbErrorName.trim() !== "") {
+    return metadata.indexedDbErrorName;
+  }
+
+  return error.name;
+}
+
 function getCurrentRoute(): string | null {
   if (typeof window === "undefined") {
     return null;
@@ -151,6 +160,7 @@ function logLocalBrowserDataCleanup(
     reason: LocalBrowserDataCleanupReason;
     indexedDbCleared: boolean;
     localStorageCleared: boolean;
+    errorName: string | null;
     errorMessage: string | null;
   }>,
 ): void {
@@ -246,6 +256,7 @@ export async function clearAllLocalBrowserData(reason: LocalBrowserDataCleanupRe
     reason,
     indexedDbCleared: false,
     localStorageCleared: false,
+    errorName: null,
     errorMessage: null,
   });
 
@@ -268,6 +279,10 @@ export async function clearAllLocalBrowserData(reason: LocalBrowserDataCleanupRe
       reason,
       indexedDbCleared: false,
       localStorageCleared: browserStorage !== null,
+      // The privacy sanitizer redacts errorMessage; errorName stays readable
+      // in Sentry and carries the underlying IndexedDB error name when the
+      // failure originated in the local database layer.
+      errorName: readCleanupErrorName(indexedDbError),
       errorMessage: indexedDbError.message,
     });
     throw indexedDbError;
@@ -278,6 +293,7 @@ export async function clearAllLocalBrowserData(reason: LocalBrowserDataCleanupRe
     reason,
     indexedDbCleared: true,
     localStorageCleared: browserStorage !== null,
+    errorName: null,
     errorMessage: null,
   });
 }

--- a/apps/web/src/api/ApiTestSupport.ts
+++ b/apps/web/src/api/ApiTestSupport.ts
@@ -97,14 +97,8 @@ export function expectLocalBrowserStatePreservedForReauth(): void {
   expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
 }
 
-export function mockBlockedDeleteDatabase(): ReturnType<typeof vi.spyOn> {
-  return vi.spyOn(indexedDB, "deleteDatabase").mockImplementation(() => {
-    const request = {} as IDBOpenDBRequest;
-    queueMicrotask(() => {
-      request.onblocked?.(new Event("blocked"));
-    });
-    return request;
-  });
+export function spyOnDeleteDatabase(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(indexedDB, "deleteDatabase");
 }
 
 export function setNavigatorLanguages(languages: ReadonlyArray<string>, language: string): void {

--- a/apps/web/src/api/transport/transport.test.ts
+++ b/apps/web/src/api/transport/transport.test.ts
@@ -14,7 +14,7 @@ import {
   createStorageMock,
   expectLocalBrowserStatePreserved,
   expectLocalBrowserStatePreservedForReauth,
-  mockBlockedDeleteDatabase,
+  spyOnDeleteDatabase,
   seedLocalBrowserState,
   setNavigatorLanguages,
 } from "../ApiTestSupport";
@@ -311,7 +311,7 @@ describe("session transport auth recovery", () => {
 
   it("redirects to login without attempting IndexedDB cleanup", async () => {
     seedLocalBrowserState();
-    const deleteDatabaseSpy = mockBlockedDeleteDatabase();
+    const deleteDatabaseSpy = spyOnDeleteDatabase();
     const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
       .mockResolvedValueOnce(new Response(null, { status: 401 }))
       .mockResolvedValueOnce(new Response(null, { status: 401 }));
@@ -499,7 +499,7 @@ describe("API transport network retry", () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
       endpoint: "GET /me",
       attemptCount: 1,
-      maximumAttemptCount: 3,
+      maximumAttemptCount: 4,
       nextAttemptCount: 2,
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
@@ -523,11 +523,11 @@ describe("API transport network retry", () => {
       responseBodyKind: "empty",
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
-      attemptCount: 3,
+      attemptCount: 4,
     } satisfies Partial<ApiNetworkError>);
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(3);
   });
 
   it("retries a transient network failure for workspace bootstrap reads", async () => {
@@ -551,7 +551,7 @@ describe("API transport network retry", () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
       endpoint: "GET /workspaces",
       attemptCount: 1,
-      maximumAttemptCount: 3,
+      maximumAttemptCount: 4,
       nextAttemptCount: 2,
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
@@ -574,7 +574,7 @@ describe("API transport network retry", () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith("API transport retry", expect.objectContaining({
       endpoint: "GET /chat",
       attemptCount: 1,
-      maximumAttemptCount: 3,
+      maximumAttemptCount: 4,
       nextAttemptCount: 2,
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
@@ -867,11 +867,11 @@ describe("API transport network retry", () => {
       responseBodyKind: "empty",
       originalErrorName: "TypeError",
       originalErrorMessage: "Failed to fetch",
-      attemptCount: 3,
+      attemptCount: 4,
     } satisfies Partial<ApiNetworkError>);
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(3);
   });
 
   it("does not retry mutating chat stop requests when network retry is not enabled", async () => {

--- a/apps/web/src/api/transport/transport.ts
+++ b/apps/web/src/api/transport/transport.ts
@@ -28,9 +28,9 @@ const refreshSessionEndpoint = "POST /api/refresh-session";
 const refreshSessionMaximumAttemptCount = 3;
 const refreshSessionBaseRetryDelayMs = 100;
 const refreshSessionMaximumRetryDelayMs = 500;
-const apiNetworkRetryMaximumAttemptCount = 3;
-const apiNetworkRetryBaseDelayMs = 100;
-const apiNetworkRetryMaximumDelayMs = 500;
+const apiNetworkRetryMaximumAttemptCount = 4;
+const apiNetworkRetryBaseDelayMs = 250;
+const apiNetworkRetryMaximumDelayMs = 2000;
 const uuidPathSegmentPattern = /\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=\/|$)/giu;
 const transientRefreshSessionStatusCodes: ReadonlySet<number> = new Set([
   408,

--- a/apps/web/src/localDb/core/database.ts
+++ b/apps/web/src/localDb/core/database.ts
@@ -96,6 +96,7 @@ export type IndexedDbOpenLifecycleSnapshot = Readonly<{
 
 const databaseName = "flashcards-web-sync";
 const databaseVersion = 13;
+const deleteDatabaseBlockedWaitMs = 3000;
 const activeDatabaseOperationPromises = new Set<Promise<unknown>>();
 let isDatabaseDeleteInProgress = false;
 let activeDatabaseDeletePromise: Promise<void> | null = null;
@@ -516,6 +517,13 @@ export function openDatabase(): Promise<IDBDatabase> {
     };
 
     request.onsuccess = () => {
+      // Release the connection as soon as another context requests a database
+      // delete or upgrade; otherwise that request stays blocked for as long as
+      // this connection lives (other tabs, or a cleanup in this tab).
+      request.result.onversionchange = () => {
+        request.result.close();
+      };
+
       const indexedDbOpenLifecycleSnapshot: IndexedDbOpenLifecycleSnapshot = {
         observedAt: new Date().toISOString(),
         databaseName,
@@ -651,24 +659,159 @@ export async function closeDatabaseAfterWrite(
   });
 }
 
-function requestDeleteDatabase(): Promise<void> {
+function clearAllObjectStores(database: IDBDatabase): Promise<void> {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.deleteDatabase(databaseName);
-
-    request.onerror = () => {
-      reject(describeIndexedDbError("Failed to delete IndexedDB", request.error));
-    };
-
-    request.onsuccess = () => {
+    const storeNames = [...database.objectStoreNames];
+    if (storeNames.length === 0) {
       resolve();
+      return;
+    }
+
+    let transaction: IDBTransaction;
+    try {
+      transaction = database.transaction(storeNames, "readwrite");
+      for (const storeName of storeNames) {
+        transaction.objectStore(storeName).clear();
+      }
+    } catch (error) {
+      // transaction() and clear() throw synchronously when the connection was
+      // closed concurrently (e.g. by the versionchange auto-close).
+      const wrappedError = describeIndexedDbOperationError("Failed to clear IndexedDB stores", error, "clear");
+      addIndexedDbOperationFailedBreadcrumb("clear", error, wrappedError);
+      reject(wrappedError);
+      return;
+    }
+
+    // Every failure path ends in `abort`: failed clear requests abort the
+    // transaction, and forced closes or commit-time quota errors fire only
+    // `abort`. Rejecting there (not in `error`) matters because
+    // `transaction.error` is populated only once `abort` fires.
+    transaction.onabort = () => {
+      const error = describeIndexedDbOperationError("Failed to clear IndexedDB stores", transaction.error, "clear");
+      addIndexedDbOperationFailedBreadcrumb("clear", transaction.error, error);
+      reject(error);
     };
 
-    request.onblocked = () => {
-      reject(new Error("Failed to delete IndexedDB: delete request was blocked"));
+    transaction.oncomplete = () => {
+      resolve();
     };
   });
 }
 
+async function wipeAllObjectStores(): Promise<void> {
+  const database = await openDatabase();
+  try {
+    await clearAllObjectStores(database);
+  } finally {
+    database.close();
+  }
+}
+
+async function databaseExists(): Promise<boolean> {
+  if (typeof indexedDB.databases !== "function") {
+    // Capability missing in older browsers: assume the database exists; the
+    // wipe open below creates it when absent, which is harmless.
+    return true;
+  }
+
+  try {
+    const databases = await indexedDB.databases();
+    return databases.some((databaseInfo) => databaseInfo.name === databaseName);
+  } catch (error) {
+    // Enumeration failure is non-fatal: proceed with the wipe open, which
+    // raises an actionable open error when storage is actually broken.
+    console.warn("IndexedDB databases() enumeration failed", {
+      databaseName,
+      errorName: getIndexedDbErrorName(error),
+    });
+    return true;
+  }
+}
+
+type DeleteDatabaseOutcome = "deleted" | "blocked_timeout" | "delete_error";
+
+function addIndexedDbDeleteOutcomeBreadcrumb(
+  outcome: Exclude<DeleteDatabaseOutcome, "deleted">,
+  sourceError: unknown,
+): void {
+  addWebBreadcrumb({
+    action: "indexed_db_operation",
+    scope: buildIndexedDbObservationScope(),
+    details: {
+      eventName: "indexed_db_delete_lifecycle",
+      databaseName,
+      databaseVersion,
+      indexedDbDeleteOutcome: outcome,
+      indexedDbErrorName: getIndexedDbErrorName(sourceError),
+    },
+  });
+}
+
+/**
+ * Requests full database deletion and reports the outcome instead of throwing.
+ *
+ * A `blocked` event is informational: the browser keeps the delete queued and
+ * completes it once the remaining connections close. Safari also fires
+ * `blocked` for connections that are already closing, so treating it as a
+ * failure produced unrecoverable cleanup loops. After a bounded wait the
+ * promise resolves anyway because user data was already wiped from the stores.
+ *
+ * On `blocked_timeout` the delete request stays queued in the browser, so the
+ * next database open may wait briefly until the blocking connection closes
+ * and the queued deletion completes.
+ */
+function requestDeleteDatabaseBestEffort(): Promise<DeleteDatabaseOutcome> {
+  return new Promise((resolve) => {
+    const request = indexedDB.deleteDatabase(databaseName);
+    let blockedWaitTimeoutId: number | null = null;
+    let isSettled = false;
+
+    const settle = (outcome: DeleteDatabaseOutcome, sourceError: unknown): void => {
+      if (isSettled) {
+        return;
+      }
+
+      isSettled = true;
+      if (blockedWaitTimeoutId !== null) {
+        window.clearTimeout(blockedWaitTimeoutId);
+      }
+
+      if (outcome !== "deleted") {
+        addIndexedDbDeleteOutcomeBreadcrumb(outcome, sourceError);
+      }
+
+      resolve(outcome);
+    };
+
+    request.onsuccess = () => {
+      settle("deleted", null);
+    };
+
+    request.onerror = () => {
+      settle("delete_error", request.error);
+    };
+
+    request.onblocked = () => {
+      if (isSettled || blockedWaitTimeoutId !== null) {
+        return;
+      }
+
+      blockedWaitTimeoutId = window.setTimeout(() => {
+        settle("blocked_timeout", null);
+      }, deleteDatabaseBlockedWaitMs);
+    };
+  });
+}
+
+/**
+ * Resets the local database for user-scoped cleanup.
+ *
+ * Object stores are wiped through a readwrite transaction first because store
+ * clearing cannot be blocked by other open connections, then the database file
+ * itself is deleted as a best-effort full reset. The cleanup succeeds when
+ * either step removed the data; it fails only when the stores could not be
+ * wiped and the database was not confirmed deleted.
+ */
 export function deleteDatabase(): Promise<void> {
   const activeDelete = activeDatabaseDeletePromise;
   if (activeDelete !== null) {
@@ -679,7 +822,22 @@ export function deleteDatabase(): Promise<void> {
     isDatabaseDeleteInProgress = true;
     try {
       await Promise.allSettled([...activeDatabaseOperationPromises]);
-      await requestDeleteDatabase();
+
+      let wipeError: Error | null = null;
+      try {
+        // A missing database has nothing to wipe; skipping avoids creating
+        // the full schema just to delete it on fresh browsers.
+        if (await databaseExists()) {
+          await wipeAllObjectStores();
+        }
+      } catch (error) {
+        wipeError = error instanceof Error ? error : new Error(String(error));
+      }
+
+      const deleteOutcome = await requestDeleteDatabaseBestEffort();
+      if (wipeError !== null && deleteOutcome !== "deleted") {
+        throw wipeError;
+      }
     } finally {
       activeDatabaseDeletePromise = null;
       isDatabaseDeleteInProgress = false;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,7 +3,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import { I18nProvider } from "./i18n";
+import { installStaleBundleReloadGuard } from "./staleBundleReload";
 import "./styles/index.css";
+
+installStaleBundleReloadGuard();
 
 const rootElement = document.getElementById("root");
 

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -4,6 +4,7 @@ import { ApiNetworkError } from "../api";
 import { isWebSentryEnabled } from "./instrument";
 
 export type WebObservationFeature =
+  | "app"
   | "auth"
   | "workspace"
   | "sync"
@@ -116,6 +117,7 @@ export type LocalBrowserDataCleanupBreadcrumbDetails = Readonly<{
   reason: LocalBrowserDataCleanupReason;
   indexedDbCleared: boolean;
   localStorageCleared: boolean;
+  errorName: string | null;
   errorMessage: string | null;
 }>;
 
@@ -129,7 +131,7 @@ export type PersistentStorageBreadcrumbDetails = Readonly<{
   storagePersistGranted: boolean | null;
 }>;
 
-export type IndexedDbOperation = "open";
+export type IndexedDbOperation = "open" | "clear";
 
 export type IndexedDbOperationFailedBreadcrumbDetails = Readonly<{
   eventName: "indexed_db_operation_failed";
@@ -150,9 +152,23 @@ export type IndexedDbOpenLifecycleBreadcrumbDetails = Readonly<{
   indexedDbDatabaseUpgraded: boolean;
 }>;
 
+export type StaleBundleReloadBreadcrumbDetails = Readonly<{
+  eventName: "stale_bundle_reload_recovered";
+  reloadAgeMs: number | null;
+}>;
+
+export type IndexedDbDeleteLifecycleBreadcrumbDetails = Readonly<{
+  eventName: "indexed_db_delete_lifecycle";
+  databaseName: string;
+  databaseVersion: number;
+  indexedDbDeleteOutcome: "blocked_timeout" | "delete_error";
+  indexedDbErrorName: string | null;
+}>;
+
 export type IndexedDbOperationBreadcrumbDetails =
   | IndexedDbOperationFailedBreadcrumbDetails
-  | IndexedDbOpenLifecycleBreadcrumbDetails;
+  | IndexedDbOpenLifecycleBreadcrumbDetails
+  | IndexedDbDeleteLifecycleBreadcrumbDetails;
 
 export type WebBreadcrumbEvent =
   | Readonly<{
@@ -199,6 +215,11 @@ export type WebBreadcrumbEvent =
     action: "sync_local_db_recovery_succeeded";
     scope: WebObservationScope;
     details: SyncLocalDbRecoverySucceededBreadcrumbDetails;
+  }>
+  | Readonly<{
+    action: "stale_bundle_reload";
+    scope: WebObservationScope;
+    details: StaleBundleReloadBreadcrumbDetails;
   }>;
 
 export type ApiContractFailureDetails = Readonly<{
@@ -678,7 +699,10 @@ export function addWebBreadcrumb(event: WebBreadcrumbEvent): void {
   Sentry.addBreadcrumb({
     category: `web.${event.action}`,
     level: "info",
-    message: event.details.eventName,
+    // The `web.` prefix marks the message as safe app telemetry for the
+    // privacy sanitizer; unprefixed messages arrive in Sentry as
+    // "[Filtered message]".
+    message: `web.${event.details.eventName}`,
     data: {
       ...scopeToContext(event.scope),
       ...detailsToContext(event.details),
@@ -706,6 +730,12 @@ export function captureWebException(event: WebExceptionEvent): void {
 
   Sentry.withScope((scope: Scope): void => {
     applyObservationScope(scope, event.scope, event.action);
+    // Network-level failures are environmental (offline, captive portal,
+    // blocked API host), not app defects; keep them out of the error level.
+    if (event.error instanceof ApiNetworkError) {
+      scope.setLevel("warning");
+    }
+
     scope.setFingerprint(buildWebExceptionFingerprint(event));
     scope.setContext("web.exception", detailsToContext(event.details));
     scope.setContext("web.error", errorMetadataToContext(readErrorMetadata(event.error)));

--- a/apps/web/src/staleBundleReload.ts
+++ b/apps/web/src/staleBundleReload.ts
@@ -1,0 +1,104 @@
+import {
+  addWebBreadcrumb,
+  type WebObservationScope,
+} from "./observability/webObservability";
+
+const PRELOAD_ERROR_RELOADED_AT_STORAGE_KEY = "flashcards-preload-error-reloaded-at";
+const PRELOAD_ERROR_REPORT_PENDING_STORAGE_KEY = "flashcards-preload-error-report-pending";
+const PRELOAD_ERROR_RELOAD_MIN_INTERVAL_MS = 60_000;
+
+function getSessionStorage(): Storage | null {
+  try {
+    const storageValue = window.sessionStorage;
+    if (
+      typeof storageValue?.getItem !== "function"
+      || typeof storageValue.setItem !== "function"
+      || typeof storageValue.removeItem !== "function"
+    ) {
+      return null;
+    }
+
+    return storageValue;
+  } catch {
+    // Browsers with blocked site data throw on the sessionStorage getter
+    // itself; treat that as storage being unavailable.
+    return null;
+  }
+}
+
+function getCurrentRoute(): string {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildReloadObservationScope(): WebObservationScope {
+  return {
+    app: "web",
+    feature: "app",
+    userId: null,
+    workspaceId: null,
+    installationId: null,
+    route: getCurrentRoute(),
+    requestId: null,
+    statusCode: null,
+    code: null,
+  };
+}
+
+function reportRecoveredReload(sessionStorage: Storage): void {
+  if (sessionStorage.getItem(PRELOAD_ERROR_REPORT_PENDING_STORAGE_KEY) !== "1") {
+    return;
+  }
+
+  sessionStorage.removeItem(PRELOAD_ERROR_REPORT_PENDING_STORAGE_KEY);
+  const lastReloadAtMs = Number(sessionStorage.getItem(PRELOAD_ERROR_RELOADED_AT_STORAGE_KEY) ?? "0");
+  const isReloadTimestampValid = Number.isFinite(lastReloadAtMs) && lastReloadAtMs > 0;
+  addWebBreadcrumb({
+    action: "stale_bundle_reload",
+    scope: buildReloadObservationScope(),
+    details: {
+      eventName: "stale_bundle_reload_recovered",
+      reloadAgeMs: isReloadTimestampValid ? Math.max(0, Date.now() - lastReloadAtMs) : null,
+    },
+  });
+}
+
+/**
+ * Reloads the page once when a lazy route chunk fails to load.
+ *
+ * A browser-cached `index.html` from a previous deploy can reference hashed
+ * assets that no longer resolve; a reload fetches the current entry and heals
+ * the session. The reload runs at most once per interval per tab so a real
+ * outage still surfaces as an error instead of a reload loop, and the load
+ * that follows a reload emits a recovery breadcrumb so this self-healing
+ * stays observable.
+ */
+export function installStaleBundleReloadGuard(): void {
+  const startupSessionStorage = getSessionStorage();
+  if (startupSessionStorage !== null) {
+    reportRecoveredReload(startupSessionStorage);
+  }
+
+  window.addEventListener("vite:preloadError", (event) => {
+    const sessionStorage = getSessionStorage();
+    if (sessionStorage === null) {
+      return;
+    }
+
+    const lastReloadAtMs = Number(sessionStorage.getItem(PRELOAD_ERROR_RELOADED_AT_STORAGE_KEY) ?? "0");
+    if (Number.isFinite(lastReloadAtMs) && Date.now() - lastReloadAtMs < PRELOAD_ERROR_RELOAD_MIN_INTERVAL_MS) {
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(PRELOAD_ERROR_RELOADED_AT_STORAGE_KEY, String(Date.now()));
+      sessionStorage.setItem(PRELOAD_ERROR_REPORT_PENDING_STORAGE_KEY, "1");
+    } catch {
+      // Without a persisted rate-limit marker a reload could loop, so let the
+      // preload error surface instead of healing.
+      return;
+    }
+
+    event.preventDefault();
+    window.location.reload();
+  });
+}

--- a/scripts/deploy/deploy-web.sh
+++ b/scripts/deploy/deploy-web.sh
@@ -52,7 +52,28 @@ if [[ -z "$WEB_DISTRIBUTION_ID" || "$WEB_DISTRIBUTION_ID" == "None" ]]; then
   exit 1
 fi
 
-aws s3 sync "$RESOLVED_DIST_DIR" "s3://${WEB_BUCKET}" --delete
+# Hashed assets are immutable, so browsers may cache them long-term. Old
+# files are intentionally kept (no --delete): tabs and cached index.html from
+# a previous deploy must keep resolving their chunks until they reload.
+# Bucket growth is unbounded by design (a few MB per deploy); an age-based
+# lifecycle rule would delete the live assets of a dormant deployment, so
+# prune manually if size ever matters. The same applies to removed non-hashed
+# files (favicons and similar): they stay served at their old paths until
+# pruned manually.
+aws s3 sync "${RESOLVED_DIST_DIR}/assets" "s3://${WEB_BUCKET}/assets" \
+  --cache-control "public, max-age=31536000, immutable"
+
+# Non-hashed files must always revalidate; cp (not sync) re-applies the
+# cache-control metadata even when the file content did not change.
+aws s3 cp --recursive "$RESOLVED_DIST_DIR" "s3://${WEB_BUCKET}" \
+  --exclude "assets/*" \
+  --exclude "index.html" \
+  --cache-control "no-cache"
+
+# index.html goes last so it never references assets that are not uploaded yet.
+aws s3 cp "${RESOLVED_DIST_DIR}/index.html" "s3://${WEB_BUCKET}/index.html" \
+  --cache-control "no-cache"
+
 aws cloudfront create-invalidation --distribution-id "$WEB_DISTRIBUTION_ID" --paths "/*" >/dev/null
 
 echo "Web app deployed: ${WEB_PUBLIC_BASE}"


### PR DESCRIPTION
## Summary
- Fix the Safari session-bootstrap dead loop: IndexedDB cleanup now wipes object stores in a readwrite transaction first (unblockable), then deletes the database best-effort — a `blocked` event is informational, connections auto-close on `versionchange`, and cleanup fails only when both the wipe and the delete failed
- Heal stale cached bundles: hashed assets ship with `immutable` cache-control while `index.html` ships `no-cache` and uploads last, old assets stay in the bucket, and a one-shot `vite:preloadError` reload guard recovers tabs stuck on a previous deploy (with a recovery breadcrumb)
- Reduce network noise: bootstrap `/me` retries get a larger budget (4 attempts, up to 2s backoff) and `ApiNetworkError` captures report at warning level with their existing dedicated fingerprint
- Make cleanup telemetry debuggable: structured `errorName`/`indexedDbDeleteOutcome` fields and `web.`-prefixed breadcrumb messages that survive the privacy sanitizer (previously everything arrived as `[Filtered message]`)

## Test plan
- `npx tsc -b` clean
- `npm test` in `apps/web`: 48 files / 410 tests green, including new module-boundary coverage that pins blocked-then-success, delete-error-after-wipe, and fail-closed cleanup behavior
- After deploy: `curl -I` on `index.html` (expect `no-cache`) and on an `assets/*.js` (expect `immutable`); manual Safari check of the reauth-marker bootstrap path

🤖 Generated with [Claude Code](https://claude.com/claude-code)