### PR TITLE
[codex] Stabilize progress leaderboard height

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressLeaderboardSection.kt
@@ -31,10 +31,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -44,6 +46,8 @@ import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import java.text.NumberFormat
 import java.util.Locale
+
+private const val leaderboardReservedRowCount: Int = 7
 
 @Composable
 internal fun LeaderboardSectionCard(
@@ -237,6 +241,10 @@ private fun LeaderboardReadyContent(
                     )
                 }
             }
+
+            repeat(leaderboardReservedRowPlaceholderCount(rowCount = selectedWindow.rows.size)) {
+                LeaderboardReservedRow()
+            }
         }
 
         val snapshotGeneratedAtMillis = selectedWindow.snapshotGeneratedAtMillis
@@ -251,6 +259,10 @@ private fun LeaderboardReadyContent(
             )
         }
     }
+}
+
+private fun leaderboardReservedRowPlaceholderCount(rowCount: Int): Int {
+    return maxOf(0, leaderboardReservedRowCount - rowCount)
 }
 
 @Composable
@@ -292,6 +304,35 @@ private fun LeaderboardParticipantRow(
             color = rowColor,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = rowWeight,
+            textAlign = TextAlign.End
+        )
+    }
+}
+
+@Composable
+private fun LeaderboardReservedRow() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(0f)
+            .clearAndSetSemantics {}
+    ) {
+        Text(
+            text = "0",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = "Reserved leaderboard row",
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = "0",
+            style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.End
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+private let progressLeaderboardReservedRowCount: Int = 7
+
 struct ProgressLeaderboardSection: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
@@ -120,6 +122,13 @@ struct ProgressLeaderboardSection: View {
                     case .gap:
                         ProgressLeaderboardGapRowView()
                     }
+                }
+
+                ForEach(
+                    0..<progressLeaderboardReservedRowPlaceholderCount(rowCount: selectedWindow.rows.count),
+                    id: \.self
+                ) { _ in
+                    ProgressLeaderboardReservedRowView()
                 }
             }
 
@@ -285,6 +294,10 @@ struct ProgressLeaderboardSection: View {
     }
 }
 
+private func progressLeaderboardReservedRowPlaceholderCount(rowCount: Int) -> Int {
+    max(0, progressLeaderboardReservedRowCount - rowCount)
+}
+
 private struct ProgressLeaderboardParticipantRowView: View {
     let row: ProgressLeaderboardParticipantRowState
 
@@ -339,6 +352,27 @@ private struct ProgressLeaderboardParticipantRowView: View {
             Int64(self.row.rank),
             Int64(self.row.qualifiedReviewCount)
         )
+    }
+}
+
+private struct ProgressLeaderboardReservedRowView: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("0")
+                .font(.subheadline.monospacedDigit())
+                .frame(minWidth: 28, alignment: .leading)
+
+            Text("Reserved leaderboard row")
+                .font(.subheadline)
+                .lineLimit(1)
+
+            Spacer(minLength: 12)
+
+            Text("0")
+                .font(.subheadline.monospacedDigit())
+        }
+        .hidden()
+        .accessibilityHidden(true)
     }
 }
 

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -525,7 +525,10 @@ svg.progress-review-schedule-donut {
 
 .progress-leaderboard-list {
   display: grid;
+  align-content: start;
   gap: 4px;
+  /* Six participant rows, one gap row, and six row gaps: the compact worst case. */
+  min-height: 290px;
   margin: 0;
   padding: 0;
   list-style: none;


### PR DESCRIPTION
## Summary
- Reserve the compact worst-case leaderboard row height in the web Progress tab.
- Add invisible layout-only row reserves for shorter ready leaderboards on iOS and Android.

## Impact
The Progress leaderboard card no longer jumps in height when the viewer is near the top and fewer compact rows are rendered.

## Validation
- `npm run build` in `apps/web`
- `npx vitest run src/screens/progress/ProgressScreen.render.test.tsx`
- `swiftc -parse apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift`
- `git --no-pager diff --check`

Android Gradle and iOS simulator-backed checks were not run locally because repository instructions require explicit permission for those heavy runs.