### PR TITLE
[codex] Gate Android startup on supported runtime

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -578,6 +578,13 @@ internal fun FlashcardsAppLoadingScreen() {
     }
 }
 
+@Composable
+internal fun FlashcardsUnsupportedRuntimeScreen() {
+    FlashcardsTheme {
+        UnsupportedRuntimeScreen()
+    }
+}
+
 private fun shouldHideNavigationSuite(
     destination: TopLevelDestination,
     navigationSuiteType: NavigationSuiteType,
@@ -676,6 +683,34 @@ private fun StartupErrorScreen(
                     Button(onClick = onRetry) {
                         Text(text = stringResource(id = R.string.startup_error_retry))
                     }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UnsupportedRuntimeScreen() {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.unsupported_android_runtime_title),
+                        style = MaterialTheme.typography.titleLarge
+                    )
+                    Text(
+                        text = stringResource(id = R.string.unsupported_android_runtime_message),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
                 }
             }
         }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApplication.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApplication.kt
@@ -8,6 +8,7 @@ import com.flashcardsopensourceapp.app.navigation.AppNotificationTapHandoffReque
 import com.flashcardsopensourceapp.app.notifications.AppNotificationTapRequest
 import com.flashcardsopensourceapp.app.observability.AndroidObservabilityStartup
 import com.flashcardsopensourceapp.app.observability.startAndroidObservability
+import com.flashcardsopensourceapp.app.runtime.isAndroidRuntimeSupported
 import com.flashcardsopensourceapp.data.local.notifications.appNotificationWorkLimit
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Dispatchers
@@ -26,6 +27,7 @@ class FlashcardsApplication : Application(), Configuration.Provider {
     private val appGraphStateMutable = MutableStateFlow<AppGraph?>(value = null)
     private val appNotificationTapStateMutable = MutableStateFlow<AppNotificationTapHandoffRequest?>(value = null)
     private lateinit var observabilityStartup: AndroidObservabilityStartup
+    private var runtimeSupported: Boolean = true
 
     val appGraph: AppGraph
         get() = requireNotNull(appGraphOrNull) { "App graph is unavailable." }
@@ -41,6 +43,9 @@ class FlashcardsApplication : Application(), Configuration.Provider {
     val appNotificationTapState: StateFlow<AppNotificationTapHandoffRequest?>
         get() = appNotificationTapStateMutable.asStateFlow()
 
+    val isRuntimeSupported: Boolean
+        get() = runtimeSupported
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setMaxSchedulerLimit(appNotificationWorkLimit)
@@ -50,6 +55,11 @@ class FlashcardsApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        if (isAndroidRuntimeSupported().not()) {
+            runtimeSupported = false
+            return
+        }
+
         observabilityStartup = startAndroidObservability(application = this)
         publishAppGraph(appGraph = createAppGraph())
     }
@@ -73,6 +83,10 @@ class FlashcardsApplication : Application(), Configuration.Provider {
     }
 
     fun shouldKeepSplashScreenVisible(): Boolean {
+        if (runtimeSupported.not()) {
+            return false
+        }
+
         val currentAppGraph = appGraphOrNull ?: return true
         return currentAppGraph.startupState.value is AppStartupState.Loading
     }
@@ -101,6 +115,10 @@ class FlashcardsApplication : Application(), Configuration.Provider {
     }
 
     private fun createAppGraph(): AppGraph {
+        require(runtimeSupported) {
+            "Android runtime is unsupported."
+        }
+
         return AppGraph(
             context = this,
             observability = observabilityStartup.observability,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/MainActivity.kt
@@ -23,9 +23,16 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        handleIntent(intent = intent, application = application)
+        if (application.isRuntimeSupported) {
+            handleIntent(intent = intent, application = application)
+        }
 
         setContent {
+            if (application.isRuntimeSupported.not()) {
+                FlashcardsUnsupportedRuntimeScreen()
+                return@setContent
+            }
+
             // The app graph can be replaced while the activity is stopped, so this state
             // must stay current even outside STARTED to avoid reusing a closed graph.
             val currentAppGraph by application.appGraphState.collectAsState()
@@ -75,6 +82,10 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         val application = application as FlashcardsApplication
+        if (application.isRuntimeSupported.not()) {
+            return
+        }
+
         handleIntent(intent = intent, application = application)
     }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidObservabilityStartup.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/AndroidObservabilityStartup.kt
@@ -1,8 +1,8 @@
 package com.flashcardsopensourceapp.app.observability
 
 import android.app.Application
-import android.os.Build
 import com.flashcardsopensourceapp.app.BuildConfig
+import com.flashcardsopensourceapp.app.runtime.isAndroidRuntimeSupported
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.data.local.network.TracePropagationTarget
 import io.sentry.BaggageHeader
@@ -37,12 +37,11 @@ data class AndroidObservabilityStartup(
 
 fun startAndroidObservability(application: Application): AndroidObservabilityStartup {
     val sentryDsn = BuildConfig.ANDROID_SENTRY_DSN.trim()
-    // Run Sentry only on devices at or above the declared minSdk. Reports from lower API levels
-    // come from out-of-contract devices (emulators, cloud test farms, spoofed or sideloaded
-    // installs) where the latest-only codepath is expected to fail and only pollute crash-free
-    // metrics. Sentry recommends skipping init entirely to fully disable the SDK; that also stops
-    // native (NDK) and ANR capture, which a beforeSend filter cannot reach.
-    val isSentryEnabled = sentryDsn.isNotBlank() && isDeviceAtOrAboveMinimumSupportedSdk()
+    // Run Sentry only on the supported Android runtime. Some out-of-contract environments report
+    // a high SDK level while missing framework methods that AndroidX expects, and those reports
+    // only pollute crash-free metrics. Skipping SentryAndroid.init also stops native (NDK) and ANR
+    // capture, which a beforeSend filter cannot reach.
+    val isSentryEnabled = sentryDsn.isNotBlank() && isAndroidRuntimeSupported()
     if (isSentryEnabled) {
         SentryAndroid.init(application) { options ->
             configureSentryOptions(
@@ -84,10 +83,6 @@ private fun configureSentryOptions(
     options.setBeforeBreadcrumb { breadcrumb, _ ->
         sanitizeSentryBreadcrumb(breadcrumb = breadcrumb)
     }
-}
-
-private fun isDeviceAtOrAboveMinimumSupportedSdk(): Boolean {
-    return Build.VERSION.SDK_INT >= BuildConfig.ANDROID_MIN_SDK
 }
 
 private fun sentryEnvironment(): String {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/runtime/AndroidRuntimeSupport.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/runtime/AndroidRuntimeSupport.kt
@@ -1,0 +1,27 @@
+package com.flashcardsopensourceapp.app.runtime
+
+import android.os.Build
+import com.flashcardsopensourceapp.app.BuildConfig
+
+private const val jobSchedulerClassName: String = "android.app.job.JobScheduler"
+private const val jobSchedulerForNamespaceMethodName: String = "forNamespace"
+
+internal fun isAndroidRuntimeSupported(): Boolean {
+    if (Build.VERSION.SDK_INT < BuildConfig.ANDROID_MIN_SDK) {
+        return false
+    }
+
+    return hasJobSchedulerNamespaceSupport()
+}
+
+private fun hasJobSchedulerNamespaceSupport(): Boolean {
+    return try {
+        val jobSchedulerClass: Class<*> = Class.forName(jobSchedulerClassName)
+        jobSchedulerClass.getMethod(jobSchedulerForNamespaceMethodName, String::class.java)
+        true
+    } catch (error: ClassNotFoundException) {
+        false
+    } catch (error: NoSuchMethodException) {
+        false
+    }
+}

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="top_level_settings">Settings</string>
     <string name="startup_error_title">Startup failed</string>
     <string name="startup_error_retry">Retry startup</string>
+    <string name="unsupported_android_runtime_title">Android version unsupported</string>
+    <string name="unsupported_android_runtime_message">Flashcards requires Android 14 or newer. Update Android on this device or install the app on a supported device.</string>
     <string name="account_deletion_blocking_title">Deleting account</string>
     <string name="account_deletion_in_progress_message">Your account deletion is in progress. Keep this screen open until it finishes.</string>
     <string name="account_deletion_failed_message">The delete request did not finish yet. Retry to keep the account deletion moving forward.</string>


### PR DESCRIPTION
## Summary
- add an Android runtime support probe for the declared minSdk and required JobScheduler namespace API
- stop unsupported runtimes before Sentry, AppGraph, and WorkManager-dependent managers initialize
- show a simple unsupported Android screen instead of holding the splash/loading state

## Validation
- git --no-pager diff --check
- targeted rg searches around Android startup, Sentry, MainActivity, AppGraph, and WorkManager entrypoints

Gradle was not run locally because repository instructions require explicit approval for ./gradlew runs.