### PR TITLE
[codex] Add Android cloud transient retry

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
@@ -173,6 +173,27 @@ private fun addBreadcrumbData(
                 )
             )
         }
+        is AndroidBreadcrumbEvent.HttpTransientRetry -> {
+            breadcrumb.setData(
+                "http",
+                SentryHttpContext(
+                    endpointName = sanitizeSentryContextValue(fieldName = "endpointName", value = event.endpointName),
+                    method = sanitizeSentryContextValue(fieldName = "method", value = event.method),
+                    requestId = sanitizeSentryIdentifier(value = event.requestId),
+                    statusCode = event.statusCode,
+                    code = sanitizeSentryContextValue(fieldName = "code", value = event.code),
+                    stage = sanitizeSentryContextValue(fieldName = "stage", value = event.stage)
+                )
+            )
+            breadcrumb.setData(
+                "retry",
+                SentryHttpRetryContext(
+                    attemptNumber = event.attemptNumber,
+                    maxAttemptCount = event.maxAttemptCount,
+                    delayMs = event.delayMs
+                )
+            )
+        }
         is AndroidBreadcrumbEvent.AiRuntimeBreadcrumb -> {
             breadcrumb.setData(
                 "ai",
@@ -869,6 +890,12 @@ private data class SentryHttpContext(
     val statusCode: Int?,
     val code: String?,
     val stage: String?
+)
+
+private data class SentryHttpRetryContext(
+    val attemptNumber: Int,
+    val maxAttemptCount: Int,
+    val delayMs: Long
 )
 
 private data class SentryAiContext(

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
@@ -20,6 +20,7 @@ enum class AndroidObservationAction(
     CLOUD_IDENTITY_SET(tagValue = "cloud_identity_set"),
     CLOUD_IDENTITY_CLEARED(tagValue = "cloud_identity_cleared"),
     EXPECTED_HTTP_FAILURE(tagValue = "expected_http_failure"),
+    HTTP_TRANSIENT_RETRY(tagValue = "http_transient_retry"),
     HTTP_5XX_WARNING(tagValue = "http_5xx_warning"),
     HTTP_UNEXPECTED_CLIENT_ERROR(tagValue = "http_unexpected_client_error"),
     AI_STREAM_CRASH(tagValue = "ai_stream_crash"),
@@ -168,6 +169,34 @@ sealed interface AndroidBreadcrumbEvent : AndroidObservationEvent {
         val versionCode: Int?
     ) : AndroidBreadcrumbEvent {
         override val action: AndroidObservationAction = AndroidObservationAction.EXPECTED_HTTP_FAILURE
+        override val tags: AndroidObservationTags = AndroidObservationTags(
+            userId = null,
+            workspaceId = null,
+            requestId = requestId,
+            statusCode = statusCode,
+            code = code,
+            appVersion = appVersion,
+            clientVersion = clientVersion,
+            versionCode = versionCode
+        )
+    }
+
+    data class HttpTransientRetry(
+        override val feature: AndroidObservationFeature,
+        val endpointName: String,
+        val method: String,
+        val requestId: String?,
+        val statusCode: Int?,
+        val code: String?,
+        val stage: String,
+        val attemptNumber: Int,
+        val maxAttemptCount: Int,
+        val delayMs: Long,
+        val appVersion: String?,
+        val clientVersion: String?,
+        val versionCode: Int?
+    ) : AndroidBreadcrumbEvent {
+        override val action: AndroidObservationAction = AndroidObservationAction.HTTP_TRANSIENT_RETRY
         override val tags: AndroidObservationTags = AndroidObservationTags(
             userId = null,
             workspaceId = null,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -32,11 +33,20 @@ import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 
 private const val cloudRequestIdHeaderName: String = "X-Request-Id"
+private const val cloudAmazonRequestIdHeaderName: String = "X-Amzn-RequestId"
+private const val cloudApiGatewayRequestIdHeaderName: String = "X-Amz-Apigw-Id"
+private const val cloudHttpTransientRetryMaxAttemptCount: Int = 4
+private const val cloudHttpTransientRetryBaseDelayMs: Long = 250L
+private const val cloudHttpTransientRetryMaxDelayMs: Long = 2_000L
+private const val cloudHttpRetryHttpResponseStage: String = "http_response"
+private const val cloudHttpRetryIoExceptionStage: String = "io_exception"
 private const val officialCloudApiHost: String = "api.flashcards-open-source-app.com"
 private const val officialCloudAuthHost: String = "auth.flashcards-open-source-app.com"
 private val cloudJsonMediaType = "application/json".toMediaType()
+private val transientCloudHttpStatusCodes: Set<Int> = setOf(408, 429, 500, 502, 503, 504)
 private val expectedCloudHttpFailureCodes: Set<String> = setOf(
     "AGENT_API_KEY_INVALID",
     "AGENT_API_KEY_REQUIRED",
@@ -258,81 +268,154 @@ internal class CloudJsonHttpClient(
             authorizationHeader = authorizationHeader,
             body = body
         )
-        val call = httpClient.newCall(request)
-        val coroutineJob = currentCoroutineContext().job
-        val cancellationRequested = AtomicBoolean(false)
-        val cancellationHandle = coroutineJob.invokeOnCompletion(
-            onCancelling = true,
-            invokeImmediately = true
-        ) { cause ->
-            if (cause != null) {
-                cancellationRequested.set(true)
-                call.cancel()
-            }
-        }
+        val retryEligible = isTransientCloudHttpRetryEligible(
+            path = path,
+            method = method,
+            body = body
+        )
+        var attemptNumber = 1
 
-        try {
-            call.awaitOkHttpResponse().use { response ->
-                val statusCode = response.code
-                val requestId = response.header(cloudRequestIdHeaderName)
-                val responseContentType = response.body.contentType()
-                    ?.toString()
-                    ?.trim()
-                    ?.ifEmpty { null }
-                val responseBody = readCloudResponseBody(response = response)
-                if (response.isSuccessful.not()) {
-                    val parsedError = parseCloudErrorPayloadWithHeaderRequestId(
-                        responseBody = responseBody,
-                        requestId = requestId
+        while (true) {
+            val call = httpClient.newCall(request)
+            val coroutineJob = currentCoroutineContext().job
+            val cancellationRequested = AtomicBoolean(false)
+            val cancellationHandle = coroutineJob.invokeOnCompletion(
+                onCancelling = true,
+                invokeImmediately = true
+            ) { cause ->
+                if (cause != null) {
+                    cancellationRequested.set(true)
+                    call.cancel()
+                }
+            }
+            var retryDelayMs: Long? = null
+            var successfulResponse: JSONObject? = null
+
+            try {
+                call.awaitOkHttpResponse().use { response ->
+                    val statusCode = response.code
+                    val requestId = readCloudResponseRequestId(response = response)
+                    val responseContentType = response.body.contentType()
+                        ?.toString()
+                        ?.trim()
+                        ?.ifEmpty { null }
+                    val responseBody = readCloudResponseBody(response = response)
+                    if (response.isSuccessful.not()) {
+                        val parsedError = parseCloudErrorPayloadWithHeaderRequestId(
+                            responseBody = responseBody,
+                            requestId = requestId
+                        )
+                        if (
+                            shouldRetryTransientCloudHttpResponse(
+                                retryEligible = retryEligible,
+                                statusCode = statusCode,
+                                attemptNumber = attemptNumber
+                            )
+                        ) {
+                            val delayMs = calculateCloudHttpTransientRetryDelayMs(attemptNumber)
+                            captureCloudHttpTransientRetryObservation(
+                                observability = observability,
+                                observationVersions = observationVersions,
+                                request = request,
+                                path = path,
+                                method = method.requestMethod,
+                                requestId = parsedError?.requestId,
+                                statusCode = statusCode,
+                                code = parsedError?.code,
+                                stage = cloudHttpRetryHttpResponseStage,
+                                attemptNumber = attemptNumber,
+                                delayMs = delayMs
+                            )
+                            retryDelayMs = delayMs
+                        } else {
+                            captureCloudHttpFailureObservation(
+                                observability = observability,
+                                observationVersions = observationVersions,
+                                request = request,
+                                path = path,
+                                method = method.requestMethod,
+                                requestId = parsedError?.requestId,
+                                statusCode = statusCode,
+                                code = parsedError?.code,
+                                syncConflict = parsedError?.syncConflict
+                            )
+                            throw CloudRemoteException(
+                                message = formatCloudRemoteErrorMessage(
+                                    parsedError = parsedError,
+                                    responseBody = responseBody,
+                                    responseMetadata = CloudErrorResponseMetadata(
+                                        statusCode = statusCode,
+                                        path = cloudObservationEndpointName(path = path),
+                                        requestId = parsedError?.requestId,
+                                        responseBodyLengthBytes = responseBody
+                                            .toByteArray(StandardCharsets.UTF_8)
+                                            .size,
+                                        responseContentType = responseContentType
+                                    )
+                                ),
+                                statusCode = statusCode,
+                                responseBody = responseBody,
+                                errorCode = parsedError?.code,
+                                requestId = parsedError?.requestId,
+                                syncConflict = parsedError?.syncConflict
+                            )
+                        }
+                    } else {
+                        successfulResponse = if (responseBody.isBlank()) {
+                            JSONObject()
+                        } else {
+                            JSONObject(responseBody)
+                        }
+                    }
+                }
+            } catch (error: IOException) {
+                if (cancellationRequested.get() || coroutineJob.isCancelled) {
+                    throw cancellationException(
+                        message = "Cloud request was cancelled.",
+                        cause = error
                     )
-                    captureCloudHttpFailureObservation(
+                }
+                if (
+                    shouldRetryTransientCloudIOException(
+                        retryEligible = retryEligible,
+                        attemptNumber = attemptNumber
+                    )
+                ) {
+                    val delayMs = calculateCloudHttpTransientRetryDelayMs(attemptNumber)
+                    captureCloudHttpTransientRetryObservation(
                         observability = observability,
                         observationVersions = observationVersions,
                         request = request,
                         path = path,
                         method = method.requestMethod,
-                        requestId = parsedError?.requestId,
-                        statusCode = statusCode,
-                        code = parsedError?.code,
-                        syncConflict = parsedError?.syncConflict
+                        requestId = null,
+                        statusCode = null,
+                        code = null,
+                        stage = cloudHttpRetryIoExceptionStage,
+                        attemptNumber = attemptNumber,
+                        delayMs = delayMs
                     )
-                    throw CloudRemoteException(
-                        message = formatCloudRemoteErrorMessage(
-                            parsedError = parsedError,
-                            responseBody = responseBody,
-                            responseMetadata = CloudErrorResponseMetadata(
-                                statusCode = statusCode,
-                                path = cloudObservationEndpointName(path = path),
-                                requestId = parsedError?.requestId,
-                                responseBodyLengthBytes = responseBody
-                                    .toByteArray(StandardCharsets.UTF_8)
-                                    .size,
-                                responseContentType = responseContentType
-                            )
-                        ),
-                        statusCode = statusCode,
-                        responseBody = responseBody,
-                        errorCode = parsedError?.code,
-                        requestId = parsedError?.requestId,
-                        syncConflict = parsedError?.syncConflict
-                    )
-                }
-                if (responseBody.isBlank()) {
-                    JSONObject()
+                    retryDelayMs = delayMs
                 } else {
-                    JSONObject(responseBody)
+                    throw error
                 }
+            } finally {
+                cancellationHandle.dispose()
             }
-        } catch (error: IOException) {
-            if (cancellationRequested.get() || coroutineJob.isCancelled) {
-                throw cancellationException(
-                    message = "Cloud request was cancelled.",
-                    cause = error
-                )
+
+            val completedResponse = successfulResponse
+            if (completedResponse != null) {
+                return@withContext completedResponse
             }
-            throw error
-        } finally {
-            cancellationHandle.dispose()
+
+            val delayMs = retryDelayMs
+            if (delayMs != null) {
+                delay(delayMs)
+                attemptNumber += 1
+                continue
+            }
+
+            throw IllegalStateException("Cloud request attempt finished without a response or retry decision.")
         }
     }
 
@@ -371,6 +454,97 @@ internal class CloudJsonHttpClient(
             reader.readText()
         }
     }
+}
+
+private fun readCloudResponseRequestId(response: Response): String? {
+    return listOf(
+        response.header(cloudRequestIdHeaderName),
+        response.header(cloudAmazonRequestIdHeaderName),
+        response.header(cloudApiGatewayRequestIdHeaderName)
+    ).firstNotNullOfOrNull { value ->
+        value?.trim()?.ifEmpty { null }
+    }
+}
+
+private fun isTransientCloudHttpRetryEligible(
+    path: String,
+    method: CloudHttpMethod,
+    body: JSONObject?
+): Boolean {
+    if (method == CloudHttpMethod.GET) {
+        return true
+    }
+    if (method != CloudHttpMethod.POST) {
+        return false
+    }
+
+    val pathOnly = path.substringBefore(delimiter = "?").trim()
+    return when {
+        pathOnly.endsWith(suffix = "/sync/pull") -> true
+        pathOnly.endsWith(suffix = "/sync/review-history/pull") -> true
+        pathOnly.endsWith(suffix = "/sync/bootstrap") -> body?.optString("mode") == "pull"
+        else -> false
+    }
+}
+
+private fun shouldRetryTransientCloudHttpResponse(
+    retryEligible: Boolean,
+    statusCode: Int,
+    attemptNumber: Int
+): Boolean {
+    return retryEligible &&
+        transientCloudHttpStatusCodes.contains(element = statusCode) &&
+        attemptNumber < cloudHttpTransientRetryMaxAttemptCount
+}
+
+private fun shouldRetryTransientCloudIOException(
+    retryEligible: Boolean,
+    attemptNumber: Int
+): Boolean {
+    return retryEligible && attemptNumber < cloudHttpTransientRetryMaxAttemptCount
+}
+
+private fun calculateCloudHttpTransientRetryDelayMs(attemptNumber: Int): Long {
+    val exponent = (attemptNumber - 1).coerceAtLeast(0).coerceAtMost(30)
+    val exponentialDelayMs = cloudHttpTransientRetryBaseDelayMs * (1L shl exponent)
+    val cappedDelayMs = minOf(exponentialDelayMs, cloudHttpTransientRetryMaxDelayMs)
+    return if (cappedDelayMs <= 1L) {
+        0L
+    } else {
+        Random.nextLong(until = cappedDelayMs)
+    }
+}
+
+private fun captureCloudHttpTransientRetryObservation(
+    observability: AppObservability,
+    observationVersions: CloudHttpObservationVersions,
+    request: Request,
+    path: String,
+    method: String,
+    requestId: String?,
+    statusCode: Int?,
+    code: String?,
+    stage: String,
+    attemptNumber: Int,
+    delayMs: Long
+) {
+    observability.addBreadcrumb(
+        event = AndroidBreadcrumbEvent.HttpTransientRetry(
+            feature = cloudObservationFeature(request = request),
+            endpointName = cloudObservationEndpointName(path = path),
+            method = method,
+            requestId = requestId,
+            statusCode = statusCode,
+            code = code,
+            stage = stage,
+            attemptNumber = attemptNumber,
+            maxAttemptCount = cloudHttpTransientRetryMaxAttemptCount,
+            delayMs = delayMs,
+            appVersion = observationVersions.appVersion,
+            clientVersion = observationVersions.clientVersion,
+            versionCode = observationVersions.versionCode
+        )
+    )
 }
 
 private fun captureCloudHttpFailureObservation(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClientTest.kt
@@ -1,0 +1,184 @@
+package com.flashcardsopensourceapp.data.local.cloud.remote.transport
+
+import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
+import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
+import com.flashcardsopensourceapp.core.observability.AppObservability
+import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
+
+class CloudRemoteHttpClientTest {
+    @Test
+    fun syncPullRetriesTransientGatewayTimeoutBeforeCapturingWarning() = runBlocking {
+        val requestCount = AtomicInteger(0)
+        val observability = RecordingCloudHttpObservability()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/workspaces/workspace-1/sync/pull") { exchange ->
+            val currentRequestCount = requestCount.incrementAndGet()
+            if (currentRequestCount == 1) {
+                writeCloudTestResponse(
+                    exchange = exchange,
+                    statusCode = 504,
+                    body = "",
+                    headers = mapOf("X-Amz-Apigw-Id" to "gateway-request-1")
+                )
+            } else {
+                writeCloudTestResponse(
+                    exchange = exchange,
+                    statusCode = 200,
+                    body = """{"changes":[],"nextHotChangeId":42,"hasMore":false}""",
+                    headers = emptyMap()
+                )
+            }
+        }
+        server.start()
+
+        try {
+            val client = CloudJsonHttpClient(
+                okHttpClient = OkHttpClient(),
+                observability = observability,
+                appVersion = "1.9.0",
+                versionCode = 123
+            )
+            val response = client.postJson(
+                baseUrl = "http://127.0.0.1:${server.address.port}",
+                path = "/workspaces/workspace-1/sync/pull",
+                authorizationHeader = null,
+                body = JSONObject()
+                    .put("installationId", "installation-1")
+                    .put("platform", "android")
+                    .put("appVersion", "1.9.0")
+                    .put("afterHotChangeId", 0)
+                    .put("limit", 200)
+            )
+
+            assertEquals(42L, response.getLong("nextHotChangeId"))
+            assertEquals(2, requestCount.get())
+            assertTrue(observability.warnings.isEmpty())
+            val retryEvent = observability.breadcrumbs.single()
+            assertTrue(retryEvent is AndroidBreadcrumbEvent.HttpTransientRetry)
+            retryEvent as AndroidBreadcrumbEvent.HttpTransientRetry
+            assertEquals("/workspaces/{workspaceId}/sync/pull", retryEvent.endpointName)
+            assertEquals("POST", retryEvent.method)
+            assertEquals("gateway-request-1", retryEvent.requestId)
+            assertEquals(504, retryEvent.statusCode)
+            assertEquals("http_response", retryEvent.stage)
+            assertEquals(1, retryEvent.attemptNumber)
+            assertEquals(4, retryEvent.maxAttemptCount)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun syncBootstrapPushDoesNotRetryTransientGatewayTimeout() = runBlocking {
+        val requestCount = AtomicInteger(0)
+        val observability = RecordingCloudHttpObservability()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/workspaces/workspace-1/sync/bootstrap") { exchange ->
+            requestCount.incrementAndGet()
+            writeCloudTestResponse(
+                exchange = exchange,
+                statusCode = 504,
+                body = "",
+                headers = mapOf("X-Amzn-RequestId" to "lambda-request-1")
+            )
+        }
+        server.start()
+
+        try {
+            val client = CloudJsonHttpClient(
+                okHttpClient = OkHttpClient(),
+                observability = observability,
+                appVersion = "1.9.0",
+                versionCode = 123
+            )
+            var thrownError: CloudRemoteException? = null
+            try {
+                client.postJson(
+                    baseUrl = "http://127.0.0.1:${server.address.port}",
+                    path = "/workspaces/workspace-1/sync/bootstrap",
+                    authorizationHeader = null,
+                    body = JSONObject()
+                        .put("mode", "push")
+                        .put("installationId", "installation-1")
+                        .put("platform", "android")
+                        .put("appVersion", "1.9.0")
+                        .put("entries", JSONArray())
+                )
+            } catch (error: CloudRemoteException) {
+                thrownError = error
+            }
+
+            val error = thrownError ?: throw AssertionError("Expected CloudRemoteException")
+            assertEquals(504, error.statusCode)
+            assertEquals("lambda-request-1", error.requestId)
+            assertEquals(1, requestCount.get())
+            assertTrue(observability.breadcrumbs.isEmpty())
+            val warning = observability.warnings.single()
+            assertTrue(warning is AndroidWarningIssueEvent.HttpServerError)
+            warning as AndroidWarningIssueEvent.HttpServerError
+            assertEquals("/workspaces/{workspaceId}/sync/bootstrap", warning.endpointName)
+            assertEquals("lambda-request-1", warning.requestId)
+        } finally {
+            server.stop(0)
+        }
+    }
+}
+
+private class RecordingCloudHttpObservability : AppObservability {
+    val breadcrumbs: MutableList<AndroidBreadcrumbEvent> = mutableListOf()
+    val warnings: MutableList<AndroidWarningIssueEvent> = mutableListOf()
+
+    override fun setCloudIdentity(identity: CloudObservationIdentity) {
+    }
+
+    override fun clearCloudIdentity() {
+    }
+
+    override fun addBreadcrumb(event: AndroidBreadcrumbEvent) {
+        breadcrumbs += event
+    }
+
+    override fun captureWarning(event: AndroidWarningIssueEvent) {
+        warnings += event
+    }
+
+    override fun captureException(event: AndroidExceptionIssueEvent) {
+    }
+}
+
+private fun writeCloudTestResponse(
+    exchange: HttpExchange,
+    statusCode: Int,
+    body: String,
+    headers: Map<String, String>
+) {
+    headers.forEach { (name, value) ->
+        exchange.responseHeaders.add(name, value)
+    }
+    val responseBytes = body.toByteArray(StandardCharsets.UTF_8)
+    exchange.sendResponseHeaders(
+        statusCode,
+        if (responseBytes.isEmpty()) -1L else responseBytes.size.toLong()
+    )
+    if (responseBytes.isEmpty()) {
+        exchange.responseBody.close()
+    } else {
+        exchange.responseBody.use { output ->
+            output.write(responseBytes)
+        }
+    }
+}

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -145,6 +145,7 @@ test("default API Gateway generated errors expose supported request id headers",
     "gatewayresponse.header.Access-Control-Allow-Origin": "method.request.header.Origin",
     "gatewayresponse.header.Access-Control-Expose-Headers": "'x-request-id,x-amzn-requestid,x-amz-apigw-id'",
     "gatewayresponse.header.Vary": "'Origin'",
+    "gatewayresponse.header.X-Request-Id": "context.requestId",
   };
 
   template.hasResourceProperties("AWS::ApiGateway::GatewayResponse", {

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -103,6 +103,7 @@ export interface GatewayErrorResponseHeaders {
   readonly "Access-Control-Allow-Methods": string;
   readonly "Access-Control-Allow-Credentials": string;
   readonly "Access-Control-Expose-Headers": string;
+  readonly "X-Request-Id": string;
 }
 
 const browserCorsAllowHeaders = [
@@ -162,6 +163,7 @@ export function createGatewayErrorResponseHeaders(): GatewayErrorResponseHeaders
     "Access-Control-Allow-Methods": "'GET,POST,PATCH,OPTIONS'",
     "Access-Control-Allow-Credentials": "'true'",
     "Access-Control-Expose-Headers": `'${gatewayErrorCorsExposeHeaders.join(",")}'`,
+    "X-Request-Id": "context.requestId",
   };
 }
 

--- a/infra/aws/lib/gateways/auth-gateway.test.ts
+++ b/infra/aws/lib/gateways/auth-gateway.test.ts
@@ -43,6 +43,7 @@ test("auth API Gateway generated errors expose CORS and supported request id hea
     "gatewayresponse.header.Access-Control-Allow-Origin": "method.request.header.Origin",
     "gatewayresponse.header.Access-Control-Expose-Headers": "'retry-after,x-request-id,x-amzn-requestid,x-amz-apigw-id'",
     "gatewayresponse.header.Vary": "'Origin'",
+    "gatewayresponse.header.X-Request-Id": "context.requestId",
   };
   const gatewayResponses = template.findResources("AWS::ApiGateway::GatewayResponse");
 

--- a/infra/aws/lib/gateways/auth-gateway.ts
+++ b/infra/aws/lib/gateways/auth-gateway.ts
@@ -36,6 +36,7 @@ export interface AuthGatewayErrorResponseHeaders {
   readonly "Access-Control-Allow-Methods": string;
   readonly "Access-Control-Allow-Credentials": string;
   readonly "Access-Control-Expose-Headers": string;
+  readonly "X-Request-Id": string;
 }
 
 const authCorsAllowHeaders = [
@@ -61,6 +62,7 @@ export function createAuthGatewayErrorResponseHeaders(): AuthGatewayErrorRespons
     "Access-Control-Allow-Methods": "'GET,POST,OPTIONS'",
     "Access-Control-Allow-Credentials": "'true'",
     "Access-Control-Expose-Headers": `'${authGatewayErrorCorsExposeHeaders.join(",")}'`,
+    "X-Request-Id": "context.requestId",
   };
 }
 


### PR DESCRIPTION
## Summary

- add Android cloud HTTP retries for transient pull-safe requests
- add retry breadcrumbs and Sentry rendering for transient retry attempts
- expose request-id headers on API Gateway-generated error responses

## Validation

- git --no-pager diff --cached --check
- git --no-pager diff --check
- reviewed source and contract consumers

Gradle was not run locally because this repository requires explicit approval before ./gradlew runs.