### PR TITLE
[codex] Split admin review events report subfeatures

### DIFF
--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
@@ -6,9 +6,9 @@ import {
   type ReviewEventPlatform,
   type ReviewEventsByDateReport,
 } from "../../adminApi";
-import { buildReviewEventsByDateChartModel } from "./chartModel";
-import { ReviewEventsByDateCharts } from "./ReviewEventsByDateCharts";
-import { ReviewEventsByDateFilters } from "./ReviewEventsByDateFilters";
+import { ReviewEventsByDateCharts } from "./charts/ReviewEventsByDateCharts";
+import { buildReviewEventsByDateChartModel } from "./charts/chartModel";
+import { ReviewEventsByDateFilters } from "./filters/ReviewEventsByDateFilters";
 import {
   buildReviewEventsByDateSummaryCards,
   ReviewEventsByDateSummary,
@@ -20,7 +20,7 @@ import {
   doesUserMatchSearch,
   getNormalizedSearchValue,
   visibleUserFilterOptionLimit,
-} from "./userFilters";
+} from "./filters/userFilters";
 import {
   filterReviewEventsByDateReport,
   type ReviewEventsByDateRange,

--- a/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type JSX } from "react";
-import { reviewEventPlatforms, type ReviewEventsByDateUser } from "../../adminApi";
+import { reviewEventPlatforms, type ReviewEventsByDateUser } from "../../../adminApi";
 import {
   getPlatformColor,
   platformLabels,
@@ -15,7 +15,7 @@ import {
   renderPlatformReviewEventsChart,
   renderUserReviewEventsChart,
 } from "./chartRenderers";
-import { formatGeneratedAt } from "./formatting";
+import { formatGeneratedAt } from "../formatting";
 
 type ReviewEventsByDateChartsProps = Readonly<{
   chartModel: ReviewEventsByDateChartModel;

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
@@ -7,7 +7,7 @@ import {
   type ReviewEventsByDateReport,
   type ReviewEventsByDateUniqueUserCohort,
   type ReviewEventsByDateUser,
-} from "../../adminApi";
+} from "../../../adminApi";
 
 export type ChartTooltipState = Readonly<{
   visible: boolean;

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
@@ -3,7 +3,7 @@ import {
   reviewEventPlatforms,
   type ReviewEventPlatform,
   type ReviewEventsByDateUser,
-} from "../../adminApi";
+} from "../../../adminApi";
 import {
   chartMargin,
   chartWidth,
@@ -19,7 +19,7 @@ import {
   type StackedChartRectEntry,
   type UniqueUserCohortKey,
 } from "./chartModel";
-import { escapeHtml, formatCompactDateLabel, formatDateRangeLabel } from "./formatting";
+import { escapeHtml, formatCompactDateLabel, formatDateRangeLabel } from "../formatting";
 
 type ChartFrameParams = Readonly<{
   chartHeight: number;

--- a/apps/admin/src/reports/reviewEventsByDate/filters/ReviewEventsByDateFilters.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/filters/ReviewEventsByDateFilters.tsx
@@ -5,14 +5,14 @@ import {
   type ReviewEventCohort,
   type ReviewEventPlatform,
   type ReviewEventsByDateUser,
-} from "../../adminApi";
+} from "../../../adminApi";
 import {
   getPlatformColor,
   platformLabels,
   uniqueUserCohortColors,
   uniqueUserCohortLabels,
-} from "./chartModel";
-import type { ReviewEventsByDateRange } from "./query";
+} from "../charts/chartModel";
+import type { ReviewEventsByDateRange } from "../query";
 import { getUserFilterLabel, type ActiveUserFilter } from "./userFilters";
 
 type ReviewEventsByDateFilterPopover = "time" | "users" | "cohort" | "platform";

--- a/apps/admin/src/reports/reviewEventsByDate/filters/userFilters.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/filters/userFilters.ts
@@ -1,4 +1,4 @@
-import type { ReviewEventsByDateUser } from "../../adminApi";
+import type { ReviewEventsByDateUser } from "../../../adminApi";
 
 export type ActiveUserFilter = Readonly<{
   userId: string;


### PR DESCRIPTION
## Summary
- move review-events chart files into a charts subfolder
- move review-events filter files into a filters subfolder
- update imports while keeping dashboard, query, summary, and formatting flat

## Validation
- cd apps/admin && npm run build