### PR TITLE
Fix Android startup guest bootstrap timeout handling

### DIFF
--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinatorTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.data.local.ai.remote.GuestCloudSessionCreator
 import com.flashcardsopensourceapp.data.local.cloud.PendingGuestUpgradeState
+import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
+import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryReason
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
@@ -12,15 +14,16 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeCompl
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkSelection
-import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.cloud.makeOfficialCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.CloudIdentityTestEnvironment
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.FakeCloudRemoteGateway
+import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.RestartedCloudGuestSessionRuntime
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createCloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createCloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createStoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createStoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.support.createSyncCardOutboxEntry
+import java.net.SocketTimeoutException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -264,6 +267,69 @@ class CloudGuestSessionCoordinatorTest {
     }
 
     @Test
+    fun startupReconciliationFailsTransientGuestBootstrapFailureBeforeUnsafeGuestWorkspaceMigration() = runBlocking {
+        val localWorkspaceId: String = environment.requireLocalWorkspaceId()
+        val guestSession: StoredGuestAiSession = createStoredGuestAiSession(
+            workspaceId = "remote-guest-workspace",
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            guestToken = "guest-token",
+            userId = "guest-user"
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = guestSession.userId,
+            linkedWorkspaceId = guestSession.workspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = guestSession.workspaceId
+        )
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = guestSession.workspaceId,
+            session = guestSession
+        )
+        val restartedRuntime: RestartedCloudGuestSessionRuntime =
+            environment.createRestartedCloudGuestSessionRuntime(
+                remoteGateway = FakeCloudRemoteGateway.forBootstrapPullError(
+                    bootstrapPullError = SocketTimeoutException("startup bootstrap timed out")
+                )
+            )
+
+        try {
+            restartedRuntime.cloudGuestSessionCoordinator.reconcilePersistedCloudStateForStartup()
+            throw AssertionError("Expected transient guest bootstrap failure to fail startup before unsafe migration.")
+        } catch (error: IllegalStateException) {
+            assertTrue(
+                error.message?.contains("Startup cloud reconciliation could not finish") == true
+            )
+            assertTrue(
+                error.message?.contains("startup bootstrap timed out") == true
+            )
+        }
+
+        val syncState: SyncStateEntity = requireNotNull(
+            environment.database.syncStateDao().loadSyncState(localWorkspaceId)
+        )
+        assertEquals(CloudAccountState.GUEST, restartedRuntime.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(localWorkspaceId, restartedRuntime.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId)
+        assertEquals(
+            guestSession.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().linkedWorkspaceId
+        )
+        assertEquals(localWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)
+        assertNotNull(
+            restartedRuntime.guestAiSessionStore.loadAnySession(
+                configuration = makeOfficialCloudServiceConfiguration()
+            )
+        )
+        assertTrue(
+            syncState.lastSyncError?.contains("Startup cloud reconciliation could not finish") == true
+        )
+        assertTrue(
+            syncState.lastSyncError?.contains("startup bootstrap timed out") == true
+        )
+    }
+
+    @Test
     fun corruptCredentialRecoveryStateDoesNotPreventStoreRestartAndLoadsInvalidRecovery() = runBlocking {
         val localWorkspaceId = environment.requireLocalWorkspaceId()
         val metadataPreferences = environment.context.getSharedPreferences(
@@ -503,6 +569,95 @@ class CloudGuestSessionCoordinatorTest {
                 configuration = makeOfficialCloudServiceConfiguration()
             )
         )
+    }
+
+    @Test
+    fun startupReconciliationFailsPendingGuestUpgradeHydrationTransientFailure() = runBlocking {
+        val localWorkspaceId: String = environment.requireLocalWorkspaceId()
+        val linkedWorkspace = createCloudWorkspaceSummary(
+            workspaceId = "workspace-linked",
+            name = "Linked Workspace",
+            createdAtMillis = 200L,
+            isSelected = true
+        )
+        val accountSnapshot = createCloudAccountSnapshot(
+            userId = "user-1",
+            email = "user@example.com",
+            workspaces = listOf(linkedWorkspace)
+        )
+        val credentials = createStoredCloudCredentials(idTokenExpiresAtMillis = Long.MAX_VALUE)
+        val guestSession: StoredGuestAiSession = createStoredGuestAiSession(
+            workspaceId = localWorkspaceId,
+            configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+            apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+            guestToken = "guest-token",
+            userId = "guest-user"
+        )
+        environment.cloudPreferencesStore.updateCloudSettings(
+            cloudState = CloudAccountState.GUEST,
+            linkedUserId = guestSession.userId,
+            linkedWorkspaceId = localWorkspaceId,
+            linkedEmail = null,
+            activeWorkspaceId = localWorkspaceId
+        )
+        environment.guestAiSessionStore.saveSession(
+            localWorkspaceId = localWorkspaceId,
+            session = guestSession
+        )
+        environment.cloudPreferencesStore.savePendingGuestUpgrade(
+            pendingGuestUpgradeState = PendingGuestUpgradeState(
+                configuration = makeOfficialCloudServiceConfiguration(),
+                credentials = credentials,
+                accountSnapshot = accountSnapshot,
+                guestSession = guestSession,
+                guestUpgradeMode = CloudGuestUpgradeMode.MERGE_REQUIRED,
+                selection = CloudWorkspaceLinkSelection.Existing(workspaceId = linkedWorkspace.workspaceId),
+                completion = CloudGuestUpgradeCompletion(
+                    workspace = linkedWorkspace,
+                    reconciliation = null
+                )
+            )
+        )
+        environment.cloudPreferencesStore.saveCloudCredentialRecoveryState(
+            recoveryState = CloudCredentialRecoveryState(
+                reason = CloudCredentialRecoveryReason.LINKED_CREDENTIALS_MISSING,
+                previousCloudState = CloudAccountState.GUEST,
+                installationId = environment.cloudPreferencesStore.currentCloudSettings().installationId,
+                linkedUserId = guestSession.userId,
+                linkedWorkspaceId = localWorkspaceId,
+                activeWorkspaceId = localWorkspaceId,
+                linkedEmail = null,
+                configurationMode = CloudServiceConfigurationMode.OFFICIAL,
+                apiBaseUrl = "https://api.flashcards-open-source-app.com/v1",
+                detectedAtMillis = 500L
+            )
+        )
+        val restartedRuntime: RestartedCloudGuestSessionRuntime =
+            environment.createRestartedCloudGuestSessionRuntime(
+                remoteGateway = FakeCloudRemoteGateway.forBootstrapPullError(
+                    bootstrapPullError = SocketTimeoutException("pending guest upgrade hydration timed out")
+                )
+            )
+
+        try {
+            restartedRuntime.cloudGuestSessionCoordinator.reconcilePersistedCloudStateForStartup()
+            throw AssertionError("Expected pending guest upgrade hydration failure to fail startup explicitly.")
+        } catch (error: IllegalStateException) {
+            assertTrue(
+                error.message?.contains("Guest upgrade completed on the server") == true
+            )
+            assertTrue(
+                error.message?.contains("pending guest upgrade hydration timed out") == true
+            )
+        }
+
+        assertEquals(CloudAccountState.LINKED, restartedRuntime.cloudPreferencesStore.currentCloudSettings().cloudState)
+        assertEquals(
+            linkedWorkspace.workspaceId,
+            restartedRuntime.cloudPreferencesStore.currentCloudSettings().activeWorkspaceId
+        )
+        assertNotNull(restartedRuntime.cloudPreferencesStore.loadPendingGuestUpgrade())
+        assertNotNull(restartedRuntime.cloudPreferencesStore.loadCredentials())
     }
 
     @Test

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/network/TransientNetworkFailure.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/network/TransientNetworkFailure.kt
@@ -1,0 +1,121 @@
+package com.flashcardsopensourceapp.data.local.network
+
+import java.io.IOException
+import java.net.ConnectException
+import java.net.MalformedURLException
+import java.net.NoRouteToHostException
+import java.net.ProtocolException
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.security.cert.CertPathValidatorException
+import java.security.cert.CertificateException
+import javax.net.ssl.SSLException
+import javax.net.ssl.SSLHandshakeException
+import javax.net.ssl.SSLPeerUnverifiedException
+import javax.net.ssl.SSLProtocolException
+
+fun isLikelyTransientNetworkIoException(error: IOException): Boolean {
+    if (error is MalformedURLException || error is ProtocolException) {
+        return false
+    }
+    if (error is SSLPeerUnverifiedException || error is SSLProtocolException) {
+        return false
+    }
+    if (error is SSLHandshakeException) {
+        return isTransientSslHandshakeException(error = error)
+    }
+    if (
+        error is SocketTimeoutException ||
+        error is ConnectException ||
+        error is UnknownHostException ||
+        error is NoRouteToHostException ||
+        error is SocketException
+    ) {
+        return true
+    }
+    if (error is SSLException) {
+        return isTransportLikeSslException(error = error)
+    }
+    return hasTransientTransportMessage(error = error)
+}
+
+fun isRetryableHttpStatusCode(statusCode: Int?): Boolean {
+    val resolvedStatusCode: Int = statusCode ?: return false
+    return resolvedStatusCode == 408 || resolvedStatusCode == 429 || resolvedStatusCode in 500..599
+}
+
+private fun isTransientSslHandshakeException(error: SSLHandshakeException): Boolean {
+    if (hasNonRetryableTlsCause(error = error)) {
+        return false
+    }
+    if (hasTransientTransportCause(error = error)) {
+        return true
+    }
+    return hasTransientTransportMessage(error = error)
+}
+
+private fun isTransportLikeSslException(error: SSLException): Boolean {
+    if (hasNonRetryableTlsCause(error = error)) {
+        return false
+    }
+    if (hasTransientTransportCause(error = error)) {
+        return true
+    }
+    return hasTransientTransportMessage(error = error)
+}
+
+private fun hasTransientTransportMessage(error: Throwable): Boolean {
+    val message: String = error.message?.lowercase() ?: return false
+    val transportMessageFragments: List<String> = listOf(
+        "connection reset",
+        "connection closed",
+        "connection abort",
+        "broken pipe",
+        "socket closed",
+        "read error",
+        "write error",
+        "timed out",
+        "timeout"
+    )
+    return transportMessageFragments.any { fragment -> message.contains(fragment) }
+}
+
+private fun hasNonRetryableTlsCause(error: Throwable): Boolean {
+    var currentCause: Throwable? = error.cause
+    while (currentCause != null) {
+        if (
+            currentCause is SSLPeerUnverifiedException ||
+            currentCause is SSLProtocolException ||
+            currentCause is CertPathValidatorException ||
+            currentCause is CertificateException
+        ) {
+            return true
+        }
+        currentCause = currentCause.cause
+    }
+    return false
+}
+
+private fun hasTransientTransportCause(error: Throwable): Boolean {
+    var currentCause: Throwable? = error.cause
+    while (currentCause != null) {
+        if (
+            currentCause is SSLPeerUnverifiedException ||
+            currentCause is SSLProtocolException
+        ) {
+            return false
+        }
+        if (
+            currentCause is SocketTimeoutException ||
+            currentCause is ConnectException ||
+            currentCause is UnknownHostException ||
+            currentCause is NoRouteToHostException ||
+            currentCause is SocketException
+        ) {
+            return true
+        }
+        currentCause = currentCause.cause
+    }
+    return false
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -1,7 +1,7 @@
 package com.flashcardsopensourceapp.data.local.repository.cloudsync.guest
 
-import com.flashcardsopensourceapp.data.local.ai.store.GuestAiSessionStore
 import com.flashcardsopensourceapp.data.local.ai.remote.GuestCloudSessionCreator
+import com.flashcardsopensourceapp.data.local.ai.store.GuestAiSessionStore
 import com.flashcardsopensourceapp.data.local.bootstrap.ensureLocalWorkspaceShell
 import com.flashcardsopensourceapp.data.local.cloud.CloudPreferencesStore
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
@@ -10,6 +10,7 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.sync.RemoteBootstrapP
 import com.flashcardsopensourceapp.data.local.cloud.sync.SyncLocalStore
 import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
+import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryReason
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
@@ -17,11 +18,14 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecover
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfigurationMode
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
-import com.flashcardsopensourceapp.data.local.model.ai.StoredGuestAiSession
+import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIoException
+import com.flashcardsopensourceapp.data.local.network.isRetryableHttpStatusCode
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.account.CloudIdentityResetCoordinator
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.runtime.CloudOperationCoordinator
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.androidClientPlatform
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.loadCurrentWorkspaceOrNull
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 
@@ -41,6 +45,9 @@ data class EnsuredGuestCloudSession(
     val workspaceId: String
 )
 
+private typealias GuestCloudLinkFinisher = suspend (StoredGuestAiSession, String?) -> Boolean
+private typealias GuestBootstrapProbeLoader = suspend (StoredGuestAiSession, String) -> RemoteBootstrapPullResponse
+
 class CloudGuestSessionCoordinator(
     private val database: AppDatabase,
     private val preferencesStore: CloudPreferencesStore,
@@ -53,7 +60,11 @@ class CloudGuestSessionCoordinator(
     private val appVersion: String
 ) {
     suspend fun reconcilePersistedCloudStateForStartup() {
-        reconcilePersistedCloudState()
+        operationCoordinator.runExclusive {
+            reconcilePersistedCloudStateLocked(
+                finishGuestCloudLink = ::finishGuestCloudLinkForStartupNonCancellableLocked
+            )
+        }
     }
 
     suspend fun ensureGuestCloudSession(workspaceId: String): EnsuredGuestCloudSession {
@@ -91,6 +102,14 @@ class CloudGuestSessionCoordinator(
     }
 
     internal suspend fun reconcilePersistedCloudStateLocked(): CloudIdentityReconciliationResult {
+        return reconcilePersistedCloudStateLocked(
+            finishGuestCloudLink = ::finishGuestCloudLinkNonCancellableLocked
+        )
+    }
+
+    private suspend fun reconcilePersistedCloudStateLocked(
+        finishGuestCloudLink: GuestCloudLinkFinisher
+    ): CloudIdentityReconciliationResult {
         val activeRecoveryState = preferencesStore.loadCloudCredentialRecoveryState()
         if (activeRecoveryState == null || activeRecoveryState.isPendingGuestUpgradeRecovery()) {
             val recoveredGuestUpgrade: CloudWorkspaceSummary? = resumePendingGuestUpgradeRecoveryIfNeeded(
@@ -179,10 +198,7 @@ class CloudGuestSessionCoordinator(
                         didRunSync = false
                     )
                 } else {
-                    val shouldSync = finishGuestCloudLinkNonCancellableLocked(
-                        session = storedGuestSession,
-                        workspaceId = storedGuestSession.workspaceId
-                    )
+                    val shouldSync = finishGuestCloudLink(storedGuestSession, storedGuestSession.workspaceId)
                     preferencesStore.clearCloudCredentialRecoveryState()
                     CloudIdentityReconciliationResult(
                         cloudSettings = preferencesStore.currentCloudSettings(),
@@ -327,7 +343,21 @@ class CloudGuestSessionCoordinator(
         return withContext(NonCancellable) {
             finishGuestCloudLinkIfNeededLocked(
                 session = session,
-                workspaceId = workspaceId
+                workspaceId = workspaceId,
+                bootstrapProbeLoader = ::loadRequiredGuestBootstrapProbe
+            )
+        }
+    }
+
+    private suspend fun finishGuestCloudLinkForStartupNonCancellableLocked(
+        session: StoredGuestAiSession,
+        workspaceId: String?
+    ): Boolean {
+        return withContext(NonCancellable) {
+            finishGuestCloudLinkIfNeededLocked(
+                session = session,
+                workspaceId = workspaceId,
+                bootstrapProbeLoader = ::loadStartupGuestBootstrapProbe
             )
         }
     }
@@ -352,7 +382,8 @@ class CloudGuestSessionCoordinator(
 
     private suspend fun finishGuestCloudLinkIfNeededLocked(
         session: StoredGuestAiSession,
-        workspaceId: String?
+        workspaceId: String?,
+        bootstrapProbeLoader: GuestBootstrapProbeLoader
     ): Boolean {
         val currentCloudSettings = preferencesStore.currentCloudSettings()
         val currentWorkspace = loadCurrentWorkspaceForRestoreOrNull(workspaceId = workspaceId)
@@ -367,9 +398,9 @@ class CloudGuestSessionCoordinator(
             return false
         }
 
-        val bootstrapProbe = runGuestBootstrapPull(
-            session = session,
-            installationId = currentCloudSettings.installationId
+        val bootstrapProbe: RemoteBootstrapPullResponse = bootstrapProbeLoader(
+            session,
+            currentCloudSettings.installationId
         )
         val workspaceSummary = guestWorkspaceSummary(
             currentWorkspaceId = currentWorkspace?.workspaceId,
@@ -455,6 +486,39 @@ class CloudGuestSessionCoordinator(
         )
     }
 
+    private suspend fun loadRequiredGuestBootstrapProbe(
+        session: StoredGuestAiSession,
+        installationId: String
+    ): RemoteBootstrapPullResponse {
+        return runGuestBootstrapPull(
+            session = session,
+            installationId = installationId
+        )
+    }
+
+    private suspend fun loadStartupGuestBootstrapProbe(
+        session: StoredGuestAiSession,
+        installationId: String
+    ): RemoteBootstrapPullResponse {
+        return try {
+            loadRequiredGuestBootstrapProbe(
+                session = session,
+                installationId = installationId
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            if (isRetryableStartupCloudReconciliationFailure(error = error).not()) {
+                throw error
+            }
+            markStartupCloudReconciliationFailure(error = error)
+            throw IllegalStateException(
+                startupCloudReconciliationFailureMessage(error = error),
+                error
+            )
+        }
+    }
+
     private fun guestWorkspaceSummary(
         currentWorkspaceId: String?,
         currentWorkspaceName: String?,
@@ -524,5 +588,66 @@ class CloudGuestSessionCoordinator(
             linkedEmail = null,
             activeWorkspaceId = cloudSettings.activeWorkspaceId
         )
+    }
+
+    private fun isRetryableStartupCloudReconciliationFailure(error: Exception): Boolean {
+        val cloudRemoteError: CloudRemoteException? = error as? CloudRemoteException
+            ?: findCloudRemoteCause(error = error)
+        if (cloudRemoteError != null) {
+            return isRetryableHttpStatusCode(statusCode = cloudRemoteError.statusCode)
+        }
+        val ioError: IOException? = error as? IOException ?: findIoCause(error = error)
+        return ioError != null && isLikelyTransientNetworkIoException(error = ioError)
+    }
+
+    private fun findCloudRemoteCause(error: Throwable): CloudRemoteException? {
+        var currentCause: Throwable? = error.cause
+        while (currentCause != null) {
+            if (currentCause is CloudRemoteException) {
+                return currentCause
+            }
+            currentCause = currentCause.cause
+        }
+        return null
+    }
+
+    private fun findIoCause(error: Throwable): IOException? {
+        var currentCause: Throwable? = error.cause
+        while (currentCause != null) {
+            if (currentCause is IOException) {
+                return currentCause
+            }
+            currentCause = currentCause.cause
+        }
+        return null
+    }
+
+    private suspend fun markStartupCloudReconciliationFailure(error: Exception) {
+        val cloudSettings: CloudSettings = preferencesStore.currentCloudSettings()
+        val workspaceId: String = localWorkspaceIdForSyncFailure(cloudSettings = cloudSettings) ?: return
+        syncLocalStore.markSyncFailure(
+            workspaceId = workspaceId,
+            errorMessage = startupCloudReconciliationFailureMessage(error = error)
+        )
+    }
+
+    private suspend fun localWorkspaceIdForSyncFailure(cloudSettings: CloudSettings): String? {
+        val candidateWorkspaceIds: List<String> = listOfNotNull(
+            cloudSettings.activeWorkspaceId,
+            cloudSettings.linkedWorkspaceId
+        ).distinct()
+        return candidateWorkspaceIds.firstOrNull { workspaceId ->
+            database.workspaceDao().loadWorkspaceById(workspaceId = workspaceId) != null
+        }
+    }
+
+    private fun startupCloudReconciliationFailureMessage(error: Exception): String {
+        val retryableCause: Throwable = findIoCause(error = error)
+            ?: findCloudRemoteCause(error = error)
+            ?: error
+        val causeMessage: String = retryableCause.message?.trim()?.takeIf { message -> message.isNotEmpty() }
+            ?: retryableCause::class.java.simpleName
+        return "Startup cloud reconciliation could not finish because cloud sync is temporarily unavailable. " +
+            "Check your connection and reopen the app. Cause=$causeMessage"
     }
 }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapRetryPolicy.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/bootstrap/AiChatBootstrapRetryPolicy.kt
@@ -2,20 +2,9 @@ package com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap
 
 import com.flashcardsopensourceapp.data.local.ai.remote.AiChatRemoteException
 import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIoException
+import com.flashcardsopensourceapp.data.local.network.isRetryableHttpStatusCode
 import java.io.IOException
-import java.net.ConnectException
-import java.net.MalformedURLException
-import java.net.NoRouteToHostException
-import java.net.ProtocolException
-import java.net.SocketException
-import java.net.SocketTimeoutException
-import java.net.UnknownHostException
-import java.security.cert.CertPathValidatorException
-import java.security.cert.CertificateException
-import javax.net.ssl.SSLException
-import javax.net.ssl.SSLHandshakeException
-import javax.net.ssl.SSLPeerUnverifiedException
-import javax.net.ssl.SSLProtocolException
 import kotlinx.coroutines.CancellationException
 import kotlin.random.Random
 
@@ -37,11 +26,11 @@ internal fun isRetryableBootstrapFailure(error: Exception): Boolean {
     }
     val remoteError = error as? AiChatRemoteException
     if (remoteError != null) {
-        return shouldRetryHttpStatus(statusCode = remoteError.statusCode)
+        return isRetryableHttpStatusCode(statusCode = remoteError.statusCode)
     }
     val cloudRemoteError = error as? CloudRemoteException ?: findCloudRemoteCause(error = error)
     if (cloudRemoteError != null) {
-        return shouldRetryHttpStatus(statusCode = cloudRemoteError.statusCode)
+        return isRetryableHttpStatusCode(statusCode = cloudRemoteError.statusCode)
     }
     return error is IOException && isLikelyTransientNetworkIoException(error = error)
 }
@@ -67,109 +56,4 @@ private fun findCloudRemoteCause(error: Throwable): CloudRemoteException? {
         currentCause = currentCause.cause
     }
     return null
-}
-
-internal fun isLikelyTransientNetworkIoException(error: IOException): Boolean {
-    if (error is MalformedURLException || error is ProtocolException) {
-        return false
-    }
-    if (error is SSLPeerUnverifiedException || error is SSLProtocolException) {
-        return false
-    }
-    if (error is SSLHandshakeException) {
-        return isTransientSslHandshakeException(error = error)
-    }
-    if (
-        error is SocketTimeoutException ||
-        error is ConnectException ||
-        error is UnknownHostException ||
-        error is NoRouteToHostException ||
-        error is SocketException
-    ) {
-        return true
-    }
-    if (error is SSLException) {
-        return isTransportLikeSslException(error = error)
-    }
-    return hasTransientTransportMessage(error = error)
-}
-
-private fun isTransientSslHandshakeException(error: SSLHandshakeException): Boolean {
-    if (hasNonRetryableTlsCause(error = error)) {
-        return false
-    }
-    if (hasTransientTransportCause(error = error)) {
-        return true
-    }
-    return hasTransientTransportMessage(error = error)
-}
-
-private fun isTransportLikeSslException(error: SSLException): Boolean {
-    if (hasNonRetryableTlsCause(error = error)) {
-        return false
-    }
-    if (hasTransientTransportCause(error = error)) {
-        return true
-    }
-    return hasTransientTransportMessage(error = error)
-}
-
-private fun hasTransientTransportMessage(error: Throwable): Boolean {
-    val message = error.message?.lowercase() ?: return false
-    val transportMessageFragments: List<String> = listOf(
-        "connection reset",
-        "connection closed",
-        "connection abort",
-        "broken pipe",
-        "socket closed",
-        "read error",
-        "write error",
-        "timed out",
-        "timeout"
-    )
-    return transportMessageFragments.any { fragment -> message.contains(fragment) }
-}
-
-private fun hasNonRetryableTlsCause(error: Throwable): Boolean {
-    var currentCause: Throwable? = error.cause
-    while (currentCause != null) {
-        if (
-            currentCause is SSLPeerUnverifiedException ||
-            currentCause is SSLProtocolException ||
-            currentCause is CertPathValidatorException ||
-            currentCause is CertificateException
-        ) {
-            return true
-        }
-        currentCause = currentCause.cause
-    }
-    return false
-}
-
-private fun hasTransientTransportCause(error: Throwable): Boolean {
-    var currentCause: Throwable? = error.cause
-    while (currentCause != null) {
-        if (
-            currentCause is SSLPeerUnverifiedException ||
-            currentCause is SSLProtocolException
-        ) {
-            return false
-        }
-        if (
-            currentCause is SocketTimeoutException ||
-            currentCause is ConnectException ||
-            currentCause is UnknownHostException ||
-            currentCause is NoRouteToHostException ||
-            currentCause is SocketException
-        ) {
-            return true
-        }
-        currentCause = currentCause.cause
-    }
-    return false
-}
-
-private fun shouldRetryHttpStatus(statusCode: Int?): Boolean {
-    val resolvedStatusCode = statusCode ?: return false
-    return resolvedStatusCode == 408 || resolvedStatusCode == 429 || resolvedStatusCode in 500..599
 }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiChatObservability.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/observability/AiChatObservability.kt
@@ -11,8 +11,8 @@ import com.flashcardsopensourceapp.data.local.ai.remote.AiChatRequestTooLargeExc
 import com.flashcardsopensourceapp.data.local.ai.remote.isAiChatAttachmentUnsupportedTypeRemoteError
 import com.flashcardsopensourceapp.data.local.ai.remote.isAiChatRequestTooLargeRemoteError
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatContentPart
+import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIoException
 import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.AiChatBootstrapBlockedException
-import com.flashcardsopensourceapp.feature.ai.runtime.coordinators.bootstrap.isLikelyTransientNetworkIoException
 import java.io.IOException
 
 internal data class AiChatContentPartCounts(


### PR DESCRIPTION
## Summary
- share transient network retry classification between AI bootstrap and Android startup cloud reconciliation
- keep startup from entering a writable app state when guest bootstrap cannot safely finish
- add Android guest-session reconciliation regression coverage

## Validation
- git --no-pager diff --check

Android Gradle/instrumentation tests were not run locally because this repository requires explicit approval for local ./gradlew runs.