### PR TITLE
[codex] Split Android notification workflows

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
@@ -19,7 +19,7 @@ import com.flashcardsopensourceapp.app.livesmoke.support.appGraph
 import com.flashcardsopensourceapp.app.livesmoke.support.externalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
-import com.flashcardsopensourceapp.app.notifications.showReviewReminderNotification
+import com.flashcardsopensourceapp.app.notifications.review.showReviewReminderNotification
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.feature.review.reviewCurrentCardTag
 import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -24,9 +24,9 @@ import com.flashcardsopensourceapp.core.ui.AppMessageBus
 import com.flashcardsopensourceapp.core.ui.TestModeStore
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreenController
 import com.flashcardsopensourceapp.app.navigation.AppHandoffCoordinator
-import com.flashcardsopensourceapp.app.notifications.ReviewNotificationsManager
-import com.flashcardsopensourceapp.app.notifications.AndroidStrictRemindersScheduler
-import com.flashcardsopensourceapp.app.notifications.StrictRemindersManager
+import com.flashcardsopensourceapp.app.notifications.review.ReviewNotificationsManager
+import com.flashcardsopensourceapp.app.notifications.strict.AndroidStrictRemindersScheduler
+import com.flashcardsopensourceapp.app.notifications.strict.StrictRemindersManager
 import com.flashcardsopensourceapp.data.local.bootstrap.ensureLocalWorkspaceShell
 import com.flashcardsopensourceapp.data.local.ai.remote.AiChatLiveRemoteService
 import com.flashcardsopensourceapp.data.local.ai.store.AiChatHistoryStore

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/AppNotificationTap.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/AppNotificationTap.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.app.notifications
 
+import android.content.Intent
 import android.util.Log
 
 const val appNotificationTapTypeDataKey: String = "notificationType"
@@ -52,4 +53,49 @@ private fun buildAppNotificationTapLogMessage(fallback: AppNotificationTapFallba
     return "domain=android_notifications action=notification_tap_fallback " +
         "stage=${fallback.stage} reason=${fallback.reason} " +
         "notificationType=$notificationType details=$details"
+}
+
+internal fun parseAppNotificationTapRequest(
+    getStringExtra: (String) -> String?
+): AppNotificationTapRequest? {
+    val rawNotificationType = getStringExtra("$appNotificationTapExtraPrefix::$appNotificationTapTypeDataKey")
+        ?: return null
+    val notificationType = AppNotificationTapType.fromRawValue(rawValue = rawNotificationType)
+    if (notificationType == null) {
+        logAppNotificationTapFallback(
+            fallback = AppNotificationTapFallback(
+                stage = "parse",
+                reason = "unsupported_notification_type",
+                notificationType = rawNotificationType,
+                details = null
+            )
+        )
+        return null
+    }
+
+    return AppNotificationTapRequest(type = notificationType)
+}
+
+fun parseAppNotificationTapRequest(intent: Intent): AppNotificationTapRequest? {
+    return parseAppNotificationTapRequest(getStringExtra = intent::getStringExtra)
+}
+
+internal fun consumeAppNotificationTapRequest(
+    getStringExtra: (String) -> String?,
+    removeExtra: (String) -> Unit
+): AppNotificationTapRequest? {
+    val request = parseAppNotificationTapRequest(getStringExtra = getStringExtra) ?: return null
+    clearAppNotificationTapExtras(removeExtra = removeExtra)
+    return request
+}
+
+fun consumeAppNotificationTapRequest(intent: Intent): AppNotificationTapRequest? {
+    return consumeAppNotificationTapRequest(
+        getStringExtra = intent::getStringExtra,
+        removeExtra = intent::removeExtra
+    )
+}
+
+private fun clearAppNotificationTapExtras(removeExtra: (String) -> Unit) {
+    appNotificationTapIntentExtraKeys.forEach(removeExtra)
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationChannel.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationChannel.kt
@@ -1,0 +1,26 @@
+package com.flashcardsopensourceapp.app.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import com.flashcardsopensourceapp.app.R
+
+const val reviewNotificationChannelId: String = "review-reminders"
+
+internal fun ensureReviewNotificationChannel(context: Context) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+        return
+    }
+
+    val manager = context.getSystemService(NotificationManager::class.java)
+    manager.createNotificationChannel(
+        NotificationChannel(
+            reviewNotificationChannelId,
+            context.getString(R.string.review_notification_channel_name),
+            NotificationManager.IMPORTANCE_DEFAULT
+        ).apply {
+            description = context.getString(R.string.review_notification_channel_description)
+        }
+    )
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationPermission.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/NotificationPermission.kt
@@ -1,0 +1,13 @@
+package com.flashcardsopensourceapp.app.notifications
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+fun hasNotificationPermission(context: Context): Boolean {
+    return ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.POST_NOTIFICATIONS
+    ) == PackageManager.PERMISSION_GRANTED
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationWorker.kt
@@ -1,93 +1,13 @@
 package com.flashcardsopensourceapp.app.notifications
 
 import android.content.Context
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.flashcardsopensourceapp.app.FlashcardsApplication
-import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
-import com.flashcardsopensourceapp.data.local.notifications.SharedPreferencesReviewNotificationsStore
+import com.flashcardsopensourceapp.app.notifications.review.ReviewNotificationWorker as ReviewNotificationWorkflowWorker
 
+/**
+ * Compatibility entry point for WorkManager rows persisted before the notification package split.
+ */
 class ReviewNotificationWorker(
     appContext: Context,
     params: WorkerParameters
-) : CoroutineWorker(appContext, params) {
-    override suspend fun doWork(): Result {
-        val requestId = inputData.getString(reviewNotificationRequestIdDataKey)
-        val workspaceId = inputData.getString(reviewNotificationWorkspaceIdDataKey)
-        val permissionAllowed: Boolean = hasNotificationPermission(context = applicationContext)
-        addWorkerBreadcrumb(
-            stage = "worker_start",
-            requestId = requestId,
-            workspaceId = workspaceId,
-            permissionAllowed = permissionAllowed
-        )
-        if (permissionAllowed.not()) {
-            addWorkerBreadcrumb(
-                stage = "worker_permission_blocked",
-                requestId = requestId,
-                workspaceId = workspaceId,
-                permissionAllowed = permissionAllowed
-            )
-            return Result.success()
-        }
-
-        val frontText = inputData.getString(reviewNotificationFrontTextDataKey)
-        if (frontText == null || requestId == null || workspaceId == null) {
-            addWorkerBreadcrumb(
-                stage = "worker_invalid_input_failure",
-                requestId = requestId,
-                workspaceId = workspaceId,
-                permissionAllowed = permissionAllowed
-            )
-            return Result.failure()
-        }
-
-        // Read live so a toggle-off after schedule time wins immediately, even if a
-        // worker is already mid-flight.
-        val store = resolveReviewNotificationsStore()
-        val showAppIconBadge = store.loadSettings(workspaceId = workspaceId).showAppIconBadge
-
-        showReviewReminderNotification(
-            context = applicationContext,
-            frontText = frontText,
-            requestId = requestId,
-            showAppIconBadge = showAppIconBadge
-        )
-        addWorkerBreadcrumb(
-            stage = "worker_notification_posted",
-            requestId = requestId,
-            workspaceId = workspaceId,
-            permissionAllowed = permissionAllowed
-        )
-        return Result.success()
-    }
-
-    private fun resolveReviewNotificationsStore(): ReviewNotificationsStore {
-        val appGraphStore = (applicationContext as? FlashcardsApplication)
-            ?.appGraphOrNull
-            ?.reviewNotificationsStore
-        if (appGraphStore != null) {
-            return appGraphStore
-        }
-        // Cold-start fallback: the worker can fire before Application.onCreate has published the graph.
-        return SharedPreferencesReviewNotificationsStore(context = applicationContext)
-    }
-
-    private fun addWorkerBreadcrumb(
-        stage: String,
-        requestId: String?,
-        workspaceId: String?,
-        permissionAllowed: Boolean
-    ) {
-        addNotificationWorkerBreadcrumb(
-            applicationContext = applicationContext,
-            notificationKind = reviewReminderNotificationKind,
-            stage = stage,
-            requestId = requestId,
-            workspaceId = workspaceId,
-            permissionAllowed = permissionAllowed,
-            workTag = reviewNotificationWorkTag,
-            workLimit = null
-        )
-    }
-}
+) : ReviewNotificationWorkflowWorker(appContext, params)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictReminderWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/StrictReminderWorker.kt
@@ -1,80 +1,13 @@
 package com.flashcardsopensourceapp.app.notifications
 
 import android.content.Context
-import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.flashcardsopensourceapp.data.local.notifications.StrictReminderTimeOffset
-import com.flashcardsopensourceapp.data.local.notifications.strictReminderWorkLimit
+import com.flashcardsopensourceapp.app.notifications.strict.StrictReminderWorker as StrictReminderWorkflowWorker
 
+/**
+ * Compatibility entry point for WorkManager rows persisted before the notification package split.
+ */
 class StrictReminderWorker(
     appContext: Context,
     params: WorkerParameters
-) : CoroutineWorker(appContext, params) {
-    override suspend fun doWork(): Result {
-        val requestId = inputData.getString(strictReminderRequestIdDataKey)
-        val permissionAllowed: Boolean = hasNotificationPermission(context = applicationContext)
-        addWorkerBreadcrumb(
-            stage = "worker_start",
-            requestId = requestId,
-            permissionAllowed = permissionAllowed
-        )
-        if (permissionAllowed.not()) {
-            addWorkerBreadcrumb(
-                stage = "worker_permission_blocked",
-                requestId = requestId,
-                permissionAllowed = permissionAllowed
-            )
-            return Result.success()
-        }
-
-        val rawTimeOffset = inputData.getString(strictReminderTimeOffsetDataKey)
-        if (requestId == null || rawTimeOffset == null) {
-            addWorkerBreadcrumb(
-                stage = "worker_invalid_input_failure",
-                requestId = requestId,
-                permissionAllowed = permissionAllowed
-            )
-            return Result.failure()
-        }
-
-        val timeOffset = try {
-            StrictReminderTimeOffset.fromRawValue(rawValue = rawTimeOffset)
-        } catch (_: IllegalArgumentException) {
-            addWorkerBreadcrumb(
-                stage = "worker_invalid_input_failure",
-                requestId = requestId,
-                permissionAllowed = permissionAllowed
-            )
-            return Result.failure()
-        }
-
-        showStrictReminderNotification(
-            context = applicationContext,
-            timeOffset = timeOffset,
-            requestId = requestId
-        )
-        addWorkerBreadcrumb(
-            stage = "worker_notification_posted",
-            requestId = requestId,
-            permissionAllowed = permissionAllowed
-        )
-        return Result.success()
-    }
-
-    private fun addWorkerBreadcrumb(
-        stage: String,
-        requestId: String?,
-        permissionAllowed: Boolean
-    ) {
-        addNotificationWorkerBreadcrumb(
-            applicationContext = applicationContext,
-            notificationKind = strictReminderNotificationKind,
-            stage = stage,
-            requestId = requestId,
-            workspaceId = null,
-            permissionAllowed = permissionAllowed,
-            workTag = strictReminderWorkTag,
-            workLimit = strictReminderWorkLimit
-        )
-    }
-}
+) : StrictReminderWorkflowWorker(appContext, params)

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationWorker.kt
@@ -1,0 +1,96 @@
+package com.flashcardsopensourceapp.app.notifications.review
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.flashcardsopensourceapp.app.FlashcardsApplication
+import com.flashcardsopensourceapp.app.notifications.addNotificationWorkerBreadcrumb
+import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
+import com.flashcardsopensourceapp.app.notifications.reviewReminderNotificationKind
+import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
+import com.flashcardsopensourceapp.data.local.notifications.SharedPreferencesReviewNotificationsStore
+
+open class ReviewNotificationWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val requestId = inputData.getString(reviewNotificationRequestIdDataKey)
+        val workspaceId = inputData.getString(reviewNotificationWorkspaceIdDataKey)
+        val permissionAllowed: Boolean = hasNotificationPermission(context = applicationContext)
+        addWorkerBreadcrumb(
+            stage = "worker_start",
+            requestId = requestId,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed
+        )
+        if (permissionAllowed.not()) {
+            addWorkerBreadcrumb(
+                stage = "worker_permission_blocked",
+                requestId = requestId,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed
+            )
+            return Result.success()
+        }
+
+        val frontText = inputData.getString(reviewNotificationFrontTextDataKey)
+        if (frontText == null || requestId == null || workspaceId == null) {
+            addWorkerBreadcrumb(
+                stage = "worker_invalid_input_failure",
+                requestId = requestId,
+                workspaceId = workspaceId,
+                permissionAllowed = permissionAllowed
+            )
+            return Result.failure()
+        }
+
+        // Read live so a toggle-off after schedule time wins immediately, even if a
+        // worker is already mid-flight.
+        val store = resolveReviewNotificationsStore()
+        val showAppIconBadge = store.loadSettings(workspaceId = workspaceId).showAppIconBadge
+
+        showReviewReminderNotification(
+            context = applicationContext,
+            frontText = frontText,
+            requestId = requestId,
+            showAppIconBadge = showAppIconBadge
+        )
+        addWorkerBreadcrumb(
+            stage = "worker_notification_posted",
+            requestId = requestId,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed
+        )
+        return Result.success()
+    }
+
+    private fun resolveReviewNotificationsStore(): ReviewNotificationsStore {
+        val appGraphStore = (applicationContext as? FlashcardsApplication)
+            ?.appGraphOrNull
+            ?.reviewNotificationsStore
+        if (appGraphStore != null) {
+            return appGraphStore
+        }
+        // Cold-start fallback: the worker can fire before Application.onCreate has published the graph.
+        return SharedPreferencesReviewNotificationsStore(context = applicationContext)
+    }
+
+    private fun addWorkerBreadcrumb(
+        stage: String,
+        requestId: String?,
+        workspaceId: String?,
+        permissionAllowed: Boolean
+    ) {
+        addNotificationWorkerBreadcrumb(
+            applicationContext = applicationContext,
+            notificationKind = reviewReminderNotificationKind,
+            stage = stage,
+            requestId = requestId,
+            workspaceId = workspaceId,
+            permissionAllowed = permissionAllowed,
+            workTag = reviewNotificationWorkTag,
+            workLimit = null
+        )
+    }
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationsManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationsManager.kt
@@ -1,18 +1,26 @@
-package com.flashcardsopensourceapp.app.notifications
+package com.flashcardsopensourceapp.app.notifications.review
 
-import android.Manifest
 import android.app.NotificationManager
 import android.content.Context
-import android.content.pm.PackageManager
 import android.service.notification.StatusBarNotification
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.ContextCompat
 import androidx.work.Constraints
 import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.await
+import com.flashcardsopensourceapp.app.notifications.NotificationDelayRange
+import com.flashcardsopensourceapp.app.notifications.NotificationExpectedWorkInfoReadback
+import com.flashcardsopensourceapp.app.notifications.calculateNotificationDelayRange
+import com.flashcardsopensourceapp.app.notifications.emptyNotificationDelayRange
+import com.flashcardsopensourceapp.app.notifications.hasMissingExpectedWorkNames
+import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
+import com.flashcardsopensourceapp.app.notifications.hasOnlyCancelledOrFailedExpectedWork
+import com.flashcardsopensourceapp.app.notifications.loadExpectedWorkInfoReadback
+import com.flashcardsopensourceapp.app.notifications.loadWorkInfoStateCountsByTag
+import com.flashcardsopensourceapp.app.notifications.reviewReminderNotificationKind
+import com.flashcardsopensourceapp.app.notifications.reviewNotificationChannelId
 import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
 import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
@@ -55,7 +63,6 @@ import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
-const val reviewNotificationChannelId: String = "review-reminders"
 const val reviewNotificationFrontTextDataKey: String = "frontText"
 const val reviewNotificationRequestIdDataKey: String = "requestId"
 const val reviewNotificationWorkspaceIdDataKey: String = "workspaceId"
@@ -907,58 +914,6 @@ internal fun resolveExactStoredReviewTagNames(
     }.distinct()
 }
 
-fun hasNotificationPermission(context: Context): Boolean {
-    return ContextCompat.checkSelfPermission(
-        context,
-        Manifest.permission.POST_NOTIFICATIONS
-    ) == PackageManager.PERMISSION_GRANTED
-}
-
 fun reviewNotificationWorkspaceTag(workspaceId: String): String {
     return "review-notification::$workspaceId"
-}
-
-internal fun parseAppNotificationTapRequest(
-    getStringExtra: (String) -> String?
-): AppNotificationTapRequest? {
-    val rawNotificationType = getStringExtra("$appNotificationTapExtraPrefix::$appNotificationTapTypeDataKey")
-        ?: return null
-    val notificationType = AppNotificationTapType.fromRawValue(rawValue = rawNotificationType)
-    if (notificationType == null) {
-        logAppNotificationTapFallback(
-            fallback = AppNotificationTapFallback(
-                stage = "parse",
-                reason = "unsupported_notification_type",
-                notificationType = rawNotificationType,
-                details = null
-            )
-        )
-        return null
-    }
-
-    return AppNotificationTapRequest(type = notificationType)
-}
-
-fun parseAppNotificationTapRequest(intent: android.content.Intent): AppNotificationTapRequest? {
-    return parseAppNotificationTapRequest(getStringExtra = intent::getStringExtra)
-}
-
-internal fun consumeAppNotificationTapRequest(
-    getStringExtra: (String) -> String?,
-    removeExtra: (String) -> Unit
-): AppNotificationTapRequest? {
-    val request = parseAppNotificationTapRequest(getStringExtra = getStringExtra) ?: return null
-    clearAppNotificationTapExtras(removeExtra = removeExtra)
-    return request
-}
-
-fun consumeAppNotificationTapRequest(intent: android.content.Intent): AppNotificationTapRequest? {
-    return consumeAppNotificationTapRequest(
-        getStringExtra = intent::getStringExtra,
-        removeExtra = intent::removeExtra
-    )
-}
-
-private fun clearAppNotificationTapExtras(removeExtra: (String) -> Unit) {
-    appNotificationTapIntentExtraKeys.forEach(removeExtra)
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewReminderNotificationContent.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewReminderNotificationContent.kt
@@ -1,17 +1,20 @@
-package com.flashcardsopensourceapp.app.notifications
+package com.flashcardsopensourceapp.app.notifications.review
 
 import android.annotation.SuppressLint
 import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.flashcardsopensourceapp.app.MainActivity
 import com.flashcardsopensourceapp.app.R
+import com.flashcardsopensourceapp.app.notifications.AppNotificationTapType
+import com.flashcardsopensourceapp.app.notifications.appNotificationTapExtraPrefix
+import com.flashcardsopensourceapp.app.notifications.appNotificationTapTypeDataKey
+import com.flashcardsopensourceapp.app.notifications.ensureReviewNotificationChannel
+import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
+import com.flashcardsopensourceapp.app.notifications.reviewNotificationChannelId
 import com.flashcardsopensourceapp.core.ui.bidiWrap
 import com.flashcardsopensourceapp.core.ui.currentResourceLocale
 
@@ -136,21 +139,4 @@ private fun reviewReminderNotificationId(requestId: String): Int {
 
 internal fun reviewReminderNotificationTag(requestId: String): String {
     return "$reviewReminderNotificationTagPrefix$requestId"
-}
-
-internal fun ensureReviewNotificationChannel(context: Context) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-        return
-    }
-
-    val manager = context.getSystemService(NotificationManager::class.java)
-    manager.createNotificationChannel(
-        NotificationChannel(
-            reviewNotificationChannelId,
-            context.getString(R.string.review_notification_channel_name),
-            NotificationManager.IMPORTANCE_DEFAULT
-        ).apply {
-            description = context.getString(R.string.review_notification_channel_description)
-        }
-    )
 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/strict/StrictReminderNotificationContent.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/strict/StrictReminderNotificationContent.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.notifications
+package com.flashcardsopensourceapp.app.notifications.strict
 
 import android.annotation.SuppressLint
 import android.app.Notification
@@ -9,6 +9,12 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.flashcardsopensourceapp.app.MainActivity
 import com.flashcardsopensourceapp.app.R
+import com.flashcardsopensourceapp.app.notifications.AppNotificationTapType
+import com.flashcardsopensourceapp.app.notifications.appNotificationTapExtraPrefix
+import com.flashcardsopensourceapp.app.notifications.appNotificationTapTypeDataKey
+import com.flashcardsopensourceapp.app.notifications.ensureReviewNotificationChannel
+import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
+import com.flashcardsopensourceapp.app.notifications.reviewNotificationChannelId
 import com.flashcardsopensourceapp.data.local.notifications.StrictReminderTimeOffset
 import com.flashcardsopensourceapp.feature.review.reviewTextProvider
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/strict/StrictReminderWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/strict/StrictReminderWorker.kt
@@ -1,0 +1,83 @@
+package com.flashcardsopensourceapp.app.notifications.strict
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.flashcardsopensourceapp.app.notifications.addNotificationWorkerBreadcrumb
+import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
+import com.flashcardsopensourceapp.app.notifications.strictReminderNotificationKind
+import com.flashcardsopensourceapp.data.local.notifications.StrictReminderTimeOffset
+import com.flashcardsopensourceapp.data.local.notifications.strictReminderWorkLimit
+
+open class StrictReminderWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val requestId = inputData.getString(strictReminderRequestIdDataKey)
+        val permissionAllowed: Boolean = hasNotificationPermission(context = applicationContext)
+        addWorkerBreadcrumb(
+            stage = "worker_start",
+            requestId = requestId,
+            permissionAllowed = permissionAllowed
+        )
+        if (permissionAllowed.not()) {
+            addWorkerBreadcrumb(
+                stage = "worker_permission_blocked",
+                requestId = requestId,
+                permissionAllowed = permissionAllowed
+            )
+            return Result.success()
+        }
+
+        val rawTimeOffset = inputData.getString(strictReminderTimeOffsetDataKey)
+        if (requestId == null || rawTimeOffset == null) {
+            addWorkerBreadcrumb(
+                stage = "worker_invalid_input_failure",
+                requestId = requestId,
+                permissionAllowed = permissionAllowed
+            )
+            return Result.failure()
+        }
+
+        val timeOffset = try {
+            StrictReminderTimeOffset.fromRawValue(rawValue = rawTimeOffset)
+        } catch (_: IllegalArgumentException) {
+            addWorkerBreadcrumb(
+                stage = "worker_invalid_input_failure",
+                requestId = requestId,
+                permissionAllowed = permissionAllowed
+            )
+            return Result.failure()
+        }
+
+        showStrictReminderNotification(
+            context = applicationContext,
+            timeOffset = timeOffset,
+            requestId = requestId
+        )
+        addWorkerBreadcrumb(
+            stage = "worker_notification_posted",
+            requestId = requestId,
+            permissionAllowed = permissionAllowed
+        )
+        return Result.success()
+    }
+
+    private fun addWorkerBreadcrumb(
+        stage: String,
+        requestId: String?,
+        permissionAllowed: Boolean
+    ) {
+        addNotificationWorkerBreadcrumb(
+            applicationContext = applicationContext,
+            notificationKind = strictReminderNotificationKind,
+            stage = stage,
+            requestId = requestId,
+            workspaceId = null,
+            permissionAllowed = permissionAllowed,
+            workTag = strictReminderWorkTag,
+            workLimit = strictReminderWorkLimit
+        )
+    }
+}

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/strict/StrictRemindersManager.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/strict/StrictRemindersManager.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.app.notifications
+package com.flashcardsopensourceapp.app.notifications.strict
 
 import android.app.NotificationManager
 import android.content.Context
@@ -10,6 +10,17 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.await
+import com.flashcardsopensourceapp.app.notifications.NotificationDelayRange
+import com.flashcardsopensourceapp.app.notifications.NotificationExpectedWorkInfoReadback
+import com.flashcardsopensourceapp.app.notifications.calculateNotificationDelayRange
+import com.flashcardsopensourceapp.app.notifications.emptyNotificationDelayRange
+import com.flashcardsopensourceapp.app.notifications.hasMissingExpectedWorkNames
+import com.flashcardsopensourceapp.app.notifications.hasOnlyCancelledOrFailedExpectedWork
+import com.flashcardsopensourceapp.app.notifications.loadExpectedWorkInfoReadback
+import com.flashcardsopensourceapp.app.notifications.loadWorkInfoStateCountsByTag
+import com.flashcardsopensourceapp.app.notifications.strictReminderNotificationKind
+import com.flashcardsopensourceapp.app.notifications.reviewNotificationChannelId
+import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission as hasNotificationPermissionGranted
 import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
 import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
@@ -80,7 +91,7 @@ class AndroidStrictRemindersScheduler(
     private val workManager: WorkManager = WorkManager.getInstance(context)
 
     override fun hasNotificationPermission(): Boolean {
-        return hasNotificationPermission(context = context)
+        return hasNotificationPermissionGranted(context = context)
     }
 
     override fun clearDeliveredNotifications() {

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/ReviewNotificationsManagerTest.kt
@@ -1,5 +1,10 @@
 package com.flashcardsopensourceapp.app.notifications
 
+import com.flashcardsopensourceapp.app.notifications.review.ReviewNotificationFilterPlan
+import com.flashcardsopensourceapp.app.notifications.review.resolveExactStoredReviewTagNames
+import com.flashcardsopensourceapp.app.notifications.review.resolveReviewNotificationFilterPlan
+import com.flashcardsopensourceapp.app.notifications.review.reviewReminderNotificationTag
+import com.flashcardsopensourceapp.app.notifications.strict.strictReminderNotificationTag
 import com.flashcardsopensourceapp.data.local.model.cards.DeckFilterDefinition
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
 import org.junit.Assert.assertEquals

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.app.notifications
 
-import com.flashcardsopensourceapp.data.local.database.review.ReviewLogDao
+import com.flashcardsopensourceapp.app.notifications.strict.StrictRemindersManager
+import com.flashcardsopensourceapp.app.notifications.strict.StrictRemindersScheduler
 import com.flashcardsopensourceapp.core.observability.AndroidBreadcrumbEvent
 import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
@@ -8,6 +9,7 @@ import com.flashcardsopensourceapp.core.observability.AndroidWorkInfoStateCounts
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
+import com.flashcardsopensourceapp.data.local.database.review.ReviewLogDao
 import com.flashcardsopensourceapp.data.local.notifications.ScheduledStrictReminderPayload
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersReconcileTrigger
 import com.flashcardsopensourceapp.data.local.notifications.StrictRemindersSettings


### PR DESCRIPTION
## Summary
- Split Android notification orchestration into review and strict workflow packages.
- Kept shared tap, permission, diagnostics, and notification channel helpers in the parent notifications package.
- Preserved old WorkManager worker class names as compatibility wrappers for persisted work rows.

## Validation
- git diff --check
- Read-only source/package scans with rg
- Android Gradle checks not run because repo policy requires explicit approval for ./gradlew.