### PR TITLE
[codex] Add review leaderboard shortcut

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -494,6 +494,9 @@ const arCatalog: TranslationCatalog = {
     errors: {
       schedulerUnavailable: "لم يتم تحميل إعدادات جدولة مساحة العمل",
     },
+    leaderboardShortcut: {
+      ariaLabel: "فتح لوحة المتصدرين",
+    },
     progressBadge: {
       ariaLabel: "سلسلة المراجعة {{streak}} يومًا. {{todayStatus}}.",
       notReviewedToday: "لم تُراجع اليوم",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -494,6 +494,9 @@ const deCatalog: TranslationCatalog = {
     errors: {
       schedulerUnavailable: "Die Planer-Einstellungen des Arbeitsbereichs sind nicht geladen",
     },
+    leaderboardShortcut: {
+      ariaLabel: "Bestenliste öffnen",
+    },
     progressBadge: {
       ariaLabel: "Lernserie {{streak}} Tage. {{todayStatus}}.",
       notReviewedToday: "Heute noch nicht wiederholt",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -492,6 +492,9 @@ const enCatalog = {
     errors: {
       schedulerUnavailable: "Workspace scheduler settings are not loaded",
     },
+    leaderboardShortcut: {
+      ariaLabel: "Open leaderboard",
+    },
     progressBadge: {
       ariaLabel: "Review streak {{streak}} days. {{todayStatus}}.",
       notReviewedToday: "Not reviewed today",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -494,6 +494,9 @@ const esEsCatalog: TranslationCatalog = {
     errors: {
       schedulerUnavailable: "Los ajustes del programador del espacio de trabajo no están cargados",
     },
+    leaderboardShortcut: {
+      ariaLabel: "Abrir clasificación",
+    },
     progressBadge: {
       ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}.",
       notReviewedToday: "Sin repaso hoy",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -494,6 +494,9 @@ const esMxCatalog: TranslationCatalog = {
     errors: {
       schedulerUnavailable: "La configuración del programador del espacio de trabajo no está cargada",
     },
+    leaderboardShortcut: {
+      ariaLabel: "Abrir clasificación",
+    },
     progressBadge: {
       ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}.",
       notReviewedToday: "Sin repaso hoy",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -494,6 +494,9 @@ const hiCatalog: TranslationCatalog = {
     errors: {
       schedulerUnavailable: "वर्कस्पेस शेड्यूलर सेटिंग्स लोड नहीं हुई हैं",
     },
+    leaderboardShortcut: {
+      ariaLabel: "लीडरबोर्ड खोलें",
+    },
     progressBadge: {
       ariaLabel: "रिव्यू स्ट्रीक {{streak}} दिन। {{todayStatus}}।",
       notReviewedToday: "आज रिव्यू नहीं किया",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -494,6 +494,9 @@ export const jaCatalog = {
     errors: {
       schedulerUnavailable: "ワークスペースのスケジューラー設定が読み込まれていません",
     },
+    leaderboardShortcut: {
+      ariaLabel: "リーダーボードを開く",
+    },
     progressBadge: {
       ariaLabel: "復習連続 {{streak}} 日。{{todayStatus}}。",
       notReviewedToday: "今日はまだ復習していません",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -494,6 +494,9 @@ export const ruCatalog = {
     errors: {
       schedulerUnavailable: "Настройки планировщика рабочего пространства не загружены",
     },
+    leaderboardShortcut: {
+      ariaLabel: "Открыть таблицу лидеров",
+    },
     progressBadge: {
       ariaLabel: "Серия повторений: {{streak}} дн. {{todayStatus}}.",
       notReviewedToday: "Сегодня ещё не повторяли",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -494,6 +494,9 @@ export const zhHansCatalog = {
     errors: {
       schedulerUnavailable: "工作区调度器设置尚未加载",
     },
+    leaderboardShortcut: {
+      ariaLabel: "打开排行榜",
+    },
     progressBadge: {
       ariaLabel: "复习连续 {{streak}} 天。{{todayStatus}}。",
       notReviewedToday: "今天还没复习",

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -7,6 +7,8 @@
 export const reviewRoute: string = "/review";
 export const chatRoute: string = "/chat";
 export const progressRoute: string = "/progress";
+export const progressLeaderboardHash: string = "leaderboard";
+export const progressLeaderboardRoute: string = `${progressRoute}#${progressLeaderboardHash}`;
 export const cardsRoute: string = "/cards";
 export const settingsHubRoute: string = "/settings";
 export const settingsCurrentWorkspaceRoute: string = "/settings/current-workspace";

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../i18n";
+import { progressLeaderboardHash } from "../../routes";
 import type { AppDataContextValue } from "../../appData";
 import {
   createEmptyProgressLeaderboardSourceState,
@@ -353,6 +354,11 @@ describe("ProgressScreen", () => {
     window.localStorage.clear();
 
     HTMLElement.prototype.scrollIntoView = vi.fn();
+    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback): number => {
+      callback(0);
+      return 1;
+    });
+    window.cancelAnimationFrame = vi.fn((_animationFrameId: number): void => undefined);
 
     useAppDataMock.mockReturnValue(createAppData());
     useProgressInvalidationStateMock.mockReturnValue({
@@ -716,6 +722,29 @@ describe("ProgressScreen", () => {
     }
     expect(signInLink.textContent).toBe("Sign in");
     expect(container.querySelector("[data-testid='progress-leaderboard-row-viewer']")).toBeNull();
+  });
+
+  it("scrolls to the leaderboard card when the route hash targets it", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={[`/progress#${progressLeaderboardHash}`]}>
+          <I18nProvider>
+            <ProgressScreen />
+          </I18nProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    const leaderboardCard = container.querySelector("[data-testid='progress-leaderboard-card']");
+    if (!(leaderboardCard instanceof HTMLElement)) {
+      throw new Error("Leaderboard card was not found");
+    }
+
+    expect(leaderboardCard.id).toBe(progressLeaderboardHash);
+    expect(vi.mocked(HTMLElement.prototype.scrollIntoView)).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
   });
 
   it("renders the leaderboard participation-disabled placeholder with a settings link", async () => {

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type CSSProperties, type ReactElement } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useRef, useState, type CSSProperties, type ReactElement, type Ref } from "react";
+import { Link, useLocation } from "react-router-dom";
 import { buildLoginUrl } from "../../api";
 import { useAppData } from "../../appData";
 import {
@@ -10,7 +10,7 @@ import { useProgressInvalidationState } from "../../appData/progress/invalidatio
 import { canLoadProgressServerBase, useProgressSource } from "../../appData/progress/progressSource";
 import { resolveLocaleWeekContext, useI18n, type LocaleDirection } from "../../i18n";
 import { parseLocalDate, shiftLocalDate } from "../../progress/progressDates";
-import { settingsLeaderboardParticipationRoute } from "../../routes";
+import { progressLeaderboardHash, settingsLeaderboardParticipationRoute } from "../../routes";
 import type {
   DailyReviewPoint,
   ProgressLeaderboardSourceState,
@@ -464,11 +464,16 @@ function getLeaderboardPeriodLabel(windowKey: ProgressLeaderboardWindowKey, t: T
   return t("progressScreen.leaderboard.periods.allTime");
 }
 
-type ProgressLeaderboardSectionProps = Readonly<{
+type ProgressLeaderboardBodyProps = Readonly<{
   sourceState: ProgressLeaderboardSourceState;
   canRenderServerBase: boolean;
   selectedWindowKey: ProgressLeaderboardWindowKey | null;
   onSelectWindowKey: (windowKey: ProgressLeaderboardWindowKey) => void;
+}>;
+
+type ProgressLeaderboardSectionProps = ProgressLeaderboardBodyProps & Readonly<{
+  sectionId: string;
+  sectionRef: Ref<HTMLElement>;
   isInfoVisible: boolean;
   onToggleInfo: () => void;
 }>;
@@ -546,7 +551,7 @@ function ProgressLeaderboardRows(props: Readonly<{
   );
 }
 
-function ProgressLeaderboardBody(props: ProgressLeaderboardSectionProps): ReactElement {
+function ProgressLeaderboardBody(props: ProgressLeaderboardBodyProps): ReactElement {
   const { t } = useI18n();
   const { sourceState, canRenderServerBase, selectedWindowKey, onSelectWindowKey } = props;
   const leaderboard = sourceState.renderedSnapshot;
@@ -639,10 +644,24 @@ function ProgressLeaderboardBody(props: ProgressLeaderboardSectionProps): ReactE
 
 function ProgressLeaderboardSection(props: ProgressLeaderboardSectionProps): ReactElement {
   const { t } = useI18n();
-  const { isInfoVisible, onToggleInfo } = props;
+  const {
+    sourceState,
+    canRenderServerBase,
+    selectedWindowKey,
+    onSelectWindowKey,
+    sectionId,
+    sectionRef,
+    isInfoVisible,
+    onToggleInfo,
+  } = props;
 
   return (
-    <section className="content-card progress-section progress-leaderboard-card" data-testid="progress-leaderboard-card">
+    <section
+      id={sectionId}
+      ref={sectionRef}
+      className="content-card progress-section progress-leaderboard-card"
+      data-testid="progress-leaderboard-card"
+    >
       <div className="progress-section-head">
         <div className="progress-chart-heading">
           <h2 className="progress-section-title">{t("progressScreen.leaderboard.title")}</h2>
@@ -665,7 +684,12 @@ function ProgressLeaderboardSection(props: ProgressLeaderboardSectionProps): Rea
         </p>
       ) : null}
 
-      <ProgressLeaderboardBody {...props} />
+      <ProgressLeaderboardBody
+        sourceState={sourceState}
+        canRenderServerBase={canRenderServerBase}
+        selectedWindowKey={selectedWindowKey}
+        onSelectWindowKey={onSelectWindowKey}
+      />
     </section>
   );
 }
@@ -682,6 +706,7 @@ export function ProgressScreen(): ReactElement {
     progressScheduleLocalVersion,
     progressServerInvalidationVersion,
   } = useProgressInvalidationState();
+  const location = useLocation();
   const { progressSourceState, refreshProgress } = useProgressSource({
     activeWorkspace,
     availableWorkspaces,
@@ -702,6 +727,7 @@ export function ProgressScreen(): ReactElement {
   const [selectedReviewScheduleBucket, setSelectedReviewScheduleBucket] = useState<ProgressReviewScheduleBucketKey | null>(null);
   const [selectedLeaderboardWindowKey, setSelectedLeaderboardWindowKey] = useState<ProgressLeaderboardWindowKey | null>(null);
   const [isLeaderboardInfoVisible, setIsLeaderboardInfoVisible] = useState<boolean>(false);
+  const leaderboardSectionRef = useRef<HTMLElement | null>(null);
   const progressSummary = progressSourceState.summary.renderedSnapshot;
   const progress = progressSourceState.series.renderedSnapshot;
   const reviewSchedule = progressSourceState.reviewSchedule.renderedSnapshot;
@@ -722,6 +748,25 @@ export function ProgressScreen(): ReactElement {
   useEffect(() => {
     setSelectedReviewScheduleBucket(null);
   }, [progressSourceState.reviewSchedule.renderedSnapshot]);
+
+  useEffect(() => {
+    if (location.hash !== `#${progressLeaderboardHash}` || progress === null) {
+      return;
+    }
+
+    const leaderboardSection = leaderboardSectionRef.current;
+    if (leaderboardSection === null) {
+      return;
+    }
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      leaderboardSection.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(animationFrameId);
+    };
+  }, [location.hash, progress, progressSourceState.leaderboard.renderedSnapshot]);
 
   const dailyReviews = progress === null ? [] : sortDailyReviews(progress.dailyReviews);
   const today = progress === null ? "" : progress.to;
@@ -1064,6 +1109,8 @@ export function ProgressScreen(): ReactElement {
             ) : null}
 
             <ProgressLeaderboardSection
+              sectionId={progressLeaderboardHash}
+              sectionRef={leaderboardSectionRef}
               sourceState={progressSourceState.leaderboard}
               canRenderServerBase={canRenderLeaderboardServerBase}
               selectedWindowKey={selectedLeaderboardWindowKey}

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -2,8 +2,8 @@ import type { ComponentProps, ReactElement } from "react";
 import { Link } from "react-router-dom";
 import { formatReviewProgressBadgeValue } from "../../../appData/progress/badge/reviewProgressBadge";
 import { useI18n } from "../../../i18n";
-import { progressRoute } from "../../../routes";
-import { ReviewProgressBadgeIcon } from "../../shared/ReviewProgressBadgeIcon";
+import { progressLeaderboardRoute, progressRoute } from "../../../routes";
+import { ProgressLeaderboardShortcutIcon, ReviewProgressBadgeIcon } from "../../shared/ReviewProgressBadgeIcon";
 import { ReviewFilterMenu } from "../filters/ReviewFilterMenu";
 
 type ReviewProgressBadgeState = Readonly<{
@@ -38,6 +38,7 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
     streak: formatNumber(reviewProgressBadge.streakDays),
     todayStatus: reviewProgressBadgeTodayStatus,
   });
+  const leaderboardShortcutAriaLabel = t("reviewScreen.leaderboardShortcut.ariaLabel");
 
   return (
     <div className="screen-head review-screen-head">
@@ -56,17 +57,28 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
         <ReviewFilterMenu {...filterMenuProps} />
         <div className="review-filter-summary-wrap">
           <span className="review-filter-label">{t("reviewScreen.progressBadge.title")}</span>
-          <Link
-            className={`badge review-progress-badge review-screen-head-badge${reviewProgressBadge.hasReviewedToday ? " review-progress-badge-active" : ""}`}
-            to={progressRoute}
-            aria-label={reviewProgressBadgeAriaLabel}
-            title={reviewProgressBadgeAriaLabel}
-            data-testid="review-progress-badge"
-            aria-disabled={reviewProgressBadge.isInteractive ? undefined : "true"}
-          >
-            <ReviewProgressBadgeIcon />
-            <span className="review-progress-badge-value">{formatReviewProgressBadgeValue(reviewProgressBadge.streakDays)}</span>
-          </Link>
+          <div className="review-progress-shortcuts">
+            <Link
+              className="badge review-progress-badge review-screen-head-badge review-leaderboard-shortcut"
+              to={progressLeaderboardRoute}
+              aria-label={leaderboardShortcutAriaLabel}
+              title={leaderboardShortcutAriaLabel}
+              data-testid="review-leaderboard-shortcut"
+            >
+              <ProgressLeaderboardShortcutIcon />
+            </Link>
+            <Link
+              className={`badge review-progress-badge review-screen-head-badge${reviewProgressBadge.hasReviewedToday ? " review-progress-badge-active" : ""}`}
+              to={progressRoute}
+              aria-label={reviewProgressBadgeAriaLabel}
+              title={reviewProgressBadgeAriaLabel}
+              data-testid="review-progress-badge"
+              aria-disabled={reviewProgressBadge.isInteractive ? undefined : "true"}
+            >
+              <ReviewProgressBadgeIcon />
+              <span className="review-progress-badge-value">{formatReviewProgressBadgeValue(reviewProgressBadge.streakDays)}</span>
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/screens/shared/ReviewProgressBadgeIcon.tsx
+++ b/apps/web/src/screens/shared/ReviewProgressBadgeIcon.tsx
@@ -15,3 +15,19 @@ export function ReviewProgressBadgeIcon(): ReactElement {
     </svg>
   );
 }
+
+export function ProgressLeaderboardShortcutIcon(): ReactElement {
+  return (
+    <svg
+      className="review-progress-badge-icon"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M7 3h10v2h4v3.4c0 2.7-1.8 5-4.3 5.7-.7 1.5-2 2.6-3.7 3V20h3v2H8v-2h3v-2.9c-1.7-.4-3-1.5-3.7-3C4.8 13.4 3 11.1 3 8.4V5h4V3Zm0 4H5v1.4c0 1.4.8 2.7 2 3.4V7Zm10 4.8c1.2-.7 2-2 2-3.4V7h-2v4.8ZM9 5v6.5c0 2.1 1.3 3.6 3 3.6s3-1.5 3-3.6V5H9Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/styles/features/review/review-responsive.css
+++ b/apps/web/src/styles/features/review/review-responsive.css
@@ -70,6 +70,21 @@
     width: 100%;
   }
 
+  .review-progress-shortcuts {
+    width: 100%;
+  }
+
+  .review-progress-shortcuts > .review-leaderboard-shortcut {
+    width: 42px;
+    min-width: 42px;
+    flex: 0 0 42px;
+  }
+
+  .review-progress-shortcuts > .review-screen-head-badge:not(.review-leaderboard-shortcut) {
+    width: auto;
+    flex: 1 1 auto;
+  }
+
   .review-pane,
   .review-queue-panel {
     padding: 10px;

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -46,3 +46,14 @@
   padding: 0 16px;
   font-size: 15px;
 }
+
+.review-screen-head-badge.review-leaderboard-shortcut {
+  padding-inline: 0;
+}
+
+.review-progress-shortcuts {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -43,6 +43,14 @@
   color: #fff5f2;
 }
 
+.review-leaderboard-shortcut {
+  width: 42px;
+  min-width: 42px;
+  height: 42px;
+  padding-inline: 0;
+  justify-content: center;
+}
+
 .review-progress-badge-icon,
 .review-progress-badge-value {
   line-height: 1;


### PR DESCRIPTION
## Summary

- add a Review header trophy shortcut that opens the Progress leaderboard anchor
- add `/progress#leaderboard` route constants and smooth-scroll behavior on the Progress screen
- add responsive styling, shared icon SVG, i18n labels, and a focused render test for hash scrolling

## Validation

- `npx vitest run src/screens/progress/ProgressScreen.render.test.tsx`
- `npx vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx`
- `npm run build`

diff review: no P0-P4 issues found