### PR TITLE
Move progress leaderboard after streak

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
@@ -39,8 +39,8 @@ import com.flashcardsopensourceapp.feature.ai.aiComposerSendButtonTag
 import com.flashcardsopensourceapp.feature.ai.aiConversationSurfaceTag
 import com.flashcardsopensourceapp.feature.cards.cardsCardFrontTextTag
 import com.flashcardsopensourceapp.feature.cards.cardsSearchFieldTag
-import com.flashcardsopensourceapp.feature.progress.progressReviewsActivityChartTag
-import com.flashcardsopensourceapp.feature.progress.progressReviewsSectionTag
+import com.flashcardsopensourceapp.feature.progress.progressLeaderboardResolvedContentTag
+import com.flashcardsopensourceapp.feature.progress.progressLeaderboardSectionTag
 import com.flashcardsopensourceapp.feature.progress.progressStreakSectionTag
 import com.flashcardsopensourceapp.feature.progress.R as ProgressFeatureR
 import com.flashcardsopensourceapp.feature.review.reviewRateAgainButtonTag
@@ -201,7 +201,7 @@ internal class MarketingScreenshotRobot(
         expectedReviewedToday: Boolean
     ) {
         openProgressTab()
-        waitForLoadedProgressWithReviewActivity()
+        waitForLoadedProgressWithLeaderboard()
         waitForProgressStreakSummary(
             expectedProgressStreakDays = expectedProgressStreakDays,
             expectedReviewedToday = expectedReviewedToday
@@ -315,11 +315,11 @@ internal class MarketingScreenshotRobot(
         }
     }
 
-    private fun waitForLoadedProgressWithReviewActivity() {
+    private fun waitForLoadedProgressWithLeaderboard() {
         waitUntilWithSystemDialogMitigation(timeoutMillis = progressScreenshotUiTimeoutMillis) {
             composeRule.onAllNodesWithTag(progressStreakSectionTag).fetchSemanticsNodes().isNotEmpty() &&
-                composeRule.onAllNodesWithTag(progressReviewsSectionTag).fetchSemanticsNodes().isNotEmpty() &&
-                composeRule.onAllNodesWithTag(progressReviewsActivityChartTag).fetchSemanticsNodes().isNotEmpty()
+                composeRule.onAllNodesWithTag(progressLeaderboardSectionTag).fetchSemanticsNodes().isNotEmpty() &&
+                composeRule.onAllNodesWithTag(progressLeaderboardResolvedContentTag).fetchSemanticsNodes().isNotEmpty()
         }
     }
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressLeaderboardSection.kt
@@ -108,42 +108,52 @@ internal fun LeaderboardSectionCard(
                 }
 
                 ProgressLeaderboardSectionUiState.SignInRequired -> {
-                    LeaderboardPlaceholder(
-                        message = stringResource(id = R.string.progress_leaderboard_sign_in_message),
-                        buttonLabel = stringResource(id = R.string.progress_leaderboard_sign_in_button),
-                        onButtonClick = onOpenSignIn
-                    )
+                    LeaderboardResolvedContent {
+                        LeaderboardPlaceholder(
+                            message = stringResource(id = R.string.progress_leaderboard_sign_in_message),
+                            buttonLabel = stringResource(id = R.string.progress_leaderboard_sign_in_button),
+                            onButtonClick = onOpenSignIn
+                        )
+                    }
                 }
 
                 ProgressLeaderboardSectionUiState.ParticipationDisabled -> {
-                    LeaderboardPlaceholder(
-                        message = stringResource(id = R.string.progress_leaderboard_participation_disabled_message),
-                        buttonLabel = stringResource(id = R.string.progress_leaderboard_participation_disabled_button),
-                        onButtonClick = onOpenLeaderboardSettings
-                    )
+                    LeaderboardResolvedContent {
+                        LeaderboardPlaceholder(
+                            message = stringResource(id = R.string.progress_leaderboard_participation_disabled_message),
+                            buttonLabel = stringResource(id = R.string.progress_leaderboard_participation_disabled_button),
+                            onButtonClick = onOpenLeaderboardSettings
+                        )
+                    }
                 }
 
                 ProgressLeaderboardSectionUiState.Offline -> {
-                    LeaderboardPlaceholder(
-                        message = stringResource(id = R.string.progress_leaderboard_offline_message),
-                        buttonLabel = null,
-                        onButtonClick = null
-                    )
+                    LeaderboardResolvedContent {
+                        LeaderboardPlaceholder(
+                            message = stringResource(id = R.string.progress_leaderboard_offline_message),
+                            buttonLabel = null,
+                            onButtonClick = null
+                        )
+                    }
                 }
 
                 ProgressLeaderboardSectionUiState.SnapshotUnavailable -> {
-                    LeaderboardPlaceholder(
-                        message = stringResource(id = R.string.progress_leaderboard_unavailable_message),
-                        buttonLabel = null,
-                        onButtonClick = null
-                    )
+                    LeaderboardResolvedContent {
+                        LeaderboardPlaceholder(
+                            message = stringResource(id = R.string.progress_leaderboard_unavailable_message),
+                            buttonLabel = null,
+                            onButtonClick = null
+                        )
+                    }
                 }
 
                 is ProgressLeaderboardSectionUiState.Ready -> {
-                    LeaderboardReadyContent(
-                        uiState = uiState,
-                        onSelectWindow = onSelectWindow
-                    )
+                    LeaderboardResolvedContent {
+                        LeaderboardReadyContent(
+                            uiState = uiState,
+                            onSelectWindow = onSelectWindow
+                        )
+                    }
                 }
             }
         }
@@ -167,6 +177,20 @@ internal fun LeaderboardSectionCard(
                 Text(infoBody)
             }
         )
+    }
+}
+
+@Composable
+private fun LeaderboardResolvedContent(
+    content: @Composable () -> Unit
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(progressLeaderboardResolvedContentTag)
+    ) {
+        content()
     }
 }
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -131,6 +131,14 @@ fun ProgressRoute(
                         )
                     }
                     item {
+                        LeaderboardSectionCard(
+                            uiState = uiState.leaderboardSection,
+                            onSelectWindow = onSelectLeaderboardWindow,
+                            onOpenSignIn = onOpenSignIn,
+                            onOpenLeaderboardSettings = onOpenLeaderboardSettings
+                        )
+                    }
+                    item {
                         ReviewsSectionCard(
                             uiState = uiState.reviewsSection
                         )
@@ -142,14 +150,6 @@ fun ProgressRoute(
                                 uiState = reviewScheduleSection
                             )
                         }
-                    }
-                    item {
-                        LeaderboardSectionCard(
-                            uiState = uiState.leaderboardSection,
-                            onSelectWindow = onSelectLeaderboardWindow,
-                            onOpenSignIn = onOpenSignIn,
-                            onOpenLeaderboardSettings = onOpenLeaderboardSettings
-                        )
                     }
                 }
             }

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressSectionDefaults.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressSectionDefaults.kt
@@ -11,5 +11,6 @@ const val progressReviewsActivityChartTag: String = "progress_reviews_activity_c
 const val progressReviewScheduleSectionTag: String = "progress_review_schedule_section"
 const val progressReviewScheduleDonutChartTag: String = "progress_review_schedule_donut_chart"
 const val progressLeaderboardSectionTag: String = "progress_leaderboard_section"
+const val progressLeaderboardResolvedContentTag: String = "progress_leaderboard_resolved_content"
 const val progressLeaderboardPeriodSelectorTag: String = "progress_leaderboard_period_selector"
 const val progressLeaderboardInfoButtonTag: String = "progress_leaderboard_info_button"

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -63,6 +63,18 @@ struct ProgressScreen: View {
                         .accessibilityValue(progressSummaryUITestValue(summary: progressSnapshot.summary))
                         .modifier(ProgressCardModifier())
 
+                        if let leaderboardSnapshot = self.store.progressLeaderboardSnapshot {
+                            VStack(alignment: .leading, spacing: 0) {
+                                ProgressLeaderboardSection(
+                                    snapshot: leaderboardSnapshot,
+                                    isRefreshing: self.store.isProgressRefreshing
+                                )
+                            }
+                            .id(ProgressScreenSectionID.leaderboard)
+                            .accessibilityIdentifier(UITestIdentifier.progressLeaderboardSection)
+                            .modifier(ProgressCardModifier())
+                        }
+
                         VStack(alignment: .leading, spacing: 0) {
                             ProgressReviewsSection(
                                 chartDays: progressSnapshot.chartData.chartDays,
@@ -78,18 +90,6 @@ struct ProgressScreen: View {
                                 ProgressReviewScheduleSection(snapshot: reviewScheduleSnapshot)
                             }
                             .accessibilityIdentifier(UITestIdentifier.progressReviewScheduleSection)
-                            .modifier(ProgressCardModifier())
-                        }
-
-                        if let leaderboardSnapshot = self.store.progressLeaderboardSnapshot {
-                            VStack(alignment: .leading, spacing: 0) {
-                                ProgressLeaderboardSection(
-                                    snapshot: leaderboardSnapshot,
-                                    isRefreshing: self.store.isProgressRefreshing
-                                )
-                            }
-                            .id(ProgressScreenSectionID.leaderboard)
-                            .accessibilityIdentifier(UITestIdentifier.progressLeaderboardSection)
                             .modifier(ProgressCardModifier())
                         }
                     } else if self.store.isProgressRefreshing == false {

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -21,6 +21,7 @@ enum LiveSmokeIdentifier {
     static let progressScreen: String = "progress.screen"
     static let progressStreakSection: String = "progress.streakSection"
     static let progressReviewsSection: String = "progress.reviewsSection"
+    static let progressLeaderboardSection: String = "progress.leaderboardSection"
     static let cardsScreen: String = "cards.screen"
     static let settingsScreen: String = "settings.screen"
     static let settingsAccountStatusRow: String = "settings.accountStatusRow"

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
@@ -263,7 +263,7 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
             timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
         )
         try self.assertElementExists(
-            identifier: LiveSmokeIdentifier.progressReviewsSection,
+            identifier: LiveSmokeIdentifier.progressLeaderboardSection,
             timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
         )
         let progressStreakSection = self.app.descendants(matching: .any)

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -901,6 +901,17 @@ export function ProgressScreen(): ReactElement {
               </div>
             </section>
 
+            <ProgressLeaderboardSection
+              sectionId={progressLeaderboardHash}
+              sectionRef={leaderboardSectionRef}
+              sourceState={progressSourceState.leaderboard}
+              canRenderServerBase={canRenderLeaderboardServerBase}
+              selectedWindowKey={selectedLeaderboardWindowKey}
+              onSelectWindowKey={setSelectedLeaderboardWindowKey}
+              isInfoVisible={isLeaderboardInfoVisible}
+              onToggleInfo={() => setIsLeaderboardInfoVisible((previous) => previous === false)}
+            />
+
             <section className="content-card progress-section">
               <div className="progress-section-head">
                 <div className="progress-chart-heading">
@@ -1107,17 +1118,6 @@ export function ProgressScreen(): ReactElement {
                 </div>
               </section>
             ) : null}
-
-            <ProgressLeaderboardSection
-              sectionId={progressLeaderboardHash}
-              sectionRef={leaderboardSectionRef}
-              sourceState={progressSourceState.leaderboard}
-              canRenderServerBase={canRenderLeaderboardServerBase}
-              selectedWindowKey={selectedLeaderboardWindowKey}
-              onSelectWindowKey={setSelectedLeaderboardWindowKey}
-              isInfoVisible={isLeaderboardInfoVisible}
-              onToggleInfo={() => setIsLeaderboardInfoVisible((previous) => previous === false)}
-            />
           </div>
         ) : null}
       </section>


### PR DESCRIPTION
## Summary
- move the Progress leaderboard/rating section directly after the streak section on web, iOS, and Android
- keep remaining Progress sections below it in their existing relative order
- update mobile screenshot waits for the new visible leaderboard position

## Validation
- git --no-pager diff --check
- apps/web: vitest run src/screens/progress/ProgressScreen.render.test.tsx

Android Gradle and iOS simulator-backed checks were not run because repo instructions require explicit permission.