### PR TITLE
[codex] Fix Android cloud retry return type

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemoteHttpClient.kt
@@ -274,8 +274,9 @@ internal class CloudJsonHttpClient(
             body = body
         )
         var attemptNumber = 1
+        var completedResponse: JSONObject? = null
 
-        while (true) {
+        while (completedResponse == null) {
             val call = httpClient.newCall(request)
             val coroutineJob = currentCoroutineContext().job
             val cancellationRequested = AtomicBoolean(false)
@@ -403,20 +404,21 @@ internal class CloudJsonHttpClient(
                 cancellationHandle.dispose()
             }
 
-            val completedResponse = successfulResponse
-            if (completedResponse != null) {
-                return@withContext completedResponse
-            }
+            val attemptResponse = successfulResponse
+            completedResponse = attemptResponse
 
-            val delayMs = retryDelayMs
-            if (delayMs != null) {
-                delay(delayMs)
-                attemptNumber += 1
-                continue
-            }
+            if (attemptResponse == null) {
+                val delayMs = retryDelayMs
+                if (delayMs != null) {
+                    delay(delayMs)
+                    attemptNumber += 1
+                    continue
+                }
 
-            throw IllegalStateException("Cloud request attempt finished without a response or retry decision.")
+                throw IllegalStateException("Cloud request attempt finished without a response or retry decision.")
+            }
         }
+        completedResponse ?: throw IllegalStateException("Cloud request retry loop exited without a response.")
     }
 
     private fun buildCloudRequest(


### PR DESCRIPTION
## Summary

Fixes the Android cloud JSON HTTP retry loop so the `withContext` lambda resolves to a `JSONObject` after a successful response instead of ending on a `while` expression with Kotlin `Unit` type.

## Root cause

Android Release was failing in `:data:local:compileDebugKotlin` with:

`CloudRemoteHttpClient.kt:278:9 Return type mismatch: expected 'JSONObject', actual 'Unit'.`

The transient retry change made `while (true)` the final expression of `executeJsonRequest`'s `withContext` body. Kotlin `while` expressions have type `Unit`, even when the loop body uses `return@withContext`.

## Validation

- Inspected failing Android Release GitHub Actions logs for runs `27372776170`, `27371980281`, `27362346637`, and `27361720237`.
- Ran `git --no-pager diff --check`.
- Did not run local `./gradlew`; repository instructions require explicit approval for local Gradle runs.