### PR TITLE
[codex] Fix leaderboard reserved gap layout

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressLeaderboardSection.kt
@@ -266,8 +266,12 @@ private fun LeaderboardReadyContent(
                 }
             }
 
-            repeat(leaderboardReservedRowPlaceholderCount(rowCount = selectedWindow.rows.size)) {
-                LeaderboardReservedRow()
+            val reservedRows = leaderboardReservedRows(rows = selectedWindow.rows)
+            repeat(reservedRows.gapRowCount) {
+                LeaderboardReservedGapRow()
+            }
+            repeat(reservedRows.participantRowCount) {
+                LeaderboardReservedParticipantRow()
             }
         }
 
@@ -285,8 +289,26 @@ private fun LeaderboardReadyContent(
     }
 }
 
-private fun leaderboardReservedRowPlaceholderCount(rowCount: Int): Int {
-    return maxOf(0, leaderboardReservedRowCount - rowCount)
+private data class LeaderboardReservedRows(
+    val participantRowCount: Int,
+    val gapRowCount: Int
+)
+
+private fun leaderboardReservedRows(rows: List<ProgressLeaderboardRowUiState>): LeaderboardReservedRows {
+    val reservedRowCount = maxOf(0, leaderboardReservedRowCount - rows.size)
+    val containsGapRow = rows.any { row ->
+        row == ProgressLeaderboardRowUiState.Gap
+    }
+    val gapRowCount = if (containsGapRow) {
+        0
+    } else {
+        minOf(1, reservedRowCount)
+    }
+
+    return LeaderboardReservedRows(
+        participantRowCount = reservedRowCount - gapRowCount,
+        gapRowCount = gapRowCount
+    )
 }
 
 @Composable
@@ -334,7 +356,7 @@ private fun LeaderboardParticipantRow(
 }
 
 @Composable
-private fun LeaderboardReservedRow() {
+private fun LeaderboardReservedParticipantRow() {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -360,6 +382,20 @@ private fun LeaderboardReservedRow() {
             textAlign = TextAlign.End
         )
     }
+}
+
+@Composable
+private fun LeaderboardReservedGapRow() {
+    Text(
+        text = "⋯",
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = TextAlign.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .alpha(0f)
+            .clearAndSetSemantics {}
+    )
 }
 
 @Composable

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
@@ -114,6 +114,8 @@ struct ProgressLeaderboardSection: View {
         if let selectedWindow = readyState.windows.first(where: { window in
             window.windowKey == selectedKey
         }) {
+            let reservedRows = progressLeaderboardReservedRows(rows: selectedWindow.rows)
+
             VStack(alignment: .leading, spacing: 10) {
                 ForEach(selectedWindow.rows) { row in
                     switch row {
@@ -124,11 +126,12 @@ struct ProgressLeaderboardSection: View {
                     }
                 }
 
-                ForEach(
-                    0..<progressLeaderboardReservedRowPlaceholderCount(rowCount: selectedWindow.rows.count),
-                    id: \.self
-                ) { _ in
-                    ProgressLeaderboardReservedRowView()
+                ForEach(0..<reservedRows.gapRowCount, id: \.self) { _ in
+                    ProgressLeaderboardReservedGapRowView()
+                }
+
+                ForEach(0..<reservedRows.participantRowCount, id: \.self) { _ in
+                    ProgressLeaderboardReservedParticipantRowView()
                 }
             }
 
@@ -294,8 +297,25 @@ struct ProgressLeaderboardSection: View {
     }
 }
 
-private func progressLeaderboardReservedRowPlaceholderCount(rowCount: Int) -> Int {
-    max(0, progressLeaderboardReservedRowCount - rowCount)
+private struct ProgressLeaderboardReservedRows: Hashable {
+    let participantRowCount: Int
+    let gapRowCount: Int
+}
+
+private func progressLeaderboardReservedRows(rows: [ProgressLeaderboardRowState]) -> ProgressLeaderboardReservedRows {
+    let reservedRowCount = max(0, progressLeaderboardReservedRowCount - rows.count)
+    let containsGapRow = rows.contains { row in
+        if case .gap = row {
+            return true
+        }
+        return false
+    }
+    let gapRowCount = containsGapRow ? 0 : min(1, reservedRowCount)
+
+    return ProgressLeaderboardReservedRows(
+        participantRowCount: reservedRowCount - gapRowCount,
+        gapRowCount: gapRowCount
+    )
 }
 
 private struct ProgressLeaderboardParticipantRowView: View {
@@ -355,7 +375,7 @@ private struct ProgressLeaderboardParticipantRowView: View {
     }
 }
 
-private struct ProgressLeaderboardReservedRowView: View {
+private struct ProgressLeaderboardReservedParticipantRowView: View {
     var body: some View {
         HStack(spacing: 10) {
             Text("0")
@@ -373,6 +393,14 @@ private struct ProgressLeaderboardReservedRowView: View {
         }
         .hidden()
         .accessibilityHidden(true)
+    }
+}
+
+private struct ProgressLeaderboardReservedGapRowView: View {
+    var body: some View {
+        ProgressLeaderboardGapRowView()
+            .hidden()
+            .accessibilityHidden(true)
     }
 }
 


### PR DESCRIPTION
## Summary
- reserve missing leaderboard gap rows separately from participant rows on iOS
- apply the same reserved gap layout on Android

## Validation
- reviewed the iOS and Android diffs
- checked the backend compact-row contract and web leaderboard layout behavior
- did not run iOS simulator-backed tests or Android Gradle checks per repository policy without explicit approval