### PR TITLE
[codex] Refactor web progress screen sections

### DIFF
--- a/apps/web/src/screens/progress/ProgressScreen.test.ts
+++ b/apps/web/src/screens/progress/ProgressScreen.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildStreakWeeks } from "./ProgressScreen";
+import { buildStreakWeeks } from "./streak/progressStreakModel";
 
 type DateFormatter = (
   value: Date | number | string,

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactElement, type Ref } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { buildLoginUrl } from "../../api";
+import { useEffect, useRef, useState, type ReactElement } from "react";
+import { useLocation } from "react-router-dom";
 import { useAppData } from "../../appData";
 import {
   buildReviewProgressBadgeStateFromSummarySnapshot,
@@ -8,714 +7,34 @@ import {
 } from "../../appData/progress/badge/reviewProgressBadge";
 import { useProgressInvalidationState } from "../../appData/progress/invalidation/progressInvalidation";
 import { canLoadProgressServerBase, useProgressSource } from "../../appData/progress/progressSource";
-import { resolveLocaleWeekContext, useI18n, type LocaleDirection } from "../../i18n";
-import { parseLocalDate, shiftLocalDate } from "../../progress/progressDates";
-import { progressLeaderboardHash, settingsLeaderboardParticipationRoute } from "../../routes";
+import { resolveLocaleWeekContext, useI18n } from "../../i18n";
+import { progressLeaderboardHash } from "../../routes";
 import type {
   DailyReviewPoint,
-  ProgressLeaderboardSourceState,
-  ProgressLeaderboardWindow,
   ProgressLeaderboardWindowKey,
   ProgressReviewScheduleBucketKey,
-  ProgressReviewScheduleSnapshot,
-  ProgressSeriesSnapshot,
 } from "../../types";
-import { progressLeaderboardWindowKeys } from "../../types";
-import { ReviewProgressBadgeIcon } from "../shared/ReviewProgressBadgeIcon";
+import { ProgressLeaderboardSection } from "./leaderboard/ProgressLeaderboardSection";
+import { ProgressReviewScheduleSection } from "./reviewSchedule/ProgressReviewScheduleSection";
+import {
+  buildReviewScheduleBucketViews,
+  buildReviewScheduleDonutSegments,
+} from "./reviewSchedule/progressReviewScheduleModel";
+import {
+  ProgressReviewsChartSection,
+  type ProgressReviewsChartNavigationState,
+} from "./reviewsChart/ProgressReviewsChartSection";
+import {
+  buildChartGuideLabels,
+  buildChartPages,
+  formatChartRangeLabel,
+  resolveChartNavigationArrow,
+} from "./reviewsChart/progressReviewsChartModel";
+import { ProgressStreakSection, type ProgressStreakSummaryView } from "./streak/ProgressStreakSection";
+import { buildStreakWeeks } from "./streak/progressStreakModel";
 
-const streakWeekCount = 5;
-const streakWeekLength = 7;
-const chartGuideLineCount = 3;
-const millisecondsPerMinute = 60_000;
-
-type LocaleValue = ReturnType<typeof useI18n>["locale"];
-type DateFormatter = ReturnType<typeof useI18n>["formatDate"];
-type NumberFormatter = ReturnType<typeof useI18n>["formatNumber"];
-type Translate = ReturnType<typeof useI18n>["t"];
-type WeekContext = ReturnType<typeof resolveLocaleWeekContext>;
-type DailyReview = ProgressSeriesSnapshot["dailyReviews"][number];
-type ChartNavigationDirection = "previous" | "next";
-type StreakDay = Readonly<{
-  date: string;
-  reviewCount: number;
-  isFuture: boolean;
-  isToday: boolean;
-  weekdayLabel: string;
-  dayLabel: string;
-  title: string;
-}>;
-type ChartDay = Readonly<{
-  date: string;
-  reviewCount: number;
-  isToday: boolean;
-  weekdayLabel: string;
-  dayLabel: string;
-  monthLabel: string;
-  showMonthLabel: boolean;
-  barHeightPercentage: number;
-  title: string;
-}>;
-type ChartPage = Readonly<{
-  days: ReadonlyArray<ChartDay>;
-  startDate: string;
-  endDate: string;
-  startLocalDate: string;
-  upperBound: number;
-}>;
-type ReviewScheduleBucketView = Readonly<{
-  key: ProgressReviewScheduleBucketKey;
-  label: string;
-  count: number;
-  percentageLabel: string;
-  color: string;
-}>;
-type ReviewScheduleDonutSegment = Readonly<{
-  key: ProgressReviewScheduleBucketKey;
-  color: string;
-  pathD: string;
-}>;
-
-// Canonical palette — see docs/progress-pie-palette.md.
-// Keep the hex values in sync with the iOS and Android clients.
-const reviewScheduleBucketColors: Readonly<Record<ProgressReviewScheduleBucketKey, string>> = {
-  new: "#F4C430",
-  today: "#D7263D",
-  days1To7: "#1FB5C1",
-  days8To30: "#8E5BD9",
-  days31To90: "#2BB673",
-  days91To360: "#E69F00",
-  years1To2: "#3F7CC8",
-  later: "#7A8088",
-};
-
-const reviewScheduleDonutOuterRadius = 100;
-const reviewScheduleDonutInnerRadius = 62;
-
-const futureStreakDayStyle: Readonly<CSSProperties> = {
-  borderStyle: "dashed",
-  background: "transparent",
-  opacity: 0.64,
-};
-
-const futureStreakMarkerStyle: Readonly<CSSProperties> = {
-  background: "transparent",
-  boxShadow: "inset 0 0 0 1px rgba(255, 255, 255, 0.12)",
-  color: "var(--text-tertiary)",
-};
-
-function formatLocalDateForDisplay(value: string, formatDate: DateFormatter): string {
-  return formatDate(parseLocalDate(value), {
-    timeZone: "UTC",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-function formatWeekdayLabel(value: string, formatDate: DateFormatter): string {
-  return formatDate(parseLocalDate(value), {
-    timeZone: "UTC",
-    weekday: "narrow",
-  });
-}
-
-function formatDayLabel(value: string, formatDate: DateFormatter): string {
-  return formatDate(parseLocalDate(value), {
-    timeZone: "UTC",
-    day: "numeric",
-  });
-}
-
-function formatMonthLabel(value: string, formatDate: DateFormatter): string {
-  return formatDate(parseLocalDate(value), {
-    timeZone: "UTC",
-    month: "short",
-  });
-}
-
-function sortDailyReviews(dailyReviews: ProgressSeriesSnapshot["dailyReviews"]): ReadonlyArray<DailyReview> {
+function sortDailyReviews(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyArray<DailyReviewPoint> {
   return [...dailyReviews].sort((leftDay, rightDay) => leftDay.date.localeCompare(rightDay.date));
-}
-
-function createDailyReviewCountMap(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyMap<string, number> {
-  const reviewCounts = new Map<string, number>();
-
-  for (const day of dailyReviews) {
-    reviewCounts.set(day.date, day.reviewCount);
-  }
-
-  return reviewCounts;
-}
-
-function getDayOfWeek(value: string): number {
-  return parseLocalDate(value).getUTCDay();
-}
-
-function getStartOfWeek(value: string, weekContext: WeekContext): string {
-  const dayOfWeek = getDayOfWeek(value);
-  const offsetFromWeekStart = (dayOfWeek - weekContext.firstDayOfWeek + streakWeekLength) % streakWeekLength;
-
-  return shiftLocalDate(value, -offsetFromWeekStart);
-}
-
-export function buildStreakWeeks(
-  dailyReviews: ReadonlyArray<DailyReview>,
-  today: string,
-  formatDate: DateFormatter,
-  weekContext: WeekContext,
-): ReadonlyArray<ReadonlyArray<StreakDay>> {
-  const currentWeekStart = getStartOfWeek(today, weekContext);
-  const streakWindowStart = shiftLocalDate(currentWeekStart, -((streakWeekCount - 1) * streakWeekLength));
-  const reviewCounts = createDailyReviewCountMap(dailyReviews);
-  const streakWeeks: Array<ReadonlyArray<StreakDay>> = [];
-
-  for (let weekIndex = 0; weekIndex < streakWeekCount; weekIndex += 1) {
-    const weekStart = shiftLocalDate(streakWindowStart, weekIndex * streakWeekLength);
-    const weekDays: Array<StreakDay> = [];
-
-    for (let dayOffset = 0; dayOffset < streakWeekLength; dayOffset += 1) {
-      const date = shiftLocalDate(weekStart, dayOffset);
-      weekDays.push({
-        date,
-        reviewCount: reviewCounts.get(date) ?? 0,
-        isFuture: date > today,
-        isToday: date === today,
-        weekdayLabel: formatWeekdayLabel(date, formatDate),
-        dayLabel: formatDayLabel(date, formatDate),
-        title: formatLocalDateForDisplay(date, formatDate),
-      });
-    }
-
-    streakWeeks.push(weekDays);
-  }
-
-  return streakWeeks;
-}
-
-function calculateMaxReviewCount(dailyReviews: ReadonlyArray<DailyReview>): number {
-  return dailyReviews.reduce((maxReviewCount, day) => Math.max(maxReviewCount, day.reviewCount), 0);
-}
-
-function calculateChartUpperBound(maxReviewCount: number): number {
-  if (maxReviewCount <= 0) {
-    return 1;
-  }
-
-  return Math.max(1, Math.ceil(maxReviewCount * 1.1));
-}
-
-function calculateBarHeightPercentage(reviewCount: number, upperBound: number): number {
-  if (reviewCount === 0 || upperBound === 0) {
-    return 0;
-  }
-
-  return (reviewCount / upperBound) * 100;
-}
-
-function buildChartPage(
-  dailyReviews: ReadonlyArray<DailyReview>,
-  today: string,
-  formatDate: DateFormatter,
-): ChartPage {
-  const upperBound = calculateChartUpperBound(calculateMaxReviewCount(dailyReviews));
-
-  return {
-    days: dailyReviews.map((day, dayIndex): ChartDay => ({
-      date: day.date,
-      reviewCount: day.reviewCount,
-      isToday: day.date === today,
-      weekdayLabel: formatWeekdayLabel(day.date, formatDate),
-      dayLabel: formatDayLabel(day.date, formatDate),
-      monthLabel: formatMonthLabel(day.date, formatDate),
-      showMonthLabel: dayIndex === 0 || dailyReviews[dayIndex - 1]?.date.slice(0, 7) !== day.date.slice(0, 7),
-      barHeightPercentage: calculateBarHeightPercentage(day.reviewCount, upperBound),
-      title: formatLocalDateForDisplay(day.date, formatDate),
-    })),
-    startDate: dailyReviews[0]?.date ?? "",
-    endDate: dailyReviews[dailyReviews.length - 1]?.date ?? "",
-    startLocalDate: dailyReviews[0]?.date ?? "",
-    upperBound,
-  };
-}
-
-function padPageDaysToFullWeek(
-  pageDays: ReadonlyArray<DailyReview>,
-  weekStart: string,
-): ReadonlyArray<DailyReview> {
-  const reviewCounts = createDailyReviewCountMap(pageDays);
-  const fullWeek: Array<DailyReview> = [];
-
-  for (let dayOffset = 0; dayOffset < streakWeekLength; dayOffset += 1) {
-    const date = shiftLocalDate(weekStart, dayOffset);
-    fullWeek.push({
-      date,
-      reviewCount: reviewCounts.get(date) ?? 0,
-    });
-  }
-
-  return fullWeek;
-}
-
-function buildChartPages(
-  dailyReviews: ReadonlyArray<DailyReview>,
-  today: string,
-  formatDate: DateFormatter,
-  weekContext: WeekContext,
-): ReadonlyArray<ChartPage> {
-  if (dailyReviews.length === 0) {
-    return [];
-  }
-
-  const chartPages: Array<ChartPage> = [];
-  let currentPageDays: Array<DailyReview> = [];
-  let currentWeekStart: string | null = null;
-
-  for (const day of dailyReviews) {
-    const weekStart = getStartOfWeek(day.date, weekContext);
-
-    if (currentWeekStart !== null && currentWeekStart !== weekStart) {
-      chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
-      currentPageDays = [day];
-      currentWeekStart = weekStart;
-      continue;
-    }
-
-    currentPageDays.push(day);
-    currentWeekStart = weekStart;
-  }
-
-  if (currentPageDays.length > 0 && currentWeekStart !== null) {
-    chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
-  }
-
-  return chartPages;
-}
-
-function buildChartGuideLabels(upperBound: number, formatNumber: NumberFormatter): ReadonlyArray<string> {
-  const labels: string[] = [];
-
-  for (let index = 0; index < chartGuideLineCount; index += 1) {
-    if (index === 0) {
-      labels.push(formatNumber(upperBound));
-      continue;
-    }
-
-    if (index === chartGuideLineCount - 1) {
-      labels.push(formatNumber(0));
-      continue;
-    }
-
-    labels.push("");
-  }
-
-  return labels;
-}
-
-function formatChartRangeLabel(startDate: string, endDate: string, locale: LocaleValue): string {
-  return new Intl.DateTimeFormat(locale, {
-    timeZone: "UTC",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  }).formatRange(parseLocalDate(startDate), parseLocalDate(endDate));
-}
-
-function resolveChartNavigationArrow(
-  localeDirection: LocaleDirection,
-  navigationDirection: ChartNavigationDirection,
-): string {
-  if (navigationDirection === "previous") {
-    return localeDirection === "rtl" ? ">" : "<";
-  }
-
-  return localeDirection === "rtl" ? "<" : ">";
-}
-
-function getReviewScheduleBucketLabel(bucketKey: ProgressReviewScheduleBucketKey, t: Translate): string {
-  if (bucketKey === "new") {
-    return t("progressScreen.reviewSchedule.buckets.new");
-  }
-
-  if (bucketKey === "today") {
-    return t("progressScreen.reviewSchedule.buckets.today");
-  }
-
-  if (bucketKey === "days1To7") {
-    return t("progressScreen.reviewSchedule.buckets.days1To7");
-  }
-
-  if (bucketKey === "days8To30") {
-    return t("progressScreen.reviewSchedule.buckets.days8To30");
-  }
-
-  if (bucketKey === "days31To90") {
-    return t("progressScreen.reviewSchedule.buckets.days31To90");
-  }
-
-  if (bucketKey === "days91To360") {
-    return t("progressScreen.reviewSchedule.buckets.days91To360");
-  }
-
-  if (bucketKey === "years1To2") {
-    return t("progressScreen.reviewSchedule.buckets.years1To2");
-  }
-
-  return t("progressScreen.reviewSchedule.buckets.later");
-}
-
-function formatReviewSchedulePercentage(count: number, totalCards: number, formatNumber: NumberFormatter): string {
-  if (totalCards <= 0 || count <= 0) {
-    return formatNumber(0, {
-      style: "percent",
-      maximumFractionDigits: 0,
-    });
-  }
-
-  return formatNumber(count / totalCards, {
-    style: "percent",
-    maximumFractionDigits: 1,
-  });
-}
-
-function buildReviewScheduleBucketViews(
-  reviewSchedule: ProgressReviewScheduleSnapshot,
-  t: Translate,
-  formatNumber: NumberFormatter,
-): ReadonlyArray<ReviewScheduleBucketView> {
-  return reviewSchedule.buckets.map((bucket): ReviewScheduleBucketView => ({
-    key: bucket.key,
-    label: getReviewScheduleBucketLabel(bucket.key, t),
-    count: bucket.count,
-    percentageLabel: formatReviewSchedulePercentage(bucket.count, reviewSchedule.totalCards, formatNumber),
-    color: reviewScheduleBucketColors[bucket.key],
-  }));
-}
-
-function polarToCartesian(angleDegrees: number, radius: number): { x: number; y: number } {
-  const angleRadians = ((angleDegrees - 90) * Math.PI) / 180;
-  return {
-    x: radius * Math.cos(angleRadians),
-    y: radius * Math.sin(angleRadians),
-  };
-}
-
-function buildAnnulusSegmentPath(startAngle: number, endAngle: number): string {
-  const sweep = endAngle - startAngle;
-  // Use `>=` (not `===`) to absorb floating-point drift in `(count / total) * 360`.
-  if (sweep >= 360) {
-    // Single full ring: split into two semicircle annulus arcs so the path is non-degenerate.
-    const half = startAngle + 180;
-    return [
-      buildAnnulusSegmentPath(startAngle, half),
-      buildAnnulusSegmentPath(half, startAngle + 360),
-    ].join(" ");
-  }
-  const outerStart = polarToCartesian(startAngle, reviewScheduleDonutOuterRadius);
-  const outerEnd = polarToCartesian(endAngle, reviewScheduleDonutOuterRadius);
-  const innerStart = polarToCartesian(endAngle, reviewScheduleDonutInnerRadius);
-  const innerEnd = polarToCartesian(startAngle, reviewScheduleDonutInnerRadius);
-  const largeArcFlag = sweep > 180 ? 1 : 0;
-  return [
-    `M ${outerStart.x} ${outerStart.y}`,
-    `A ${reviewScheduleDonutOuterRadius} ${reviewScheduleDonutOuterRadius} 0 ${largeArcFlag} 1 ${outerEnd.x} ${outerEnd.y}`,
-    `L ${innerStart.x} ${innerStart.y}`,
-    `A ${reviewScheduleDonutInnerRadius} ${reviewScheduleDonutInnerRadius} 0 ${largeArcFlag} 0 ${innerEnd.x} ${innerEnd.y}`,
-    "Z",
-  ].join(" ");
-}
-
-function buildReviewScheduleDonutSegments(
-  bucketViews: ReadonlyArray<ReviewScheduleBucketView>,
-): ReadonlyArray<ReviewScheduleDonutSegment> {
-  const totalCount = bucketViews.reduce((totalCards, bucket) => totalCards + bucket.count, 0);
-  if (totalCount <= 0) {
-    return [];
-  }
-  const nonEmpty = bucketViews.filter((bucket) => bucket.count > 0);
-  let currentAngle = 0;
-  return nonEmpty.map((bucket): ReviewScheduleDonutSegment => {
-    const startAngle = currentAngle;
-    const endAngle = currentAngle + (bucket.count / totalCount) * 360;
-    currentAngle = endAngle;
-    return {
-      key: bucket.key,
-      color: bucket.color,
-      pathD: buildAnnulusSegmentPath(startAngle, endAngle),
-    };
-  });
-}
-
-function getLeaderboardPeriodLabel(windowKey: ProgressLeaderboardWindowKey, t: Translate): string {
-  if (windowKey === "last_24_hours") {
-    return t("progressScreen.leaderboard.periods.last24Hours");
-  }
-
-  if (windowKey === "last_3_days") {
-    return t("progressScreen.leaderboard.periods.last3Days");
-  }
-
-  if (windowKey === "last_7_days") {
-    return t("progressScreen.leaderboard.periods.last7Days");
-  }
-
-  if (windowKey === "last_30_days") {
-    return t("progressScreen.leaderboard.periods.last30Days");
-  }
-
-  return t("progressScreen.leaderboard.periods.allTime");
-}
-
-function getLeaderboardElapsedMinutes(snapshotGeneratedAt: string, now: Date): number {
-  const snapshotTime = new Date(snapshotGeneratedAt).getTime();
-  if (Number.isNaN(snapshotTime)) {
-    throw new Error(`Invalid leaderboard snapshot timestamp: ${snapshotGeneratedAt}`);
-  }
-
-  return Math.floor(Math.max(0, now.getTime() - snapshotTime) / millisecondsPerMinute);
-}
-
-function resolveLeaderboardWindow(
-  sourceState: ProgressLeaderboardSourceState,
-  selectedWindowKey: ProgressLeaderboardWindowKey | null,
-): ProgressLeaderboardWindow | null {
-  const leaderboard = sourceState.renderedSnapshot;
-  if (leaderboard === null || leaderboard.status !== "ready") {
-    return null;
-  }
-
-  const resolvedWindowKey = selectedWindowKey ?? leaderboard.defaultWindowKey;
-
-  return leaderboard.windows.find((window) => window.windowKey === resolvedWindowKey) ?? null;
-}
-
-type ProgressLeaderboardBodyProps = Readonly<{
-  sourceState: ProgressLeaderboardSourceState;
-  canRenderServerBase: boolean;
-  selectedWindowKey: ProgressLeaderboardWindowKey | null;
-  onSelectWindowKey: (windowKey: ProgressLeaderboardWindowKey) => void;
-}>;
-
-type ProgressLeaderboardSectionProps = ProgressLeaderboardBodyProps & Readonly<{
-  sectionId: string;
-  sectionRef: Ref<HTMLElement>;
-  isInfoVisible: boolean;
-  onToggleInfo: () => void;
-}>;
-
-function ProgressLeaderboardSignInPlaceholder(): ReactElement {
-  const { locale, t } = useI18n();
-
-  return (
-    <div className="progress-leaderboard-placeholder" data-testid="progress-leaderboard-guest">
-      <p className="subtitle">{t("progressScreen.leaderboard.guestBody")}</p>
-      <a className="primary-btn" href={buildLoginUrl(window.location.origin, locale)}>
-        {t("progressScreen.leaderboard.signIn")}
-      </a>
-    </div>
-  );
-}
-
-function ProgressLeaderboardRows(props: Readonly<{
-  window: ProgressLeaderboardWindow;
-}>): ReactElement {
-  const { t, formatNumber } = useI18n();
-  const { window: leaderboardWindow } = props;
-
-  return (
-    <ol className="progress-leaderboard-list">
-      {leaderboardWindow.rows.map((row, rowIndex) => {
-        if (row.kind === "gap") {
-          return (
-            <li
-              key={`leaderboard-gap-${rowIndex}`}
-              className="progress-leaderboard-row progress-leaderboard-gap"
-              data-kind="gap"
-              data-testid="progress-leaderboard-row-gap"
-              aria-hidden="true"
-            >
-              <span className="progress-leaderboard-gap-dots">…</span>
-            </li>
-          );
-        }
-
-        const rowClassName = row.kind === "viewer"
-          ? "progress-leaderboard-row progress-leaderboard-row-viewer"
-          : "progress-leaderboard-row";
-
-        return (
-          <li
-            key={`${row.publicProfileId}-${row.rank}`}
-            className={rowClassName}
-            data-kind={row.kind}
-            data-testid={`progress-leaderboard-row-${row.kind}`}
-          >
-            <span className="progress-leaderboard-rank">
-              {t("progressScreen.leaderboard.rankLabel", { rank: formatNumber(row.rank) })}
-            </span>
-            <span className="progress-leaderboard-name">
-              {row.kind === "viewer" ? t("progressScreen.leaderboard.you") : row.anonymousDisplayName}
-            </span>
-            <span className="progress-leaderboard-count" data-testid={`progress-leaderboard-count-${row.kind}`}>
-              {formatNumber(row.qualifiedReviewCount)}
-            </span>
-          </li>
-        );
-      })}
-    </ol>
-  );
-}
-
-function ProgressLeaderboardBody(props: ProgressLeaderboardBodyProps): ReactElement {
-  const { t } = useI18n();
-  const { sourceState, canRenderServerBase, selectedWindowKey, onSelectWindowKey } = props;
-  const leaderboard = sourceState.renderedSnapshot;
-
-  if (canRenderServerBase === false) {
-    return <ProgressLeaderboardSignInPlaceholder />;
-  }
-
-  if (leaderboard === null) {
-    if (sourceState.errorMessage !== "" && sourceState.isLoading === false) {
-      if (sourceState.isNetworkError) {
-        return (
-          <p className="subtitle" data-testid="progress-leaderboard-offline-empty">
-            {t("progressScreen.leaderboard.offlineEmpty")}
-          </p>
-        );
-      }
-
-      return (
-        <p className="subtitle" data-testid="progress-leaderboard-unavailable">
-          {t("progressScreen.leaderboard.unavailable")}
-        </p>
-      );
-    }
-
-    return (
-      <p className="subtitle" data-testid="progress-leaderboard-loading">
-        {t("progressScreen.leaderboard.loading")}
-      </p>
-    );
-  }
-
-  if (leaderboard.status === "linked_account_required") {
-    return <ProgressLeaderboardSignInPlaceholder />;
-  }
-
-  if (leaderboard.status === "participation_disabled") {
-    return (
-      <div className="progress-leaderboard-placeholder" data-testid="progress-leaderboard-participation-disabled">
-        <p className="subtitle">{t("progressScreen.leaderboard.participationDisabledBody")}</p>
-        <Link className="ghost-btn" to={settingsLeaderboardParticipationRoute}>
-          {t("progressScreen.leaderboard.openParticipationSettings")}
-        </Link>
-      </div>
-    );
-  }
-
-  if (leaderboard.status === "snapshot_unavailable") {
-    return (
-      <p className="subtitle" data-testid="progress-leaderboard-unavailable">
-        {t("progressScreen.leaderboard.unavailable")}
-      </p>
-    );
-  }
-
-  const resolvedWindowKey = selectedWindowKey ?? leaderboard.defaultWindowKey;
-  const leaderboardWindow = resolveLeaderboardWindow(sourceState, selectedWindowKey);
-
-  return (
-    <>
-      <div className="progress-leaderboard-periods" role="group" aria-label={t("progressScreen.leaderboard.periodsLabel")}>
-        {progressLeaderboardWindowKeys.map((windowKey) => (
-          <button
-            key={windowKey}
-            type="button"
-            className={windowKey === resolvedWindowKey
-              ? "progress-leaderboard-period-btn is-selected"
-              : "progress-leaderboard-period-btn"}
-            aria-pressed={windowKey === resolvedWindowKey}
-            onClick={() => onSelectWindowKey(windowKey)}
-            data-testid={`progress-leaderboard-period-${windowKey}`}
-          >
-            {getLeaderboardPeriodLabel(windowKey, t)}
-          </button>
-        ))}
-      </div>
-      {leaderboardWindow === null ? (
-        <p className="subtitle" data-testid="progress-leaderboard-unavailable">
-          {t("progressScreen.leaderboard.unavailable")}
-        </p>
-      ) : (
-        <ProgressLeaderboardRows window={leaderboardWindow} />
-      )}
-    </>
-  );
-}
-
-function ProgressLeaderboardSection(props: ProgressLeaderboardSectionProps): ReactElement {
-  const { t, formatNumber } = useI18n();
-  const {
-    sourceState,
-    canRenderServerBase,
-    selectedWindowKey,
-    onSelectWindowKey,
-    sectionId,
-    sectionRef,
-    isInfoVisible,
-    onToggleInfo,
-  } = props;
-  const leaderboardWindow = resolveLeaderboardWindow(sourceState, selectedWindowKey);
-  const infoUpdatedAt = leaderboardWindow === null
-    ? null
-    : t("progressScreen.leaderboard.updatedAt", {
-      minutes: formatNumber(getLeaderboardElapsedMinutes(leaderboardWindow.snapshotGeneratedAt, new Date())),
-    });
-
-  return (
-    <section
-      id={sectionId}
-      ref={sectionRef}
-      className="content-card progress-section progress-leaderboard-card"
-      data-testid="progress-leaderboard-card"
-    >
-      <div className="progress-section-head">
-        <div className="progress-chart-heading">
-          <h2 className="progress-section-title">{t("progressScreen.leaderboard.title")}</h2>
-        </div>
-        <button
-          type="button"
-          className="ghost-btn progress-leaderboard-info-btn"
-          aria-expanded={isInfoVisible}
-          aria-label={t("progressScreen.leaderboard.infoToggleLabel")}
-          onClick={onToggleInfo}
-          data-testid="progress-leaderboard-info-toggle"
-        >
-          <span className="progress-leaderboard-info-icon" aria-hidden="true">i</span>
-        </button>
-      </div>
-
-      {isInfoVisible ? (
-        <p className="progress-leaderboard-info" data-testid="progress-leaderboard-info">
-          {t("progressScreen.leaderboard.info")}
-          {infoUpdatedAt === null ? null : (
-            <>
-              <br />
-              <br />
-              {infoUpdatedAt}
-            </>
-          )}
-        </p>
-      ) : null}
-
-      <ProgressLeaderboardBody
-        sourceState={sourceState}
-        canRenderServerBase={canRenderServerBase}
-        selectedWindowKey={selectedWindowKey}
-        onSelectWindowKey={onSelectWindowKey}
-      />
-    </section>
-  );
 }
 
 export function ProgressScreen(): ReactElement {
@@ -817,8 +136,27 @@ export function ProgressScreen(): ReactElement {
     streak: formatNumber(reviewProgressBadge.streakDays),
     todayStatus: reviewProgressBadgeTodayStatus,
   });
+  const progressStreakSummary: ProgressStreakSummaryView | null = progressSummary === null
+    ? null
+    : {
+      label: t("reviewScreen.progressBadge.title"),
+      status: reviewProgressBadgeTodayStatus,
+      hasReviewedToday: reviewProgressBadge.hasReviewedToday,
+      ariaLabel: reviewProgressBadgeAriaLabel,
+      formattedStreakValue: formatReviewProgressBadgeValue(reviewProgressBadge.streakDays),
+    };
   const previousWeekArrow = resolveChartNavigationArrow(direction, "previous");
   const nextWeekArrow = resolveChartNavigationArrow(direction, "next");
+  const chartNavigation: ProgressReviewsChartNavigationState | null = chartPages.length <= 1
+    ? null
+    : {
+      previousPageStartLocalDate: chartPages[resolvedSelectedPageIndex - 1]?.startLocalDate ?? null,
+      nextPageStartLocalDate: chartPages[resolvedSelectedPageIndex + 1]?.startLocalDate ?? null,
+      previousWeekLabel: t("progressScreen.previousWeek"),
+      nextWeekLabel: t("progressScreen.nextWeek"),
+      previousWeekArrow,
+      nextWeekArrow,
+    };
   // The bucket views and donut segments are derived from the snapshot on every render.
   // The work is cheap (8 buckets, short string concats and arc math); a useMemo here
   // would be a no-op because t/formatNumber from useI18n are rebuilt per render.
@@ -827,7 +165,6 @@ export function ProgressScreen(): ReactElement {
     : buildReviewScheduleBucketViews(reviewSchedule, t, formatNumber);
   const reviewScheduleDonutSegments = buildReviewScheduleDonutSegments(reviewScheduleBucketViews);
   const canRenderLeaderboardServerBase = canLoadProgressServerBase(sessionVerificationState, cloudSettings);
-  const reviewScheduleHasSelection = selectedReviewScheduleBucket !== null;
   const handleSelectReviewScheduleBucket = (bucketKey: ProgressReviewScheduleBucketKey): void => {
     setSelectedReviewScheduleBucket((previous) => (previous === bucketKey ? null : bucketKey));
   };
@@ -859,71 +196,11 @@ export function ProgressScreen(): ReactElement {
 
         {progress !== null ? (
           <div className="progress-layout">
-            <section className="content-card progress-section">
-              <div className="progress-section-head">
-                <h2 className="progress-section-title">{t("progressScreen.streakTitle")}</h2>
-              </div>
-
-              {progressSummary !== null ? (
-                <div className="progress-streak-summary">
-                  <div className="progress-streak-summary-copy">
-                    <span className="progress-streak-summary-label">{t("reviewScreen.progressBadge.title")}</span>
-                    <p className="progress-streak-summary-status">{reviewProgressBadgeTodayStatus}</p>
-                  </div>
-                  <span
-                    className={`badge review-progress-badge progress-streak-summary-badge${reviewProgressBadge.hasReviewedToday ? " review-progress-badge-active" : ""}`}
-                    aria-label={reviewProgressBadgeAriaLabel}
-                    title={reviewProgressBadgeAriaLabel}
-                  >
-                    <ReviewProgressBadgeIcon />
-                    <span className="review-progress-badge-value">
-                      {formatReviewProgressBadgeValue(reviewProgressBadge.streakDays)}
-                    </span>
-                  </span>
-                </div>
-              ) : null}
-
-              <div className="progress-streak-weeks">
-                {streakWeeks.map((week, weekIndex) => (
-                  <div key={`streak-week-${weekIndex}`} className="progress-streak-week">
-                    {week.map((day) => {
-                      const dayClassName = [
-                        "progress-streak-day",
-                        day.reviewCount > 0 ? "progress-streak-day-complete" : "",
-                        day.isToday && day.reviewCount === 0 ? "progress-streak-day-today" : "",
-                      ]
-                        .filter((className) => className !== "")
-                        .join(" ");
-
-                      return (
-                        <div
-                          key={day.date}
-                          className={dayClassName}
-                          title={day.title}
-                          data-streak-state={day.isFuture ? "future" : "active"}
-                          style={day.isFuture ? futureStreakDayStyle : undefined}
-                        >
-                          <span className="progress-streak-weekday">{day.weekdayLabel}</span>
-                          <span
-                            className="progress-streak-marker"
-                            aria-hidden="true"
-                            style={day.isFuture ? futureStreakMarkerStyle : undefined}
-                          >
-                            {day.reviewCount > 0 ? (
-                              <span className="progress-streak-marker-flame">
-                                <ReviewProgressBadgeIcon />
-                              </span>
-                            ) : day.isFuture ? null : (
-                              <span className="progress-streak-marker-day-value">{day.dayLabel}</span>
-                            )}
-                          </span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                ))}
-              </div>
-            </section>
+            <ProgressStreakSection
+              title={t("progressScreen.streakTitle")}
+              summary={progressStreakSummary}
+              streakWeeks={streakWeeks}
+            />
 
             <ProgressLeaderboardSection
               sectionId={progressLeaderboardHash}
@@ -936,211 +213,28 @@ export function ProgressScreen(): ReactElement {
               onToggleInfo={() => setIsLeaderboardInfoVisible((previous) => previous === false)}
             />
 
-            <section className="content-card progress-section">
-              <div className="progress-section-head">
-                <div className="progress-chart-heading">
-                  <h2 className="progress-section-title">{t("progressScreen.reviewsTitle")}</h2>
-                  {visiblePage !== null ? (
-                    <p className="progress-chart-range" data-testid="progress-chart-range">
-                      {pageRangeLabel}
-                    </p>
-                  ) : null}
-                </div>
-
-                {chartPages.length > 1 ? (
-                  <div className="progress-chart-nav">
-                    <button
-                      type="button"
-                      className="ghost-btn progress-chart-nav-btn"
-                      onClick={() => setSelectedPageStartLocalDate(chartPages[resolvedSelectedPageIndex - 1]?.startLocalDate ?? null)}
-                      disabled={resolvedSelectedPageIndex <= 0}
-                      aria-label={t("progressScreen.previousWeek")}
-                      data-testid="progress-chart-previous-week"
-                    >
-                      <span className="progress-chart-nav-icon" aria-hidden="true">
-                        {previousWeekArrow}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      className="ghost-btn progress-chart-nav-btn"
-                      onClick={() => setSelectedPageStartLocalDate(chartPages[resolvedSelectedPageIndex + 1]?.startLocalDate ?? null)}
-                      disabled={resolvedSelectedPageIndex >= chartPages.length - 1}
-                      aria-label={t("progressScreen.nextWeek")}
-                      data-testid="progress-chart-next-week"
-                    >
-                      <span className="progress-chart-nav-icon" aria-hidden="true">
-                        {nextWeekArrow}
-                      </span>
-                    </button>
-                  </div>
-                ) : null}
-              </div>
-
-              {visiblePage !== null && (
-                <div className="progress-chart-shell">
-                  <div className="progress-chart-y-axis" aria-hidden="true">
-                    {chartGuideLabels.map((label, index) => (
-                      <span
-                        key={`progress-guide-label-${index}`}
-                        className="progress-chart-y-label"
-                        data-testid={index === 0 ? "progress-chart-y-label-max" : undefined}
-                      >
-                        {label}
-                      </span>
-                    ))}
-                  </div>
-
-                  <div className="progress-chart-plot">
-                    <div className="progress-chart-guides" aria-hidden="true">
-                      {chartGuideLabels.map((_, index) => (
-                        <span key={`progress-guide-line-${index}`} className="progress-chart-guide-line" />
-                      ))}
-                    </div>
-
-                    <div className="progress-chart-columns">
-                      {visiblePage.days.map((day) => {
-                        const columnClassName = [
-                          "progress-chart-column",
-                          day.isToday && day.reviewCount === 0 ? "progress-chart-column-today" : "",
-                        ]
-                          .filter((className) => className !== "")
-                          .join(" ");
-                        const barClassName = [
-                          "progress-chart-bar",
-                          day.reviewCount > 0 ? "progress-chart-bar-active" : "",
-                        ]
-                          .filter((className) => className !== "")
-                          .join(" ");
-
-                        return (
-                          <div
-                            key={day.date}
-                            className={columnClassName}
-                            title={day.title}
-                          >
-                            <div className="progress-chart-bar-shell">
-                              <span
-                                className={barClassName}
-                                style={{
-                                  height: `${day.barHeightPercentage}%`,
-                                }}
-                                aria-hidden="true"
-                                data-testid={`progress-chart-bar-${day.date}`}
-                              />
-                            </div>
-                            <div className="progress-chart-labels" aria-hidden="true">
-                              <span className="progress-chart-month">
-                                {day.showMonthLabel ? day.monthLabel : ""}
-                              </span>
-                              <span className="progress-chart-day">{day.dayLabel}</span>
-                              <span className="progress-chart-weekday">{day.weekdayLabel}</span>
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </div>
-              )}
-            </section>
+            <ProgressReviewsChartSection
+              title={t("progressScreen.reviewsTitle")}
+              pageRangeLabel={pageRangeLabel}
+              visiblePage={visiblePage}
+              chartGuideLabels={chartGuideLabels}
+              navigation={chartNavigation}
+              onSelectPageStartLocalDate={setSelectedPageStartLocalDate}
+            />
 
             {reviewSchedule !== null ? (
-              <section
-                className="content-card progress-section"
-                data-testid="progress-review-schedule-card"
-                onClick={handleClearReviewScheduleSelection}
-              >
-                <div className="progress-section-head">
-                  <div className="progress-chart-heading">
-                    <h2 className="progress-section-title">{t("progressScreen.reviewSchedule.title")}</h2>
-                    <p className="progress-chart-range">
-                      {t("progressScreen.reviewSchedule.totalCards", {
-                        count: formatNumber(reviewSchedule.totalCards),
-                      })}
-                    </p>
-                  </div>
-                </div>
-
-                <div className="progress-review-schedule">
-                  {reviewScheduleDonutSegments.length > 0 ? (
-                    <svg
-                      className="progress-review-schedule-donut"
-                      viewBox="-110 -110 220 220"
-                      role="img"
-                      aria-label={t("progressScreen.reviewSchedule.title")}
-                    >
-                      {reviewScheduleDonutSegments.map((segment) => {
-                        const isSelected = selectedReviewScheduleBucket === segment.key;
-                        const segmentClassName = !reviewScheduleHasSelection
-                          ? "progress-donut-segment"
-                          : isSelected
-                            ? "progress-donut-segment is-selected"
-                            : "progress-donut-segment is-dimmed";
-                        return (
-                          <path
-                            key={segment.key}
-                            d={segment.pathD}
-                            fill={segment.color}
-                            className={segmentClassName}
-                            data-testid={`progress-review-schedule-segment-${segment.key}`}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              handleSelectReviewScheduleBucket(segment.key);
-                            }}
-                          />
-                        );
-                      })}
-                    </svg>
-                  ) : (
-                    <div className="progress-review-schedule-donut progress-review-schedule-donut-empty" aria-hidden="true" />
-                  )}
-
-                  <ul
-                    className="progress-review-schedule-list"
-                    aria-label={t("progressScreen.reviewSchedule.legendLabel")}
-                  >
-                    {reviewScheduleBucketViews.map((bucket) => {
-                      const isSelected = selectedReviewScheduleBucket === bucket.key;
-                      const isInteractive = bucket.count > 0;
-                      const rowClassName = !reviewScheduleHasSelection
-                        ? "progress-review-schedule-row"
-                        : isSelected
-                          ? "progress-review-schedule-row is-selected"
-                          : "progress-review-schedule-row is-dimmed";
-                      return (
-                        <li
-                          key={bucket.key}
-                          className={rowClassName}
-                          data-testid={`progress-review-schedule-bucket-${bucket.key}`}
-                        >
-                          <button
-                            type="button"
-                            className="progress-review-schedule-row-button"
-                            disabled={!isInteractive}
-                            aria-pressed={isInteractive ? isSelected : undefined}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              handleSelectReviewScheduleBucket(bucket.key);
-                            }}
-                          >
-                            <span
-                              className="progress-review-schedule-swatch"
-                              style={{ backgroundColor: bucket.color }}
-                              aria-hidden="true"
-                            />
-                            <span className="progress-review-schedule-label">{bucket.label}</span>
-                            <span className="progress-review-schedule-values">
-                              <span className="progress-review-schedule-count">{formatNumber(bucket.count)}</span>
-                              <span className="progress-review-schedule-percent">{bucket.percentageLabel}</span>
-                            </span>
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              </section>
+              <ProgressReviewScheduleSection
+                title={t("progressScreen.reviewSchedule.title")}
+                totalCardsLabel={t("progressScreen.reviewSchedule.totalCards", {
+                  count: formatNumber(reviewSchedule.totalCards),
+                })}
+                legendLabel={t("progressScreen.reviewSchedule.legendLabel")}
+                selectedBucket={selectedReviewScheduleBucket}
+                bucketViews={reviewScheduleBucketViews}
+                donutSegments={reviewScheduleDonutSegments}
+                onSelectBucket={handleSelectReviewScheduleBucket}
+                onClearSelection={handleClearReviewScheduleSelection}
+              />
             ) : null}
           </div>
         ) : null}

--- a/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
@@ -1,0 +1,286 @@
+import type { ReactElement, Ref } from "react";
+import { Link } from "react-router-dom";
+import { buildLoginUrl } from "../../../api";
+import { useI18n } from "../../../i18n";
+import { settingsLeaderboardParticipationRoute } from "../../../routes";
+import type {
+  ProgressLeaderboardSourceState,
+  ProgressLeaderboardWindow,
+  ProgressLeaderboardWindowKey,
+} from "../../../types";
+import { progressLeaderboardWindowKeys } from "../../../types";
+
+const millisecondsPerMinute = 60_000;
+
+function getLeaderboardPeriodLabel(windowKey: ProgressLeaderboardWindowKey, t: ReturnType<typeof useI18n>["t"]): string {
+  if (windowKey === "last_24_hours") {
+    return t("progressScreen.leaderboard.periods.last24Hours");
+  }
+
+  if (windowKey === "last_3_days") {
+    return t("progressScreen.leaderboard.periods.last3Days");
+  }
+
+  if (windowKey === "last_7_days") {
+    return t("progressScreen.leaderboard.periods.last7Days");
+  }
+
+  if (windowKey === "last_30_days") {
+    return t("progressScreen.leaderboard.periods.last30Days");
+  }
+
+  return t("progressScreen.leaderboard.periods.allTime");
+}
+
+function getLeaderboardElapsedMinutes(snapshotGeneratedAt: string, now: Date): number {
+  const snapshotTime = new Date(snapshotGeneratedAt).getTime();
+  if (Number.isNaN(snapshotTime)) {
+    throw new Error(`Invalid leaderboard snapshot timestamp: ${snapshotGeneratedAt}`);
+  }
+
+  return Math.floor(Math.max(0, now.getTime() - snapshotTime) / millisecondsPerMinute);
+}
+
+function resolveLeaderboardWindow(
+  sourceState: ProgressLeaderboardSourceState,
+  selectedWindowKey: ProgressLeaderboardWindowKey | null,
+): ProgressLeaderboardWindow | null {
+  const leaderboard = sourceState.renderedSnapshot;
+  if (leaderboard === null || leaderboard.status !== "ready") {
+    return null;
+  }
+
+  const resolvedWindowKey = selectedWindowKey ?? leaderboard.defaultWindowKey;
+
+  return leaderboard.windows.find((window) => window.windowKey === resolvedWindowKey) ?? null;
+}
+
+type ProgressLeaderboardBodyProps = Readonly<{
+  sourceState: ProgressLeaderboardSourceState;
+  canRenderServerBase: boolean;
+  selectedWindowKey: ProgressLeaderboardWindowKey | null;
+  onSelectWindowKey: (windowKey: ProgressLeaderboardWindowKey) => void;
+}>;
+
+type ProgressLeaderboardSectionProps = ProgressLeaderboardBodyProps & Readonly<{
+  sectionId: string;
+  sectionRef: Ref<HTMLElement>;
+  isInfoVisible: boolean;
+  onToggleInfo: () => void;
+}>;
+
+function ProgressLeaderboardSignInPlaceholder(): ReactElement {
+  const { locale, t } = useI18n();
+
+  return (
+    <div className="progress-leaderboard-placeholder" data-testid="progress-leaderboard-guest">
+      <p className="subtitle">{t("progressScreen.leaderboard.guestBody")}</p>
+      <a className="primary-btn" href={buildLoginUrl(window.location.origin, locale)}>
+        {t("progressScreen.leaderboard.signIn")}
+      </a>
+    </div>
+  );
+}
+
+function ProgressLeaderboardRows(props: Readonly<{
+  window: ProgressLeaderboardWindow;
+}>): ReactElement {
+  const { t, formatNumber } = useI18n();
+  const { window: leaderboardWindow } = props;
+
+  return (
+    <ol className="progress-leaderboard-list">
+      {leaderboardWindow.rows.map((row, rowIndex) => {
+        if (row.kind === "gap") {
+          return (
+            <li
+              key={`leaderboard-gap-${rowIndex}`}
+              className="progress-leaderboard-row progress-leaderboard-gap"
+              data-kind="gap"
+              data-testid="progress-leaderboard-row-gap"
+              aria-hidden="true"
+            >
+              <span className="progress-leaderboard-gap-dots">…</span>
+            </li>
+          );
+        }
+
+        const rowClassName = row.kind === "viewer"
+          ? "progress-leaderboard-row progress-leaderboard-row-viewer"
+          : "progress-leaderboard-row";
+
+        return (
+          <li
+            key={`${row.publicProfileId}-${row.rank}`}
+            className={rowClassName}
+            data-kind={row.kind}
+            data-testid={`progress-leaderboard-row-${row.kind}`}
+          >
+            <span className="progress-leaderboard-rank">
+              {t("progressScreen.leaderboard.rankLabel", { rank: formatNumber(row.rank) })}
+            </span>
+            <span className="progress-leaderboard-name">
+              {row.kind === "viewer" ? t("progressScreen.leaderboard.you") : row.anonymousDisplayName}
+            </span>
+            <span className="progress-leaderboard-count" data-testid={`progress-leaderboard-count-${row.kind}`}>
+              {formatNumber(row.qualifiedReviewCount)}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function ProgressLeaderboardBody(props: ProgressLeaderboardBodyProps): ReactElement {
+  const { t } = useI18n();
+  const { sourceState, canRenderServerBase, selectedWindowKey, onSelectWindowKey } = props;
+  const leaderboard = sourceState.renderedSnapshot;
+
+  if (canRenderServerBase === false) {
+    return <ProgressLeaderboardSignInPlaceholder />;
+  }
+
+  if (leaderboard === null) {
+    if (sourceState.errorMessage !== "" && sourceState.isLoading === false) {
+      if (sourceState.isNetworkError) {
+        return (
+          <p className="subtitle" data-testid="progress-leaderboard-offline-empty">
+            {t("progressScreen.leaderboard.offlineEmpty")}
+          </p>
+        );
+      }
+
+      return (
+        <p className="subtitle" data-testid="progress-leaderboard-unavailable">
+          {t("progressScreen.leaderboard.unavailable")}
+        </p>
+      );
+    }
+
+    return (
+      <p className="subtitle" data-testid="progress-leaderboard-loading">
+        {t("progressScreen.leaderboard.loading")}
+      </p>
+    );
+  }
+
+  if (leaderboard.status === "linked_account_required") {
+    return <ProgressLeaderboardSignInPlaceholder />;
+  }
+
+  if (leaderboard.status === "participation_disabled") {
+    return (
+      <div className="progress-leaderboard-placeholder" data-testid="progress-leaderboard-participation-disabled">
+        <p className="subtitle">{t("progressScreen.leaderboard.participationDisabledBody")}</p>
+        <Link className="ghost-btn" to={settingsLeaderboardParticipationRoute}>
+          {t("progressScreen.leaderboard.openParticipationSettings")}
+        </Link>
+      </div>
+    );
+  }
+
+  if (leaderboard.status === "snapshot_unavailable") {
+    return (
+      <p className="subtitle" data-testid="progress-leaderboard-unavailable">
+        {t("progressScreen.leaderboard.unavailable")}
+      </p>
+    );
+  }
+
+  const resolvedWindowKey = selectedWindowKey ?? leaderboard.defaultWindowKey;
+  const leaderboardWindow = resolveLeaderboardWindow(sourceState, selectedWindowKey);
+
+  return (
+    <>
+      <div className="progress-leaderboard-periods" role="group" aria-label={t("progressScreen.leaderboard.periodsLabel")}>
+        {progressLeaderboardWindowKeys.map((windowKey) => (
+          <button
+            key={windowKey}
+            type="button"
+            className={windowKey === resolvedWindowKey
+              ? "progress-leaderboard-period-btn is-selected"
+              : "progress-leaderboard-period-btn"}
+            aria-pressed={windowKey === resolvedWindowKey}
+            onClick={() => onSelectWindowKey(windowKey)}
+            data-testid={`progress-leaderboard-period-${windowKey}`}
+          >
+            {getLeaderboardPeriodLabel(windowKey, t)}
+          </button>
+        ))}
+      </div>
+      {leaderboardWindow === null ? (
+        <p className="subtitle" data-testid="progress-leaderboard-unavailable">
+          {t("progressScreen.leaderboard.unavailable")}
+        </p>
+      ) : (
+        <ProgressLeaderboardRows window={leaderboardWindow} />
+      )}
+    </>
+  );
+}
+
+export function ProgressLeaderboardSection(props: ProgressLeaderboardSectionProps): ReactElement {
+  const { t, formatNumber } = useI18n();
+  const {
+    sourceState,
+    canRenderServerBase,
+    selectedWindowKey,
+    onSelectWindowKey,
+    sectionId,
+    sectionRef,
+    isInfoVisible,
+    onToggleInfo,
+  } = props;
+  const leaderboardWindow = resolveLeaderboardWindow(sourceState, selectedWindowKey);
+  const infoUpdatedAt = leaderboardWindow === null
+    ? null
+    : t("progressScreen.leaderboard.updatedAt", {
+      minutes: formatNumber(getLeaderboardElapsedMinutes(leaderboardWindow.snapshotGeneratedAt, new Date())),
+    });
+
+  return (
+    <section
+      id={sectionId}
+      ref={sectionRef}
+      className="content-card progress-section progress-leaderboard-card"
+      data-testid="progress-leaderboard-card"
+    >
+      <div className="progress-section-head">
+        <div className="progress-chart-heading">
+          <h2 className="progress-section-title">{t("progressScreen.leaderboard.title")}</h2>
+        </div>
+        <button
+          type="button"
+          className="ghost-btn progress-leaderboard-info-btn"
+          aria-expanded={isInfoVisible}
+          aria-label={t("progressScreen.leaderboard.infoToggleLabel")}
+          onClick={onToggleInfo}
+          data-testid="progress-leaderboard-info-toggle"
+        >
+          <span className="progress-leaderboard-info-icon" aria-hidden="true">i</span>
+        </button>
+      </div>
+
+      {isInfoVisible ? (
+        <p className="progress-leaderboard-info" data-testid="progress-leaderboard-info">
+          {t("progressScreen.leaderboard.info")}
+          {infoUpdatedAt === null ? null : (
+            <>
+              <br />
+              <br />
+              {infoUpdatedAt}
+            </>
+          )}
+        </p>
+      ) : null}
+
+      <ProgressLeaderboardBody
+        sourceState={sourceState}
+        canRenderServerBase={canRenderServerBase}
+        selectedWindowKey={selectedWindowKey}
+        onSelectWindowKey={onSelectWindowKey}
+      />
+    </section>
+  );
+}

--- a/apps/web/src/screens/progress/reviewSchedule/ProgressReviewScheduleSection.tsx
+++ b/apps/web/src/screens/progress/reviewSchedule/ProgressReviewScheduleSection.tsx
@@ -1,0 +1,127 @@
+import type { ReactElement } from "react";
+import type { ProgressReviewScheduleBucketKey } from "../../../types";
+import type {
+  ReviewScheduleBucketView,
+  ReviewScheduleDonutSegment,
+} from "./progressReviewScheduleModel";
+
+type ProgressReviewScheduleSectionProps = Readonly<{
+  title: string;
+  totalCardsLabel: string;
+  legendLabel: string;
+  selectedBucket: ProgressReviewScheduleBucketKey | null;
+  bucketViews: ReadonlyArray<ReviewScheduleBucketView>;
+  donutSegments: ReadonlyArray<ReviewScheduleDonutSegment>;
+  onSelectBucket: (bucketKey: ProgressReviewScheduleBucketKey) => void;
+  onClearSelection: () => void;
+}>;
+
+export function ProgressReviewScheduleSection(props: ProgressReviewScheduleSectionProps): ReactElement {
+  const {
+    title,
+    totalCardsLabel,
+    legendLabel,
+    selectedBucket,
+    bucketViews,
+    donutSegments,
+    onSelectBucket,
+    onClearSelection,
+  } = props;
+  const reviewScheduleHasSelection = selectedBucket !== null;
+
+  return (
+    <section
+      className="content-card progress-section"
+      data-testid="progress-review-schedule-card"
+      onClick={onClearSelection}
+    >
+      <div className="progress-section-head">
+        <div className="progress-chart-heading">
+          <h2 className="progress-section-title">{title}</h2>
+          <p className="progress-chart-range">
+            {totalCardsLabel}
+          </p>
+        </div>
+      </div>
+
+      <div className="progress-review-schedule">
+        {donutSegments.length > 0 ? (
+          <svg
+            className="progress-review-schedule-donut"
+            viewBox="-110 -110 220 220"
+            role="img"
+            aria-label={title}
+          >
+            {donutSegments.map((segment) => {
+              const isSelected = selectedBucket === segment.key;
+              const segmentClassName = !reviewScheduleHasSelection
+                ? "progress-donut-segment"
+                : isSelected
+                  ? "progress-donut-segment is-selected"
+                  : "progress-donut-segment is-dimmed";
+              return (
+                <path
+                  key={segment.key}
+                  d={segment.pathD}
+                  fill={segment.color}
+                  className={segmentClassName}
+                  data-testid={`progress-review-schedule-segment-${segment.key}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelectBucket(segment.key);
+                  }}
+                />
+              );
+            })}
+          </svg>
+        ) : (
+          <div className="progress-review-schedule-donut progress-review-schedule-donut-empty" aria-hidden="true" />
+        )}
+
+        <ul
+          className="progress-review-schedule-list"
+          aria-label={legendLabel}
+        >
+          {bucketViews.map((bucket) => {
+            const isSelected = selectedBucket === bucket.key;
+            const isInteractive = bucket.count > 0;
+            const rowClassName = !reviewScheduleHasSelection
+              ? "progress-review-schedule-row"
+              : isSelected
+                ? "progress-review-schedule-row is-selected"
+                : "progress-review-schedule-row is-dimmed";
+            return (
+              <li
+                key={bucket.key}
+                className={rowClassName}
+                data-testid={`progress-review-schedule-bucket-${bucket.key}`}
+              >
+                <button
+                  type="button"
+                  className="progress-review-schedule-row-button"
+                  disabled={!isInteractive}
+                  aria-pressed={isInteractive ? isSelected : undefined}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onSelectBucket(bucket.key);
+                  }}
+                >
+                  <span
+                    className="progress-review-schedule-swatch"
+                    style={{ backgroundColor: bucket.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="progress-review-schedule-label">{bucket.label}</span>
+                  <span className="progress-review-schedule-values">
+                    <span className="progress-review-schedule-count">{bucket.countLabel}</span>
+                    <span className="progress-review-schedule-percent">{bucket.percentageLabel}</span>
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/screens/progress/reviewSchedule/progressReviewScheduleModel.ts
+++ b/apps/web/src/screens/progress/reviewSchedule/progressReviewScheduleModel.ts
@@ -1,0 +1,154 @@
+import type { TranslationKey, TranslationValues } from "../../../i18n";
+import type {
+  ProgressReviewScheduleBucketKey,
+  ProgressReviewScheduleSnapshot,
+} from "../../../types";
+
+type NumberFormatter = (value: number, options?: Readonly<Intl.NumberFormatOptions>) => string;
+type Translate = (key: TranslationKey, values?: TranslationValues) => string;
+
+export type ReviewScheduleBucketView = Readonly<{
+  key: ProgressReviewScheduleBucketKey;
+  label: string;
+  count: number;
+  countLabel: string;
+  percentageLabel: string;
+  color: string;
+}>;
+
+export type ReviewScheduleDonutSegment = Readonly<{
+  key: ProgressReviewScheduleBucketKey;
+  color: string;
+  pathD: string;
+}>;
+
+// Canonical palette — see docs/progress-pie-palette.md.
+// Keep the hex values in sync with the iOS and Android clients.
+const reviewScheduleBucketColors: Readonly<Record<ProgressReviewScheduleBucketKey, string>> = {
+  new: "#F4C430",
+  today: "#D7263D",
+  days1To7: "#1FB5C1",
+  days8To30: "#8E5BD9",
+  days31To90: "#2BB673",
+  days91To360: "#E69F00",
+  years1To2: "#3F7CC8",
+  later: "#7A8088",
+};
+
+const reviewScheduleDonutOuterRadius = 100;
+const reviewScheduleDonutInnerRadius = 62;
+
+function getReviewScheduleBucketLabel(bucketKey: ProgressReviewScheduleBucketKey, t: Translate): string {
+  if (bucketKey === "new") {
+    return t("progressScreen.reviewSchedule.buckets.new");
+  }
+
+  if (bucketKey === "today") {
+    return t("progressScreen.reviewSchedule.buckets.today");
+  }
+
+  if (bucketKey === "days1To7") {
+    return t("progressScreen.reviewSchedule.buckets.days1To7");
+  }
+
+  if (bucketKey === "days8To30") {
+    return t("progressScreen.reviewSchedule.buckets.days8To30");
+  }
+
+  if (bucketKey === "days31To90") {
+    return t("progressScreen.reviewSchedule.buckets.days31To90");
+  }
+
+  if (bucketKey === "days91To360") {
+    return t("progressScreen.reviewSchedule.buckets.days91To360");
+  }
+
+  if (bucketKey === "years1To2") {
+    return t("progressScreen.reviewSchedule.buckets.years1To2");
+  }
+
+  return t("progressScreen.reviewSchedule.buckets.later");
+}
+
+function formatReviewSchedulePercentage(count: number, totalCards: number, formatNumber: NumberFormatter): string {
+  if (totalCards <= 0 || count <= 0) {
+    return formatNumber(0, {
+      style: "percent",
+      maximumFractionDigits: 0,
+    });
+  }
+
+  return formatNumber(count / totalCards, {
+    style: "percent",
+    maximumFractionDigits: 1,
+  });
+}
+
+export function buildReviewScheduleBucketViews(
+  reviewSchedule: ProgressReviewScheduleSnapshot,
+  t: Translate,
+  formatNumber: NumberFormatter,
+): ReadonlyArray<ReviewScheduleBucketView> {
+  return reviewSchedule.buckets.map((bucket): ReviewScheduleBucketView => ({
+    key: bucket.key,
+    label: getReviewScheduleBucketLabel(bucket.key, t),
+    count: bucket.count,
+    countLabel: formatNumber(bucket.count),
+    percentageLabel: formatReviewSchedulePercentage(bucket.count, reviewSchedule.totalCards, formatNumber),
+    color: reviewScheduleBucketColors[bucket.key],
+  }));
+}
+
+function polarToCartesian(angleDegrees: number, radius: number): { x: number; y: number } {
+  const angleRadians = ((angleDegrees - 90) * Math.PI) / 180;
+  return {
+    x: radius * Math.cos(angleRadians),
+    y: radius * Math.sin(angleRadians),
+  };
+}
+
+function buildAnnulusSegmentPath(startAngle: number, endAngle: number): string {
+  const sweep = endAngle - startAngle;
+  // Use `>=` (not `===`) to absorb floating-point drift in `(count / total) * 360`.
+  if (sweep >= 360) {
+    // Single full ring: split into two semicircle annulus arcs so the path is non-degenerate.
+    const half = startAngle + 180;
+    return [
+      buildAnnulusSegmentPath(startAngle, half),
+      buildAnnulusSegmentPath(half, startAngle + 360),
+    ].join(" ");
+  }
+  const outerStart = polarToCartesian(startAngle, reviewScheduleDonutOuterRadius);
+  const outerEnd = polarToCartesian(endAngle, reviewScheduleDonutOuterRadius);
+  const innerStart = polarToCartesian(endAngle, reviewScheduleDonutInnerRadius);
+  const innerEnd = polarToCartesian(startAngle, reviewScheduleDonutInnerRadius);
+  const largeArcFlag = sweep > 180 ? 1 : 0;
+  return [
+    `M ${outerStart.x} ${outerStart.y}`,
+    `A ${reviewScheduleDonutOuterRadius} ${reviewScheduleDonutOuterRadius} 0 ${largeArcFlag} 1 ${outerEnd.x} ${outerEnd.y}`,
+    `L ${innerStart.x} ${innerStart.y}`,
+    `A ${reviewScheduleDonutInnerRadius} ${reviewScheduleDonutInnerRadius} 0 ${largeArcFlag} 0 ${innerEnd.x} ${innerEnd.y}`,
+    "Z",
+  ].join(" ");
+}
+
+export function buildReviewScheduleDonutSegments(
+  bucketViews: ReadonlyArray<ReviewScheduleBucketView>,
+): ReadonlyArray<ReviewScheduleDonutSegment> {
+  const totalCount = bucketViews.reduce((totalCards, bucket) => totalCards + bucket.count, 0);
+  if (totalCount <= 0) {
+    return [];
+  }
+  const nonEmpty = bucketViews.filter((bucket) => bucket.count > 0);
+  let currentAngle = 0;
+  return nonEmpty.map((bucket): ReviewScheduleDonutSegment => {
+    const startAngle = currentAngle;
+    const endAngle = currentAngle + (bucket.count / totalCount) * 360;
+    currentAngle = endAngle;
+    return {
+      key: bucket.key,
+      color: bucket.color,
+      pathD: buildAnnulusSegmentPath(startAngle, endAngle),
+    };
+  });
+}

--- a/apps/web/src/screens/progress/reviewsChart/ProgressReviewsChartSection.tsx
+++ b/apps/web/src/screens/progress/reviewsChart/ProgressReviewsChartSection.tsx
@@ -1,0 +1,148 @@
+import type { ReactElement } from "react";
+import type { ChartPage } from "./progressReviewsChartModel";
+
+export type ProgressReviewsChartNavigationState = Readonly<{
+  previousPageStartLocalDate: string | null;
+  nextPageStartLocalDate: string | null;
+  previousWeekLabel: string;
+  nextWeekLabel: string;
+  previousWeekArrow: string;
+  nextWeekArrow: string;
+}>;
+
+type ProgressReviewsChartSectionProps = Readonly<{
+  title: string;
+  pageRangeLabel: string;
+  visiblePage: ChartPage | null;
+  chartGuideLabels: ReadonlyArray<string>;
+  navigation: ProgressReviewsChartNavigationState | null;
+  onSelectPageStartLocalDate: (pageStartLocalDate: string | null) => void;
+}>;
+
+function ProgressReviewsChartColumn(props: Readonly<{
+  day: ChartPage["days"][number];
+}>): ReactElement {
+  const { day } = props;
+  const columnClassName = [
+    "progress-chart-column",
+    day.isToday && day.reviewCount === 0 ? "progress-chart-column-today" : "",
+  ]
+    .filter((className) => className !== "")
+    .join(" ");
+  const barClassName = [
+    "progress-chart-bar",
+    day.reviewCount > 0 ? "progress-chart-bar-active" : "",
+  ]
+    .filter((className) => className !== "")
+    .join(" ");
+
+  return (
+    <div
+      className={columnClassName}
+      title={day.title}
+    >
+      <div className="progress-chart-bar-shell">
+        <span
+          className={barClassName}
+          style={{
+            height: `${day.barHeightPercentage}%`,
+          }}
+          aria-hidden="true"
+          data-testid={`progress-chart-bar-${day.date}`}
+        />
+      </div>
+      <div className="progress-chart-labels" aria-hidden="true">
+        <span className="progress-chart-month">
+          {day.showMonthLabel ? day.monthLabel : ""}
+        </span>
+        <span className="progress-chart-day">{day.dayLabel}</span>
+        <span className="progress-chart-weekday">{day.weekdayLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ProgressReviewsChartSection(props: ProgressReviewsChartSectionProps): ReactElement {
+  const {
+    title,
+    pageRangeLabel,
+    visiblePage,
+    chartGuideLabels,
+    navigation,
+    onSelectPageStartLocalDate,
+  } = props;
+
+  return (
+    <section className="content-card progress-section">
+      <div className="progress-section-head">
+        <div className="progress-chart-heading">
+          <h2 className="progress-section-title">{title}</h2>
+          {visiblePage !== null ? (
+            <p className="progress-chart-range" data-testid="progress-chart-range">
+              {pageRangeLabel}
+            </p>
+          ) : null}
+        </div>
+
+        {navigation === null ? null : (
+          <div className="progress-chart-nav">
+            <button
+              type="button"
+              className="ghost-btn progress-chart-nav-btn"
+              onClick={() => onSelectPageStartLocalDate(navigation.previousPageStartLocalDate)}
+              disabled={navigation.previousPageStartLocalDate === null}
+              aria-label={navigation.previousWeekLabel}
+              data-testid="progress-chart-previous-week"
+            >
+              <span className="progress-chart-nav-icon" aria-hidden="true">
+                {navigation.previousWeekArrow}
+              </span>
+            </button>
+            <button
+              type="button"
+              className="ghost-btn progress-chart-nav-btn"
+              onClick={() => onSelectPageStartLocalDate(navigation.nextPageStartLocalDate)}
+              disabled={navigation.nextPageStartLocalDate === null}
+              aria-label={navigation.nextWeekLabel}
+              data-testid="progress-chart-next-week"
+            >
+              <span className="progress-chart-nav-icon" aria-hidden="true">
+                {navigation.nextWeekArrow}
+              </span>
+            </button>
+          </div>
+        )}
+      </div>
+
+      {visiblePage !== null && (
+        <div className="progress-chart-shell">
+          <div className="progress-chart-y-axis" aria-hidden="true">
+            {chartGuideLabels.map((label, index) => (
+              <span
+                key={`progress-guide-label-${index}`}
+                className="progress-chart-y-label"
+                data-testid={index === 0 ? "progress-chart-y-label-max" : undefined}
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+
+          <div className="progress-chart-plot">
+            <div className="progress-chart-guides" aria-hidden="true">
+              {chartGuideLabels.map((_, index) => (
+                <span key={`progress-guide-line-${index}`} className="progress-chart-guide-line" />
+              ))}
+            </div>
+
+            <div className="progress-chart-columns">
+              {visiblePage.days.map((day) => (
+                <ProgressReviewsChartColumn key={day.date} day={day} />
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/screens/progress/reviewsChart/progressReviewsChartModel.ts
+++ b/apps/web/src/screens/progress/reviewsChart/progressReviewsChartModel.ts
@@ -1,0 +1,220 @@
+import type { Locale, LocaleDirection, LocaleWeekContext } from "../../../i18n";
+import { parseLocalDate, shiftLocalDate } from "../../../progress/progressDates";
+import type { DailyReviewPoint } from "../../../types";
+
+const chartGuideLineCount = 3;
+const chartWeekLength = 7;
+
+type DateFormatter = (value: Date | number | string, options?: Readonly<Intl.DateTimeFormatOptions>) => string;
+type NumberFormatter = (value: number, options?: Readonly<Intl.NumberFormatOptions>) => string;
+type ChartNavigationDirection = "previous" | "next";
+
+export type ChartDay = Readonly<{
+  date: string;
+  reviewCount: number;
+  isToday: boolean;
+  weekdayLabel: string;
+  dayLabel: string;
+  monthLabel: string;
+  showMonthLabel: boolean;
+  barHeightPercentage: number;
+  title: string;
+}>;
+
+export type ChartPage = Readonly<{
+  days: ReadonlyArray<ChartDay>;
+  startDate: string;
+  endDate: string;
+  startLocalDate: string;
+  upperBound: number;
+}>;
+
+function formatLocalDateForDisplay(value: string, formatDate: DateFormatter): string {
+  return formatDate(parseLocalDate(value), {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatWeekdayLabel(value: string, formatDate: DateFormatter): string {
+  return formatDate(parseLocalDate(value), {
+    timeZone: "UTC",
+    weekday: "narrow",
+  });
+}
+
+function formatDayLabel(value: string, formatDate: DateFormatter): string {
+  return formatDate(parseLocalDate(value), {
+    timeZone: "UTC",
+    day: "numeric",
+  });
+}
+
+function formatMonthLabel(value: string, formatDate: DateFormatter): string {
+  return formatDate(parseLocalDate(value), {
+    timeZone: "UTC",
+    month: "short",
+  });
+}
+
+function createDailyReviewCountMap(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyMap<string, number> {
+  const reviewCounts = new Map<string, number>();
+
+  for (const day of dailyReviews) {
+    reviewCounts.set(day.date, day.reviewCount);
+  }
+
+  return reviewCounts;
+}
+
+function getDayOfWeek(value: string): number {
+  return parseLocalDate(value).getUTCDay();
+}
+
+function getStartOfWeek(value: string, weekContext: LocaleWeekContext): string {
+  const dayOfWeek = getDayOfWeek(value);
+  const offsetFromWeekStart = (dayOfWeek - weekContext.firstDayOfWeek + chartWeekLength) % chartWeekLength;
+
+  return shiftLocalDate(value, -offsetFromWeekStart);
+}
+
+function calculateMaxReviewCount(dailyReviews: ReadonlyArray<DailyReviewPoint>): number {
+  return dailyReviews.reduce((maxReviewCount, day) => Math.max(maxReviewCount, day.reviewCount), 0);
+}
+
+function calculateChartUpperBound(maxReviewCount: number): number {
+  if (maxReviewCount <= 0) {
+    return 1;
+  }
+
+  return Math.max(1, Math.ceil(maxReviewCount * 1.1));
+}
+
+function calculateBarHeightPercentage(reviewCount: number, upperBound: number): number {
+  if (reviewCount === 0 || upperBound === 0) {
+    return 0;
+  }
+
+  return (reviewCount / upperBound) * 100;
+}
+
+function buildChartPage(
+  dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  today: string,
+  formatDate: DateFormatter,
+): ChartPage {
+  const upperBound = calculateChartUpperBound(calculateMaxReviewCount(dailyReviews));
+
+  return {
+    days: dailyReviews.map((day, dayIndex): ChartDay => ({
+      date: day.date,
+      reviewCount: day.reviewCount,
+      isToday: day.date === today,
+      weekdayLabel: formatWeekdayLabel(day.date, formatDate),
+      dayLabel: formatDayLabel(day.date, formatDate),
+      monthLabel: formatMonthLabel(day.date, formatDate),
+      showMonthLabel: dayIndex === 0 || dailyReviews[dayIndex - 1]?.date.slice(0, 7) !== day.date.slice(0, 7),
+      barHeightPercentage: calculateBarHeightPercentage(day.reviewCount, upperBound),
+      title: formatLocalDateForDisplay(day.date, formatDate),
+    })),
+    startDate: dailyReviews[0]?.date ?? "",
+    endDate: dailyReviews[dailyReviews.length - 1]?.date ?? "",
+    startLocalDate: dailyReviews[0]?.date ?? "",
+    upperBound,
+  };
+}
+
+function padPageDaysToFullWeek(
+  pageDays: ReadonlyArray<DailyReviewPoint>,
+  weekStart: string,
+): ReadonlyArray<DailyReviewPoint> {
+  const reviewCounts = createDailyReviewCountMap(pageDays);
+  const fullWeek: Array<DailyReviewPoint> = [];
+
+  for (let dayOffset = 0; dayOffset < chartWeekLength; dayOffset += 1) {
+    const date = shiftLocalDate(weekStart, dayOffset);
+    fullWeek.push({
+      date,
+      reviewCount: reviewCounts.get(date) ?? 0,
+    });
+  }
+
+  return fullWeek;
+}
+
+export function buildChartPages(
+  dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  today: string,
+  formatDate: DateFormatter,
+  weekContext: LocaleWeekContext,
+): ReadonlyArray<ChartPage> {
+  if (dailyReviews.length === 0) {
+    return [];
+  }
+
+  const chartPages: Array<ChartPage> = [];
+  let currentPageDays: Array<DailyReviewPoint> = [];
+  let currentWeekStart: string | null = null;
+
+  for (const day of dailyReviews) {
+    const weekStart = getStartOfWeek(day.date, weekContext);
+
+    if (currentWeekStart !== null && currentWeekStart !== weekStart) {
+      chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
+      currentPageDays = [day];
+      currentWeekStart = weekStart;
+      continue;
+    }
+
+    currentPageDays.push(day);
+    currentWeekStart = weekStart;
+  }
+
+  if (currentPageDays.length > 0 && currentWeekStart !== null) {
+    chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
+  }
+
+  return chartPages;
+}
+
+export function buildChartGuideLabels(upperBound: number, formatNumber: NumberFormatter): ReadonlyArray<string> {
+  const labels: string[] = [];
+
+  for (let index = 0; index < chartGuideLineCount; index += 1) {
+    if (index === 0) {
+      labels.push(formatNumber(upperBound));
+      continue;
+    }
+
+    if (index === chartGuideLineCount - 1) {
+      labels.push(formatNumber(0));
+      continue;
+    }
+
+    labels.push("");
+  }
+
+  return labels;
+}
+
+export function formatChartRangeLabel(startDate: string, endDate: string, locale: Locale): string {
+  return new Intl.DateTimeFormat(locale, {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).formatRange(parseLocalDate(startDate), parseLocalDate(endDate));
+}
+
+export function resolveChartNavigationArrow(
+  localeDirection: LocaleDirection,
+  navigationDirection: ChartNavigationDirection,
+): string {
+  if (navigationDirection === "previous") {
+    return localeDirection === "rtl" ? ">" : "<";
+  }
+
+  return localeDirection === "rtl" ? "<" : ">";
+}

--- a/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
+++ b/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
@@ -1,0 +1,115 @@
+import type { CSSProperties, ReactElement } from "react";
+import { ReviewProgressBadgeIcon } from "../../shared/ReviewProgressBadgeIcon";
+import type { StreakDay } from "./progressStreakModel";
+
+const futureStreakDayStyle: Readonly<CSSProperties> = {
+  borderStyle: "dashed",
+  background: "transparent",
+  opacity: 0.64,
+};
+
+const futureStreakMarkerStyle: Readonly<CSSProperties> = {
+  background: "transparent",
+  boxShadow: "inset 0 0 0 1px rgba(255, 255, 255, 0.12)",
+  color: "var(--text-tertiary)",
+};
+
+export type ProgressStreakSummaryView = Readonly<{
+  label: string;
+  status: string;
+  hasReviewedToday: boolean;
+  ariaLabel: string;
+  formattedStreakValue: string;
+}>;
+
+type ProgressStreakSectionProps = Readonly<{
+  title: string;
+  summary: ProgressStreakSummaryView | null;
+  streakWeeks: ReadonlyArray<ReadonlyArray<StreakDay>>;
+}>;
+
+function ProgressStreakDay(props: Readonly<{
+  day: StreakDay;
+}>): ReactElement {
+  const { day } = props;
+  const dayClassName = [
+    "progress-streak-day",
+    day.reviewCount > 0 ? "progress-streak-day-complete" : "",
+    day.isToday && day.reviewCount === 0 ? "progress-streak-day-today" : "",
+  ]
+    .filter((className) => className !== "")
+    .join(" ");
+
+  return (
+    <div
+      className={dayClassName}
+      title={day.title}
+      data-streak-state={day.isFuture ? "future" : "active"}
+      style={day.isFuture ? futureStreakDayStyle : undefined}
+    >
+      <span className="progress-streak-weekday">{day.weekdayLabel}</span>
+      <span
+        className="progress-streak-marker"
+        aria-hidden="true"
+        style={day.isFuture ? futureStreakMarkerStyle : undefined}
+      >
+        {day.reviewCount > 0 ? (
+          <span className="progress-streak-marker-flame">
+            <ReviewProgressBadgeIcon />
+          </span>
+        ) : day.isFuture ? null : (
+          <span className="progress-streak-marker-day-value">{day.dayLabel}</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function ProgressStreakSummary(props: Readonly<{
+  summary: ProgressStreakSummaryView;
+}>): ReactElement {
+  const { summary } = props;
+
+  return (
+    <div className="progress-streak-summary">
+      <div className="progress-streak-summary-copy">
+        <span className="progress-streak-summary-label">{summary.label}</span>
+        <p className="progress-streak-summary-status">{summary.status}</p>
+      </div>
+      <span
+        className={`badge review-progress-badge progress-streak-summary-badge${summary.hasReviewedToday ? " review-progress-badge-active" : ""}`}
+        aria-label={summary.ariaLabel}
+        title={summary.ariaLabel}
+      >
+        <ReviewProgressBadgeIcon />
+        <span className="review-progress-badge-value">
+          {summary.formattedStreakValue}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export function ProgressStreakSection(props: ProgressStreakSectionProps): ReactElement {
+  const { title, summary, streakWeeks } = props;
+
+  return (
+    <section className="content-card progress-section">
+      <div className="progress-section-head">
+        <h2 className="progress-section-title">{title}</h2>
+      </div>
+
+      {summary === null ? null : <ProgressStreakSummary summary={summary} />}
+
+      <div className="progress-streak-weeks">
+        {streakWeeks.map((week, weekIndex) => (
+          <div key={`streak-week-${weekIndex}`} className="progress-streak-week">
+            {week.map((day) => (
+              <ProgressStreakDay key={day.date} day={day} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/screens/progress/streak/progressStreakModel.ts
+++ b/apps/web/src/screens/progress/streak/progressStreakModel.ts
@@ -1,0 +1,96 @@
+import type { LocaleWeekContext } from "../../../i18n";
+import { parseLocalDate, shiftLocalDate } from "../../../progress/progressDates";
+import type { DailyReviewPoint } from "../../../types";
+
+const streakWeekCount = 5;
+const streakWeekLength = 7;
+
+type DateFormatter = (value: Date | number | string, options?: Readonly<Intl.DateTimeFormatOptions>) => string;
+
+export type StreakDay = Readonly<{
+  date: string;
+  reviewCount: number;
+  isFuture: boolean;
+  isToday: boolean;
+  weekdayLabel: string;
+  dayLabel: string;
+  title: string;
+}>;
+
+function formatLocalDateForDisplay(value: string, formatDate: DateFormatter): string {
+  return formatDate(parseLocalDate(value), {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatWeekdayLabel(value: string, formatDate: DateFormatter): string {
+  return formatDate(parseLocalDate(value), {
+    timeZone: "UTC",
+    weekday: "narrow",
+  });
+}
+
+function formatDayLabel(value: string, formatDate: DateFormatter): string {
+  return formatDate(parseLocalDate(value), {
+    timeZone: "UTC",
+    day: "numeric",
+  });
+}
+
+function createDailyReviewCountMap(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyMap<string, number> {
+  const reviewCounts = new Map<string, number>();
+
+  for (const day of dailyReviews) {
+    reviewCounts.set(day.date, day.reviewCount);
+  }
+
+  return reviewCounts;
+}
+
+function getDayOfWeek(value: string): number {
+  return parseLocalDate(value).getUTCDay();
+}
+
+function getStartOfWeek(value: string, weekContext: LocaleWeekContext): string {
+  const dayOfWeek = getDayOfWeek(value);
+  const offsetFromWeekStart = (dayOfWeek - weekContext.firstDayOfWeek + streakWeekLength) % streakWeekLength;
+
+  return shiftLocalDate(value, -offsetFromWeekStart);
+}
+
+export function buildStreakWeeks(
+  dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  today: string,
+  formatDate: DateFormatter,
+  weekContext: LocaleWeekContext,
+): ReadonlyArray<ReadonlyArray<StreakDay>> {
+  const currentWeekStart = getStartOfWeek(today, weekContext);
+  const streakWindowStart = shiftLocalDate(currentWeekStart, -((streakWeekCount - 1) * streakWeekLength));
+  const reviewCounts = createDailyReviewCountMap(dailyReviews);
+  const streakWeeks: Array<ReadonlyArray<StreakDay>> = [];
+
+  for (let weekIndex = 0; weekIndex < streakWeekCount; weekIndex += 1) {
+    const weekStart = shiftLocalDate(streakWindowStart, weekIndex * streakWeekLength);
+    const weekDays: Array<StreakDay> = [];
+
+    for (let dayOffset = 0; dayOffset < streakWeekLength; dayOffset += 1) {
+      const date = shiftLocalDate(weekStart, dayOffset);
+      weekDays.push({
+        date,
+        reviewCount: reviewCounts.get(date) ?? 0,
+        isFuture: date > today,
+        isToday: date === today,
+        weekdayLabel: formatWeekdayLabel(date, formatDate),
+        dayLabel: formatDayLabel(date, formatDate),
+        title: formatLocalDateForDisplay(date, formatDate),
+      });
+    }
+
+    streakWeeks.push(weekDays);
+  }
+
+  return streakWeeks;
+}


### PR DESCRIPTION
## Summary
- keep ProgressScreen as the route-level orchestrator
- extract streak, reviews chart, review schedule, and leaderboard subfeatures
- preserve existing Progress tests, selectors, route hash behavior, and localization keys

## Validation
- npx vitest run src/screens/progress/ProgressScreen.test.ts src/screens/progress/ProgressScreen.render.test.tsx
- npm run build
- git --no-pager diff --check