### PR TITLE
Move Android progress sections package

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
@@ -39,10 +39,10 @@ import com.flashcardsopensourceapp.feature.ai.aiComposerSendButtonTag
 import com.flashcardsopensourceapp.feature.ai.aiConversationSurfaceTag
 import com.flashcardsopensourceapp.feature.cards.cardsCardFrontTextTag
 import com.flashcardsopensourceapp.feature.cards.cardsSearchFieldTag
-import com.flashcardsopensourceapp.feature.progress.progressLeaderboardResolvedContentTag
-import com.flashcardsopensourceapp.feature.progress.progressLeaderboardSectionTag
-import com.flashcardsopensourceapp.feature.progress.progressStreakSectionTag
 import com.flashcardsopensourceapp.feature.progress.R as ProgressFeatureR
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardResolvedContentTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressLeaderboardSectionTag
+import com.flashcardsopensourceapp.feature.progress.sections.progressStreakSectionTag
 import com.flashcardsopensourceapp.feature.review.reviewRateAgainButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateEasyButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewRateGoodButtonTag

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -20,6 +20,13 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
+import com.flashcardsopensourceapp.feature.progress.sections.ErrorCard
+import com.flashcardsopensourceapp.feature.progress.sections.GuidanceCard
+import com.flashcardsopensourceapp.feature.progress.sections.LeaderboardSectionCard
+import com.flashcardsopensourceapp.feature.progress.sections.LoadingCard
+import com.flashcardsopensourceapp.feature.progress.sections.ReviewScheduleSectionCard
+import com.flashcardsopensourceapp.feature.progress.sections.ReviewsSectionCard
+import com.flashcardsopensourceapp.feature.progress.sections.StreakSectionCard
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
@@ -1,4 +1,5 @@
-package com.flashcardsopensourceapp.feature.progress
+package com.flashcardsopensourceapp.feature.progress.sections
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,6 +43,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
+import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardRowUiState
+import com.flashcardsopensourceapp.feature.progress.ProgressLeaderboardSectionUiState
+import com.flashcardsopensourceapp.feature.progress.R
 import java.text.NumberFormat
 import java.util.Locale
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewScheduleSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewScheduleSection.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress
+package com.flashcardsopensourceapp.feature.progress.sections
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -49,6 +49,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
+import com.flashcardsopensourceapp.feature.progress.ProgressReviewScheduleBucketUiState
+import com.flashcardsopensourceapp.feature.progress.ProgressReviewScheduleSectionUiState
+import com.flashcardsopensourceapp.feature.progress.R
 import java.text.NumberFormat
 import java.util.Locale
 import kotlin.math.atan2

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewsSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewsSection.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress
+package com.flashcardsopensourceapp.feature.progress.sections
 
 import android.icu.text.DateIntervalFormat
 import android.icu.util.DateInterval
@@ -46,6 +46,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.flashcardsopensourceapp.feature.progress.ProgressHistoryDayUiState
+import com.flashcardsopensourceapp.feature.progress.ProgressReviewsSectionUiState
+import com.flashcardsopensourceapp.feature.progress.R
 import java.time.LocalDate
 import java.time.ZoneOffset
 import java.util.Locale

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressSectionDefaults.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressSectionDefaults.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress
+package com.flashcardsopensourceapp.feature.progress.sections
 
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStatusCards.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStatusCards.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress
+package com.flashcardsopensourceapp.feature.progress.sections
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,6 +15,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.flashcardsopensourceapp.feature.progress.R
 
 @Composable
 internal fun LoadingCard() {

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
@@ -1,4 +1,4 @@
-package com.flashcardsopensourceapp.feature.progress
+package com.flashcardsopensourceapp.feature.progress.sections
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -33,6 +33,10 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.flashcardsopensourceapp.feature.progress.ProgressStreakDayUiState
+import com.flashcardsopensourceapp.feature.progress.ProgressStreakSectionUiState
+import com.flashcardsopensourceapp.feature.progress.ProgressSummaryUiState
+import com.flashcardsopensourceapp.feature.progress.R
 
 private const val progressStreakOverflowThreshold: Int = 99
 


### PR DESCRIPTION
## Summary
- Move Android Progress screen section composables into one sections package
- Update ProgressRoute and marketing screenshot imports for the new package

## Validation
- git --no-pager diff --cached --check
- rg old parent package declarations under moved sections returned no matches
- Gradle not run per repository policy requiring explicit permission