### PR TITLE
[codex] Refine review toolbar progress actions

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/AppNavigationTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/App/AppNavigationTypes.swift
@@ -17,6 +17,7 @@ enum AppTab: Hashable, CaseIterable, Sendable {
 }
 
 enum ProgressPresentationTarget: Hashable, Sendable {
+    case streak
     case leaderboard
 }
 

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -2,11 +2,13 @@ import Foundation
 import SwiftUI
 
 private enum ProgressScreenSectionID: Hashable {
+    case streak
     case leaderboard
 }
 
 private struct ProgressPresentationTaskID: Hashable {
     let requestID: UUID?
+    let hasStreakSection: Bool
     let hasLeaderboardSection: Bool
 }
 
@@ -18,9 +20,14 @@ struct ProgressScreen: View {
         self.store.progressSnapshot != nil && self.store.progressLeaderboardSnapshot != nil
     }
 
+    private var isStreakSectionAvailable: Bool {
+        self.store.progressSnapshot != nil
+    }
+
     private var progressPresentationTaskID: ProgressPresentationTaskID {
         ProgressPresentationTaskID(
             requestID: self.navigation.progressPresentationRequest?.id,
+            hasStreakSection: self.isStreakSectionAvailable,
             hasLeaderboardSection: self.isLeaderboardSectionAvailable
         )
     }
@@ -59,6 +66,7 @@ struct ProgressScreen: View {
                                 calendar: presentationCalendar
                             )
                         }
+                        .id(ProgressScreenSectionID.streak)
                         .accessibilityIdentifier(UITestIdentifier.progressStreakSection)
                         .accessibilityValue(progressSummaryUITestValue(summary: progressSnapshot.summary))
                         .modifier(ProgressCardModifier())
@@ -144,23 +152,38 @@ struct ProgressScreen: View {
             return
         }
 
-        switch request.target {
-        case .leaderboard:
-            guard self.isLeaderboardSectionAvailable else {
-                return
-            }
-            await Task.yield()
-            guard self.navigation.progressPresentationRequest?.id == request.id else {
-                return
-            }
-            guard self.isLeaderboardSectionAvailable else {
-                return
-            }
+        guard self.isProgressPresentationTargetAvailable(target: request.target) else {
+            return
+        }
+        await Task.yield()
+        guard self.navigation.progressPresentationRequest?.id == request.id else {
+            return
+        }
+        guard self.isProgressPresentationTargetAvailable(target: request.target) else {
+            return
+        }
 
-            withAnimation {
-                proxy.scrollTo(ProgressScreenSectionID.leaderboard, anchor: .top)
-            }
-            self.navigation.clearProgressPresentationRequest(id: request.id)
+        withAnimation {
+            proxy.scrollTo(self.progressScreenSectionID(target: request.target), anchor: .top)
+        }
+        self.navigation.clearProgressPresentationRequest(id: request.id)
+    }
+
+    private func isProgressPresentationTargetAvailable(target: ProgressPresentationTarget) -> Bool {
+        switch target {
+        case .streak:
+            return self.isStreakSectionAvailable
+        case .leaderboard:
+            return self.isLeaderboardSectionAvailable
+        }
+    }
+
+    private func progressScreenSectionID(target: ProgressPresentationTarget) -> ProgressScreenSectionID {
+        switch target {
+        case .streak:
+            return .streak
+        case .leaderboard:
+            return .leaderboard
         }
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -522,14 +522,14 @@ struct ReviewView: View {
             Button {
                 self.isQueuePreviewPresented = true
             } label: {
-                Label {
-                    Text(self.reviewQueueButtonTitle)
-                        .monospacedDigit()
-                } icon: {
+                HStack(spacing: 4) {
                     Image(systemName: "list.bullet")
+
+                    Text(self.reviewQueueTotalButtonTitle)
+                        .monospacedDigit()
                 }
-                .labelStyle(.titleAndIcon)
             }
+            .buttonStyle(.glass)
             .disabled(store.reviewTotalCount == 0)
             .accessibilityIdentifier(UITestIdentifier.reviewQueueButton)
             .accessibilityLabel(
@@ -543,8 +543,8 @@ struct ReviewView: View {
         }
     }
 
-    private var reviewQueueButtonTitle: String {
-        "\(store.displayedReviewDueCount.formatted()) / \(store.reviewTotalCount.formatted())"
+    private var reviewQueueTotalButtonTitle: String {
+        store.reviewTotalCount.formatted()
     }
 
     private var reviewProgressBadgeButton: some View {
@@ -552,28 +552,38 @@ struct ReviewView: View {
 
         return Button {
             self.store.prepareVisibleTabForPresentation(tab: .progress, now: Date())
-            self.navigation.selectTab(.progress)
+            self.navigation.openProgress(target: .streak)
         } label: {
-            Label {
+            HStack(spacing: 4) {
+                Image(systemName: makeReviewProgressBadgePresentation(badgeState: badgeState).iconSystemName)
+                    .foregroundStyle(self.reviewProgressBadgeToolbarIconColor(badgeState: badgeState))
+
                 Text(formatReviewProgressBadgeValue(badgeState: badgeState))
                     .monospacedDigit()
-            } icon: {
-                Image(systemName: makeReviewProgressBadgePresentation(badgeState: badgeState).iconSystemName)
             }
-            .labelStyle(.titleAndIcon)
         }
+        .buttonStyle(.glass)
         .disabled(badgeState.isInteractive == false)
         .accessibilityIdentifier(UITestIdentifier.reviewProgressBadge)
         .accessibilityLabel(self.reviewProgressBadgeAccessibilityLabel(badgeState: badgeState))
         .accessibilityValue(self.reviewProgressBadgeAccessibilityValue(badgeState: badgeState))
     }
 
+    private func reviewProgressBadgeToolbarIconColor(badgeState: ReviewProgressBadgeState) -> Color {
+        if badgeState.hasReviewedToday {
+            return .accentColor
+        }
+
+        return .primary
+    }
+
     private var reviewLeaderboardButton: some View {
         Button {
             self.navigation.openProgress(target: .leaderboard)
         } label: {
-            Label(self.reviewLeaderboardButtonTitle, systemImage: "trophy")
+            Image(systemName: "trophy")
         }
+        .buttonStyle(.glass)
         .accessibilityIdentifier(UITestIdentifier.reviewLeaderboardShortcut)
         .accessibilityLabel(self.reviewLeaderboardButtonTitle)
     }


### PR DESCRIPTION
## Summary

- Use native glass styling for the Review toolbar action buttons.
- Show only the total queue count beside the queue icon.
- Show the streak count beside the flame, tint the active flame with the app accent, and route flame taps to the Progress streak section.

## Validation

- `git --no-pager diff --check`
- Reviewed `ProgressPresentationTarget` dependents, Progress scroll targets, accessibility identifiers/values, and UI-test expectations.
- Verified SwiftUI `.glass` and `sharedBackgroundVisibility(_:)` are available in the local iOS 26 SDK.

No simulator-backed iOS tests were run, per repository instructions.