### PR TITLE
[codex] Add trailing leaderboard gap row

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -227,7 +227,8 @@ paths:
       description: >-
         Returns all five leaderboard windows in one payload for the Progress tab,
         each with viewer-perspective ranks, the per-viewer tie rule, and the
-        server-computed compact rows so every client renders the same list.
+        server-computed compact rows so every client renders the same list,
+        including gap rows for hidden ranks between and after visible groups.
         Guests receive status linked_account_required and opted-out users receive
         participation_disabled, both with no other users' rows. ApiKey
         authentication is rejected. Only opaque public profile ids and
@@ -269,6 +270,16 @@ paths:
                         anonymousDisplayName: Silver Bright Harbor
                         qualifiedReviewCount: 51
                         rank: 1
+                      - kind: top
+                        publicProfileId: d4e5f6a7-8192-4d0e-af3b-4c5d6e7f8091
+                        anonymousDisplayName: Violet Calm Ridge
+                        qualifiedReviewCount: 44
+                        rank: 2
+                      - kind: top
+                        publicProfileId: e5f6a7b8-9203-4e1f-b04c-5d6e7f8091a2
+                        anonymousDisplayName: Indigo Clear Grove
+                        qualifiedReviewCount: 30
+                        rank: 3
                       - kind: gap
                       - kind: neighbor
                         publicProfileId: b2c3d4e5-6f70-4b9c-8d1e-2f3a4b5c6d7e
@@ -285,6 +296,7 @@ paths:
                         anonymousDisplayName: Coral Keen Valley
                         qualifiedReviewCount: 7
                         rank: 43
+                      - kind: gap
         '403':
           description: Forbidden authentication transport
           content:

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -49,7 +48,8 @@ import com.flashcardsopensourceapp.feature.progress.R
 import java.text.NumberFormat
 import java.util.Locale
 
-private const val leaderboardReservedRowCount: Int = 7
+private const val leaderboardReservedRowCount: Int = 8
+private const val leaderboardReservedGapRowCount: Int = 2
 private const val millisecondsPerMinute: Long = 60_000L
 
 @Composable
@@ -306,14 +306,11 @@ private data class LeaderboardReservedRows(
 
 private fun leaderboardReservedRows(rows: List<ProgressLeaderboardRowUiState>): LeaderboardReservedRows {
     val reservedRowCount = maxOf(0, leaderboardReservedRowCount - rows.size)
-    val containsGapRow = rows.any { row ->
+    val visibleGapRowCount = rows.count { row ->
         row == ProgressLeaderboardRowUiState.Gap
     }
-    val gapRowCount = if (containsGapRow) {
-        0
-    } else {
-        minOf(1, reservedRowCount)
-    }
+    val missingGapRowCount = maxOf(0, leaderboardReservedGapRowCount - visibleGapRowCount)
+    val gapRowCount = minOf(missingGapRowCount, reservedRowCount)
 
     return LeaderboardReservedRows(
         participantRowCount = reservedRowCount - gapRowCount,
@@ -396,32 +393,36 @@ private fun LeaderboardReservedParticipantRow() {
 
 @Composable
 private fun LeaderboardReservedGapRow() {
-    Text(
-        text = "⋯",
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        style = MaterialTheme.typography.bodyMedium,
-        textAlign = TextAlign.Center,
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .alpha(0f)
             .clearAndSetSemantics {}
-    )
+    ) {
+        Text(
+            text = "⋯",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
 }
 
 @Composable
 private fun LeaderboardGapRow() {
     val gapContentDescription = stringResource(id = R.string.progress_leaderboard_gap_content_description)
-    Text(
-        text = "⋯",
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        style = MaterialTheme.typography.bodyMedium,
-        textAlign = TextAlign.Center,
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .semantics {
+            .clearAndSetSemantics {
                 contentDescription = gapContentDescription
             }
-    )
+    ) {
+        Text(
+            text = "⋯",
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
 }
 
 @Composable

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
@@ -303,7 +303,7 @@ class ProgressViewModelTest {
             assertEquals(128, selectedWindow.participantCount)
 
             val rows = selectedWindow.rows
-            assertEquals(7, rows.size)
+            assertEquals(8, rows.size)
             val firstRow = rows[0] as ProgressLeaderboardRowUiState.Participant
             assertEquals(1, firstRow.rank)
             assertEquals("Silver Bright Harbor", firstRow.displayName)
@@ -328,6 +328,7 @@ class ProgressViewModelTest {
         val topRows = rows.take(3).map { row -> row as ProgressLeaderboardRowUiState.Participant }
         assertEquals(listOf(1, 2, 3), topRows.map(ProgressLeaderboardRowUiState.Participant::rank))
         assertEquals(ProgressLeaderboardRowUiState.Gap, rows[3])
+        assertEquals(ProgressLeaderboardRowUiState.Gap, rows[7])
     }
 
     @Test
@@ -765,7 +766,8 @@ private fun createCloudProgressLeaderboardWindow(): CloudProgressLeaderboardWind
                 anonymousDisplayName = "Sunny Brave Cliff",
                 qualifiedReviewCount = 7,
                 rank = 43
-            )
+            ),
+            CloudProgressLeaderboardRow.Gap
         )
     )
 }

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
@@ -365,7 +365,7 @@ test("equal counts rank the viewer below other users with the same count", async
   );
 });
 
-test("compact rows show the top three, a single gap, and the viewer with its neighbors", async () => {
+test("compact rows show the top three, gaps, and the viewer with its neighbors", async () => {
   const otherEntries: ReadonlyArray<SnapshotEntryRow> = [
     { public_profile_id: "00000000-0000-4000-8000-0000000000d1", qualified_review_count: 100, base_sort_position: 1 },
     { public_profile_id: "00000000-0000-4000-8000-0000000000d2", qualified_review_count: 90, base_sort_position: 2 },
@@ -405,12 +405,14 @@ test("compact rows show the top three, a single gap, and the viewer with its nei
     "neighbor:5",
     "viewer:6",
     "neighbor:7",
+    "gap",
   ]);
 
-  // The top three rows always precede the single gap row.
+  // The top three rows always precede the first hidden-rank gap row.
   assert.equal(window.rows[0]?.kind, "top");
   assert.equal(window.rows[3]?.kind, "gap");
-  assert.equal(window.rows.filter((row) => row.kind === "gap").length, 1);
+  assert.equal(window.rows[7]?.kind, "gap");
+  assert.equal(window.rows.filter((row) => row.kind === "gap").length, 2);
 });
 
 test("a viewer near the top produces contiguous rows with no gap", async () => {

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.ts
@@ -353,8 +353,9 @@ function buildParticipantRow(
  * Selects the compact rows server-side so every client renders the same list:
  * the top three rows (when that many participants exist), the row before the
  * viewer, the viewer, and the row after the viewer. Overlapping groups are
- * de-duplicated by rank and a single gap row is inserted only when hidden ranks
- * sit between the top block and the viewer-neighbor block.
+ * de-duplicated by rank, a gap row is inserted when hidden ranks sit between
+ * the top block and the viewer-neighbor block, and a trailing gap row is
+ * inserted when more participants remain below the last shown row.
  */
 function buildCompactRows(
   ranked: ReadonlyArray<RankedParticipant>,
@@ -389,6 +390,10 @@ function buildCompactRows(
 
     rows.push(buildParticipantRow(participant, topRowCount, resolveName));
     previousRank = rank;
+  }
+
+  if (previousRank < total) {
+    rows.push({ kind: "gap" });
   }
 
   return rows;

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+private let progressLeaderboardMaximumGapRowCount: Int = 2
+
 // Wire contract for GET /me/progress/leaderboard.
 // Keep aligned with api/src/openapi.yaml and
 // apps/backend/src/community/leaderboard/progressLeaderboard.ts.
@@ -134,7 +136,7 @@ enum ProgressLeaderboardValidationError: LocalizedError {
     case invalidViewerRank(windowKey: String, rank: Int, participantCount: Int)
     case negativeReviewCount(windowKey: String, reviewCount: Int)
     case invalidRowRank(windowKey: String, rank: Int)
-    case multipleGapRows(windowKey: String, gapRowCount: Int)
+    case tooManyGapRows(windowKey: String, gapRowCount: Int)
     case viewerRowMismatch(windowKey: String)
 
     var errorDescription: String? {
@@ -153,8 +155,8 @@ enum ProgressLeaderboardValidationError: LocalizedError {
             return "Leaderboard window \(windowKey) contained a negative review count: \(reviewCount)."
         case .invalidRowRank(let windowKey, let rank):
             return "Leaderboard window \(windowKey) contained an invalid row rank: \(rank)."
-        case .multipleGapRows(let windowKey, let gapRowCount):
-            return "Leaderboard window \(windowKey) contained \(gapRowCount) gap rows. At most one is allowed."
+        case .tooManyGapRows(let windowKey, let gapRowCount):
+            return "Leaderboard window \(windowKey) contained \(gapRowCount) gap rows. At most \(progressLeaderboardMaximumGapRowCount) are allowed."
         case .viewerRowMismatch(let windowKey):
             return "Leaderboard window \(windowKey) rows did not contain exactly one viewer row matching the viewer."
         }
@@ -276,10 +278,10 @@ private func validateProgressLeaderboardWindow(window: ProgressLeaderboardWindow
         }
     }
 
-    // The compact-row contract emits at most one ellipsis gap, and the gap row
-    // renders with a constant SwiftUI identity, so duplicates must never pass.
-    guard gapRowCount <= 1 else {
-        throw ProgressLeaderboardValidationError.multipleGapRows(
+    // The compact-row contract emits at most two ellipsis gaps; extras would
+    // stretch the leaderboard beyond its reserved compact height.
+    guard gapRowCount <= progressLeaderboardMaximumGapRowCount else {
+        throw ProgressLeaderboardValidationError.tooManyGapRows(
             windowKey: windowKey,
             gapRowCount: gapRowCount
         )

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
@@ -96,16 +96,20 @@ struct ProgressLeaderboardWindowState: Hashable, Identifiable, Sendable {
 
 enum ProgressLeaderboardRowState: Hashable, Identifiable, Sendable {
     case participant(ProgressLeaderboardParticipantRowState)
-    case gap
+    case gap(ProgressLeaderboardGapRowState)
 
     var id: String {
         switch self {
         case .participant(let row):
             return "participant-\(row.rank)-\(row.publicProfileId)"
-        case .gap:
-            return "gap"
+        case .gap(let row):
+            return row.id
         }
     }
+}
+
+struct ProgressLeaderboardGapRowState: Hashable, Sendable {
+    let id: String
 }
 
 struct ProgressLeaderboardParticipantRowState: Hashable, Sendable {

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
@@ -122,10 +122,10 @@ private func makeProgressLeaderboardWindowState(
     }
 
     let overlaidViewerCount = max(window.viewer.qualifiedReviewCount, localQualifiedReviewCount)
-    let rows = window.rows.map { row -> ProgressLeaderboardRowState in
+    let rows = window.rows.enumerated().map { index, row -> ProgressLeaderboardRowState in
         switch row {
         case .gap:
-            return .gap
+            return .gap(ProgressLeaderboardGapRowState(id: "gap-\(index)"))
         case .participant(let participantRow):
             return .participant(
                 ProgressLeaderboardParticipantRowState(

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
-private let progressLeaderboardReservedRowCount: Int = 7
+private let progressLeaderboardReservedRowCount: Int = 8
+private let progressLeaderboardReservedGapRowCount: Int = 2
 
 struct ProgressLeaderboardSection: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
@@ -137,7 +138,7 @@ struct ProgressLeaderboardSection: View {
                     switch row {
                     case .participant(let participantRow):
                         ProgressLeaderboardParticipantRowView(row: participantRow)
-                    case .gap:
+                    case .gap(_):
                         ProgressLeaderboardGapRowView()
                     }
                 }
@@ -311,13 +312,14 @@ private struct ProgressLeaderboardReservedRows: Hashable {
 
 private func progressLeaderboardReservedRows(rows: [ProgressLeaderboardRowState]) -> ProgressLeaderboardReservedRows {
     let reservedRowCount = max(0, progressLeaderboardReservedRowCount - rows.count)
-    let containsGapRow = rows.contains { row in
-        if case .gap = row {
-            return true
+    let visibleGapRowCount = rows.reduce(0) { count, row in
+        if case .gap(_) = row {
+            return count + 1
         }
-        return false
+        return count
     }
-    let gapRowCount = containsGapRow ? 0 : min(1, reservedRowCount)
+    let missingGapRowCount = max(0, progressLeaderboardReservedGapRowCount - visibleGapRowCount)
+    let gapRowCount = min(missingGapRowCount, reservedRowCount)
 
     return ProgressLeaderboardReservedRows(
         participantRowCount: reservedRowCount - gapRowCount,
@@ -413,11 +415,12 @@ private struct ProgressLeaderboardReservedGapRowView: View {
 
 private struct ProgressLeaderboardGapRowView: View {
     var body: some View {
-        HStack {
-            Spacer(minLength: 0)
+        HStack(spacing: 10) {
             Image(systemName: "ellipsis")
                 .font(.subheadline)
                 .foregroundStyle(.tertiary)
+                .frame(minWidth: 28, alignment: .leading)
+
             Spacer(minLength: 0)
         }
         .accessibilityHidden(true)

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
@@ -50,6 +50,7 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
                 qualifiedReviewCount: 7,
                 rank: 43
             ),
+            .gap,
         ]
     }
 
@@ -91,7 +92,7 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
         XCTAssertEqual(128, window.participantCount)
         XCTAssertEqual(42, window.viewerRank)
         XCTAssertEqual(7, window.viewerQualifiedReviewCount)
-        XCTAssertEqual(7, window.rows.count)
+        XCTAssertEqual(8, window.rows.count)
 
         guard case .participant(let firstRow) = window.rows[0] else {
             XCTFail("Expected a participant row first, received \(window.rows[0])")
@@ -146,7 +147,18 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
             XCTAssertEqual(index + 1, row.rank)
         }
 
-        XCTAssertEqual(.gap, window.rows[3])
+        guard case .gap(let firstGapRow) = window.rows[3] else {
+            XCTFail("Expected a gap row at index 3, received \(window.rows[3])")
+            return
+        }
+        guard case .gap(let secondGapRow) = window.rows[7] else {
+            XCTFail("Expected a gap row at index 7, received \(window.rows[7])")
+            return
+        }
+
+        XCTAssertEqual("gap-3", firstGapRow.id)
+        XCTAssertEqual("gap-7", secondGapRow.id)
+        XCTAssertNotEqual(firstGapRow.id, secondGapRow.id)
     }
 
     func testGuestAndParticipationDisabledStatusesMapToPlaceholders() throws {

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -265,6 +265,7 @@ function createLeaderboardWindow(windowKey: ProgressLeaderboardWindowKey): Progr
       { kind: "neighbor", publicProfileId: "profile-41", anonymousDisplayName: "Jade Swift River", qualifiedReviewCount: 8, rank: 41 },
       { kind: "viewer", publicProfileId: "viewer-profile", anonymousDisplayName: "Quiet Maple Grove", qualifiedReviewCount: 7, rank: 42 },
       { kind: "neighbor", publicProfileId: "profile-43", anonymousDisplayName: "Bold Cedar Crest", qualifiedReviewCount: 7, rank: 43 },
+      { kind: "gap" },
     ],
   };
 }
@@ -805,6 +806,7 @@ describe("ProgressScreen", () => {
       "neighbor",
       "viewer",
       "neighbor",
+      "gap",
     ]);
 
     const rowTexts = rows.map((row) => row.textContent);
@@ -817,12 +819,15 @@ describe("ProgressScreen", () => {
     expect(rowTexts[5]).toContain("#42");
     expect(rowTexts[6]).toContain("Bold Cedar Crest");
 
-    const gapRow = rows[3];
-    if (gapRow === undefined) {
-      throw new Error("Leaderboard gap row was not found");
+    const topGapRow = rows[3];
+    const bottomGapRow = rows[7];
+    if (topGapRow === undefined || bottomGapRow === undefined) {
+      throw new Error("Leaderboard gap rows were not found");
     }
-    expect(gapRow.querySelector("button")).toBeNull();
-    expect(gapRow.querySelector("a")).toBeNull();
+    expect(topGapRow.querySelector("button")).toBeNull();
+    expect(topGapRow.querySelector("a")).toBeNull();
+    expect(bottomGapRow.querySelector("button")).toBeNull();
+    expect(bottomGapRow.querySelector("a")).toBeNull();
   });
 
   it("reveals the leaderboard info text explaining that Again reviews are excluded", async () => {

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -527,8 +527,8 @@ svg.progress-review-schedule-donut {
   display: grid;
   align-content: start;
   gap: 4px;
-  /* Six participant rows, one gap row, and six row gaps: the compact worst case. */
-  min-height: 290px;
+  /* Six participant rows, two gap rows, and seven row gaps: the compact worst case. */
+  min-height: 320px;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -593,8 +593,8 @@ svg.progress-review-schedule-donut {
 
 .progress-leaderboard-gap {
   min-height: 26px;
-  justify-items: center;
-  grid-template-columns: minmax(0, 1fr);
+  justify-items: start;
+  grid-template-columns: minmax(3.5ch, auto) minmax(0, 1fr) auto;
   border-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- Add a trailing compact leaderboard gap row when more active participants remain below the visible viewer-neighbor group.
- Keep backend, OpenAPI, iOS, Android, and web clients aligned on the two-gap compact row contract.
- Reserve consistent compact leaderboard height and left-align ellipsis gap rows across clients.

## Validation
- `git --no-pager diff --check`
- `npm run bundle --prefix ../../api && node --test --import tsx src/community/leaderboard/progressLeaderboard.test.ts`
- `npx vitest run src/screens/progress/ProgressScreen.render.test.tsx`

Android Gradle and iOS simulator-backed checks were not run because this repository requires explicit approval for those local runs.