### PR TITLE
[codex] Align review status shortcuts across clients

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -56,6 +56,11 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         val reviewedTodayDescription = reviewString(
             ReviewStringResources.string.review_progress_badge_not_reviewed_today
         )
+        val reviewQueueContentDescription = composeRule.activity.resources.getQuantityString(
+            ReviewStringResources.plurals.review_queue_button_content_description,
+            10,
+            10
+        )
 
         composeRule.setContent {
             FlashcardsTheme {
@@ -130,7 +135,14 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
 
         composeRule.onNodeWithTag(reviewQueueButtonTag)
             .assertIsDisplayed()
+            .assert(
+                hasSemanticsValue(
+                    key = SemanticsProperties.ContentDescription,
+                    expectedValue = listOf(reviewQueueContentDescription)
+                )
+            )
             .performClick()
+        composeRule.onNodeWithText("10").assertIsDisplayed()
         composeRule.onNodeWithText("99+").assertIsDisplayed()
         composeRule.onNodeWithTag(reviewLeaderboardShortcutTag)
             .assertIsDisplayed()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppHandoffCoordinator.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/AppHandoffCoordinator.kt
@@ -34,6 +34,7 @@ data class ReviewFilterRequest(
 )
 
 enum class ProgressNavigationTarget {
+    STREAK,
     LEADERBOARD
 }
 

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/progress/ProgressNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/progress/ProgressNavGraph.kt
@@ -30,6 +30,10 @@ internal fun NavGraphBuilder.registerProgressNavGraph(
 
         ProgressRoute(
             uiState = uiState,
+            streakScrollRequestId = progressNavigationRequest
+                ?.takeIf { request -> request.target == ProgressNavigationTarget.STREAK }
+                ?.requestId,
+            onStreakScrollRequestConsumed = appGraph.appHandoffCoordinator::consumeProgressNavigation,
             leaderboardScrollRequestId = progressNavigationRequest
                 ?.takeIf { request -> request.target == ProgressNavigationTarget.LEADERBOARD }
                 ?.requestId,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -202,6 +202,9 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                     )
                 },
                 onOpenProgress = {
+                    appGraph.appHandoffCoordinator.requestProgressNavigation(
+                        target = ProgressNavigationTarget.STREAK
+                    )
                     navigateToTopLevelDestination(
                         navController = navController,
                         destination = ProgressDestination

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -32,6 +32,8 @@ import com.flashcardsopensourceapp.feature.progress.sections.StreakSectionCard
 @Composable
 fun ProgressRoute(
     uiState: ProgressUiState,
+    streakScrollRequestId: Long?,
+    onStreakScrollRequestConsumed: (Long) -> Unit,
     leaderboardScrollRequestId: Long?,
     onLeaderboardScrollRequestConsumed: (Long) -> Unit,
     onScreenVisible: () -> Unit,
@@ -43,6 +45,9 @@ fun ProgressRoute(
     val lifecycleOwner = LocalLifecycleOwner.current
     val listState = rememberLazyListState()
     val currentScreenVisibleAction = rememberUpdatedState(newValue = onScreenVisible)
+    val currentStreakScrollRequestConsumed = rememberUpdatedState(
+        newValue = onStreakScrollRequestConsumed
+    )
     val currentLeaderboardScrollRequestConsumed = rememberUpdatedState(
         newValue = onLeaderboardScrollRequestConsumed
     )
@@ -64,15 +69,19 @@ fun ProgressRoute(
         }
     }
 
+    LaunchedEffect(streakScrollRequestId, uiState) {
+        val requestId = streakScrollRequestId ?: return@LaunchedEffect
+        uiState as? ProgressUiState.Loaded ?: return@LaunchedEffect
+
+        listState.animateScrollToItem(index = progressStreakItemIndex())
+        currentStreakScrollRequestConsumed.value(requestId)
+    }
+
     LaunchedEffect(leaderboardScrollRequestId, uiState) {
         val requestId = leaderboardScrollRequestId ?: return@LaunchedEffect
-        val loadedState = uiState as? ProgressUiState.Loaded ?: return@LaunchedEffect
+        uiState as? ProgressUiState.Loaded ?: return@LaunchedEffect
 
-        listState.animateScrollToItem(
-            index = progressLeaderboardItemIndex(
-                hasReviewScheduleSection = loadedState.reviewScheduleSection != null
-            )
-        )
+        listState.animateScrollToItem(index = progressLeaderboardItemIndex())
         currentLeaderboardScrollRequestConsumed.value(requestId)
     }
 
@@ -164,14 +173,12 @@ fun ProgressRoute(
     }
 }
 
-internal fun progressLeaderboardItemIndex(
-    hasReviewScheduleSection: Boolean
-): Int {
-    return if (hasReviewScheduleSection) {
-        3
-    } else {
-        2
-    }
+internal fun progressStreakItemIndex(): Int {
+    return 0
+}
+
+internal fun progressLeaderboardItemIndex(): Int {
+    return 1
 }
 
 internal fun shouldTriggerInitialProgressLoad(

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
@@ -68,6 +68,12 @@ class ProgressViewModelTest {
     }
 
     @Test
+    fun progressSectionScrollIndexesMatchLoadedRouteOrder() {
+        assertEquals(0, progressStreakItemIndex())
+        assertEquals(1, progressLeaderboardItemIndex())
+    }
+
+    @Test
     fun repositorySnapshotsMapToLoadedUiState() = runTest(dispatcher) {
         Dispatchers.setMain(dispatcher)
         try {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewRoute.kt
@@ -193,7 +193,6 @@ fun ReviewRoute(
         topBar = {
             ReviewTopBar(
                 isLoading = uiState.isLoading,
-                remainingCount = uiState.remainingCount,
                 totalCount = uiState.totalCount,
                 reviewProgressBadge = uiState.reviewProgressBadge,
                 selectedFilterTitle = uiState.selectedFilterTitle,

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.FilterList
-import androidx.compose.material.icons.outlined.HourglassBottom
+import androidx.compose.material.icons.outlined.FormatListBulleted
 import androidx.compose.material.icons.outlined.LocalFireDepartment
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -44,7 +44,6 @@ private val reviewTopBarFilterMaxWidth = 160.dp
 @Composable
 internal fun ReviewTopBar(
     isLoading: Boolean,
-    remainingCount: Int,
     totalCount: Int,
     reviewProgressBadge: ReviewProgressBadgeState,
     selectedFilterTitle: String,
@@ -95,7 +94,6 @@ internal fun ReviewTopBar(
 
             ReviewQueueAction(
                 isLoading = isLoading,
-                remainingCount = remainingCount,
                 totalCount = totalCount,
                 onOpenPreview = onOpenPreview
             )
@@ -147,7 +145,6 @@ internal fun ReviewTopBar(
 @Composable
 private fun ReviewQueueAction(
     isLoading: Boolean,
-    remainingCount: Int,
     totalCount: Int,
     onOpenPreview: () -> Unit
 ) {
@@ -160,6 +157,12 @@ private fun ReviewQueueAction(
         )
         return
     }
+    val resources = LocalContext.current.resources
+    val queueContentDescription = resources.getQuantityString(
+        R.plurals.review_queue_button_content_description,
+        totalCount,
+        totalCount
+    )
 
     TextButton(
         onClick = onOpenPreview,
@@ -168,19 +171,17 @@ private fun ReviewQueueAction(
             contentColor = MaterialTheme.colorScheme.onSurfaceVariant
         ),
         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
-        modifier = Modifier.testTag(reviewQueueButtonTag)
+        modifier = Modifier
+            .testTag(reviewQueueButtonTag)
+            .semantics {
+                contentDescription = queueContentDescription
+            }
     ) {
         Icon(
-            imageVector = Icons.Outlined.HourglassBottom,
+            imageVector = Icons.Outlined.FormatListBulleted,
             contentDescription = null
         )
         Spacer(modifier = Modifier.size(6.dp))
-        Text(
-            text = stringResource(
-                id = R.string.review_progress_fraction,
-                remainingCount,
-                totalCount
-            )
-        )
+        Text(text = totalCount.toString())
     }
 }

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -26,7 +26,6 @@
     <string name="review_create_card">Create card</string>
     <string name="review_create_with_ai">Create with AI</string>
     <string name="review_switch_to_all_cards">Switch to all cards</string>
-    <string name="review_progress_fraction">%1$d / %2$d</string>
     <string name="review_leaderboard_shortcut_content_description">Open leaderboard</string>
     <string name="review_progress_badge_reviewed_today">Reviewed today</string>
     <string name="review_progress_badge_not_reviewed_today">Not reviewed today</string>
@@ -86,5 +85,9 @@
     <plurals name="review_progress_badge_content_description">
         <item quantity="one">Review streak %d day.</item>
         <item quantity="other">Review streak %d days.</item>
+    </plurals>
+    <plurals name="review_queue_button_content_description">
+        <item quantity="one">Review queue %d card.</item>
+        <item quantity="other">Review queue %d cards.</item>
     </plurals>
 </resources>

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -7,6 +7,8 @@
 export const reviewRoute: string = "/review";
 export const chatRoute: string = "/chat";
 export const progressRoute: string = "/progress";
+export const progressStreakHash: string = "streak";
+export const progressStreakRoute: string = `${progressRoute}#${progressStreakHash}`;
 export const progressLeaderboardHash: string = "leaderboard";
 export const progressLeaderboardRoute: string = `${progressRoute}#${progressLeaderboardHash}`;
 export const cardsRoute: string = "/cards";

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -4,7 +4,7 @@ import ReactDOM from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../i18n";
-import { progressLeaderboardHash } from "../../routes";
+import { progressLeaderboardHash, progressStreakHash } from "../../routes";
 import type { AppDataContextValue } from "../../appData";
 import {
   createEmptyProgressLeaderboardSourceState,
@@ -743,6 +743,29 @@ describe("ProgressScreen", () => {
     }
 
     expect(leaderboardCard.id).toBe(progressLeaderboardHash);
+    expect(vi.mocked(HTMLElement.prototype.scrollIntoView)).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    });
+  });
+
+  it("scrolls to the streak card when the route hash targets it", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={[`/progress#${progressStreakHash}`]}>
+          <I18nProvider>
+            <ProgressScreen />
+          </I18nProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    const streakCard = container.querySelector("[data-testid='progress-streak-card']");
+    if (!(streakCard instanceof HTMLElement)) {
+      throw new Error("Streak card was not found");
+    }
+
+    expect(streakCard.id).toBe(progressStreakHash);
     expect(vi.mocked(HTMLElement.prototype.scrollIntoView)).toHaveBeenCalledWith({
       behavior: "smooth",
       block: "start",

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -8,7 +8,7 @@ import {
 import { useProgressInvalidationState } from "../../appData/progress/invalidation/progressInvalidation";
 import { canLoadProgressServerBase, useProgressSource } from "../../appData/progress/progressSource";
 import { resolveLocaleWeekContext, useI18n } from "../../i18n";
-import { progressLeaderboardHash } from "../../routes";
+import { progressLeaderboardHash, progressStreakHash } from "../../routes";
 import type {
   DailyReviewPoint,
   ProgressLeaderboardWindowKey,
@@ -70,6 +70,7 @@ export function ProgressScreen(): ReactElement {
   const [selectedReviewScheduleBucket, setSelectedReviewScheduleBucket] = useState<ProgressReviewScheduleBucketKey | null>(null);
   const [selectedLeaderboardWindowKey, setSelectedLeaderboardWindowKey] = useState<ProgressLeaderboardWindowKey | null>(null);
   const [isLeaderboardInfoVisible, setIsLeaderboardInfoVisible] = useState<boolean>(false);
+  const streakSectionRef = useRef<HTMLElement | null>(null);
   const leaderboardSectionRef = useRef<HTMLElement | null>(null);
   const progressSummary = progressSourceState.summary.renderedSnapshot;
   const progress = progressSourceState.series.renderedSnapshot;
@@ -93,23 +94,27 @@ export function ProgressScreen(): ReactElement {
   }, [progressSourceState.reviewSchedule.renderedSnapshot]);
 
   useEffect(() => {
-    if (location.hash !== `#${progressLeaderboardHash}` || progress === null) {
+    if (progress === null) {
       return;
     }
 
-    const leaderboardSection = leaderboardSectionRef.current;
-    if (leaderboardSection === null) {
+    const targetSection = location.hash === `#${progressStreakHash}`
+      ? streakSectionRef.current
+      : location.hash === `#${progressLeaderboardHash}`
+        ? leaderboardSectionRef.current
+        : null;
+    if (targetSection === null) {
       return;
     }
 
     const animationFrameId = window.requestAnimationFrame(() => {
-      leaderboardSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      targetSection.scrollIntoView({ behavior: "smooth", block: "start" });
     });
 
     return () => {
       window.cancelAnimationFrame(animationFrameId);
     };
-  }, [location.hash, progress, progressSourceState.leaderboard.renderedSnapshot]);
+  }, [location.hash, progress]);
 
   const dailyReviews = progress === null ? [] : sortDailyReviews(progress.dailyReviews);
   const today = progress === null ? "" : progress.to;
@@ -198,6 +203,8 @@ export function ProgressScreen(): ReactElement {
           <div className="progress-layout">
             <ProgressStreakSection
               title={t("progressScreen.streakTitle")}
+              sectionId={progressStreakHash}
+              sectionRef={streakSectionRef}
               summary={progressStreakSummary}
               streakWeeks={streakWeeks}
             />

--- a/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
+++ b/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactElement } from "react";
+import type { CSSProperties, ReactElement, Ref } from "react";
 import { ReviewProgressBadgeIcon } from "../../shared/ReviewProgressBadgeIcon";
 import type { StreakDay } from "./progressStreakModel";
 
@@ -24,6 +24,8 @@ export type ProgressStreakSummaryView = Readonly<{
 
 type ProgressStreakSectionProps = Readonly<{
   title: string;
+  sectionId: string;
+  sectionRef: Ref<HTMLElement>;
   summary: ProgressStreakSummaryView | null;
   streakWeeks: ReadonlyArray<ReadonlyArray<StreakDay>>;
 }>;
@@ -91,10 +93,15 @@ function ProgressStreakSummary(props: Readonly<{
 }
 
 export function ProgressStreakSection(props: ProgressStreakSectionProps): ReactElement {
-  const { title, summary, streakWeeks } = props;
+  const { title, sectionId, sectionRef, summary, streakWeeks } = props;
 
   return (
-    <section className="content-card progress-section">
+    <section
+      id={sectionId}
+      ref={sectionRef}
+      className="content-card progress-section"
+      data-testid="progress-streak-card"
+    >
       <div className="progress-section-head">
         <h2 className="progress-section-title">{title}</h2>
       </div>

--- a/apps/web/src/screens/review/components/ReviewQueuePanel.tsx
+++ b/apps/web/src/screens/review/components/ReviewQueuePanel.tsx
@@ -38,7 +38,7 @@ export function ReviewQueuePanel(props: ReviewQueuePanelProps): ReactElement {
   const { t, formatCount, formatDateTime } = useI18n();
 
   return (
-    <aside className="review-queue-panel">
+    <aside className="review-queue-panel" id="review-queue-panel">
       <div className="review-queue-head">
         <h2 className="panel-subtitle">{t("reviewScreen.queue.title")}</h2>
         <span className="review-queue-caption">

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -1,9 +1,9 @@
-import type { ComponentProps, ReactElement } from "react";
+import type { ComponentProps, MouseEvent, ReactElement } from "react";
 import { Link } from "react-router-dom";
 import { formatReviewProgressBadgeValue } from "../../../appData/progress/badge/reviewProgressBadge";
 import { useI18n } from "../../../i18n";
-import { progressLeaderboardRoute, progressRoute } from "../../../routes";
-import { ProgressLeaderboardShortcutIcon, ReviewProgressBadgeIcon } from "../../shared/ReviewProgressBadgeIcon";
+import { progressLeaderboardRoute, progressStreakRoute } from "../../../routes";
+import { ProgressLeaderboardShortcutIcon, ReviewProgressBadgeIcon, ReviewQueueShortcutIcon } from "../../shared/ReviewProgressBadgeIcon";
 import { ReviewFilterMenu } from "../filters/ReviewFilterMenu";
 
 type ReviewProgressBadgeState = Readonly<{
@@ -16,6 +16,7 @@ export type ReviewScreenHeaderProps = Readonly<{
   filterMenuProps: ComponentProps<typeof ReviewFilterMenu>;
   hasLoadedReviewData: boolean;
   onRetry: () => void;
+  reviewQueueTotalCount: number;
   reviewLoadErrorMessage: string;
   reviewProgressBadge: ReviewProgressBadgeState;
   reviewSpeechMessage: string;
@@ -26,11 +27,17 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
     filterMenuProps,
     hasLoadedReviewData,
     onRetry,
+    reviewQueueTotalCount,
     reviewLoadErrorMessage,
     reviewProgressBadge,
     reviewSpeechMessage,
   } = props;
-  const { t, formatNumber } = useI18n();
+  const { t, formatCount, formatNumber } = useI18n();
+  const reviewQueueCountLabel = formatCount(reviewQueueTotalCount, {
+    one: t("common.countLabels.card.one"),
+    other: t("common.countLabels.card.other"),
+  });
+  const reviewQueueAriaLabel = `${t("reviewScreen.queue.title")}: ${reviewQueueCountLabel}`;
   const reviewProgressBadgeTodayStatus = reviewProgressBadge.hasReviewedToday
     ? t("reviewScreen.progressBadge.reviewedToday")
     : t("reviewScreen.progressBadge.notReviewedToday");
@@ -39,6 +46,13 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
     todayStatus: reviewProgressBadgeTodayStatus,
   });
   const leaderboardShortcutAriaLabel = t("reviewScreen.leaderboardShortcut.ariaLabel");
+  const isReviewQueueShortcutDisabled = reviewQueueTotalCount === 0;
+
+  function handleReviewQueueShortcutClick(event: MouseEvent<HTMLAnchorElement>): void {
+    if (isReviewQueueShortcutDisabled) {
+      event.preventDefault();
+    }
+  }
 
   return (
     <div className="screen-head review-screen-head">
@@ -56,8 +70,21 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
       <div className="screen-actions review-screen-head-actions">
         <ReviewFilterMenu {...filterMenuProps} />
         <div className="review-filter-summary-wrap">
-          <span className="review-filter-label">{t("reviewScreen.progressBadge.title")}</span>
+          <span className="review-filter-label">{t("common.status")}</span>
           <div className="review-progress-shortcuts">
+            <a
+              className="badge review-progress-badge review-screen-head-badge review-queue-shortcut"
+              href="#review-queue-panel"
+              aria-label={reviewQueueAriaLabel}
+              title={reviewQueueAriaLabel}
+              data-testid="review-queue-badge"
+              aria-disabled={isReviewQueueShortcutDisabled ? "true" : undefined}
+              tabIndex={isReviewQueueShortcutDisabled ? -1 : undefined}
+              onClick={handleReviewQueueShortcutClick}
+            >
+              <ReviewQueueShortcutIcon />
+              <span className="review-progress-badge-value">{formatNumber(reviewQueueTotalCount)}</span>
+            </a>
             <Link
               className="badge review-progress-badge review-screen-head-badge review-leaderboard-shortcut"
               to={progressLeaderboardRoute}
@@ -69,7 +96,7 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
             </Link>
             <Link
               className={`badge review-progress-badge review-screen-head-badge${reviewProgressBadge.hasReviewedToday ? " review-progress-badge-active" : ""}`}
-              to={progressRoute}
+              to={progressStreakRoute}
               aria-label={reviewProgressBadgeAriaLabel}
               title={reviewProgressBadgeAriaLabel}
               data-testid="review-progress-badge"

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -182,9 +182,15 @@ describe("ReviewScreen controls", () => {
     expect(progressBadge.className).toContain("review-progress-badge-active");
     expect(progressBadge.className).not.toContain("review-progress-badge-approximate");
     expect(progressBadge.textContent).not.toContain("🔥");
-    expect(getContainer().querySelector("[data-testid='review-queue-badge']")).toBeNull();
+    const queueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
+    if (!(queueBadge instanceof HTMLAnchorElement)) {
+      throw new Error("Review queue badge was not found");
+    }
+    expect(queueBadge.textContent).toContain("1");
+    expect(queueBadge.getAttribute("href")).toBe("#review-queue-panel");
     expect(getContainer().querySelector("[data-testid='review-screen-toolbar']")).toBeNull();
     expect(headerActions.contains(scopeTrigger)).toBe(true);
+    expect(headerActions.contains(queueBadge)).toBe(true);
     expect(headerActions.contains(progressBadge)).toBe(true);
     expect(scopeTrigger.compareDocumentPosition(progressBadge) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
     const progressBadgeIcon = progressBadge.querySelector("svg.review-progress-badge-icon");

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -139,6 +139,7 @@ export function useReviewScreenController(
     localWorkspaceCardCount,
     queueCards,
     resolvedReviewFilter,
+    reviewCounts,
     reviewLoadErrorMessage,
     reviewLoadingSnapshot,
     reviewTagSummaries,
@@ -628,6 +629,9 @@ export function useReviewScreenController(
       },
       hasLoadedReviewData,
       onRetry: handleRetryReviewLoad,
+      reviewQueueTotalCount: isInitialReviewLoad && reviewLoadingSnapshot !== null
+        ? reviewLoadingSnapshot.reviewCounts.totalCount
+        : reviewCounts.totalCount,
       reviewLoadErrorMessage,
       reviewProgressBadge,
       reviewSpeechMessage: reviewFeedbackMessage !== "" ? reviewFeedbackMessage : reviewSpeechMessage,

--- a/apps/web/src/screens/shared/ReviewProgressBadgeIcon.tsx
+++ b/apps/web/src/screens/shared/ReviewProgressBadgeIcon.tsx
@@ -1,5 +1,21 @@
 import type { ReactElement } from "react";
 
+export function ReviewQueueShortcutIcon(): ReactElement {
+  return (
+    <svg
+      className="review-progress-badge-icon"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M4 6.5A1.5 1.5 0 1 1 7 6.5 1.5 1.5 0 0 1 4 6.5Zm5-.9h11v1.8H9V5.6ZM4 12a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Zm5-.9h11v1.8H9v-1.8Zm-5 6.4a1.5 1.5 0 1 1 3 0 1.5 1.5 0 0 1-3 0Zm5-.9h11v1.8H9v-1.8Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
 export function ReviewProgressBadgeIcon(): ReactElement {
   return (
     <svg

--- a/apps/web/src/styles/features/review/review-responsive.css
+++ b/apps/web/src/styles/features/review/review-responsive.css
@@ -6,6 +6,10 @@
   .review-queue-panel {
     display: none;
   }
+
+  .review-queue-panel:target {
+    display: grid;
+  }
 }
 
 @media (max-width: 768px) {

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -51,6 +51,11 @@
   justify-content: center;
 }
 
+.review-queue-shortcut[aria-disabled="true"] {
+  pointer-events: none;
+  opacity: 0.64;
+}
+
 .review-progress-badge-icon,
 .review-progress-badge-value {
   line-height: 1;


### PR DESCRIPTION
## Summary
- align Review status shortcuts across web and Android with the iOS behavior
- show only the total queue count, keep trophy icon-only, and route flame actions to the streak section
- add Progress streak scroll targets and update related tests

## Validation
- git diff --check
- Web Vitest was not run because this worktree has no installed node_modules/dev dependencies
- Android Gradle checks were not run because local Gradle runs require explicit approval in this repository