### PR TITLE
[codex] Center leaderboard gap rows

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
@@ -393,36 +393,32 @@ private fun LeaderboardReservedParticipantRow() {
 
 @Composable
 private fun LeaderboardReservedGapRow() {
-    Row(
+    Text(
+        text = "⋯",
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = TextAlign.Center,
         modifier = Modifier
             .fillMaxWidth()
             .alpha(0f)
             .clearAndSetSemantics {}
-    ) {
-        Text(
-            text = "⋯",
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            style = MaterialTheme.typography.bodyMedium
-        )
-    }
+    )
 }
 
 @Composable
 private fun LeaderboardGapRow() {
     val gapContentDescription = stringResource(id = R.string.progress_leaderboard_gap_content_description)
-    Row(
+    Text(
+        text = "⋯",
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.bodyMedium,
+        textAlign = TextAlign.Center,
         modifier = Modifier
             .fillMaxWidth()
             .clearAndSetSemantics {
                 contentDescription = gapContentDescription
             }
-    ) {
-        Text(
-            text = "⋯",
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            style = MaterialTheme.typography.bodyMedium
-        )
-    }
+    )
 }
 
 @Composable

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
@@ -415,11 +415,12 @@ private struct ProgressLeaderboardReservedGapRowView: View {
 
 private struct ProgressLeaderboardGapRowView: View {
     var body: some View {
-        HStack(spacing: 10) {
+        HStack {
+            Spacer(minLength: 0)
+
             Image(systemName: "ellipsis")
                 .font(.subheadline)
                 .foregroundStyle(.tertiary)
-                .frame(minWidth: 28, alignment: .leading)
 
             Spacer(minLength: 0)
         }

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -593,8 +593,8 @@ svg.progress-review-schedule-donut {
 
 .progress-leaderboard-gap {
   min-height: 26px;
-  justify-items: start;
-  grid-template-columns: minmax(3.5ch, auto) minmax(0, 1fr) auto;
+  justify-items: center;
+  grid-template-columns: minmax(0, 1fr);
   border-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- Center leaderboard ellipsis gap rows again on iOS, Android, and web.
- Keep the reserved compact leaderboard height behavior for missing gap rows.

## Validation
- `git --no-pager diff --check`
- `npx vitest run src/screens/progress/ProgressScreen.render.test.tsx`

Android Gradle and iOS simulator-backed checks were not run because this repository requires explicit approval for those local runs.