### PR TITLE
Improve AI smoke card creation flow

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioAiHelpers.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioAiHelpers.kt
@@ -45,7 +45,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
 private const val aiCreatePromptText: String =
-    "I give you all permissions. Please create one test flashcard now."
+    "Create exactly one flashcard with frontText \"What is the smoke test AI card?\" " +
+        "and backText \"The smoke test AI card was created successfully.\"; I approve the create operation; do not ask a follow-up."
 private const val aiResetPromptText: String =
     "Please reply with one short sentence so I can verify this chat resets."
 

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -410,7 +410,8 @@ enum LiveSmokeLaunchFixtureData {
 }
 
 let aiComposerPlaceholderText: String = "Ask about cards, review history, or propose a change..."
-let aiCreatePromptText: String = "I give you all permissions. Please create one test flashcard now."
+let aiCreatePromptText: String = "Create exactly one flashcard with frontText \"What is the smoke test AI card?\" "
+    + "and backText \"The smoke test AI card was created successfully.\"; I approve the create operation; do not ask a follow-up."
 let aiResetPromptText: String = "Reply with exactly: reset ok"
 let aiCreatePromptMaximumAttempts: Int = 3
 let aiResetPromptMaximumAttempts: Int = 3

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Flows/LiveSmokeAiFlows.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Flows/LiveSmokeAiFlows.swift
@@ -46,6 +46,14 @@ extension LiveSmokeTestCase {
                 aiCreatePromptText,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
             )
+            let messageRowsBeforeSend = self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.aiMessageRow)
+                .count
+            let completedMarkerCountBeforeWait = self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.aiToolCallCompletedStatus)
+                .count
+            let errorMarkerCountBeforeWait = self.visibleAssistantErrorMessageCount()
+            let assistantTextCountBeforeWait = self.visibleMeaningfulAssistantTextMessages().count
             try self.assertElementEnabled(
                 identifier: LiveSmokeIdentifier.aiComposerSendButton,
                 timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds
@@ -60,6 +68,16 @@ extension LiveSmokeTestCase {
                 identifier: LiveSmokeIdentifier.aiComposerSendButton,
                 result: "success",
                 note: "AI create request sent"
+            )
+            try self.assertAiRunStartedOrFinished(
+                timeout: LiveSmokeConfiguration.longUiTimeoutSeconds,
+                completedMarkerCountBeforeWait: completedMarkerCountBeforeWait,
+                errorMarkerCountBeforeWait: errorMarkerCountBeforeWait,
+                assistantTextCountBeforeWait: assistantTextCountBeforeWait
+            )
+            try self.waitForUserAiMessageRowCountIncrease(
+                previousCount: messageRowsBeforeSend,
+                timeout: LiveSmokeConfiguration.longUiTimeoutSeconds
             )
             latestCompletedSqlSummaries = try self.waitForCompletedAiInsertToolCall(
                 timeout: aiCreateRunCompletionTimeoutSeconds
@@ -448,7 +466,7 @@ extension LiveSmokeTestCase {
             note: "previous=\(previousCount) current=\(currentCount)"
         )
         throw LiveSmokeFailure.unexpectedAiConversationState(
-            message: "Expected at least one new user AI message row before reset, but the count stayed at \(currentCount).",
+            message: "Expected at least one new user AI message row after sending the prompt, but the count stayed at \(currentCount).",
             screen: self.currentScreenSummary(),
             step: self.currentStepTitle
         )

--- a/apps/web/e2e/live-smoke/flows/ai.ts
+++ b/apps/web/e2e/live-smoke/flows/ai.ts
@@ -54,7 +54,8 @@ async function runAiCardCreationWithConfirmation(session: LiveSmokeSession): Pro
   const messageField = page.getByTestId("chat-composer-input");
   const sendButton = page.getByTestId("chat-send-button");
   const stopButton = page.getByTestId("chat-stop-button");
-  const createPrompt = "I give you all permissions. Please create one test flashcard now.";
+  const createPrompt = "Create exactly one flashcard with frontText \"What is the smoke test AI card?\" "
+    + "and backText \"The smoke test AI card was created successfully.\"; I approve the create operation; do not ask a follow-up.";
   const bootstrapTransportObserver = createAiTransportObserver(page);
   const transportObserver = createAiTransportObserver(page);
 


### PR DESCRIPTION
## Summary
- make the AI smoke create prompt explicit across iOS, Android, and Web
- make iOS wait for AI activity and a user message row before waiting for the card insert

## Validation
- git --no-pager diff --check --cached
- node --check apps/web/e2e/live-smoke/flows/ai.ts

Not run: iOS simulator smoke, Android Gradle/instrumentation, Web Playwright smoke.