### PR TITLE
[codex] Restore iOS review toolbar item group

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -5,7 +5,6 @@ private let reviewBottomBarHorizontalPadding: CGFloat = 20
 private let reviewBottomBarTopPadding: CGFloat = 8
 private let reviewBottomBarBottomPadding: CGFloat = 8
 private let reviewBottomBarButtonSpacing: CGFloat = 10
-private let reviewToolbarButtonSpacing: CGFloat = 8
 private let reviewAnswerButtonMinHeight: CGFloat = 40
 private let showAnswerButtonMinHeight: CGFloat = 56
 let emptyBackTextPlaceholder: String = String(localized: "No back text", table: reviewCardsStringsTableName)
@@ -181,12 +180,10 @@ struct ReviewView: View {
                 reviewFilterMenu
             }
 
-            ToolbarItem(placement: .topBarTrailing) {
-                HStack(spacing: reviewToolbarButtonSpacing) {
-                    reviewQueueButton
-                    reviewLeaderboardButton
-                    reviewProgressBadgeButton
-                }
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                reviewQueueButton
+                reviewLeaderboardButton
+                reviewProgressBadgeButton
             }
             .sharedBackgroundVisibility(.hidden)
         }


### PR DESCRIPTION
## Summary
- restore the iOS Review toolbar shortcuts as real trailing toolbar items
- keep the large glass button styling and fixed-size labels from the prior sizing fix
- remove the custom HStack toolbar item that collapsed into overflow

## Validation
- git diff --check
- SwiftUI ToolbarItemGroup/glass/fixed-size label snippet typechecked with the iOS 26 simulator SDK

Simulator-backed iOS tests were not run per repository instructions.