### PR TITLE
[codex] Make review queue shortcuts icon-only

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -142,7 +143,7 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                 )
             )
             .performClick()
-        composeRule.onNodeWithText("10").assertIsDisplayed()
+        composeRule.onNodeWithText("10").assertDoesNotExist()
         composeRule.onNodeWithText("99+").assertIsDisplayed()
         composeRule.onNodeWithTag(reviewLeaderboardShortcutTag)
             .assertIsDisplayed()

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
@@ -2,9 +2,7 @@ package com.flashcardsopensourceapp.feature.review
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -15,7 +13,6 @@ import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.FormatListBulleted
 import androidx.compose.material.icons.outlined.LocalFireDepartment
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -23,7 +20,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -164,13 +160,9 @@ private fun ReviewQueueAction(
         totalCount
     )
 
-    TextButton(
+    IconButton(
         onClick = onOpenPreview,
         enabled = totalCount > 0,
-        colors = ButtonDefaults.textButtonColors(
-            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-        ),
-        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp),
         modifier = Modifier
             .testTag(reviewQueueButtonTag)
             .semantics {
@@ -181,7 +173,5 @@ private fun ReviewQueueAction(
             imageVector = Icons.Outlined.FormatListBulleted,
             contentDescription = null
         )
-        Spacer(modifier = Modifier.size(6.dp))
-        Text(text = totalCount.toString())
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -5,6 +5,7 @@ private let reviewBottomBarHorizontalPadding: CGFloat = 20
 private let reviewBottomBarTopPadding: CGFloat = 8
 private let reviewBottomBarBottomPadding: CGFloat = 8
 private let reviewBottomBarButtonSpacing: CGFloat = 10
+private let reviewFilterMenuTitleMaxWidth: CGFloat = 180
 private let reviewAnswerButtonMinHeight: CGFloat = 40
 private let showAnswerButtonMinHeight: CGFloat = 56
 let emptyBackTextPlaceholder: String = String(localized: "No back text", table: reviewCardsStringsTableName)
@@ -389,6 +390,7 @@ struct ReviewView: View {
                 Text(self.selectedReviewFilterTitle)
                     .lineLimit(1)
                     .truncationMode(.tail)
+                    .frame(maxWidth: reviewFilterMenuTitleMaxWidth, alignment: .leading)
                 Image(systemName: "chevron.down")
                     .font(.caption.weight(.semibold))
             }
@@ -522,15 +524,8 @@ struct ReviewView: View {
             Button {
                 self.isQueuePreviewPresented = true
             } label: {
-                Label {
-                    Text(self.reviewQueueTotalButtonTitle)
-                        .monospacedDigit()
-                        .lineLimit(1)
-                } icon: {
-                    Image(systemName: "list.bullet")
-                }
-                .labelStyle(.titleAndIcon)
-                .fixedSize(horizontal: true, vertical: false)
+                Label(self.reviewQueueButtonTitle, systemImage: "list.bullet")
+                    .labelStyle(.iconOnly)
             }
             .buttonStyle(.glass)
             .controlSize(.large)
@@ -547,8 +542,12 @@ struct ReviewView: View {
         }
     }
 
-    private var reviewQueueTotalButtonTitle: String {
-        store.reviewTotalCount.formatted()
+    private var reviewQueueButtonTitle: String {
+        String(
+            localized: "Review queue",
+            table: reviewCardsStringsTableName,
+            comment: "Toolbar shortcut title for opening the Review queue preview"
+        )
     }
 
     private var reviewProgressBadgeButton: some View {
@@ -589,7 +588,8 @@ struct ReviewView: View {
         Button {
             self.navigation.openProgress(target: .leaderboard)
         } label: {
-            Image(systemName: "trophy")
+            Label(self.reviewLeaderboardButtonTitle, systemImage: "trophy")
+                .labelStyle(.iconOnly)
         }
         .buttonStyle(.glass)
         .controlSize(.large)

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -83,7 +83,6 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
               onClick={handleReviewQueueShortcutClick}
             >
               <ReviewQueueShortcutIcon />
-              <span className="review-progress-badge-value">{formatNumber(reviewQueueTotalCount)}</span>
             </a>
             <Link
               className="badge review-progress-badge review-screen-head-badge review-leaderboard-shortcut"

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -186,7 +186,8 @@ describe("ReviewScreen controls", () => {
     if (!(queueBadge instanceof HTMLAnchorElement)) {
       throw new Error("Review queue badge was not found");
     }
-    expect(queueBadge.textContent).toContain("1");
+    expect(queueBadge.querySelector(".review-progress-badge-value")).toBeNull();
+    expect(queueBadge.getAttribute("aria-label")).toContain("1 card");
     expect(queueBadge.getAttribute("href")).toBe("#review-queue-panel");
     expect(getContainer().querySelector("[data-testid='review-screen-toolbar']")).toBeNull();
     expect(headerActions.contains(scopeTrigger)).toBe(true);

--- a/apps/web/src/styles/features/review/review-responsive.css
+++ b/apps/web/src/styles/features/review/review-responsive.css
@@ -78,13 +78,14 @@
     width: 100%;
   }
 
-  .review-progress-shortcuts > .review-leaderboard-shortcut {
+  .review-progress-shortcuts > .review-leaderboard-shortcut,
+  .review-progress-shortcuts > .review-queue-shortcut {
     width: 42px;
     min-width: 42px;
     flex: 0 0 42px;
   }
 
-  .review-progress-shortcuts > .review-screen-head-badge:not(.review-leaderboard-shortcut) {
+  .review-progress-shortcuts > .review-screen-head-badge:not(.review-leaderboard-shortcut):not(.review-queue-shortcut) {
     width: auto;
     flex: 1 1 auto;
   }

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -47,7 +47,10 @@
   font-size: 15px;
 }
 
-.review-screen-head-badge.review-leaderboard-shortcut {
+.review-screen-head-badge.review-leaderboard-shortcut,
+.review-screen-head-badge.review-queue-shortcut {
+  min-width: 42px;
+  width: 42px;
   padding-inline: 0;
 }
 


### PR DESCRIPTION
## Summary
- remove visible queue counts from Review shortcuts on iOS, web, and Android
- keep queue counts in accessibility labels/content descriptions
- keep the iOS leaderboard shortcut represented by an icon-only Label so overflow can still name the action
- cap the iOS review filter menu title width to leave room for trailing shortcuts

## Validation
- git diff --check
- iOS SwiftUI toolbar snippet typechecked with the iOS 26 simulator SDK
- npm exec -- vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx

Android Gradle checks were not run because local Gradle runs require explicit approval in this repository.