### PR TITLE
[codex] Center review queue controls

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -520,6 +520,7 @@ const arCatalog: TranslationCatalog = {
     },
     queue: {
       cards: "{{count}} بطاقة",
+      close: "إغلاق قائمة الانتظار",
       loading: "جارٍ التحميل",
       title: "قائمة الانتظار",
       upcoming: "القادمة",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -520,6 +520,7 @@ const deCatalog: TranslationCatalog = {
     },
     queue: {
       cards: "{{count}} Karten",
+      close: "Warteschlange schließen",
       loading: "lädt",
       title: "Warteschlange",
       upcoming: "Anstehend",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -518,6 +518,7 @@ const enCatalog = {
     },
     queue: {
       cards: "{{count}} cards",
+      close: "Close queue",
       loading: "loading",
       title: "Queue",
       upcoming: "Upcoming",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -520,6 +520,7 @@ const esEsCatalog: TranslationCatalog = {
     },
     queue: {
       cards: "{{count}} tarjetas",
+      close: "Cerrar cola",
       loading: "cargando",
       title: "Cola",
       upcoming: "Próximas",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -520,6 +520,7 @@ const esMxCatalog: TranslationCatalog = {
     },
     queue: {
       cards: "{{count}} tarjetas",
+      close: "Cerrar cola",
       loading: "cargando",
       title: "Cola",
       upcoming: "Próximas",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -520,6 +520,7 @@ const hiCatalog: TranslationCatalog = {
     },
     queue: {
       cards: "{{count}} कार्ड",
+      close: "कतार बंद करें",
       loading: "लोड हो रहा है",
       title: "कतार",
       upcoming: "आने वाले",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -520,6 +520,7 @@ export const jaCatalog = {
     },
     queue: {
       cards: "{{count}} 枚",
+      close: "キューを閉じる",
       loading: "読み込み中",
       title: "キュー",
       upcoming: "予定",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -520,6 +520,7 @@ export const ruCatalog = {
     },
     queue: {
       cards: "{{count}} карточек",
+      close: "Закрыть очередь",
       loading: "загрузка",
       title: "Очередь",
       upcoming: "Далее",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -520,6 +520,7 @@ export const zhHansCatalog = {
     },
     queue: {
       cards: "{{count}} 张卡片",
+      close: "关闭队列",
       loading: "加载中",
       title: "队列",
       upcoming: "即将到来",

--- a/apps/web/src/screens/review/components/ReviewQueuePanel.tsx
+++ b/apps/web/src/screens/review/components/ReviewQueuePanel.tsx
@@ -8,8 +8,10 @@ import { formatEffortLevelLabel, formatNullableDateTime, formatTagSummary } from
 
 export type ReviewQueuePanelProps = Readonly<{
   isInitialReviewLoad: boolean;
+  isReviewQueuePanelOpen: boolean;
   loadingReviewCurrentCard: ReviewLoadingSnapshot["currentCard"];
   nowTimestamp: number;
+  onClose: () => void;
   queueCards: ReadonlyArray<Card>;
   reviewLoadingSnapshot: ReviewLoadingSnapshot | null;
   selectedCardId: string | null;
@@ -28,27 +30,42 @@ function isReviewLoadingPreviewDue(dueAt: string | null, nowTimestamp: number): 
 export function ReviewQueuePanel(props: ReviewQueuePanelProps): ReactElement {
   const {
     isInitialReviewLoad,
+    isReviewQueuePanelOpen,
     loadingReviewCurrentCard,
     nowTimestamp,
+    onClose,
     queueCards,
     reviewLoadingSnapshot,
     selectedCardId,
     visibleQueueCardsCount,
   } = props;
   const { t, formatCount, formatDateTime } = useI18n();
+  const closeLabel = t("reviewScreen.queue.close");
 
   return (
-    <aside className="review-queue-panel" id="review-queue-panel">
+    <aside className={`review-queue-panel${isReviewQueuePanelOpen ? " review-queue-panel-open" : ""}`} id="review-queue-panel">
       <div className="review-queue-head">
-        <h2 className="panel-subtitle">{t("reviewScreen.queue.title")}</h2>
-        <span className="review-queue-caption">
-          {isInitialReviewLoad && reviewLoadingSnapshot === null
-            ? t("reviewScreen.queue.loading")
-            : formatCount(visibleQueueCardsCount, {
-              one: t("common.countLabels.card.one"),
-              other: t("common.countLabels.card.other"),
-            })}
-        </span>
+        <div className="review-queue-title-group">
+          <h2 className="panel-subtitle">{t("reviewScreen.queue.title")}</h2>
+          <span className="review-queue-caption">
+            {isInitialReviewLoad && reviewLoadingSnapshot === null
+              ? t("reviewScreen.queue.loading")
+              : formatCount(visibleQueueCardsCount, {
+                one: t("common.countLabels.card.one"),
+                other: t("common.countLabels.card.other"),
+              })}
+          </span>
+        </div>
+        <button
+          className="ghost-btn review-queue-close-btn"
+          type="button"
+          aria-label={closeLabel}
+          title={closeLabel}
+          data-testid="review-queue-close"
+          onClick={onClose}
+        >
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
       {isInitialReviewLoad ? (
         reviewLoadingSnapshot !== null && reviewLoadingSnapshot.queuePreview.length > 0 ? (

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -15,7 +15,9 @@ type ReviewProgressBadgeState = Readonly<{
 export type ReviewScreenHeaderProps = Readonly<{
   filterMenuProps: ComponentProps<typeof ReviewFilterMenu>;
   hasLoadedReviewData: boolean;
+  isReviewQueuePanelOpen: boolean;
   onRetry: () => void;
+  onReviewQueueShortcutClick: (event: MouseEvent<HTMLAnchorElement>) => void;
   reviewQueueTotalCount: number;
   reviewLoadErrorMessage: string;
   reviewProgressBadge: ReviewProgressBadgeState;
@@ -26,7 +28,9 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
   const {
     filterMenuProps,
     hasLoadedReviewData,
+    isReviewQueuePanelOpen,
     onRetry,
+    onReviewQueueShortcutClick,
     reviewQueueTotalCount,
     reviewLoadErrorMessage,
     reviewProgressBadge,
@@ -51,7 +55,10 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
   function handleReviewQueueShortcutClick(event: MouseEvent<HTMLAnchorElement>): void {
     if (isReviewQueueShortcutDisabled) {
       event.preventDefault();
+      return;
     }
+
+    onReviewQueueShortcutClick(event);
   }
 
   return (
@@ -75,6 +82,8 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
             <a
               className="badge review-progress-badge review-screen-head-badge review-queue-shortcut"
               href="#review-queue-panel"
+              aria-controls="review-queue-panel"
+              aria-expanded={isReviewQueueShortcutDisabled ? undefined : isReviewQueuePanelOpen}
               aria-label={reviewQueueAriaLabel}
               title={reviewQueueAriaLabel}
               data-testid="review-queue-badge"

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -188,7 +188,19 @@ describe("ReviewScreen controls", () => {
     }
     expect(queueBadge.querySelector(".review-progress-badge-value")).toBeNull();
     expect(queueBadge.getAttribute("aria-label")).toContain("1 card");
+    expect(queueBadge.getAttribute("aria-controls")).toBe("review-queue-panel");
+    expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
     expect(queueBadge.getAttribute("href")).toBe("#review-queue-panel");
+    const queuePanel = getContainer().querySelector("#review-queue-panel");
+    if (!(queuePanel instanceof HTMLElement)) {
+      throw new Error("Review queue panel was not found");
+    }
+    const queueCloseButton = getContainer().querySelector("[data-testid='review-queue-close']");
+    if (!(queueCloseButton instanceof HTMLButtonElement)) {
+      throw new Error("Review queue close button was not found");
+    }
+    expect(queuePanel.className).not.toContain("review-queue-panel-open");
+    expect(queueCloseButton.getAttribute("aria-label")).toBe("Close queue");
     expect(getContainer().querySelector("[data-testid='review-screen-toolbar']")).toBeNull();
     expect(headerActions.contains(scopeTrigger)).toBe(true);
     expect(headerActions.contains(queueBadge)).toBe(true);
@@ -200,6 +212,21 @@ describe("ReviewScreen controls", () => {
     }
 
     expect(progressBadgeIcon.getAttribute("aria-hidden")).toBe("true");
+
+    await clickElementAsync(queueBadge);
+    expect(queueBadge.getAttribute("aria-expanded")).toBe("true");
+    expect(queuePanel.className).toContain("review-queue-panel-open");
+
+    await clickElementAsync(queueCloseButton);
+    expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
+    expect(queuePanel.className).not.toContain("review-queue-panel-open");
+
+    await clickElementAsync(queueBadge);
+    expect(queueBadge.getAttribute("aria-expanded")).toBe("true");
+
+    await clickElementAsync(queueBadge);
+    expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
+    expect(queuePanel.className).not.toContain("review-queue-panel-open");
   });
 
   it("reveals the answer with Space and submits the selected rating shortcut", async () => {

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type MouseEvent } from "react";
 import type { ReviewRating } from "../../../../backend/src/scheduling";
 import {
   loadFeedbackState,
@@ -56,6 +56,8 @@ import { useReviewKeyboardShortcuts } from "./input/useReviewKeyboardShortcuts";
 import { useReviewRatingReactions, type UseReviewRatingReactionsResult } from "./reactions/useReviewRatingReactions";
 import { makeReviewSpeakableText, useReviewSpeech } from "./speech/reviewSpeech";
 
+const reviewQueuePanelHash = "#review-queue-panel";
+
 export type UseReviewScreenControllerResult = Readonly<{
   dismissReviewReactions: UseReviewRatingReactionsResult["dismissReactions"];
   editorModalProps: ReviewEditorModalProps;
@@ -71,6 +73,16 @@ export type UseReviewScreenControllerResult = Readonly<{
 export type UseReviewScreenControllerParams = Readonly<{
   reviewReactionAnimationsEnabled: boolean;
 }>;
+
+function isReviewQueuePanelHashActive(): boolean {
+  return window.location.hash === reviewQueuePanelHash;
+}
+
+function clearReviewQueuePanelHash(): void {
+  if (isReviewQueuePanelHashActive()) {
+    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+  }
+}
 
 type AutomaticFeedbackPromptUiState = Readonly<{
   isEditorPresented: boolean;
@@ -111,6 +123,7 @@ export function useReviewScreenController(
   const [feedbackMessage, setFeedbackMessage] = useState<string>("");
   const [feedbackErrorMessage, setFeedbackErrorMessage] = useState<string>("");
   const [isFeedbackSubmitting, setIsFeedbackSubmitting] = useState<boolean>(false);
+  const [isReviewQueuePanelOpen, setIsReviewQueuePanelOpen] = useState<boolean>(() => isReviewQueuePanelHashActive());
   const [hardReminderLastShownAt, setHardReminderLastShownAt] = useState<number | null>(() => loadReviewHardReminderLastShownAt());
   const automaticFeedbackPromptUiStateRef = useRef<AutomaticFeedbackPromptUiState>({
     isEditorPresented: false,
@@ -240,6 +253,15 @@ export function useReviewScreenController(
   let reviewButtonErrorMessage: string = "";
   let reviewButtonScheduleError: Error | null = null;
 
+  useEffect(() => {
+    function handleHashChange(): void {
+      setIsReviewQueuePanelOpen(isReviewQueuePanelHashActive());
+    }
+
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
+
   function captureFeedbackOperationError(
     error: unknown,
     operation: "feedback_activity_load" | "feedback_state_load" | "feedback_prompt_event" | "feedback_submit",
@@ -261,6 +283,22 @@ export function useReviewScreenController(
       || uiState.isFeedbackDialogOpen
       || uiState.isHardReminderVisible
       || uiState.isReviewFilterMenuOpen;
+  }
+
+  function handleReviewQueueShortcutClick(event: MouseEvent<HTMLAnchorElement>): void {
+    if (isReviewQueuePanelOpen || isReviewQueuePanelHashActive()) {
+      event.preventDefault();
+      clearReviewQueuePanelHash();
+      setIsReviewQueuePanelOpen(false);
+      return;
+    }
+
+    setIsReviewQueuePanelOpen(true);
+  }
+
+  function handleReviewQueuePanelClose(): void {
+    clearReviewQueuePanelHash();
+    setIsReviewQueuePanelOpen(false);
   }
 
   async function postAutomaticFeedbackPromptEvent(eventType: FeedbackPromptEventType): Promise<void> {
@@ -628,7 +666,9 @@ export function useReviewScreenController(
         visibleReviewTagFilterMenuItems,
       },
       hasLoadedReviewData,
+      isReviewQueuePanelOpen,
       onRetry: handleRetryReviewLoad,
+      onReviewQueueShortcutClick: handleReviewQueueShortcutClick,
       reviewQueueTotalCount: isInitialReviewLoad && reviewLoadingSnapshot !== null
         ? reviewLoadingSnapshot.reviewCounts.totalCount
         : reviewCounts.totalCount,
@@ -661,8 +701,10 @@ export function useReviewScreenController(
     },
     queuePanelProps: {
       isInitialReviewLoad,
+      isReviewQueuePanelOpen,
       loadingReviewCurrentCard,
       nowTimestamp,
+      onClose: handleReviewQueuePanelClose,
       queueCards,
       reviewLoadingSnapshot,
       selectedCardId: selectedCard?.cardId ?? null,

--- a/apps/web/src/styles/features/review/review-queue.css
+++ b/apps/web/src/styles/features/review/review-queue.css
@@ -1,7 +1,7 @@
 .review-queue-head {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: flex-start;
   gap: 10px;
   position: sticky;
   top: 0;
@@ -10,11 +10,30 @@
   background: transparent;
 }
 
+.review-queue-title-group {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
 .review-queue-caption {
   color: var(--text-tertiary);
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.12em;
+}
+
+.review-queue-close-btn {
+  display: none;
+  width: 30px;
+  min-width: 30px;
+  height: 30px;
+  min-height: 30px;
+  padding: 0;
+  flex-shrink: 0;
+  border-radius: var(--radius-pill);
+  font-size: 22px;
+  line-height: 1;
 }
 
 .review-queue-list {

--- a/apps/web/src/styles/features/review/review-responsive.css
+++ b/apps/web/src/styles/features/review/review-responsive.css
@@ -7,8 +7,13 @@
     display: none;
   }
 
-  .review-queue-panel:target {
+  .review-queue-panel:target,
+  .review-queue-panel.review-queue-panel-open {
     display: grid;
+  }
+
+  .review-queue-close-btn {
+    display: inline-flex;
   }
 }
 

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -52,6 +52,8 @@
   min-width: 42px;
   width: 42px;
   padding-inline: 0;
+  align-items: center;
+  justify-content: center;
 }
 
 .review-progress-shortcuts {


### PR DESCRIPTION
## Summary

- Center the review queue shortcut icon now that it no longer has adjacent text.
- Make the review queue shortcut toggle the queue panel closed after opening it.
- Add a compact close button to the queue panel header with localized labels.

## Root Cause

The queue shortcut kept legacy badge layout behavior from when the control included text, so the icon inherited spacing meant for icon-plus-label content. The queue panel also relied only on the URL hash target, which opened it but did not provide a close interaction.

## Validation

- `npx vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx`
- `npx tsc -b`
- `npm run build`