### PR TITLE
[codex] Fix review queue toggle

### DIFF
--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, MouseEvent, ReactElement } from "react";
+import type { ComponentProps, ReactElement } from "react";
 import { Link } from "react-router-dom";
 import { formatReviewProgressBadgeValue } from "../../../appData/progress/badge/reviewProgressBadge";
 import { useI18n } from "../../../i18n";
@@ -17,7 +17,7 @@ export type ReviewScreenHeaderProps = Readonly<{
   hasLoadedReviewData: boolean;
   isReviewQueuePanelOpen: boolean;
   onRetry: () => void;
-  onReviewQueueShortcutClick: (event: MouseEvent<HTMLAnchorElement>) => void;
+  onReviewQueueShortcutClick: () => void;
   reviewQueueTotalCount: number;
   reviewLoadErrorMessage: string;
   reviewProgressBadge: ReviewProgressBadgeState;
@@ -52,15 +52,6 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
   const leaderboardShortcutAriaLabel = t("reviewScreen.leaderboardShortcut.ariaLabel");
   const isReviewQueueShortcutDisabled = reviewQueueTotalCount === 0;
 
-  function handleReviewQueueShortcutClick(event: MouseEvent<HTMLAnchorElement>): void {
-    if (isReviewQueueShortcutDisabled) {
-      event.preventDefault();
-      return;
-    }
-
-    onReviewQueueShortcutClick(event);
-  }
-
   return (
     <div className="screen-head review-screen-head">
       <div>
@@ -79,20 +70,19 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
         <div className="review-filter-summary-wrap">
           <span className="review-filter-label">{t("common.status")}</span>
           <div className="review-progress-shortcuts">
-            <a
+            <button
               className="badge review-progress-badge review-screen-head-badge review-queue-shortcut"
-              href="#review-queue-panel"
+              type="button"
               aria-controls="review-queue-panel"
               aria-expanded={isReviewQueueShortcutDisabled ? undefined : isReviewQueuePanelOpen}
               aria-label={reviewQueueAriaLabel}
               title={reviewQueueAriaLabel}
               data-testid="review-queue-badge"
-              aria-disabled={isReviewQueueShortcutDisabled ? "true" : undefined}
-              tabIndex={isReviewQueueShortcutDisabled ? -1 : undefined}
-              onClick={handleReviewQueueShortcutClick}
+              disabled={isReviewQueueShortcutDisabled}
+              onClick={onReviewQueueShortcutClick}
             >
               <ReviewQueueShortcutIcon />
-            </a>
+            </button>
             <Link
               className="badge review-progress-badge review-screen-head-badge review-leaderboard-shortcut"
               to={progressLeaderboardRoute}

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -183,14 +183,15 @@ describe("ReviewScreen controls", () => {
     expect(progressBadge.className).not.toContain("review-progress-badge-approximate");
     expect(progressBadge.textContent).not.toContain("🔥");
     const queueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
-    if (!(queueBadge instanceof HTMLAnchorElement)) {
+    if (!(queueBadge instanceof HTMLButtonElement)) {
       throw new Error("Review queue badge was not found");
     }
     expect(queueBadge.querySelector(".review-progress-badge-value")).toBeNull();
     expect(queueBadge.getAttribute("aria-label")).toContain("1 card");
     expect(queueBadge.getAttribute("aria-controls")).toBe("review-queue-panel");
     expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
-    expect(queueBadge.getAttribute("href")).toBe("#review-queue-panel");
+    expect(queueBadge.getAttribute("href")).toBeNull();
+    expect(queueBadge.disabled).toBe(false);
     const queuePanel = getContainer().querySelector("#review-queue-panel");
     if (!(queuePanel instanceof HTMLElement)) {
       throw new Error("Review queue panel was not found");
@@ -216,17 +217,21 @@ describe("ReviewScreen controls", () => {
     await clickElementAsync(queueBadge);
     expect(queueBadge.getAttribute("aria-expanded")).toBe("true");
     expect(queuePanel.className).toContain("review-queue-panel-open");
+    expect(window.location.hash).toBe("");
 
     await clickElementAsync(queueCloseButton);
     expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
     expect(queuePanel.className).not.toContain("review-queue-panel-open");
+    expect(window.location.hash).toBe("");
 
     await clickElementAsync(queueBadge);
     expect(queueBadge.getAttribute("aria-expanded")).toBe("true");
+    expect(window.location.hash).toBe("");
 
     await clickElementAsync(queueBadge);
     expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
     expect(queuePanel.className).not.toContain("review-queue-panel-open");
+    expect(window.location.hash).toBe("");
   });
 
   it("reveals the answer with Space and submits the selected rating shortcut", async () => {

--- a/apps/web/src/screens/review/useReviewScreenController.ts
+++ b/apps/web/src/screens/review/useReviewScreenController.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ReviewRating } from "../../../../backend/src/scheduling";
 import {
   loadFeedbackState,
@@ -56,8 +56,6 @@ import { useReviewKeyboardShortcuts } from "./input/useReviewKeyboardShortcuts";
 import { useReviewRatingReactions, type UseReviewRatingReactionsResult } from "./reactions/useReviewRatingReactions";
 import { makeReviewSpeakableText, useReviewSpeech } from "./speech/reviewSpeech";
 
-const reviewQueuePanelHash = "#review-queue-panel";
-
 export type UseReviewScreenControllerResult = Readonly<{
   dismissReviewReactions: UseReviewRatingReactionsResult["dismissReactions"];
   editorModalProps: ReviewEditorModalProps;
@@ -73,16 +71,6 @@ export type UseReviewScreenControllerResult = Readonly<{
 export type UseReviewScreenControllerParams = Readonly<{
   reviewReactionAnimationsEnabled: boolean;
 }>;
-
-function isReviewQueuePanelHashActive(): boolean {
-  return window.location.hash === reviewQueuePanelHash;
-}
-
-function clearReviewQueuePanelHash(): void {
-  if (isReviewQueuePanelHashActive()) {
-    window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
-  }
-}
 
 type AutomaticFeedbackPromptUiState = Readonly<{
   isEditorPresented: boolean;
@@ -123,7 +111,7 @@ export function useReviewScreenController(
   const [feedbackMessage, setFeedbackMessage] = useState<string>("");
   const [feedbackErrorMessage, setFeedbackErrorMessage] = useState<string>("");
   const [isFeedbackSubmitting, setIsFeedbackSubmitting] = useState<boolean>(false);
-  const [isReviewQueuePanelOpen, setIsReviewQueuePanelOpen] = useState<boolean>(() => isReviewQueuePanelHashActive());
+  const [isReviewQueuePanelOpen, setIsReviewQueuePanelOpen] = useState<boolean>(false);
   const [hardReminderLastShownAt, setHardReminderLastShownAt] = useState<number | null>(() => loadReviewHardReminderLastShownAt());
   const automaticFeedbackPromptUiStateRef = useRef<AutomaticFeedbackPromptUiState>({
     isEditorPresented: false,
@@ -253,15 +241,6 @@ export function useReviewScreenController(
   let reviewButtonErrorMessage: string = "";
   let reviewButtonScheduleError: Error | null = null;
 
-  useEffect(() => {
-    function handleHashChange(): void {
-      setIsReviewQueuePanelOpen(isReviewQueuePanelHashActive());
-    }
-
-    window.addEventListener("hashchange", handleHashChange);
-    return () => window.removeEventListener("hashchange", handleHashChange);
-  }, []);
-
   function captureFeedbackOperationError(
     error: unknown,
     operation: "feedback_activity_load" | "feedback_state_load" | "feedback_prompt_event" | "feedback_submit",
@@ -285,19 +264,11 @@ export function useReviewScreenController(
       || uiState.isReviewFilterMenuOpen;
   }
 
-  function handleReviewQueueShortcutClick(event: MouseEvent<HTMLAnchorElement>): void {
-    if (isReviewQueuePanelOpen || isReviewQueuePanelHashActive()) {
-      event.preventDefault();
-      clearReviewQueuePanelHash();
-      setIsReviewQueuePanelOpen(false);
-      return;
-    }
-
-    setIsReviewQueuePanelOpen(true);
+  function handleReviewQueueShortcutClick(): void {
+    setIsReviewQueuePanelOpen((currentIsReviewQueuePanelOpen) => !currentIsReviewQueuePanelOpen);
   }
 
   function handleReviewQueuePanelClose(): void {
-    clearReviewQueuePanelHash();
     setIsReviewQueuePanelOpen(false);
   }
 

--- a/apps/web/src/styles/features/review/review-responsive.css
+++ b/apps/web/src/styles/features/review/review-responsive.css
@@ -7,7 +7,6 @@
     display: none;
   }
 
-  .review-queue-panel:target,
   .review-queue-panel.review-queue-panel-open {
     display: grid;
   }

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -20,6 +20,7 @@
   flex-shrink: 0;
   padding-inline: 10px 12px;
   color: var(--text-secondary);
+  cursor: pointer;
   text-decoration: none;
 }
 
@@ -51,7 +52,7 @@
   justify-content: center;
 }
 
-.review-queue-shortcut[aria-disabled="true"] {
+.review-queue-shortcut:disabled {
   pointer-events: none;
   opacity: 0.64;
 }


### PR DESCRIPTION
## Summary

- Change the review queue shortcut from a hash link into a state-driven button.
- Remove the responsive `:target` display path so the queue cannot stay open outside React state.
- Keep the close button and shortcut toggle covered by the existing review controls test.

## Root Cause

The queue panel had two independent open paths: React state and the URL fragment target. When the fragment matched the queue panel id, CSS could keep the panel visible after the UI tried to close it.

## Validation

- `npx vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx`
- `npx tsc -b`
- `npm run build`