### PR TITLE
[codex] Use regular iOS review toolbar controls

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -582,7 +582,7 @@ struct ReviewView: View {
             .fixedSize(horizontal: true, vertical: false)
         }
         .buttonStyle(.glass)
-        .controlSize(.large)
+        .controlSize(.regular)
         .disabled(badgeState.isInteractive == false)
         .accessibilityIdentifier(UITestIdentifier.reviewProgressBadge)
         .accessibilityLabel(self.reviewProgressBadgeAccessibilityLabel(badgeState: badgeState))
@@ -611,7 +611,7 @@ struct ReviewView: View {
                 .labelStyle(.iconOnly)
         }
         .buttonStyle(.glass)
-        .controlSize(.large)
+        .controlSize(.regular)
         .accessibilityIdentifier(UITestIdentifier.reviewLeaderboardShortcut)
         .accessibilityLabel(self.reviewLeaderboardButtonTitle)
     }


### PR DESCRIPTION
## Summary
- reduce the visible iOS Review trophy and streak glass toolbar controls from large to regular control size
- keep the native SwiftUI toolbar and Liquid Glass rendering unchanged otherwise

## Validation
- git diff --check -- apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
- SwiftUI toolbar label typecheck with the iOS 26.5 simulator SDK

Simulator-backed iOS UI tests were not run locally because the repository requires explicit permission for those heavy checks.