### PR TITLE
[codex] Fix iOS cards AI handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ For the optional private analytical DB access path, granted reporting permission
 ## Release Gates and Monitoring
 
 Pushes to `main` use three independent release streams: AWS/web, Android, and iOS.
+Keep the Xcode Cloud `Test - iOS` action non-required on purpose so TestFlight can receive builds even when smoke tests fail.
 Details, rollback rules, and live smoke references: [docs/release-gates.md](docs/release-gates.md).
 
 ## Repository Strategy

--- a/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
@@ -1,6 +1,41 @@
+import OSLog
 import SwiftUI
 
 private let reviewCardsStringsTableName: String = "ReviewCards"
+private let cardsAIHandoffLogger: Logger = Logger(
+    subsystem: appBundleIdentifier(),
+    category: "ai_handoff"
+)
+
+private enum CardsAIHandoffEvent: String {
+    case capture
+    case saveFailed = "save_failed"
+    case open
+}
+
+private func cardsAIHandoffDiagnosticIdSuffix(_ value: String) -> String {
+    let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmedValue.isEmpty == false else {
+        return "-"
+    }
+
+    return String(trimmedValue.suffix(8))
+}
+
+private func cardsAIHandoffAppTabDiagnosticValue(_ tab: AppTab) -> String {
+    switch tab {
+    case .review:
+        return "review"
+    case .progress:
+        return "progress"
+    case .ai:
+        return "ai"
+    case .cards:
+        return "cards"
+    case .settings:
+        return "settings"
+    }
+}
 
 enum CardEditorPresentation: Hashable, Identifiable {
     case create
@@ -173,26 +208,7 @@ struct CardsScreen: View {
                     formState: self.$cardFormState,
                     onEditWithAI: presentation.editingCardId.map { editingCardId in
                         {
-                            let cardReference: AIChatCardReference?
-                            if self.isEditingCardDirty() {
-                                cardReference = self.saveEditingCardForAIHandoff()
-                            } else {
-                                let normalizedInput = self.normalizedCardEditorInput()
-                                cardReference = AIChatCardReference(
-                                    cardId: editingCardId,
-                                    frontText: normalizedInput.frontText,
-                                    backText: normalizedInput.backText,
-                                    tags: normalizedInput.tags,
-                                    effortLevel: normalizedInput.effortLevel
-                                )
-                            }
-                            guard let cardReference else {
-                                return
-                            }
-                            self.editorPresentation = nil
-                            Task { @MainActor in
-                                self.navigation.openAICardHandoff(card: cardReference)
-                            }
+                            self.openEditingCardWithAI(editingCardId: editingCardId)
                         }
                     },
                     onCancel: {
@@ -329,6 +345,62 @@ struct CardsScreen: View {
             self.screenErrorMessage = Flashcards.errorMessage(error: error)
             return nil
         }
+    }
+
+    private func openEditingCardWithAI(editingCardId: String) {
+        let isDirty = self.isEditingCardDirty()
+        self.logCardsAIHandoff(
+            event: .capture,
+            cardId: editingCardId,
+            isDirty: isDirty
+        )
+
+        let cardReference: AIChatCardReference?
+        if isDirty {
+            cardReference = self.saveEditingCardForAIHandoff()
+        } else {
+            let normalizedInput = self.normalizedCardEditorInput()
+            cardReference = AIChatCardReference(
+                cardId: editingCardId,
+                frontText: normalizedInput.frontText,
+                backText: normalizedInput.backText,
+                tags: normalizedInput.tags,
+                effortLevel: normalizedInput.effortLevel
+            )
+        }
+
+        guard let cardReference else {
+            self.logCardsAIHandoff(
+                event: .saveFailed,
+                cardId: editingCardId,
+                isDirty: isDirty
+            )
+            return
+        }
+
+        self.navigation.openAICardHandoff(card: cardReference)
+        self.logCardsAIHandoff(
+            event: .open,
+            cardId: cardReference.cardId,
+            isDirty: isDirty
+        )
+        self.editorPresentation = nil
+    }
+
+    private func logCardsAIHandoff(
+        event: CardsAIHandoffEvent,
+        cardId: String,
+        isDirty: Bool
+    ) {
+        cardsAIHandoffLogger.log(
+            """
+            event=cards_\(event.rawValue, privacy: .public) \
+            cardIdSuffix=\(cardsAIHandoffDiagnosticIdSuffix(cardId), privacy: .public) \
+            isDirty=\(String(isDirty), privacy: .public) \
+            selectedTab=\(cardsAIHandoffAppTabDiagnosticValue(self.navigation.selectedTab), privacy: .public) \
+            hasRequest=\(String(self.navigation.aiChatPresentationRequest != nil), privacy: .public)
+            """
+        )
     }
 
     private func dismissCardsSearch() {

--- a/docs/ios-ci-cd.md
+++ b/docs/ios-ci-cd.md
@@ -52,7 +52,7 @@ Optional Sentry environment values:
 
 - `XCODE_CLOUD_SENTRY_ENVIRONMENT` (defaults to `production` in Xcode Cloud)
 - `XCODE_CLOUD_SENTRY_TRACES_SAMPLE_RATE` (defaults to `0.0`)
-- `SENTRY_URL` (only needed for a non-default Sentry endpoint)
+- `SENTRY_URL` (only needed for a non-default Sentry endpoint; the URL must match the endpoint that issued `SENTRY_AUTH_TOKEN`)
 
 `ci_post_clone.sh` fails the build before `xcodebuild` if any required build-time variable is missing or if any URL value is malformed for `.xcconfig` usage. `ci_post_xcodebuild.sh` fails the archive if any required Sentry upload value is missing, if `sentry-cli` cannot be downloaded, or if the downloaded binary fails SHA-256 verification.
 

--- a/docs/ios-local-setup.md
+++ b/docs/ios-local-setup.md
@@ -70,7 +70,7 @@ Optional Sentry values:
 
 - `XCODE_CLOUD_SENTRY_ENVIRONMENT` (defaults to `production` in Xcode Cloud and `local` outside it)
 - `XCODE_CLOUD_SENTRY_TRACES_SAMPLE_RATE` (defaults to `0.0`)
-- `SENTRY_URL` (only needed for a non-default Sentry endpoint)
+- `SENTRY_URL` (only needed for a non-default Sentry endpoint; the URL must match the endpoint that issued `SENTRY_AUTH_TOKEN`)
 
 `apps/ios/Flashcards/ci_scripts/ci_post_clone.sh` writes those values into the generated `Config/Local.xcconfig` file during Xcode Cloud builds.
 The same script can be run locally and will read the repo-root `.env` when those


### PR DESCRIPTION
## Summary
- make Cards editor AI handoff set the durable AI navigation request before dismissing the editor
- add Cards-side structured AI handoff breadcrumbs
- document the intentional Xcode Cloud Test - iOS non-required setting and clarify Sentry endpoint/token matching

## Validation
- `git --no-pager diff --check`
- `xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift`

Simulator-backed UI smoke was not run locally.