### PR TITLE
[codex] Update progress leaderboard participant snapshots

### DIFF
--- a/apps/backend/src/community/leaderboard/leaderboardSnapshots.test.ts
+++ b/apps/backend/src/community/leaderboard/leaderboardSnapshots.test.ts
@@ -19,11 +19,23 @@ import {
 
 type QueryResultRow = pg.QueryResultRow;
 
+type StoredActivityActorKind =
+  | "client_installation"
+  | "workspace_seed"
+  | "workspace_reset"
+  | "agent_connection"
+  | "ai_chat";
+
+type StoredActivityPlatform = "web" | "android" | "ios" | "system";
+
 type StoredFact = Readonly<{
   publicProfileId: string;
   metricVersion: string;
   isCountable: boolean;
   reviewedAtClient: string;
+  actorKind: StoredActivityActorKind;
+  platform: StoredActivityPlatform;
+  reviewedByEmail: string | null;
 }>;
 
 type StoredProfile = Readonly<{
@@ -120,6 +132,20 @@ function isLinkedNonDemoEmail(email: string | null): boolean {
   return !email.trim().toLowerCase().endsWith("@example.com");
 }
 
+function isNonDemoEmailOrUnknown(email: string | null): boolean {
+  return email === null || !email.trim().toLowerCase().endsWith("@example.com");
+}
+
+function isSupportedClientPlatform(platform: StoredActivityPlatform): boolean {
+  return platform === "web" || platform === "android" || platform === "ios";
+}
+
+function isRealClientActivityFact(fact: StoredFact): boolean {
+  return fact.actorKind === "client_installation"
+    && isSupportedClientPlatform(fact.platform)
+    && isNonDemoEmailOrUnknown(fact.reviewedByEmail);
+}
+
 function computeEligibleEntries(
   state: MutableLeaderboardStoreState,
   call: RefreshCall,
@@ -145,6 +171,9 @@ function computeEligibleEntries(
 
   for (const fact of state.facts) {
     if (fact.metricVersion !== call.metricVersion || !fact.isCountable) {
+      continue;
+    }
+    if (!isRealClientActivityFact(fact)) {
       continue;
     }
 
@@ -244,6 +273,42 @@ const PROFILE_F = "00000000-0000-4000-8000-00000000000f";
 const NOW = new Date("2026-06-10T14:30:00.000Z");
 const AS_OF = "2026-06-10T14:00:00.000Z";
 
+function createWebClientFact(
+  publicProfileId: string,
+  metricVersion: string,
+  isCountable: boolean,
+  reviewedAtClient: string,
+  reviewedByEmail: string | null,
+): StoredFact {
+  return {
+    publicProfileId,
+    metricVersion,
+    isCountable,
+    reviewedAtClient,
+    actorKind: "client_installation",
+    platform: "web",
+    reviewedByEmail,
+  };
+}
+
+function createSystemFact(
+  publicProfileId: string,
+  metricVersion: string,
+  isCountable: boolean,
+  reviewedAtClient: string,
+  reviewedByEmail: string | null,
+): StoredFact {
+  return {
+    publicProfileId,
+    metricVersion,
+    isCountable,
+    reviewedAtClient,
+    actorKind: "workspace_seed",
+    platform: "system",
+    reviewedByEmail,
+  };
+}
+
 function seedLeaderboardFixture(state: MutableLeaderboardStoreState): void {
   state.profilesById.set(PROFILE_A, { publicProfileId: PROFILE_A, userId: "user-a", participationEnabled: true });
   state.profilesById.set(PROFILE_B, { publicProfileId: PROFILE_B, userId: "user-b", participationEnabled: true });
@@ -262,27 +327,30 @@ function seedLeaderboardFixture(state: MutableLeaderboardStoreState): void {
   const metricVersion = LEADERBOARD_SNAPSHOT_METRIC_VERSION;
   state.facts.push(
     // profile-a: 1h before as_of (in every window).
-    { publicProfileId: PROFILE_A, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T13:00:00.000Z" },
+    createWebClientFact(PROFILE_A, metricVersion, true, "2026-06-10T13:00:00.000Z", "a@real.test"),
     // profile-a: again (rating 0) is never countable.
-    { publicProfileId: PROFILE_A, metricVersion, isCountable: false, reviewedAtClient: "2026-06-10T13:30:00.000Z" },
+    createWebClientFact(PROFILE_A, metricVersion, false, "2026-06-10T13:30:00.000Z", "a@real.test"),
     // profile-a: 25h before as_of (excluded from 24h, included from 3 days on).
-    { publicProfileId: PROFILE_A, metricVersion, isCountable: true, reviewedAtClient: "2026-06-09T13:00:00.000Z" },
+    createWebClientFact(PROFILE_A, metricVersion, true, "2026-06-09T13:00:00.000Z", "a@real.test"),
     // profile-a: exactly at as_of (included by the <= upper bound).
-    { publicProfileId: PROFILE_A, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T14:00:00.000Z" },
+    createWebClientFact(PROFILE_A, metricVersion, true, "2026-06-10T14:00:00.000Z", "a@real.test"),
     // profile-a: after as_of (excluded everywhere).
-    { publicProfileId: PROFILE_A, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T15:00:00.000Z" },
+    createWebClientFact(PROFILE_A, metricVersion, true, "2026-06-10T15:00:00.000Z", "a@real.test"),
+    // profile-a: demo fact author activity is excluded by the public metrics email filter.
+    createWebClientFact(PROFILE_A, metricVersion, true, "2026-06-10T13:15:00.000Z", "demo@example.com"),
     // profile-b: three countable reviews inside 24h.
-    { publicProfileId: PROFILE_B, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T11:00:00.000Z" },
-    { publicProfileId: PROFILE_B, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T12:00:00.000Z" },
-    { publicProfileId: PROFILE_B, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T12:30:00.000Z" },
+    createWebClientFact(PROFILE_B, metricVersion, true, "2026-06-10T11:00:00.000Z", "b@real.test"),
+    createWebClientFact(PROFILE_B, metricVersion, true, "2026-06-10T12:00:00.000Z", "b@real.test"),
+    createWebClientFact(PROFILE_B, metricVersion, true, "2026-06-10T12:30:00.000Z", "b@real.test"),
     // profile-c: opted out of leaderboard participation.
-    { publicProfileId: PROFILE_C, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T13:00:00.000Z" },
+    createWebClientFact(PROFILE_C, metricVersion, true, "2026-06-10T13:00:00.000Z", "c@real.test"),
     // profile-d: unlinked guest (email IS NULL).
-    { publicProfileId: PROFILE_D, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T13:00:00.000Z" },
+    createWebClientFact(PROFILE_D, metricVersion, true, "2026-06-10T13:00:00.000Z", null),
     // profile-e: demo example.com account.
-    { publicProfileId: PROFILE_E, metricVersion, isCountable: true, reviewedAtClient: "2026-06-10T13:00:00.000Z" },
-    // profile-f: only an again fact, so it never qualifies.
-    { publicProfileId: PROFILE_F, metricVersion, isCountable: false, reviewedAtClient: "2026-06-10T13:00:00.000Z" },
+    createWebClientFact(PROFILE_E, metricVersion, true, "2026-06-10T13:00:00.000Z", "demo@example.com"),
+    // profile-f: again and system facts do not count, but the linked opted-in profile still appears with zero.
+    createWebClientFact(PROFILE_F, metricVersion, false, "2026-06-10T13:00:00.000Z", "f@real.test"),
+    createSystemFact(PROFILE_F, metricVersion, true, "2026-06-10T13:15:00.000Z", "f@real.test"),
   );
 }
 
@@ -369,7 +437,7 @@ test("last_24_hours snapshot includes opted-in linked accounts even with zero co
 
   // profile-b has 3 countable reviews in 24h; profile-a has 2 (1h-before plus the as_of
   // boundary fact); the again fact, the 25h fact, and the future fact are all excluded.
-  // profile-f is linked and opted in, so it appears with zero countable reviews.
+  // profile-f is linked and opted in, so it appears with zero real-client countable reviews.
   assert.deepEqual(entriesForWindow(state, "last_24_hours"), [
     { publicProfileId: PROFILE_B, qualifiedReviewCount: 3, baseSortPosition: 1 },
     { publicProfileId: PROFILE_A, qualifiedReviewCount: 2, baseSortPosition: 2 },
@@ -412,6 +480,21 @@ test("opted-out, unlinked guest, and demo profiles are excluded from every windo
   }
 });
 
+test("every window uses the same eligible participant universe", async () => {
+  const state = createLeaderboardStoreState();
+  seedLeaderboardFixture(state);
+
+  await generateWithFake(state, LEADERBOARD_SNAPSHOT_METRIC_VERSION, NOW);
+
+  const expectedProfileIds = [PROFILE_A, PROFILE_B, PROFILE_F].sort();
+  for (const window of LEADERBOARD_WINDOWS) {
+    const profileIdsInWindow = entriesForWindow(state, window.windowKey)
+      .map((entry) => entry.publicProfileId)
+      .sort();
+    assert.deepEqual(profileIdsInWindow, expectedProfileIds, window.windowKey);
+  }
+});
+
 test("regenerating the same server hour reuses snapshots and replaces entries idempotently", async () => {
   const state = createLeaderboardStoreState();
   seedLeaderboardFixture(state);
@@ -442,6 +525,28 @@ test("generateLeaderboardSnapshots rejects an unsupported metric version before 
     UnsupportedLeaderboardMetricVersionError,
   );
   assert.equal(state.refreshCalls.length, 0);
+});
+
+test("production leaderboard snapshot generation uses one repeatable-read transaction", () => {
+  const sourcePath = resolve(
+    process.cwd(),
+    "src/community/leaderboard/leaderboardSnapshots.ts",
+  );
+  const source = readFileSync(sourcePath, "utf8").replace(/\s+/g, " ");
+
+  assert.match(source, /import \{ unsafeRepeatableReadTransaction \} from "\.\.\/\.\.\/database\/unsafe"/);
+  assert.match(source, /withTransactionFn: unsafeRepeatableReadTransaction/);
+});
+
+test("community leaderboard snapshot Lambda retries transient database failures", () => {
+  const sourcePath = resolve(
+    process.cwd(),
+    "src/entrypoints/lambda-community-leaderboard-snapshot.ts",
+  );
+  const source = readFileSync(sourcePath, "utf8").replace(/\s+/g, " ");
+
+  assert.match(source, /import \{ withTransientDatabaseRetry \} from "\.\.\/database\/transient"/);
+  assert.match(source, /const result = await withTransientDatabaseRetry\( \(\) => runtime\.generateLeaderboardSnapshots\(\), \(\) => observationScope, \)/);
 });
 
 test("assertLeaderboardWindowKey accepts known keys and rejects unknown ones", () => {
@@ -528,4 +633,30 @@ test("0060 migration includes zero-count linked opted-in profiles in snapshots",
   assert.match(sql, /NOT LIKE '%@example\.com'/);
   assert.match(sql, /ROW_NUMBER\(\) OVER \( ORDER BY eligible\.qualified_review_count DESC, eligible\.public_profile_id ASC \)/);
   assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.refresh_leaderboard_snapshot\(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ\) TO backend_app/);
+});
+
+test("0061 migration counts only real client-app activity without shrinking the participant universe", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "../../db/migrations/0061_leaderboard_real_client_activity.sql",
+  );
+  const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
+
+  assert.match(sql, /CREATE OR REPLACE FUNCTION community\.refresh_leaderboard_snapshot/);
+  assert.match(sql, /FROM community\.public_profiles AS profiles/);
+  assert.match(sql, /LEFT JOIN \( SELECT facts\.public_profile_id FROM community\.public_review_activity_facts AS facts/);
+  assert.match(sql, /INNER JOIN content\.review_events AS review_events/);
+  assert.match(sql, /INNER JOIN sync\.workspace_replicas AS workspace_replicas/);
+  assert.match(sql, /ON fact_user_settings\.user_id = facts\.reviewed_by_user_id/);
+  assert.match(sql, /workspace_replicas\.actor_kind = 'client_installation'/);
+  assert.match(sql, /workspace_replicas\.platform IN \('web', 'android', 'ios'\)/);
+  assert.match(sql, /fact_user_settings\.email IS NULL OR LOWER\(btrim\(fact_user_settings\.email\)\) NOT LIKE '%@example\.com'/);
+  assert.match(sql, /COUNT\(countable_facts\.public_profile_id\)::int AS qualified_review_count/);
+  assert.match(sql, /profiles\.leaderboard_participation_enabled = TRUE/);
+  assert.match(sql, /user_settings\.email IS NOT NULL/);
+  assert.match(sql, /LOWER\(btrim\(user_settings\.email\)\) NOT LIKE '%@example\.com'/);
+  assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.refresh_leaderboard_snapshot\(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ\) TO backend_app/);
+  assert.match(sql, /CREATE OR REPLACE FUNCTION community\.read_current_user_latest_leaderboard_review/);
+  assert.match(sql, /WHERE facts\.reviewed_by_user_id = security\.current_user_id\(\)/);
+  assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.read_current_user_latest_leaderboard_review\(TEXT\) TO backend_app/);
 });

--- a/apps/backend/src/community/leaderboard/leaderboardSnapshots.ts
+++ b/apps/backend/src/community/leaderboard/leaderboardSnapshots.ts
@@ -1,4 +1,4 @@
-import { unsafeTransaction } from "../../database/unsafe";
+import { unsafeRepeatableReadTransaction } from "../../database/unsafe";
 import { type DatabaseExecutor } from "../../database";
 import {
   LEADERBOARD_SNAPSHOT_METRIC_VERSION,
@@ -17,9 +17,9 @@ import {
  * The cross-user read, exclusion rules, tie-neutral ordering, and atomic entry
  * replacement live in the SECURITY DEFINER function
  * community.refresh_leaderboard_snapshot (see db/migrations/0059_leaderboard_snapshots.sql
- * and db/migrations/0060_leaderboard_zero_count_participants.sql); this module owns
- * the injectable clock, the window set, metric-version validation, and sequencing
- * the per-window refreshes inside one transaction.
+ * through db/migrations/0061_leaderboard_real_client_activity.sql); this module
+ * owns the injectable clock, the window set, metric-version validation, and
+ * sequencing the per-window refreshes inside one repeatable-read transaction.
  */
 
 type RefreshLeaderboardSnapshotParams = Readonly<{
@@ -122,7 +122,7 @@ export async function generateLeaderboardSnapshots(): Promise<LeaderboardSnapsho
   return generateLeaderboardSnapshotsWithDependencies({
     metricVersion: LEADERBOARD_SNAPSHOT_METRIC_VERSION,
     now: () => new Date(),
-    withTransactionFn: unsafeTransaction,
+    withTransactionFn: unsafeRepeatableReadTransaction,
     refreshLeaderboardSnapshotFn: refreshLeaderboardSnapshotInExecutor,
   });
 }

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
@@ -143,7 +143,7 @@ function createLeaderboardExecutor(
         throw new Error("viewer profile was pre-seeded; no insert expected");
       }
 
-      if (text.includes("MAX(facts.reviewed_at_client)")) {
+      if (text.includes("community.read_current_user_latest_leaderboard_review($1)")) {
         return createQueryResult([
           { latest_reviewed_at_client: fixture.latestReviewedAtClient },
         ]) as unknown as pg.QueryResult<Row>;
@@ -362,6 +362,36 @@ test("equal counts rank the viewer below other users with the same count", async
       { kind: "viewer", rank: 3, count: 5 },
       { kind: "neighbor", rank: 4, count: 3 },
     ],
+  );
+});
+
+test("compact rows show the next rank when the viewer is exactly third", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: "00000000-0000-4000-8000-000000000131", qualified_review_count: 30, base_sort_position: 1 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000132", qualified_review_count: 20, base_sort_position: 2 },
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 10, base_sort_position: 3 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000134", qualified_review_count: 8, base_sort_position: 4 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000135", qualified_review_count: 4, base_sort_position: 5 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000136", qualified_review_count: 0, base_sort_position: 6 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  assert.equal(window.viewer.rank, 3);
+  assert.deepEqual(
+    window.rows.map((row) => (row.kind === "gap" ? "gap" : `${row.kind}:${row.rank}`)),
+    ["top:1", "top:2", "viewer:3", "neighbor:4", "gap", "neighbor:6"],
   );
 });
 

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.ts
@@ -351,8 +351,9 @@ function buildParticipantRow(
 
 /**
  * Selects the compact rows server-side so every client renders the same list:
- * the top three rows (when that many participants exist), the viewer-neighbor
- * group when the viewer is outside the top block, and the last-place row.
+ * the top three rows (when that many participants exist), the next row when
+ * the viewer is exactly third, the viewer-neighbor group when the viewer is
+ * outside the top block, and the last-place row.
  * Overlapping groups are de-duplicated by rank and gap rows are inserted
  * wherever hidden ranks sit between visible groups.
  */
@@ -374,6 +375,8 @@ function buildCompactRows(
         shownRanks.add(candidate);
       }
     }
+  } else if (viewerRank === topRowCount && viewerRank < total) {
+    shownRanks.add(viewerRank + 1);
   }
   if (total > topRowCount) {
     shownRanks.add(total);
@@ -437,10 +440,7 @@ async function readViewerLatestCountableReviewInExecutor(
 ): Promise<string | null> {
   const result = await executor.query<ViewerLatestReviewRow>(
     [
-      "SELECT MAX(facts.reviewed_at_client) AS latest_reviewed_at_client",
-      "FROM community.public_review_activity_facts AS facts",
-      "WHERE facts.metric_version = $1",
-      "AND facts.is_countable = TRUE",
+      "SELECT community.read_current_user_latest_leaderboard_review($1) AS latest_reviewed_at_client",
     ].join(" "),
     [LEADERBOARD_SNAPSHOT_METRIC_VERSION],
   );

--- a/apps/backend/src/entrypoints/lambda-community-leaderboard-snapshot.ts
+++ b/apps/backend/src/entrypoints/lambda-community-leaderboard-snapshot.ts
@@ -8,6 +8,7 @@ import {
   wrapBackendHandler,
 } from "../observability/sentry";
 import { LEADERBOARD_SNAPSHOT_METRIC_VERSION } from "../community/leaderboard/leaderboardWindows";
+import { withTransientDatabaseRetry } from "../database/transient";
 
 initializeBackendSentry("community-leaderboard-snapshot");
 
@@ -57,7 +58,10 @@ const communityLeaderboardSnapshotHandler: Handler<
   );
   try {
     const runtime = await getCommunityLeaderboardSnapshotRuntime();
-    const result = await runtime.generateLeaderboardSnapshots();
+    const result = await withTransientDatabaseRetry(
+      () => runtime.generateLeaderboardSnapshots(),
+      () => observationScope,
+    );
 
     addBackendBreadcrumb({
       action: "community_leaderboard_snapshot_generated",

--- a/db/migrations/0061_leaderboard_real_client_activity.sql
+++ b/db/migrations/0061_leaderboard_real_client_activity.sql
@@ -1,0 +1,132 @@
+-- Counts only real client-app review activity in leaderboard snapshots while
+-- keeping the participant universe fixed to every opted-in linked non-demo public
+-- profile. This mirrors the public/admin activity dashboards' system-actor filter.
+
+CREATE OR REPLACE FUNCTION community.refresh_leaderboard_snapshot(
+  p_metric_version           TEXT,
+  p_window_key               TEXT,
+  p_window_lower_bound_hours INTEGER,
+  p_as_of_server_hour        TIMESTAMPTZ,
+  p_generated_at             TIMESTAMPTZ
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_snapshot_id UUID;
+BEGIN
+  INSERT INTO community.leaderboard_snapshots AS snapshots (
+    snapshot_id,
+    metric_version,
+    window_key,
+    generated_at,
+    as_of_server_hour
+  )
+  VALUES (
+    gen_random_uuid(),
+    p_metric_version,
+    p_window_key,
+    p_generated_at,
+    p_as_of_server_hour
+  )
+  ON CONFLICT (metric_version, window_key, as_of_server_hour)
+  DO UPDATE SET generated_at = EXCLUDED.generated_at
+  RETURNING snapshots.snapshot_id INTO v_snapshot_id;
+
+  DELETE FROM community.leaderboard_snapshot_entries
+  WHERE snapshot_id = v_snapshot_id;
+
+  INSERT INTO community.leaderboard_snapshot_entries (
+    snapshot_id,
+    public_profile_id,
+    qualified_review_count,
+    base_sort_position
+  )
+  SELECT
+    v_snapshot_id,
+    eligible.public_profile_id,
+    eligible.qualified_review_count,
+    (ROW_NUMBER() OVER (
+      ORDER BY eligible.qualified_review_count DESC, eligible.public_profile_id ASC
+    ))::int AS base_sort_position
+  FROM (
+    SELECT
+      profiles.public_profile_id AS public_profile_id,
+      COUNT(countable_facts.public_profile_id)::int AS qualified_review_count
+    FROM community.public_profiles AS profiles
+    INNER JOIN org.user_settings AS user_settings
+      ON user_settings.user_id = profiles.user_id
+    LEFT JOIN (
+      SELECT facts.public_profile_id
+      FROM community.public_review_activity_facts AS facts
+      INNER JOIN content.review_events AS review_events
+        ON review_events.review_event_id = facts.review_event_id
+      INNER JOIN sync.workspace_replicas AS workspace_replicas
+        ON workspace_replicas.replica_id = review_events.replica_id
+      LEFT JOIN org.user_settings AS fact_user_settings
+        ON fact_user_settings.user_id = facts.reviewed_by_user_id
+      WHERE facts.metric_version = p_metric_version
+        AND facts.is_countable = TRUE
+        AND facts.reviewed_at_client <= p_as_of_server_hour
+        AND (
+          p_window_lower_bound_hours IS NULL
+          OR facts.reviewed_at_client > p_as_of_server_hour - (p_window_lower_bound_hours * interval '1 hour')
+        )
+        AND workspace_replicas.actor_kind = 'client_installation'
+        AND workspace_replicas.platform IN ('web', 'android', 'ios')
+        AND (
+          fact_user_settings.email IS NULL
+          OR LOWER(btrim(fact_user_settings.email)) NOT LIKE '%@example.com'
+        )
+    ) AS countable_facts
+      ON countable_facts.public_profile_id = profiles.public_profile_id
+    WHERE profiles.leaderboard_participation_enabled = TRUE
+      AND user_settings.email IS NOT NULL
+      AND LOWER(btrim(user_settings.email)) NOT LIKE '%@example.com'
+    GROUP BY profiles.public_profile_id
+  ) AS eligible;
+
+  RETURN v_snapshot_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION community.refresh_leaderboard_snapshot(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION community.refresh_leaderboard_snapshot(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ) TO backend_app;
+
+COMMENT ON FUNCTION community.refresh_leaderboard_snapshot(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ) IS
+  'Regenerates one leaderboard snapshot (metric_version, window_key) at a server hour. Includes every opted-in linked non-demo public profile, counts only matching countable facts from real client-app activity, orders tie-neutrally, and atomically replaces the snapshot entries. Returns the snapshot_id.';
+
+CREATE OR REPLACE FUNCTION community.read_current_user_latest_leaderboard_review(
+  p_metric_version TEXT
+)
+RETURNS TIMESTAMPTZ
+LANGUAGE SQL
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT MAX(facts.reviewed_at_client)
+  FROM community.public_review_activity_facts AS facts
+  INNER JOIN content.review_events AS review_events
+    ON review_events.review_event_id = facts.review_event_id
+  INNER JOIN sync.workspace_replicas AS workspace_replicas
+    ON workspace_replicas.replica_id = review_events.replica_id
+  LEFT JOIN org.user_settings AS fact_user_settings
+    ON fact_user_settings.user_id = facts.reviewed_by_user_id
+  WHERE facts.reviewed_by_user_id = security.current_user_id()
+    AND facts.metric_version = p_metric_version
+    AND facts.is_countable = TRUE
+    AND workspace_replicas.actor_kind = 'client_installation'
+    AND workspace_replicas.platform IN ('web', 'android', 'ios')
+    AND (
+      fact_user_settings.email IS NULL
+      OR LOWER(btrim(fact_user_settings.email)) NOT LIKE '%@example.com'
+    );
+$$;
+
+REVOKE ALL ON FUNCTION community.read_current_user_latest_leaderboard_review(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION community.read_current_user_latest_leaderboard_review(TEXT) TO backend_app;
+
+COMMENT ON FUNCTION community.read_current_user_latest_leaderboard_review(TEXT) IS
+  'Returns the scoped user latest countable leaderboard review timestamp using the same real client-app activity filters as leaderboard snapshots.';


### PR DESCRIPTION
## Summary
- Include all eligible public leaderboard participants in every snapshot window while counting only real client-app review activity.
- Add the final compact leaderboard row behavior for the third-place viewer boundary case.
- Use repeatable-read snapshot generation with transient database retries for the scheduled leaderboard job.

## Validation
- `git --no-pager diff --check`
- `npm run bundle --prefix ../../api && node --test --import tsx src/community/leaderboard/progressLeaderboard.test.ts src/community/leaderboard/leaderboardSnapshots.test.ts`