### PR TITLE
[codex] Use large iOS review toolbar controls

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -399,6 +399,7 @@ struct ReviewView: View {
                     .font(.caption.weight(.semibold))
             }
         }
+        .controlSize(.large)
     }
 
     private var reviewLoadingView: some View {
@@ -582,7 +583,7 @@ struct ReviewView: View {
             .fixedSize(horizontal: true, vertical: false)
         }
         .buttonStyle(.glass)
-        .controlSize(.regular)
+        .controlSize(.large)
         .disabled(badgeState.isInteractive == false)
         .accessibilityIdentifier(UITestIdentifier.reviewProgressBadge)
         .accessibilityLabel(self.reviewProgressBadgeAccessibilityLabel(badgeState: badgeState))
@@ -611,7 +612,7 @@ struct ReviewView: View {
                 .labelStyle(.iconOnly)
         }
         .buttonStyle(.glass)
-        .controlSize(.regular)
+        .controlSize(.large)
         .accessibilityIdentifier(UITestIdentifier.reviewLeaderboardShortcut)
         .accessibilityLabel(self.reviewLeaderboardButtonTitle)
     }


### PR DESCRIPTION
## Summary
- set the Review filter menu, trophy shortcut, and streak shortcut to the same large control size
- keep the native SwiftUI toolbar and Liquid Glass rendering path without manual height frames

## Validation
- git diff --check -- apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
- SwiftUI toolbar/menu typecheck with the iOS 26.5 simulator SDK

Simulator-backed iOS UI tests were not run locally because the repository requires explicit permission for those heavy checks.