### PR TITLE
[codex] Fix settings attention badges

### DIFF
--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsAttentionBadge.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/SettingsAttentionBadge.kt
@@ -1,12 +1,16 @@
 package com.flashcardsopensourceapp.feature.settings
 
 import androidx.compose.material3.Badge
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 
 @Composable
 fun SettingsAttentionBadge(count: Int) {
-    Badge {
+    Badge(
+        containerColor = MaterialTheme.colorScheme.error,
+        contentColor = MaterialTheme.colorScheme.onError
+    ) {
         Text(text = count.toString())
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/AccountLegalView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/AccountLegalView.swift
@@ -15,7 +15,8 @@ struct AccountLegalView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("common.privacyPolicy", "Privacy Policy"),
                             value: aiSettingsLocalized("common.open", "Open"),
-                            systemImage: "hand.raised"
+                            systemImage: "hand.raised",
+                            attentionCount: nil
                         )
                     }
                 }
@@ -25,7 +26,8 @@ struct AccountLegalView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("common.termsOfService", "Terms of Service"),
                             value: aiSettingsLocalized("common.open", "Open"),
-                            systemImage: "doc.text"
+                            systemImage: "doc.text",
+                            attentionCount: nil
                         )
                     }
                 }
@@ -35,7 +37,8 @@ struct AccountLegalView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("settings.account.legal.githubRepository", "GitHub Repository"),
                             value: aiSettingsLocalized("common.open", "Open"),
-                            systemImage: "chevron.left.forwardslash.chevron.right"
+                            systemImage: "chevron.left.forwardslash.chevron.right",
+                            attentionCount: nil
                         )
                     }
                 }
@@ -95,7 +98,8 @@ struct AccountSupportView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("common.support", "Support"),
                             value: aiSettingsLocalized("common.open", "Open"),
-                            systemImage: "questionmark.circle"
+                            systemImage: "questionmark.circle",
+                            attentionCount: nil
                         )
                     }
                 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/AccountOpenSourceView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/AccountOpenSourceView.swift
@@ -226,7 +226,8 @@ struct AccountOpenSourceView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("settings.account.openSource.repository", "GitHub Repository (MIT License)"),
                             value: aiSettingsLocalized("common.open", "Open"),
-                            systemImage: "arrow.up.forward.square"
+                            systemImage: "arrow.up.forward.square",
+                            attentionCount: nil
                         )
                     }
                 }
@@ -256,7 +257,8 @@ struct AccountOpenSourceView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("settings.account.openSource.thirdPartyNoticeFull", "Full Third-Party Notices"),
                             value: aiSettingsLocalized("common.open", "Open"),
-                            systemImage: "arrow.up.forward.square"
+                            systemImage: "arrow.up.forward.square",
+                            attentionCount: nil
                         )
                     }
                 }
@@ -267,7 +269,8 @@ struct AccountOpenSourceView: View {
                             SettingsNavigationRow(
                                 title: aiSettingsLocalized(sourceLink.localizationKey, sourceLink.fallbackTitle),
                                 value: aiSettingsLocalized("common.open", "Open"),
-                                systemImage: "arrow.up.forward.square"
+                                systemImage: "arrow.up.forward.square",
+                                attentionCount: nil
                             )
                         }
                     }
@@ -278,7 +281,8 @@ struct AccountOpenSourceView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("settings.account.openSource.thirdPartyNoticeLicense", "Creative Commons Attribution 4.0"),
                             value: aiSettingsLocalized("common.open", "Open"),
-                            systemImage: "arrow.up.forward.square"
+                            systemImage: "arrow.up.forward.square",
+                            attentionCount: nil
                         )
                     }
                 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/AccountStatusView.swift
@@ -100,16 +100,24 @@ struct AccountStatusView: View {
 
                     switch cloudSettings.cloudState {
                     case .disconnected, .linkingReady:
-                        Button(aiSettingsLocalized("settings.account.status.signIn", "Sign in or sign up")) {
+                        Button {
                             self.isCloudSignInPresented = true
+                        } label: {
+                            AccountStatusPrimaryActionLabel(
+                                title: aiSettingsLocalized("settings.account.status.signIn", "Sign in or sign up"),
+                                attentionCount: self.settingsAttentionSummary.accountStatusPrimaryActionCount
+                            )
                         }
-                        .badge(self.settingsAttentionSummary.accountStatusPrimaryActionCount)
                         .accessibilityIdentifier(UITestIdentifier.accountStatusSignInButton)
                     case .guest:
-                        Button(aiSettingsLocalized("settings.account.status.signIn", "Sign in or sign up")) {
+                        Button {
                             self.isCloudSignInPresented = true
+                        } label: {
+                            AccountStatusPrimaryActionLabel(
+                                title: aiSettingsLocalized("settings.account.status.signIn", "Sign in or sign up"),
+                                attentionCount: self.settingsAttentionSummary.accountStatusPrimaryActionCount
+                            )
                         }
-                        .badge(self.settingsAttentionSummary.accountStatusPrimaryActionCount)
                         .accessibilityIdentifier(UITestIdentifier.accountStatusSignInButton)
                     case .linked:
                         Button(aiSettingsLocalized("settings.account.status.syncNow", "Sync now")) {
@@ -189,6 +197,24 @@ struct AccountStatusView: View {
             return true
         }
         return false
+    }
+}
+
+private struct AccountStatusPrimaryActionLabel: View {
+    let title: String
+    let attentionCount: Int
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(title)
+
+            Spacer()
+
+            if attentionCount > 0 {
+                SettingsAttentionBadgeView(count: attentionCount)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/CurrentWorkspaceView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/CurrentWorkspaceView.swift
@@ -44,7 +44,8 @@ struct CurrentWorkspaceView: View {
                         value: self.isWorkspacePickerLoading
                             ? aiSettingsLocalized("common.loading", "Loading...")
                             : self.currentWorkspaceName,
-                        systemImage: "square.stack"
+                        systemImage: "square.stack",
+                        attentionCount: nil
                     )
                 }
                 .buttonStyle(.plain)

--- a/apps/ios/Flashcards/Flashcards/Settings/FeedbackSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/FeedbackSettingsView.swift
@@ -20,7 +20,8 @@ struct FeedbackSettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.sendFeedback", "Send Feedback"),
                         value: aiSettingsLocalized("settings.row.sendFeedback.value", "Share an idea"),
-                        systemImage: "text.bubble"
+                        systemImage: "text.bubble",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.feedbackSettingsOpenFeedbackButton)

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsAttentionSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsAttentionSupport.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwiftUI
 
 enum SettingsAttentionIssue: Hashable, Sendable {
     case accountNotLinked
@@ -14,6 +14,21 @@ struct SettingsAttentionSummary: Equatable, Sendable {
     let settingsTabCount: Int
     let accountStatusRowCount: Int
     let accountStatusPrimaryActionCount: Int
+}
+
+struct SettingsAttentionBadgeView: View {
+    let count: Int
+
+    var body: some View {
+        Text(count.formatted())
+            .font(.caption2.weight(.bold))
+            .monospacedDigit()
+            .foregroundStyle(.white)
+            .padding(.horizontal, 6)
+            .frame(minWidth: 22, minHeight: 22)
+            .background(Capsule().fill(Color(.systemRed)))
+            .fixedSize()
+    }
 }
 
 func makeSettingsAttentionIssues(cloudState: CloudAccountState?) -> [SettingsAttentionIssue] {

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -52,17 +52,18 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.accountStatus", "Account Status"),
                         value: self.accountStatusValue,
-                        systemImage: "person.crop.circle"
+                        systemImage: "person.crop.circle",
+                        attentionCount: self.settingsAttentionSummary.accountStatusRowCount
                     )
                 }
-                .badge(self.settingsAttentionSummary.accountStatusRowCount)
                 .accessibilityIdentifier(UITestIdentifier.settingsAccountStatusRow)
 
                 NavigationLink(value: SettingsNavigationDestination.currentWorkspace) {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.currentWorkspace", "Workspace"),
                         value: self.currentWorkspaceValue,
-                        systemImage: "square.stack"
+                        systemImage: "square.stack",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsCurrentWorkspaceRow)
@@ -73,7 +74,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.reviewReminders", "Review Reminders"),
                         value: aiSettingsLocalized("settings.row.reviewReminders.value", "This Device"),
-                        systemImage: "bell.badge"
+                        systemImage: "bell.badge",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsReviewRemindersRow)
@@ -84,7 +86,8 @@ struct SettingsView: View {
                         value: store.accountPreferences.reviewReactionAnimationsEnabled
                             ? aiSettingsLocalized("common.on", "On")
                             : aiSettingsLocalized("common.off", "Off"),
-                        systemImage: "sparkles"
+                        systemImage: "sparkles",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsReviewAnimationsRow)
@@ -93,7 +96,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.leaderboardParticipation", "Leaderboard participation"),
                         value: self.leaderboardParticipationValue,
-                        systemImage: "list.number"
+                        systemImage: "list.number",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsLeaderboardParticipationRow)
@@ -102,7 +106,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.language", "Language"),
                         value: aiSettingsLocalized("settings.row.language.value", "iOS"),
-                        systemImage: "globe"
+                        systemImage: "globe",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsLanguageRow)
@@ -111,7 +116,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.access", "Access"),
                         value: aiSettingsLocalized("settings.row.access.permissionsCount", "3 permissions"),
-                        systemImage: "hand.raised"
+                        systemImage: "hand.raised",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsAccessRow)
@@ -120,7 +126,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.decks", "Decks"),
                         value: aiSettingsLocalized("settings.row.workspaceScoped.value", "Workspace"),
-                        systemImage: "rectangle.stack"
+                        systemImage: "rectangle.stack",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsDecksRow)
@@ -129,7 +136,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.tags", "Tags"),
                         value: aiSettingsLocalized("settings.row.workspaceScoped.value", "Workspace"),
-                        systemImage: "tag"
+                        systemImage: "tag",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsTagsRow)
@@ -138,7 +146,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.export", "Export"),
                         value: "CSV",
-                        systemImage: "square.and.arrow.up"
+                        systemImage: "square.and.arrow.up",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsExportRow)
@@ -149,7 +158,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.sendFeedback", "Send Feedback"),
                         value: aiSettingsLocalized("settings.row.sendFeedback.value", "Share an idea"),
-                        systemImage: "text.bubble"
+                        systemImage: "text.bubble",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsFeedbackRow)
@@ -158,7 +168,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.support", "Support"),
                         value: nil,
-                        systemImage: "questionmark.circle"
+                        systemImage: "questionmark.circle",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsSupportRow)
@@ -167,7 +178,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.legal", "Legal"),
                         value: nil,
-                        systemImage: "doc.text"
+                        systemImage: "doc.text",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsLegalRow)
@@ -176,7 +188,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.openSource", "Open Source"),
                         value: aiSettingsLocalized("settings.account.row.openSourceValue", "GitHub + MIT"),
-                        systemImage: "chevron.left.forwardslash.chevron.right"
+                        systemImage: "chevron.left.forwardslash.chevron.right",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsOpenSourceRow)
@@ -187,7 +200,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.scheduling", "Scheduling / FSRS"),
                         value: "FSRS",
-                        systemImage: "calendar.badge.clock"
+                        systemImage: "calendar.badge.clock",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsSchedulingRow)
@@ -196,7 +210,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.agentConnections", "Agent Connections"),
                         value: aiSettingsLocalized("settings.row.agentConnections.value", "API keys"),
-                        systemImage: "link"
+                        systemImage: "link",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsAgentConnectionsRow)
@@ -205,7 +220,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.server", "Server"),
                         value: aiSettingsLocalized("settings.row.server.value", "Domain"),
-                        systemImage: "network"
+                        systemImage: "network",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsServerRow)
@@ -214,7 +230,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.deviceDiagnostics", "Device"),
                         value: nil,
-                        systemImage: "internaldrive"
+                        systemImage: "internaldrive",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsDeviceDiagnosticsRow)
@@ -223,7 +240,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.resetStudyProgress", "Reset Study Progress"),
                         value: aiSettingsLocalized("settings.row.resetStudyProgress.value", "Progress"),
-                        systemImage: "arrow.counterclockwise.circle"
+                        systemImage: "arrow.counterclockwise.circle",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsResetStudyProgressRow)
@@ -232,7 +250,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.deleteCurrentWorkspace", "Delete Current Workspace"),
                         value: aiSettingsLocalized("settings.row.permanent.value", "Permanent"),
-                        systemImage: "trash"
+                        systemImage: "trash",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsDeleteCurrentWorkspaceRow)
@@ -241,7 +260,8 @@ struct SettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.row.deleteAccount", "Delete Account"),
                         value: aiSettingsLocalized("settings.row.permanent.value", "Permanent"),
-                        systemImage: "person.crop.circle.badge.xmark"
+                        systemImage: "person.crop.circle.badge.xmark",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.settingsDeleteAccountRow)
@@ -251,7 +271,8 @@ struct SettingsView: View {
                         SettingsNavigationRow(
                             title: aiSettingsLocalized("settings.row.test", "Test"),
                             value: aiSettingsLocalized("settings.row.test.itemCount", "2 items"),
-                            systemImage: "wrench.and.screwdriver"
+                            systemImage: "wrench.and.screwdriver",
+                            attentionCount: nil
                         )
                     }
                     .accessibilityIdentifier(UITestIdentifier.settingsTestRow)
@@ -271,6 +292,7 @@ struct SettingsNavigationRow: View {
     let title: String
     let value: String?
     let systemImage: String
+    let attentionCount: Int?
 
     var body: some View {
         HStack(spacing: 12) {
@@ -282,6 +304,10 @@ struct SettingsNavigationRow: View {
                 Text(value)
                     .font(.subheadline.monospacedDigit())
                     .foregroundStyle(.secondary)
+            }
+
+            if let attentionCount, attentionCount > 0 {
+                SettingsAttentionBadgeView(count: attentionCount)
             }
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/TestSettingsView.swift
@@ -10,7 +10,8 @@ struct TestSettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.test.animations", "Animations"),
                         value: aiSettingsLocalized("settings.test.animations.itemCount", "38 items"),
-                        systemImage: "sparkles"
+                        systemImage: "sparkles",
+                        attentionCount: nil
                     )
                 }
                 .accessibilityIdentifier(UITestIdentifier.testSettingsAnimationsRow)
@@ -21,7 +22,8 @@ struct TestSettingsView: View {
                     SettingsNavigationRow(
                         title: aiSettingsLocalized("settings.test.storeReviewPromptReset", "Reset App Store review prompt"),
                         value: aiSettingsLocalized("settings.test.storeReviewPromptReset.value", "Local state"),
-                        systemImage: "star.bubble"
+                        systemImage: "star.bubble",
+                        attentionCount: nil
                     )
                 }
             }


### PR DESCRIPTION
## Summary
- render iOS settings attention counts as red badges with white numbers inside Settings and Account Status
- keep Android settings attention badges on Material error/onError colors across tab, row, and sign-in action
- update existing iOS SettingsNavigationRow call sites for the explicit attention count parameter

## Validation
- git --no-pager diff --check
- iOS build was attempted earlier but local Xcode had no installed iOS 26.5 destination
- Android Gradle was not run because repository rules require explicit permission