### PR TITLE
Include guest profiles in leaderboard

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -135,11 +135,13 @@ paths:
     get:
       tags:
         - bootstrap
-      summary: Load signed-in community public profile
+      summary: Load community public profile
       description: >-
-        Ensures the authenticated app user has a stable opaque public community
-        profile and returns only client-safe public profile fields. ApiKey
-        authentication is rejected.
+        Ensures the authenticated app user or guest has a stable opaque public
+        community profile and returns only client-safe public profile fields.
+        Guest callers can manage anonymous leaderboard visibility but still
+        receive linkedAccountRequiredForLeaderboard=true until they link an
+        account. ApiKey authentication is rejected.
       security:
         - BearerAuth: []
         - GuestAuthorizationHeader: []
@@ -174,8 +176,9 @@ paths:
       summary: Update community leaderboard participation preference
       description: >-
         Updates only the leaderboard participation preference on the
-        authenticated user's community public profile. Session callers must send
-        a valid X-CSRF-Token header. ApiKey authentication is rejected.
+        authenticated app user's or guest's community public profile. Session
+        callers must send a valid X-CSRF-Token header. ApiKey authentication is
+        rejected.
       security:
         - BearerAuth: []
         - GuestAuthorizationHeader: []

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/leaderboard/LeaderboardParticipationViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/leaderboard/LeaderboardParticipationViewModel.kt
@@ -136,7 +136,7 @@ class LeaderboardParticipationViewModel(
 }
 
 private fun canManageLeaderboardParticipation(cloudState: CloudAccountState): Boolean {
-    return cloudState == CloudAccountState.LINKED
+    return cloudState == CloudAccountState.GUEST || cloudState == CloudAccountState.LINKED
 }
 
 fun createLeaderboardParticipationViewModelFactory(

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -94,8 +94,8 @@
     <string name="settings_leaderboard_participation_title">Leaderboard participation</string>
     <string name="settings_leaderboard_participation_summary">Control community leaderboard visibility</string>
     <string name="settings_leaderboard_participation_toggle_title">Show me on the leaderboard</string>
-    <string name="settings_leaderboard_participation_toggle_body">When this is off, you will not appear on the leaderboard and leaderboard rankings will be hidden from you.</string>
-    <string name="settings_leaderboard_participation_sign_in_required">Sign in with email to manage leaderboard participation.</string>
+    <string name="settings_leaderboard_participation_toggle_body">When this is off, your anonymous activity will not appear on the leaderboard.</string>
+    <string name="settings_leaderboard_participation_sign_in_required">Connect cloud sync to manage leaderboard participation.</string>
     <string name="settings_leaderboard_participation_load_failed">Could not load leaderboard participation.</string>
     <string name="settings_leaderboard_participation_update_failed">Couldn\'t update leaderboard participation.</string>
     <string name="settings_account_preferences_refresh_failed">Could not refresh account preferences.</string>

--- a/apps/backend/src/community/leaderboard/leaderboardSnapshots.test.ts
+++ b/apps/backend/src/community/leaderboard/leaderboardSnapshots.test.ts
@@ -124,14 +124,6 @@ function readNullableHoursParam(params: ReadonlyArray<SqlValue>, index: number, 
 
 const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
 
-function isLinkedNonDemoEmail(email: string | null): boolean {
-  if (email === null) {
-    return false;
-  }
-
-  return !email.trim().toLowerCase().endsWith("@example.com");
-}
-
 function isNonDemoEmailOrUnknown(email: string | null): boolean {
   return email === null || !email.trim().toLowerCase().endsWith("@example.com");
 }
@@ -162,7 +154,7 @@ function computeEligibleEntries(
     }
 
     const user = state.usersById.get(profile.userId);
-    if (user === undefined || !isLinkedNonDemoEmail(user.email)) {
+    if (user === undefined || !isNonDemoEmailOrUnknown(user.email)) {
       continue;
     }
 
@@ -212,7 +204,7 @@ function computeEligibleEntries(
 
 /**
  * In-memory fake of the SECURITY DEFINER community.refresh_leaderboard_snapshot function.
- * It reproduces the documented contract (countable + linked + opted-in + non-demo, window
+ * It reproduces the documented contract (countable + opted-in + non-demo, window
  * bound, tie-neutral ordering, upsert by (metric, window, hour), atomic entry replace) so
  * the production SQL string, parameter order, and orchestration are exercised offline.
  *
@@ -429,7 +421,7 @@ test("generateLeaderboardSnapshots refreshes every window once with the matching
   }
 });
 
-test("last_24_hours snapshot includes opted-in linked accounts even with zero countable reviews", async () => {
+test("last_24_hours snapshot includes opted-in public profiles even with zero countable reviews", async () => {
   const state = createLeaderboardStoreState();
   seedLeaderboardFixture(state);
 
@@ -437,11 +429,13 @@ test("last_24_hours snapshot includes opted-in linked accounts even with zero co
 
   // profile-b has 3 countable reviews in 24h; profile-a has 2 (1h-before plus the as_of
   // boundary fact); the again fact, the 25h fact, and the future fact are all excluded.
+  // profile-d is an unlinked guest and still appears as an anonymized participant.
   // profile-f is linked and opted in, so it appears with zero real-client countable reviews.
   assert.deepEqual(entriesForWindow(state, "last_24_hours"), [
     { publicProfileId: PROFILE_B, qualifiedReviewCount: 3, baseSortPosition: 1 },
     { publicProfileId: PROFILE_A, qualifiedReviewCount: 2, baseSortPosition: 2 },
-    { publicProfileId: PROFILE_F, qualifiedReviewCount: 0, baseSortPosition: 3 },
+    { publicProfileId: PROFILE_D, qualifiedReviewCount: 1, baseSortPosition: 3 },
+    { publicProfileId: PROFILE_F, qualifiedReviewCount: 0, baseSortPosition: 4 },
   ]);
 });
 
@@ -456,17 +450,18 @@ test("all_time snapshot includes older reviews and breaks count ties by public_p
   assert.deepEqual(entriesForWindow(state, "all_time"), [
     { publicProfileId: PROFILE_A, qualifiedReviewCount: 3, baseSortPosition: 1 },
     { publicProfileId: PROFILE_B, qualifiedReviewCount: 3, baseSortPosition: 2 },
-    { publicProfileId: PROFILE_F, qualifiedReviewCount: 0, baseSortPosition: 3 },
+    { publicProfileId: PROFILE_D, qualifiedReviewCount: 1, baseSortPosition: 3 },
+    { publicProfileId: PROFILE_F, qualifiedReviewCount: 0, baseSortPosition: 4 },
   ]);
 });
 
-test("opted-out, unlinked guest, and demo profiles are excluded from every window", async () => {
+test("opted-out and demo profiles are excluded while unlinked guests participate", async () => {
   const state = createLeaderboardStoreState();
   seedLeaderboardFixture(state);
 
   await generateWithFake(state, LEADERBOARD_SNAPSHOT_METRIC_VERSION, NOW);
 
-  const excludedProfileIds = new Set([PROFILE_C, PROFILE_D, PROFILE_E]);
+  const excludedProfileIds = new Set([PROFILE_C, PROFILE_E]);
   for (const window of LEADERBOARD_WINDOWS) {
     const profileIdsInWindow = entriesForWindow(state, window.windowKey).map((entry) => entry.publicProfileId);
     for (const excludedProfileId of excludedProfileIds) {
@@ -476,6 +471,7 @@ test("opted-out, unlinked guest, and demo profiles are excluded from every windo
         `${excludedProfileId} must not appear in ${window.windowKey}`,
       );
     }
+    assert.equal(profileIdsInWindow.includes(PROFILE_D), true, `${PROFILE_D} must appear in ${window.windowKey}`);
     assert.equal(profileIdsInWindow.includes(PROFILE_F), true, `${PROFILE_F} must appear in ${window.windowKey}`);
   }
 });
@@ -486,7 +482,7 @@ test("every window uses the same eligible participant universe", async () => {
 
   await generateWithFake(state, LEADERBOARD_SNAPSHOT_METRIC_VERSION, NOW);
 
-  const expectedProfileIds = [PROFILE_A, PROFILE_B, PROFILE_F].sort();
+  const expectedProfileIds = [PROFILE_A, PROFILE_B, PROFILE_D, PROFILE_F].sort();
   for (const window of LEADERBOARD_WINDOWS) {
     const profileIdsInWindow = entriesForWindow(state, window.windowKey)
       .map((entry) => entry.publicProfileId)
@@ -512,7 +508,8 @@ test("regenerating the same server hour reuses snapshots and replaces entries id
   assert.deepEqual(entriesForWindow(state, "last_24_hours"), [
     { publicProfileId: PROFILE_B, qualifiedReviewCount: 3, baseSortPosition: 1 },
     { publicProfileId: PROFILE_A, qualifiedReviewCount: 2, baseSortPosition: 2 },
-    { publicProfileId: PROFILE_F, qualifiedReviewCount: 0, baseSortPosition: 3 },
+    { publicProfileId: PROFILE_D, qualifiedReviewCount: 1, baseSortPosition: 3 },
+    { publicProfileId: PROFILE_F, qualifiedReviewCount: 0, baseSortPosition: 4 },
   ]);
 });
 
@@ -659,4 +656,22 @@ test("0061 migration counts only real client-app activity without shrinking the 
   assert.match(sql, /CREATE OR REPLACE FUNCTION community\.read_current_user_latest_leaderboard_review/);
   assert.match(sql, /WHERE facts\.reviewed_by_user_id = security\.current_user_id\(\)/);
   assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.read_current_user_latest_leaderboard_review\(TEXT\) TO backend_app/);
+});
+
+test("0062 migration includes unlinked guest public profiles in snapshots", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "../../db/migrations/0062_leaderboard_guest_participants.sql",
+  );
+  const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
+
+  assert.match(sql, /CREATE OR REPLACE FUNCTION community\.refresh_leaderboard_snapshot/);
+  assert.match(sql, /FROM community\.public_profiles AS profiles/);
+  assert.match(sql, /LEFT JOIN \( SELECT facts\.public_profile_id FROM community\.public_review_activity_facts AS facts/);
+  assert.match(sql, /fact_user_settings\.email IS NULL OR LOWER\(btrim\(fact_user_settings\.email\)\) NOT LIKE '%@example\.com'/);
+  assert.match(sql, /COUNT\(countable_facts\.public_profile_id\)::int AS qualified_review_count/);
+  assert.match(sql, /profiles\.leaderboard_participation_enabled = TRUE/);
+  assert.match(sql, /user_settings\.email IS NULL OR LOWER\(btrim\(user_settings\.email\)\) NOT LIKE '%@example\.com'/);
+  assert.equal(/user_settings\.email IS NOT NULL/.test(sql), false);
+  assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.refresh_leaderboard_snapshot\(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ\) TO backend_app/);
 });

--- a/apps/backend/src/community/leaderboard/leaderboardSnapshots.ts
+++ b/apps/backend/src/community/leaderboard/leaderboardSnapshots.ts
@@ -12,12 +12,12 @@ import {
 /**
  * Community leaderboard snapshot generation.
  *
- * Each hourly job run regenerates every window's snapshot from opted-in linked
+ * Each hourly job run regenerates every window's snapshot from opted-in
  * public profiles plus their countable community.public_review_activity_facts.
  * The cross-user read, exclusion rules, tie-neutral ordering, and atomic entry
  * replacement live in the SECURITY DEFINER function
  * community.refresh_leaderboard_snapshot (see db/migrations/0059_leaderboard_snapshots.sql
- * through db/migrations/0061_leaderboard_real_client_activity.sql); this module
+ * through db/migrations/0062_leaderboard_guest_participants.sql); this module
  * owns the injectable clock, the window set, metric-version validation, and
  * sequencing the per-window refreshes inside one repeatable-read transaction.
  */

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.ts
@@ -592,8 +592,8 @@ export async function loadProgressLeaderboard(
   request: ProgressLeaderboardRequest,
 ): Promise<ProgressLeaderboard> {
   if (request.transport === "guest") {
-    // Guests get the linked-account-required state with no rows and never open a
-    // transaction, since they are excluded from leaderboard participation.
+    // Guests can contribute opted-in anonymous activity to leaderboard snapshots,
+    // but viewing leaderboard rows still requires a linked account.
     return buildNonReadyProgressLeaderboard("linked_account_required", request.localeHint);
   }
 

--- a/apps/backend/src/routes/system.test.ts
+++ b/apps/backend/src/routes/system.test.ts
@@ -448,6 +448,41 @@ test("PATCH /me/community/profile updates only leaderboard participation", async
   });
 });
 
+test("PATCH /me/community/profile lets guest accounts manage leaderboard participation", async () => {
+  let persistedProfile = createPublicProfile(true);
+  const app = createSystemTestApp({
+    transport: "guest",
+    locale: "ru",
+    updateLeaderboardParticipationFn: async (userId, leaderboardParticipationEnabled, localeHint) => {
+      assert.equal(userId, "user-1");
+      assert.equal(localeHint, "ru");
+      persistedProfile = {
+        ...persistedProfile,
+        leaderboardParticipationEnabled,
+      };
+      return persistedProfile;
+    },
+  });
+
+  const response = await app.request("http://localhost/me/community/profile", {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      leaderboardParticipationEnabled: false,
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    publicProfileId: "00000000-0000-4000-8000-000000000001",
+    anonymousDisplayName: "Silver Bright Harbor",
+    leaderboardParticipationEnabled: false,
+    linkedAccountRequiredForLeaderboard: true,
+  });
+});
+
 test("PATCH /me/community/profile rejects attempts to update public identity fields", async () => {
   let updateCalled = false;
   const app = createSystemTestApp({

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CommunityProfile.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CommunityProfile.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 /// Community public profile lifecycle for the leaderboard participation setting.
-/// Participation only affects linked accounts: guests never appear on the
-/// leaderboard, so the toggle is exposed for linked accounts only.
+/// Participation controls anonymous leaderboard visibility for linked and guest
+/// accounts. Guests can manage visibility, but still cannot view leaderboard rows.
 @MainActor
 extension FlashcardsStore {
     var canManageLeaderboardParticipation: Bool {
-        self.cloudSettings?.cloudState == .linked
+        switch self.cloudSettings?.cloudState {
+        case .guest, .linked:
+            return true
+        case .disconnected, .linkingReady, nil:
+            return false
+        }
     }
 
     func refreshCommunityPublicProfileIfAvailable() async throws {
@@ -39,7 +44,7 @@ extension FlashcardsStore {
 
     func updateLeaderboardParticipationEnabled(isEnabled: Bool) async throws {
         guard self.canManageLeaderboardParticipation else {
-            throw LocalStoreError.uninitialized("Leaderboard participation requires a linked account")
+            throw LocalStoreError.uninitialized("Leaderboard participation requires a cloud account")
         }
 
         // Apply the optimistic value before any await so the toggle reflects the

--- a/apps/ios/Flashcards/Flashcards/Settings/LeaderboardParticipationSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/LeaderboardParticipationSettingsView.swift
@@ -60,7 +60,7 @@ struct LeaderboardParticipationSettingsView: View {
             Text(
                 aiSettingsLocalized(
                     "settings.leaderboardParticipation.description",
-                    "When this is off, you will not appear on the leaderboard and leaderboard rankings will be hidden from you."
+                    "When this is off, your anonymous activity will not appear on the leaderboard."
                 )
             )
             .foregroundStyle(.secondary)
@@ -68,7 +68,7 @@ struct LeaderboardParticipationSettingsView: View {
             Text(
                 aiSettingsLocalized(
                     "settings.leaderboardParticipation.signInRequired",
-                    "Sign in with email to manage leaderboard participation."
+                    "Connect cloud sync to manage leaderboard participation."
                 )
             )
             .foregroundStyle(.secondary)

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "إظهار الرسوم المتحركة بعد تقييم بطاقة";
 "settings.leaderboardParticipation.title" = "المشاركة في لوحة الصدارة";
 "settings.leaderboardParticipation.toggle" = "إظهاري في لوحة الصدارة";
-"settings.leaderboardParticipation.description" = "عند إيقاف هذا الخيار، لن تظهر في لوحة الصدارة وستُخفى عنك تصنيفات لوحة الصدارة.";
-"settings.leaderboardParticipation.signInRequired" = "سجّل الدخول بالبريد الإلكتروني لإدارة المشاركة في لوحة الصدارة.";
+"settings.leaderboardParticipation.description" = "عند إيقاف هذا الخيار، لن يظهر نشاطك المجهول في لوحة الصدارة.";
+"settings.leaderboardParticipation.signInRequired" = "اتصل بالمزامنة السحابية لإدارة المشاركة في لوحة الصدارة.";
 "settings.language.title" = "اللغة";
 "settings.language.systemDescription" = "يتحكم iOS في لغة التطبيق. في إعدادات iOS، افتح Flashcards واستخدم اللغة المفضلة. إذا لم تظهر اللغة المفضلة، فأضف لغة أخرى أولاً من الإعدادات > عام > اللغة والمنطقة.";
 "settings.language.action.openAppSettings" = "افتح إعدادات Flashcards";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "Animationen nach dem Bewerten einer Karte anzeigen";
 "settings.leaderboardParticipation.title" = "Bestenlisten-Teilnahme";
 "settings.leaderboardParticipation.toggle" = "Mich in der Bestenliste anzeigen";
-"settings.leaderboardParticipation.description" = "Wenn diese Einstellung aus ist, erscheinst du nicht in der Bestenliste und die Rangliste wird für dich ausgeblendet.";
-"settings.leaderboardParticipation.signInRequired" = "Melde dich mit E-Mail an, um die Bestenlisten-Teilnahme zu verwalten.";
+"settings.leaderboardParticipation.description" = "Wenn diese Einstellung aus ist, erscheint deine anonyme Aktivität nicht in der Bestenliste.";
+"settings.leaderboardParticipation.signInRequired" = "Verbinde die Cloud-Synchronisierung, um die Bestenlisten-Teilnahme zu verwalten.";
 "settings.language.title" = "Sprache";
 "settings.language.systemDescription" = "iOS steuert die App-Sprache. Öffne in den iOS-Einstellungen Flashcards und verwende Bevorzugte Sprache. Wenn Bevorzugte Sprache nicht angezeigt wird, füge zuerst unter Einstellungen > Allgemein > Sprache & Region eine weitere Sprache hinzu.";
 "settings.language.action.openAppSettings" = "Einstellungen für Flashcards öffnen";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "Mostrar animaciones despues de valorar una tarjeta";
 "settings.leaderboardParticipation.title" = "Participación en la clasificación";
 "settings.leaderboardParticipation.toggle" = "Mostrarme en la tabla de clasificación";
-"settings.leaderboardParticipation.description" = "Cuando está desactivado, no apareces en la tabla de clasificación y sus puestos se ocultan para ti.";
-"settings.leaderboardParticipation.signInRequired" = "Inicia sesión con tu correo para gestionar la participación en la tabla de clasificación.";
+"settings.leaderboardParticipation.description" = "Cuando está desactivado, tu actividad anónima no aparece en la tabla de clasificación.";
+"settings.leaderboardParticipation.signInRequired" = "Conecta la sincronización en la nube para gestionar la participación en la tabla de clasificación.";
 "settings.language.title" = "Idioma";
 "settings.language.systemDescription" = "iOS controla el idioma de la app. En Ajustes de iOS, abre Flashcards y usa Idioma preferido. Si Idioma preferido no aparece, primero añade otro idioma en Ajustes > General > Idioma y región.";
 "settings.language.action.openAppSettings" = "Abrir ajustes de Flashcards";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "Mostrar animaciones despues de valorar una tarjeta";
 "settings.leaderboardParticipation.title" = "Participación en la tabla";
 "settings.leaderboardParticipation.toggle" = "Mostrarme en la tabla de posiciones";
-"settings.leaderboardParticipation.description" = "Cuando está desactivado, no apareces en la tabla de posiciones y sus posiciones se ocultan para ti.";
-"settings.leaderboardParticipation.signInRequired" = "Inicia sesión con tu correo para gestionar la participación en la tabla.";
+"settings.leaderboardParticipation.description" = "Cuando está desactivado, tu actividad anónima no aparece en la tabla de posiciones.";
+"settings.leaderboardParticipation.signInRequired" = "Conecta la sincronización en la nube para gestionar la participación en la tabla.";
 "settings.language.title" = "Idioma";
 "settings.language.systemDescription" = "iOS controla el idioma de la app. En Ajustes de iOS, abre Flashcards y usa Idioma preferido. Si Idioma preferido no aparece, primero agrega otro idioma en Ajustes > General > Idioma y región.";
 "settings.language.action.openAppSettings" = "Abrir ajustes de Flashcards";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "कार्ड को रेट करने के बाद एनिमेशन दिखाएं";
 "settings.leaderboardParticipation.title" = "लीडरबोर्ड भागीदारी";
 "settings.leaderboardParticipation.toggle" = "मुझे लीडरबोर्ड पर दिखाएँ";
-"settings.leaderboardParticipation.description" = "यह बंद होने पर आप लीडरबोर्ड पर नहीं दिखेंगे और लीडरबोर्ड रैंकिंग आपसे छिपी रहेगी.";
-"settings.leaderboardParticipation.signInRequired" = "लीडरबोर्ड भागीदारी प्रबंधित करने के लिए ईमेल से साइन इन करें.";
+"settings.leaderboardParticipation.description" = "यह बंद होने पर आपकी गुमनाम गतिविधि लीडरबोर्ड पर नहीं दिखेगी.";
+"settings.leaderboardParticipation.signInRequired" = "लीडरबोर्ड भागीदारी प्रबंधित करने के लिए क्लाउड सिंक कनेक्ट करें.";
 "settings.language.title" = "भाषा";
 "settings.language.systemDescription" = "iOS ऐप की भाषा नियंत्रित करता है। iOS सेटिंग्स में Flashcards खोलें और पसंदीदा भाषा इस्तेमाल करें। अगर पसंदीदा भाषा दिखाई नहीं देती, तो पहले सेटिंग्स > सामान्य > भाषा और क्षेत्र में कोई दूसरी भाषा जोड़ें।";
 "settings.language.action.openAppSettings" = "Flashcards सेटिंग्स खोलें";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "カード評価後にアニメーションを表示";
 "settings.leaderboardParticipation.title" = "リーダーボード参加";
 "settings.leaderboardParticipation.toggle" = "リーダーボードに自分を表示";
-"settings.leaderboardParticipation.description" = "オフにすると、リーダーボードに表示されず、ランキングも見られなくなります。";
-"settings.leaderboardParticipation.signInRequired" = "リーダーボード参加を管理するにはメールでサインインしてください。";
+"settings.leaderboardParticipation.description" = "オフにすると、匿名のアクティビティはリーダーボードに表示されません。";
+"settings.leaderboardParticipation.signInRequired" = "リーダーボード参加を管理するにはクラウド同期に接続してください。";
 "settings.language.title" = "言語";
 "settings.language.systemDescription" = "iOS がアプリの言語を管理します。iOS の「設定」で Flashcards を開き、「優先する言語」を使用してください。「優先する言語」が表示されない場合は、先に「設定」>「一般」>「言語と地域」で別の言語を追加してください。";
 "settings.language.action.openAppSettings" = "Flashcards の設定を開く";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "Показывать анимации после оценки карточки";
 "settings.leaderboardParticipation.title" = "Участие в таблице лидеров";
 "settings.leaderboardParticipation.toggle" = "Показывать меня в таблице лидеров";
-"settings.leaderboardParticipation.description" = "Когда настройка выключена, вы не появляетесь в таблице лидеров, а рейтинг таблицы лидеров скрыт от вас.";
-"settings.leaderboardParticipation.signInRequired" = "Войдите по электронной почте, чтобы управлять участием в таблице лидеров.";
+"settings.leaderboardParticipation.description" = "Когда настройка выключена, ваша обезличенная активность не появляется в таблице лидеров.";
+"settings.leaderboardParticipation.signInRequired" = "Подключите облачную синхронизацию, чтобы управлять участием в таблице лидеров.";
 "settings.language.title" = "Язык";
 "settings.language.systemDescription" = "iOS управляет языком приложения. В настройках iOS откройте Flashcards и используйте «Предпочитаемый язык». Если «Предпочитаемый язык» не отображается, сначала добавьте другой язык в «Настройки» > «Основные» > «Язык и регион».";
 "settings.language.action.openAppSettings" = "Открыть настройки Flashcards";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -169,8 +169,8 @@
 "settings.reviewAnimations.toggle" = "给卡片评分后显示动画";
 "settings.leaderboardParticipation.title" = "排行榜参与";
 "settings.leaderboardParticipation.toggle" = "在排行榜中显示我";
-"settings.leaderboardParticipation.description" = "关闭后，你不会出现在排行榜中，也无法查看排行榜排名。";
-"settings.leaderboardParticipation.signInRequired" = "使用邮箱登录后即可管理排行榜参与。";
+"settings.leaderboardParticipation.description" = "关闭后，你的匿名活动不会显示在排行榜中。";
+"settings.leaderboardParticipation.signInRequired" = "连接云同步后即可管理排行榜参与。";
 "settings.language.title" = "语言";
 "settings.language.systemDescription" = "iOS 控制 App 语言。在 iOS 设置中打开 Flashcards，并使用“首选语言”。如果没有显示“首选语言”，请先在“设置”>“通用”>“语言与地区”中添加另一种语言。";
 "settings.language.action.openAppSettings" = "打开 Flashcards 设置";

--- a/db/migrations/0062_leaderboard_guest_participants.sql
+++ b/db/migrations/0062_leaderboard_guest_participants.sql
@@ -1,0 +1,100 @@
+-- Includes opted-in unlinked guest public profiles in community leaderboard
+-- snapshots while preserving guest read restrictions in the API layer.
+
+CREATE OR REPLACE FUNCTION community.refresh_leaderboard_snapshot(
+  p_metric_version           TEXT,
+  p_window_key               TEXT,
+  p_window_lower_bound_hours INTEGER,
+  p_as_of_server_hour        TIMESTAMPTZ,
+  p_generated_at             TIMESTAMPTZ
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_snapshot_id UUID;
+BEGIN
+  INSERT INTO community.leaderboard_snapshots AS snapshots (
+    snapshot_id,
+    metric_version,
+    window_key,
+    generated_at,
+    as_of_server_hour
+  )
+  VALUES (
+    gen_random_uuid(),
+    p_metric_version,
+    p_window_key,
+    p_generated_at,
+    p_as_of_server_hour
+  )
+  ON CONFLICT (metric_version, window_key, as_of_server_hour)
+  DO UPDATE SET generated_at = EXCLUDED.generated_at
+  RETURNING snapshots.snapshot_id INTO v_snapshot_id;
+
+  DELETE FROM community.leaderboard_snapshot_entries
+  WHERE snapshot_id = v_snapshot_id;
+
+  INSERT INTO community.leaderboard_snapshot_entries (
+    snapshot_id,
+    public_profile_id,
+    qualified_review_count,
+    base_sort_position
+  )
+  SELECT
+    v_snapshot_id,
+    eligible.public_profile_id,
+    eligible.qualified_review_count,
+    (ROW_NUMBER() OVER (
+      ORDER BY eligible.qualified_review_count DESC, eligible.public_profile_id ASC
+    ))::int AS base_sort_position
+  FROM (
+    SELECT
+      profiles.public_profile_id AS public_profile_id,
+      COUNT(countable_facts.public_profile_id)::int AS qualified_review_count
+    FROM community.public_profiles AS profiles
+    INNER JOIN org.user_settings AS user_settings
+      ON user_settings.user_id = profiles.user_id
+    LEFT JOIN (
+      SELECT facts.public_profile_id
+      FROM community.public_review_activity_facts AS facts
+      INNER JOIN content.review_events AS review_events
+        ON review_events.review_event_id = facts.review_event_id
+      INNER JOIN sync.workspace_replicas AS workspace_replicas
+        ON workspace_replicas.replica_id = review_events.replica_id
+      LEFT JOIN org.user_settings AS fact_user_settings
+        ON fact_user_settings.user_id = facts.reviewed_by_user_id
+      WHERE facts.metric_version = p_metric_version
+        AND facts.is_countable = TRUE
+        AND facts.reviewed_at_client <= p_as_of_server_hour
+        AND (
+          p_window_lower_bound_hours IS NULL
+          OR facts.reviewed_at_client > p_as_of_server_hour - (p_window_lower_bound_hours * interval '1 hour')
+        )
+        AND workspace_replicas.actor_kind = 'client_installation'
+        AND workspace_replicas.platform IN ('web', 'android', 'ios')
+        AND (
+          fact_user_settings.email IS NULL
+          OR LOWER(btrim(fact_user_settings.email)) NOT LIKE '%@example.com'
+        )
+    ) AS countable_facts
+      ON countable_facts.public_profile_id = profiles.public_profile_id
+    WHERE profiles.leaderboard_participation_enabled = TRUE
+      AND (
+        user_settings.email IS NULL
+        OR LOWER(btrim(user_settings.email)) NOT LIKE '%@example.com'
+      )
+    GROUP BY profiles.public_profile_id
+  ) AS eligible;
+
+  RETURN v_snapshot_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION community.refresh_leaderboard_snapshot(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION community.refresh_leaderboard_snapshot(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ) TO backend_app;
+
+COMMENT ON FUNCTION community.refresh_leaderboard_snapshot(TEXT, TEXT, INTEGER, TIMESTAMPTZ, TIMESTAMPTZ) IS
+  'Regenerates one leaderboard snapshot (metric_version, window_key) at a server hour. Includes every opted-in non-demo public profile, including unlinked guests, counts only matching countable facts from real client-app activity, orders tie-neutrally, and atomically replaces the snapshot entries. Returns the snapshot_id.';


### PR DESCRIPTION
## Summary
- include opted-in guest public profiles in leaderboard snapshots
- allow guest mobile users to manage leaderboard participation while keeping leaderboard viewing linked-only
- update API docs, mobile copy, and backend contract coverage

## Validation
- node --test --import tsx src/routes/system.test.ts src/community/leaderboard/leaderboardSnapshots.test.ts
- npm run lint --prefix api
- npm run lint --prefix apps/backend
- npm test --prefix apps/backend
- plutil -lint iOS AISettings.strings files
- xmllint --noout apps/android/feature/settings/src/main/res/values/strings.xml