### PR TITLE
[codex] Pad iOS review filter menu

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -6,6 +6,7 @@ private let reviewBottomBarTopPadding: CGFloat = 8
 private let reviewBottomBarBottomPadding: CGFloat = 8
 private let reviewBottomBarButtonSpacing: CGFloat = 10
 private let reviewFilterMenuTitleMaxWidth: CGFloat = 180
+private let reviewFilterMenuVerticalPadding: CGFloat = 2
 private let reviewToolbarActionIconFont: Font = .body
 private let reviewToolbarBadgeValueFont: Font = .body
 private let reviewAnswerButtonMinHeight: CGFloat = 40
@@ -398,6 +399,7 @@ struct ReviewView: View {
                 Image(systemName: "chevron.down")
                     .font(.caption.weight(.semibold))
             }
+            .padding(.vertical, reviewFilterMenuVerticalPadding)
         }
         .controlSize(.large)
     }


### PR DESCRIPTION
## Summary
- add a small vertical padding constant for the iOS Review filter menu label
- keep the native toolbar/menu rendering path and existing large control sizing

## Validation
- git diff --check -- apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
- SwiftUI menu label padding typecheck with the iOS 26.5 simulator SDK

Simulator-backed iOS UI tests were not run locally because the repository requires explicit permission for those heavy checks.