### PR TITLE
[codex] Use glass style for iOS review filter menu

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -6,7 +6,6 @@ private let reviewBottomBarTopPadding: CGFloat = 8
 private let reviewBottomBarBottomPadding: CGFloat = 8
 private let reviewBottomBarButtonSpacing: CGFloat = 10
 private let reviewFilterMenuTitleMaxWidth: CGFloat = 180
-private let reviewFilterMenuVerticalPadding: CGFloat = 2
 private let reviewToolbarActionIconFont: Font = .body
 private let reviewToolbarBadgeValueFont: Font = .body
 private let reviewAnswerButtonMinHeight: CGFloat = 40
@@ -399,8 +398,8 @@ struct ReviewView: View {
                 Image(systemName: "chevron.down")
                     .font(.caption.weight(.semibold))
             }
-            .padding(.vertical, reviewFilterMenuVerticalPadding)
         }
+        .buttonStyle(.glass)
         .controlSize(.large)
     }
 


### PR DESCRIPTION
## Summary
- replace the Review filter menu padding experiment with an explicit glass button style
- keep the native toolbar menu control size and existing Review toolbar behavior

## Validation
- git diff --check -- apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
- SwiftUI toolbar menu typecheck with the iOS 26.5 simulator SDK

Simulator-backed iOS UI tests were not run locally because the repository requires explicit permission for those heavy checks.