### PR TITLE
[codex] Fix iOS cloud sync retry recovery

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudLink.swift
@@ -764,12 +764,14 @@ extension FlashcardsStore {
                 installationId: self.cloudSettings?.installationId,
                 errorMessage: Flashcards.errorMessage(error: error)
             )
-            self.captureCloudSyncFailure(
-                error: error,
-                linkedSession: linkedSession,
-                fallbackCloudState: self.cloudSettings?.cloudState,
-                action: "cloud_link_sync"
-            )
+            if isRetryableNetworkTransportFailure(error: error) == false {
+                self.captureCloudSyncFailure(
+                    error: error,
+                    linkedSession: linkedSession,
+                    fallbackCloudState: self.cloudSettings?.cloudState,
+                    action: "cloud_link_sync"
+                )
+            }
             self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
             if trigger.surfacesGlobalErrorMessage {
                 self.globalErrorMessage = Flashcards.errorMessage(error: error)

--- a/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudDiagnosticsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudDiagnosticsSupport.swift
@@ -90,7 +90,7 @@ func logCloudFlowPhase(
     FlashcardsObservability.addBreadcrumb(.cloudFlow(observation))
 }
 
-private func cloudObservationFeature(phase: CloudFlowPhase) -> IOSObservationFeature {
+func cloudObservationFeature(phase: CloudFlowPhase) -> IOSObservationFeature {
     switch phase {
     case .authSendCode,
             .authRefreshToken,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncRunner.swift
@@ -55,23 +55,15 @@ struct CloudSyncRunner {
     }
 
     func runLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
-        try await self.runLinkedSync(
-            linkedSession: linkedSession,
-            importsLocalReviewHistoryBeforeReviewPull: false
-        )
+        try await self.runLinkedSyncWithRecovery(linkedSession: linkedSession)
     }
 
     func runGuestLocalRecoveryLinkedSync(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
-        try await self.runLinkedSync(
-            linkedSession: linkedSession,
-            importsLocalReviewHistoryBeforeReviewPull: true
-        )
+        try self.markLegacyGuestLocalReviewHistoryImportIfNeeded(workspaceId: linkedSession.workspaceId)
+        return try await self.runLinkedSyncWithRecovery(linkedSession: linkedSession)
     }
 
-    private func runLinkedSync(
-        linkedSession: CloudLinkedSession,
-        importsLocalReviewHistoryBeforeReviewPull: Bool
-    ) async throws -> CloudSyncResult {
+    private func runLinkedSyncWithRecovery(linkedSession: CloudLinkedSession) async throws -> CloudSyncResult {
         let cloudSettings = try self.database.loadBootstrapSnapshot().cloudSettings
         let workspaceId = linkedSession.workspaceId
         let syncBasePath = "/workspaces/\(workspaceId)/sync"
@@ -84,8 +76,7 @@ struct CloudSyncRunner {
                     linkedSession: linkedSession,
                     workspaceId: workspaceId,
                     installationId: cloudSettings.installationId,
-                    syncBasePath: syncBasePath,
-                    importsLocalReviewHistoryBeforeReviewPull: importsLocalReviewHistoryBeforeReviewPull
+                    syncBasePath: syncBasePath
                 )
 
                 guard publicWorkspaceForkRepairEntityTypes.isEmpty == false else {
@@ -126,8 +117,7 @@ struct CloudSyncRunner {
         linkedSession: CloudLinkedSession,
         workspaceId: String,
         installationId: String,
-        syncBasePath: String,
-        importsLocalReviewHistoryBeforeReviewPull: Bool
+        syncBasePath: String
     ) async throws -> CloudSyncResult {
         var syncResult = try self.cleanupStaleReviewEventOutboxEntries(
             workspaceId: workspaceId,
@@ -173,13 +163,11 @@ struct CloudSyncRunner {
             )
         }
         syncResult = syncResult.merging(hotPullResult)
-        if importsLocalReviewHistoryBeforeReviewPull,
-            try self.database.hasHydratedReviewHistory(workspaceId: workspaceId) == false {
-            // Guest local recovery creates a new workspace. If review history is
-            // still unhydrated here, an earlier attempt may have pushed hot state
-            // before review-history import completed.
+        let hasHydratedReviewHistory = try self.database.hasHydratedReviewHistory(workspaceId: workspaceId)
+        let hasPendingReviewHistoryImport = try self.database.hasPendingReviewHistoryImport(workspaceId: workspaceId)
+        if hasHydratedReviewHistory == false && hasPendingReviewHistoryImport {
             syncResult = syncResult.merging(
-                try await self.importLocalReviewHistory(
+                try await self.importPendingLocalReviewHistory(
                     linkedSession: linkedSession,
                     workspaceId: workspaceId,
                     installationId: installationId,
@@ -197,6 +185,30 @@ struct CloudSyncRunner {
         )
 
         return syncResult
+    }
+
+    private func markLegacyGuestLocalReviewHistoryImportIfNeeded(workspaceId: String) throws {
+        guard try self.database.hasHydratedHotState(workspaceId: workspaceId) else {
+            return
+        }
+        guard try self.database.hasHydratedReviewHistory(workspaceId: workspaceId) == false else {
+            return
+        }
+        guard try self.database.hasPendingReviewHistoryImport(workspaceId: workspaceId) == false else {
+            return
+        }
+        guard try self.database.loadReviewEvents(workspaceId: workspaceId).isEmpty == false else {
+            return
+        }
+
+        // Legacy iOS guest-local recovery predates `pending_review_history_import`.
+        // A device can upgrade after local hot state was committed to the new cloud
+        // workspace but before local review history was imported. Convert that
+        // partial state to the marker-driven recovery path used by current builds.
+        try self.database.setPendingReviewHistoryImport(
+            workspaceId: workspaceId,
+            pendingReviewHistoryImport: true
+        )
     }
 
     private func repairPublicWorkspaceForkConflictIfNeeded(
@@ -556,6 +568,13 @@ struct CloudSyncRunner {
         }.count
         let pendingReviewScheduleImpactingOutboxCount = pendingOutboxEntries.filter(\.reviewScheduleImpact).count
 
+        if reviewEvents.isEmpty == false {
+            try self.database.setPendingReviewHistoryImport(
+                workspaceId: workspaceId,
+                pendingReviewHistoryImport: true
+            )
+        }
+
         var bootstrapHotChangeId: Int64 = 0
         if bootstrapEntries.isEmpty == false {
             let response: RemoteBootstrapPushResponseEnvelope = try await self.transport.request(
@@ -580,35 +599,16 @@ struct CloudSyncRunner {
             bootstrapHotChangeId = responseHotChangeId
         }
 
-        let nextReviewSequenceId = try await self.importReviewEventsToRemote(
-            linkedSession: linkedSession,
-            installationId: installationId,
-            syncBasePath: syncBasePath,
-            initialReviewSequenceId: 0,
-            reviewEvents: reviewEvents
-        )
-
         try self.database.deleteAllOutboxEntries(workspaceId: workspaceId)
         try self.database.setLastAppliedHotChangeId(
             workspaceId: workspaceId,
             changeId: bootstrapHotChangeId
         )
-        try self.database.setLastAppliedReviewSequenceId(
-            workspaceId: workspaceId,
-            reviewSequenceId: nextReviewSequenceId
-        )
         try self.database.setHasHydratedHotState(workspaceId: workspaceId, hasHydratedHotState: true)
-        try self.database.setHasHydratedReviewHistory(
-            workspaceId: workspaceId,
-            hasHydratedReviewHistory: true
-        )
 
         var changedEntityTypes = Set<SyncEntityType>()
         if bootstrapEntries.isEmpty == false {
             changedEntityTypes.formUnion(bootstrapEntries.map(\.entityType))
-        }
-        if reviewEvents.isEmpty == false {
-            changedEntityTypes.insert(.reviewEvent)
         }
 
         return CloudSyncResult(
@@ -625,7 +625,7 @@ struct CloudSyncRunner {
         )
     }
 
-    private func importLocalReviewHistory(
+    private func importPendingLocalReviewHistory(
         linkedSession: CloudLinkedSession,
         workspaceId: String,
         installationId: String,
@@ -633,26 +633,26 @@ struct CloudSyncRunner {
     ) async throws -> CloudSyncResult {
         let reviewEvents = try self.database.loadReviewEvents(workspaceId: workspaceId)
         let currentReviewSequenceId = try self.database.loadLastAppliedReviewSequenceId(workspaceId: workspaceId)
-        let nextReviewSequenceId = try await self.importReviewEventsToRemote(
+
+        guard reviewEvents.isEmpty == false else {
+            try self.database.setPendingReviewHistoryImport(
+                workspaceId: workspaceId,
+                pendingReviewHistoryImport: false
+            )
+            return .noChanges
+        }
+
+        _ = try await self.importReviewEventsToRemote(
             linkedSession: linkedSession,
             installationId: installationId,
             syncBasePath: syncBasePath,
             initialReviewSequenceId: currentReviewSequenceId,
             reviewEvents: reviewEvents
         )
-
-        try self.database.setLastAppliedReviewSequenceId(
+        try self.database.setPendingReviewHistoryImport(
             workspaceId: workspaceId,
-            reviewSequenceId: nextReviewSequenceId
+            pendingReviewHistoryImport: false
         )
-        try self.database.setHasHydratedReviewHistory(
-            workspaceId: workspaceId,
-            hasHydratedReviewHistory: true
-        )
-
-        guard reviewEvents.isEmpty == false else {
-            return .noChanges
-        }
 
         return CloudSyncResult(
             appliedPullChangeCount: 0,
@@ -926,6 +926,12 @@ struct CloudSyncRunner {
             )
 
             if reviewHistoryEnvelope.hasMore == false {
+                if try self.database.hasPendingReviewHistoryImport(workspaceId: workspaceId) {
+                    try self.database.setPendingReviewHistoryImport(
+                        workspaceId: workspaceId,
+                        pendingReviewHistoryImport: false
+                    )
+                }
                 if try self.database.hasHydratedReviewHistory(workspaceId: workspaceId) == false {
                     try self.database.setHasHydratedReviewHistory(
                         workspaceId: workspaceId,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
@@ -3,6 +3,15 @@ import Foundation
 private let collectionPageLimit: Int = 100
 private let cloudSyncResponseDecodingFailedCode: String = "RESPONSE_DECODING_FAILED"
 private let cloudSyncResponseDecodingFailedMessage: String = "Failed to decode cloud sync response"
+private let cloudSyncTransportMaxAttempts: Int = 3
+private let cloudSyncTransportRetryDelayNanoseconds: UInt64 = 500_000_000
+
+private protocol CloudSyncBootstrapModeRequest {
+    var mode: String { get }
+}
+
+extension BootstrapPullRequest: CloudSyncBootstrapModeRequest {}
+extension BootstrapPushRequest: CloudSyncBootstrapModeRequest {}
 
 struct CloudSyncTransport {
     private let session: URLSession
@@ -117,12 +126,17 @@ struct CloudSyncTransport {
             request.httpBody = try JSONEncoder().encode(body)
         }
 
-        let phase = self.phase(for: path, method: method)
+        let phase = self.phase(for: path, method: method, body: body)
         logCloudFlowPhase(phase: phase, outcome: "start")
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await self.session.data(for: request)
+            (data, response) = try await self.sendRequestWithRetry(
+                request: request,
+                phase: phase,
+                apiBaseUrl: apiBaseUrl,
+                allowsRetry: self.allowsRetry(path: path, method: method, body: body)
+            )
         } catch {
             logCloudFlowPhase(
                 phase: phase,
@@ -182,7 +196,59 @@ struct CloudSyncTransport {
         return url
     }
 
-    private func phase(for path: String, method: String) -> CloudFlowPhase {
+    private func sendRequestWithRetry(
+        request: URLRequest,
+        phase: CloudFlowPhase,
+        apiBaseUrl: String,
+        allowsRetry: Bool
+    ) async throws -> (Data, URLResponse) {
+        var lastError: Error?
+        for attempt in 1...cloudSyncTransportMaxAttempts {
+            do {
+                return try await self.session.data(for: request)
+            } catch let error as CancellationError {
+                throw error
+            } catch {
+                lastError = error
+                guard allowsRetry
+                    && isRetryableNetworkTransportFailure(error: error)
+                    && attempt < cloudSyncTransportMaxAttempts else {
+                    throw error
+                }
+
+                FlashcardsObservability.captureWarning(
+                    .cloudRetry(
+                        CloudRetryWarning(
+                            action: "cloud_sync_transport_retry",
+                            scope: IOSObservationScope(
+                                feature: cloudObservationFeature(phase: phase),
+                                userId: nil,
+                                workspaceId: nil,
+                                requestId: nil,
+                                clientRequestId: nil,
+                                sessionId: nil,
+                                runId: nil,
+                                cloudState: nil,
+                                configurationMode: nil
+                            ),
+                            attempt: attempt,
+                            maxAttempts: cloudSyncTransportMaxAttempts,
+                            apiBaseUrl: apiBaseUrl,
+                            messageSummary: Flashcards.errorMessage(error: error)
+                        )
+                    )
+                )
+                try await Task.sleep(nanoseconds: cloudSyncTransportRetryDelayNanoseconds)
+            }
+        }
+
+        guard let lastError else {
+            throw LocalStoreError.database("Cloud sync transport retry failed without an error")
+        }
+        throw lastError
+    }
+
+    private func phase<Body: Encodable>(for path: String, method: String, body: Body?) -> CloudFlowPhase {
         let requestPath = self.requestPath(from: path)
 
         if requestPath == "/workspaces" && method == "GET" {
@@ -202,6 +268,11 @@ struct CloudSyncTransport {
         }
 
         if requestPath.hasSuffix("/sync/bootstrap") {
+            if let body,
+                let bootstrapRequest = body as? any CloudSyncBootstrapModeRequest,
+                bootstrapRequest.mode == "push" {
+                return .initialPush
+            }
             return .initialPull
         }
 
@@ -218,6 +289,33 @@ struct CloudSyncTransport {
         }
 
         return .cloudSyncRequest
+    }
+
+    private func allowsRetry<Body: Encodable>(path: String, method: String, body: Body?) -> Bool {
+        let requestPath = self.requestPath(from: path)
+        if method == "GET" {
+            return true
+        }
+        if requestPath.hasSuffix("/sync/push") {
+            return true
+        }
+        if requestPath.hasSuffix("/sync/pull") {
+            return true
+        }
+        if requestPath.hasSuffix("/sync/review-history/import") {
+            return true
+        }
+        if requestPath.hasSuffix("/sync/review-history/pull") {
+            return true
+        }
+        if requestPath.hasSuffix("/sync/bootstrap") {
+            guard let body,
+                let bootstrapRequest = body as? any CloudSyncBootstrapModeRequest else {
+                return false
+            }
+            return bootstrapRequest.mode == "pull"
+        }
+        return false
     }
 
     private func requestPath(from path: String) -> String {

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Sync.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Sync.swift
@@ -26,6 +26,7 @@ extension LocalDatabase {
                     last_applied_review_sequence_id = 0,
                     has_hydrated_hot_state = 0,
                     has_hydrated_review_history = 0,
+                    pending_review_history_import = 0,
                     updated_at = ?
                 WHERE workspace_id = ?
                 """,
@@ -44,9 +45,10 @@ extension LocalDatabase {
                         last_applied_review_sequence_id,
                         has_hydrated_hot_state,
                         has_hydrated_review_history,
+                        pending_review_history_import,
                         updated_at
                     )
-                    VALUES (?, 0, 0, 0, 0, ?)
+                    VALUES (?, 0, 0, 0, 0, 0, ?)
                     """,
                     values: [
                         .text(workspaceId),
@@ -109,6 +111,17 @@ extension LocalDatabase {
         try self.outboxStore.setHasHydratedReviewHistory(
             workspaceId: workspaceId,
             hasHydratedReviewHistory: hasHydratedReviewHistory
+        )
+    }
+
+    func hasPendingReviewHistoryImport(workspaceId: String) throws -> Bool {
+        try self.outboxStore.hasPendingReviewHistoryImport(workspaceId: workspaceId)
+    }
+
+    func setPendingReviewHistoryImport(workspaceId: String, pendingReviewHistoryImport: Bool) throws {
+        try self.outboxStore.setPendingReviewHistoryImport(
+            workspaceId: workspaceId,
+            pendingReviewHistoryImport: pendingReviewHistoryImport
         )
     }
 

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseBootstrapper.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseBootstrapper.swift
@@ -202,9 +202,10 @@ struct LocalDatabaseBootstrapper {
                     last_applied_review_sequence_id,
                     has_hydrated_hot_state,
                     has_hydrated_review_history,
+                    pending_review_history_import,
                     updated_at
                 )
-                VALUES (?, 0, 0, 0, 0, ?)
+                VALUES (?, 0, 0, 0, 0, 0, ?)
                 """,
                 values: [
                     .text(workspaceId),

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
@@ -67,6 +67,9 @@ struct LocalDatabaseMigrator {
             case 15:
                 try self.migrateSchemaVersion15To16()
                 schemaVersion = 16
+            case 16:
+                try self.migrateSchemaVersion16To17()
+                schemaVersion = 17
             default:
                 throw LocalStoreError.database("Unsupported local schema version: \(schemaVersion)")
             }
@@ -548,6 +551,20 @@ struct LocalDatabaseMigrator {
 
         try self.populateFsrsLastReviewedAtMillisFromText()
         try self.createFsrsLastReviewedAtMillisIndex()
+    }
+
+    private func migrateSchemaVersion16To17() throws {
+        guard try self.core.columnExists(tableName: "sync_state", columnName: "pending_review_history_import") == false else {
+            return
+        }
+
+        try self.core.execute(
+            sql: """
+            ALTER TABLE sync_state
+            ADD COLUMN pending_review_history_import INTEGER NOT NULL DEFAULT 0 CHECK (pending_review_history_import IN (0, 1))
+            """,
+            values: []
+        )
     }
 
     private func populateDueAtMillisFromDueAtText() throws {

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum LocalDatabaseSchema {
-    static let currentVersion: Int = 16
+    static let currentVersion: Int = 17
 
     static var baseMigrationSQL: String {
         let defaultEnableFuzzValue: Int = defaultSchedulerSettingsConfig.enableFuzz ? 1 : 0
@@ -111,6 +111,7 @@ enum LocalDatabaseSchema {
             last_applied_review_sequence_id INTEGER NOT NULL DEFAULT 0, -- highest append-only review-history sequence already imported locally
             has_hydrated_hot_state INTEGER NOT NULL DEFAULT 0, -- whether the blocking current-state bootstrap already completed locally
             has_hydrated_review_history INTEGER NOT NULL DEFAULT 0, -- whether the background review-history backfill already completed locally
+            pending_review_history_import INTEGER NOT NULL DEFAULT 0 CHECK (pending_review_history_import IN (0, 1)), -- whether an empty-remote bootstrap still needs local review-history import before pull
             updated_at TEXT NOT NULL -- last time the local pull cursor state changed
         );
 

--- a/apps/ios/Flashcards/Flashcards/Database/Sync/OutboxStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Sync/OutboxStore.swift
@@ -70,6 +70,7 @@ private struct SyncStateRow {
     let lastAppliedReviewSequenceId: Int64
     let hasHydratedHotState: Bool
     let hasHydratedReviewHistory: Bool
+    let pendingReviewHistoryImport: Bool
 }
 
 struct OutboxStore {
@@ -289,6 +290,10 @@ struct OutboxStore {
         try self.loadSyncState(workspaceId: workspaceId).hasHydratedReviewHistory
     }
 
+    func hasPendingReviewHistoryImport(workspaceId: String) throws -> Bool {
+        try self.loadSyncState(workspaceId: workspaceId).pendingReviewHistoryImport
+    }
+
     private func loadSyncState(workspaceId: String) throws -> SyncStateRow {
         try self.ensureSyncStateExists(workspaceId: workspaceId)
 
@@ -298,7 +303,8 @@ struct OutboxStore {
                 last_applied_hot_change_id,
                 last_applied_review_sequence_id,
                 has_hydrated_hot_state,
-                has_hydrated_review_history
+                has_hydrated_review_history,
+                pending_review_history_import
             FROM sync_state
             WHERE workspace_id = ?
             LIMIT 1
@@ -309,7 +315,8 @@ struct OutboxStore {
                 lastAppliedHotChangeId: DatabaseCore.columnInt64(statement: statement, index: 0),
                 lastAppliedReviewSequenceId: DatabaseCore.columnInt64(statement: statement, index: 1),
                 hasHydratedHotState: DatabaseCore.columnInt64(statement: statement, index: 2) != 0,
-                hasHydratedReviewHistory: DatabaseCore.columnInt64(statement: statement, index: 3) != 0
+                hasHydratedReviewHistory: DatabaseCore.columnInt64(statement: statement, index: 3) != 0,
+                pendingReviewHistoryImport: DatabaseCore.columnInt64(statement: statement, index: 4) != 0
             )
         }
 
@@ -345,9 +352,10 @@ struct OutboxStore {
                 last_applied_review_sequence_id,
                 has_hydrated_hot_state,
                 has_hydrated_review_history,
+                pending_review_history_import,
                 updated_at
             )
-            VALUES (?, 0, 0, 0, 0, ?)
+            VALUES (?, 0, 0, 0, 0, 0, ?)
             """,
             values: [
                 .text(workspaceId),
@@ -414,6 +422,22 @@ struct OutboxStore {
             """,
             values: [
                 .integer(hasHydratedReviewHistory ? 1 : 0),
+                .text(nowIsoTimestamp()),
+                .text(workspaceId)
+            ]
+        )
+    }
+
+    func setPendingReviewHistoryImport(workspaceId: String, pendingReviewHistoryImport: Bool) throws {
+        try self.updateSyncState(
+            workspaceId: workspaceId,
+            sql: """
+            UPDATE sync_state
+            SET pending_review_history_import = ?, updated_at = ?
+            WHERE workspace_id = ?
+            """,
+            values: [
+                .integer(pendingReviewHistoryImport ? 1 : 0),
                 .text(nowIsoTimestamp()),
                 .text(workspaceId)
             ]

--- a/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceShellStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceShellStore.swift
@@ -139,9 +139,10 @@ struct WorkspaceShellStore {
                     last_applied_review_sequence_id,
                     has_hydrated_hot_state,
                     has_hydrated_review_history,
+                    pending_review_history_import,
                     updated_at
                 )
-                VALUES (?, 0, 0, 0, 0, ?)
+                VALUES (?, 0, 0, 0, 0, 0, ?)
                 """,
                 values: [
                     .text(workspaceId),

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
@@ -671,9 +671,9 @@ enum LinkedSyncRunnerTestTransportSupport {
         throw URLError(.badURL)
     }
 
-    static func handleGuestLocalRecoveryReviewHistoryImportRetryRequest(
+    static func handleReviewHistoryImportRecoveryRequest(
         request: URLRequest,
-        reviewEventId: String
+        reviewEvent: ReviewEvent
     ) throws -> (HTTPURLResponse, Data) {
         let path = try XCTUnwrap(request.url?.path)
         if path.hasSuffix("/sync/pull") {
@@ -695,7 +695,7 @@ enum LinkedSyncRunnerTestTransportSupport {
             let reviewEvents = try XCTUnwrap(body["reviewEvents"] as? [[String: Any]])
             let importedReviewEvent = try XCTUnwrap(reviewEvents.first)
             XCTAssertEqual(1, reviewEvents.count)
-            XCTAssertEqual(reviewEventId, importedReviewEvent["reviewEventId"] as? String)
+            XCTAssertEqual(reviewEvent.reviewEventId, importedReviewEvent["reviewEventId"] as? String)
             CloudSyncRunnerTestURLProtocol.reviewHistoryImportEventCounts.append(reviewEvents.count)
             return try Self.jsonResponse(
                 request: request,
@@ -719,8 +719,76 @@ enum LinkedSyncRunnerTestTransportSupport {
                 statusCode: 200,
                 body: """
                 {
-                  "reviewEvents": [],
+                  "reviewEvents": [
+                    {
+                      "reviewEventId": "\(reviewEvent.reviewEventId)",
+                      "workspaceId": "\(reviewEvent.workspaceId)",
+                      "cardId": "\(reviewEvent.cardId)",
+                      "replicaId": "\(reviewEvent.replicaId)",
+                      "clientEventId": "\(reviewEvent.clientEventId)",
+                      "rating": \(reviewEvent.rating.rawValue),
+                      "reviewedAtClient": "\(reviewEvent.reviewedAtClient)",
+                      "reviewedAtServer": "\(reviewEvent.reviewedAtServer)"
+                    }
+                  ],
                   "nextReviewSequenceId": 5,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        XCTFail("Unexpected sync request path: \(path)")
+        throw URLError(.badURL)
+    }
+
+    static func handleReviewHistoryPullHydrationRequest(
+        request: URLRequest,
+        remoteReviewEvent: ReviewEvent,
+        nextReviewSequenceId: Int64
+    ) throws -> (HTTPURLResponse, Data) {
+        let path = try XCTUnwrap(request.url?.path)
+        if path.hasSuffix("/sync/pull") {
+            return try Self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "changes": [],
+                  "nextHotChangeId": 20,
+                  "hasMore": false
+                }
+                """
+            )
+        }
+
+        if path.hasSuffix("/sync/review-history/import") {
+            XCTFail("Review history import should require a pending import marker")
+            throw URLError(.badURL)
+        }
+
+        if path.hasSuffix("/sync/review-history/pull") {
+            let body = try Self.jsonObjectBody(request: request)
+            let afterReviewSequenceId = try XCTUnwrap(body["afterReviewSequenceId"] as? NSNumber).int64Value
+            CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds.append(afterReviewSequenceId)
+            return try Self.jsonResponse(
+                request: request,
+                statusCode: 200,
+                body: """
+                {
+                  "reviewEvents": [
+                    {
+                      "reviewEventId": "\(remoteReviewEvent.reviewEventId)",
+                      "workspaceId": "\(remoteReviewEvent.workspaceId)",
+                      "cardId": "\(remoteReviewEvent.cardId)",
+                      "replicaId": "\(remoteReviewEvent.replicaId)",
+                      "clientEventId": "\(remoteReviewEvent.clientEventId)",
+                      "rating": \(remoteReviewEvent.rating.rawValue),
+                      "reviewedAtClient": "\(remoteReviewEvent.reviewedAtClient)",
+                      "reviewedAtServer": "\(remoteReviewEvent.reviewedAtServer)"
+                    }
+                  ],
+                  "nextReviewSequenceId": \(nextReviewSequenceId),
                   "hasMore": false
                 }
                 """

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
@@ -412,7 +412,7 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
         XCTAssertTrue(syncState.hasHydratedHotState)
     }
 
-    func testGuestLocalRecoveryLinkedSyncImportsReviewHistoryWhenHotStateAlreadyHydrated() async throws {
+    func testLinkedSyncImportsPendingReviewHistoryWhenHotStateAlreadyHydrated() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
         let savedCard = try database.saveCard(
@@ -439,6 +439,7 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
         try database.setLastAppliedReviewSequenceId(workspaceId: workspace.workspaceId, reviewSequenceId: 0)
         try database.setHasHydratedHotState(workspaceId: workspace.workspaceId, hasHydratedHotState: true)
         try database.setHasHydratedReviewHistory(workspaceId: workspace.workspaceId, hasHydratedReviewHistory: false)
+        try database.setPendingReviewHistoryImport(workspaceId: workspace.workspaceId, pendingReviewHistoryImport: true)
 
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
@@ -447,9 +448,65 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
             decoder: makeFlashcardsRemoteJSONDecoder()
         )
         CloudSyncRunnerTestURLProtocol.requestHandler = { request in
-            try LinkedSyncRunnerTestTransportSupport.handleGuestLocalRecoveryReviewHistoryImportRetryRequest(
+            try LinkedSyncRunnerTestTransportSupport.handleReviewHistoryImportRecoveryRequest(
                 request: request,
-                reviewEventId: reviewEvent.reviewEventId
+                reviewEvent: reviewEvent
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
+        XCTAssertEqual([1], CloudSyncRunnerTestURLProtocol.reviewHistoryImportEventCounts)
+        XCTAssertEqual([0], CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds)
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.reviewEvent))
+        XCTAssertEqual(5, syncState.lastAppliedReviewSequenceId)
+        XCTAssertTrue(syncState.hasHydratedHotState)
+        XCTAssertTrue(syncState.hasHydratedReviewHistory)
+        XCTAssertFalse(try database.hasPendingReviewHistoryImport(workspaceId: workspace.workspaceId))
+    }
+
+    func testGuestLocalRecoveryImportsLegacyUnmarkedReviewHistoryWhenHotStateAlreadyHydrated() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: savedCard.cardId,
+                rating: .good,
+                reviewedAtClient: "2026-04-01T00:00:00.000Z"
+            )
+        )
+        let reviewEvent = try XCTUnwrap(try database.loadReviewEvents(workspaceId: workspace.workspaceId).first)
+        try database.deleteAllOutboxEntries(workspaceId: workspace.workspaceId)
+        try database.setLastAppliedHotChangeId(workspaceId: workspace.workspaceId, changeId: 20)
+        try database.setLastAppliedReviewSequenceId(workspaceId: workspace.workspaceId, reviewSequenceId: 0)
+        try database.setHasHydratedHotState(workspaceId: workspace.workspaceId, hasHydratedHotState: true)
+        try database.setHasHydratedReviewHistory(workspaceId: workspace.workspaceId, hasHydratedReviewHistory: false)
+        try database.setPendingReviewHistoryImport(workspaceId: workspace.workspaceId, pendingReviewHistoryImport: false)
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try LinkedSyncRunnerTestTransportSupport.handleReviewHistoryImportRecoveryRequest(
+                request: request,
+                reviewEvent: reviewEvent
             )
         }
 
@@ -459,11 +516,79 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
 
         let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
         XCTAssertEqual([1], CloudSyncRunnerTestURLProtocol.reviewHistoryImportEventCounts)
-        XCTAssertEqual([5], CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds)
+        XCTAssertEqual([0], CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds)
         XCTAssertTrue(syncResult.changedEntityTypes.contains(.reviewEvent))
         XCTAssertEqual(5, syncState.lastAppliedReviewSequenceId)
         XCTAssertTrue(syncState.hasHydratedHotState)
         XCTAssertTrue(syncState.hasHydratedReviewHistory)
+        XCTAssertFalse(try database.hasPendingReviewHistoryImport(workspaceId: workspace.workspaceId))
+    }
+
+    func testLinkedSyncPullsReviewHistoryWithoutImportWhenNoPendingImportMarker() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let savedCard = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: savedCard.cardId,
+                rating: .good,
+                reviewedAtClient: "2026-04-01T00:00:00.000Z"
+            )
+        )
+        try database.deleteAllOutboxEntries(workspaceId: workspace.workspaceId)
+        try database.setLastAppliedHotChangeId(workspaceId: workspace.workspaceId, changeId: 20)
+        try database.setLastAppliedReviewSequenceId(workspaceId: workspace.workspaceId, reviewSequenceId: 0)
+        try database.setHasHydratedHotState(workspaceId: workspace.workspaceId, hasHydratedHotState: true)
+        try database.setHasHydratedReviewHistory(workspaceId: workspace.workspaceId, hasHydratedReviewHistory: false)
+        try database.setPendingReviewHistoryImport(workspaceId: workspace.workspaceId, pendingReviewHistoryImport: false)
+
+        let remoteReviewEvent = ReviewEvent(
+            reviewEventId: "remote-review-event",
+            workspaceId: workspace.workspaceId,
+            cardId: savedCard.cardId,
+            replicaId: "remote-replica",
+            clientEventId: "remote-client-event",
+            rating: .easy,
+            reviewedAtClient: "2026-04-02T00:00:00.000Z",
+            reviewedAtServer: "2026-04-02T00:00:01.000Z"
+        )
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            try LinkedSyncRunnerTestTransportSupport.handleReviewHistoryPullHydrationRequest(
+                request: request,
+                remoteReviewEvent: remoteReviewEvent,
+                nextReviewSequenceId: 2
+            )
+        }
+
+        let syncResult = try await CloudSyncRunner(database: database, transport: transport).runLinkedSync(
+            linkedSession: self.makeLinkedSession(workspaceId: workspace.workspaceId)
+        )
+
+        let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
+        let reviewEvents = try database.loadReviewEvents(workspaceId: workspace.workspaceId)
+        XCTAssertTrue(syncResult.changedEntityTypes.contains(.reviewEvent))
+        XCTAssertTrue(reviewEvents.contains { event in event.reviewEventId == remoteReviewEvent.reviewEventId })
+        XCTAssertTrue(CloudSyncRunnerTestURLProtocol.reviewHistoryImportEventCounts.isEmpty)
+        XCTAssertEqual([0], CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds)
+        XCTAssertEqual(2, syncState.lastAppliedReviewSequenceId)
+        XCTAssertTrue(syncState.hasHydratedReviewHistory)
+        XCTAssertFalse(try database.hasPendingReviewHistoryImport(workspaceId: workspace.workspaceId))
     }
 }
 

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion14To15MigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion14To15MigrationTests.swift
@@ -165,10 +165,24 @@ final class LocalDatabaseSchemaVersion14To15MigrationTests: LocalDatabaseTestCas
             )
         )
         XCTAssertTrue(
+            try self.hasColumn(
+                database: migratedDatabase,
+                tableName: "sync_state",
+                columnName: "pending_review_history_import"
+            )
+        )
+        XCTAssertTrue(
             try self.hasIndex(
                 database: migratedDatabase,
                 tableName: "cards",
                 indexName: "idx_cards_workspace_fsrs_last_reviewed_millis_due_active"
+            )
+        )
+        XCTAssertEqual(
+            0,
+            try migratedDatabase.core.scalarInt(
+                sql: "SELECT pending_review_history_import FROM sync_state WHERE workspace_id = ?",
+                values: [.text(workspace.workspaceId)]
             )
         )
         XCTAssertEqual(
@@ -379,4 +393,3 @@ final class LocalDatabaseSchemaVersion14To15MigrationTests: LocalDatabaseTestCas
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- add retry handling for retryable iOS cloud sync transport failures
- keep retryable transport failures out of sync-failure Sentry capture
- add a pending review-history import marker and legacy guest-local recovery handling
- cover marker-driven import and migration behavior in iOS tests

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse $(git --no-pager diff --cached --name-only -- "*.swift")

Note: local generic iOS xcodebuild could not compile because the iOS 26.5 platform is not installed in this Xcode environment.