### PR TITLE
[codex] add progress leaderboard ranking rows

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -230,9 +230,12 @@ paths:
       description: >-
         Returns all five leaderboard windows in one payload for the Progress tab,
         each with viewer-perspective ranks, the per-viewer tie rule, and the
-        server-computed compact rows so every client renders the same list,
-        including gap rows for hidden ranks and a final last-place row when
-        hidden participants remain below the viewer-neighbor group.
+        server-computed compact rows so every client renders the same list.
+        Ready windows also include rankingRows, the full frozen viewer-perspective
+        ranking list with no gaps, so clients can locally reinsert the viewer
+        with live local counts. Compact rows include gap rows for hidden ranks
+        and a final last-place row when hidden participants remain below the
+        viewer-neighbor group.
         Guests receive status linked_account_required and opted-out users receive
         participation_disabled, both with no other users' rows. ApiKey
         authentication is rejected. Only opaque public profile ids and
@@ -262,11 +265,11 @@ paths:
                     snapshotGeneratedAt: '2026-06-10T14:00:05.000Z'
                     asOfServerHour: '2026-06-10T14:00:00.000Z'
                     nextRefreshAfter: '2026-06-10T15:00:00.000Z'
-                    participantCount: 128
+                    participantCount: 8
                     viewer:
                       publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
                       displayName: You
-                      rank: 42
+                      rank: 6
                       qualifiedReviewCount: 7
                     rows:
                       - kind: top
@@ -289,23 +292,63 @@ paths:
                         publicProfileId: b2c3d4e5-6f70-4b9c-8d1e-2f3a4b5c6d7e
                         anonymousDisplayName: Amber Calm Meadow
                         qualifiedReviewCount: 8
-                        rank: 41
+                        rank: 5
                       - kind: viewer
                         publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
                         anonymousDisplayName: Jade Swift River
                         qualifiedReviewCount: 7
-                        rank: 42
+                        rank: 6
                       - kind: neighbor
                         publicProfileId: c3d4e5f6-7081-4c0d-9e2f-3a4b5c6d7e8f
                         anonymousDisplayName: Coral Keen Valley
-                        qualifiedReviewCount: 7
-                        rank: 43
-                      - kind: gap
+                        qualifiedReviewCount: 6
+                        rank: 7
                       - kind: neighbor
                         publicProfileId: f6a7b8c9-0314-4f20-805d-6e7f8091a2b3
                         anonymousDisplayName: Blue Final Harbor
                         qualifiedReviewCount: 0
-                        rank: 128
+                        rank: 8
+                    rankingRows:
+                      - kind: participant
+                        publicProfileId: a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d
+                        anonymousDisplayName: Silver Bright Harbor
+                        qualifiedReviewCount: 51
+                        rank: 1
+                      - kind: participant
+                        publicProfileId: d4e5f6a7-8192-4d0e-af3b-4c5d6e7f8091
+                        anonymousDisplayName: Violet Calm Ridge
+                        qualifiedReviewCount: 44
+                        rank: 2
+                      - kind: participant
+                        publicProfileId: e5f6a7b8-9203-4e1f-b04c-5d6e7f8091a2
+                        anonymousDisplayName: Indigo Clear Grove
+                        qualifiedReviewCount: 30
+                        rank: 3
+                      - kind: participant
+                        publicProfileId: 8091a2b3-c4d5-4e6f-8708-91a2b3c4d5e6
+                        anonymousDisplayName: Green Quiet Summit
+                        qualifiedReviewCount: 12
+                        rank: 4
+                      - kind: participant
+                        publicProfileId: b2c3d4e5-6f70-4b9c-8d1e-2f3a4b5c6d7e
+                        anonymousDisplayName: Amber Calm Meadow
+                        qualifiedReviewCount: 8
+                        rank: 5
+                      - kind: viewer
+                        publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
+                        anonymousDisplayName: Jade Swift River
+                        qualifiedReviewCount: 7
+                        rank: 6
+                      - kind: participant
+                        publicProfileId: c3d4e5f6-7081-4c0d-9e2f-3a4b5c6d7e8f
+                        anonymousDisplayName: Coral Keen Valley
+                        qualifiedReviewCount: 6
+                        rank: 7
+                      - kind: participant
+                        publicProfileId: f6a7b8c9-0314-4f20-805d-6e7f8091a2b3
+                        anonymousDisplayName: Blue Final Harbor
+                        qualifiedReviewCount: 0
+                        rank: 8
         '403':
           description: Forbidden authentication transport
           content:
@@ -480,6 +523,32 @@ components:
       oneOf:
         - $ref: '#/components/schemas/ProgressLeaderboardParticipantRow'
         - $ref: '#/components/schemas/ProgressLeaderboardGapRow'
+    ProgressLeaderboardRankingRow:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - publicProfileId
+        - anonymousDisplayName
+        - qualifiedReviewCount
+        - rank
+      properties:
+        kind:
+          type: string
+          enum:
+            - participant
+            - viewer
+        publicProfileId:
+          $ref: ./components/schemas/UuidString.yaml
+        anonymousDisplayName:
+          type: string
+          description: Locale-aware anonymous display label derived from the public profile id.
+        qualifiedReviewCount:
+          type: integer
+          minimum: 0
+        rank:
+          type: integer
+          minimum: 1
     ProgressLeaderboardWindow:
       type: object
       additionalProperties: false
@@ -492,6 +561,7 @@ components:
         - participantCount
         - viewer
         - rows
+        - rankingRows
       properties:
         windowKey:
           $ref: '#/components/schemas/LeaderboardWindowKey'
@@ -519,6 +589,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProgressLeaderboardRow'
+        rankingRows:
+          type: array
+          description: Full frozen viewer-perspective ranking list with contiguous ranks and no gap rows.
+          items:
+            $ref: '#/components/schemas/ProgressLeaderboardRankingRow'
     ProgressLeaderboardResponse:
       type: object
       additionalProperties: false

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
@@ -8,6 +8,7 @@ import {
   loadProgressLeaderboardInExecutor,
   type ProgressLeaderboard,
   type ProgressLeaderboardParticipantRow,
+  type ProgressLeaderboardRankingRow,
   type ProgressLeaderboardRow,
 } from "./progressLeaderboard";
 
@@ -40,6 +41,13 @@ type LeaderboardExecutorFixture = Readonly<{
 }>;
 
 type RecordedQuery = Readonly<{ text: string; params: ReadonlyArray<SqlValue> }>;
+
+type RankingSummary = Readonly<{
+  kind: ProgressLeaderboardRankingRow["kind"];
+  publicProfileId: string;
+  count: number;
+  rank: number;
+}>;
 
 const VIEWER_USER_ID = "user-viewer";
 const VIEWER_PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
@@ -185,6 +193,20 @@ function participantRows(
   rows: ReadonlyArray<ProgressLeaderboardRow>,
 ): ReadonlyArray<ProgressLeaderboardParticipantRow> {
   return rows.filter((row): row is ProgressLeaderboardParticipantRow => row.kind !== "gap");
+}
+
+function summarizeRankingRows(rows: ReadonlyArray<ProgressLeaderboardRankingRow>): ReadonlyArray<RankingSummary> {
+  return rows.map((row) => ({
+    kind: row.kind,
+    publicProfileId: row.publicProfileId,
+    count: row.qualifiedReviewCount,
+    rank: row.rank,
+  }));
+}
+
+function assertRankingRowsHaveNoGaps(rows: ReadonlyArray<ProgressLeaderboardRankingRow>): void {
+  assert.deepEqual(rows.map((row) => row.rank), rows.map((_row, index) => index + 1));
+  assert.equal(JSON.stringify(rows).includes("\"gap\""), false);
 }
 
 function includesQuery(recordedQueries: ReadonlyArray<RecordedQuery>, substring: string): boolean {
@@ -350,6 +372,27 @@ test("a zero-count viewer with tied ranks defaults to last_24_hours and still ap
   assert.equal(viewerRow?.qualifiedReviewCount, 0);
   assert.equal(viewerRow?.rank, 3);
   assert.equal(viewerRow?.publicProfileId, VIEWER_PROFILE_ID);
+  assertRankingRowsHaveNoGaps(window.rankingRows);
+  assert.deepEqual(summarizeRankingRows(window.rankingRows), [
+    {
+      kind: "participant",
+      publicProfileId: "00000000-0000-4000-8000-0000000000b1",
+      count: 5,
+      rank: 1,
+    },
+    {
+      kind: "participant",
+      publicProfileId: "00000000-0000-4000-8000-0000000000b2",
+      count: 3,
+      rank: 2,
+    },
+    {
+      kind: "viewer",
+      publicProfileId: VIEWER_PROFILE_ID,
+      count: 0,
+      rank: 3,
+    },
+  ]);
 });
 
 test("equal counts rank the viewer below other users with the same count", async () => {
@@ -384,6 +427,36 @@ test("equal counts rank the viewer below other users with the same count", async
       { kind: "top", rank: 2, count: 5 },
       { kind: "viewer", rank: 3, count: 5 },
       { kind: "neighbor", rank: 4, count: 3 },
+    ],
+  );
+  assertRankingRowsHaveNoGaps(window.rankingRows);
+  assert.deepEqual(
+    summarizeRankingRows(window.rankingRows),
+    [
+      {
+        kind: "participant",
+        publicProfileId: "00000000-0000-4000-8000-0000000000c1",
+        count: 5,
+        rank: 1,
+      },
+      {
+        kind: "participant",
+        publicProfileId: "00000000-0000-4000-8000-0000000000c2",
+        count: 5,
+        rank: 2,
+      },
+      {
+        kind: "viewer",
+        publicProfileId: VIEWER_PROFILE_ID,
+        count: 5,
+        rank: 3,
+      },
+      {
+        kind: "participant",
+        publicProfileId: "00000000-0000-4000-8000-0000000000c4",
+        count: 3,
+        rank: 4,
+      },
     ],
   );
 });
@@ -448,6 +521,26 @@ test("compact rows show the top three, gaps, the viewer group, and the last-plac
   const window = findWindow(leaderboard, "last_24_hours");
   assert.equal(window.participantCount, 10);
   assert.equal(window.viewer.rank, 6);
+  assertRankingRowsHaveNoGaps(window.rankingRows);
+  assert.deepEqual(
+    window.rankingRows.map((row) => row.publicProfileId),
+    otherEntries.map((entry) => entry.public_profile_id),
+  );
+  assert.deepEqual(
+    window.rankingRows.map((row) => row.kind),
+    [
+      "participant",
+      "participant",
+      "participant",
+      "participant",
+      "participant",
+      "viewer",
+      "participant",
+      "participant",
+      "participant",
+      "participant",
+    ],
+  );
 
   const kindsAndRanks = window.rows.map((row) => (row.kind === "gap" ? "gap" : `${row.kind}:${row.rank}`));
   assert.deepEqual(kindsAndRanks, [
@@ -576,10 +669,11 @@ test("anonymous names change with locale while ids, counts, and ranks stay stabl
 });
 
 test("ready response serializes only public fields, never internal identifiers", async () => {
+  const rawReviewTimestamp = new Date("2026-06-10T12:12:34.567Z");
   const { executor } = createLeaderboardExecutor({
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
-    latestReviewedAtClient: new Date(NOW.getTime() - 2 * MILLISECONDS_PER_HOUR),
+    latestReviewedAtClient: rawReviewTimestamp,
     headers: createReadyHeaders(),
     entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
       { public_profile_id: "00000000-0000-4000-8000-000000000aa1", qualified_review_count: 7, base_sort_position: 1 },
@@ -597,8 +691,10 @@ test("ready response serializes only public fields, never internal identifiers",
   assert.equal(serialized.includes("publicProfileId"), true);
   assert.equal(serialized.includes("anonymousDisplayName"), true);
   assert.equal(serialized.includes("qualifiedReviewCount"), true);
+  assert.equal(serialized.includes("rankingRows"), true);
   for (const internalField of [
     VIEWER_USER_ID,
+    rawReviewTimestamp.toISOString(),
     "user_id",
     "userId",
     "reviewed_by",

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.ts
@@ -88,6 +88,14 @@ export type ProgressLeaderboardGapRow = Readonly<{
 
 export type ProgressLeaderboardRow = ProgressLeaderboardParticipantRow | ProgressLeaderboardGapRow;
 
+export type ProgressLeaderboardRankingRow = Readonly<{
+  kind: "participant" | "viewer";
+  publicProfileId: string;
+  anonymousDisplayName: string;
+  qualifiedReviewCount: number;
+  rank: number;
+}>;
+
 export type ProgressLeaderboardWindow = Readonly<{
   windowKey: LeaderboardWindowKey;
   snapshotId: string;
@@ -97,6 +105,7 @@ export type ProgressLeaderboardWindow = Readonly<{
   participantCount: number;
   viewer: ProgressLeaderboardViewer;
   rows: ReadonlyArray<ProgressLeaderboardRow>;
+  rankingRows: ReadonlyArray<ProgressLeaderboardRankingRow>;
 }>;
 
 export type ProgressLeaderboard = Readonly<{
@@ -334,6 +343,26 @@ function buildParticipantRow(
   };
 }
 
+function buildRankingRow(
+  participant: RankedParticipant,
+  resolveName: (publicProfileId: string) => string,
+): ProgressLeaderboardRankingRow {
+  return {
+    kind: participant.isViewer ? "viewer" : "participant",
+    publicProfileId: participant.publicProfileId,
+    anonymousDisplayName: resolveName(participant.publicProfileId),
+    qualifiedReviewCount: participant.qualifiedReviewCount,
+    rank: participant.rank,
+  };
+}
+
+function buildRankingRows(
+  ranked: ReadonlyArray<RankedParticipant>,
+  resolveName: (publicProfileId: string) => string,
+): ReadonlyArray<ProgressLeaderboardRankingRow> {
+  return ranked.map((participant) => buildRankingRow(participant, resolveName));
+}
+
 /**
  * Selects the compact rows server-side so every client renders the same list:
  * the top three rows (when that many participants exist), the next row when
@@ -417,6 +446,7 @@ function buildLeaderboardWindow(
       qualifiedReviewCount: ranking.viewerCount,
     },
     rows: buildCompactRows(ranking.ranked, ranking.viewerRank, resolveName),
+    rankingRows: buildRankingRows(ranking.ranked, resolveName),
   };
 }
 

--- a/apps/backend/src/routes/system.test.ts
+++ b/apps/backend/src/routes/system.test.ts
@@ -170,6 +170,22 @@ function createProgressLeaderboard(): ProgressLeaderboard {
             rank: 2,
           },
         ],
+        rankingRows: [
+          {
+            kind: "participant",
+            publicProfileId: "a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d",
+            anonymousDisplayName: "Silver Bright Harbor",
+            qualifiedReviewCount: 5,
+            rank: 1,
+          },
+          {
+            kind: "viewer",
+            publicProfileId: "5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f",
+            anonymousDisplayName: "Jade Swift River",
+            qualifiedReviewCount: 3,
+            rank: 2,
+          },
+        ],
       },
     ],
   };
@@ -813,6 +829,7 @@ test("published OpenAPI documents the progress leaderboard without internal ids"
     "rank",
     "nextRefreshAfter",
     "participantCount",
+    "rankingRows",
   ]) {
     assert.equal(serializedSchemas.includes(expectedField), true, `OpenAPI must document ${expectedField}`);
   }


### PR DESCRIPTION
## Summary

Adds `rankingRows` to ready Progress leaderboard windows so clients can access the full frozen viewer-perspective ranking while keeping the existing compact `rows` contract intact.

## Changes

- Adds the backend `ProgressLeaderboardRankingRow` type and `rankingRows` response field.
- Builds `rankingRows` from the existing viewer-perspective ranking source.
- Documents the new schema and example in OpenAPI.
- Extends backend tests for full contiguous ranking rows, viewer row kind, tie behavior, and privacy serialization.

## Validation

- `npm test --prefix apps/backend`
- `npm run lint --prefix apps/backend`
- `npm run lint --prefix api`