### PR TITLE
[codex] Rerank web leaderboard viewer locally

### DIFF
--- a/apps/web/src/apiContracts/progress.ts
+++ b/apps/web/src/apiContracts/progress.ts
@@ -1,6 +1,7 @@
 import type {
   ProgressLeaderboard,
   ProgressLeaderboardMetric,
+  ProgressLeaderboardRankingRow,
   ProgressLeaderboardRow,
   ProgressLeaderboardViewer,
   ProgressLeaderboardWindow,
@@ -12,6 +13,7 @@ import type {
 } from "../types";
 import {
   progressLeaderboardParticipantRowKinds,
+  progressLeaderboardRankingRowKinds,
   progressLeaderboardStatuses,
   progressLeaderboardWindowKeys,
   progressReviewScheduleBucketKeys,
@@ -20,6 +22,7 @@ import { findProgressReviewScheduleValidationIssue } from "../progress/progressR
 import {
   ApiContractError,
   describePath,
+  joinIndexPath,
   joinPath,
   type JsonObject,
   parseArray,
@@ -274,21 +277,101 @@ function parseProgressLeaderboardRowArray(
   return parseArray(value, endpoint, path, parseProgressLeaderboardRow);
 }
 
+function parseProgressLeaderboardRankingRow(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ProgressLeaderboardRankingRow {
+  const objectValue = parseObject(value, endpoint, path);
+
+  return {
+    kind: parseEnum(objectValue.kind, endpoint, joinPath(path, "kind"), progressLeaderboardRankingRowKinds),
+    publicProfileId: parseRequiredField(objectValue, "publicProfileId", endpoint, path, parseString),
+    anonymousDisplayName: parseRequiredField(objectValue, "anonymousDisplayName", endpoint, path, parseString),
+    qualifiedReviewCount: parseRequiredField(objectValue, "qualifiedReviewCount", endpoint, path, parseNonNegativeSafeInteger),
+    rank: parseRequiredField(objectValue, "rank", endpoint, path, parseLeaderboardRank),
+  };
+}
+
+function parseProgressLeaderboardRankingRowArray(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ReadonlyArray<ProgressLeaderboardRankingRow> {
+  return parseArray(value, endpoint, path, parseProgressLeaderboardRankingRow);
+}
+
+function validateProgressLeaderboardRankingRows(
+  participantCount: number,
+  viewer: ProgressLeaderboardViewer,
+  rankingRows: ReadonlyArray<ProgressLeaderboardRankingRow>,
+  endpoint: string,
+  path: string,
+): void {
+  const rankingRowsPath = joinPath(path, "rankingRows");
+
+  if (rankingRows.length !== participantCount) {
+    throw new ApiContractError(endpoint, describePath(rankingRowsPath), "one row per participant");
+  }
+
+  let viewerRowCount = 0;
+  let previousQualifiedReviewCount: number | null = null;
+
+  rankingRows.forEach((row, index) => {
+    const rowPath = joinIndexPath(rankingRowsPath, index);
+
+    if (row.rank !== index + 1) {
+      throw new ApiContractError(endpoint, describePath(joinPath(rowPath, "rank")), "a contiguous rank matching array order");
+    }
+
+    if (previousQualifiedReviewCount !== null && row.qualifiedReviewCount > previousQualifiedReviewCount) {
+      throw new ApiContractError(endpoint, describePath(joinPath(rowPath, "qualifiedReviewCount")), "non-increasing ranking order");
+    }
+
+    previousQualifiedReviewCount = row.qualifiedReviewCount;
+
+    if (row.kind === "viewer") {
+      viewerRowCount += 1;
+
+      if (
+        row.publicProfileId !== viewer.publicProfileId
+        || row.rank !== viewer.rank
+        || row.qualifiedReviewCount !== viewer.qualifiedReviewCount
+      ) {
+        throw new ApiContractError(endpoint, describePath(rowPath), "the current viewer row");
+      }
+    } else if (row.publicProfileId === viewer.publicProfileId) {
+      throw new ApiContractError(endpoint, describePath(rowPath), "a non-viewer participant");
+    }
+  });
+
+  if (viewerRowCount !== 1) {
+    throw new ApiContractError(endpoint, describePath(rankingRowsPath), "exactly one current viewer row");
+  }
+}
+
 function parseProgressLeaderboardWindow(
   value: unknown,
   endpoint: string,
   path: string,
 ): ProgressLeaderboardWindow {
   const objectValue = parseObject(value, endpoint, path);
+  const participantCount = parseRequiredField(objectValue, "participantCount", endpoint, path, parseNonNegativeSafeInteger);
+  const viewer = parseRequiredField(objectValue, "viewer", endpoint, path, parseProgressLeaderboardViewer);
+  const rankingRows = parseRequiredField(objectValue, "rankingRows", endpoint, path, parseProgressLeaderboardRankingRowArray);
+
+  validateProgressLeaderboardRankingRows(participantCount, viewer, rankingRows, endpoint, path);
+
   return {
     windowKey: parseRequiredField(objectValue, "windowKey", endpoint, path, parseProgressLeaderboardWindowKey),
     snapshotId: parseRequiredField(objectValue, "snapshotId", endpoint, path, parseString),
     snapshotGeneratedAt: parseRequiredField(objectValue, "snapshotGeneratedAt", endpoint, path, parseString),
     asOfServerHour: parseRequiredField(objectValue, "asOfServerHour", endpoint, path, parseString),
     nextRefreshAfter: parseRequiredField(objectValue, "nextRefreshAfter", endpoint, path, parseString),
-    participantCount: parseRequiredField(objectValue, "participantCount", endpoint, path, parseNonNegativeSafeInteger),
-    viewer: parseRequiredField(objectValue, "viewer", endpoint, path, parseProgressLeaderboardViewer),
+    participantCount,
+    viewer,
     rows: parseRequiredField(objectValue, "rows", endpoint, path, parseProgressLeaderboardRowArray),
+    rankingRows,
   };
 }
 

--- a/apps/web/src/appData/progress/snapshots/progressLeaderboardSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressLeaderboardSnapshots.ts
@@ -1,10 +1,21 @@
 import type {
   ProgressLeaderboard,
   ProgressLeaderboardLocalViewerCounts,
+  ProgressLeaderboardParticipantRow,
+  ProgressLeaderboardRankingRow,
   ProgressLeaderboardRow,
   ProgressLeaderboardSnapshot,
   ProgressLeaderboardWindow,
+  ProgressLeaderboardWindowKey,
 } from "../../../types";
+import { progressLeaderboardWindowKeys } from "../../../types";
+
+type ProgressLeaderboardRanklessRankingRow = Readonly<{
+  kind: ProgressLeaderboardRankingRow["kind"];
+  publicProfileId: string;
+  anonymousDisplayName: string;
+  qualifiedReviewCount: number;
+}>;
 
 export function createProgressLeaderboardSnapshot(
   leaderboard: ProgressLeaderboard,
@@ -20,32 +31,217 @@ export function createProgressLeaderboardSnapshot(
   };
 }
 
-function overlayProgressLeaderboardWindowViewerCount(
+function findViewerRankingRow(
   window: ProgressLeaderboardWindow,
-  localViewerCount: number,
+): ProgressLeaderboardRankingRow {
+  const viewerRankingRow = window.rankingRows.find((row) => (
+    row.kind === "viewer" && row.publicProfileId === window.viewer.publicProfileId
+  )) ?? null;
+
+  if (viewerRankingRow === null) {
+    throw new Error(`Leaderboard window ${window.windowKey} rankingRows must include viewer ${window.viewer.publicProfileId}.`);
+  }
+
+  return viewerRankingRow;
+}
+
+function buildOtherRankingRows(
+  window: ProgressLeaderboardWindow,
+): ReadonlyArray<ProgressLeaderboardRankingRow> {
+  return window.rankingRows.filter((row) => {
+    if (row.kind === "viewer" && row.publicProfileId !== window.viewer.publicProfileId) {
+      throw new Error(`Leaderboard window ${window.windowKey} rankingRows contains a viewer row for ${row.publicProfileId}, expected ${window.viewer.publicProfileId}.`);
+    }
+
+    if (row.kind === "participant" && row.publicProfileId === window.viewer.publicProfileId) {
+      throw new Error(`Leaderboard window ${window.windowKey} rankingRows contains viewer ${window.viewer.publicProfileId} as a participant row.`);
+    }
+
+    return row.publicProfileId !== window.viewer.publicProfileId;
+  });
+}
+
+function toRanklessRankingRow(
+  row: ProgressLeaderboardRankingRow,
+): ProgressLeaderboardRanklessRankingRow {
+  return {
+    kind: row.kind,
+    publicProfileId: row.publicProfileId,
+    anonymousDisplayName: row.anonymousDisplayName,
+    qualifiedReviewCount: row.qualifiedReviewCount,
+  };
+}
+
+function findViewerInsertionIndex(
+  rows: ReadonlyArray<ProgressLeaderboardRankingRow>,
+  viewerCount: number,
+): number {
+  const index = rows.findIndex((row) => row.qualifiedReviewCount < viewerCount);
+  return index === -1 ? rows.length : index;
+}
+
+function buildProjectedRankingRows(
+  window: ProgressLeaderboardWindow,
+  viewerCount: number,
+): ReadonlyArray<ProgressLeaderboardRankingRow> {
+  const viewerRankingRow = findViewerRankingRow(window);
+  const otherRows = buildOtherRankingRows(window);
+  const viewerInsertionIndex = findViewerInsertionIndex(otherRows, viewerCount);
+  const projectedRows: Array<ProgressLeaderboardRanklessRankingRow> = [];
+  const projectedViewerRow: ProgressLeaderboardRanklessRankingRow = {
+    kind: "viewer",
+    publicProfileId: window.viewer.publicProfileId,
+    anonymousDisplayName: viewerRankingRow.anonymousDisplayName,
+    qualifiedReviewCount: viewerCount,
+  };
+
+  otherRows.forEach((row, index) => {
+    if (index === viewerInsertionIndex) {
+      projectedRows.push(projectedViewerRow);
+    }
+
+    projectedRows.push(toRanklessRankingRow(row));
+  });
+
+  if (viewerInsertionIndex === otherRows.length) {
+    projectedRows.push(projectedViewerRow);
+  }
+
+  return projectedRows.map((row, index): ProgressLeaderboardRankingRow => ({
+    ...row,
+    rank: index + 1,
+  }));
+}
+
+function buildProgressLeaderboardParticipantRow(
+  row: ProgressLeaderboardRankingRow,
+  topRowCount: number,
+): ProgressLeaderboardParticipantRow {
+  return {
+    kind: row.kind === "viewer" ? "viewer" : row.rank <= topRowCount ? "top" : "neighbor",
+    publicProfileId: row.publicProfileId,
+    anonymousDisplayName: row.anonymousDisplayName,
+    qualifiedReviewCount: row.qualifiedReviewCount,
+    rank: row.rank,
+  };
+}
+
+function buildShownRankList(total: number, viewerRank: number): ReadonlyArray<number> {
+  const topRowCount = Math.min(3, total);
+  const shownRanks = new Set<number>();
+
+  for (let rank = 1; rank <= topRowCount; rank += 1) {
+    shownRanks.add(rank);
+  }
+
+  if (viewerRank > topRowCount) {
+    for (const candidate of [viewerRank - 1, viewerRank, viewerRank + 1]) {
+      if (candidate >= 1 && candidate <= total) {
+        shownRanks.add(candidate);
+      }
+    }
+  } else if (viewerRank === topRowCount && viewerRank < total) {
+    shownRanks.add(viewerRank + 1);
+  }
+
+  if (total > topRowCount) {
+    shownRanks.add(total);
+  }
+
+  return [...shownRanks].sort((left, right) => left - right);
+}
+
+function buildCompactRows(
+  rankingRows: ReadonlyArray<ProgressLeaderboardRankingRow>,
+): ReadonlyArray<ProgressLeaderboardRow> {
+  const viewerRankingRow = rankingRows.find((row) => row.kind === "viewer") ?? null;
+  if (viewerRankingRow === null) {
+    throw new Error("Projected leaderboard rankingRows must include a viewer row.");
+  }
+
+  const total = rankingRows.length;
+  const topRowCount = Math.min(3, total);
+  const shownRanks = buildShownRankList(total, viewerRankingRow.rank);
+  const rows: Array<ProgressLeaderboardRow> = [];
+  let previousRank = 0;
+
+  for (const rank of shownRanks) {
+    if (previousRank !== 0 && rank > previousRank + 1) {
+      rows.push({ kind: "gap" });
+    }
+
+    const rankingRow = rankingRows[rank - 1];
+    if (rankingRow === undefined) {
+      throw new Error(`Projected leaderboard rankingRows is missing rank ${rank}.`);
+    }
+
+    rows.push(buildProgressLeaderboardParticipantRow(rankingRow, topRowCount));
+    previousRank = rank;
+  }
+
+  if (previousRank < total) {
+    rows.push({ kind: "gap" });
+  }
+
+  return rows;
+}
+
+function projectProgressLeaderboardWindow(
+  window: ProgressLeaderboardWindow,
+  localViewerCounts: ProgressLeaderboardLocalViewerCounts,
 ): ProgressLeaderboardWindow {
+  const viewerCount = Math.max(
+    window.viewer.qualifiedReviewCount,
+    localViewerCounts[window.windowKey],
+  );
+
+  if (viewerCount === window.viewer.qualifiedReviewCount) {
+    return window;
+  }
+
+  const projectedRankingRows = buildProjectedRankingRows(window, viewerCount);
+  const projectedViewerRow = projectedRankingRows.find((row) => row.kind === "viewer") ?? null;
+  if (projectedViewerRow === null) {
+    throw new Error(`Projected leaderboard window ${window.windowKey} rankingRows must include a viewer row.`);
+  }
+
   return {
     ...window,
     viewer: {
       ...window.viewer,
-      qualifiedReviewCount: localViewerCount,
+      rank: projectedViewerRow.rank,
+      qualifiedReviewCount: viewerCount,
     },
-    rows: window.rows.map((row): ProgressLeaderboardRow => (
-      row.kind === "viewer"
-        ? {
-          ...row,
-          qualifiedReviewCount: localViewerCount,
-        }
-        : row
-    )),
+    rows: buildCompactRows(projectedRankingRows),
+    rankingRows: window.rankingRows,
   };
 }
 
+function resolveProjectedDefaultWindowKey(
+  windows: ReadonlyArray<ProgressLeaderboardWindow>,
+  currentDefaultWindowKey: ProgressLeaderboardWindowKey,
+): ProgressLeaderboardWindowKey {
+  let bestWindow: ProgressLeaderboardWindow | null = null;
+
+  for (const windowKey of progressLeaderboardWindowKeys) {
+    const window = windows.find((candidate) => candidate.windowKey === windowKey);
+    if (window === undefined) {
+      continue;
+    }
+
+    if (bestWindow === null || window.viewer.rank < bestWindow.viewer.rank) {
+      bestWindow = window;
+    }
+  }
+
+  return bestWindow === null ? currentDefaultWindowKey : bestWindow.windowKey;
+}
+
 /**
- * Replaces only the viewer's qualified review count with the locally computed
- * live count. Ranks, participant counts, and all other users' rows stay exactly
- * as the server snapshot reported them, so a diverging local count never
- * invents a new rank.
+ * Projects a live viewer-only count onto the server-frozen ranking rows. Other
+ * participants retain server order; the viewer is reinserted below equal counts
+ * and above the first lower count, then compact rows are rebuilt from that
+ * projected rank list.
  */
 function mergeProgressLeaderboardWithLocalViewerCounts(
   serverBase: ProgressLeaderboardSnapshot,
@@ -57,14 +253,13 @@ function mergeProgressLeaderboardWithLocalViewerCounts(
 
   let hasOverlay = false;
   const windows = serverBase.windows.map((window): ProgressLeaderboardWindow => {
-    const localViewerCount = localViewerCounts[window.windowKey];
+    const projectedWindow = projectProgressLeaderboardWindow(window, localViewerCounts);
 
-    if (localViewerCount === window.viewer.qualifiedReviewCount) {
-      return window;
+    if (projectedWindow !== window) {
+      hasOverlay = true;
     }
 
-    hasOverlay = true;
-    return overlayProgressLeaderboardWindowViewerCount(window, localViewerCount);
+    return projectedWindow;
   });
 
   if (hasOverlay === false) {
@@ -73,6 +268,7 @@ function mergeProgressLeaderboardWithLocalViewerCounts(
 
   return {
     ...serverBase,
+    defaultWindowKey: resolveProjectedDefaultWindowKey(windows, serverBase.defaultWindowKey),
     windows,
     isApproximate: true,
   };

--- a/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
@@ -3,6 +3,7 @@ import type {
   ProgressChartData,
   ProgressLeaderboardLocalViewerCounts,
   ProgressLeaderboardMetric,
+  ProgressLeaderboardRankingRow,
   ProgressLeaderboardRow,
   ProgressLeaderboardSnapshot,
   ProgressLeaderboardSourceState,
@@ -306,6 +307,37 @@ function areProgressLeaderboardRowArraysEqual(
   return true;
 }
 
+function areProgressLeaderboardRankingRowsEqual(
+  left: ProgressLeaderboardRankingRow,
+  right: ProgressLeaderboardRankingRow,
+): boolean {
+  return left.kind === right.kind
+    && left.publicProfileId === right.publicProfileId
+    && left.anonymousDisplayName === right.anonymousDisplayName
+    && left.qualifiedReviewCount === right.qualifiedReviewCount
+    && left.rank === right.rank;
+}
+
+function areProgressLeaderboardRankingRowArraysEqual(
+  left: ReadonlyArray<ProgressLeaderboardRankingRow>,
+  right: ReadonlyArray<ProgressLeaderboardRankingRow>,
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    const leftRow = left[index];
+    const rightRow = right[index];
+
+    if (leftRow === undefined || rightRow === undefined || areProgressLeaderboardRankingRowsEqual(leftRow, rightRow) === false) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function areProgressLeaderboardWindowsEqual(
   left: ProgressLeaderboardWindow,
   right: ProgressLeaderboardWindow,
@@ -317,7 +349,8 @@ function areProgressLeaderboardWindowsEqual(
     && left.nextRefreshAfter === right.nextRefreshAfter
     && left.participantCount === right.participantCount
     && areProgressLeaderboardViewersEqual(left.viewer, right.viewer)
-    && areProgressLeaderboardRowArraysEqual(left.rows, right.rows);
+    && areProgressLeaderboardRowArraysEqual(left.rows, right.rows)
+    && areProgressLeaderboardRankingRowArraysEqual(left.rankingRows, right.rankingRows);
 }
 
 function areProgressLeaderboardWindowArraysEqual(

--- a/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 import type {
+  ProgressLeaderboard,
   ProgressReviewSchedule,
   ProgressSeries,
   ProgressSummaryPayload,
 } from "../../../types";
 import {
   addWebBreadcrumbMock,
+  buildCurrentLeaderboardScopeKey,
   buildCurrentReviewScheduleInput,
   buildCurrentReviewScheduleScopeKey,
   buildCurrentSeriesInput,
@@ -17,7 +19,9 @@ import {
   buildServerSummary,
   createDeferredPromise,
   flushEffects,
+  leaderboardOnlySections,
   linkedCloudSettings,
+  loadProgressLeaderboardMock,
   loadProgressReviewScheduleMock,
   loadProgressSeriesMock,
   loadProgressSummaryMock,
@@ -25,6 +29,7 @@ import {
   replaceProgressReviewScheduleBucketCount,
   reviewScheduleOnlySections,
   seriesOnlySections,
+  storePersistedProgressLeaderboardForTest,
   storePersistedProgressReviewScheduleForTest,
   storePersistedProgressSeriesForTest,
   storePersistedProgressSummaryForTest,
@@ -32,7 +37,7 @@ import {
   swapFirstProgressReviewScheduleBuckets,
 } from "./progressSourceTestSupport";
 
-type ExpectedProgressCacheMissSection = "summary" | "series" | "review_schedule";
+type ExpectedProgressCacheMissSection = "summary" | "series" | "review_schedule" | "leaderboard";
 type ExpectedProgressCacheMissReason = "invalid_json" | "invalid_shape" | "scope_mismatch" | "time_zone_mismatch";
 
 function expectProgressCacheMissBreadcrumb(
@@ -55,6 +60,44 @@ function expectProgressCacheMissBreadcrumb(
       workspaceIds: ["workspace-1"],
     }),
   }));
+}
+
+function buildCachedLeaderboard(): ProgressLeaderboard {
+  return {
+    status: "ready",
+    metric: {
+      metricVersion: "qualified_reviews_v1",
+      title: "Qualified reviews",
+      description: "Hard, Good, and Easy reviews count toward your rank. Again does not.",
+    },
+    defaultWindowKey: "last_24_hours",
+    windows: [
+      {
+        windowKey: "last_24_hours",
+        snapshotId: "0cc86d10-18cb-4d64-a2f2-a5fd960b45b2",
+        snapshotGeneratedAt: "2026-04-18T09:10:00.000Z",
+        asOfServerHour: "2026-04-18T09:00:00.000Z",
+        nextRefreshAfter: "2026-04-18T10:00:00.000Z",
+        participantCount: 3,
+        viewer: {
+          publicProfileId: "viewer-profile",
+          displayName: "You",
+          rank: 2,
+          qualifiedReviewCount: 5,
+        },
+        rows: [
+          { kind: "top", publicProfileId: "profile-1", anonymousDisplayName: "Silver Bright Harbor", qualifiedReviewCount: 7, rank: 1 },
+          { kind: "viewer", publicProfileId: "viewer-profile", anonymousDisplayName: "Quiet Maple Grove", qualifiedReviewCount: 5, rank: 2 },
+          { kind: "top", publicProfileId: "profile-3", anonymousDisplayName: "Coral Keen Valley", qualifiedReviewCount: 1, rank: 3 },
+        ],
+        rankingRows: [
+          { kind: "participant", publicProfileId: "profile-1", anonymousDisplayName: "Silver Bright Harbor", qualifiedReviewCount: 7, rank: 1 },
+          { kind: "viewer", publicProfileId: "viewer-profile", anonymousDisplayName: "Quiet Maple Grove", qualifiedReviewCount: 5, rank: 2 },
+          { kind: "participant", publicProfileId: "profile-3", anonymousDisplayName: "Coral Keen Valley", qualifiedReviewCount: 1, rank: 3 },
+        ],
+      },
+    ],
+  };
 }
 
 describe("useProgressSource cache", () => {
@@ -94,6 +137,38 @@ describe("useProgressSource cache", () => {
       date: buildCurrentSeriesInput().to,
       reviewCount: 7,
     });
+  });
+
+  it("hydrates matching leaderboard cache with rankingRows before remote refresh completes", async () => {
+    const cachedLeaderboard = buildCachedLeaderboard();
+    const deferredLeaderboard = createDeferredPromise<ProgressLeaderboard>();
+    storePersistedProgressLeaderboardForTest(buildCurrentLeaderboardScopeKey(), cachedLeaderboard);
+    loadProgressLeaderboardMock.mockImplementation(() => deferredLeaderboard.promise);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: leaderboardOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.leaderboard.serverBase?.windows[0]?.rankingRows).toEqual(
+      cachedLeaderboard.windows[0]?.rankingRows,
+    );
+    expect(harness.getApi().progressSourceState.leaderboard.renderedSnapshot?.windows[0]?.viewer.rank).toBe(2);
+
+    deferredLeaderboard.resolve({
+      ...cachedLeaderboard,
+      windows: cachedLeaderboard.windows.map((window) => ({
+        ...window,
+        snapshotGeneratedAt: "2026-04-18T09:11:00.000Z",
+      })),
+    });
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.leaderboard.serverBase?.windows[0]?.snapshotGeneratedAt).toBe("2026-04-18T09:11:00.000Z");
   });
 
   it("treats corrupt and mismatched cache entries as misses", async () => {

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -27,7 +27,10 @@ import {
   buildProgressSeriesInputForDateContext,
   buildProgressSummaryInputForDateContext,
 } from "../../../progress/progressDates";
-import { buildProgressSummaryScopeKey } from "../state/progressScope";
+import {
+  buildProgressLeaderboardScopeKey,
+  buildProgressSummaryScopeKey,
+} from "../state/progressScope";
 import { resetProgressTimeContextStateForTests } from "../time/progressTimeContext";
 import type { SessionVerificationState } from "../../session/workspaceSessionTypes";
 
@@ -469,6 +472,10 @@ export function buildCurrentReviewScheduleScopeKey(): ProgressScopeKey {
   );
 }
 
+export function buildCurrentLeaderboardScopeKey(): ProgressScopeKey {
+  return buildProgressLeaderboardScopeKey([workspace.workspaceId]);
+}
+
 export function storePersistedProgressSummaryForTest(
   scopeKey: ProgressScopeKey,
   serverBase: ProgressSummaryPayload,
@@ -498,6 +505,18 @@ export function storePersistedProgressReviewScheduleForTest(
   serverBase: ProgressReviewSchedule,
 ): void {
   window.localStorage.setItem(`flashcards-progress-server-review-schedule:${scopeKey}`, JSON.stringify({
+    version: 2,
+    scopeKey,
+    savedAt: "2026-04-18T09:00:00.000Z",
+    serverBase,
+  }));
+}
+
+export function storePersistedProgressLeaderboardForTest(
+  scopeKey: ProgressScopeKey,
+  serverBase: ProgressLeaderboard,
+): void {
+  window.localStorage.setItem("flashcards-progress-server-leaderboard", JSON.stringify({
     version: 2,
     scopeKey,
     savedAt: "2026-04-18T09:00:00.000Z",

--- a/apps/web/src/appData/progress/storage/progressStorage.ts
+++ b/apps/web/src/appData/progress/storage/progressStorage.ts
@@ -2,6 +2,7 @@ import type {
   DailyReviewPoint,
   ProgressLeaderboard,
   ProgressLeaderboardMetric,
+  ProgressLeaderboardRankingRow,
   ProgressLeaderboardRow,
   ProgressLeaderboardStatus,
   ProgressLeaderboardViewer,
@@ -18,6 +19,7 @@ import { INSTALLATION_ID_STORAGE_KEY } from "../../../clientIdentity";
 import { addWebBreadcrumb, type WebObservationScope } from "../../../observability/webObservability";
 import {
   progressLeaderboardParticipantRowKinds,
+  progressLeaderboardRankingRowKinds,
   progressLeaderboardStatuses,
   progressLeaderboardWindowKeys,
   progressReviewScheduleBucketKeys,
@@ -34,7 +36,7 @@ const progressLeaderboardStorageKey = "flashcards-progress-server-leaderboard";
 const progressServerSummaryVersion = 2;
 const progressServerSeriesVersion = 2;
 const progressServerReviewScheduleVersion = 2;
-const progressServerLeaderboardVersion = 1;
+const progressServerLeaderboardVersion = 2;
 
 type PersistedProgressSummary = Readonly<{
   version: 2;
@@ -58,7 +60,7 @@ type PersistedProgressReviewSchedule = Readonly<{
 }>;
 
 type PersistedProgressLeaderboard = Readonly<{
-  version: 1;
+  version: 2;
   scopeKey: ProgressScopeKey;
   savedAt: string;
   serverBase: ProgressLeaderboard;
@@ -616,6 +618,74 @@ function parsePersistedProgressLeaderboardRow(value: unknown): ProgressLeaderboa
   };
 }
 
+function parsePersistedProgressLeaderboardRankingRow(value: unknown): ProgressLeaderboardRankingRow | null {
+  if (
+    isRecord(value) === false
+    || progressLeaderboardRankingRowKinds.includes(value.kind as typeof progressLeaderboardRankingRowKinds[number]) === false
+    || typeof value.publicProfileId !== "string"
+    || typeof value.anonymousDisplayName !== "string"
+    || isNonNegativeSafeIntegerValue(value.qualifiedReviewCount) === false
+    || isNonNegativeSafeIntegerValue(value.rank) === false
+    || value.rank < 1
+  ) {
+    return null;
+  }
+
+  return {
+    kind: value.kind as typeof progressLeaderboardRankingRowKinds[number],
+    publicProfileId: value.publicProfileId,
+    anonymousDisplayName: value.anonymousDisplayName,
+    qualifiedReviewCount: value.qualifiedReviewCount,
+    rank: value.rank,
+  };
+}
+
+function isValidPersistedProgressLeaderboardRankingRows(
+  participantCount: number,
+  viewer: ProgressLeaderboardViewer,
+  rankingRows: ReadonlyArray<ProgressLeaderboardRankingRow>,
+): boolean {
+  if (rankingRows.length !== participantCount) {
+    return false;
+  }
+
+  let viewerRowCount = 0;
+  let previousQualifiedReviewCount: number | null = null;
+
+  for (let index = 0; index < rankingRows.length; index += 1) {
+    const row = rankingRows[index];
+    if (row === undefined) {
+      return false;
+    }
+
+    if (row.rank !== index + 1) {
+      return false;
+    }
+
+    if (previousQualifiedReviewCount !== null && row.qualifiedReviewCount > previousQualifiedReviewCount) {
+      return false;
+    }
+
+    previousQualifiedReviewCount = row.qualifiedReviewCount;
+
+    if (row.kind === "viewer") {
+      viewerRowCount += 1;
+
+      if (
+        row.publicProfileId !== viewer.publicProfileId
+        || row.rank !== viewer.rank
+        || row.qualifiedReviewCount !== viewer.qualifiedReviewCount
+      ) {
+        return false;
+      }
+    } else if (row.publicProfileId === viewer.publicProfileId) {
+      return false;
+    }
+  }
+
+  return viewerRowCount === 1;
+}
+
 function parsePersistedProgressLeaderboardWindow(value: unknown): ProgressLeaderboardWindow | null {
   if (
     isRecord(value) === false
@@ -626,6 +696,7 @@ function parsePersistedProgressLeaderboardWindow(value: unknown): ProgressLeader
     || typeof value.nextRefreshAfter !== "string"
     || isNonNegativeSafeIntegerValue(value.participantCount) === false
     || Array.isArray(value.rows) === false
+    || Array.isArray(value.rankingRows) === false
   ) {
     return null;
   }
@@ -643,6 +714,18 @@ function parsePersistedProgressLeaderboardWindow(value: unknown): ProgressLeader
     return null;
   }
 
+  const rankingRows = value.rankingRows
+    .map(parsePersistedProgressLeaderboardRankingRow)
+    .filter((row): row is ProgressLeaderboardRankingRow => row !== null);
+
+  if (rankingRows.length !== value.rankingRows.length) {
+    return null;
+  }
+
+  if (isValidPersistedProgressLeaderboardRankingRows(value.participantCount, viewer, rankingRows) === false) {
+    return null;
+  }
+
   return {
     windowKey: value.windowKey,
     snapshotId: value.snapshotId,
@@ -652,6 +735,7 @@ function parsePersistedProgressLeaderboardWindow(value: unknown): ProgressLeader
     participantCount: value.participantCount,
     viewer,
     rows,
+    rankingRows,
   };
 }
 
@@ -708,7 +792,7 @@ function parsePersistedProgressLeaderboard(
   return {
     status: "hit",
     value: {
-      version: 1,
+      version: 2,
       scopeKey: parsedValue.scopeKey,
       savedAt: parsedValue.savedAt,
       serverBase: {
@@ -858,7 +942,7 @@ export function loadPersistedProgressLeaderboard(scopeKey: ProgressScopeKey): Pr
 
 export function storePersistedProgressLeaderboard(scopeKey: ProgressScopeKey, serverBase: ProgressLeaderboard): void {
   const persistedValue: PersistedProgressLeaderboard = {
-    version: 1,
+    version: 2,
     scopeKey,
     savedAt: new Date().toISOString(),
     serverBase,

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -15,6 +15,7 @@ import type {
   CloudSettings,
   ProgressLeaderboard,
   ProgressLeaderboardLocalViewerCounts,
+  ProgressLeaderboardRankingRow,
   ProgressLeaderboardSourceState,
   ProgressLeaderboardWindow,
   ProgressLeaderboardWindowKey,
@@ -243,6 +244,59 @@ const linkedCloudSettings: CloudSettings = {
   updatedAt: "2026-04-18T09:15:00.000Z",
 };
 
+function createRankingParticipantRow(
+  rank: number,
+  publicProfileId: string,
+  anonymousDisplayName: string,
+  qualifiedReviewCount: number,
+): ProgressLeaderboardRankingRow {
+  return {
+    kind: "participant",
+    publicProfileId,
+    anonymousDisplayName,
+    qualifiedReviewCount,
+    rank,
+  };
+}
+
+function createHiddenRankingParticipantRow(rank: number, qualifiedReviewCount: number): ProgressLeaderboardRankingRow {
+  return createRankingParticipantRow(
+    rank,
+    `profile-${rank}`,
+    `Hidden Rank ${rank}`,
+    qualifiedReviewCount,
+  );
+}
+
+function createLeaderboardRankingRows(): ReadonlyArray<ProgressLeaderboardRankingRow> {
+  const hiddenRowsAboveViewer = Array.from(
+    { length: 37 },
+    (_value, index): ProgressLeaderboardRankingRow => createHiddenRankingParticipantRow(index + 4, 10),
+  );
+  const hiddenRowsBelowViewer = Array.from(
+    { length: 84 },
+    (_value, index): ProgressLeaderboardRankingRow => createHiddenRankingParticipantRow(index + 44, 1),
+  );
+
+  return [
+    createRankingParticipantRow(1, "profile-1", "Silver Bright Harbor", 51),
+    createRankingParticipantRow(2, "profile-2", "Amber Calm Meadow", 44),
+    createRankingParticipantRow(3, "profile-3", "Coral Keen Valley", 30),
+    ...hiddenRowsAboveViewer,
+    createRankingParticipantRow(41, "profile-41", "Jade Swift River", 8),
+    {
+      kind: "viewer",
+      publicProfileId: "viewer-profile",
+      anonymousDisplayName: "Quiet Maple Grove",
+      qualifiedReviewCount: 7,
+      rank: 42,
+    },
+    createRankingParticipantRow(43, "profile-43", "Bold Cedar Crest", 7),
+    ...hiddenRowsBelowViewer,
+    createRankingParticipantRow(128, "profile-128", "Blue Final Harbor", 0),
+  ];
+}
+
 function createLeaderboardWindow(windowKey: ProgressLeaderboardWindowKey): ProgressLeaderboardWindow {
   return {
     windowKey,
@@ -268,6 +322,7 @@ function createLeaderboardWindow(windowKey: ProgressLeaderboardWindowKey): Progr
       { kind: "gap" },
       { kind: "neighbor", publicProfileId: "profile-128", anonymousDisplayName: "Blue Final Harbor", qualifiedReviewCount: 0, rank: 128 },
     ],
+    rankingRows: createLeaderboardRankingRows(),
   };
 }
 
@@ -923,7 +978,7 @@ describe("ProgressScreen", () => {
     expect(container.querySelector("[data-testid='progress-leaderboard-freshness']")).toBeNull();
   });
 
-  it("overlays only the viewer count when the local qualified review count differs", async () => {
+  it("reranks the viewer and renders new neighbors when the local qualified review count moves higher", async () => {
     useAppDataMock.mockReturnValue({
       ...createAppData(),
       cloudSettings: linkedCloudSettings,
@@ -952,11 +1007,21 @@ describe("ProgressScreen", () => {
     }
 
     expect(viewerRow.querySelector("[data-testid='progress-leaderboard-count-viewer']")?.textContent).toBe("9");
-    expect(viewerRow.textContent).toContain("#42");
+    expect(viewerRow.textContent).toContain("#41");
+
+    const rows = [...container.querySelectorAll(".progress-leaderboard-row")];
+    const rowTexts = rows.map((row) => row.textContent);
+    expect(rowTexts[4]).toContain("Hidden Rank 40");
+    expect(rowTexts[4]).toContain("#40");
+    expect(rowTexts[5]).toContain("You");
+    expect(rowTexts[5]).toContain("#41");
+    expect(rowTexts[6]).toContain("Jade Swift River");
+    expect(rowTexts[6]).toContain("#42");
+    expect(container.textContent).not.toContain("Bold Cedar Crest");
 
     const neighborCounts = [...container.querySelectorAll("[data-testid='progress-leaderboard-count-neighbor']")]
       .map((count) => count.textContent);
-    expect(neighborCounts).toEqual(["8", "7", "0"]);
+    expect(neighborCounts).toEqual(["10", "8", "0"]);
 
     const topCounts = [...container.querySelectorAll("[data-testid='progress-leaderboard-count-top']")]
       .map((count) => count.textContent);

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -272,6 +272,18 @@ export type ProgressLeaderboardGapRow = Readonly<{
 
 export type ProgressLeaderboardRow = ProgressLeaderboardParticipantRow | ProgressLeaderboardGapRow;
 
+export const progressLeaderboardRankingRowKinds = ["participant", "viewer"] as const;
+
+export type ProgressLeaderboardRankingRowKind = typeof progressLeaderboardRankingRowKinds[number];
+
+export type ProgressLeaderboardRankingRow = Readonly<{
+  kind: ProgressLeaderboardRankingRowKind;
+  publicProfileId: string;
+  anonymousDisplayName: string;
+  qualifiedReviewCount: number;
+  rank: number;
+}>;
+
 export type ProgressLeaderboardWindow = Readonly<{
   windowKey: ProgressLeaderboardWindowKey;
   snapshotId: string;
@@ -281,6 +293,7 @@ export type ProgressLeaderboardWindow = Readonly<{
   participantCount: number;
   viewer: ProgressLeaderboardViewer;
   rows: ReadonlyArray<ProgressLeaderboardRow>;
+  rankingRows: ReadonlyArray<ProgressLeaderboardRankingRow>;
 }>;
 
 export type ProgressLeaderboard = Readonly<{


### PR DESCRIPTION
## Summary

- add web leaderboard rankingRows contract parsing and cache persistence
- project local viewer review counts onto frozen server ranking rows
- update Progress rendering and cache tests for live viewer rerank behavior

## Validation

- npm run test --prefix apps/web -- src/screens/progress/ProgressScreen.render.test.tsx src/appData/progress/source/progressSource.cache.test.tsx
- npm run build --prefix apps/web