### PR TITLE
[codex] android live viewer leaderboard rerank

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -17,6 +17,8 @@ import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudString
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardMetric
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardViewer
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardWindow
@@ -321,6 +323,15 @@ private fun JSONObject.toCloudProgressLeaderboardWindow(
             )
         }
     }
+    val rankingRowsArray = requireCloudArray("rankingRows", "$fieldPath.rankingRows")
+    val rankingRows = buildList {
+        for (index in 0 until rankingRowsArray.length()) {
+            add(
+                rankingRowsArray.requireCloudObject(index, "$fieldPath.rankingRows[$index]")
+                    .toCloudProgressLeaderboardRankingRow(fieldPath = "$fieldPath.rankingRows[$index]")
+            )
+        }
+    }
 
     return CloudProgressLeaderboardWindow(
         windowKey = ProgressLeaderboardWindowKey.fromWireKey(
@@ -336,13 +347,17 @@ private fun JSONObject.toCloudProgressLeaderboardWindow(
         ),
         viewer = CloudProgressLeaderboardViewer(
             publicProfileId = viewer.requireCloudString("publicProfileId", "$fieldPath.viewer.publicProfileId"),
-            rank = viewer.requireCloudInt("rank", "$fieldPath.viewer.rank"),
+            rank = requirePositiveLeaderboardRank(
+                value = viewer.requireCloudInt("rank", "$fieldPath.viewer.rank"),
+                fieldPath = "$fieldPath.viewer.rank"
+            ),
             qualifiedReviewCount = requireNonNegativeReviewScheduleInt(
                 value = viewer.requireCloudInt("qualifiedReviewCount", "$fieldPath.viewer.qualifiedReviewCount"),
                 fieldPath = "$fieldPath.viewer.qualifiedReviewCount"
             )
         ),
-        rows = rows
+        rows = rows,
+        rankingRows = rankingRows
     )
 }
 
@@ -362,7 +377,40 @@ private fun JSONObject.toCloudProgressLeaderboardRow(
             value = requireCloudInt("qualifiedReviewCount", "$fieldPath.qualifiedReviewCount"),
             fieldPath = "$fieldPath.qualifiedReviewCount"
         ),
-        rank = requireCloudInt("rank", "$fieldPath.rank")
+        rank = requirePositiveLeaderboardRank(
+            value = requireCloudInt("rank", "$fieldPath.rank"),
+            fieldPath = "$fieldPath.rank"
+        )
     )
 }
 
+private fun JSONObject.toCloudProgressLeaderboardRankingRow(
+    fieldPath: String
+): CloudProgressLeaderboardRankingRow {
+    return CloudProgressLeaderboardRankingRow(
+        kind = CloudProgressLeaderboardRankingRowKind.fromWireKey(
+            wireKey = requireCloudString("kind", "$fieldPath.kind")
+        ),
+        publicProfileId = requireCloudString("publicProfileId", "$fieldPath.publicProfileId"),
+        anonymousDisplayName = requireCloudString("anonymousDisplayName", "$fieldPath.anonymousDisplayName"),
+        qualifiedReviewCount = requireNonNegativeReviewScheduleInt(
+            value = requireCloudInt("qualifiedReviewCount", "$fieldPath.qualifiedReviewCount"),
+            fieldPath = "$fieldPath.qualifiedReviewCount"
+        ),
+        rank = requirePositiveLeaderboardRank(
+            value = requireCloudInt("rank", "$fieldPath.rank"),
+            fieldPath = "$fieldPath.rank"
+        )
+    )
+}
+
+private fun requirePositiveLeaderboardRank(
+    value: Int,
+    fieldPath: String
+): Int {
+    if (value < 1) {
+        throw CloudContractMismatchException("$fieldPath must be at least 1.")
+    }
+
+    return value
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
@@ -121,7 +121,7 @@ data class ProgressReviewScheduleCardDueEntity(
     val dueAtMillis: Long?
 )
 
-// Query projections over review_logs for the leaderboard viewer overlay. Qualified
+// Query projections over review_logs for the leaderboard viewer projection. Qualified
 // reviews are Hard/Good/Easy; Again never counts.
 data class ProgressQualifiedReviewWorkspaceCountEntity(
     val workspaceId: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressLeaderboardModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressLeaderboardModels.kt
@@ -60,6 +60,20 @@ enum class ProgressLeaderboardParticipantRowKind(
     }
 }
 
+enum class CloudProgressLeaderboardRankingRowKind(
+    val wireKey: String
+) {
+    PARTICIPANT("participant"),
+    VIEWER("viewer");
+
+    companion object {
+        fun fromWireKey(wireKey: String): CloudProgressLeaderboardRankingRowKind {
+            return entries.firstOrNull { kind -> kind.wireKey == wireKey }
+                ?: throw IllegalArgumentException("Unknown leaderboard ranking row kind '$wireKey'.")
+        }
+    }
+}
+
 data class CloudProgressLeaderboardMetric(
     val metricVersion: String,
     val title: String,
@@ -84,6 +98,14 @@ sealed interface CloudProgressLeaderboardRow {
     data object Gap : CloudProgressLeaderboardRow
 }
 
+data class CloudProgressLeaderboardRankingRow(
+    val kind: CloudProgressLeaderboardRankingRowKind,
+    val publicProfileId: String,
+    val anonymousDisplayName: String,
+    val qualifiedReviewCount: Int,
+    val rank: Int
+)
+
 data class CloudProgressLeaderboardWindow(
     val windowKey: ProgressLeaderboardWindowKey,
     val snapshotId: String,
@@ -92,7 +114,8 @@ data class CloudProgressLeaderboardWindow(
     val nextRefreshAfter: String,
     val participantCount: Int,
     val viewer: CloudProgressLeaderboardViewer,
-    val rows: List<CloudProgressLeaderboardRow>
+    val rows: List<CloudProgressLeaderboardRow>,
+    val rankingRows: List<CloudProgressLeaderboardRankingRow>
 )
 
 data class CloudProgressLeaderboard(
@@ -137,7 +160,7 @@ fun resolveBestLeaderboardPlacement(
 fun resolveBestLeaderboardPlacement(
     snapshot: ProgressLeaderboardSnapshot?
 ): ProgressLeaderboardBestPlacement? {
-    return resolveBestLeaderboardPlacement(leaderboard = snapshot?.leaderboard)
+    return resolveBestLeaderboardPlacement(leaderboard = snapshot?.renderedLeaderboard)
 }
 
 data class ProgressLeaderboardScopeKey(
@@ -147,14 +170,142 @@ data class ProgressLeaderboardScopeKey(
 data class ProgressLeaderboardSnapshot(
     val scopeKey: ProgressLeaderboardScopeKey,
     val cloudState: CloudAccountState,
-    // Last successfully fetched payload for this scope; server ranks stay authoritative.
+    // Last successfully fetched payload for this scope.
     val leaderboard: CloudProgressLeaderboard?,
+    // Server payload projected with locally observed viewer reviews for display.
+    val renderedLeaderboard: CloudProgressLeaderboard?,
     val payloadUpdatedAtMillis: Long?,
     // Locally computed qualified review counts (rating != again) per rolling window,
-    // used only to overlay the viewer row count.
+    // used to project only the current viewer row.
     val viewerLocalQualifiedCounts: Map<ProgressLeaderboardWindowKey, Int>,
     // True once the device clock passed the payload's earliest nextRefreshAfter, so a
     // still-rendered cached payload means the refresh could not happen (e.g. offline).
     val isRefreshDue: Boolean,
     val didLastRemoteLoadFail: Boolean
 )
+
+fun createRenderedProgressLeaderboard(
+    leaderboard: CloudProgressLeaderboard?,
+    viewerLocalQualifiedCounts: Map<ProgressLeaderboardWindowKey, Int>
+): CloudProgressLeaderboard? {
+    if (leaderboard == null || leaderboard.status != ProgressLeaderboardStatus.READY) {
+        return leaderboard
+    }
+
+    return leaderboard.copy(
+        windows = leaderboard.windows.map { window ->
+            window.toRenderedProgressLeaderboardWindow(
+                viewerLocalQualifiedCounts = viewerLocalQualifiedCounts
+            )
+        }
+    )
+}
+
+private fun CloudProgressLeaderboardWindow.toRenderedProgressLeaderboardWindow(
+    viewerLocalQualifiedCounts: Map<ProgressLeaderboardWindowKey, Int>
+): CloudProgressLeaderboardWindow {
+    val viewerRankingRow = requireNotNull(
+        rankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }
+    ) {
+        "Leaderboard rankingRows for window '${windowKey.wireKey}' must include viewer '${viewer.publicProfileId}'."
+    }
+    val viewerCount = maxOf(
+        viewer.qualifiedReviewCount,
+        viewerLocalQualifiedCounts[windowKey] ?: 0
+    )
+    val participantRows = rankingRows.filter { row ->
+        row.kind != CloudProgressLeaderboardRankingRowKind.VIEWER
+    }
+    val viewerInsertionIndex = participantRows.indexOfFirst { row ->
+        row.qualifiedReviewCount < viewerCount
+    }.let { index ->
+        if (index == -1) {
+            participantRows.size
+        } else {
+            index
+        }
+    }
+    val unrankedRows = participantRows.toMutableList().apply {
+        add(
+            viewerInsertionIndex,
+            viewerRankingRow.copy(qualifiedReviewCount = viewerCount)
+        )
+    }
+    val projectedRankingRows = unrankedRows.mapIndexed { index, row ->
+        row.copy(rank = index + 1)
+    }
+    val projectedViewer = requireNotNull(
+        projectedRankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }
+    ) {
+        "Projected leaderboard rankingRows for window '${windowKey.wireKey}' must include viewer '${viewer.publicProfileId}'."
+    }
+
+    return copy(
+        viewer = viewer.copy(
+            rank = projectedViewer.rank,
+            qualifiedReviewCount = projectedViewer.qualifiedReviewCount
+        ),
+        rows = buildProgressLeaderboardCompactRows(rankingRows = projectedRankingRows),
+        rankingRows = projectedRankingRows
+    )
+}
+
+private fun buildProgressLeaderboardCompactRows(
+    rankingRows: List<CloudProgressLeaderboardRankingRow>
+): List<CloudProgressLeaderboardRow> {
+    val totalRowCount = rankingRows.size
+    val topRowCount = minOf(3, totalRowCount)
+    val viewerRank = requireNotNull(
+        rankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }?.rank
+    ) {
+        "Projected leaderboard rankingRows must include a viewer row."
+    }
+    val shownRanks = mutableSetOf<Int>()
+    (1..topRowCount).forEach { rank ->
+        shownRanks.add(rank)
+    }
+    if (viewerRank > topRowCount) {
+        listOf(viewerRank - 1, viewerRank, viewerRank + 1).forEach { rank ->
+            if (rank >= 1 && rank <= totalRowCount) {
+                shownRanks.add(rank)
+            }
+        }
+    } else if (viewerRank == topRowCount && viewerRank < totalRowCount) {
+        shownRanks.add(viewerRank + 1)
+    }
+    if (totalRowCount > topRowCount) {
+        shownRanks.add(totalRowCount)
+    }
+
+    val rowsByRank = rankingRows.associateBy { row -> row.rank }
+    return buildList {
+        var previousRank = 0
+        shownRanks.sorted().forEach { rank ->
+            if (previousRank != 0 && rank > previousRank + 1) {
+                add(CloudProgressLeaderboardRow.Gap)
+            }
+
+            val rankingRow = requireNotNull(rowsByRank[rank]) {
+                "Projected leaderboard rankingRows must include rank $rank."
+            }
+            add(rankingRow.toCompactProgressLeaderboardRow(topRowCount = topRowCount))
+            previousRank = rank
+        }
+    }
+}
+
+private fun CloudProgressLeaderboardRankingRow.toCompactProgressLeaderboardRow(
+    topRowCount: Int
+): CloudProgressLeaderboardRow.Participant {
+    return CloudProgressLeaderboardRow.Participant(
+        kind = when {
+            kind == CloudProgressLeaderboardRankingRowKind.VIEWER -> ProgressLeaderboardParticipantRowKind.VIEWER
+            rank <= topRowCount -> ProgressLeaderboardParticipantRowKind.TOP
+            else -> ProgressLeaderboardParticipantRowKind.NEIGHBOR
+        },
+        publicProfileId = publicProfileId,
+        anonymousDisplayName = anonymousDisplayName,
+        qualifiedReviewCount = qualifiedReviewCount,
+        rank = rank
+    )
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/LocalProgressRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/LocalProgressRepository.kt
@@ -175,7 +175,7 @@ class LocalProgressRepository(
             inputs = inputs,
             clockSnapshot = clockSnapshot
         )
-        // The leaderboard republishes its snapshot here for the viewer-count overlay;
+        // The leaderboard republishes its snapshot here for the viewer projection;
         // remote refreshes stay gated on nextRefreshAfter, not on sync completion.
         leaderboardOrchestration.handleInputs(
             inputs = inputs,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
@@ -7,6 +7,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.ProgressSeriesCa
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSummaryCacheEntity
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewScheduleBucket
@@ -205,6 +206,14 @@ internal fun serializeCloudProgressLeaderboard(
                                     }
                                 }
                             )
+                            .put(
+                                "rankingRows",
+                                JSONArray().apply {
+                                    window.rankingRows.forEach { row ->
+                                        put(row.toCacheJson())
+                                    }
+                                }
+                            )
                     )
                 }
             }
@@ -221,6 +230,15 @@ private fun CloudProgressLeaderboardRow.toCacheJson(): JSONObject {
             .put("qualifiedReviewCount", qualifiedReviewCount)
             .put("rank", rank)
     }
+}
+
+private fun CloudProgressLeaderboardRankingRow.toCacheJson(): JSONObject {
+    return JSONObject()
+        .put("kind", kind.wireKey)
+        .put("publicProfileId", publicProfileId)
+        .put("anonymousDisplayName", anonymousDisplayName)
+        .put("qualifiedReviewCount", qualifiedReviewCount)
+        .put("rank", rank)
 }
 
 internal fun findProgressReviewScheduleServerBase(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressObservedInputs.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressObservedInputs.kt
@@ -23,7 +23,7 @@ import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 
-// Hour-resolution data for the leaderboard viewer overlay. Recent qualified review
+// Hour-resolution data for the leaderboard viewer projection. Recent qualified review
 // times cover every bounded rolling window; total counts back the all-time window.
 internal data class ProgressQualifiedReviewActivity(
     val workspaceCounts: List<ProgressQualifiedReviewWorkspaceCountEntity>,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressLeaderboardOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressLeaderboardOrchestration.kt
@@ -27,8 +27,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 // Compact community leaderboard pipeline. Unlike the other progress surfaces there is
-// no local fallback: the server snapshot is the only source of ranks and anonymous
-// names, the device only caches the last payload and overlays the viewer count.
+// no local fallback: the server snapshot provides participant ranking and anonymous
+// names, while the device projects only the current viewer from local review counts.
 internal class ProgressLeaderboardOrchestration(
     private val database: AppDatabase,
     private val cloudAccountRepository: CloudAccountRepository,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
@@ -17,6 +17,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScope
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.ProgressLeaderboardCachedPayload
 import com.flashcardsopensourceapp.data.local.repository.progress.inputs.ProgressPendingReviewLocalDate
@@ -213,6 +214,11 @@ internal fun createProgressReviewScheduleStoreState(
 internal fun createProgressLeaderboardStoreState(
     inputs: ProgressLeaderboardStoreInputs
 ): ProgressLeaderboardStoreState {
+    val viewerLocalQualifiedCounts = computeProgressLeaderboardViewerLocalQualifiedCounts(
+        qualifiedReviewActivity = inputs.qualifiedReviewActivity,
+        workspaceIds = inputs.workspaceIds,
+        currentTimeMillis = inputs.currentTimeMillis
+    )
     return ProgressLeaderboardStoreState(
         scopeKey = inputs.scopeKey,
         cloudState = inputs.cloudState,
@@ -220,12 +226,12 @@ internal fun createProgressLeaderboardStoreState(
             scopeKey = inputs.scopeKey,
             cloudState = inputs.cloudState,
             leaderboard = inputs.serverBase?.leaderboard,
-            payloadUpdatedAtMillis = inputs.serverBase?.updatedAtMillis,
-            viewerLocalQualifiedCounts = computeProgressLeaderboardViewerLocalQualifiedCounts(
-                qualifiedReviewActivity = inputs.qualifiedReviewActivity,
-                workspaceIds = inputs.workspaceIds,
-                currentTimeMillis = inputs.currentTimeMillis
+            renderedLeaderboard = createRenderedProgressLeaderboard(
+                leaderboard = inputs.serverBase?.leaderboard,
+                viewerLocalQualifiedCounts = viewerLocalQualifiedCounts
             ),
+            payloadUpdatedAtMillis = inputs.serverBase?.updatedAtMillis,
+            viewerLocalQualifiedCounts = viewerLocalQualifiedCounts,
             isRefreshDue = isProgressLeaderboardRefreshDue(
                 leaderboard = inputs.serverBase?.leaderboard,
                 currentTimeMillis = inputs.currentTimeMillis

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -2,6 +2,7 @@ package com.flashcardsopensourceapp.data.local.cloud.remote
 
 import com.flashcardsopensourceapp.data.local.cloud.identity.syncWorkspaceForkRequiredErrorCode
 import com.flashcardsopensourceapp.data.local.cloud.remote.guest.buildGuestUpgradeCompleteRequest
+import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressReviewScheduleResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSeriesResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSummaryResponse
@@ -9,6 +10,8 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.sync.parseRemotePushR
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.parseCloudErrorPayload
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
 import org.json.JSONObject
@@ -257,6 +260,81 @@ class CloudRemoteServiceTest {
         )
 
         assertTrue(schedule.reviewHistoryWatermarks.isEmpty())
+    }
+
+    @Test
+    fun parseCloudProgressLeaderboardReadsRankingRows() {
+        val response = JSONObject(
+            """
+            {
+              "status": "ready",
+              "metric": {
+                "metricVersion": "qualified_reviews_v1",
+                "title": "Qualified reviews",
+                "description": "Hard, Good, and Easy reviews count toward your rank. Again does not."
+              },
+              "defaultWindowKey": "last_24_hours",
+              "windows": [
+                {
+                  "windowKey": "last_24_hours",
+                  "snapshotId": "snapshot-1",
+                  "snapshotGeneratedAt": "2026-04-18T14:00:05.000Z",
+                  "asOfServerHour": "2026-04-18T14:00:00.000Z",
+                  "nextRefreshAfter": "2026-04-18T15:00:00.000Z",
+                  "participantCount": 2,
+                  "viewer": {
+                    "publicProfileId": "viewer-profile",
+                    "rank": 2,
+                    "qualifiedReviewCount": 7
+                  },
+                  "rows": [
+                    {
+                      "kind": "top",
+                      "publicProfileId": "participant-1",
+                      "anonymousDisplayName": "Silver Bright Harbor",
+                      "qualifiedReviewCount": 9,
+                      "rank": 1
+                    },
+                    {
+                      "kind": "viewer",
+                      "publicProfileId": "viewer-profile",
+                      "anonymousDisplayName": "Misty Quiet Grove",
+                      "qualifiedReviewCount": 7,
+                      "rank": 2
+                    }
+                  ],
+                  "rankingRows": [
+                    {
+                      "kind": "participant",
+                      "publicProfileId": "participant-1",
+                      "anonymousDisplayName": "Silver Bright Harbor",
+                      "qualifiedReviewCount": 9,
+                      "rank": 1
+                    },
+                    {
+                      "kind": "viewer",
+                      "publicProfileId": "viewer-profile",
+                      "anonymousDisplayName": "Misty Quiet Grove",
+                      "qualifiedReviewCount": 7,
+                      "rank": 2
+                    }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val leaderboard = parseCloudProgressLeaderboard(
+            payload = response,
+            fieldPath = "progress.leaderboard"
+        )
+
+        val window = leaderboard.windows.single()
+        assertEquals(ProgressLeaderboardWindowKey.LAST_24_HOURS, window.windowKey)
+        assertEquals(2, window.rankingRows.size)
+        assertEquals(CloudProgressLeaderboardRankingRowKind.VIEWER, window.rankingRows[1].kind)
+        assertEquals("viewer-profile", window.rankingRows[1].publicProfileId)
     }
 
     @Test

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
@@ -7,9 +7,19 @@ import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewSc
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewHistoryStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardMetric
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardViewer
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardWindow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewScheduleBucket
-import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import java.time.LocalDate
 import java.time.ZoneId
@@ -130,6 +140,89 @@ internal fun createReviewSchedule(
         reviewHistoryWatermarks = emptyList(),
         totalCards = buckets.sumOf(CloudProgressReviewScheduleBucket::count),
         buckets = buckets
+    )
+}
+
+internal fun createProgressLeaderboardForTest(
+    windowKey: ProgressLeaderboardWindowKey,
+    rankingRows: List<CloudProgressLeaderboardRankingRow>
+): CloudProgressLeaderboard {
+    return CloudProgressLeaderboard(
+        status = ProgressLeaderboardStatus.READY,
+        metric = CloudProgressLeaderboardMetric(
+            metricVersion = "qualified_reviews_v1",
+            title = "Qualified reviews",
+            description = "Hard, Good, and Easy reviews count toward your rank. Again does not."
+        ),
+        defaultWindowKey = windowKey,
+        windows = listOf(
+            createProgressLeaderboardWindowForTest(
+                windowKey = windowKey,
+                rankingRows = rankingRows
+            )
+        )
+    )
+}
+
+internal fun createProgressLeaderboardWindowForTest(
+    windowKey: ProgressLeaderboardWindowKey,
+    rankingRows: List<CloudProgressLeaderboardRankingRow>
+): CloudProgressLeaderboardWindow {
+    val viewerRow = requireNotNull(
+        rankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }
+    )
+    return CloudProgressLeaderboardWindow(
+        windowKey = windowKey,
+        snapshotId = "snapshot-1",
+        snapshotGeneratedAt = "2026-04-18T14:00:05.000Z",
+        asOfServerHour = "2026-04-18T14:00:00.000Z",
+        nextRefreshAfter = "2026-04-18T15:00:00.000Z",
+        participantCount = rankingRows.size,
+        viewer = CloudProgressLeaderboardViewer(
+            publicProfileId = viewerRow.publicProfileId,
+            rank = viewerRow.rank,
+            qualifiedReviewCount = viewerRow.qualifiedReviewCount
+        ),
+        rows = rankingRows.map { row ->
+            createProgressLeaderboardParticipantRowForTest(
+                kind = when {
+                    row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER -> ProgressLeaderboardParticipantRowKind.VIEWER
+                    row.rank <= 3 -> ProgressLeaderboardParticipantRowKind.TOP
+                    else -> ProgressLeaderboardParticipantRowKind.NEIGHBOR
+                },
+                rankingRow = row
+            )
+        },
+        rankingRows = rankingRows
+    )
+}
+
+internal fun createProgressLeaderboardRankingRowForTest(
+    kind: CloudProgressLeaderboardRankingRowKind,
+    publicProfileId: String,
+    anonymousDisplayName: String,
+    qualifiedReviewCount: Int,
+    rank: Int
+): CloudProgressLeaderboardRankingRow {
+    return CloudProgressLeaderboardRankingRow(
+        kind = kind,
+        publicProfileId = publicProfileId,
+        anonymousDisplayName = anonymousDisplayName,
+        qualifiedReviewCount = qualifiedReviewCount,
+        rank = rank
+    )
+}
+
+private fun createProgressLeaderboardParticipantRowForTest(
+    kind: ProgressLeaderboardParticipantRowKind,
+    rankingRow: CloudProgressLeaderboardRankingRow
+): CloudProgressLeaderboardRow.Participant {
+    return CloudProgressLeaderboardRow.Participant(
+        kind = kind,
+        publicProfileId = rankingRow.publicProfileId,
+        anonymousDisplayName = rankingRow.anonymousDisplayName,
+        qualifiedReviewCount = rankingRow.qualifiedReviewCount,
+        rank = rankingRow.rank
     )
 }
 

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
@@ -5,15 +5,21 @@ import com.flashcardsopensourceapp.data.local.database.entities.ProgressSeriesCa
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSummaryCacheEntity
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.findProgressReviewScheduleServerBase
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCacheEntity
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressLeaderboardOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressReviewScheduleOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressSeriesOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressSummaryOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.createCloudSettings
+import com.flashcardsopensourceapp.data.local.repository.progress.createProgressLeaderboardForTest
+import com.flashcardsopensourceapp.data.local.repository.progress.createProgressLeaderboardRankingRowForTest
 import com.flashcardsopensourceapp.data.local.repository.progress.createReviewSchedule
 import java.time.LocalDate
 import java.time.ZoneId
@@ -204,5 +210,43 @@ class ProgressCacheValidationTest {
                 updatedAtMillis = 1L
             ).toCloudProgressReviewScheduleOrNull()?.reviewHistoryWatermarks
         )
+    }
+
+    @Test
+    fun progressLeaderboardCachePreservesRankingRows(): Unit {
+        val leaderboard = createProgressLeaderboardForTest(
+            windowKey = ProgressLeaderboardWindowKey.LAST_24_HOURS,
+            rankingRows = listOf(
+                createProgressLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+                    publicProfileId = "participant-1",
+                    anonymousDisplayName = "Silver Bright Harbor",
+                    qualifiedReviewCount = 9,
+                    rank = 1
+                ),
+                createProgressLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.VIEWER,
+                    publicProfileId = "viewer-profile",
+                    anonymousDisplayName = "Misty Quiet Grove",
+                    qualifiedReviewCount = 7,
+                    rank = 2
+                )
+            )
+        )
+
+        val restoredLeaderboard = leaderboard.toCacheEntity(
+            scopeKey = ProgressLeaderboardScopeKey(scopeId = "linked:user-1"),
+            updatedAtMillis = 1L
+        ).toCloudProgressLeaderboardOrNull()
+
+        val restoredRows = checkNotNull(restoredLeaderboard).windows.single().rankingRows
+        assertEquals(
+            listOf(
+                CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+                CloudProgressLeaderboardRankingRowKind.VIEWER
+            ),
+            restoredRows.map { row -> row.kind }
+        )
+        assertEquals(listOf(1, 2), restoredRows.map { row -> row.rank })
     }
 }

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -199,7 +199,7 @@ internal fun createProgressLeaderboardSectionUiState(
         return ProgressLeaderboardSectionUiState.SignInRequired
     }
 
-    val leaderboard = snapshot.leaderboard
+    val leaderboard = snapshot.renderedLeaderboard
     if (leaderboard == null) {
         return if (snapshot.didLastRemoteLoadFail) {
             ProgressLeaderboardSectionUiState.Offline
@@ -214,9 +214,7 @@ internal fun createProgressLeaderboardSectionUiState(
         ProgressLeaderboardStatus.SNAPSHOT_UNAVAILABLE -> ProgressLeaderboardSectionUiState.SnapshotUnavailable
         ProgressLeaderboardStatus.READY -> {
             val windows = leaderboard.windows.map { window ->
-                window.toUiState(
-                    viewerLocalQualifiedCount = snapshot.viewerLocalQualifiedCounts[window.windowKey] ?: 0
-                )
+                window.toUiState()
             }
             ProgressLeaderboardSectionUiState.Ready(
                 metricDescription = leaderboard.metric.description.takeIf { description ->
@@ -224,7 +222,7 @@ internal fun createProgressLeaderboardSectionUiState(
                 },
                 selectedWindowKey = selectedWindowKey
                     ?.takeIf { windowKey -> windows.any { window -> window.windowKey == windowKey } }
-                    ?: resolveBestLeaderboardPlacement(leaderboard = leaderboard)?.windowKey
+                    ?: resolveBestLeaderboardPlacement(snapshot = snapshot)?.windowKey
                     ?: leaderboard.defaultWindowKey,
                 windows = windows
             )
@@ -232,9 +230,7 @@ internal fun createProgressLeaderboardSectionUiState(
     }
 }
 
-private fun CloudProgressLeaderboardWindow.toUiState(
-    viewerLocalQualifiedCount: Int
-): ProgressLeaderboardWindowUiState {
+private fun CloudProgressLeaderboardWindow.toUiState(): ProgressLeaderboardWindowUiState {
     return ProgressLeaderboardWindowUiState(
         windowKey = windowKey,
         participantCount = participantCount,
@@ -244,13 +240,7 @@ private fun CloudProgressLeaderboardWindow.toUiState(
                 is CloudProgressLeaderboardRow.Participant -> ProgressLeaderboardRowUiState.Participant(
                     rank = row.rank,
                     displayName = row.anonymousDisplayName,
-                    // Only the viewer count is overlaid with the locally observed
-                    // qualified reviews; ranks and other rows stay server-authoritative.
-                    qualifiedReviewCount = if (row.kind == ProgressLeaderboardParticipantRowKind.VIEWER) {
-                        maxOf(row.qualifiedReviewCount, viewerLocalQualifiedCount)
-                    } else {
-                        row.qualifiedReviewCount
-                    },
+                    qualifiedReviewCount = row.qualifiedReviewCount,
                     isViewer = row.kind == ProgressLeaderboardParticipantRowKind.VIEWER
                 )
             }

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
@@ -5,6 +5,8 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardMetric
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardViewer
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardWindow
@@ -25,6 +27,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnaps
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -406,7 +409,7 @@ class ProgressViewModelTest {
     }
 
     @Test
-    fun leaderboardLiveOverlayChangesOnlyViewerCount() {
+    fun leaderboardLiveProjectionMovesViewerRankAndRows() {
         val sectionUiState = createProgressLeaderboardSectionUiState(
             snapshot = createProgressLeaderboardSnapshot(
                 viewerLocalQualifiedCounts = mapOf(
@@ -420,16 +423,20 @@ class ProgressViewModelTest {
         val participants = rows.filterIsInstance<ProgressLeaderboardRowUiState.Participant>()
         val viewerRow = participants.single(ProgressLeaderboardRowUiState.Participant::isViewer)
         assertEquals(9, viewerRow.qualifiedReviewCount)
-        assertEquals(42, viewerRow.rank)
+        assertEquals(41, viewerRow.rank)
         assertEquals(
-            listOf(51, 33, 21, 8, 7, 0),
+            listOf(1, 2, 3, 40, 41, 42, 128),
+            participants.map(ProgressLeaderboardRowUiState.Participant::rank)
+        )
+        assertEquals(
+            listOf(51, 33, 21, 9, 8, 0),
             participants.filterNot(ProgressLeaderboardRowUiState.Participant::isViewer)
                 .map(ProgressLeaderboardRowUiState.Participant::qualifiedReviewCount)
         )
     }
 
     @Test
-    fun leaderboardLiveOverlayNeverLowersServerViewerCount() {
+    fun leaderboardLiveProjectionNeverLowersServerViewerCount() {
         val sectionUiState = createProgressLeaderboardSectionUiState(
             snapshot = createProgressLeaderboardSnapshot(
                 viewerLocalQualifiedCounts = mapOf(
@@ -727,6 +734,10 @@ private fun createProgressLeaderboardSnapshot(
         scopeKey = ProgressLeaderboardScopeKey(scopeId = "linked:user-1"),
         cloudState = cloudState,
         leaderboard = leaderboard,
+        renderedLeaderboard = createRenderedProgressLeaderboard(
+            leaderboard = leaderboard,
+            viewerLocalQualifiedCounts = viewerLocalQualifiedCounts
+        ),
         payloadUpdatedAtMillis = if (leaderboard == null) null else 1_750_000_000_000L,
         viewerLocalQualifiedCounts = viewerLocalQualifiedCounts,
         isRefreshDue = false,
@@ -761,6 +772,11 @@ private fun createCloudProgressLeaderboardWindow(
     windowKey: ProgressLeaderboardWindowKey,
     viewerRank: Int
 ): CloudProgressLeaderboardWindow {
+    val rankingRows = createLeaderboardRankingRows(
+        viewerRank = viewerRank,
+        viewerQualifiedReviewCount = 7,
+        participantCount = 128
+    )
     return CloudProgressLeaderboardWindow(
         windowKey = windowKey,
         snapshotId = "snapshot-1",
@@ -773,59 +789,136 @@ private fun createCloudProgressLeaderboardWindow(
             rank = viewerRank,
             qualifiedReviewCount = 7
         ),
-        rows = listOf(
-            createLeaderboardParticipantRow(
-                kind = ProgressLeaderboardParticipantRowKind.TOP,
-                publicProfileId = "top-1",
-                anonymousDisplayName = "Silver Bright Harbor",
-                qualifiedReviewCount = 51,
-                rank = 1
-            ),
-            createLeaderboardParticipantRow(
-                kind = ProgressLeaderboardParticipantRowKind.TOP,
-                publicProfileId = "top-2",
-                anonymousDisplayName = "Amber Calm Meadow",
-                qualifiedReviewCount = 33,
-                rank = 2
-            ),
-            createLeaderboardParticipantRow(
-                kind = ProgressLeaderboardParticipantRowKind.TOP,
-                publicProfileId = "top-3",
-                anonymousDisplayName = "Coral Keen Valley",
-                qualifiedReviewCount = 21,
-                rank = 3
-            ),
-            CloudProgressLeaderboardRow.Gap,
-            createLeaderboardParticipantRow(
-                kind = ProgressLeaderboardParticipantRowKind.NEIGHBOR,
-                publicProfileId = "neighbor-41",
-                anonymousDisplayName = "Jade Swift River",
-                qualifiedReviewCount = 8,
-                rank = 41
-            ),
-            createLeaderboardParticipantRow(
-                kind = ProgressLeaderboardParticipantRowKind.VIEWER,
-                publicProfileId = "viewer-profile",
-                anonymousDisplayName = "Misty Quiet Grove",
-                qualifiedReviewCount = 7,
-                rank = viewerRank
-            ),
-            createLeaderboardParticipantRow(
-                kind = ProgressLeaderboardParticipantRowKind.NEIGHBOR,
-                publicProfileId = "neighbor-43",
-                anonymousDisplayName = "Sunny Brave Cliff",
-                qualifiedReviewCount = 7,
-                rank = 43
-            ),
-            CloudProgressLeaderboardRow.Gap,
-            createLeaderboardParticipantRow(
-                kind = ProgressLeaderboardParticipantRowKind.NEIGHBOR,
-                publicProfileId = "last-128",
-                anonymousDisplayName = "Blue Final Harbor",
-                qualifiedReviewCount = 0,
-                rank = 128
-            )
+        rows = createLeaderboardCompactRows(rankingRows = rankingRows),
+        rankingRows = rankingRows
+    )
+}
+
+private fun createLeaderboardRankingRows(
+    viewerRank: Int,
+    viewerQualifiedReviewCount: Int,
+    participantCount: Int
+): List<CloudProgressLeaderboardRankingRow> {
+    return (1..participantCount).map { rank ->
+        val isViewer = rank == viewerRank
+        CloudProgressLeaderboardRankingRow(
+            kind = if (isViewer) {
+                CloudProgressLeaderboardRankingRowKind.VIEWER
+            } else {
+                CloudProgressLeaderboardRankingRowKind.PARTICIPANT
+            },
+            publicProfileId = if (isViewer) {
+                "viewer-profile"
+            } else {
+                "participant-$rank"
+            },
+            anonymousDisplayName = if (isViewer) {
+                "Misty Quiet Grove"
+            } else {
+                leaderboardDisplayNameForRank(rank = rank)
+            },
+            qualifiedReviewCount = if (isViewer) {
+                viewerQualifiedReviewCount
+            } else {
+                leaderboardQualifiedReviewCountForRank(
+                    rank = rank,
+                    viewerRank = viewerRank,
+                    viewerQualifiedReviewCount = viewerQualifiedReviewCount,
+                    participantCount = participantCount
+                )
+            },
+            rank = rank
         )
+    }
+}
+
+private fun leaderboardDisplayNameForRank(rank: Int): String {
+    return when (rank) {
+        1 -> "Silver Bright Harbor"
+        2 -> "Amber Calm Meadow"
+        3 -> "Coral Keen Valley"
+        40 -> "Teal Steady Summit"
+        41 -> "Jade Swift River"
+        42 -> "Misty Quiet Grove"
+        43 -> "Sunny Brave Cliff"
+        128 -> "Blue Final Harbor"
+        else -> "Participant $rank"
+    }
+}
+
+private fun leaderboardQualifiedReviewCountForRank(
+    rank: Int,
+    viewerRank: Int,
+    viewerQualifiedReviewCount: Int,
+    participantCount: Int
+): Int {
+    return when {
+        rank == 1 -> 51
+        rank == 2 -> 33
+        rank == 3 -> 21
+        rank == participantCount -> 0
+        rank < viewerRank - 1 -> viewerQualifiedReviewCount + 2
+        rank < viewerRank -> viewerQualifiedReviewCount + 1
+        else -> maxOf(0, viewerQualifiedReviewCount - 1)
+    }
+}
+
+private fun createLeaderboardCompactRows(
+    rankingRows: List<CloudProgressLeaderboardRankingRow>
+): List<CloudProgressLeaderboardRow> {
+    val totalRowCount = rankingRows.size
+    val topRowCount = minOf(3, totalRowCount)
+    val viewerRank = checkNotNull(
+        rankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }?.rank
+    )
+    val shownRanks = mutableSetOf<Int>()
+    (1..topRowCount).forEach { rank ->
+        shownRanks.add(rank)
+    }
+    if (viewerRank > topRowCount) {
+        listOf(viewerRank - 1, viewerRank, viewerRank + 1).forEach { rank ->
+            if (rank >= 1 && rank <= totalRowCount) {
+                shownRanks.add(rank)
+            }
+        }
+    } else if (viewerRank == topRowCount && viewerRank < totalRowCount) {
+        shownRanks.add(viewerRank + 1)
+    }
+    if (totalRowCount > topRowCount) {
+        shownRanks.add(totalRowCount)
+    }
+
+    val rowsByRank = rankingRows.associateBy { row -> row.rank }
+    return buildList {
+        var previousRank = 0
+        shownRanks.sorted().forEach { rank ->
+            if (previousRank != 0 && rank > previousRank + 1) {
+                add(CloudProgressLeaderboardRow.Gap)
+            }
+
+            add(
+                checkNotNull(rowsByRank[rank]).toLeaderboardParticipantRow(
+                    topRowCount = topRowCount
+                )
+            )
+            previousRank = rank
+        }
+    }
+}
+
+private fun CloudProgressLeaderboardRankingRow.toLeaderboardParticipantRow(
+    topRowCount: Int
+): CloudProgressLeaderboardRow.Participant {
+    return createLeaderboardParticipantRow(
+        kind = when {
+            kind == CloudProgressLeaderboardRankingRowKind.VIEWER -> ProgressLeaderboardParticipantRowKind.VIEWER
+            rank <= topRowCount -> ProgressLeaderboardParticipantRowKind.TOP
+            else -> ProgressLeaderboardParticipantRowKind.NEIGHBOR
+        },
+        publicProfileId = publicProfileId,
+        anonymousDisplayName = anonymousDisplayName,
+        qualifiedReviewCount = qualifiedReviewCount,
+        rank = rank
     )
 }
 

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
@@ -1,10 +1,24 @@
 package com.flashcardsopensourceapp.feature.review
 
 import androidx.lifecycle.Lifecycle
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardMetric
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardViewer
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardWindow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressLeaderboard
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -47,6 +61,139 @@ class ReviewProgressBadgeStateTest {
             shouldTriggerInitialReviewProgressLoad(lifecycleState = Lifecycle.State.STARTED)
         )
     }
+
+    @Test
+    fun reviewLeaderboardBadgeUsesProjectedViewerRank() {
+        val leaderboard = createProgressLeaderboardForBadgeTest()
+        val viewerLocalQualifiedCounts = mapOf(
+            ProgressLeaderboardWindowKey.LAST_24_HOURS to 10
+        )
+        val snapshot = ProgressLeaderboardSnapshot(
+            scopeKey = ProgressLeaderboardScopeKey(scopeId = "linked:user-1"),
+            cloudState = CloudAccountState.LINKED,
+            leaderboard = leaderboard,
+            renderedLeaderboard = createRenderedProgressLeaderboard(
+                leaderboard = leaderboard,
+                viewerLocalQualifiedCounts = viewerLocalQualifiedCounts
+            ),
+            payloadUpdatedAtMillis = 1_750_000_000_000L,
+            viewerLocalQualifiedCounts = viewerLocalQualifiedCounts,
+            isRefreshDue = false,
+            didLastRemoteLoadFail = false
+        )
+
+        val badgeState = snapshot.toReviewLeaderboardBadgeState()
+
+        assertEquals(2, badgeState.rank)
+        assertEquals(ProgressLeaderboardWindowKey.LAST_24_HOURS, badgeState.windowKey)
+    }
+}
+
+private fun createProgressLeaderboardForBadgeTest(): CloudProgressLeaderboard {
+    return CloudProgressLeaderboard(
+        status = ProgressLeaderboardStatus.READY,
+        metric = CloudProgressLeaderboardMetric(
+            metricVersion = "qualified_reviews_v1",
+            title = "Qualified reviews",
+            description = "Hard, Good, and Easy reviews count toward your rank. Again does not."
+        ),
+        defaultWindowKey = ProgressLeaderboardWindowKey.LAST_24_HOURS,
+        windows = listOf(createProgressLeaderboardWindowForBadgeTest())
+    )
+}
+
+private fun createProgressLeaderboardWindowForBadgeTest(): CloudProgressLeaderboardWindow {
+    val rankingRows = listOf(
+        createProgressLeaderboardRankingRowForBadgeTest(
+            kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+            publicProfileId = "participant-1",
+            anonymousDisplayName = "Silver Bright Harbor",
+            qualifiedReviewCount = 10,
+            rank = 1
+        ),
+        createProgressLeaderboardRankingRowForBadgeTest(
+            kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+            publicProfileId = "participant-2",
+            anonymousDisplayName = "Amber Calm Meadow",
+            qualifiedReviewCount = 9,
+            rank = 2
+        ),
+        createProgressLeaderboardRankingRowForBadgeTest(
+            kind = CloudProgressLeaderboardRankingRowKind.VIEWER,
+            publicProfileId = "viewer-profile",
+            anonymousDisplayName = "Misty Quiet Grove",
+            qualifiedReviewCount = 7,
+            rank = 3
+        ),
+        createProgressLeaderboardRankingRowForBadgeTest(
+            kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+            publicProfileId = "participant-4",
+            anonymousDisplayName = "Sunny Brave Cliff",
+            qualifiedReviewCount = 6,
+            rank = 4
+        )
+    )
+    return CloudProgressLeaderboardWindow(
+        windowKey = ProgressLeaderboardWindowKey.LAST_24_HOURS,
+        snapshotId = "snapshot-1",
+        snapshotGeneratedAt = "2026-04-18T14:00:05.000Z",
+        asOfServerHour = "2026-04-18T14:00:00.000Z",
+        nextRefreshAfter = "2026-04-18T15:00:00.000Z",
+        participantCount = rankingRows.size,
+        viewer = CloudProgressLeaderboardViewer(
+            publicProfileId = "viewer-profile",
+            rank = 3,
+            qualifiedReviewCount = 7
+        ),
+        rows = listOf(
+            createProgressLeaderboardRowForBadgeTest(
+                kind = ProgressLeaderboardParticipantRowKind.TOP,
+                rankingRow = rankingRows[0]
+            ),
+            createProgressLeaderboardRowForBadgeTest(
+                kind = ProgressLeaderboardParticipantRowKind.TOP,
+                rankingRow = rankingRows[1]
+            ),
+            createProgressLeaderboardRowForBadgeTest(
+                kind = ProgressLeaderboardParticipantRowKind.VIEWER,
+                rankingRow = rankingRows[2]
+            ),
+            createProgressLeaderboardRowForBadgeTest(
+                kind = ProgressLeaderboardParticipantRowKind.NEIGHBOR,
+                rankingRow = rankingRows[3]
+            )
+        ),
+        rankingRows = rankingRows
+    )
+}
+
+private fun createProgressLeaderboardRankingRowForBadgeTest(
+    kind: CloudProgressLeaderboardRankingRowKind,
+    publicProfileId: String,
+    anonymousDisplayName: String,
+    qualifiedReviewCount: Int,
+    rank: Int
+): CloudProgressLeaderboardRankingRow {
+    return CloudProgressLeaderboardRankingRow(
+        kind = kind,
+        publicProfileId = publicProfileId,
+        anonymousDisplayName = anonymousDisplayName,
+        qualifiedReviewCount = qualifiedReviewCount,
+        rank = rank
+    )
+}
+
+private fun createProgressLeaderboardRowForBadgeTest(
+    kind: ProgressLeaderboardParticipantRowKind,
+    rankingRow: CloudProgressLeaderboardRankingRow
+): CloudProgressLeaderboardRow.Participant {
+    return CloudProgressLeaderboardRow.Participant(
+        kind = kind,
+        publicProfileId = rankingRow.publicProfileId,
+        anonymousDisplayName = rankingRow.anonymousDisplayName,
+        qualifiedReviewCount = rankingRow.qualifiedReviewCount,
+        rank = rankingRow.rank
+    )
 }
 
 private fun createProgressSummarySnapshot(


### PR DESCRIPTION
## Summary
- Parse and cache leaderboard `rankingRows` on Android.
- Project the current viewer's leaderboard rank from local Room review counts.
- Use projected ranks in the Progress leaderboard and Review trophy badge.

## Validation
- `git --no-pager diff --check`
- Android Gradle tests were not run because this repository requires explicit approval before local `./gradlew` runs.