### PR TITLE
[codex] Rerank iOS leaderboard viewer locally

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -73,6 +73,10 @@ extension FlashcardsStore {
                 return
             }
 
+            guard self.shouldRefreshProgressLeaderboard(scopeKey: leaderboardScopeKey, now: now) else {
+                return
+            }
+
             guard let activeSession = self.activeProgressCloudSession(scopeKey: scopeKey) else {
                 return
             }

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
@@ -77,6 +77,21 @@ struct ProgressLeaderboardParticipantRow: Codable, Hashable, Sendable {
     let rank: Int
 }
 
+enum ProgressLeaderboardRankingRowKind: String, Codable, Hashable, Sendable {
+    case participant
+    case viewer
+}
+
+struct ProgressLeaderboardRankingRow: Codable, Hashable, Sendable {
+    let kind: ProgressLeaderboardRankingRowKind
+    let publicProfileId: String
+    /// Server-generated from the public profile id and the request locale.
+    /// Clients must never generate or persist their own anonymous names.
+    let anonymousDisplayName: String
+    let qualifiedReviewCount: Int
+    let rank: Int
+}
+
 enum ProgressLeaderboardRow: Codable, Hashable, Sendable {
     case participant(ProgressLeaderboardParticipantRow)
     case gap
@@ -118,6 +133,7 @@ struct ProgressLeaderboardWindow: Codable, Hashable, Sendable {
     let participantCount: Int
     let viewer: ProgressLeaderboardViewer
     let rows: [ProgressLeaderboardRow]
+    let rankingRows: [ProgressLeaderboardRankingRow]
 }
 
 struct UserProgressLeaderboard: Codable, Hashable, Sendable {
@@ -136,8 +152,12 @@ enum ProgressLeaderboardValidationError: LocalizedError {
     case invalidViewerRank(windowKey: String, rank: Int, participantCount: Int)
     case negativeReviewCount(windowKey: String, reviewCount: Int)
     case invalidRowRank(windowKey: String, rank: Int)
+    case rankingRowCountMismatch(windowKey: String, participantCount: Int, rankingRowCount: Int)
+    case invalidRankingRowRank(windowKey: String, expectedRank: Int, actualRank: Int)
+    case unorderedRankingRows(windowKey: String, previousRank: Int, previousReviewCount: Int, rank: Int, reviewCount: Int)
     case tooManyGapRows(windowKey: String, gapRowCount: Int)
     case viewerRowMismatch(windowKey: String)
+    case viewerRankingRowMismatch(windowKey: String)
 
     var errorDescription: String? {
         switch self {
@@ -155,10 +175,18 @@ enum ProgressLeaderboardValidationError: LocalizedError {
             return "Leaderboard window \(windowKey) contained a negative review count: \(reviewCount)."
         case .invalidRowRank(let windowKey, let rank):
             return "Leaderboard window \(windowKey) contained an invalid row rank: \(rank)."
+        case .rankingRowCountMismatch(let windowKey, let participantCount, let rankingRowCount):
+            return "Leaderboard window \(windowKey) participant count \(participantCount) did not match ranking row count \(rankingRowCount)."
+        case .invalidRankingRowRank(let windowKey, let expectedRank, let actualRank):
+            return "Leaderboard window \(windowKey) expected ranking row rank \(expectedRank), received \(actualRank)."
+        case .unorderedRankingRows(let windowKey, let previousRank, let previousReviewCount, let rank, let reviewCount):
+            return "Leaderboard window \(windowKey) ranking row \(rank) count \(reviewCount) exceeded previous rank \(previousRank) count \(previousReviewCount)."
         case .tooManyGapRows(let windowKey, let gapRowCount):
             return "Leaderboard window \(windowKey) contained \(gapRowCount) gap rows. At most \(progressLeaderboardMaximumGapRowCount) are allowed."
         case .viewerRowMismatch(let windowKey):
             return "Leaderboard window \(windowKey) rows did not contain exactly one viewer row matching the viewer."
+        case .viewerRankingRowMismatch(let windowKey):
+            return "Leaderboard window \(windowKey) ranking rows did not contain exactly one viewer row matching the viewer."
         }
     }
 }
@@ -251,6 +279,8 @@ private func validateProgressLeaderboardWindow(window: ProgressLeaderboardWindow
         )
     }
 
+    try validateProgressLeaderboardRankingRows(window: window)
+
     var viewerRows: [ProgressLeaderboardParticipantRow] = []
     var gapRowCount: Int = 0
     for row in window.rows {
@@ -295,5 +325,64 @@ private func validateProgressLeaderboardWindow(window: ProgressLeaderboardWindow
         viewerRow.qualifiedReviewCount == window.viewer.qualifiedReviewCount
     else {
         throw ProgressLeaderboardValidationError.viewerRowMismatch(windowKey: windowKey)
+    }
+}
+
+private func validateProgressLeaderboardRankingRows(window: ProgressLeaderboardWindow) throws {
+    let windowKey = window.windowKey.rawValue
+
+    guard window.rankingRows.count == window.participantCount else {
+        throw ProgressLeaderboardValidationError.rankingRowCountMismatch(
+            windowKey: windowKey,
+            participantCount: window.participantCount,
+            rankingRowCount: window.rankingRows.count
+        )
+    }
+
+    var viewerRows: [ProgressLeaderboardRankingRow] = []
+    var previousRankingRow: ProgressLeaderboardRankingRow?
+    for (index, rankingRow) in window.rankingRows.enumerated() {
+        guard rankingRow.qualifiedReviewCount >= 0 else {
+            throw ProgressLeaderboardValidationError.negativeReviewCount(
+                windowKey: windowKey,
+                reviewCount: rankingRow.qualifiedReviewCount
+            )
+        }
+
+        let expectedRank = index + 1
+        guard rankingRow.rank == expectedRank else {
+            throw ProgressLeaderboardValidationError.invalidRankingRowRank(
+                windowKey: windowKey,
+                expectedRank: expectedRank,
+                actualRank: rankingRow.rank
+            )
+        }
+
+        if let previousRankingRow,
+           rankingRow.qualifiedReviewCount > previousRankingRow.qualifiedReviewCount {
+            throw ProgressLeaderboardValidationError.unorderedRankingRows(
+                windowKey: windowKey,
+                previousRank: previousRankingRow.rank,
+                previousReviewCount: previousRankingRow.qualifiedReviewCount,
+                rank: rankingRow.rank,
+                reviewCount: rankingRow.qualifiedReviewCount
+            )
+        }
+
+        if rankingRow.kind == .viewer {
+            viewerRows.append(rankingRow)
+        }
+
+        previousRankingRow = rankingRow
+    }
+
+    guard
+        viewerRows.count == 1,
+        let viewerRow = viewerRows.first,
+        viewerRow.publicProfileId == window.viewer.publicProfileId,
+        viewerRow.rank == window.viewer.rank,
+        viewerRow.qualifiedReviewCount == window.viewer.qualifiedReviewCount
+    else {
+        throw ProgressLeaderboardValidationError.viewerRankingRowMismatch(windowKey: windowKey)
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
@@ -122,6 +122,7 @@ struct ProgressLeaderboardWindowState: Hashable, Identifiable, Sendable {
     let windowKey: LeaderboardWindowKey
     let snapshotGeneratedAt: String
     let participantCount: Int
+    /// Viewer rank after applying the local live qualified count to the frozen ranking.
     let viewerRank: Int
     /// Server snapshot count overlaid with the local live qualified count for the viewer.
     let viewerQualifiedReviewCount: Int

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 private let progressStreakWeekCount: Int = 5
+private let progressLeaderboardTopRowCount: Int = 3
 
 func makeProgressSnapshot(
     summary: ProgressSummary,
@@ -97,20 +98,21 @@ func makeProgressLeaderboardSnapshot(
             localQualifiedReviewCounts: localQualifiedReviewCounts
         )
     }
+    let defaultWindowKey = try resolveProgressLeaderboardDefaultWindowKey(windowStates: windowStates)
 
     return ProgressLeaderboardSnapshot(
         scopeKey: scopeKey,
         state: .ready(
             ProgressLeaderboardReadyState(
-                defaultWindowKey: leaderboard.defaultWindowKey,
+                defaultWindowKey: defaultWindowKey,
                 windows: windowStates
             )
         )
     )
 }
 
-/// The live overlay only lifts the viewer's own count; other rows and every rank
-/// stay exactly as the authoritative server snapshot reported them.
+/// The live overlay only reranks the current viewer against the frozen server
+/// ranking; other participants stay in the server-provided order.
 private func makeProgressLeaderboardWindowState(
     window: ProgressLeaderboardWindow,
     localQualifiedReviewCounts: [LeaderboardWindowKey: Int]
@@ -122,33 +124,196 @@ private func makeProgressLeaderboardWindowState(
     }
 
     let overlaidViewerCount = max(window.viewer.qualifiedReviewCount, localQualifiedReviewCount)
-    let rows = window.rows.enumerated().map { index, row -> ProgressLeaderboardRowState in
-        switch row {
-        case .gap:
-            return .gap(ProgressLeaderboardGapRowState(id: "gap-\(index)"))
-        case .participant(let participantRow):
-            return .participant(
-                ProgressLeaderboardParticipantRowState(
-                    kind: participantRow.kind,
-                    publicProfileId: participantRow.publicProfileId,
-                    anonymousDisplayName: participantRow.anonymousDisplayName,
-                    qualifiedReviewCount: participantRow.kind == .viewer
-                        ? overlaidViewerCount
-                        : participantRow.qualifiedReviewCount,
-                    rank: participantRow.rank
-                )
-            )
-        }
-    }
+    let projectedRankingRows = try makeProjectedProgressLeaderboardRankingRows(
+        window: window,
+        viewerQualifiedReviewCount: overlaidViewerCount
+    )
+    let projectedViewerRank = try progressLeaderboardViewerRank(rankingRows: projectedRankingRows)
+    let rows = try makeCompactProgressLeaderboardRowStates(
+        rankingRows: projectedRankingRows,
+        viewerRank: projectedViewerRank
+    )
 
     return ProgressLeaderboardWindowState(
         windowKey: window.windowKey,
         snapshotGeneratedAt: window.snapshotGeneratedAt,
         participantCount: window.participantCount,
-        viewerRank: window.viewer.rank,
+        viewerRank: projectedViewerRank,
         viewerQualifiedReviewCount: overlaidViewerCount,
         rows: rows
     )
+}
+
+private func makeProjectedProgressLeaderboardRankingRows(
+    window: ProgressLeaderboardWindow,
+    viewerQualifiedReviewCount: Int
+) throws -> [ProgressLeaderboardRankingRow] {
+    guard let serverViewerRow = window.rankingRows.first(where: { rankingRow in
+        rankingRow.kind == .viewer
+    }) else {
+        throw LocalStoreError.validation(
+            "Leaderboard ranking rows are missing the viewer for window \(window.windowKey.rawValue)"
+        )
+    }
+
+    let participantRows = window.rankingRows.filter { rankingRow in
+        rankingRow.kind == .participant
+    }
+    let projectedViewerRow = ProgressLeaderboardRankingRow(
+        kind: .viewer,
+        publicProfileId: serverViewerRow.publicProfileId,
+        anonymousDisplayName: serverViewerRow.anonymousDisplayName,
+        qualifiedReviewCount: viewerQualifiedReviewCount,
+        rank: serverViewerRow.rank
+    )
+    let insertionIndex = participantRows.firstIndex { rankingRow in
+        rankingRow.qualifiedReviewCount < viewerQualifiedReviewCount
+    } ?? participantRows.count
+    let projectedRows = Array(participantRows.prefix(insertionIndex))
+        + [projectedViewerRow]
+        + Array(participantRows.suffix(participantRows.count - insertionIndex))
+
+    return projectedRows.enumerated().map { index, rankingRow in
+        ProgressLeaderboardRankingRow(
+            kind: rankingRow.kind,
+            publicProfileId: rankingRow.publicProfileId,
+            anonymousDisplayName: rankingRow.anonymousDisplayName,
+            qualifiedReviewCount: rankingRow.qualifiedReviewCount,
+            rank: index + 1
+        )
+    }
+}
+
+private func progressLeaderboardViewerRank(
+    rankingRows: [ProgressLeaderboardRankingRow]
+) throws -> Int {
+    guard let viewerRow = rankingRows.first(where: { rankingRow in
+        rankingRow.kind == .viewer
+    }) else {
+        throw LocalStoreError.validation("Projected leaderboard ranking rows are missing the viewer")
+    }
+
+    return viewerRow.rank
+}
+
+private func makeCompactProgressLeaderboardRowStates(
+    rankingRows: [ProgressLeaderboardRankingRow],
+    viewerRank: Int
+) throws -> [ProgressLeaderboardRowState] {
+    let participantCount = rankingRows.count
+    let topRowCount = min(progressLeaderboardTopRowCount, participantCount)
+    var shownRanks: Set<Int> = []
+
+    if topRowCount > 0 {
+        for rank in 1...topRowCount {
+            shownRanks.insert(rank)
+        }
+    }
+
+    if viewerRank > topRowCount {
+        for rank in [viewerRank - 1, viewerRank, viewerRank + 1] {
+            guard rank >= 1, rank <= participantCount else {
+                continue
+            }
+
+            shownRanks.insert(rank)
+        }
+    } else if viewerRank == topRowCount && viewerRank < participantCount {
+        shownRanks.insert(viewerRank + 1)
+    }
+
+    if participantCount > topRowCount {
+        shownRanks.insert(participantCount)
+    }
+
+    var rows: [ProgressLeaderboardRowState] = []
+    var previousRank: Int = 0
+    for rank in shownRanks.sorted() {
+        if previousRank != 0, rank > previousRank + 1 {
+            rows.append(.gap(ProgressLeaderboardGapRowState(id: "gap-\(rows.count)")))
+        }
+
+        let rankingRowIndex = rank - 1
+        guard rankingRows.indices.contains(rankingRowIndex) else {
+            throw LocalStoreError.validation("Projected leaderboard ranking rows are missing rank \(rank)")
+        }
+
+        rows.append(
+            .participant(
+                makeProgressLeaderboardParticipantRowState(
+                    rankingRow: rankingRows[rankingRowIndex],
+                    topRowCount: topRowCount
+                )
+            )
+        )
+        previousRank = rank
+    }
+
+    if previousRank < participantCount {
+        rows.append(.gap(ProgressLeaderboardGapRowState(id: "gap-\(rows.count)")))
+    }
+
+    return rows
+}
+
+private func makeProgressLeaderboardParticipantRowState(
+    rankingRow: ProgressLeaderboardRankingRow,
+    topRowCount: Int
+) -> ProgressLeaderboardParticipantRowState {
+    ProgressLeaderboardParticipantRowState(
+        kind: progressLeaderboardParticipantKind(
+            rankingRow: rankingRow,
+            topRowCount: topRowCount
+        ),
+        publicProfileId: rankingRow.publicProfileId,
+        anonymousDisplayName: rankingRow.anonymousDisplayName,
+        qualifiedReviewCount: rankingRow.qualifiedReviewCount,
+        rank: rankingRow.rank
+    )
+}
+
+private func progressLeaderboardParticipantKind(
+    rankingRow: ProgressLeaderboardRankingRow,
+    topRowCount: Int
+) -> ProgressLeaderboardParticipantKind {
+    if rankingRow.kind == .viewer {
+        return .viewer
+    }
+
+    if rankingRow.rank <= topRowCount {
+        return .top
+    }
+
+    return .neighbor
+}
+
+private func resolveProgressLeaderboardDefaultWindowKey(
+    windowStates: [ProgressLeaderboardWindowState]
+) throws -> LeaderboardWindowKey {
+    var bestWindowKey: LeaderboardWindowKey?
+    var bestRank: Int?
+
+    for windowKey in LeaderboardWindowKey.stableOrder {
+        guard let window = windowStates.first(where: { candidate in
+            candidate.windowKey == windowKey
+        }) else {
+            continue
+        }
+
+        if let currentBestRank = bestRank,
+           window.viewerRank >= currentBestRank {
+            continue
+        }
+
+        bestWindowKey = window.windowKey
+        bestRank = window.viewerRank
+    }
+
+    guard let bestWindowKey else {
+        throw LocalStoreError.validation("Projected leaderboard windows are missing a default window")
+    }
+
+    return bestWindowKey
 }
 
 private struct ProgressTimelineDay: Hashable, Sendable {

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressBadgeRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressBadgeRefreshTests.swift
@@ -4,6 +4,140 @@ import XCTest
 
 final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
     @MainActor
+    func testRefreshReviewLeaderboardBadgeReranksViewerFromCachedServerBaseWithoutNetworkRefresh() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T14:45:00.000Z"))
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: "2026-06-10T14:30:00.000Z"
+        )
+        try self.addReviewedCard(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            reviewedAtClient: "2026-06-10T14:31:00.000Z"
+        )
+
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T14:00:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T14:00:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        context.store.cloudRuntime.setActiveCloudSession(
+            linkedSession: CloudLinkedSession(
+                userId: linkedUserId,
+                workspaceId: workspace.workspaceId,
+                email: nil,
+                configurationMode: .official,
+                apiBaseUrl: context.apiBaseUrl,
+                authorization: .bearer("id-token-1")
+            )
+        )
+
+        let scopeKey = try context.store.prepareProgressScope(now: now)
+        let leaderboardScopeKey = context.store.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+        context.store.progressLeaderboardServerBaseCache = PersistedProgressLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            serverBase: makeReadyProgressLeaderboardForTests(
+                defaultWindowKey: .last24Hours,
+                participantCount: 3,
+                viewer: ProgressLeaderboardViewer(
+                    publicProfileId: "profile-viewer",
+                    displayName: "You",
+                    rank: 3,
+                    qualifiedReviewCount: 1
+                ),
+                rows: [
+                    makeProgressLeaderboardParticipantRowForTests(
+                        kind: .top,
+                        publicProfileId: "profile-top-1",
+                        anonymousDisplayName: "Silver Bright Harbor",
+                        qualifiedReviewCount: 5,
+                        rank: 1
+                    ),
+                    makeProgressLeaderboardParticipantRowForTests(
+                        kind: .top,
+                        publicProfileId: "profile-peer-2",
+                        anonymousDisplayName: "Amber Calm Meadow",
+                        qualifiedReviewCount: 1,
+                        rank: 2
+                    ),
+                    makeProgressLeaderboardParticipantRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        qualifiedReviewCount: 1,
+                        rank: 3
+                    ),
+                ],
+                rankingRows: [
+                    makeProgressLeaderboardRankingRowForTests(
+                        kind: .participant,
+                        publicProfileId: "profile-top-1",
+                        anonymousDisplayName: "Silver Bright Harbor",
+                        qualifiedReviewCount: 5,
+                        rank: 1
+                    ),
+                    makeProgressLeaderboardRankingRowForTests(
+                        kind: .participant,
+                        publicProfileId: "profile-peer-2",
+                        anonymousDisplayName: "Amber Calm Meadow",
+                        qualifiedReviewCount: 1,
+                        rank: 2
+                    ),
+                    makeProgressLeaderboardRankingRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        qualifiedReviewCount: 1,
+                        rank: 3
+                    ),
+                ]
+            ),
+            storedAt: "2026-06-10T14:00:05.000Z"
+        )
+
+        await context.store.refreshReviewLeaderboardBadgeIfNeeded(now: now)
+
+        XCTAssertEqual(
+            ReviewLeaderboardBadgeState(
+                rank: 2,
+                windowKey: .last24Hours,
+                isInteractive: true
+            ),
+            context.store.reviewLeaderboardBadgeState
+        )
+        XCTAssertEqual(0, context.cloudSyncService.loadProgressLeaderboardCallCount)
+    }
+
+    @MainActor
     func testRefreshReviewProgressBadgeKeepsLocalTodayReviewWhenServerSummaryIsStale() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
@@ -47,7 +47,7 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
                 kind: .neighbor,
                 publicProfileId: "profile-neighbor-43",
                 anonymousDisplayName: "Lilac Bold Summit",
-                qualifiedReviewCount: 7,
+                qualifiedReviewCount: 6,
                 rank: 43
             ),
             .gap,
@@ -59,6 +59,94 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
                 rank: 128
             ),
         ]
+    }
+
+    private var rankingRows: [ProgressLeaderboardRankingRow] {
+        (1...128).map { rank in
+            switch rank {
+            case 1:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-top-1",
+                    anonymousDisplayName: "Silver Bright Harbor",
+                    qualifiedReviewCount: 51,
+                    rank: rank
+                )
+            case 2:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-top-2",
+                    anonymousDisplayName: "Amber Calm Meadow",
+                    qualifiedReviewCount: 44,
+                    rank: rank
+                )
+            case 3:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-top-3",
+                    anonymousDisplayName: "Coral Keen Valley",
+                    qualifiedReviewCount: 39,
+                    rank: rank
+                )
+            case 4...40:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-mid-\(rank)",
+                    anonymousDisplayName: "Rank \(rank)",
+                    qualifiedReviewCount: 9,
+                    rank: rank
+                )
+            case 41:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-neighbor-41",
+                    anonymousDisplayName: "Jade Swift River",
+                    qualifiedReviewCount: 8,
+                    rank: rank
+                )
+            case 42:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    qualifiedReviewCount: 7,
+                    rank: rank
+                )
+            case 43:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-neighbor-43",
+                    anonymousDisplayName: "Lilac Bold Summit",
+                    qualifiedReviewCount: 6,
+                    rank: rank
+                )
+            case 44...127:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-tail-\(rank)",
+                    anonymousDisplayName: "Rank \(rank)",
+                    qualifiedReviewCount: 1,
+                    rank: rank
+                )
+            case 128:
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-last-128",
+                    anonymousDisplayName: "Blue Final Harbor",
+                    qualifiedReviewCount: 0,
+                    rank: rank
+                )
+            default:
+                XCTFail("Unexpected leaderboard rank \(rank)")
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-invalid-\(rank)",
+                    anonymousDisplayName: "Invalid Rank",
+                    qualifiedReviewCount: 0,
+                    rank: rank
+                )
+            }
+        }
     }
 
     private var viewer: ProgressLeaderboardViewer {
@@ -162,7 +250,8 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
             defaultWindowKey: .last7Days,
             participantCount: 128,
             viewer: self.viewer,
-            rows: self.compactRows
+            rows: self.compactRows,
+            rankingRows: self.rankingRows
         )
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
 
@@ -179,7 +268,7 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(.last7Days, readyState.defaultWindowKey)
+        XCTAssertEqual(.last24Hours, readyState.defaultWindowKey)
         XCTAssertEqual(LeaderboardWindowKey.stableOrder, readyState.windows.map(\.windowKey))
 
         let window = try XCTUnwrap(readyState.windows.first)
@@ -213,7 +302,8 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
             defaultWindowKey: .last24Hours,
             participantCount: 128,
             viewer: self.viewer,
-            rows: self.compactRows
+            rows: self.compactRows,
+            rankingRows: self.rankingRows
         )
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
 
@@ -297,12 +387,13 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
         XCTAssertTrue(infoMessage.contains(ReviewRating.again.title))
     }
 
-    func testLiveOverlayChangesOnlyViewerCount() throws {
+    func testLiveOverlayReranksOnlyViewerFromRankingRows() throws {
         let leaderboard = makeReadyProgressLeaderboardForTests(
             defaultWindowKey: .last24Hours,
             participantCount: 128,
             viewer: self.viewer,
-            rows: self.compactRows
+            rows: self.compactRows,
+            rankingRows: self.rankingRows
         )
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
         let qualifiedReviewEvents = (0 ..< 9).map { index in
@@ -329,26 +420,79 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
 
         for window in readyState.windows {
             XCTAssertEqual(9, window.viewerQualifiedReviewCount)
-            XCTAssertEqual(42, window.viewerRank)
+            XCTAssertEqual(41, window.viewerRank)
             XCTAssertEqual(128, window.participantCount)
 
-            for row in window.rows {
+            let participantRows = window.rows.compactMap { row -> ProgressLeaderboardParticipantRowState? in
                 guard case .participant(let participantRow) = row else {
-                    continue
+                    return nil
                 }
 
-                if participantRow.kind == .viewer {
-                    XCTAssertEqual(9, participantRow.qualifiedReviewCount)
-                    XCTAssertEqual(42, participantRow.rank)
-                } else if participantRow.rank == 1 {
-                    XCTAssertEqual(51, participantRow.qualifiedReviewCount)
-                } else if participantRow.rank == 41 {
-                    XCTAssertEqual(8, participantRow.qualifiedReviewCount)
-                } else if participantRow.rank == 43 {
-                    XCTAssertEqual(7, participantRow.qualifiedReviewCount)
-                }
+                return participantRow
             }
+            let viewerRow = try XCTUnwrap(participantRows.first { row in
+                row.kind == .viewer
+            })
+            let promotedNeighborRow = try XCTUnwrap(participantRows.first { row in
+                row.rank == 42
+            })
+
+            XCTAssertEqual(9, viewerRow.qualifiedReviewCount)
+            XCTAssertEqual(41, viewerRow.rank)
+            XCTAssertEqual("profile-viewer", viewerRow.publicProfileId)
+            XCTAssertEqual("profile-neighbor-41", promotedNeighborRow.publicProfileId)
+            XCTAssertEqual(8, promotedNeighborRow.qualifiedReviewCount)
         }
+    }
+
+    func testFactoryRecomputesDefaultWindowKeyFromProjectedRanks() throws {
+        let leaderboard = makeReadyProgressLeaderboardForTests(
+            defaultWindowKey: .last24Hours,
+            participantCount: 128,
+            viewer: self.viewer,
+            rows: self.compactRows,
+            rankingRows: self.rankingRows
+        )
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
+        let qualifiedReviewEvents = (0 ..< 40).map { index in
+            ProgressQualifiedReviewEventSource(
+                reviewEventId: "review-event-\(index)",
+                reviewedAtClient: "2026-06-08T15:00:00.000Z"
+            )
+        }
+
+        let snapshot = try makeProgressLeaderboardSnapshot(
+            leaderboard: leaderboard,
+            scopeKey: self.scopeKey,
+            canonicalQualifiedReviewEvents: qualifiedReviewEvents,
+            pendingQualifiedReviewEvents: [],
+            now: now
+        )
+
+        guard case .ready(let readyState) = snapshot.state else {
+            XCTFail("Expected ready leaderboard state, received \(snapshot.state)")
+            return
+        }
+
+        let last24HoursWindow = try XCTUnwrap(readyState.windows.first { window in
+            window.windowKey == .last24Hours
+        })
+        let last3DaysWindow = try XCTUnwrap(readyState.windows.first { window in
+            window.windowKey == .last3Days
+        })
+        let badgeState = makeReviewLeaderboardBadgeState(progressLeaderboardSnapshot: snapshot)
+
+        XCTAssertEqual(.last3Days, readyState.defaultWindowKey)
+        XCTAssertEqual(42, last24HoursWindow.viewerRank)
+        XCTAssertEqual(3, last3DaysWindow.viewerRank)
+        XCTAssertEqual(
+            ReviewLeaderboardBadgeState(
+                rank: 3,
+                windowKey: .last3Days,
+                isInteractive: true
+            ),
+            badgeState
+        )
     }
 
     func testLiveOverlayNeverLowersServerViewerCount() throws {
@@ -356,7 +500,8 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
             defaultWindowKey: .last24Hours,
             participantCount: 128,
             viewer: self.viewer,
-            rows: self.compactRows
+            rows: self.compactRows,
+            rankingRows: self.rankingRows
         )
         let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
         let qualifiedReviewEvents = (0 ..< 2).map { index in
@@ -381,6 +526,105 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
 
         for window in readyState.windows {
             XCTAssertEqual(7, window.viewerQualifiedReviewCount)
+            XCTAssertEqual(42, window.viewerRank)
+        }
+    }
+
+    func testFactoryRejectsRankingRowsWithoutViewerRow() throws {
+        let rankingRowsWithoutViewer = self.rankingRows.map { rankingRow in
+            if rankingRow.kind == .viewer {
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: rankingRow.publicProfileId,
+                    anonymousDisplayName: rankingRow.anonymousDisplayName,
+                    qualifiedReviewCount: rankingRow.qualifiedReviewCount,
+                    rank: rankingRow.rank
+                )
+            }
+
+            return rankingRow
+        }
+        let leaderboard = makeReadyProgressLeaderboardForTests(
+            defaultWindowKey: .last24Hours,
+            participantCount: 128,
+            viewer: self.viewer,
+            rows: self.compactRows,
+            rankingRows: rankingRowsWithoutViewer
+        )
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
+
+        XCTAssertThrowsError(
+            try makeProgressLeaderboardSnapshot(
+                leaderboard: leaderboard,
+                scopeKey: self.scopeKey,
+                canonicalQualifiedReviewEvents: [],
+                pendingQualifiedReviewEvents: [],
+                now: now
+            )
+        ) { error in
+            guard let validationError = error as? ProgressLeaderboardValidationError else {
+                XCTFail("Expected ProgressLeaderboardValidationError, received \(error)")
+                return
+            }
+
+            guard case .viewerRankingRowMismatch(windowKey: let windowKey) = validationError else {
+                XCTFail("Expected viewerRankingRowMismatch, received \(error)")
+                return
+            }
+
+            XCTAssertEqual(LeaderboardWindowKey.last24Hours.rawValue, windowKey)
+        }
+    }
+
+    func testFactoryRejectsNonContiguousRankingRowRanks() throws {
+        let rankingRowsWithSkippedRank = self.rankingRows.map { rankingRow in
+            if rankingRow.rank == 3 {
+                return makeProgressLeaderboardRankingRowForTests(
+                    kind: rankingRow.kind,
+                    publicProfileId: rankingRow.publicProfileId,
+                    anonymousDisplayName: rankingRow.anonymousDisplayName,
+                    qualifiedReviewCount: rankingRow.qualifiedReviewCount,
+                    rank: 4
+                )
+            }
+
+            return rankingRow
+        }
+        let leaderboard = makeReadyProgressLeaderboardForTests(
+            defaultWindowKey: .last24Hours,
+            participantCount: 128,
+            viewer: self.viewer,
+            rows: self.compactRows,
+            rankingRows: rankingRowsWithSkippedRank
+        )
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T15:00:00.000Z"))
+
+        XCTAssertThrowsError(
+            try makeProgressLeaderboardSnapshot(
+                leaderboard: leaderboard,
+                scopeKey: self.scopeKey,
+                canonicalQualifiedReviewEvents: [],
+                pendingQualifiedReviewEvents: [],
+                now: now
+            )
+        ) { error in
+            guard let validationError = error as? ProgressLeaderboardValidationError else {
+                XCTFail("Expected ProgressLeaderboardValidationError, received \(error)")
+                return
+            }
+
+            guard case .invalidRankingRowRank(
+                windowKey: let windowKey,
+                expectedRank: let expectedRank,
+                actualRank: let actualRank
+            ) = validationError else {
+                XCTFail("Expected invalidRankingRowRank, received \(error)")
+                return
+            }
+
+            XCTAssertEqual(LeaderboardWindowKey.last24Hours.rawValue, windowKey)
+            XCTAssertEqual(3, expectedRank)
+            XCTAssertEqual(4, actualRank)
         }
     }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -188,7 +188,8 @@ func makeReadyProgressLeaderboardForTests(
     defaultWindowKey: LeaderboardWindowKey,
     participantCount: Int,
     viewer: ProgressLeaderboardViewer,
-    rows: [ProgressLeaderboardRow]
+    rows: [ProgressLeaderboardRow],
+    rankingRows: [ProgressLeaderboardRankingRow]
 ) -> UserProgressLeaderboard {
     let windows = LeaderboardWindowKey.stableOrder.map { windowKey in
         ProgressLeaderboardWindow(
@@ -199,7 +200,8 @@ func makeReadyProgressLeaderboardForTests(
             nextRefreshAfter: "2026-06-10T15:00:00.000Z",
             participantCount: participantCount,
             viewer: viewer,
-            rows: rows
+            rows: rows,
+            rankingRows: rankingRows
         )
     }
 
@@ -234,6 +236,22 @@ func makeProgressLeaderboardParticipantRowForTests(
             qualifiedReviewCount: qualifiedReviewCount,
             rank: rank
         )
+    )
+}
+
+func makeProgressLeaderboardRankingRowForTests(
+    kind: ProgressLeaderboardRankingRowKind,
+    publicProfileId: String,
+    anonymousDisplayName: String,
+    qualifiedReviewCount: Int,
+    rank: Int
+) -> ProgressLeaderboardRankingRow {
+    ProgressLeaderboardRankingRow(
+        kind: kind,
+        publicProfileId: publicProfileId,
+        anonymousDisplayName: anonymousDisplayName,
+        qualifiedReviewCount: qualifiedReviewCount,
+        rank: rank
     )
 }
 


### PR DESCRIPTION
## Summary
- Add iOS decoding and validation for leaderboard `rankingRows`.
- Project the current viewer's live qualified review count into the frozen server ranking.
- Rebuild compact leaderboard rows and Review badge placement from the projected rank.
- Gate Review badge leaderboard network refreshes with the existing leaderboard freshness policy.

## Impact
The Progress leaderboard and Review badge can reflect local qualified reviews immediately without a per-review leaderboard refresh, while keeping other participants in the server-provided order.

## Validation
- `git --no-pager diff --cached --check`
- `xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift apps/ios/Flashcards/FlashcardsTests/Progress/ProgressBadgeRefreshTests.swift`

Simulator-backed XCTest was not run.