### PR TITLE
[codex] Align rendered leaderboard ranking rows

### DIFF
--- a/apps/web/src/appData/progress/snapshots/progressLeaderboardSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressLeaderboardSnapshots.ts
@@ -213,7 +213,7 @@ function projectProgressLeaderboardWindow(
       qualifiedReviewCount: viewerCount,
     },
     rows: buildCompactRows(projectedRankingRows),
-    rankingRows: window.rankingRows,
+    rankingRows: projectedRankingRows,
   };
 }
 


### PR DESCRIPTION
## Summary
- Keep rendered leaderboard rankingRows aligned with the locally projected viewer rank.

## Validation
- npm run test --prefix apps/web -- src/appData/progress/source/progressSource.cache.test.tsx src/screens/progress/ProgressScreen.render.test.tsx
- npm run build --prefix apps/web