### PR TITLE
[codex] Soften web scrollbars

### DIFF
--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -166,7 +166,6 @@
   box-shadow: var(--shadow);
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-gutter: stable;
   z-index: 200;
 }
 

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -1,5 +1,7 @@
 * {
   box-sizing: border-box;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  scrollbar-width: thin;
 }
 
 *:focus {
@@ -60,4 +62,29 @@ select {
 ::selection {
   background: rgba(196, 75, 45, 0.34);
   color: var(--text);
+}
+
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+*::-webkit-scrollbar-thumb {
+  min-height: 40px;
+  border: 2px solid transparent;
+  border-radius: var(--radius-pill);
+  background-color: var(--scrollbar-thumb);
+  background-clip: content-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
 }

--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -54,7 +54,6 @@
   box-shadow: var(--shadow);
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-gutter: stable;
 }
 
 .cards-filter-section {

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -17,7 +17,6 @@
   flex-direction: column;
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-gutter: stable;
   scroll-padding-bottom: 132px;
 }
 

--- a/apps/web/src/styles/features/review/review-filter.css
+++ b/apps/web/src/styles/features/review/review-filter.css
@@ -63,7 +63,6 @@
   box-shadow: var(--shadow);
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-gutter: stable;
 }
 
 .review-filter-search-field {

--- a/apps/web/src/styles/features/review/review-queue.css
+++ b/apps/web/src/styles/features/review/review-queue.css
@@ -42,7 +42,6 @@
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-gutter: stable;
   padding-inline-end: 4px;
 }
 

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -211,7 +211,6 @@
   min-height: 0;
   overflow-y: auto;
   padding-inline-end: 4px;
-  scrollbar-gutter: stable;
 }
 
 .settings-test-animation-rows {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -14,6 +14,9 @@
   --text-primary: #f6f6f8;
   --text-secondary: rgba(235, 235, 245, 0.62);
   --text-tertiary: rgba(235, 235, 245, 0.38);
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: rgba(235, 235, 245, 0.22);
+  --scrollbar-thumb-hover: rgba(235, 235, 245, 0.36);
   --muted: var(--text-secondary);
   --accent: #c44b2d;
   --accent-strong: #d65a38;


### PR DESCRIPTION
## Summary
- Add shared dark-theme scrollbar tokens and global thin scrollbar styling.
- Remove always-reserved scrollbar gutters from scrollable web surfaces where they made the UI feel heavy.

## Validation
- npm run build
- git --no-pager diff --check