### PR TITLE
[codex] Fix review panel height

### DIFF
--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -1,18 +1,13 @@
 .review-screen-panel {
+  --review-screen-panel-height: var(--chat-shell-pane-height, calc(100dvh - 128px));
   position: relative;
   container-type: inline-size;
   container-name: review-screen;
   grid-template-rows: auto minmax(0, 1fr);
-  height: min(880px, calc(100dvh - 76px));
-  min-height: min(760px, calc(100dvh - 76px));
-  max-height: calc(100dvh - 72px);
+  height: var(--review-screen-panel-height);
+  min-height: var(--review-screen-panel-height);
+  max-height: var(--review-screen-panel-height);
   overflow: hidden;
-}
-
-.chat-layout-shell-sidebar-open .review-screen-panel {
-  height: var(--chat-shell-pane-height);
-  min-height: var(--chat-shell-pane-height);
-  max-height: none;
 }
 
 .review-layout {


### PR DESCRIPTION
## Summary
- Align the review screen panel height with the existing chat shell pane height.
- Remove the separate sidebar-open review height override so open and closed chat states use one layout contract.

## Validation
- npm run build
- git --no-pager diff --check
