### PR TITLE
[codex] Unify web shell spacing

### DIFF
--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -11,7 +11,7 @@
   top: 0;
   z-index: 50;
   flex-shrink: 0;
-  padding: 18px var(--header-inline-padding) 0;
+  padding: var(--shell-frame-gap) var(--header-inline-padding) 0;
   background:
     linear-gradient(180deg, rgba(5, 5, 5, 0.96), rgba(5, 5, 5, 0.72) 80%, transparent);
   backdrop-filter: var(--blur);
@@ -266,7 +266,7 @@
 
 .global-error-wrap {
   width: 100%;
-  padding: 14px var(--desktop-shell-gutter) 0;
+  padding: var(--shell-frame-gap) var(--desktop-shell-gutter) 0;
 }
 
 .global-error {
@@ -282,16 +282,17 @@
 .container {
   width: 100%;
   min-width: 0;
-  min-height: calc(100dvh - 104px);
+  min-height: 100%;
   padding: var(--chat-shell-pane-top, 12px) 0 var(--chat-shell-pane-bottom, 12px);
 }
 
 .chat-layout-shell-sidebar-open .chat-main-content > .container {
+  height: var(--chat-shell-content-height);
   min-height: var(--chat-shell-content-height);
 }
 
 .chat-layout-shell-sidebar-open .chat-main-content > .container > .panel {
-  min-height: var(--chat-shell-pane-height);
+  min-height: 100%;
 }
 
 .page-state {
@@ -330,8 +331,8 @@
 
 @media (max-width: 768px) {
   .header-sticky {
-    --header-inline-padding: 18px;
-    padding: 14px 18px 0;
+    --header-inline-padding: var(--shell-frame-gap);
+    padding: var(--shell-frame-gap) var(--header-inline-padding) 0;
   }
 
   .topbar-shell,
@@ -339,10 +340,6 @@
   .page-state,
   .global-error-wrap {
     width: 100%;
-  }
-
-  .container {
-    min-height: calc(100dvh - 104px);
   }
 
   .chat-layout-shell-sidebar-open .chat-main-content > .container > .panel {

--- a/apps/web/src/styles/features/chat.css
+++ b/apps/web/src/styles/features/chat.css
@@ -1,13 +1,13 @@
 .chat-page {
   display: flex;
   justify-content: center;
-  padding: 24px 0 40px;
+  padding: var(--shell-frame-gap) 0;
 }
 
 .chat-layout-shell {
-  --chat-shell-pane-top: 12px;
-  --chat-shell-pane-bottom: 12px;
-  --chat-shell-content-height: calc(100dvh - 104px);
+  --chat-shell-pane-top: var(--shell-frame-gap);
+  --chat-shell-pane-bottom: var(--shell-frame-gap);
+  --chat-shell-content-height: 100%;
   --chat-shell-pane-offset: calc(var(--chat-shell-pane-top) + var(--chat-shell-pane-bottom));
   --chat-shell-pane-height: calc(var(--chat-shell-content-height) - var(--chat-shell-pane-offset));
   display: flex;
@@ -15,8 +15,8 @@
   min-height: 0;
   overflow: hidden;
   align-items: stretch;
-  gap: var(--desktop-shell-gutter);
-  padding-inline: var(--desktop-shell-gutter);
+  gap: var(--shell-frame-gap);
+  padding-inline: var(--shell-frame-gap);
 }
 
 .chat-main-content {
@@ -844,8 +844,8 @@
 
 .chat-toggle-floating {
   position: fixed;
-  bottom: 24px;
-  inset-inline-start: 24px;
+  bottom: var(--shell-frame-gap);
+  inset-inline-start: var(--shell-frame-gap);
   z-index: 60;
   min-height: 52px;
   padding: 0 22px;
@@ -865,21 +865,21 @@
 
 @media (max-width: 768px) {
   .chat-page {
-    padding-inline: 18px;
+    padding-inline: 0;
   }
 
   .chat-layout-shell {
     gap: 0;
-    padding-inline: 0;
+    padding-inline: var(--shell-frame-gap);
   }
 
   .chat-sidebar {
     position: fixed;
-    top: 14px;
-    inset-inline-start: 14px;
-    width: calc(100% - 28px) !important;
-    height: calc(100dvh - 28px);
-    max-height: calc(100dvh - 28px);
+    top: var(--shell-frame-gap);
+    inset-inline-start: var(--shell-frame-gap);
+    width: calc(100% - (2 * var(--shell-frame-gap))) !important;
+    height: calc(100dvh - (2 * var(--shell-frame-gap)));
+    max-height: calc(100dvh - (2 * var(--shell-frame-gap)));
     z-index: 100;
     margin: 0;
   }

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -10,6 +10,10 @@
   overflow: hidden;
 }
 
+.chat-layout-shell-sidebar-open .review-screen-panel {
+  --review-screen-panel-height: 100%;
+}
+
 .review-layout {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -200,8 +200,8 @@
 }
 
 .chat-layout-shell-sidebar-open .settings-panel-test-animations {
-  height: var(--chat-shell-pane-height);
-  min-height: var(--chat-shell-pane-height);
+  height: 100%;
+  min-height: 100%;
   max-height: none;
 }
 

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -36,7 +36,8 @@
   --page-title-line-height: 1;
   --page-title-font-weight: 720;
   --page-title-letter-spacing: -0.04em;
-  --desktop-shell-gutter: 24px;
+  --shell-frame-gap: 12px;
+  --desktop-shell-gutter: var(--shell-frame-gap);
   --content-width: 1240px;
   --shell-width: 1320px;
 }


### PR DESCRIPTION
## Summary

- unify the web shell frame spacing around the header, AI chat sidebar, main content, and mobile chat overlay
- keep sidebar-open review and settings animation panels aligned with the shared shell height contract

## Validation

- `npm run build`
- `git --no-pager diff --check`
- compiled CSS geometry check in headless Chrome for desktop review, desktop settings test animations, and mobile AI overlay