### PR TITLE
[codex] Fix web contained scrolling

### DIFF
--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -282,8 +282,10 @@
 .container {
   width: 100%;
   min-width: 0;
-  min-height: 100%;
+  height: var(--chat-shell-content-height, 100%);
+  min-height: 0;
   padding: var(--chat-shell-pane-top, 12px) 0 var(--chat-shell-pane-bottom, 12px);
+  overflow: hidden;
 }
 
 .chat-layout-shell-sidebar-open .chat-main-content > .container {
@@ -293,6 +295,13 @@
 
 .chat-layout-shell-sidebar-open .chat-main-content > .container > .panel {
   min-height: 100%;
+}
+
+.chat-main-content > .container > .panel {
+  min-height: 0;
+  max-height: 100%;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .page-state {

--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -1,6 +1,11 @@
 .cards-panel {
+  display: flex;
+  flex-direction: column;
   gap: 18px;
-  min-height: min(760px, calc(100dvh - 196px));
+  height: 100%;
+  min-height: 0;
+  max-height: 100%;
+  overflow: hidden;
 }
 
 .cards-screen-head,
@@ -98,7 +103,10 @@
 }
 
 .cards-scroll {
-  min-height: 420px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
   padding-bottom: 6px;
 }
 

--- a/apps/web/src/styles/features/chat.css
+++ b/apps/web/src/styles/features/chat.css
@@ -20,10 +20,12 @@
 }
 
 .chat-main-content {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   min-width: 0;
-  overflow-y: auto;
-  overflow-x: hidden;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .chat-layout-shell-sidebar-closed .chat-main-content,

--- a/apps/web/src/styles/features/review/review-responsive.css
+++ b/apps/web/src/styles/features/review/review-responsive.css
@@ -17,42 +17,8 @@
 }
 
 @media (max-width: 768px) {
-  .review-screen-panel {
-    height: auto;
-    min-height: 0;
-    max-height: none;
-    overflow: visible;
-  }
-
-  .chat-layout-shell-sidebar-open .review-screen-panel {
-    height: auto;
-    min-height: 0;
-    max-height: none;
-  }
-
   .review-layout {
     grid-template-columns: 1fr;
-  }
-
-  .review-pane {
-    overflow: visible;
-    scrollbar-gutter: auto;
-    scroll-padding-bottom: 0;
-  }
-
-  .review-queue-panel {
-    overflow: visible;
-  }
-
-  .review-queue-head {
-    position: static;
-    padding-bottom: 0;
-  }
-
-  .review-queue-list {
-    overflow: visible;
-    scrollbar-gutter: auto;
-    padding-inline-end: 0;
   }
 
   .review-editor-overlay {


### PR DESCRIPTION
## Summary

- keep the routed web area fixed below the header
- move page overflow into screen-owned panels and lists
- keep Cards table scrolling inside the table container

## Validation

- npm run build
- npm test
- CSS layout smoke in Chrome for Cards, Settings, Review, and fullscreen Chat
