### PR TITLE
[codex] Flatten web chrome

### DIFF
--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -12,9 +12,8 @@
   z-index: 50;
   flex-shrink: 0;
   padding: var(--shell-frame-gap) var(--header-inline-padding) 0;
-  background:
-    linear-gradient(180deg, rgba(5, 5, 5, 0.96), rgba(5, 5, 5, 0.72) 80%, transparent);
-  backdrop-filter: var(--blur);
+  background: var(--bg);
+  backdrop-filter: none;
 }
 
 .topbar-shell {
@@ -22,10 +21,10 @@
   position: relative;
   width: 100%;
   padding: 10px var(--topbar-shell-inline-padding);
-  border: 1px solid var(--panel-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-lg);
-  background: var(--surface-glass);
-  box-shadow: var(--shadow-soft);
+  background: var(--bg);
+  box-shadow: none;
 }
 
 .topbar {

--- a/apps/web/src/styles/features/chat.css
+++ b/apps/web/src/styles/features/chat.css
@@ -44,10 +44,10 @@
   max-height: 100%;
   position: relative;
   overflow: hidden;
-  border: 1px solid var(--panel-border);
+  border: 1px solid transparent;
   border-radius: var(--chat-sidebar-radius);
-  background: rgba(19, 19, 23, 0.96);
-  box-shadow: var(--shadow);
+  background: var(--bg);
+  box-shadow: none;
 }
 
 .chat-sidebar {

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -93,6 +93,12 @@
   box-shadow: var(--shadow-soft);
 }
 
+.chat-main-content > .container > .panel {
+  border-color: transparent;
+  background: var(--bg);
+  box-shadow: none;
+}
+
 .panel-center {
   max-width: 520px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- Flatten the web app's top-level chrome toward the iOS dark visual direction.
- Remove visible outer borders, elevated backgrounds, and shadows from the header, routed panel, and chat sidebar.
- Preserve inner cards, controls, navigation pills, and existing app behavior.

## Validation
- `npm run build`
- `git --no-pager diff --check`

## Notes
- Browser visual smoke was intentionally not run.