### PR TITLE
[codex] Black out web background chrome

### DIFF
--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -22,7 +22,6 @@
   width: 100%;
   padding: 10px var(--topbar-shell-inline-padding);
   border: 1px solid transparent;
-  border-radius: var(--radius-lg);
   background: var(--bg);
   box-shadow: none;
 }

--- a/apps/web/src/styles/base.css
+++ b/apps/web/src/styles/base.css
@@ -17,10 +17,7 @@ body,
 }
 
 html {
-  background:
-    radial-gradient(circle at top, rgba(196, 75, 45, 0.12), transparent 30%),
-    radial-gradient(circle at bottom left, rgba(255, 255, 255, 0.05), transparent 26%),
-    var(--bg);
+  background: var(--bg);
 }
 
 body {

--- a/apps/web/src/styles/features/chat.css
+++ b/apps/web/src/styles/features/chat.css
@@ -45,7 +45,6 @@
   position: relative;
   overflow: hidden;
   border: 1px solid transparent;
-  border-radius: var(--chat-sidebar-radius);
   background: var(--bg);
   box-shadow: none;
 }
@@ -99,7 +98,7 @@
   gap: 12px;
   padding: 12px 14px;
   border-bottom: 1px solid var(--divider);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg);
   flex-shrink: 0;
 }
 
@@ -394,9 +393,7 @@
   gap: 12px;
   flex-shrink: 0;
   min-height: 0;
-  background:
-    radial-gradient(circle at top, rgba(196, 75, 45, 0.08), transparent 42%),
-    rgba(255, 255, 255, 0.02);
+  background: var(--bg);
 }
 
 .chat-input-area-loading {

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -95,6 +95,7 @@
 
 .chat-main-content > .container > .panel {
   border-color: transparent;
+  border-radius: 0;
   background: var(--bg);
   box-shadow: none;
 }


### PR DESCRIPTION
## Summary
- Replace the global web background gradient with the existing black background token.
- Make AI chat header and composer surfaces black so they blend into the app background.
- Remove no-longer-visible outer radii from black top-level chrome shells.

## Validation
- `npm run build`
- `git --no-pager diff --check`

## Notes
- This is a CSS-only follow-up; app behavior is unchanged.
- Browser visual smoke was intentionally not run.