### PR TITLE
[codex] Update web header title

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -337,7 +337,6 @@ export function AppShell(): ReactElement {
   const workspaceManagementLockedMessage = t("workspaceManagement.lockedMessage");
   const activeWorkspaceId: string | null = activeWorkspace?.workspaceId ?? null;
   const activeWorkspaceName: string | null = activeWorkspace?.name ?? null;
-  const activeWorkspaceLabel: string = activeWorkspaceName ?? t("app.workspaceUnavailable");
 
   const completeAccountDeletion = useCallback(async function completeAccountDeletion(): Promise<void> {
     if (isSessionVerified === false) {
@@ -522,22 +521,20 @@ export function AppShell(): ReactElement {
             <div className="topbar-brand-block">
               <div className="topbar-brand-row">
                 <a className="topbar-brand" href={reviewRoute}>
-                  <span className="brand-full">flashcards-open-source-app</span>
-                  <span className="brand-short">flashcards</span>
+                  <span className="brand-full">Flashcards Open Source App</span>
+                  <span className="brand-short">Flashcards</span>
                 </a>
                 {isSyncing ? <span className="topbar-sync-status">{t("app.syncing")}</span> : null}
                 {!isSyncing && sessionRestoringMessage !== "" ? <span className="topbar-sync-status">{sessionRestoringMessage}</span> : null}
               </div>
               <span data-testid="topbar-active-workspace-id-value" hidden>{activeWorkspaceId ?? ""}</span>
               <span data-testid="topbar-active-workspace-value" hidden>{activeWorkspaceName ?? ""}</span>
-              <p
-                className="topbar-workspace"
+              <span
                 data-testid="topbar-active-workspace"
                 data-workspace-id={activeWorkspaceId ?? ""}
                 data-workspace-name={activeWorkspaceName ?? ""}
-              >
-                {activeWorkspaceLabel}
-              </p>
+                hidden
+              />
             </div>
             <nav className="nav" aria-label={t("shell.primaryNavigation")}>
               {primaryNavigationItems.map((item) => (

--- a/apps/web/src/styles/app-shell.css
+++ b/apps/web/src/styles/app-shell.css
@@ -37,7 +37,6 @@
 .topbar-brand-block {
   min-width: 0;
   display: grid;
-  gap: 4px;
 }
 
 .topbar-brand-row {
@@ -51,20 +50,16 @@
   display: inline-flex;
   align-items: center;
   width: fit-content;
+  max-width: 100%;
   color: var(--text);
-  font-size: 15px;
-  font-weight: 650;
-  letter-spacing: -0.02em;
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.08;
 }
 
 .topbar-brand:hover {
   color: var(--text);
-}
-
-.topbar-workspace {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 13px;
 }
 
 .topbar-sync-status {


### PR DESCRIPTION
## Summary
- Replace the visible web topbar brand with `Flashcards Open Source App` on wide screens.
- Keep the narrow-screen brand fallback as `Flashcards`.
- Remove the visible workspace subtitle while preserving hidden workspace diagnostics used by smoke flows.

## Validation
- `npm run build` in `apps/web`