### PR TITLE
[codex] Use iOS-style web surfaces

### DIFF
--- a/apps/web/src/styles/features/cards.css
+++ b/apps/web/src/styles/features/cards.css
@@ -5,6 +5,10 @@
   height: 100%;
   min-height: 0;
   max-height: 100%;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   overflow: hidden;
 }
 
@@ -277,7 +281,7 @@
   display: block;
   min-height: 14px;
   border-radius: var(--radius-pill);
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.05));
+  background: var(--surface-hover);
 }
 
 .cards-loading-line-wide {
@@ -435,20 +439,18 @@
 
 .deck-card {
   padding: 18px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--panel-inner-radius, var(--radius-md));
-  background: var(--surface-elevated);
-  box-shadow: var(--shadow-soft);
+  background: var(--surface);
+  box-shadow: none;
   transition:
-    border-color 140ms ease,
     transform 140ms ease,
     background 140ms ease;
 }
 
 .deck-card-link:hover .deck-card {
-  border-color: var(--panel-border-strong);
   transform: translateY(-1px);
-  background: linear-gradient(180deg, rgba(34, 34, 40, 0.98), rgba(22, 22, 28, 0.98));
+  background: var(--surface-hover);
 }
 
 .deck-card-head {

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -3,6 +3,10 @@
   width: min(100%, var(--progress-panel-max-width));
   max-width: none;
   margin: 0 auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   container: progress-panel / inline-size;
 }
 
@@ -20,6 +24,9 @@
   gap: 14px;
   min-width: 0;
   padding: 14px;
+  border: 0;
+  background: var(--surface);
+  box-shadow: none;
   container: progress-section / inline-size;
 }
 
@@ -567,7 +574,6 @@ svg.progress-review-schedule-donut {
 .progress-leaderboard-row-viewer {
   border-bottom-color: transparent;
   background: var(--accent-soft);
-  box-shadow: inset 0 0 0 1px var(--accent-muted);
 }
 
 .progress-leaderboard-rank {

--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -8,10 +8,10 @@
   min-width: 0;
   min-height: 0;
   padding: var(--review-pane-padding);
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--review-pane-radius);
-  background: var(--surface-elevated);
-  box-shadow: var(--shadow-soft);
+  background: var(--surface);
+  box-shadow: none;
 }
 
 .review-pane {
@@ -22,6 +22,7 @@
   overscroll-behavior: contain;
   scrollbar-gutter: stable both-edges;
   scroll-padding-bottom: 132px;
+  background: transparent;
 }
 
 .review-queue-panel {
@@ -108,20 +109,16 @@
   min-height: 112px;
   min-width: 0;
   padding: 12px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--review-pane-inner-radius, var(--radius-sm));
-  background:
-    radial-gradient(circle at top, rgba(255, 255, 255, 0.06), transparent 44%),
-    linear-gradient(180deg, rgba(33, 33, 39, 0.96), rgba(23, 23, 28, 0.98));
+  background: var(--surface);
   display: grid;
   grid-template-rows: auto minmax(64px, 1fr);
   gap: 6px;
 }
 
 .review-card-answer {
-  background:
-    radial-gradient(circle at top, rgba(196, 75, 45, 0.08), transparent 44%),
-    linear-gradient(180deg, rgba(30, 30, 36, 0.98), rgba(18, 18, 24, 0.98));
+  background: var(--surface);
 }
 
 .review-loading-card-surface {
@@ -166,7 +163,7 @@
   display: block;
   min-height: 14px;
   border-radius: var(--radius-pill);
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0.05));
+  background: var(--surface-hover);
 }
 
 .review-loading-line-title {

--- a/apps/web/src/styles/features/review/review-queue.css
+++ b/apps/web/src/styles/features/review/review-queue.css
@@ -49,9 +49,9 @@
   display: grid;
   gap: 6px;
   padding: 10px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--review-pane-inner-radius, var(--radius-md));
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--surface-hover);
   color: var(--text);
   text-align: start;
   cursor: pointer;
@@ -62,12 +62,10 @@
 }
 
 .review-queue-card:hover {
-  border-color: var(--panel-border-strong);
-  background: rgba(255, 255, 255, 0.07);
+  background: var(--surface-pressed);
 }
 
 .review-queue-card-active {
-  border-color: rgba(196, 75, 45, 0.28);
   background: var(--accent-soft);
 }
 

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -1,6 +1,10 @@
 .review-screen-panel {
   --review-screen-panel-height: var(--chat-shell-pane-height, calc(100dvh - 128px));
   position: relative;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   container-type: inline-size;
   container-name: review-screen;
   grid-template-rows: auto minmax(0, 1fr);

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -6,6 +6,10 @@
 .settings-panel {
   max-width: 980px;
   align-content: start;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .settings-summary-grid {
@@ -123,9 +127,9 @@
 .settings-nav-card-button {
   width: 100%;
   padding: 18px 20px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--panel-inner-radius, var(--radius-md));
-  background: rgba(20, 20, 24, 0.92);
+  background: var(--surface);
   color: inherit;
   cursor: pointer;
   font: inherit;
@@ -140,14 +144,12 @@
 
 .settings-nav-card-button:disabled:hover {
   transform: none;
-  border-color: var(--panel-border);
-  background: rgba(20, 20, 24, 0.92);
+  background: var(--surface);
 }
 
 .settings-nav-card:hover {
   transform: translateY(-1px);
-  border-color: var(--panel-border-strong);
-  background: linear-gradient(180deg, rgba(34, 34, 40, 0.98), rgba(22, 22, 28, 0.98));
+  background: var(--surface-hover);
 }
 
 .settings-nav-card-muted {
@@ -225,9 +227,9 @@
   justify-content: space-between;
   width: 100%;
   padding: 16px 18px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--panel-inner-radius, var(--radius-md));
-  background: rgba(20, 20, 24, 0.92);
+  background: var(--surface);
   color: inherit;
   cursor: pointer;
   font: inherit;
@@ -240,8 +242,7 @@
 
 .settings-test-animation-row:hover {
   transform: translateY(-1px);
-  border-color: var(--panel-border-strong);
-  background: linear-gradient(180deg, rgba(34, 34, 40, 0.98), rgba(22, 22, 28, 0.98));
+  background: var(--surface-hover);
 }
 
 .settings-test-animation-name {
@@ -264,7 +265,7 @@
 .settings-danger-card {
   display: grid;
   gap: 16px;
-  border-color: rgba(196, 75, 45, 0.45);
+  background: rgba(196, 75, 45, 0.12);
 }
 
 .settings-danger-btn {
@@ -339,9 +340,9 @@
   align-items: center;
   min-height: 48px;
   padding: 12px 14px;
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--panel-inner-radius, var(--radius-md));
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface);
   color: var(--text);
   cursor: pointer;
   text-align: start;
@@ -349,8 +350,7 @@
 }
 
 .settings-workspace-choice:hover:not(:disabled) {
-  border-color: var(--panel-border-strong);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-hover);
 }
 
 .settings-workspace-choice:disabled {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,9 +1,11 @@
 :root {
   color-scheme: dark;
-  --bg: #050505;
-  --bg-elevated: #0a0a0c;
-  --surface: linear-gradient(180deg, rgba(24, 24, 30, 0.96), rgba(17, 17, 22, 0.98));
-  --surface-elevated: linear-gradient(180deg, rgba(30, 30, 36, 0.96), rgba(18, 18, 22, 0.98));
+  --bg: #000000;
+  --bg-elevated: #000000;
+  --surface: #1c1c1e;
+  --surface-elevated: #1c1c1e;
+  --surface-hover: #242426;
+  --surface-pressed: #2c2c2e;
   --surface-glass: rgba(26, 26, 30, 0.78);
   --surface-muted: rgba(255, 255, 255, 0.04);
   --panel: var(--surface);

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -111,13 +111,14 @@
   --content-card-radius: var(--panel-inner-radius, var(--radius-md));
   --content-card-inner-radius: max(0px, calc(var(--content-card-radius) - var(--content-card-padding-block)));
   padding: var(--content-card-padding-block) var(--content-card-padding-inline);
-  border: 1px solid var(--panel-border);
+  border: 0;
   border-radius: var(--content-card-radius);
-  background: var(--surface-elevated);
+  background: var(--surface);
+  box-shadow: none;
 }
 
 .content-card-muted {
-  background: linear-gradient(180deg, rgba(30, 30, 36, 0.64), rgba(22, 22, 26, 0.92));
+  background: var(--surface);
 }
 
 .content-card-section {
@@ -272,25 +273,25 @@
 }
 
 .txn-row td {
-  background: var(--surface-elevated);
-  border-top: 1px solid var(--panel-border);
-  border-bottom: 1px solid var(--panel-border);
+  background: var(--surface);
+  border-top: 0;
+  border-bottom: 0;
 }
 
 .txn-row td:first-child {
-  border-inline-start: 1px solid var(--panel-border);
+  border-inline-start: 0;
   border-start-start-radius: var(--radius-md);
   border-end-start-radius: var(--radius-md);
 }
 
 .txn-row td:last-child {
-  border-inline-end: 1px solid var(--panel-border);
+  border-inline-end: 0;
   border-start-end-radius: var(--radius-md);
   border-end-end-radius: var(--radius-md);
 }
 
 .txn-row:hover td {
-  background: linear-gradient(180deg, rgba(34, 34, 40, 0.98), rgba(22, 22, 28, 0.98));
+  background: var(--surface-hover);
 }
 
 .txn-cell {


### PR DESCRIPTION
## Summary
- replace web surface tokens with solid iOS dark grouped colors
- remove gradients, glow borders, and shadows from Review, Progress, Cards, and Settings content surfaces
- keep semantic accent/error states while making primary content blocks solid gray

## Validation
- npm run build in apps/web
- browser fixture check for target CSS computed styles: no background-image, no border, no box-shadow on the restyled surfaces

## Notes
- Local route screenshots were blocked by the local API bootstrap because GET /me was unavailable without the backend stack running.