### PR TITLE
[codex] Polish review card and queue surfaces

### DIFF
--- a/apps/web/src/styles/features/review/review-card.css
+++ b/apps/web/src/styles/features/review/review-card.css
@@ -3,6 +3,7 @@
   --review-pane-padding: 12px;
   --review-pane-radius: var(--panel-inner-radius, var(--radius-lg));
   --review-pane-inner-radius: max(0px, calc(var(--review-pane-radius) - var(--review-pane-padding)));
+  --review-card-radius: var(--panel-inner-radius, var(--radius-lg));
   display: grid;
   gap: 10px;
   min-width: 0;
@@ -20,7 +21,7 @@
   flex-direction: column;
   overflow-y: auto;
   overscroll-behavior: contain;
-  scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: auto;
   scroll-padding-bottom: 132px;
   background: transparent;
 }
@@ -28,6 +29,7 @@
 .review-queue-panel {
   grid-template-rows: auto minmax(0, 1fr);
   overflow: hidden;
+  background: transparent;
 }
 
 .review-pane-head {
@@ -101,16 +103,18 @@
 
 .review-card-stack {
   display: grid;
+  width: 100%;
   min-width: 0;
   gap: 10px;
 }
 
 .review-card-surface {
   min-height: 112px;
+  width: 100%;
   min-width: 0;
   padding: 12px;
   border: 0;
-  border-radius: var(--review-pane-inner-radius, var(--radius-sm));
+  border-radius: var(--review-card-radius);
   background: var(--surface);
   display: grid;
   grid-template-rows: auto minmax(64px, 1fr);

--- a/apps/web/src/styles/features/review/review-queue.css
+++ b/apps/web/src/styles/features/review/review-queue.css
@@ -38,7 +38,7 @@
 
 .review-queue-list {
   display: grid;
-  gap: 6px;
+  gap: 8px;
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -48,10 +48,10 @@
 .review-queue-card {
   display: grid;
   gap: 6px;
-  padding: 10px;
+  padding: 14px;
   border: 0;
-  border-radius: var(--review-pane-inner-radius, var(--radius-md));
-  background: var(--surface-hover);
+  border-radius: var(--radius-md);
+  background: var(--surface);
   color: var(--text);
   text-align: start;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- increase the review front/back card radius to match the rounded iOS-style surfaces
- remove the symmetrical scrollbar gutter that left extra space around review cards
- make the Queue panel background transparent while keeping queue cards as solid gray blocks

## Validation
- `npm run build` in `apps/web`
- Playwright fixture checked computed review/queue styles after the build