### PR TITLE
[codex] Implement Android stale chat rollover

### DIFF
--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiChatRuntime.kt
@@ -119,6 +119,13 @@ internal class AiChatRuntime(
                     resumeDiagnostics = resumeDiagnostics
                 )
             },
+            startFreshConversation = {
+                sessionCoordinator.startFreshConversation(
+                    draftMessage = "",
+                    pendingAttachments = emptyList(),
+                    shouldFocusComposer = false
+                )
+            },
             detachLiveStream = { reason ->
                 liveStreamCoordinator.detachLiveStream(reason = reason)
             },

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/lifecycle/AiChatRuntimeLifecycleCoordinator.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/coordinators/lifecycle/AiChatRuntimeLifecycleCoordinator.kt
@@ -5,8 +5,10 @@ import com.flashcardsopensourceapp.data.local.model.ai.AiChatResumeDiagnostics
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.feature.ai.runtime.AiChatRuntimeContext
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiAccessContext
+import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiChatRuntimeState
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiComposerPhase
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiConversationBootstrapState
+import com.flashcardsopensourceapp.feature.ai.runtime.conversation.isAiChatConversationStale
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.makeAiDraftState
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.normalizeAiChatPersistedStateForWorkspace
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.resolveAiChatSessionIdForWorkspace
@@ -34,6 +36,7 @@ import kotlinx.coroutines.launch
 internal class AiChatRuntimeLifecycleCoordinator(
     private val context: AiChatRuntimeContext,
     private val startConversationBootstrap: (Boolean, AiChatResumeDiagnostics?) -> Unit,
+    private val startFreshConversation: () -> Unit,
     private val detachLiveStream: (String) -> Unit,
     private val cancelActiveDictation: (String) -> Unit
 ) {
@@ -86,7 +89,6 @@ internal class AiChatRuntimeLifecycleCoordinator(
                 workspaceId = accessContext.workspaceId,
                 persistedState = context.aiChatRepository.loadPersistedState(workspaceId = accessContext.workspaceId)
             )
-            val currentState = context.runtimeStateMutable.value
             val persistedSessionId = resolveAiChatSessionIdForWorkspace(
                 workspaceId = accessContext.workspaceId,
                 sessionId = persistedState.chatSessionId
@@ -117,6 +119,15 @@ internal class AiChatRuntimeLifecycleCoordinator(
             context.runtimeStateMutable.value = nextState
             context.persistCurrentState()
             if (accessContext.workspaceId == null) {
+                return@launch
+            }
+            if (
+                shouldStartFreshConversationForStaleState(
+                    state = nextState,
+                    accessContext = accessContext
+                )
+            ) {
+                startFreshConversation()
                 return@launch
             }
             if (shouldPrepareGuestAccess(
@@ -169,6 +180,15 @@ internal class AiChatRuntimeLifecycleCoordinator(
             return
         }
         if (context.activeWarmUpJob != null) {
+            return
+        }
+        if (
+            shouldStartFreshConversationForStaleState(
+                state = currentState,
+                accessContext = accessContext
+            )
+        ) {
+            startFreshConversation()
             return
         }
         if (
@@ -304,6 +324,31 @@ internal class AiChatRuntimeLifecycleCoordinator(
         return shouldPrepareGuestAccess(
             accessContext = context.activeAccessContext,
             hasConsent = context.hasConsent()
+        )
+    }
+
+    private fun shouldStartFreshConversationForStaleState(
+        state: AiChatRuntimeState,
+        accessContext: AiAccessContext
+    ): Boolean {
+        val hasConsent = context.hasConsent()
+        val canUseAi = shouldPrepareGuestAccess(
+            accessContext = accessContext,
+            hasConsent = hasConsent
+        ) || shouldBootstrapConversation(
+            accessContext = accessContext,
+            hasConsent = hasConsent
+        )
+        if (canUseAi.not()) {
+            return false
+        }
+        if (context.activeFreshSessionJob != null) {
+            return false
+        }
+
+        return isAiChatConversationStale(
+            messages = state.persistedState.messages,
+            nowMillis = System.currentTimeMillis()
         )
     }
 }

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapStaleStateTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapStaleStateTest.kt
@@ -27,6 +27,7 @@ class AiChatRuntimeBootstrapStaleStateTest {
     @Test
     fun sameSessionRefreshSessionMismatchFailurePreservesExistingConversationState() = runTest {
         val repository = FakeAiChatRepository()
+        val nowMillis = System.currentTimeMillis()
         val attachment = AiChatAttachment.Binary(
             id = "attachment-1",
             fileName = "notes.txt",
@@ -36,9 +37,9 @@ class AiChatRuntimeBootstrapStaleStateTest {
         val messages = listOf(
             makeUserMessage(
                 content = listOf(AiChatContentPart.Text(text = "Existing question")),
-                timestampMillis = 1L
+                timestampMillis = nowMillis - 2_000L
             ),
-            makeAssistantStatusMessage(timestampMillis = 2L)
+            makeAssistantStatusMessage(timestampMillis = nowMillis - 1_000L)
         )
         val activeRun = makeActiveRun(runId = "run-1", cursor = "0")
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapWarmUpTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/bootstrap/AiChatRuntimeBootstrapWarmUpTest.kt
@@ -41,6 +41,7 @@ class AiChatRuntimeBootstrapWarmUpTest {
             startConversationBootstrap = { _, _ ->
                 bootstrapCalls += 1
             },
+            startFreshConversation = {},
             detachLiveStream = { _ -> },
             cancelActiveDictation = { _ -> }
         )

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeConversationResetRaceTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeConversationResetRaceTest.kt
@@ -62,6 +62,7 @@ class AiChatRuntimeConversationResetRaceTest {
     @Test
     fun clearConversationKeepsFreshLocalSessionWhileBootstrapReloadIsInFlight() = runTest {
         val repository = FakeAiChatRepository()
+        val nowMillis = System.currentTimeMillis()
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
             chatSessionId = "session-1"
         )
@@ -73,9 +74,9 @@ class AiChatRuntimeConversationResetRaceTest {
                 messages = listOf(
                     makeUserMessage(
                         content = listOf(AiChatContentPart.Text(text = "Hello")),
-                        timestampMillis = 1L
+                        timestampMillis = nowMillis - 2_000L
                     ),
-                    makeAssistantStatusMessage(timestampMillis = 2L)
+                    makeAssistantStatusMessage(timestampMillis = nowMillis - 1_000L)
                 ),
                 updatedAtMillis = 100L,
                 mainContentInvalidationVersion = 0L,
@@ -100,7 +101,7 @@ class AiChatRuntimeConversationResetRaceTest {
                 messages = listOf(
                     makeUserMessage(
                         content = listOf(AiChatContentPart.Text(text = "Reloaded")),
-                        timestampMillis = 3L
+                        timestampMillis = nowMillis
                     )
                 ),
                 updatedAtMillis = 100L,

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeGuestQuotaPromptTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeGuestQuotaPromptTest.kt
@@ -80,14 +80,15 @@ class AiChatRuntimeGuestQuotaPromptTest {
     @Test
     fun guestQuotaSendFailureAppendsUpgradePromptAfterRealAssistantReply() = runTest {
         val repository = FakeAiChatRepository()
+        val nowMillis = System.currentTimeMillis()
         val restoredMessages = listOf(
             makeUserMessage(
                 content = listOf(AiChatContentPart.Text(text = "Original question")),
-                timestampMillis = 1L
+                timestampMillis = nowMillis - 1_000L
             ),
             makeAssistantTextMessage(
                 text = "Original answer",
-                timestampMillis = 2L
+                timestampMillis = nowMillis
             )
         )
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
@@ -125,12 +126,13 @@ class AiChatRuntimeGuestQuotaPromptTest {
     @Test
     fun guestQuotaSendFailureReplacesOptimisticAssistantPlaceholderWithUpgradePrompt() = runTest {
         val repository = FakeAiChatRepository()
+        val nowMillis = System.currentTimeMillis()
         val restoredMessages = listOf(
             makeUserMessage(
                 content = listOf(AiChatContentPart.Text(text = "Original question")),
-                timestampMillis = 1L
+                timestampMillis = nowMillis - 1_000L
             ),
-            makeAssistantStatusMessage(timestampMillis = 2L)
+            makeAssistantStatusMessage(timestampMillis = nowMillis)
         )
         repository.persistedStates[defaultTestWorkspaceId] = makeDefaultAiChatPersistedState().copy(
             chatSessionId = "session-1",

--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeWorkspaceSessionTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/session/AiChatRuntimeWorkspaceSessionTest.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -341,7 +342,7 @@ class AiChatRuntimeWorkspaceSessionTest {
     }
 
     @Test
-    fun stalePersistedChatPreservesCurrentBootstrapPath() = runTest {
+    fun stalePersistedChatStartsFreshConversation() = runTest {
         val repository = FakeAiChatRepository()
         val nowMillis = System.currentTimeMillis()
         val staleTimestamp = nowMillis - aiChatStalenessThresholdMillis - 1_000L
@@ -359,18 +360,66 @@ class AiChatRuntimeWorkspaceSessionTest {
                 )
             )
         )
-        repository.bootstrapResponses += makeBootstrapResponse(
-            sessionId = oldSessionId,
-            activeRun = null
+        repository.draftStates[defaultTestWorkspaceId to oldSessionId] = AiChatDraftState(
+            draftMessage = "Keep this old draft",
+            pendingAttachments = emptyList()
         )
         val runtime = makeRuntime(scope = this, repository = repository)
 
         runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
         advanceUntilIdle()
 
-        assertEquals(1, repository.loadBootstrapCalls)
+        val freshSessionId = repository.createNewSessionRequests.single()
+        assertNotEquals(oldSessionId, freshSessionId)
+        assertEquals(0, repository.loadBootstrapCalls)
+        assertTrue(repository.loadBootstrapSessionIds.isEmpty())
+        assertEquals(freshSessionId, runtime.state.value.persistedState.chatSessionId)
+        assertTrue(runtime.state.value.persistedState.messages.isEmpty())
+        assertEquals("", runtime.state.value.draftMessage)
+        assertEquals(
+            "Keep this old draft",
+            repository.draftStates[defaultTestWorkspaceId to oldSessionId]?.draftMessage
+        )
+        assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
+    }
+
+    @Test
+    fun stalePersistedChatStartsFreshConversationAfterConsentWarmUp() = runTest {
+        val repository = FakeAiChatRepository()
+        repository.consent.value = false
+        val nowMillis = System.currentTimeMillis()
+        val staleTimestamp = nowMillis - aiChatStalenessThresholdMillis - 1_000L
+        val oldSessionId = "session-old"
+        repository.setPersistedState(
+            workspaceId = defaultTestWorkspaceId,
+            state = makeDefaultAiChatPersistedState().copy(
+                chatSessionId = oldSessionId,
+                messages = listOf(
+                    makeUserMessage(
+                        content = listOf(AiChatContentPart.Text(text = "Stale question")),
+                        timestampMillis = staleTimestamp
+                    )
+                )
+            )
+        )
+        val runtime = makeRuntime(scope = this, repository = repository)
+
+        runtime.updateAccessContext(makeAccessContext(workspaceId = defaultTestWorkspaceId))
+        advanceUntilIdle()
+
         assertTrue(repository.createNewSessionRequests.isEmpty())
+        assertEquals(0, repository.loadBootstrapCalls)
         assertEquals(oldSessionId, runtime.state.value.persistedState.chatSessionId)
+
+        repository.updateConsent(hasConsent = true)
+        runtime.warmUpLinkedSessionIfNeeded(resumeDiagnostics = null)
+        advanceUntilIdle()
+
+        val freshSessionId = repository.createNewSessionRequests.single()
+        assertNotEquals(oldSessionId, freshSessionId)
+        assertEquals(0, repository.loadBootstrapCalls)
+        assertTrue(repository.loadBootstrapSessionIds.isEmpty())
+        assertEquals(freshSessionId, runtime.state.value.persistedState.chatSessionId)
         assertTrue(runtime.state.value.persistedState.messages.isEmpty())
         assertEquals(AiConversationBootstrapState.READY, runtime.state.value.conversationBootstrapState)
     }


### PR DESCRIPTION
Summary
- Start a fresh Android AI chat when persisted local user history is older than the six-hour staleness threshold.
- Reuse the existing fresh-chat provisioning path so the new session starts empty and provisions remotely through the current flow.
- Cover restore, consent warm-up, non-stale, and assistant-only behavior in runtime tests.

Validation
- git --no-pager diff --check
- Android Gradle tests were not run because this repository requires explicit permission before local ./gradlew runs.