### PR TITLE
[codex] Add iOS silent failure observability

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatHistoryStore.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatHistoryStore.swift
@@ -178,6 +178,13 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
                 suppressDraftRestore: state.suppressDraftRestore
             )
         } catch {
+            self.captureAIChatPersistenceSilentFailure(
+                error: error,
+                action: "ai_chat_history_state_load",
+                stage: "decode",
+                workspaceId: workspaceId,
+                sessionId: nil
+            )
             self.userDefaults.removeObject(forKey: storageKey)
             return AIChatPersistedState(
                 messages: [],
@@ -205,6 +212,13 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
                 state: state
             )
         } catch {
+            self.captureAIChatPersistenceSilentFailure(
+                error: error,
+                action: "ai_chat_history_state_save",
+                stage: "encode",
+                workspaceId: workspaceId,
+                sessionId: state.chatSessionId
+            )
             self.userDefaults.removeObject(forKey: aiChatHistoryStorageKeyForWorkspace(workspaceId: workspaceId))
         }
     }
@@ -231,6 +245,13 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
             do {
                 return try self.decoder.decode(AIChatComposerDraft.self, from: data)
             } catch {
+                self.captureAIChatPersistenceSilentFailure(
+                    error: error,
+                    action: "ai_chat_draft_load",
+                    stage: "decode",
+                    workspaceId: workspaceId,
+                    sessionId: normalizedSessionId
+                )
                 self.userDefaults.removeObject(forKey: resolvedKey)
                 return AIChatComposerDraft(inputText: "", pendingAttachments: [])
             }
@@ -273,6 +294,13 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
             guard let normalizedSessionId = normalizedAIChatDraftSessionId(sessionId: sessionId) else {
                 return
             }
+            self.captureAIChatPersistenceSilentFailure(
+                error: error,
+                action: "ai_chat_draft_save",
+                stage: "encode",
+                workspaceId: workspaceId,
+                sessionId: normalizedSessionId
+            )
             self.userDefaults.removeObject(
                 forKey: aiChatDraftStorageKeyForWorkspace(
                     workspaceId: workspaceId,
@@ -297,6 +325,34 @@ final class AIChatHistoryStore: AIChatHistoryStoring, @unchecked Sendable {
 
     private func storageKey() -> String {
         aiChatHistoryStorageKeyForWorkspace(workspaceId: self.currentWorkspaceId)
+    }
+
+    private func captureAIChatPersistenceSilentFailure(
+        error: Error,
+        action: String,
+        stage: String,
+        workspaceId: String?,
+        sessionId: String?
+    ) {
+        FlashcardsObservability.captureSilentFailure(
+            error: error,
+            scope: IOSObservationScope(
+                feature: .aiChat,
+                userId: nil,
+                workspaceId: workspaceId,
+                requestId: nil,
+                clientRequestId: nil,
+                sessionId: sessionId,
+                runId: nil,
+                cloudState: nil,
+                configurationMode: nil
+            ),
+            action: action,
+            stage: stage,
+            statusCode: nil,
+            backendCode: nil,
+            requestId: nil
+        )
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
@@ -688,9 +688,11 @@ extension AIChatStore {
         }
 
         Task {
+            var refreshedSessionId: String?
             do {
                 let session = try await self.flashcardsStore.cloudSessionForAI()
                 let sessionId = try await self.ensureRemoteSessionIfNeeded(session: session)
+                refreshedSessionId = sessionId
                 let refreshedBaselineState = self.currentPersistedState()
                 let bootstrap = try await self.chatService.loadBootstrap(
                     session: session,
@@ -707,9 +709,57 @@ extension AIChatStore {
                     session: session,
                     resumeAttemptDiagnostics: nil
                 )
+            } catch is CancellationError {
+                return
             } catch {
+                if self.shouldIgnoreAIChatPassiveSnapshotRefreshFailure(error: error) {
+                    return
+                }
+                let diagnostics = (error as? any AIChatFailureDiagnosticProviding)?.diagnostics
+                FlashcardsObservability.captureSilentFailure(
+                    error: error,
+                    scope: IOSObservationScope(
+                        feature: .aiChat,
+                        userId: nil,
+                        workspaceId: self.flashcardsStore.workspace?.workspaceId,
+                        requestId: diagnostics?.backendRequestId,
+                        clientRequestId: diagnostics?.clientRequestId,
+                        sessionId: refreshedSessionId,
+                        runId: self.activeRunId,
+                        cloudState: self.flashcardsStore.cloudSettings?.cloudState,
+                        configurationMode: nil
+                    ),
+                    action: "ai_chat_passive_snapshot_refresh",
+                    stage: diagnostics?.stage.rawValue ?? "refresh",
+                    statusCode: diagnostics?.statusCode,
+                    backendCode: nil,
+                    requestId: diagnostics?.backendRequestId
+                )
             }
         }
+    }
+
+    private func shouldIgnoreAIChatPassiveSnapshotRefreshFailure(error: Error) -> Bool {
+        if isAIChatRequestCancellationError(error: error) {
+            return true
+        }
+        if isRetryableNetworkTransportFailure(error: error) {
+            return true
+        }
+        return self.isAIChatPassiveSnapshotRefreshBlockedGateFailure(error: error)
+    }
+
+    private func isAIChatPassiveSnapshotRefreshBlockedGateFailure(error: Error) -> Bool {
+        guard case .blocked(let blockedMessage) = self.flashcardsStore.syncStatus else {
+            return false
+        }
+        guard let localStoreError = error as? LocalStoreError else {
+            return false
+        }
+        guard case .validation(let message) = localStoreError else {
+            return false
+        }
+        return message == blockedMessage
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -480,6 +480,25 @@ struct FlashcardsApp: App {
             } catch is CancellationError {
                 return
             } catch {
+                FlashcardsObservability.captureSilentFailure(
+                    error: error,
+                    scope: IOSObservationScope(
+                        feature: .cloudSync,
+                        userId: self.store.cloudSettings?.linkedUserId,
+                        workspaceId: self.store.workspace?.workspaceId,
+                        requestId: nil,
+                        clientRequestId: nil,
+                        sessionId: nil,
+                        runId: nil,
+                        cloudState: self.store.cloudSettings?.cloudState,
+                        configurationMode: try? self.store.currentCloudServiceConfiguration().mode
+                    ),
+                    action: "cloud_sync_polling_loop_sleep",
+                    stage: "sleep",
+                    statusCode: nil,
+                    backendCode: nil,
+                    requestId: nil
+                )
                 return
             }
 
@@ -533,6 +552,25 @@ struct FlashcardsApp: App {
             } catch is CancellationError {
                 return
             } catch {
+                FlashcardsObservability.captureSilentFailure(
+                    error: error,
+                    scope: IOSObservationScope(
+                        feature: .progress,
+                        userId: self.store.cloudSettings?.linkedUserId,
+                        workspaceId: self.store.workspace?.workspaceId,
+                        requestId: nil,
+                        clientRequestId: nil,
+                        sessionId: nil,
+                        runId: nil,
+                        cloudState: self.store.cloudSettings?.cloudState,
+                        configurationMode: try? self.store.currentCloudServiceConfiguration().mode
+                    ),
+                    action: "progress_context_watcher_sleep",
+                    stage: "sleep",
+                    statusCode: nil,
+                    backendCode: nil,
+                    requestId: nil
+                )
                 return
             }
 

--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -196,6 +196,25 @@ struct RootTabView: View {
         } catch is CancellationError {
             return
         } catch {
+            FlashcardsObservability.captureSilentFailure(
+                error: error,
+                scope: IOSObservationScope(
+                    feature: .prompts,
+                    userId: store.cloudSettings?.linkedUserId,
+                    workspaceId: store.workspace?.workspaceId,
+                    requestId: nil,
+                    clientRequestId: nil,
+                    sessionId: nil,
+                    runId: nil,
+                    cloudState: store.cloudSettings?.cloudState,
+                    configurationMode: try? store.currentCloudServiceConfiguration().mode
+                ),
+                action: "guest_sign_in_after_review_prompt_recheck_sleep",
+                stage: "sleep",
+                statusCode: nil,
+                backendCode: nil,
+                requestId: nil
+            )
             assertionFailure("Unexpected guest sign-in prompt recheck sleep failure: \(error)")
             return
         }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+AccountPreferences.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+AccountPreferences.swift
@@ -355,6 +355,11 @@ extension FlashcardsStore {
         do {
             return try self.decoder.decode(PersistedAccountPreferencesCache.self, from: data)
         } catch {
+            self.captureAccountPreferencesSilentFailure(
+                error: error,
+                action: "account_preferences_cache_load",
+                stage: "decode"
+            )
             self.userDefaults.removeObject(forKey: accountPreferencesCacheUserDefaultsKey)
             return PersistedAccountPreferencesCache(preferencesByIdentityKey: [:])
         }
@@ -365,6 +370,11 @@ extension FlashcardsStore {
             let data = try self.encoder.encode(cache)
             self.userDefaults.set(data, forKey: accountPreferencesCacheUserDefaultsKey)
         } catch {
+            self.captureAccountPreferencesSilentFailure(
+                error: error,
+                action: "account_preferences_cache_save",
+                stage: "encode"
+            )
             self.userDefaults.removeObject(forKey: accountPreferencesCacheUserDefaultsKey)
         }
     }
@@ -376,5 +386,31 @@ extension FlashcardsStore {
         var cache = self.loadPersistedAccountPreferencesCache()
         cache.preferencesByIdentityKey[identityKey] = preferences
         self.savePersistedAccountPreferencesCache(cache)
+    }
+
+    private func captureAccountPreferencesSilentFailure(
+        error: Error,
+        action: String,
+        stage: String
+    ) {
+        FlashcardsObservability.captureSilentFailure(
+            error: error,
+            scope: IOSObservationScope(
+                feature: .cloudAuth,
+                userId: self.cloudSettings?.linkedUserId,
+                workspaceId: self.workspace?.workspaceId,
+                requestId: nil,
+                clientRequestId: nil,
+                sessionId: nil,
+                runId: nil,
+                cloudState: self.cloudSettings?.cloudState,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            ),
+            action: action,
+            stage: stage,
+            statusCode: nil,
+            backendCode: nil,
+            requestId: nil
+        )
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Support/CloudSupport.swift
@@ -38,6 +38,7 @@ enum AppConfigurationError: LocalizedError, Equatable {
 let customCloudServerOverrideUserDefaultsKey: String = "custom-cloud-server-override"
 let pendingCloudServerBootstrapUserDefaultsKey: String = "pending-cloud-server-bootstrap"
 let cloudCredentialRecoveryStateUserDefaultsKey: String = "cloud-credential-recovery-state"
+let cloudCredentialRecoveryStateSilentFailureDigestUserDefaultsKey: String = "cloud-credential-recovery-state-silent-failure-digest"
 let guestLocalRecoveryWorkspaceCheckpointUserDefaultsKey: String = "guest-local-recovery-workspace-checkpoint"
 let flashcardsRepositoryUrl: String = "https://github.com/kirill-markin/flashcards-open-source-app"
 
@@ -157,8 +158,43 @@ func loadCloudCredentialRecoveryState(
     do {
         return try decoder.decode(CloudCredentialRecoveryState.self, from: storedData)
     } catch {
+        let payloadDigest = stableCloudCredentialRecoveryStatePayloadDigest(data: storedData)
+        if userDefaults.string(forKey: cloudCredentialRecoveryStateSilentFailureDigestUserDefaultsKey) != payloadDigest {
+            captureCloudCredentialRecoveryStateSilentFailure(
+                error: error,
+                action: "cloud_credential_recovery_state_load",
+                stage: "decode"
+            )
+            userDefaults.set(payloadDigest, forKey: cloudCredentialRecoveryStateSilentFailureDigestUserDefaultsKey)
+        }
         return invalidStoredCloudCredentialRecoveryState()
     }
+}
+
+private func captureCloudCredentialRecoveryStateSilentFailure(
+    error: Error,
+    action: String,
+    stage: String
+) {
+    FlashcardsObservability.captureSilentFailure(
+        error: error,
+        scope: IOSObservationScope(
+            feature: .cloudAuth,
+            userId: nil,
+            workspaceId: nil,
+            requestId: nil,
+            clientRequestId: nil,
+            sessionId: nil,
+            runId: nil,
+            cloudState: nil,
+            configurationMode: nil
+        ),
+        action: action,
+        stage: stage,
+        statusCode: nil,
+        backendCode: nil,
+        requestId: nil
+    )
 }
 
 private func invalidStoredCloudCredentialRecoveryState() -> CloudCredentialRecoveryState {
@@ -176,6 +212,15 @@ private func invalidStoredCloudCredentialRecoveryState() -> CloudCredentialRecov
     )
 }
 
+private func stableCloudCredentialRecoveryStatePayloadDigest(data: Data) -> String {
+    var hash: UInt64 = 1_469_598_103_934_665_603
+    for byte in data {
+        hash ^= UInt64(byte)
+        hash &*= 1_099_511_628_211
+    }
+    return "\(data.count):\(String(hash, radix: 16))"
+}
+
 func saveCloudCredentialRecoveryState(
     state: CloudCredentialRecoveryState,
     userDefaults: UserDefaults,
@@ -184,6 +229,7 @@ func saveCloudCredentialRecoveryState(
     do {
         let storedData = try encoder.encode(state)
         userDefaults.set(storedData, forKey: cloudCredentialRecoveryStateUserDefaultsKey)
+        userDefaults.removeObject(forKey: cloudCredentialRecoveryStateSilentFailureDigestUserDefaultsKey)
     } catch {
         throw LocalStoreError.validation(
             "Cloud credential recovery state could not be saved: \(Flashcards.errorMessage(error: error))"
@@ -193,6 +239,7 @@ func saveCloudCredentialRecoveryState(
 
 func clearCloudCredentialRecoveryState(userDefaults: UserDefaults) {
     userDefaults.removeObject(forKey: cloudCredentialRecoveryStateUserDefaultsKey)
+    userDefaults.removeObject(forKey: cloudCredentialRecoveryStateSilentFailureDigestUserDefaultsKey)
     clearGuestLocalRecoveryWorkspaceCheckpoint(userDefaults: userDefaults)
 }
 

--- a/apps/ios/Flashcards/Flashcards/Feedback/FeedbackPersistence.swift
+++ b/apps/ios/Flashcards/Flashcards/Feedback/FeedbackPersistence.swift
@@ -26,6 +26,11 @@ func loadFeedbackPromptState(
     do {
         return try decoder.decode(PersistedFeedbackPromptState.self, from: data)
     } catch {
+        captureFeedbackPersistenceSilentFailure(
+            error: error,
+            action: "feedback_prompt_state_load",
+            stage: "decode"
+        )
         userDefaults.removeObject(forKey: storageKey)
         return makeDefaultFeedbackPromptState()
     }
@@ -42,6 +47,11 @@ func saveFeedbackPromptState(
         let data = try encoder.encode(state)
         userDefaults.set(data, forKey: storageKey)
     } catch {
+        captureFeedbackPersistenceSilentFailure(
+            error: error,
+            action: "feedback_prompt_state_save",
+            stage: "encode"
+        )
         userDefaults.removeObject(forKey: storageKey)
     }
 }
@@ -82,4 +92,30 @@ func clearFeedbackPromptPersistence(
     userDefaults.removeObject(forKey: feedbackDraftUserDefaultsKey(identityKey: identityKey))
     userDefaults.removeObject(forKey: legacyFeedbackPromptStateUserDefaultsKey)
     userDefaults.removeObject(forKey: legacyFeedbackDraftUserDefaultsKey)
+}
+
+private func captureFeedbackPersistenceSilentFailure(
+    error: Error,
+    action: String,
+    stage: String
+) {
+    FlashcardsObservability.captureSilentFailure(
+        error: error,
+        scope: IOSObservationScope(
+            feature: .feedback,
+            userId: nil,
+            workspaceId: nil,
+            requestId: nil,
+            clientRequestId: nil,
+            sessionId: nil,
+            runId: nil,
+            cloudState: nil,
+            configurationMode: nil
+        ),
+        action: action,
+        stage: stage,
+        statusCode: nil,
+        backendCode: nil,
+        requestId: nil
+    )
 }

--- a/apps/ios/Flashcards/Flashcards/Feedback/FeedbackTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Feedback/FeedbackTypes.swift
@@ -4,6 +4,7 @@ let feedbackMessageMaximumCharacters: Int = 5000
 let feedbackAutomaticReviewThreshold: Int = 15
 let feedbackAutomaticPromptCooldownSeconds: TimeInterval = 30 * 24 * 60 * 60
 let feedbackServerStateStaleSeconds: TimeInterval = 24 * 60 * 60
+let feedbackAutomaticPromptFailureBackoffSeconds: TimeInterval = 30 * 60
 
 enum FeedbackTrigger: String, Codable, Hashable, Sendable {
     case settings

--- a/apps/ios/Flashcards/Flashcards/Feedback/FlashcardsStore+Feedback.swift
+++ b/apps/ios/Flashcards/Flashcards/Feedback/FlashcardsStore+Feedback.swift
@@ -91,6 +91,12 @@ extension FlashcardsStore {
         guard self.activeAutomaticFeedbackPromptTask == nil else {
             return
         }
+        if let nextRetryAt = self.nextAutomaticFeedbackPromptRetryAt {
+            guard now >= nextRetryAt else {
+                return
+            }
+            self.nextAutomaticFeedbackPromptRetryAt = nil
+        }
         guard self.isAutomaticFeedbackPromptBlockedByModal == false else {
             return
         }
@@ -115,6 +121,7 @@ extension FlashcardsStore {
         self.feedbackPromptState = makeDefaultFeedbackPromptState()
         self.activeAutomaticFeedbackPromptTask?.cancel()
         self.activeAutomaticFeedbackPromptTask = nil
+        self.nextAutomaticFeedbackPromptRetryAt = nil
         clearFeedbackPromptPersistence(
             identityKey: self.feedbackPromptIdentityKey,
             userDefaults: self.userDefaults
@@ -122,6 +129,7 @@ extension FlashcardsStore {
     }
 
     func reloadFeedbackPromptStateForCurrentIdentity() {
+        self.nextAutomaticFeedbackPromptRetryAt = nil
         self.feedbackPromptState = loadFeedbackPromptState(
             identityKey: self.feedbackPromptIdentityKey,
             userDefaults: self.userDefaults,
@@ -130,31 +138,39 @@ extension FlashcardsStore {
     }
 
     private func runAutomaticFeedbackPromptCheck(now: Date) async {
+        var failureStage: String = "start"
         do {
+            failureStage = "resolve_workspace"
             guard let workspaceId = self.workspace?.workspaceId else {
                 return
             }
+            failureStage = "modal_gate"
             guard self.isAutomaticFeedbackPromptBlockedByModal == false else {
                 return
             }
+            failureStage = "local_cooldown_gate"
             guard isFeedbackAutomaticCooldownExpired(promptState: self.feedbackPromptState, now: now) else {
                 return
             }
 
+            failureStage = "load_review_activity"
             let database = try requireLocalDatabase(database: self.database)
             let reviewActivity = try database.loadFeedbackReviewActivitySummary(
                 workspaceId: workspaceId,
                 now: now,
                 timeZone: TimeZone.current
             )
+            failureStage = "previous_review_day_gate"
             guard reviewActivity.hasPreviousLocalReviewDay else {
                 return
             }
+            failureStage = "current_day_review_count_gate"
             guard reviewActivity.currentLocalDayReviewCount >= feedbackAutomaticReviewThreshold else {
                 return
             }
 
             if shouldFetchFeedbackServerState(promptState: self.feedbackPromptState, now: now) {
+                failureStage = "load_feedback_state"
                 let feedbackState = try await self.loadFeedbackStateFromServer()
                 self.updateFeedbackPromptState(
                     state: applyFeedbackServerState(
@@ -164,13 +180,16 @@ extension FlashcardsStore {
                     )
                 )
             }
+            failureStage = "post_server_cooldown_gate"
             guard isFeedbackAutomaticCooldownExpired(promptState: self.feedbackPromptState, now: Date()) else {
                 return
             }
+            failureStage = "post_server_modal_gate"
             guard self.isAutomaticFeedbackPromptBlockedByModal == false else {
                 return
             }
 
+            failureStage = "record_prompt_shown"
             let shownAt = Date()
             let feedbackState = try await self.recordAutomaticFeedbackPromptShown(now: shownAt)
             self.updateFeedbackPromptState(
@@ -180,8 +199,23 @@ extension FlashcardsStore {
                     shownAt: shownAt
                 )
             )
+            failureStage = "present_sheet"
+            self.nextAutomaticFeedbackPromptRetryAt = nil
             self.presentFeedbackSheet(trigger: .automatic)
+        } catch is CancellationError {
+            return
         } catch {
+            if self.shouldRetryAutomaticFeedbackPromptSilently(error: error, stage: failureStage) {
+                self.nextAutomaticFeedbackPromptRetryAt = Date().addingTimeInterval(
+                    feedbackAutomaticPromptFailureBackoffSeconds
+                )
+                return
+            }
+            self.captureFeedbackSilentFailure(
+                error: error,
+                action: "automatic_feedback_prompt_check",
+                stage: failureStage
+            )
             return
         }
     }
@@ -255,4 +289,121 @@ extension FlashcardsStore {
     private var feedbackPromptIdentityKey: FeedbackPromptIdentityKey {
         makeFeedbackPromptIdentityKey(cloudSettings: self.cloudSettings)
     }
+
+    private func shouldRetryAutomaticFeedbackPromptSilently(
+        error: Error,
+        stage: String
+    ) -> Bool {
+        guard isFeedbackAutomaticPromptServerStage(stage: stage) else {
+            return false
+        }
+        if isRequestCancellationError(error: error) {
+            return true
+        }
+        if isRetryableNetworkTransportFailure(error: error) {
+            return true
+        }
+        if let statusCode = feedbackFailureDiagnostics(error: error).statusCode,
+           isRetryableFeedbackAutomaticPromptStatusCode(statusCode) {
+            return true
+        }
+        return self.isAutomaticFeedbackPromptBlockedGateFailure(error: error)
+    }
+
+    private func isAutomaticFeedbackPromptBlockedGateFailure(error: Error) -> Bool {
+        guard case .blocked(let blockedMessage) = self.syncStatus else {
+            return false
+        }
+        guard let localStoreError = error as? LocalStoreError else {
+            return false
+        }
+        guard case .validation(let message) = localStoreError else {
+            return false
+        }
+        return message == blockedMessage
+    }
+
+    private func captureFeedbackSilentFailure(
+        error: Error,
+        action: String,
+        stage: String
+    ) {
+        let diagnostics = feedbackFailureDiagnostics(error: error)
+        FlashcardsObservability.captureSilentFailure(
+            error: error,
+            scope: IOSObservationScope(
+                feature: .feedback,
+                userId: self.cloudSettings?.linkedUserId,
+                workspaceId: self.workspace?.workspaceId,
+                requestId: diagnostics.requestId,
+                clientRequestId: nil,
+                sessionId: nil,
+                runId: nil,
+                cloudState: self.cloudSettings?.cloudState,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            ),
+            action: action,
+            stage: stage,
+            statusCode: diagnostics.statusCode,
+            backendCode: diagnostics.backendCode,
+            requestId: diagnostics.requestId
+        )
+    }
+}
+
+private struct FeedbackFailureDiagnostics {
+    let statusCode: Int?
+    let backendCode: String?
+    let requestId: String?
+}
+
+private func feedbackFailureDiagnostics(error: Error) -> FeedbackFailureDiagnostics {
+    if let syncError = error as? CloudSyncError {
+        switch syncError {
+        case .invalidResponse(let details, let statusCode):
+            return FeedbackFailureDiagnostics(
+                statusCode: statusCode,
+                backendCode: details.code,
+                requestId: details.requestId
+            )
+        case .invalidBaseUrl:
+            return FeedbackFailureDiagnostics(statusCode: nil, backendCode: nil, requestId: nil)
+        }
+    }
+
+    if let authError = error as? CloudAuthError {
+        switch authError {
+        case .invalidResponse(let details, let statusCode):
+            return FeedbackFailureDiagnostics(
+                statusCode: statusCode,
+                backendCode: details.code,
+                requestId: details.requestId
+            )
+        case .invalidBaseUrl, .invalidResponseBody:
+            return FeedbackFailureDiagnostics(statusCode: nil, backendCode: nil, requestId: nil)
+        }
+    }
+
+    if let guestAuthError = error as? GuestCloudAuthError {
+        switch guestAuthError {
+        case .invalidResponse(let details, let statusCode):
+            return FeedbackFailureDiagnostics(
+                statusCode: statusCode,
+                backendCode: details.code,
+                requestId: details.requestId
+            )
+        case .invalidBaseUrl, .invalidResponseBody:
+            return FeedbackFailureDiagnostics(statusCode: nil, backendCode: nil, requestId: nil)
+        }
+    }
+
+    return FeedbackFailureDiagnostics(statusCode: nil, backendCode: nil, requestId: nil)
+}
+
+private func isFeedbackAutomaticPromptServerStage(stage: String) -> Bool {
+    stage == "load_feedback_state" || stage == "record_prompt_shown"
+}
+
+private func isRetryableFeedbackAutomaticPromptStatusCode(_ statusCode: Int) -> Bool {
+    statusCode == 408 || statusCode == 429 || (statusCode >= 500 && statusCode <= 599)
 }

--- a/apps/ios/Flashcards/Flashcards/Observability/FlashcardsObservability.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/FlashcardsObservability.swift
@@ -20,5 +20,29 @@ enum FlashcardsObservability {
     static func captureException(_ event: IOSExceptionEvent) {
         SentryObservabilityAdapter.captureException(event)
     }
-}
 
+    static func captureSilentFailure(
+        error: Error,
+        scope: IOSObservationScope,
+        action: String,
+        stage: String?,
+        statusCode: Int?,
+        backendCode: String?,
+        requestId: String?
+    ) {
+        self.captureException(
+            .silentFailure(
+                error: error,
+                scope: scope,
+                details: SilentFailureDetails(
+                    action: action,
+                    stage: stage,
+                    statusCode: statusCode,
+                    backendCode: backendCode,
+                    requestId: requestId,
+                    messageSummary: Flashcards.errorMessage(error: error)
+                )
+            )
+        )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -16,11 +16,14 @@ enum IOSObservationFeature: String, Sendable {
     case cards = "cards"
     case cloudAuth = "cloud_auth"
     case cloudSync = "cloud_sync"
+    case feedback = "feedback"
     case aiChat = "ai_chat"
     case aiLive = "ai_live"
     case notifications = "notifications"
     case localData = "local_data"
+    case prompts = "prompts"
     case progress = "progress"
+    case storeReview = "store_review"
 }
 
 struct IOSObservationScope: Sendable, Hashable {
@@ -64,6 +67,7 @@ enum IOSExceptionEvent {
     case aiLiveStreamFailed(error: Error, scope: IOSObservationScope, details: AILiveStreamFailureDetails)
     case notificationSchedulingFailed(error: Error, scope: IOSObservationScope, details: NotificationFailureDetails)
     case localDataRepairFailed(error: Error, scope: IOSObservationScope, details: LocalDataRepairFailureDetails)
+    case silentFailure(error: Error, scope: IOSObservationScope, details: SilentFailureDetails)
 }
 
 struct CloudFlowObservation: Sendable, Hashable {
@@ -370,5 +374,14 @@ struct LocalDataRepairFailureDetails: Sendable, Hashable {
     let workspaceId: String?
     let entityId: String?
     let reason: String
+    let messageSummary: String?
+}
+
+struct SilentFailureDetails: Sendable, Hashable {
+    let action: String
+    let stage: String?
+    let statusCode: Int?
+    let backendCode: String?
+    let requestId: String?
     let messageSummary: String?
 }

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -508,6 +508,26 @@ extension SentryObservabilityAdapter {
                     localFields: stringifyContext(context)
                 )
             )
+        case .silentFailure(let error, let scope, let details):
+            let context: [String: Any] = [
+                "stage": details.stage ?? "",
+                "status_code": details.statusCode.map { statusCode in String(statusCode) } ?? "",
+                "backend_code": details.backendCode ?? "",
+                "request_id": details.requestId ?? "",
+                "message_summary": details.messageSummary ?? ""
+            ]
+            return ExceptionPayload(
+                error: error,
+                observation: ObservationPayload(
+                    message: "iOS silent failure: \(details.action)",
+                    action: details.action,
+                    scope: scope,
+                    statusCode: details.statusCode,
+                    backendCode: details.backendCode,
+                    context: context,
+                    localFields: stringifyContext(context)
+                )
+            )
         }
     }
 

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -288,6 +288,14 @@ extension FlashcardsStore {
             let data = try self.encoder.encode(self.reviewNotificationsSettings)
             self.userDefaults.set(data, forKey: makeReviewNotificationsSettingsUserDefaultsKey(workspaceId: workspaceId))
         } catch {
+            captureReviewNotificationsSilentFailure(
+                error: error,
+                action: "review_notifications_settings_save",
+                stage: "encode",
+                cloudSettings: self.cloudSettings,
+                workspaceId: workspaceId,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            )
             self.userDefaults.removeObject(forKey: makeReviewNotificationsSettingsUserDefaultsKey(workspaceId: workspaceId))
         }
     }
@@ -299,6 +307,14 @@ extension FlashcardsStore {
             let data = try self.encoder.encode(state)
             self.userDefaults.set(data, forKey: reviewNotificationPromptStateUserDefaultsKey)
         } catch {
+            captureReviewNotificationsSilentFailure(
+                error: error,
+                action: "review_notification_permission_prompt_state_save",
+                stage: "encode",
+                cloudSettings: self.cloudSettings,
+                workspaceId: self.workspace?.workspaceId,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            )
             self.userDefaults.removeObject(forKey: reviewNotificationPromptStateUserDefaultsKey)
         }
     }
@@ -472,7 +488,17 @@ extension FlashcardsStore {
                     plannedRequestIdentifiers: payloads.map(\.requestId),
                     delayNanoseconds: notificationSchedulingDelayedReadbackNanoseconds
                 )
+            } catch is CancellationError {
+                return
             } catch {
+                captureReviewNotificationsSilentFailure(
+                    error: error,
+                    action: "review_notifications_delayed_readback",
+                    stage: "readback",
+                    cloudSettings: self.cloudSettings,
+                    workspaceId: workspaceId,
+                    configurationMode: try? self.currentCloudServiceConfiguration().mode
+                )
                 return
             }
             guard self.reviewNotificationsRescheduleGeneration == generation else {
@@ -566,6 +592,14 @@ extension FlashcardsStore {
             let data = try self.encoder.encode(payloads)
             self.userDefaults.set(data, forKey: makeScheduledReviewNotificationsUserDefaultsKey(workspaceId: workspaceId))
         } catch {
+            captureReviewNotificationsSilentFailure(
+                error: error,
+                action: "review_notifications_scheduled_payloads_save",
+                stage: "encode",
+                cloudSettings: self.cloudSettings,
+                workspaceId: workspaceId,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            )
             self.userDefaults.removeObject(forKey: makeScheduledReviewNotificationsUserDefaultsKey(workspaceId: workspaceId))
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPayloadSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPayloadSupport.swift
@@ -152,6 +152,14 @@ func loadScheduledReviewNotifications(
     do {
         return try decoder.decode([ScheduledReviewNotificationPayload].self, from: data)
     } catch {
+        captureReviewNotificationsSilentFailure(
+            error: error,
+            action: "review_notifications_scheduled_payloads_load",
+            stage: "decode",
+            cloudSettings: nil,
+            workspaceId: workspaceId,
+            configurationMode: nil
+        )
         userDefaults.removeObject(forKey: makeScheduledReviewNotificationsUserDefaultsKey(workspaceId: workspaceId))
         return []
     }

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsSettingsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsSettingsSupport.swift
@@ -195,6 +195,14 @@ func loadReviewNotificationsSettings(
     do {
         return try decoder.decode(ReviewNotificationsSettings.self, from: data)
     } catch {
+        captureReviewNotificationsSilentFailure(
+            error: error,
+            action: "review_notifications_settings_load",
+            stage: "decode",
+            cloudSettings: nil,
+            workspaceId: workspaceId,
+            configurationMode: nil
+        )
         userDefaults.removeObject(forKey: makeReviewNotificationsSettingsUserDefaultsKey(workspaceId: workspaceId))
         return makeDefaultReviewNotificationsSettings()
     }
@@ -211,7 +219,44 @@ func loadNotificationPermissionPromptState(
     do {
         return try decoder.decode(NotificationPermissionPromptState.self, from: data)
     } catch {
+        captureReviewNotificationsSilentFailure(
+            error: error,
+            action: "review_notification_permission_prompt_state_load",
+            stage: "decode",
+            cloudSettings: nil,
+            workspaceId: nil,
+            configurationMode: nil
+        )
         userDefaults.removeObject(forKey: reviewNotificationPromptStateUserDefaultsKey)
         return makeDefaultNotificationPermissionPromptState()
     }
+}
+
+func captureReviewNotificationsSilentFailure(
+    error: Error,
+    action: String,
+    stage: String,
+    cloudSettings: CloudSettings?,
+    workspaceId: String?,
+    configurationMode: CloudServiceConfigurationMode?
+) {
+    FlashcardsObservability.captureSilentFailure(
+        error: error,
+        scope: IOSObservationScope(
+            feature: .notifications,
+            userId: cloudSettings?.linkedUserId,
+            workspaceId: workspaceId,
+            requestId: nil,
+            clientRequestId: nil,
+            sessionId: nil,
+            runId: nil,
+            cloudState: cloudSettings?.cloudState,
+            configurationMode: configurationMode
+        ),
+        action: action,
+        stage: stage,
+        statusCode: nil,
+        backendCode: nil,
+        requestId: nil
+    )
 }

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
@@ -237,6 +237,14 @@ extension FlashcardsStore {
             let data = try self.encoder.encode(persistedReviewFilter)
             self.userDefaults.set(data, forKey: makeSelectedReviewFilterUserDefaultsKey(workspaceId: workspaceId))
         } catch {
+            captureReviewFilterPersistenceSilentFailure(
+                error: error,
+                action: "review_filter_save",
+                stage: "encode",
+                cloudSettings: self.cloudSettings,
+                workspaceId: workspaceId,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            )
             self.userDefaults.removeObject(forKey: makeSelectedReviewFilterUserDefaultsKey(workspaceId: workspaceId))
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStoreReviewFilterPersistence.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStoreReviewFilterPersistence.swift
@@ -84,8 +84,45 @@ extension FlashcardsStore {
             let persistedReviewFilter = try decoder.decode(PersistedReviewFilter.self, from: data)
             return try makeReviewFilter(persistedReviewFilter: persistedReviewFilter)
         } catch {
+            captureReviewFilterPersistenceSilentFailure(
+                error: error,
+                action: "review_filter_load",
+                stage: "decode",
+                cloudSettings: nil,
+                workspaceId: workspaceId,
+                configurationMode: nil
+            )
             userDefaults.removeObject(forKey: makeSelectedReviewFilterUserDefaultsKey(workspaceId: workspaceId))
             return .allCards
         }
     }
+}
+
+func captureReviewFilterPersistenceSilentFailure(
+    error: Error,
+    action: String,
+    stage: String,
+    cloudSettings: CloudSettings?,
+    workspaceId: String?,
+    configurationMode: CloudServiceConfigurationMode?
+) {
+    FlashcardsObservability.captureSilentFailure(
+        error: error,
+        scope: IOSObservationScope(
+            feature: .localData,
+            userId: cloudSettings?.linkedUserId,
+            workspaceId: workspaceId,
+            requestId: nil,
+            clientRequestId: nil,
+            sessionId: nil,
+            runId: nil,
+            cloudState: cloudSettings?.cloudState,
+            configurationMode: configurationMode
+        ),
+        action: action,
+        stage: stage,
+        statusCode: nil,
+        backendCode: nil,
+        requestId: nil
+    )
 }

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
@@ -88,6 +88,14 @@ extension FlashcardsStore {
             let data = try self.encoder.encode(self.strictRemindersSettings)
             self.userDefaults.set(data, forKey: strictRemindersSettingsUserDefaultsKey)
         } catch {
+            captureStrictRemindersSilentFailure(
+                error: error,
+                action: "strict_reminders_settings_save",
+                stage: "encode",
+                cloudSettings: self.cloudSettings,
+                workspaceId: self.workspace?.workspaceId,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            )
             self.userDefaults.removeObject(forKey: strictRemindersSettingsUserDefaultsKey)
         }
     }
@@ -97,6 +105,14 @@ extension FlashcardsStore {
             let data = try self.encoder.encode(payloads)
             self.userDefaults.set(data, forKey: strictReminderScheduledPayloadsUserDefaultsKey)
         } catch {
+            captureStrictRemindersSilentFailure(
+                error: error,
+                action: "strict_reminders_scheduled_payloads_save",
+                stage: "encode",
+                cloudSettings: self.cloudSettings,
+                workspaceId: self.workspace?.workspaceId,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            )
             self.userDefaults.removeObject(forKey: strictReminderScheduledPayloadsUserDefaultsKey)
         }
     }
@@ -279,7 +295,17 @@ extension FlashcardsStore {
                     plannedRequestIdentifiers: payloads.map(\.requestId),
                     delayNanoseconds: notificationSchedulingDelayedReadbackNanoseconds
                 )
+            } catch is CancellationError {
+                return
             } catch {
+                captureStrictRemindersSilentFailure(
+                    error: error,
+                    action: "strict_reminders_delayed_readback",
+                    stage: "readback",
+                    cloudSettings: self.cloudSettings,
+                    workspaceId: self.workspace?.workspaceId,
+                    configurationMode: try? self.currentCloudServiceConfiguration().mode
+                )
                 return
             }
             guard Task.isCancelled == false else {

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
@@ -193,6 +193,14 @@ func loadStrictRemindersSettings(
     do {
         return try decoder.decode(StrictRemindersSettings.self, from: data)
     } catch {
+        captureStrictRemindersSilentFailure(
+            error: error,
+            action: "strict_reminders_settings_load",
+            stage: "decode",
+            cloudSettings: nil,
+            workspaceId: nil,
+            configurationMode: nil
+        )
         userDefaults.removeObject(forKey: strictRemindersSettingsUserDefaultsKey)
         return makeDefaultStrictRemindersSettings()
     }
@@ -209,9 +217,46 @@ func loadScheduledStrictReminders(
     do {
         return try decoder.decode([ScheduledStrictReminderPayload].self, from: data)
     } catch {
+        captureStrictRemindersSilentFailure(
+            error: error,
+            action: "strict_reminders_scheduled_payloads_load",
+            stage: "decode",
+            cloudSettings: nil,
+            workspaceId: nil,
+            configurationMode: nil
+        )
         userDefaults.removeObject(forKey: strictReminderScheduledPayloadsUserDefaultsKey)
         return []
     }
+}
+
+func captureStrictRemindersSilentFailure(
+    error: Error,
+    action: String,
+    stage: String,
+    cloudSettings: CloudSettings?,
+    workspaceId: String?,
+    configurationMode: CloudServiceConfigurationMode?
+) {
+    FlashcardsObservability.captureSilentFailure(
+        error: error,
+        scope: IOSObservationScope(
+            feature: .notifications,
+            userId: cloudSettings?.linkedUserId,
+            workspaceId: workspaceId,
+            requestId: nil,
+            clientRequestId: nil,
+            sessionId: nil,
+            runId: nil,
+            cloudState: cloudSettings?.cloudState,
+            configurationMode: configurationMode
+        ),
+        action: action,
+        stage: stage,
+        statusCode: nil,
+        backendCode: nil,
+        requestId: nil
+    )
 }
 
 func strictReminderDayStartMillis(date: Date) -> Int64 {

--- a/apps/ios/Flashcards/Flashcards/Review/StoreReview/FlashcardsStore+StoreReview.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/StoreReview/FlashcardsStore+StoreReview.swift
@@ -6,6 +6,25 @@ extension FlashcardsStore {
         do {
             try self.prepareStoreReviewRequestAttemptIfEligible(now: now)
         } catch {
+            FlashcardsObservability.captureSilentFailure(
+                error: error,
+                scope: IOSObservationScope(
+                    feature: .storeReview,
+                    userId: self.cloudSettings?.linkedUserId,
+                    workspaceId: self.workspace?.workspaceId,
+                    requestId: nil,
+                    clientRequestId: nil,
+                    sessionId: nil,
+                    runId: nil,
+                    cloudState: self.cloudSettings?.cloudState,
+                    configurationMode: try? self.currentCloudServiceConfiguration().mode
+                ),
+                action: "store_review_request_prepare_after_successful_review",
+                stage: "eligibility",
+                statusCode: nil,
+                backendCode: nil,
+                requestId: nil
+            )
             assertionFailure("Store review eligibility failed: \(Flashcards.errorMessage(error: error))")
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/FlashcardsStore+GuestSignInAfterReviewPrompt.swift
@@ -78,7 +78,44 @@ extension FlashcardsStore {
             let data: Data = try self.encoder.encode(state)
             self.userDefaults.set(data, forKey: guestSignInAfterReviewPromptUserDefaultsKey)
         } catch {
+            captureGuestSignInAfterReviewPromptSilentFailure(
+                error: error,
+                action: "guest_sign_in_after_review_prompt_state_save",
+                stage: "encode",
+                cloudSettings: self.cloudSettings,
+                workspaceId: self.workspace?.workspaceId,
+                configurationMode: try? self.currentCloudServiceConfiguration().mode
+            )
             self.userDefaults.removeObject(forKey: guestSignInAfterReviewPromptUserDefaultsKey)
         }
     }
+}
+
+func captureGuestSignInAfterReviewPromptSilentFailure(
+    error: Error,
+    action: String,
+    stage: String,
+    cloudSettings: CloudSettings?,
+    workspaceId: String?,
+    configurationMode: CloudServiceConfigurationMode?
+) {
+    FlashcardsObservability.captureSilentFailure(
+        error: error,
+        scope: IOSObservationScope(
+            feature: .prompts,
+            userId: cloudSettings?.linkedUserId,
+            workspaceId: workspaceId,
+            requestId: nil,
+            clientRequestId: nil,
+            sessionId: nil,
+            runId: nil,
+            cloudState: cloudSettings?.cloudState,
+            configurationMode: configurationMode
+        ),
+        action: action,
+        stage: stage,
+        statusCode: nil,
+        backendCode: nil,
+        requestId: nil
+    )
 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/GuestSignInAfterReviewPromptSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/GuestSignInAfterReviewPromptSupport.swift
@@ -132,6 +132,14 @@ func loadGuestSignInAfterReviewPromptState(
     do {
         return try decoder.decode(GuestSignInAfterReviewPromptState.self, from: data)
     } catch {
+        captureGuestSignInAfterReviewPromptSilentFailure(
+            error: error,
+            action: "guest_sign_in_after_review_prompt_state_load",
+            stage: "decode",
+            cloudSettings: nil,
+            workspaceId: nil,
+            configurationMode: nil
+        )
         userDefaults.removeObject(forKey: guestSignInAfterReviewPromptUserDefaultsKey)
         return makeDefaultGuestSignInAfterReviewPromptState()
     }

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -165,6 +165,7 @@ final class FlashcardsStore {
     @ObservationIgnored var progressReviewedAtClientCache: ProgressReviewedAtClientCacheEntry?
     @ObservationIgnored var progressReviewScheduleLocalCache: ProgressReviewScheduleLocalCacheEntry?
     @ObservationIgnored var activeAutomaticFeedbackPromptTask: Task<Void, Never>?
+    @ObservationIgnored var nextAutomaticFeedbackPromptRetryAt: Date?
 
     var aiChatStore: AIChatStore {
         if let cachedAIChatStore {
@@ -484,6 +485,7 @@ final class FlashcardsStore {
         self.progressReviewedAtClientCache = nil
         self.progressReviewScheduleLocalCache = nil
         self.activeAutomaticFeedbackPromptTask = nil
+        self.nextAutomaticFeedbackPromptRetryAt = nil
 
         if database != nil && initialGlobalErrorMessage.isEmpty {
             do {


### PR DESCRIPTION
## Summary

- add a shared iOS silent-failure Sentry capture path
- report important previously swallowed iOS persistence, prompt, notification, feedback, and AI passive refresh failures
- keep noisy retryable/cancellation/offline paths out of Sentry and dedupe corrupt cloud recovery payload reports

## Validation

- `git --no-pager diff --check HEAD~1 HEAD`
- `git show --name-only --format= HEAD -- '*.swift' | sed '/^$/d' | xargs -n 1 swiftc -parse`

Simulator-backed iOS tests were not run.
