### PR TITLE
[codex] Add Android feedback prompt observability

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -317,6 +317,9 @@ class AppGraph(
         reviewRepository = reviewRepository,
         promptStore = feedbackPromptStore,
         messageController = appMessageBus,
+        observability = observability,
+        appVersion = appPackageInfo.versionName,
+        versionCode = appPackageInfo.longVersionCode.toInt(),
         feedbackPromptIdentityKeyProvider = {
             feedbackPromptIdentityKey(cloudSettings = cloudPreferencesStore.currentCloudSettings())
         }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/observability/SentryAppObservability.kt
@@ -95,6 +95,10 @@ class SentryAppObservability : AppObservability {
         )
         Sentry.captureException(event.throwable) { scope ->
             applyTags(scope = scope, event = event)
+            val fingerprint: List<String>? = exceptionIssueFingerprint(event = event)
+            if (fingerprint != null) {
+                scope.setFingerprint(fingerprint)
+            }
             scope.setContexts("android_observability", exceptionContext(event = event))
         }
     }
@@ -245,7 +249,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ),
             ai = null,
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.HttpUnexpectedClientError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -260,7 +265,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             ),
             ai = null,
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.AiRemoteError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -293,7 +299,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 message = null
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.AiLifecycleWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -325,7 +332,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.AiSendWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -357,7 +365,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.AiBootstrapWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -389,7 +398,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.ProgressRefreshWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -402,7 +412,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.ProgressRepositoryWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -415,7 +426,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.AiRuntimeWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -447,7 +459,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidWarningIssueEvent.NotificationSchedulingWarning -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -458,7 +471,8 @@ private fun warningContext(event: AndroidWarningIssueEvent): SentryAndroidObserv
             notifications = notificationSchedulingContext(
                 diagnostic = event.diagnostic,
                 warningReason = event.warningReason
-            )
+            ),
+            feedback = null
         )
     }
 }
@@ -471,7 +485,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             http = null,
             ai = null,
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.AppStartupException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -479,7 +494,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
             http = null,
             ai = null,
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.AiStreamCrash -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -511,7 +527,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 message = null
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.AiLifecycleError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -543,7 +560,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.AiSendError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -575,7 +593,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.AiBootstrapError -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -607,7 +626,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.ProgressRefreshException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -620,7 +640,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.ProgressRepositoryException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -633,7 +654,8 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 scopeId = sanitizeSentryIdentifier(value = event.scopeId),
                 source = sanitizeSentryContextValue(fieldName = "source", value = event.source)
             ),
-            notifications = null
+            notifications = null,
+            feedback = null
         )
         is AndroidExceptionIssueEvent.AiRuntimeException -> SentryAndroidObservationContext(
             feature = event.feature.tagValue,
@@ -665,7 +687,17 @@ private fun exceptionContext(event: AndroidExceptionIssueEvent): SentryAndroidOb
                 message = sanitizeSentryContextValue(fieldName = "message", value = event.message)
             ),
             progress = null,
-            notifications = null
+            notifications = null,
+            feedback = null
+        )
+        is AndroidExceptionIssueEvent.FeedbackPromptException -> SentryAndroidObservationContext(
+            feature = event.feature.tagValue,
+            action = event.action.tagValue,
+            http = null,
+            ai = null,
+            progress = null,
+            notifications = null,
+            feedback = feedbackPromptContext(event = event)
         )
     }
 }
@@ -843,6 +875,19 @@ internal fun warningIssueFingerprint(event: AndroidWarningIssueEvent): List<Stri
     )
 }
 
+internal fun exceptionIssueFingerprint(event: AndroidExceptionIssueEvent): List<String>? {
+    return when (event) {
+        is AndroidExceptionIssueEvent.FeedbackPromptException -> listOf(
+            "android",
+            event.feature.tagValue,
+            event.action.tagValue,
+            sanitizeSentryTagValue(fieldName = "promptAction", value = event.promptAction.tagValue)
+                ?: "no_prompt_action"
+        )
+        else -> null
+    }
+}
+
 private fun warningIssueGroupKey(event: AndroidWarningIssueEvent): String? {
     val rawGroupKey = when (event) {
         is AndroidWarningIssueEvent.HttpServerError -> event.endpointName
@@ -857,6 +902,15 @@ private fun warningIssueGroupKey(event: AndroidWarningIssueEvent): String? {
         is AndroidWarningIssueEvent.NotificationSchedulingWarning -> event.diagnostic.notificationKind
     }
     return sanitizeSentryTagValue(fieldName = "warningGroup", value = rawGroupKey)
+}
+
+internal fun feedbackPromptContext(
+    event: AndroidExceptionIssueEvent.FeedbackPromptException
+): SentryFeedbackContext {
+    return SentryFeedbackContext(
+        promptAction = sanitizeSentryContextValue(fieldName = "promptAction", value = event.promptAction.tagValue),
+        trigger = sanitizeSentryContextValue(fieldName = "trigger", value = event.trigger.tagValue)
+    )
 }
 
 private data class SentryCloudIdentityContext(
@@ -880,7 +934,8 @@ private data class SentryAndroidObservationContext(
     val http: SentryHttpContext?,
     val ai: SentryAiContext?,
     val progress: SentryProgressContext?,
-    val notifications: SentryNotificationSchedulingContext?
+    val notifications: SentryNotificationSchedulingContext?,
+    val feedback: SentryFeedbackContext?
 )
 
 private data class SentryHttpContext(
@@ -923,6 +978,11 @@ private data class SentryProgressContext(
     val progressAction: String?,
     val scopeId: String?,
     val source: String?
+)
+
+internal data class SentryFeedbackContext(
+    val promptAction: String?,
+    val trigger: String?
 )
 
 private data class SentryNotificationSchedulingContext(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/prompts/feedback/FeedbackPromptController.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/prompts/feedback/FeedbackPromptController.kt
@@ -2,12 +2,19 @@ package com.flashcardsopensourceapp.app.prompts.feedback
 
 import android.content.Context
 import com.flashcardsopensourceapp.app.R
+import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidFeedbackPromptAction
+import com.flashcardsopensourceapp.core.observability.AndroidFeedbackPromptTrigger
+import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackState
 import com.flashcardsopensourceapp.data.local.model.feedback.CloudFeedbackTrigger
 import com.flashcardsopensourceapp.data.local.model.feedback.cloudFeedbackMessageMaximumLength
 import com.flashcardsopensourceapp.data.local.repository.FeedbackRepository
 import com.flashcardsopensourceapp.data.local.repository.ReviewRepository
+import java.io.IOException
 import java.time.ZoneId
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellationException
@@ -36,6 +43,9 @@ class FeedbackPromptController(
     private val reviewRepository: ReviewRepository,
     private val promptStore: FeedbackPromptStore,
     private val messageController: TransientMessageController,
+    private val observability: AppObservability,
+    private val appVersion: String,
+    private val versionCode: Int,
     private val feedbackPromptIdentityKeyProvider: () -> FeedbackPromptIdentityKey
 ) {
     private val applicationContext = context.applicationContext
@@ -325,6 +335,10 @@ class FeedbackPromptController(
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
+            captureAutomaticFeedbackPromptException(
+                error = error,
+                promptAction = AndroidFeedbackPromptAction.AUTOMATIC_FEEDBACK_STATE_LOAD_FAILED
+            )
             FeedbackStateFetchResult.Failed
         }
     }
@@ -335,8 +349,32 @@ class FeedbackPromptController(
         } catch (error: CancellationException) {
             throw error
         } catch (error: Exception) {
+            captureAutomaticFeedbackPromptException(
+                error = error,
+                promptAction = AndroidFeedbackPromptAction.AUTOMATIC_PROMPT_SHOWN_RECORD_FAILED
+            )
             null
         }
+    }
+
+    private fun captureAutomaticFeedbackPromptException(
+        error: Exception,
+        promptAction: AndroidFeedbackPromptAction
+    ) {
+        if (shouldSkipAutomaticFeedbackPromptExceptionCapture(error = error)) {
+            return
+        }
+
+        observability.captureException(
+            event = AndroidExceptionIssueEvent.FeedbackPromptException(
+                throwable = error,
+                promptAction = promptAction,
+                trigger = AndroidFeedbackPromptTrigger.AUTOMATIC,
+                appVersion = appVersion,
+                clientVersion = appVersion,
+                versionCode = versionCode
+            )
+        )
     }
 
     private fun validateFeedbackMessage(message: String): String? {
@@ -352,6 +390,22 @@ class FeedbackPromptController(
 
         return null
     }
+}
+
+private fun shouldSkipAutomaticFeedbackPromptExceptionCapture(error: Throwable): Boolean {
+    var currentError: Throwable? = error
+    while (currentError != null) {
+        if (
+            currentError is CloudRemoteException ||
+            currentError is CloudCredentialRecoveryRequiredException ||
+            currentError is IOException
+        ) {
+            return true
+        }
+        currentError = currentError.cause
+    }
+
+    return false
 }
 
 private fun isAutomaticPromptContextBlocked(context: FeedbackPromptContext): Boolean {

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/observability/SentryAppObservabilityTest.kt
@@ -1,5 +1,8 @@
 package com.flashcardsopensourceapp.app.observability
 
+import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
+import com.flashcardsopensourceapp.core.observability.AndroidFeedbackPromptAction
+import com.flashcardsopensourceapp.core.observability.AndroidFeedbackPromptTrigger
 import com.flashcardsopensourceapp.core.observability.AndroidObservationFeature
 import com.flashcardsopensourceapp.core.observability.AndroidNotificationSchedulingDiagnostic
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
@@ -214,6 +217,54 @@ class SentryAppObservabilityTest {
                 "no_status"
             ),
             warningIssueFingerprint(event = notificationWarning)
+        )
+    }
+
+    @Test
+    fun feedbackPromptExceptionFingerprintAndContextUseStablePromptFields(): Unit {
+        val stateLoadEvent: AndroidExceptionIssueEvent.FeedbackPromptException =
+            AndroidExceptionIssueEvent.FeedbackPromptException(
+                throwable = RuntimeException("state load failed"),
+                promptAction = AndroidFeedbackPromptAction.AUTOMATIC_FEEDBACK_STATE_LOAD_FAILED,
+                trigger = AndroidFeedbackPromptTrigger.AUTOMATIC,
+                appVersion = testAppVersion,
+                clientVersion = testAppVersion,
+                versionCode = testVersionCode
+            )
+        val promptShownEvent: AndroidExceptionIssueEvent.FeedbackPromptException =
+            AndroidExceptionIssueEvent.FeedbackPromptException(
+                throwable = RuntimeException("prompt shown record failed"),
+                promptAction = AndroidFeedbackPromptAction.AUTOMATIC_PROMPT_SHOWN_RECORD_FAILED,
+                trigger = AndroidFeedbackPromptTrigger.AUTOMATIC,
+                appVersion = testAppVersion,
+                clientVersion = testAppVersion,
+                versionCode = testVersionCode
+            )
+
+        assertEquals(
+            listOf(
+                "android",
+                "feedback",
+                "feedback_prompt_exception",
+                "automatic_feedback_state_load_failed"
+            ),
+            exceptionIssueFingerprint(event = stateLoadEvent)
+        )
+        assertEquals(
+            listOf(
+                "android",
+                "feedback",
+                "feedback_prompt_exception",
+                "automatic_prompt_shown_record_failed"
+            ),
+            exceptionIssueFingerprint(event = promptShownEvent)
+        )
+        assertEquals(
+            SentryFeedbackContext(
+                promptAction = "automatic_feedback_state_load_failed",
+                trigger = "automatic"
+            ),
+            feedbackPromptContext(event = stateLoadEvent)
         )
     }
 }

--- a/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
+++ b/apps/android/core/observability/src/main/java/com/flashcardsopensourceapp/core/observability/AndroidObservationContracts.kt
@@ -9,6 +9,7 @@ enum class AndroidObservationFeature(
     AUTH(tagValue = "auth"),
     AI(tagValue = "ai"),
     PROGRESS(tagValue = "progress"),
+    FEEDBACK(tagValue = "feedback"),
     NOTIFICATIONS(tagValue = "notifications")
 }
 
@@ -38,6 +39,7 @@ enum class AndroidObservationAction(
     PROGRESS_REFRESH_EXCEPTION(tagValue = "progress_refresh_exception"),
     PROGRESS_REPOSITORY_WARNING(tagValue = "progress_repository_warning"),
     PROGRESS_REPOSITORY_EXCEPTION(tagValue = "progress_repository_exception"),
+    FEEDBACK_PROMPT_EXCEPTION(tagValue = "feedback_prompt_exception"),
     NOTIFICATION_SCHEDULING_BREADCRUMB(tagValue = "notification_scheduling_breadcrumb"),
     NOTIFICATION_SCHEDULING_WARNING(tagValue = "notification_scheduling_warning")
 }
@@ -63,6 +65,19 @@ enum class AndroidAiObservationName(
     RUNTIME_HANDOFF_APPLIED_TO_RUNNING_DRAFT(tagValue = "ai_runtime_handoff_applied_to_running_draft"),
     RUNTIME_HANDOFF_START_FRESH_CONVERSATION(tagValue = "ai_runtime_handoff_start_fresh_conversation"),
     RUNTIME_HANDOFF_APPLIED_TO_EXISTING_SESSION(tagValue = "ai_runtime_handoff_applied_to_existing_session")
+}
+
+enum class AndroidFeedbackPromptAction(
+    val tagValue: String
+) {
+    AUTOMATIC_FEEDBACK_STATE_LOAD_FAILED(tagValue = "automatic_feedback_state_load_failed"),
+    AUTOMATIC_PROMPT_SHOWN_RECORD_FAILED(tagValue = "automatic_prompt_shown_record_failed")
+}
+
+enum class AndroidFeedbackPromptTrigger(
+    val tagValue: String
+) {
+    AUTOMATIC(tagValue = "automatic")
 }
 
 data class AndroidObservationTags(
@@ -771,6 +786,28 @@ sealed interface AndroidExceptionIssueEvent : AndroidObservationEvent {
             requestId = requestId,
             statusCode = statusCode,
             code = code ?: name.tagValue,
+            appVersion = appVersion,
+            clientVersion = clientVersion,
+            versionCode = versionCode
+        )
+    }
+
+    data class FeedbackPromptException(
+        override val throwable: Throwable,
+        val promptAction: AndroidFeedbackPromptAction,
+        val trigger: AndroidFeedbackPromptTrigger,
+        val appVersion: String?,
+        val clientVersion: String?,
+        val versionCode: Int?
+    ) : AndroidExceptionIssueEvent {
+        override val feature: AndroidObservationFeature = AndroidObservationFeature.FEEDBACK
+        override val action: AndroidObservationAction = AndroidObservationAction.FEEDBACK_PROMPT_EXCEPTION
+        override val tags: AndroidObservationTags = AndroidObservationTags(
+            userId = null,
+            workspaceId = null,
+            requestId = null,
+            statusCode = null,
+            code = promptAction.tagValue,
             appVersion = appVersion,
             clientVersion = clientVersion,
             versionCode = versionCode


### PR DESCRIPTION
## Summary
- Add a typed Android observability event for automatic feedback prompt failures.
- Capture unexpected local/contract feedback prompt failures in Sentry while keeping the UI silent.
- Group Sentry feedback prompt exceptions by prompt action and add focused context coverage.

## Validation
- `git --no-pager diff --check`
- `git --no-pager diff --check --cached`

Android Gradle tests were not run because the repository instructions require explicit approval for local `./gradlew` runs.