### PR TITLE
Add backend friend invitation API

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -222,6 +222,183 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /me/community/friend-invitations:
+    post:
+      tags:
+        - bootstrap
+      summary: Create a friend invitation link
+      description: >-
+        Creates a single-use friend invitation link for the signed-in human
+        account. The invitee display name is private to the inviter and is
+        normalized with trim before storage. ApiKey and Guest authentication are
+        rejected. Session callers must send a valid X-CSRF-Token header.
+      security:
+        - BearerAuth: []
+        - SessionCookie: []
+          CsrfTokenHeader: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FriendInvitationCreateRequest'
+            example:
+              inviteeDisplayName: Priya
+      responses:
+        '200':
+          description: Created friend invitation link
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FriendInvitationCreateResponse'
+              example:
+                inviteUrl: https://app.flashcards-open-source-app.com/invite/LjCTCGK7DLEh6IJeujO4GtcZD2VN7z5oFMVozdjlggo
+                expiresAt: '2026-06-17T10:00:00.000Z'
+        '400':
+          description: Invalid friend invitation payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden authentication transport or invalid session CSRF token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Active invitation limit reached
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /community/friend-invitations/{inviteToken}:
+    get:
+      tags:
+        - bootstrap
+      summary: Preview a friend invitation link
+      description: >-
+        Public no-auth preview for a raw friend invite token. The response is
+        intentionally small: active links return only status and expiry; unknown,
+        expired, inactive, or accepted links return only inactive status. Inviter
+        identity, email, public profile id, and private stored display names are
+        never returned.
+      security: []
+      parameters:
+        - name: inviteToken
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Raw invite token from the app invite URL path.
+      responses:
+        '200':
+          description: Friend invitation preview
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FriendInvitationPreviewResponse'
+              examples:
+                active:
+                  value:
+                    status: active
+                    expiresAt: '2026-06-17T10:00:00.000Z'
+                inactive:
+                  value:
+                    status: inactive
+        '403':
+          description: ApiKey authentication is not supported for public preview
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /me/community/friend-invitations/{inviteToken}/accept:
+    post:
+      tags:
+        - bootstrap
+      summary: Accept a friend invitation link
+      description: >-
+        Accepts an active friend invitation link for the signed-in human account
+        and creates the directed friendship rows. The inviter display name is
+        private to the invitee and is normalized with trim before storage. ApiKey
+        and Guest authentication are rejected. Session callers must send a valid
+        X-CSRF-Token header.
+      security:
+        - BearerAuth: []
+        - SessionCookie: []
+          CsrfTokenHeader: []
+      parameters:
+        - name: inviteToken
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Raw invite token from the app invite URL path.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FriendInvitationAcceptRequest'
+            example:
+              inviterDisplayName: Alex
+      responses:
+        '200':
+          description: Friend invitation acceptance status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FriendInvitationAcceptResponse'
+              examples:
+                accepted:
+                  value:
+                    status: accepted
+                alreadyFriends:
+                  value:
+                    status: already_friends
+                    existingFriendDisplayName: Alex
+                inactive:
+                  value:
+                    status: inactive
+        '400':
+          description: Invalid friend invitation payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden authentication transport or invalid session CSRF token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Invitation cannot be accepted by this account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: This is your own invitation link.
+                code: FRIEND_INVITATION_SELF
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /me/progress/leaderboard:
     get:
       tags:
@@ -435,6 +612,109 @@ components:
           type: boolean
         linkedAccountRequiredForLeaderboard:
           type: boolean
+    FriendInvitationDisplayName:
+      type: string
+      minLength: 1
+      maxLength: 30
+      description: >-
+        User-entered private display name after server trim normalization.
+        Unicode and emoji are allowed; control characters and newlines are
+        rejected.
+    FriendInvitationCreateRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - inviteeDisplayName
+      properties:
+        inviteeDisplayName:
+          $ref: '#/components/schemas/FriendInvitationDisplayName'
+    FriendInvitationCreateResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - inviteUrl
+        - expiresAt
+      properties:
+        inviteUrl:
+          type: string
+          format: uri
+        expiresAt:
+          type: string
+          format: date-time
+    FriendInvitationPreviewActiveResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - expiresAt
+      properties:
+        status:
+          type: string
+          enum:
+            - active
+        expiresAt:
+          type: string
+          format: date-time
+    FriendInvitationPreviewInactiveResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - inactive
+    FriendInvitationPreviewResponse:
+      oneOf:
+        - $ref: '#/components/schemas/FriendInvitationPreviewActiveResponse'
+        - $ref: '#/components/schemas/FriendInvitationPreviewInactiveResponse'
+    FriendInvitationAcceptRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - inviterDisplayName
+      properties:
+        inviterDisplayName:
+          $ref: '#/components/schemas/FriendInvitationDisplayName'
+    FriendInvitationAcceptedResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - accepted
+    FriendInvitationAlreadyFriendsResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - existingFriendDisplayName
+      properties:
+        status:
+          type: string
+          enum:
+            - already_friends
+        existingFriendDisplayName:
+          $ref: '#/components/schemas/FriendInvitationDisplayName'
+    FriendInvitationInactiveAcceptResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum:
+            - inactive
+    FriendInvitationAcceptResponse:
+      oneOf:
+        - $ref: '#/components/schemas/FriendInvitationAcceptedResponse'
+        - $ref: '#/components/schemas/FriendInvitationAlreadyFriendsResponse'
+        - $ref: '#/components/schemas/FriendInvitationInactiveAcceptResponse'
     LeaderboardWindowKey:
       type: string
       enum:

--- a/apps/backend/src/community/friendInvitations.test.ts
+++ b/apps/backend/src/community/friendInvitations.test.ts
@@ -1,0 +1,423 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type {
+  DatabaseExecutor,
+  SqlValue,
+  UserDatabaseScope,
+} from "../database";
+import { HttpError } from "../shared/errors";
+import {
+  acceptFriendInvitationWithDependencies,
+  createFriendInvitationWithDependencies,
+  friendInviteTokenByteLength,
+  friendInviteUrlBase,
+  hashFriendInviteToken,
+  parseFriendInvitationDisplayName,
+  previewFriendInvitationWithDependencies,
+  type FriendInvitationServiceDependencies,
+} from "./friendInvitations";
+
+type QueryResultRow = pg.QueryResultRow;
+
+type RecordedQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<SqlValue>;
+}>;
+
+type CreatedInvitationRecord = Readonly<{
+  invitationId: string;
+  inviterUserId: string;
+  inviteTokenHash: string;
+  inviteeDisplayName: string;
+}>;
+
+type PreviewInvitationFixtureRow = QueryResultRow & Readonly<{
+  invitation_status: string;
+  expires_at: Date | string | null;
+  inviter_user_id?: string;
+  inviter_email?: string;
+  public_profile_id?: string;
+  invitee_display_name_for_inviter?: string;
+}>;
+
+type AcceptInvitationFixtureRow = QueryResultRow & Readonly<{
+  acceptance_status: string;
+  inviter_public_profile_id: string | null;
+  invitee_public_profile_id: string | null;
+}>;
+
+type MutableFriendInvitationState = {
+  activeInvitationCount: number;
+  currentProfileUserId: string;
+  createdInvitations: Array<CreatedInvitationRecord>;
+  previewRows: Array<PreviewInvitationFixtureRow>;
+  acceptRows: Array<AcceptInvitationFixtureRow>;
+  existingFriendDisplayName: string | null;
+  operationOrder: Array<string>;
+  queries: Array<RecordedQuery>;
+  scopes: Array<UserDatabaseScope>;
+  tokenBytes: Buffer;
+  requestedTokenByteCounts: Array<number>;
+};
+
+const expiresAt = new Date("2026-06-17T10:00:00.000Z");
+const inviterPublicProfileId = "00000000-0000-4000-8000-0000000000a1";
+const inviteePublicProfileId = "00000000-0000-4000-8000-0000000000b2";
+
+function createQueryResult<Row extends QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createFriendInvitationState(): MutableFriendInvitationState {
+  return {
+    activeInvitationCount: 0,
+    currentProfileUserId: "user-1",
+    createdInvitations: [],
+    previewRows: [],
+    acceptRows: [],
+    existingFriendDisplayName: null,
+    operationOrder: [],
+    queries: [],
+    scopes: [],
+    tokenBytes: Buffer.alloc(friendInviteTokenByteLength, 7),
+    requestedTokenByteCounts: [],
+  };
+}
+
+function readStringParam(params: ReadonlyArray<SqlValue>, index: number, label: string): string {
+  const value = params[index];
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string.`);
+  }
+
+  return value;
+}
+
+function createFriendInvitationExecutor(state: MutableFriendInvitationState): DatabaseExecutor {
+  return {
+    async query<Row extends QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      state.queries.push({ text, params });
+
+      if (text.includes("COUNT(*)::INTEGER AS active_invitation_count")) {
+        state.operationOrder.push("count");
+        return createQueryResult([
+          { active_invitation_count: state.activeInvitationCount },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text === "SELECT pg_advisory_xact_lock(hashtextextended($1, 0::bigint))") {
+        state.operationOrder.push("lock");
+        assert.equal(readStringParam(params, 0, "lockKey"), "community.friend_invitations:user-1");
+        return createQueryResult([]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.startsWith("INSERT INTO community.friend_invitations")) {
+        state.operationOrder.push("insert");
+        state.createdInvitations.push({
+          invitationId: readStringParam(params, 0, "friendInvitationId"),
+          inviterUserId: readStringParam(params, 1, "inviterUserId"),
+          inviteTokenHash: readStringParam(params, 2, "inviteTokenHash"),
+          inviteeDisplayName: readStringParam(params, 3, "inviteeDisplayName"),
+        });
+        return createQueryResult([{ expires_at: expiresAt }]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("community.preview_friend_invitation")) {
+        state.operationOrder.push("preview");
+        return createQueryResult(state.previewRows) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("community.accept_friend_invitation")) {
+        state.operationOrder.push("accept");
+        return createQueryResult(state.acceptRows) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("FROM community.friendships")) {
+        state.operationOrder.push("existing_friend");
+        if (state.existingFriendDisplayName === null) {
+          return createQueryResult([]) as unknown as pg.QueryResult<Row>;
+        }
+
+        return createQueryResult([
+          { friend_display_name: state.existingFriendDisplayName },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      throw new Error(`Unexpected friend invitation query: ${text}`);
+    },
+  };
+}
+
+function createFriendInvitationDependencies(
+  state: MutableFriendInvitationState,
+): FriendInvitationServiceDependencies {
+  const executor = createFriendInvitationExecutor(state);
+
+  return {
+    transactionWithUserScopeFn: async <Result>(
+      scope: UserDatabaseScope,
+      callback: (transactionExecutor: DatabaseExecutor) => Promise<Result>,
+    ): Promise<Result> => {
+      state.scopes.push(scope);
+      return callback(executor);
+    },
+    unsafeQueryFn: async <Row extends QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => executor.query<Row>(text, params),
+    ensureCurrentUserPublicProfileFn: async () => {
+      state.operationOrder.push("ensure");
+      return {
+        userId: state.currentProfileUserId,
+        publicProfileId: "00000000-0000-4000-8000-000000000001",
+      };
+    },
+    randomBytesFn: (byteCount) => {
+      state.requestedTokenByteCounts.push(byteCount);
+      return state.tokenBytes;
+    },
+    randomUuidFn: () => "00000000-0000-4000-8000-000000000099",
+    inviteUrlBase: friendInviteUrlBase,
+    activeInviteLimit: 20,
+  };
+}
+
+function assertHttpError(
+  error: unknown,
+  statusCode: number,
+  code: string,
+  message: string,
+): boolean {
+  assert.ok(error instanceof HttpError);
+  assert.equal(error.statusCode, statusCode);
+  assert.equal(error.code, code);
+  assert.equal(error.message, message);
+  return true;
+}
+
+test("createFriendInvitation stores only the token hash and returns the raw token URL", async () => {
+  const state = createFriendInvitationState();
+  const dependencies = createFriendInvitationDependencies(state);
+  const rawToken = state.tokenBytes.toString("base64url");
+
+  const response = await createFriendInvitationWithDependencies(
+    {
+      userId: "user-1",
+      inviteeDisplayName: "  Priya 🎯  ",
+    },
+    dependencies,
+  );
+
+  assert.deepEqual(response, {
+    inviteUrl: `${friendInviteUrlBase}/${rawToken}`,
+    expiresAt: "2026-06-17T10:00:00.000Z",
+  });
+  assert.deepEqual(state.scopes, [{ userId: "user-1" }]);
+  assert.deepEqual(state.operationOrder, ["ensure", "lock", "count", "insert"]);
+  assert.deepEqual(state.requestedTokenByteCounts, [friendInviteTokenByteLength]);
+
+  const createdInvitation = state.createdInvitations[0];
+  assert.notEqual(createdInvitation, undefined);
+  assert.equal(createdInvitation?.inviterUserId, "user-1");
+  assert.equal(createdInvitation?.inviteeDisplayName, "Priya 🎯");
+  assert.equal(createdInvitation?.inviteTokenHash, hashFriendInviteToken(rawToken));
+  assert.notEqual(createdInvitation?.inviteTokenHash, rawToken);
+  assert.match(createdInvitation?.inviteTokenHash ?? "", /^[0-9a-f]{64}$/);
+});
+
+test("createFriendInvitation rejects the twentieth active unaccepted invitation before insert", async () => {
+  const state = createFriendInvitationState();
+  state.activeInvitationCount = 20;
+  const dependencies = createFriendInvitationDependencies(state);
+
+  await assert.rejects(
+    async () => createFriendInvitationWithDependencies(
+      {
+        userId: "user-1",
+        inviteeDisplayName: "Priya",
+      },
+      dependencies,
+    ),
+    (error: unknown) => assertHttpError(
+      error,
+      409,
+      "FRIEND_INVITATION_LIMIT_REACHED",
+      "You already have 20 active friend invitation links. Wait for one to expire or be accepted before creating another.",
+    ),
+  );
+
+  assert.deepEqual(state.operationOrder, ["ensure", "lock", "count"]);
+  assert.deepEqual(state.createdInvitations, []);
+});
+
+test("previewFriendInvitation hashes the raw token and returns no identity fields", async () => {
+  const state = createFriendInvitationState();
+  state.previewRows = [{
+    invitation_status: "active",
+    expires_at: expiresAt,
+    inviter_user_id: "user-inviter",
+    inviter_email: "inviter@example.com",
+    public_profile_id: inviterPublicProfileId,
+    invitee_display_name_for_inviter: "Private invitee name",
+  }];
+  const dependencies = createFriendInvitationDependencies(state);
+
+  const response = await previewFriendInvitationWithDependencies("raw-token", dependencies);
+
+  assert.deepEqual(response, {
+    status: "active",
+    expiresAt: "2026-06-17T10:00:00.000Z",
+  });
+  assert.equal(Object.hasOwn(response, "inviterUserId"), false);
+  assert.equal(Object.hasOwn(response, "email"), false);
+  assert.equal(Object.hasOwn(response, "publicProfileId"), false);
+  assert.equal(Object.hasOwn(response, "inviteeDisplayName"), false);
+  assert.deepEqual(state.operationOrder, ["preview"]);
+  assert.deepEqual(state.queries[0]?.params, [hashFriendInviteToken("raw-token")]);
+});
+
+test("acceptFriendInvitation returns accepted after ensuring the invitee public profile", async () => {
+  const state = createFriendInvitationState();
+  state.acceptRows = [{
+    acceptance_status: "accepted",
+    inviter_public_profile_id: inviterPublicProfileId,
+    invitee_public_profile_id: inviteePublicProfileId,
+  }];
+  const dependencies = createFriendInvitationDependencies(state);
+
+  const response = await acceptFriendInvitationWithDependencies(
+    {
+      userId: "user-1",
+      rawInviteToken: "raw-token",
+      inviterDisplayName: "  Alex  ",
+    },
+    dependencies,
+  );
+
+  assert.deepEqual(response, { status: "accepted" });
+  assert.deepEqual(state.scopes, [{ userId: "user-1" }]);
+  assert.deepEqual(state.operationOrder, ["ensure", "accept"]);
+  assert.deepEqual(state.queries[0]?.params, [hashFriendInviteToken("raw-token"), "Alex"]);
+});
+
+test("acceptFriendInvitation rejects self invite links with a clear typed error", async () => {
+  const state = createFriendInvitationState();
+  state.acceptRows = [{
+    acceptance_status: "self",
+    inviter_public_profile_id: null,
+    invitee_public_profile_id: null,
+  }];
+  const dependencies = createFriendInvitationDependencies(state);
+
+  await assert.rejects(
+    async () => acceptFriendInvitationWithDependencies(
+      {
+        userId: "user-1",
+        rawInviteToken: "raw-token",
+        inviterDisplayName: "Alex",
+      },
+      dependencies,
+    ),
+    (error: unknown) => assertHttpError(
+      error,
+      409,
+      "FRIEND_INVITATION_SELF",
+      "This is your own invitation link.",
+    ),
+  );
+});
+
+test("acceptFriendInvitation returns the existing stored display name for already-friends links", async () => {
+  const state = createFriendInvitationState();
+  state.acceptRows = [{
+    acceptance_status: "already_friends",
+    inviter_public_profile_id: inviterPublicProfileId,
+    invitee_public_profile_id: inviteePublicProfileId,
+  }];
+  state.existingFriendDisplayName = "Stored Alex";
+  const dependencies = createFriendInvitationDependencies(state);
+
+  const response = await acceptFriendInvitationWithDependencies(
+    {
+      userId: "user-1",
+      rawInviteToken: "raw-token",
+      inviterDisplayName: "Changed Alex",
+    },
+    dependencies,
+  );
+
+  assert.deepEqual(response, {
+    status: "already_friends",
+    existingFriendDisplayName: "Stored Alex",
+  });
+  assert.deepEqual(state.operationOrder, ["ensure", "accept", "existing_friend"]);
+});
+
+test("acceptFriendInvitation maps inactive and already-accepted links to inactive", async () => {
+  for (const acceptanceStatus of ["inactive", "already_accepted"] as const) {
+    const state = createFriendInvitationState();
+    state.acceptRows = [{
+      acceptance_status: acceptanceStatus,
+      inviter_public_profile_id: null,
+      invitee_public_profile_id: null,
+    }];
+    const dependencies = createFriendInvitationDependencies(state);
+
+    const response = await acceptFriendInvitationWithDependencies(
+      {
+        userId: "user-1",
+        rawInviteToken: "raw-token",
+        inviterDisplayName: "Alex",
+      },
+      dependencies,
+    );
+
+    assert.deepEqual(response, { status: "inactive" });
+    assert.deepEqual(state.operationOrder, ["ensure", "accept"]);
+  }
+});
+
+test("friend invitation display-name validation trims Unicode names and rejects invalid input", () => {
+  assert.equal(parseFriendInvitationDisplayName("  Alex 😊  ", "inviteeDisplayName"), "Alex 😊");
+
+  const invalidCases = [
+    {
+      value: "   ",
+      message: "inviteeDisplayName must be 1 to 30 characters after trimming.",
+    },
+    {
+      value: "a".repeat(31),
+      message: "inviteeDisplayName must be 1 to 30 characters after trimming.",
+    },
+    {
+      value: "Line\nBreak",
+      message: "inviteeDisplayName must not contain control characters or newlines.",
+    },
+    {
+      value: 42,
+      message: "inviteeDisplayName must be a string.",
+    },
+  ] as const;
+
+  for (const invalidCase of invalidCases) {
+    assert.throws(
+      () => parseFriendInvitationDisplayName(invalidCase.value, "inviteeDisplayName"),
+      (error: unknown) => assertHttpError(
+        error,
+        400,
+        "FRIEND_INVITATION_DISPLAY_NAME_INVALID",
+        invalidCase.message,
+      ),
+    );
+  }
+});

--- a/apps/backend/src/community/friendInvitations.ts
+++ b/apps/backend/src/community/friendInvitations.ts
@@ -1,0 +1,435 @@
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import type pg from "pg";
+import {
+  transactionWithUserScope,
+  type DatabaseExecutor,
+  type SqlValue,
+  type UserDatabaseScope,
+} from "../database";
+import { unsafeQuery } from "../database/unsafe";
+import { HttpError } from "../shared/errors";
+import {
+  ensurePublicProfileIdForCurrentUserInExecutor,
+  type CurrentUserPublicProfileId,
+} from "./publicProfiles";
+
+export const activeFriendInvitationLimit = 20;
+export const friendInvitationDisplayNameMaxLength = 30;
+export const friendInviteTokenByteLength = 32;
+export const friendInviteUrlBase = "https://app.flashcards-open-source-app.com/invite";
+
+const displayNameControlCharacterPattern = /[\u0000-\u001F\u007F]/u;
+
+export type FriendInvitationCreateInput = Readonly<{
+  userId: string;
+  inviteeDisplayName: string;
+}>;
+
+export type FriendInvitationCreateResponse = Readonly<{
+  inviteUrl: string;
+  expiresAt: string;
+}>;
+
+export type FriendInvitationPreviewResponse =
+  | Readonly<{ status: "active"; expiresAt: string }>
+  | Readonly<{ status: "inactive" }>;
+
+export type FriendInvitationAcceptInput = Readonly<{
+  userId: string;
+  rawInviteToken: string;
+  inviterDisplayName: string;
+}>;
+
+export type FriendInvitationAcceptResponse =
+  | Readonly<{ status: "accepted" }>
+  | Readonly<{ status: "already_friends"; existingFriendDisplayName: string }>
+  | Readonly<{ status: "inactive" }>;
+
+type UserScopedTransactionFn = <Result>(
+  scope: UserDatabaseScope,
+  callback: (executor: DatabaseExecutor) => Promise<Result>,
+) => Promise<Result>;
+
+type UnsafeQueryFn = <Row extends pg.QueryResultRow>(
+  text: string,
+  params: ReadonlyArray<SqlValue>,
+) => Promise<pg.QueryResult<Row>>;
+
+type EnsureCurrentUserPublicProfileFn = (
+  executor: DatabaseExecutor,
+) => Promise<CurrentUserPublicProfileId>;
+
+export type FriendInvitationServiceDependencies = Readonly<{
+  transactionWithUserScopeFn: UserScopedTransactionFn;
+  unsafeQueryFn: UnsafeQueryFn;
+  ensureCurrentUserPublicProfileFn: EnsureCurrentUserPublicProfileFn;
+  randomBytesFn: (byteCount: number) => Buffer;
+  randomUuidFn: () => string;
+  inviteUrlBase: string;
+  activeInviteLimit: number;
+}>;
+
+type ActiveInvitationCountRow = pg.QueryResultRow & Readonly<{
+  active_invitation_count: number | string;
+}>;
+
+type CreatedInvitationRow = pg.QueryResultRow & Readonly<{
+  expires_at: Date | string;
+}>;
+
+type PreviewInvitationRow = pg.QueryResultRow & Readonly<{
+  invitation_status: string;
+  expires_at: Date | string | null;
+}>;
+
+type AcceptInvitationRow = pg.QueryResultRow & Readonly<{
+  acceptance_status: string;
+  inviter_public_profile_id: string | null;
+  invitee_public_profile_id: string | null;
+}>;
+
+type ExistingFriendRow = pg.QueryResultRow & Readonly<{
+  friend_display_name: string;
+}>;
+
+export const defaultFriendInvitationServiceDependencies: FriendInvitationServiceDependencies = {
+  transactionWithUserScopeFn: transactionWithUserScope,
+  unsafeQueryFn: unsafeQuery,
+  ensureCurrentUserPublicProfileFn: ensurePublicProfileIdForCurrentUserInExecutor,
+  randomBytesFn: randomBytes,
+  randomUuidFn: randomUUID,
+  inviteUrlBase: friendInviteUrlBase,
+  activeInviteLimit: activeFriendInvitationLimit,
+};
+
+export function hashFriendInviteToken(rawInviteToken: string): string {
+  return createHash("sha256").update(rawInviteToken, "utf8").digest("hex");
+}
+
+export function parseFriendInvitationDisplayName(value: unknown, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new HttpError(
+      400,
+      `${fieldName} must be a string.`,
+      "FRIEND_INVITATION_DISPLAY_NAME_INVALID",
+    );
+  }
+
+  if (displayNameControlCharacterPattern.test(value)) {
+    throw new HttpError(
+      400,
+      `${fieldName} must not contain control characters or newlines.`,
+      "FRIEND_INVITATION_DISPLAY_NAME_INVALID",
+    );
+  }
+
+  const normalizedDisplayName = value.trim();
+  const displayNameLength = Array.from(normalizedDisplayName).length;
+  if (displayNameLength < 1 || displayNameLength > friendInvitationDisplayNameMaxLength) {
+    throw new HttpError(
+      400,
+      `${fieldName} must be 1 to ${friendInvitationDisplayNameMaxLength} characters after trimming.`,
+      "FRIEND_INVITATION_DISPLAY_NAME_INVALID",
+    );
+  }
+
+  return normalizedDisplayName;
+}
+
+function createRawFriendInviteToken(dependencies: FriendInvitationServiceDependencies): string {
+  return dependencies.randomBytesFn(friendInviteTokenByteLength).toString("base64url");
+}
+
+function createFriendInviteUrl(inviteUrlBase: string, rawInviteToken: string): string {
+  return `${inviteUrlBase}/${rawInviteToken}`;
+}
+
+function normalizeTimestamp(value: Date | string, fieldName: string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid friend invitation timestamp for ${fieldName}: ${String(value)}.`);
+  }
+
+  return date.toISOString();
+}
+
+function normalizeActiveInvitationCount(value: number | string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsedValue) || parsedValue < 0) {
+    throw new Error(`Invalid active friend invitation count: ${String(value)}.`);
+  }
+
+  return parsedValue;
+}
+
+function assertCurrentUserProfileMatchesRequestUser(
+  currentProfile: CurrentUserPublicProfileId,
+  requestUserId: string,
+): void {
+  if (currentProfile.userId !== requestUserId) {
+    throw new Error(
+      `Current user public profile scope mismatch: expected ${requestUserId}, got ${currentProfile.userId}.`,
+    );
+  }
+}
+
+function assertValidActiveInviteLimit(activeInviteLimit: number): void {
+  if (!Number.isInteger(activeInviteLimit) || activeInviteLimit < 1) {
+    throw new Error(`activeInviteLimit must be a positive integer, got ${activeInviteLimit}.`);
+  }
+}
+
+async function readActiveInvitationCountForInviterInExecutor(
+  executor: DatabaseExecutor,
+  inviterUserId: string,
+): Promise<number> {
+  const result = await executor.query<ActiveInvitationCountRow>(
+    [
+      "SELECT COUNT(*)::INTEGER AS active_invitation_count",
+      "FROM community.friend_invitations",
+      "WHERE inviter_user_id = $1",
+      "AND accepted_at IS NULL",
+      "AND expires_at > now()",
+    ].join(" "),
+    [inviterUserId],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Failed to count active friend invitations for inviter user ${inviterUserId}.`);
+  }
+
+  return normalizeActiveInvitationCount(row.active_invitation_count);
+}
+
+async function lockFriendInvitationCreateForInviterInExecutor(
+  executor: DatabaseExecutor,
+  inviterUserId: string,
+): Promise<void> {
+  await executor.query(
+    "SELECT pg_advisory_xact_lock(hashtextextended($1, 0::bigint))",
+    [`community.friend_invitations:${inviterUserId}`],
+  );
+}
+
+async function insertFriendInvitationInExecutor(
+  executor: DatabaseExecutor,
+  inviterUserId: string,
+  inviteTokenHash: string,
+  inviteeDisplayName: string,
+  dependencies: FriendInvitationServiceDependencies,
+): Promise<string> {
+  const result = await executor.query<CreatedInvitationRow>(
+    [
+      "INSERT INTO community.friend_invitations",
+      "(friend_invitation_id, inviter_user_id, invite_token_hash, invitee_display_name_for_inviter, expires_at)",
+      "VALUES ($1, $2, $3, $4, now() + interval '2 days')",
+      "RETURNING expires_at",
+    ].join(" "),
+    [dependencies.randomUuidFn(), inviterUserId, inviteTokenHash, inviteeDisplayName],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Failed to create friend invitation for inviter user ${inviterUserId}.`);
+  }
+
+  return normalizeTimestamp(row.expires_at, "expires_at");
+}
+
+function assertActiveInvitationLimitNotReached(activeInvitationCount: number, activeInviteLimit: number): void {
+  if (activeInvitationCount < activeInviteLimit) {
+    return;
+  }
+
+  throw new HttpError(
+    409,
+    `You already have ${activeInviteLimit} active friend invitation links. Wait for one to expire or be accepted before creating another.`,
+    "FRIEND_INVITATION_LIMIT_REACHED",
+  );
+}
+
+async function readExistingFriendDisplayNameInExecutor(
+  executor: DatabaseExecutor,
+  viewerUserId: string,
+  friendPublicProfileId: string,
+): Promise<string> {
+  const result = await executor.query<ExistingFriendRow>(
+    [
+      "SELECT friend_display_name",
+      "FROM community.friendships",
+      "WHERE viewer_user_id = $1",
+      "AND friend_public_profile_id = $2",
+      "LIMIT 1",
+    ].join(" "),
+    [viewerUserId, friendPublicProfileId],
+  );
+
+  const existingFriendDisplayName = result.rows[0]?.friend_display_name;
+  if (existingFriendDisplayName === undefined) {
+    throw new Error(
+      `community.accept_friend_invitation returned already_friends without an existing friendship display name for viewer user ${viewerUserId}.`,
+    );
+  }
+
+  return existingFriendDisplayName;
+}
+
+function assertAcceptProfileIdsPresent(
+  row: AcceptInvitationRow,
+): asserts row is AcceptInvitationRow & Readonly<{
+  inviter_public_profile_id: string;
+  invitee_public_profile_id: string;
+}> {
+  if (row.inviter_public_profile_id === null || row.invitee_public_profile_id === null) {
+    throw new Error(
+      `community.accept_friend_invitation returned ${row.acceptance_status} without both public profile ids.`,
+    );
+  }
+}
+
+async function mapAcceptInvitationRow(
+  executor: DatabaseExecutor,
+  viewerUserId: string,
+  row: AcceptInvitationRow,
+): Promise<FriendInvitationAcceptResponse> {
+  switch (row.acceptance_status) {
+    case "accepted":
+      assertAcceptProfileIdsPresent(row);
+      return { status: "accepted" };
+    case "already_friends":
+      assertAcceptProfileIdsPresent(row);
+      return {
+        status: "already_friends",
+        existingFriendDisplayName: await readExistingFriendDisplayNameInExecutor(
+          executor,
+          viewerUserId,
+          row.inviter_public_profile_id,
+        ),
+      };
+    case "inactive":
+    case "already_accepted":
+      return { status: "inactive" };
+    case "self":
+      throw new HttpError(
+        409,
+        "This is your own invitation link.",
+        "FRIEND_INVITATION_SELF",
+      );
+    default:
+      throw new Error(
+        `community.accept_friend_invitation returned unexpected status: ${row.acceptance_status}.`,
+      );
+  }
+}
+
+export async function createFriendInvitationWithDependencies(
+  input: FriendInvitationCreateInput,
+  dependencies: FriendInvitationServiceDependencies,
+): Promise<FriendInvitationCreateResponse> {
+  assertValidActiveInviteLimit(dependencies.activeInviteLimit);
+  const inviteeDisplayName = parseFriendInvitationDisplayName(input.inviteeDisplayName, "inviteeDisplayName");
+
+  return dependencies.transactionWithUserScopeFn({ userId: input.userId }, async (executor) => {
+    const currentProfile = await dependencies.ensureCurrentUserPublicProfileFn(executor);
+    assertCurrentUserProfileMatchesRequestUser(currentProfile, input.userId);
+
+    await lockFriendInvitationCreateForInviterInExecutor(executor, input.userId);
+    const activeInvitationCount = await readActiveInvitationCountForInviterInExecutor(executor, input.userId);
+    assertActiveInvitationLimitNotReached(activeInvitationCount, dependencies.activeInviteLimit);
+
+    const rawInviteToken = createRawFriendInviteToken(dependencies);
+    const inviteTokenHash = hashFriendInviteToken(rawInviteToken);
+    const expiresAt = await insertFriendInvitationInExecutor(
+      executor,
+      input.userId,
+      inviteTokenHash,
+      inviteeDisplayName,
+      dependencies,
+    );
+
+    return {
+      inviteUrl: createFriendInviteUrl(dependencies.inviteUrlBase, rawInviteToken),
+      expiresAt,
+    };
+  });
+}
+
+export async function createFriendInvitation(
+  input: FriendInvitationCreateInput,
+): Promise<FriendInvitationCreateResponse> {
+  return createFriendInvitationWithDependencies(input, defaultFriendInvitationServiceDependencies);
+}
+
+export async function previewFriendInvitationWithDependencies(
+  rawInviteToken: string,
+  dependencies: FriendInvitationServiceDependencies,
+): Promise<FriendInvitationPreviewResponse> {
+  const result = await dependencies.unsafeQueryFn<PreviewInvitationRow>(
+    [
+      "SELECT invitation_status, expires_at",
+      "FROM community.preview_friend_invitation($1)",
+    ].join(" "),
+    [hashFriendInviteToken(rawInviteToken)],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error("community.preview_friend_invitation returned no row.");
+  }
+
+  if (row.invitation_status === "inactive") {
+    return { status: "inactive" };
+  }
+
+  if (row.invitation_status !== "active") {
+    throw new Error(`community.preview_friend_invitation returned unexpected status: ${row.invitation_status}.`);
+  }
+
+  if (row.expires_at === null) {
+    throw new Error("community.preview_friend_invitation returned active without expires_at.");
+  }
+
+  return {
+    status: "active",
+    expiresAt: normalizeTimestamp(row.expires_at, "expires_at"),
+  };
+}
+
+export async function previewFriendInvitation(rawInviteToken: string): Promise<FriendInvitationPreviewResponse> {
+  return previewFriendInvitationWithDependencies(rawInviteToken, defaultFriendInvitationServiceDependencies);
+}
+
+export async function acceptFriendInvitationWithDependencies(
+  input: FriendInvitationAcceptInput,
+  dependencies: FriendInvitationServiceDependencies,
+): Promise<FriendInvitationAcceptResponse> {
+  const inviterDisplayName = parseFriendInvitationDisplayName(input.inviterDisplayName, "inviterDisplayName");
+  const inviteTokenHash = hashFriendInviteToken(input.rawInviteToken);
+
+  return dependencies.transactionWithUserScopeFn({ userId: input.userId }, async (executor) => {
+    const currentProfile = await dependencies.ensureCurrentUserPublicProfileFn(executor);
+    assertCurrentUserProfileMatchesRequestUser(currentProfile, input.userId);
+
+    const result = await executor.query<AcceptInvitationRow>(
+      [
+        "SELECT acceptance_status, inviter_public_profile_id, invitee_public_profile_id",
+        "FROM community.accept_friend_invitation($1, $2)",
+      ].join(" "),
+      [inviteTokenHash, inviterDisplayName],
+    );
+
+    const row = result.rows[0];
+    if (row === undefined) {
+      throw new Error("community.accept_friend_invitation returned no row.");
+    }
+
+    return mapAcceptInvitationRow(executor, input.userId, row);
+  });
+}
+
+export async function acceptFriendInvitation(
+  input: FriendInvitationAcceptInput,
+): Promise<FriendInvitationAcceptResponse> {
+  return acceptFriendInvitationWithDependencies(input, defaultFriendInvitationServiceDependencies);
+}

--- a/apps/backend/src/routes/system.test.ts
+++ b/apps/backend/src/routes/system.test.ts
@@ -19,6 +19,13 @@ import { createSystemRoutes } from "./system";
 import type { RequestContext } from "../server/requestContext";
 import type { AccountPreferences } from "../auth/ensureUser";
 import type { PublicProfile } from "../community/publicProfiles";
+import type {
+  FriendInvitationAcceptInput,
+  FriendInvitationAcceptResponse,
+  FriendInvitationCreateInput,
+  FriendInvitationCreateResponse,
+  FriendInvitationPreviewResponse,
+} from "../community/friendInvitations";
 import { loadOpenApiDocument } from "../shared/openapi";
 
 type SystemTestAppOptions = Readonly<{
@@ -33,6 +40,9 @@ type SystemTestAppOptions = Readonly<{
     leaderboardParticipationEnabled: boolean,
     localeHint: string,
   ) => Promise<PublicProfile>;
+  createFriendInvitationFn?: (input: FriendInvitationCreateInput) => Promise<FriendInvitationCreateResponse>;
+  previewFriendInvitationFn?: (rawInviteToken: string) => Promise<FriendInvitationPreviewResponse>;
+  acceptFriendInvitationFn?: (input: FriendInvitationAcceptInput) => Promise<FriendInvitationAcceptResponse>;
   loadUserProgressReviewScheduleFn?: (args: ProgressReviewScheduleRequest) => Promise<ProgressReviewSchedule>;
   loadUserProgressSeriesFn?: (args: ProgressSeriesRequest) => Promise<ProgressSeries>;
   loadUserProgressSummaryFn?: (args: Readonly<{ userId: string; timeZone: string }>) => Promise<ProgressSummaryResponse>;
@@ -237,6 +247,9 @@ function createSystemTestApp(options: SystemTestAppOptions): Hono<AppEnv> {
     updateAccountPreferencesFn: options.updateAccountPreferencesFn,
     ensurePublicProfileForUserFn: options.ensurePublicProfileForUserFn,
     updateLeaderboardParticipationFn: options.updateLeaderboardParticipationFn,
+    createFriendInvitationFn: options.createFriendInvitationFn,
+    previewFriendInvitationFn: options.previewFriendInvitationFn,
+    acceptFriendInvitationFn: options.acceptFriendInvitationFn,
     loadUserProgressReviewScheduleFn: options.loadUserProgressReviewScheduleFn,
     loadUserProgressSeriesFn: options.loadUserProgressSeriesFn,
     loadUserProgressSummaryFn: options.loadUserProgressSummaryFn,
@@ -600,7 +613,7 @@ test("API Gateway predeclares /me/community/profile", () => {
 
   assert.match(
     apiGatewaySource,
-    /const meCommunityProfile = me\.addResource\("community"\)\.addResource\("profile"\);/,
+    /const meCommunityProfile = meCommunity\.addResource\("profile"\);/,
   );
   assert.match(apiGatewaySource, /meCommunityProfile\.addMethod\("GET", integration\);/);
   assert.match(apiGatewaySource, /meCommunityProfile\.addMethod\("PATCH", integration\);/);
@@ -627,6 +640,323 @@ test("published OpenAPI includes community profile endpoint without internal ids
   assert.equal(serializedSchema.includes("workspaceId"), false);
   assert.equal(serializedSchema.includes("replicaId"), false);
   assert.equal(serializedSchema.includes("email"), false);
+});
+
+test("POST /me/community/friend-invitations creates an invite link for signed-in humans", async () => {
+  let createCalled = false;
+  const app = createSystemTestApp({
+    transport: "bearer",
+    createFriendInvitationFn: async (input) => {
+      createCalled = true;
+      assert.deepEqual(input, {
+        userId: "user-1",
+        inviteeDisplayName: "Priya 🎯",
+      });
+      return {
+        inviteUrl: "https://app.flashcards-open-source-app.com/invite/raw-token",
+        expiresAt: "2026-06-17T10:00:00.000Z",
+      };
+    },
+  });
+
+  const response = await app.request("http://localhost/me/community/friend-invitations", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      inviteeDisplayName: "  Priya 🎯  ",
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(createCalled, true);
+  assert.deepEqual(await response.json(), {
+    inviteUrl: "https://app.flashcards-open-source-app.com/invite/raw-token",
+    expiresAt: "2026-06-17T10:00:00.000Z",
+  });
+});
+
+test("GET /community/friend-invitations/:inviteToken previews without identity fields", async () => {
+  let previewCalled = false;
+  const app = createSystemTestApp({
+    transport: "session",
+    previewFriendInvitationFn: async (rawInviteToken) => {
+      previewCalled = true;
+      assert.equal(rawInviteToken, "raw-token");
+      return {
+        status: "active",
+        expiresAt: "2026-06-17T10:00:00.000Z",
+      };
+    },
+  });
+
+  const response = await app.request("http://localhost/community/friend-invitations/raw-token");
+  const payload = await response.json() as Readonly<Record<string, unknown>>;
+
+  assert.equal(response.status, 200);
+  assert.equal(previewCalled, true);
+  assert.deepEqual(payload, {
+    status: "active",
+    expiresAt: "2026-06-17T10:00:00.000Z",
+  });
+  assert.equal(Object.hasOwn(payload, "inviterUserId"), false);
+  assert.equal(Object.hasOwn(payload, "email"), false);
+  assert.equal(Object.hasOwn(payload, "publicProfileId"), false);
+  assert.equal(Object.hasOwn(payload, "inviteeDisplayName"), false);
+});
+
+test("GET /community/friend-invitations/:inviteToken rejects ApiKey authentication", async () => {
+  let previewCalled = false;
+  const app = createSystemTestApp({
+    transport: "session",
+    previewFriendInvitationFn: async () => {
+      previewCalled = true;
+      return { status: "inactive" };
+    },
+  });
+
+  const response = await app.request("http://localhost/community/friend-invitations/raw-token", {
+    headers: {
+      Authorization: "ApiKey test-key",
+    },
+  });
+
+  assert.equal(previewCalled, false);
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    error: "Friend invitation preview does not support ApiKey authentication",
+    requestId: "request-1",
+    code: "FRIEND_INVITATION_API_KEY_AUTH_UNSUPPORTED",
+  });
+});
+
+test("POST /me/community/friend-invitations/:inviteToken/accept accepts for signed-in humans", async () => {
+  let acceptCalled = false;
+  const app = createSystemTestApp({
+    transport: "session",
+    acceptFriendInvitationFn: async (input) => {
+      acceptCalled = true;
+      assert.deepEqual(input, {
+        userId: "user-1",
+        rawInviteToken: "raw-token",
+        inviterDisplayName: "Alex",
+      });
+      return { status: "accepted" };
+    },
+  });
+
+  const response = await app.request("http://localhost/me/community/friend-invitations/raw-token/accept", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      inviterDisplayName: "  Alex  ",
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(acceptCalled, true);
+  assert.deepEqual(await response.json(), {
+    status: "accepted",
+  });
+});
+
+test("POST /me/community/friend-invitations/:inviteToken/accept returns self-link errors", async () => {
+  const app = createSystemTestApp({
+    transport: "bearer",
+    acceptFriendInvitationFn: async () => {
+      throw new HttpError(
+        409,
+        "This is your own invitation link.",
+        "FRIEND_INVITATION_SELF",
+      );
+    },
+  });
+
+  const response = await app.request("http://localhost/me/community/friend-invitations/raw-token/accept", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      inviterDisplayName: "Alex",
+    }),
+  });
+
+  assert.equal(response.status, 409);
+  assert.deepEqual(await response.json(), {
+    error: "This is your own invitation link.",
+    requestId: "request-1",
+    code: "FRIEND_INVITATION_SELF",
+  });
+});
+
+test("friend invitation human endpoints reject ApiKey and Guest authentication", async () => {
+  const cases = [
+    {
+      url: "http://localhost/me/community/friend-invitations",
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          inviteeDisplayName: "Priya",
+        }),
+      },
+    },
+    {
+      url: "http://localhost/me/community/friend-invitations/raw-token/accept",
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          inviterDisplayName: "Alex",
+        }),
+      },
+    },
+  ] as const;
+  const transports: ReadonlyArray<RequestContext["transport"]> = ["api_key", "guest"];
+
+  for (const transport of transports) {
+    for (const testCase of cases) {
+      let serviceCalled = false;
+      const app = createSystemTestApp({
+        transport,
+        createFriendInvitationFn: async () => {
+          serviceCalled = true;
+          return {
+            inviteUrl: "https://app.flashcards-open-source-app.com/invite/raw-token",
+            expiresAt: "2026-06-17T10:00:00.000Z",
+          };
+        },
+        acceptFriendInvitationFn: async () => {
+          serviceCalled = true;
+          return { status: "accepted" };
+        },
+      });
+      const response = await app.request(testCase.url, testCase.init);
+
+      assert.equal(serviceCalled, false);
+      assert.equal(response.status, 403);
+      assert.deepEqual(await response.json(), {
+        error: "This endpoint requires signed-in human authentication",
+        requestId: "request-1",
+        code: "FRIEND_INVITATION_HUMAN_AUTH_REQUIRED",
+      });
+    }
+  }
+});
+
+test("friend invitation routes reject invalid display names before service calls", async () => {
+  const cases = [
+    {
+      url: "http://localhost/me/community/friend-invitations",
+      body: {
+        inviteeDisplayName: "Line\nBreak",
+      },
+      expectedError: "inviteeDisplayName must not contain control characters or newlines.",
+    },
+    {
+      url: "http://localhost/me/community/friend-invitations/raw-token/accept",
+      body: {
+        inviterDisplayName: "",
+      },
+      expectedError: "inviterDisplayName must be 1 to 30 characters after trimming.",
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    let serviceCalled = false;
+    const app = createSystemTestApp({
+      transport: "session",
+      createFriendInvitationFn: async () => {
+        serviceCalled = true;
+        return {
+          inviteUrl: "https://app.flashcards-open-source-app.com/invite/raw-token",
+          expiresAt: "2026-06-17T10:00:00.000Z",
+        };
+      },
+      acceptFriendInvitationFn: async () => {
+        serviceCalled = true;
+        return { status: "accepted" };
+      },
+    });
+    const response = await app.request(testCase.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(testCase.body),
+    });
+
+    assert.equal(serviceCalled, false);
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      error: testCase.expectedError,
+      requestId: "request-1",
+      code: "FRIEND_INVITATION_DISPLAY_NAME_INVALID",
+    });
+  }
+});
+
+test("API Gateway predeclares friend invitation routes", () => {
+  const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(
+    apiGatewaySource,
+    /const meCommunityFriendInvitations = meCommunity\.addResource\("friend-invitations"\);/,
+  );
+  assert.match(apiGatewaySource, /meCommunityFriendInvitations\.addMethod\("POST", integration\);/);
+  assert.match(
+    apiGatewaySource,
+    /meCommunityFriendInvitations\s*\.addResource\("\{inviteToken\}"\)\s*\.addResource\("accept"\)\s*\.addMethod\("POST", integration\);/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /const communityFriendInvitations = community\.addResource\("friend-invitations"\);/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /communityFriendInvitations\.addResource\("\{inviteToken\}"\)\.addMethod\("GET", integration\);/,
+  );
+});
+
+test("published OpenAPI documents friend invitations without internal ids", () => {
+  const openApiDocument = loadOpenApiDocument() as Readonly<{
+    paths?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
+    components?: Readonly<{ schemas?: Readonly<Record<string, unknown>> }>;
+  }>;
+  const createPath = openApiDocument.paths?.["/me/community/friend-invitations"];
+  const previewPath = openApiDocument.paths?.["/community/friend-invitations/{inviteToken}"];
+  const acceptPath = openApiDocument.paths?.["/me/community/friend-invitations/{inviteToken}/accept"];
+  const schemas = openApiDocument.components?.schemas ?? {};
+  const invitationSchemas = Object.fromEntries(
+    Object.entries(schemas).filter(([name]) => name.startsWith("FriendInvitation")),
+  );
+  const serializedContract = JSON.stringify({
+    createPath,
+    previewPath,
+    acceptPath,
+    invitationSchemas,
+  });
+  const serializedInvitationSchemas = JSON.stringify(invitationSchemas);
+
+  assert.notEqual(createPath?.post, undefined);
+  assert.notEqual(previewPath?.get, undefined);
+  assert.notEqual(acceptPath?.post, undefined);
+  assert.equal(serializedContract.includes("inviteUrl"), true);
+  assert.equal(serializedContract.includes("expiresAt"), true);
+  assert.equal(serializedContract.includes("existingFriendDisplayName"), true);
+  assert.equal(serializedInvitationSchemas.includes("publicProfileId"), false);
+  assert.equal(serializedInvitationSchemas.includes("userId"), false);
+  assert.equal(serializedInvitationSchemas.includes("email"), false);
+  assert.equal(serializedInvitationSchemas.includes("inviteeDisplayNameForInviter"), false);
 });
 
 test("GET /me/progress/summary returns 200 for Session, Bearer, and Guest authentication", async () => {

--- a/apps/backend/src/routes/system.ts
+++ b/apps/backend/src/routes/system.ts
@@ -8,6 +8,17 @@ import {
   updateLeaderboardParticipation,
   type PublicProfile,
 } from "../community/publicProfiles";
+import {
+  acceptFriendInvitation,
+  createFriendInvitation,
+  parseFriendInvitationDisplayName,
+  previewFriendInvitation,
+  type FriendInvitationAcceptInput,
+  type FriendInvitationAcceptResponse,
+  type FriendInvitationCreateInput,
+  type FriendInvitationCreateResponse,
+  type FriendInvitationPreviewResponse,
+} from "../community/friendInvitations";
 import { HttpError } from "../shared/errors";
 import { queryWithUserScope } from "../database";
 import {
@@ -55,6 +66,9 @@ type SystemRoutesOptions = Readonly<{
   updateAccountPreferencesFn?: UpdateAccountPreferencesFn;
   ensurePublicProfileForUserFn?: EnsurePublicProfileForUserFn;
   updateLeaderboardParticipationFn?: UpdateLeaderboardParticipationFn;
+  createFriendInvitationFn?: CreateFriendInvitationFn;
+  previewFriendInvitationFn?: PreviewFriendInvitationFn;
+  acceptFriendInvitationFn?: AcceptFriendInvitationFn;
 }>;
 
 type ProgressRequestedParameters = Readonly<{
@@ -79,6 +93,12 @@ type UpdateLeaderboardParticipationFn = (
   leaderboardParticipationEnabled: boolean,
   localeHint: string,
 ) => Promise<PublicProfile>;
+
+type CreateFriendInvitationFn = (input: FriendInvitationCreateInput) => Promise<FriendInvitationCreateResponse>;
+
+type PreviewFriendInvitationFn = (rawInviteToken: string) => Promise<FriendInvitationPreviewResponse>;
+
+type AcceptFriendInvitationFn = (input: FriendInvitationAcceptInput) => Promise<FriendInvitationAcceptResponse>;
 
 type CommunityPublicProfileResponse = PublicProfile & Readonly<{
   linkedAccountRequiredForLeaderboard: boolean;
@@ -128,6 +148,27 @@ function assertCommunityProfileHumanTransport(transport: AuthTransport): void {
   }
 }
 
+function assertFriendInvitationHumanTransport(transport: AuthTransport): void {
+  if (transport !== "session" && transport !== "bearer" && transport !== "none") {
+    throw new HttpError(
+      403,
+      "This endpoint requires signed-in human authentication",
+      "FRIEND_INVITATION_HUMAN_AUTH_REQUIRED",
+    );
+  }
+}
+
+function assertFriendInvitationPublicPreviewTransport(request: Request): void {
+  const authorizationHeader = request.headers.get("authorization");
+  if (authorizationHeader !== null && authorizationHeader.startsWith("ApiKey ")) {
+    throw new HttpError(
+      403,
+      "Friend invitation preview does not support ApiKey authentication",
+      "FRIEND_INVITATION_API_KEY_AUTH_UNSUPPORTED",
+    );
+  }
+}
+
 function parseAccountPreferencesInput(body: Record<string, unknown>): AccountPreferences {
   const unexpectedKey = Object.keys(body).find((key) => key !== "reviewReactionAnimationsEnabled");
   if (unexpectedKey !== undefined) {
@@ -164,6 +205,52 @@ function parseCommunityProfileInput(body: Record<string, unknown>): Readonly<{
       "leaderboardParticipationEnabled",
     ),
   };
+}
+
+function parseFriendInvitationCreateInput(body: Record<string, unknown>): Readonly<{
+  inviteeDisplayName: string;
+}> {
+  const unexpectedKey = Object.keys(body).find((key) => key !== "inviteeDisplayName");
+  if (unexpectedKey !== undefined) {
+    throw new HttpError(
+      400,
+      `Unexpected friend invitation field: ${unexpectedKey}`,
+      "FRIEND_INVITATION_FIELD_UNKNOWN",
+    );
+  }
+
+  return {
+    inviteeDisplayName: parseFriendInvitationDisplayName(body.inviteeDisplayName, "inviteeDisplayName"),
+  };
+}
+
+function parseFriendInvitationAcceptInput(body: Record<string, unknown>): Readonly<{
+  inviterDisplayName: string;
+}> {
+  const unexpectedKey = Object.keys(body).find((key) => key !== "inviterDisplayName");
+  if (unexpectedKey !== undefined) {
+    throw new HttpError(
+      400,
+      `Unexpected friend invitation field: ${unexpectedKey}`,
+      "FRIEND_INVITATION_FIELD_UNKNOWN",
+    );
+  }
+
+  return {
+    inviterDisplayName: parseFriendInvitationDisplayName(body.inviterDisplayName, "inviterDisplayName"),
+  };
+}
+
+function parseInviteTokenParam(value: string | undefined): string {
+  if (value === undefined || value.trim() === "") {
+    throw new HttpError(
+      400,
+      "inviteToken is required",
+      "FRIEND_INVITATION_TOKEN_REQUIRED",
+    );
+  }
+
+  return value;
 }
 
 async function updateAccountPreferences(
@@ -228,6 +315,9 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
   const updateAccountPreferencesFn = options.updateAccountPreferencesFn ?? updateAccountPreferences;
   const ensurePublicProfileForUserFn = options.ensurePublicProfileForUserFn ?? ensurePublicProfileForUser;
   const updateLeaderboardParticipationFn = options.updateLeaderboardParticipationFn ?? updateLeaderboardParticipation;
+  const createFriendInvitationFn = options.createFriendInvitationFn ?? createFriendInvitation;
+  const previewFriendInvitationFn = options.previewFriendInvitationFn ?? previewFriendInvitation;
+  const acceptFriendInvitationFn = options.acceptFriendInvitationFn ?? acceptFriendInvitation;
 
   app.get("/", async (context) => context.json(createAgentDiscoveryEnvelope(context.req.url)));
   app.get("/agent", async (context) => context.json(createAgentDiscoveryEnvelope(context.req.url)));
@@ -314,6 +404,51 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
     );
 
     return context.json(createCommunityPublicProfileResponse(profile, requestContext.transport));
+  });
+
+  app.post("/me/community/friend-invitations", async (context) => {
+    const { requestContext } = await loadRequestContextFromRequestFn(
+      context.req.raw,
+      options.allowedOrigins,
+    );
+
+    assertFriendInvitationHumanTransport(requestContext.transport);
+
+    const body = expectRecord(await parseJsonBody(context.req.raw));
+    const input = parseFriendInvitationCreateInput(body);
+    const invitation = await createFriendInvitationFn({
+      userId: requestContext.userId,
+      inviteeDisplayName: input.inviteeDisplayName,
+    });
+
+    return context.json(invitation satisfies FriendInvitationCreateResponse);
+  });
+
+  app.get("/community/friend-invitations/:inviteToken", async (context) => {
+    assertFriendInvitationPublicPreviewTransport(context.req.raw);
+    const rawInviteToken = parseInviteTokenParam(context.req.param("inviteToken"));
+    const invitation = await previewFriendInvitationFn(rawInviteToken);
+    return context.json(invitation satisfies FriendInvitationPreviewResponse);
+  });
+
+  app.post("/me/community/friend-invitations/:inviteToken/accept", async (context) => {
+    const { requestContext } = await loadRequestContextFromRequestFn(
+      context.req.raw,
+      options.allowedOrigins,
+    );
+
+    assertFriendInvitationHumanTransport(requestContext.transport);
+
+    const rawInviteToken = parseInviteTokenParam(context.req.param("inviteToken"));
+    const body = expectRecord(await parseJsonBody(context.req.raw));
+    const input = parseFriendInvitationAcceptInput(body);
+    const invitation = await acceptFriendInvitationFn({
+      userId: requestContext.userId,
+      rawInviteToken,
+      inviterDisplayName: input.inviterDisplayName,
+    });
+
+    return context.json(invitation satisfies FriendInvitationAcceptResponse);
   });
 
   app.get("/me/progress/summary", async (context) => {

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -18,10 +18,33 @@ test("API Gateway predeclares /me/community/profile", () => {
 
   assert.match(
     apiGatewaySource,
-    /const meCommunityProfile = me\.addResource\("community"\)\.addResource\("profile"\);/,
+    /const meCommunityProfile = meCommunity\.addResource\("profile"\);/,
   );
   assert.match(apiGatewaySource, /meCommunityProfile\.addMethod\("GET", integration\);/);
   assert.match(apiGatewaySource, /meCommunityProfile\.addMethod\("PATCH", integration\);/);
+});
+
+test("API Gateway predeclares friend invitation routes", () => {
+  const apiGatewayPath = resolve(process.cwd(), "lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(
+    apiGatewaySource,
+    /const meCommunityFriendInvitations = meCommunity\.addResource\("friend-invitations"\);/,
+  );
+  assert.match(apiGatewaySource, /meCommunityFriendInvitations\.addMethod\("POST", integration\);/);
+  assert.match(
+    apiGatewaySource,
+    /meCommunityFriendInvitations\s*\.addResource\("\{inviteToken\}"\)\s*\.addResource\("accept"\)\s*\.addMethod\("POST", integration\);/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /const communityFriendInvitations = community\.addResource\("friend-invitations"\);/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /communityFriendInvitations\.addResource\("\{inviteToken\}"\)\.addMethod\("GET", integration\);/,
+  );
 });
 
 test("API Gateway predeclares /me/progress/leaderboard", () => {

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -615,15 +615,26 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   const me = restApi.root.addResource("me");
   me.addMethod("GET", integration);
   me.addResource("preferences").addMethod("PATCH", integration);
-  const meCommunityProfile = me.addResource("community").addResource("profile");
+  const meCommunity = me.addResource("community");
+  const meCommunityProfile = meCommunity.addResource("profile");
   meCommunityProfile.addMethod("GET", integration);
   meCommunityProfile.addMethod("PATCH", integration);
+  const meCommunityFriendInvitations = meCommunity.addResource("friend-invitations");
+  meCommunityFriendInvitations.addMethod("POST", integration);
+  meCommunityFriendInvitations
+    .addResource("{inviteToken}")
+    .addResource("accept")
+    .addMethod("POST", integration);
   const meProgress = me.addResource("progress");
   meProgress.addResource("summary").addMethod("GET", integration);
   meProgress.addResource("review-schedule").addMethod("GET", integration);
   meProgress.addResource("series").addMethod("GET", integration);
   meProgress.addResource("leaderboard").addMethod("GET", integration);
   me.addResource("delete").addMethod("POST", integration);
+
+  const community = restApi.root.addResource("community");
+  const communityFriendInvitations = community.addResource("friend-invitations");
+  communityFriendInvitations.addResource("{inviteToken}").addMethod("GET", integration);
 
   const feedback = restApi.root.addResource("feedback");
   feedback.addResource("state").addMethod("GET", integration);


### PR DESCRIPTION
## Summary
- add backend friend invitation create, preview, and accept service logic
- wire human/public HTTP routes and API Gateway resources
- document the new contract in OpenAPI and add route/service/gateway coverage

## Validation
- npm run lint --prefix apps/backend
- npm run lint --prefix api
- npm test --prefix apps/backend
- npm test --prefix infra/aws
- git --no-pager diff --check