### PR TITLE
[codex] Add backend leaderboard friend metadata

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -416,8 +416,10 @@ paths:
         Guests receive status linked_account_required and opted-out users receive
         participation_disabled, both with no other users' rows. ApiKey
         authentication is rejected. Only opaque public profile ids and
-        locale-derived anonymous display names are returned; internal user ids and
-        raw review timestamps are never exposed.
+        locale-derived anonymous display names are returned by default. Rows can
+        also include a viewer-private friendDisplayName when the participant is
+        a current opted-in friend of the viewer. Internal user ids, invitation
+        ids, emails, and raw review timestamps are never exposed.
       security:
         - BearerAuth: []
         - GuestAuthorizationHeader: []
@@ -783,6 +785,9 @@ components:
         anonymousDisplayName:
           type: string
           description: Locale-aware anonymous display label derived from the public profile id.
+        friendDisplayName:
+          type: string
+          description: Viewer-private friend label shown only for current opted-in friends.
         qualifiedReviewCount:
           type: integer
           minimum: 0
@@ -823,6 +828,9 @@ components:
         anonymousDisplayName:
           type: string
           description: Locale-aware anonymous display label derived from the public profile id.
+        friendDisplayName:
+          type: string
+          description: Viewer-private friend label shown only for current opted-in friends.
         qualifiedReviewCount:
           type: integer
           minimum: 0

--- a/apps/backend/src/community/friendships.test.ts
+++ b/apps/backend/src/community/friendships.test.ts
@@ -79,3 +79,27 @@ test("0063 migration creates friend invitations, directed friendships, and narro
   assert.match(sql, /REVOKE ALL ON FUNCTION community\.accept_friend_invitation\(TEXT, TEXT\) FROM PUBLIC/);
   assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.accept_friend_invitation\(TEXT, TEXT\) TO backend_app/);
 });
+
+test("0064 migration exposes only current viewer leaderboard friend labels", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "../../db/migrations/0064_leaderboard_friend_labels.sql",
+  );
+  const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
+
+  assert.match(sql, /CREATE OR REPLACE FUNCTION community\.read_current_user_leaderboard_friend_labels\(\)/);
+  assert.match(sql, /RETURNS TABLE \( friend_public_profile_id UUID, friend_display_name TEXT \)/);
+  assert.match(sql, /SECURITY DEFINER/);
+  assert.match(sql, /SET search_path = pg_catalog, public/);
+  assert.match(sql, /FROM community\.friendships AS friendships/);
+  assert.match(sql, /INNER JOIN community\.public_profiles AS friend_profiles/);
+  assert.match(sql, /friend_profiles\.public_profile_id = friendships\.friend_public_profile_id/);
+  assert.match(sql, /friendships\.viewer_user_id = security\.current_user_id\(\)/);
+  assert.match(sql, /friend_profiles\.leaderboard_participation_enabled = TRUE/);
+  assert.match(sql, /REVOKE ALL ON FUNCTION community\.read_current_user_leaderboard_friend_labels\(\) FROM PUBLIC/);
+  assert.match(sql, /GRANT EXECUTE ON FUNCTION community\.read_current_user_leaderboard_friend_labels\(\) TO backend_app/);
+  assert.equal(sql.includes("friend_user_id"), false);
+  assert.equal(sql.includes("created_from_invitation_id"), false);
+  assert.equal(sql.includes("inviter_user_id"), false);
+  assert.equal(sql.includes("email"), false);
+});

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.test.ts
@@ -27,6 +27,12 @@ type SnapshotEntryRow = Readonly<{
   base_sort_position: number;
 }>;
 
+type FriendshipFixture = Readonly<{
+  friendPublicProfileId: string;
+  friendDisplayName: string;
+  leaderboardParticipationEnabled: boolean;
+}>;
+
 type ViewerProfileFixture = Readonly<{
   publicProfileId: string;
   leaderboardParticipationEnabled: boolean;
@@ -36,6 +42,7 @@ type LeaderboardExecutorFixture = Readonly<{
   viewerUserId: string;
   viewerProfile: ViewerProfileFixture;
   latestReviewedAtClient: Date | null;
+  friendships: ReadonlyArray<FriendshipFixture>;
   headers: ReadonlyArray<SnapshotHeaderRow>;
   entriesBySnapshotId: Readonly<Record<string, ReadonlyArray<SnapshotEntryRow>>>;
 }>;
@@ -51,6 +58,7 @@ type RankingSummary = Readonly<{
 
 const VIEWER_USER_ID = "user-viewer";
 const VIEWER_PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
+const FRIEND_PROFILE_ID = "00000000-0000-4000-8000-000000000fa1";
 const AS_OF_SERVER_HOUR = new Date("2026-06-10T14:00:00.000Z");
 const SNAPSHOT_GENERATED_AT = new Date("2026-06-10T14:00:05.000Z");
 const EXPECTED_AS_OF_ISO = "2026-06-10T14:00:00.000Z";
@@ -148,6 +156,27 @@ function createLeaderboardExecutor(
         throw new Error("viewer profile was pre-seeded; no insert expected");
       }
 
+      if (text.includes("FROM community.read_current_user_leaderboard_friend_labels() AS friend_labels")) {
+        if (scopedUserId !== fixture.viewerUserId) {
+          throw new Error("friendship read requires the viewer user scope");
+        }
+        if (params.length !== 0) {
+          throw new Error("friendship read helper does not accept request parameters");
+        }
+        if (text.includes("friend_user_id")) {
+          throw new Error("friendship leaderboard read must not select internal friend user ids");
+        }
+
+        return createQueryResult(
+          fixture.friendships
+            .filter((friendship) => friendship.leaderboardParticipationEnabled)
+            .map((friendship) => ({
+              friend_public_profile_id: friendship.friendPublicProfileId,
+              friend_display_name: friendship.friendDisplayName,
+            })),
+        ) as unknown as pg.QueryResult<Row>;
+      }
+
       if (
         text.includes("FROM community.leaderboard_snapshots")
         && text.includes("DISTINCT ON (snapshots.window_key)")
@@ -213,6 +242,12 @@ function includesQuery(recordedQueries: ReadonlyArray<RecordedQuery>, substring:
   return recordedQueries.some((query) => query.text.includes(substring));
 }
 
+function assertNoFriendDisplayName(
+  row: ProgressLeaderboardParticipantRow | ProgressLeaderboardRankingRow,
+): void {
+  assert.equal("friendDisplayName" in row, false);
+}
+
 test("guest viewers receive linked_account_required with no rows and no database access", async () => {
   const leaderboard = await loadProgressLeaderboard({
     userId: VIEWER_USER_ID,
@@ -231,6 +266,7 @@ test("opted-out viewers receive participation_disabled without reading any other
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: false },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: {},
   });
@@ -252,6 +288,7 @@ test("missing snapshots yield snapshot_unavailable without reading entries", asy
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: [],
     entriesBySnapshotId: {},
   });
@@ -267,11 +304,154 @@ test("missing snapshots yield snapshot_unavailable without reading entries", asy
   assert.equal(includesQuery(recordedQueries, "community.leaderboard_snapshot_entries"), false);
 });
 
+test("ready response without friendships preserves the old row shape", async () => {
+  const otherProfileId = "00000000-0000-4000-8000-000000000a01";
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    friendships: [],
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: otherProfileId, qualified_review_count: 8, base_sort_position: 1 },
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 3, base_sort_position: 2 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  const compactRow = participantRows(window.rows).find((row) => row.publicProfileId === otherProfileId);
+  const rankingRow = window.rankingRows.find((row) => row.publicProfileId === otherProfileId);
+
+  if (compactRow === undefined || rankingRow === undefined) {
+    throw new Error("Expected no-friendship leaderboard rows to include the non-viewer participant.");
+  }
+
+  assertNoFriendDisplayName(compactRow);
+  assertNoFriendDisplayName(rankingRow);
+  assert.equal(JSON.stringify(leaderboard).includes("friendDisplayName"), false);
+});
+
+test("friend in rankingRows receives the viewer-private friend display name", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    friendships: [
+      {
+        friendPublicProfileId: FRIEND_PROFILE_ID,
+        friendDisplayName: "Ari",
+        leaderboardParticipationEnabled: true,
+      },
+    ],
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 50, base_sort_position: 1 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000a11", qualified_review_count: 40, base_sort_position: 2 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000a12", qualified_review_count: 30, base_sort_position: 3 },
+      { public_profile_id: FRIEND_PROFILE_ID, qualified_review_count: 20, base_sort_position: 4 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000a13", qualified_review_count: 10, base_sort_position: 5 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  const friendRankingRow = window.rankingRows.find((row) => row.publicProfileId === FRIEND_PROFILE_ID);
+
+  assert.equal(window.rankingRows.length, window.participantCount);
+  assert.notEqual(friendRankingRow, undefined);
+  assert.equal(friendRankingRow?.kind, "participant");
+  assert.equal(friendRankingRow?.friendDisplayName, "Ari");
+  assert.equal(participantRows(window.rows).some((row) => row.publicProfileId === FRIEND_PROFILE_ID), false);
+});
+
+test("friend in compact rows keeps the old row kind and receives optional metadata", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    friendships: [
+      {
+        friendPublicProfileId: FRIEND_PROFILE_ID,
+        friendDisplayName: "Mina",
+        leaderboardParticipationEnabled: true,
+      },
+    ],
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: FRIEND_PROFILE_ID, qualified_review_count: 12, base_sort_position: 1 },
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 6, base_sort_position: 2 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  const friendCompactRow = participantRows(window.rows).find((row) => row.publicProfileId === FRIEND_PROFILE_ID);
+
+  assert.notEqual(friendCompactRow, undefined);
+  assert.equal(friendCompactRow?.kind, "top");
+  assert.equal(friendCompactRow?.friendDisplayName, "Mina");
+});
+
+test("opted-out friends keep anonymous labels without friend display metadata", async () => {
+  const { executor } = createLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    latestReviewedAtClient: null,
+    friendships: [
+      {
+        friendPublicProfileId: FRIEND_PROFILE_ID,
+        friendDisplayName: "Noor",
+        leaderboardParticipationEnabled: false,
+      },
+    ],
+    headers: createReadyHeaders(),
+    entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
+      { public_profile_id: FRIEND_PROFILE_ID, qualified_review_count: 12, base_sort_position: 1 },
+      { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 6, base_sort_position: 2 },
+    ]),
+  });
+
+  const leaderboard = await loadProgressLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+    NOW,
+  );
+
+  const window = findWindow(leaderboard, "last_24_hours");
+  const friendCompactRow = participantRows(window.rows).find((row) => row.publicProfileId === FRIEND_PROFILE_ID);
+  const friendRankingRow = window.rankingRows.find((row) => row.publicProfileId === FRIEND_PROFILE_ID);
+
+  if (friendCompactRow === undefined || friendRankingRow === undefined) {
+    throw new Error("Expected opted-out friend to remain in the snapshot rows without friend metadata.");
+  }
+
+  assertNoFriendDisplayName(friendCompactRow);
+  assertNoFriendDisplayName(friendRankingRow);
+  assert.notEqual(friendCompactRow.anonymousDisplayName, "");
+});
+
 test("ready response defaults to the viewer's best rank, ignoring latest activity", async () => {
   const { executor } = createLeaderboardExecutor({
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: new Date(NOW.getTime() - 2 * MILLISECONDS_PER_HOUR),
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: {
       ...createEntriesForWindow("last_24_hours", [
@@ -314,6 +494,7 @@ test("ready response defaults to the shortest window when best ranks tie", async
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: {
       ...createEntriesForWindow("last_24_hours", sameRankEntries),
@@ -345,6 +526,7 @@ test("a zero-count viewer with tied ranks defaults to last_24_hours and still ap
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: {
       ...createEntriesForWindow("last_24_hours", zeroCountEntries),
@@ -400,6 +582,7 @@ test("equal counts rank the viewer below other users with the same count", async
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
       { public_profile_id: "00000000-0000-4000-8000-0000000000c1", qualified_review_count: 5, base_sort_position: 1 },
@@ -466,6 +649,7 @@ test("compact rows show the next rank when the viewer is exactly third", async (
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
       { public_profile_id: "00000000-0000-4000-8000-000000000131", qualified_review_count: 30, base_sort_position: 1 },
@@ -508,6 +692,7 @@ test("compact rows show the top three, gaps, the viewer group, and the last-plac
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: createEntriesForWindow("last_24_hours", otherEntries),
   });
@@ -568,6 +753,7 @@ test("compact rows skip the viewer-neighbor group when the viewer is already in 
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
       { public_profile_id: "00000000-0000-4000-8000-000000000101", qualified_review_count: 90, base_sort_position: 1 },
@@ -599,6 +785,7 @@ test("a viewer near the top produces contiguous rows with no gap", async () => {
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
       { public_profile_id: "00000000-0000-4000-8000-0000000000e1", qualified_review_count: 30, base_sort_position: 1 },
@@ -634,6 +821,7 @@ test("anonymous names change with locale while ids, counts, and ranks stay stabl
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: null,
+    friendships: [],
     headers: createReadyHeaders(),
     entriesBySnapshotId: entries,
   });
@@ -674,9 +862,16 @@ test("ready response serializes only public fields, never internal identifiers",
     viewerUserId: VIEWER_USER_ID,
     viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
     latestReviewedAtClient: rawReviewTimestamp,
+    friendships: [
+      {
+        friendPublicProfileId: FRIEND_PROFILE_ID,
+        friendDisplayName: "Kai",
+        leaderboardParticipationEnabled: true,
+      },
+    ],
     headers: createReadyHeaders(),
     entriesBySnapshotId: createEntriesForWindow("last_24_hours", [
-      { public_profile_id: "00000000-0000-4000-8000-000000000aa1", qualified_review_count: 7, base_sort_position: 1 },
+      { public_profile_id: FRIEND_PROFILE_ID, qualified_review_count: 7, base_sort_position: 1 },
       { public_profile_id: VIEWER_PROFILE_ID, qualified_review_count: 2, base_sort_position: 2 },
     ]),
   });
@@ -690,6 +885,8 @@ test("ready response serializes only public fields, never internal identifiers",
 
   assert.equal(serialized.includes("publicProfileId"), true);
   assert.equal(serialized.includes("anonymousDisplayName"), true);
+  assert.equal(serialized.includes("friendDisplayName"), true);
+  assert.equal(serialized.includes("Kai"), true);
   assert.equal(serialized.includes("qualifiedReviewCount"), true);
   assert.equal(serialized.includes("rankingRows"), true);
   for (const internalField of [
@@ -697,6 +894,15 @@ test("ready response serializes only public fields, never internal identifiers",
     rawReviewTimestamp.toISOString(),
     "user_id",
     "userId",
+    "friend_user_id",
+    "friendUserId",
+    "friend_public_profile_id",
+    "friendPublicProfileId",
+    "created_from_invitation_id",
+    "createdFromInvitationId",
+    "friendInvitationId",
+    "inviter_user_id",
+    "inviterUserId",
     "reviewed_by",
     "reviewedBy",
     "base_sort",

--- a/apps/backend/src/community/leaderboard/progressLeaderboard.ts
+++ b/apps/backend/src/community/leaderboard/progressLeaderboard.ts
@@ -78,6 +78,7 @@ export type ProgressLeaderboardParticipantRow = Readonly<{
   kind: "top" | "neighbor" | "viewer";
   publicProfileId: string;
   anonymousDisplayName: string;
+  friendDisplayName?: string;
   qualifiedReviewCount: number;
   rank: number;
 }>;
@@ -92,6 +93,7 @@ export type ProgressLeaderboardRankingRow = Readonly<{
   kind: "participant" | "viewer";
   publicProfileId: string;
   anonymousDisplayName: string;
+  friendDisplayName?: string;
   qualifiedReviewCount: number;
   rank: number;
 }>;
@@ -209,6 +211,11 @@ type LeaderboardSnapshotEntryRow = Readonly<{
   base_sort_position: number | string;
 }>;
 
+type LeaderboardFriendDisplayNameRow = Readonly<{
+  friend_public_profile_id: string;
+  friend_display_name: string;
+}>;
+
 function resolveProgressLeaderboardMetric(localeHint: string): ProgressLeaderboardMetric {
   const copy = PROGRESS_LEADERBOARD_METRIC_COPY_BY_LOCALE[resolveAnonymousDisplayNameLocale(localeHint)];
   return {
@@ -257,6 +264,15 @@ function normalizeNonNegativeInteger(value: number | string, field: string): num
   }
 
   return parsed;
+}
+
+function normalizeFriendDisplayName(value: string, publicProfileId: string): string {
+  const displayNameLength = Array.from(value.trim()).length;
+  if (displayNameLength < 1 || displayNameLength > 30 || /[\u0000-\u001F\u007F]/u.test(value)) {
+    throw new Error(`Invalid friend display name for public profile ${publicProfileId}.`);
+  }
+
+  return value;
 }
 
 function computeNextRefreshAfter(now: Date): string {
@@ -327,17 +343,20 @@ function buildParticipantRow(
   participant: RankedParticipant,
   topRowCount: number,
   resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
 ): ProgressLeaderboardParticipantRow {
   const kind: "top" | "neighbor" | "viewer" = participant.isViewer
     ? "viewer"
     : participant.rank <= topRowCount
       ? "top"
       : "neighbor";
+  const friendDisplayName = friendDisplayNamesByPublicProfileId.get(participant.publicProfileId);
 
   return {
     kind,
     publicProfileId: participant.publicProfileId,
     anonymousDisplayName: resolveName(participant.publicProfileId),
+    ...(friendDisplayName === undefined ? {} : { friendDisplayName }),
     qualifiedReviewCount: participant.qualifiedReviewCount,
     rank: participant.rank,
   };
@@ -346,11 +365,15 @@ function buildParticipantRow(
 function buildRankingRow(
   participant: RankedParticipant,
   resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
 ): ProgressLeaderboardRankingRow {
+  const friendDisplayName = friendDisplayNamesByPublicProfileId.get(participant.publicProfileId);
+
   return {
     kind: participant.isViewer ? "viewer" : "participant",
     publicProfileId: participant.publicProfileId,
     anonymousDisplayName: resolveName(participant.publicProfileId),
+    ...(friendDisplayName === undefined ? {} : { friendDisplayName }),
     qualifiedReviewCount: participant.qualifiedReviewCount,
     rank: participant.rank,
   };
@@ -359,8 +382,11 @@ function buildRankingRow(
 function buildRankingRows(
   ranked: ReadonlyArray<RankedParticipant>,
   resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
 ): ReadonlyArray<ProgressLeaderboardRankingRow> {
-  return ranked.map((participant) => buildRankingRow(participant, resolveName));
+  return ranked.map((participant) => (
+    buildRankingRow(participant, resolveName, friendDisplayNamesByPublicProfileId)
+  ));
 }
 
 /**
@@ -375,6 +401,7 @@ function buildCompactRows(
   ranked: ReadonlyArray<RankedParticipant>,
   viewerRank: number,
   resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
 ): ReadonlyArray<ProgressLeaderboardRow> {
   const total = ranked.length;
   const topRowCount = Math.min(3, total);
@@ -409,7 +436,7 @@ function buildCompactRows(
       throw new Error(`Missing ranked participant for rank ${rank}.`);
     }
 
-    rows.push(buildParticipantRow(participant, topRowCount, resolveName));
+    rows.push(buildParticipantRow(participant, topRowCount, resolveName, friendDisplayNamesByPublicProfileId));
     previousRank = rank;
   }
 
@@ -425,6 +452,7 @@ function buildLeaderboardWindow(
   entries: ReadonlyArray<LeaderboardSnapshotEntry>,
   viewerPublicProfileId: string,
   resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
   now: Date,
 ): ProgressLeaderboardWindow {
   const ranking = buildViewerPerspectiveRanking(entries, viewerPublicProfileId);
@@ -445,8 +473,13 @@ function buildLeaderboardWindow(
       rank: ranking.viewerRank,
       qualifiedReviewCount: ranking.viewerCount,
     },
-    rows: buildCompactRows(ranking.ranked, ranking.viewerRank, resolveName),
-    rankingRows: buildRankingRows(ranking.ranked, resolveName),
+    rows: buildCompactRows(
+      ranking.ranked,
+      ranking.viewerRank,
+      resolveName,
+      friendDisplayNamesByPublicProfileId,
+    ),
+    rankingRows: buildRankingRows(ranking.ranked, resolveName, friendDisplayNamesByPublicProfileId),
   };
 }
 
@@ -513,6 +546,31 @@ async function readLeaderboardSnapshotEntriesInExecutor(
   return entriesBySnapshotId;
 }
 
+async function readViewerFriendDisplayNamesInExecutor(
+  executor: DatabaseExecutor,
+): Promise<ReadonlyMap<string, string>> {
+  const result = await executor.query<LeaderboardFriendDisplayNameRow>(
+    [
+      "SELECT",
+      "friend_labels.friend_public_profile_id::text AS friend_public_profile_id,",
+      "friend_labels.friend_display_name AS friend_display_name",
+      "FROM community.read_current_user_leaderboard_friend_labels() AS friend_labels",
+      "ORDER BY friend_labels.friend_public_profile_id",
+    ].join(" "),
+    [],
+  );
+
+  const friendDisplayNamesByPublicProfileId = new Map<string, string>();
+  for (const row of result.rows) {
+    friendDisplayNamesByPublicProfileId.set(
+      row.friend_public_profile_id,
+      normalizeFriendDisplayName(row.friend_display_name, row.friend_public_profile_id),
+    );
+  }
+
+  return friendDisplayNamesByPublicProfileId;
+}
+
 function indexSnapshotHeadersByWindowKey(
   headers: ReadonlyArray<LeaderboardSnapshotHeader>,
 ): ReadonlyMap<LeaderboardWindowKey, LeaderboardSnapshotHeader> {
@@ -561,6 +619,7 @@ export async function loadProgressLeaderboardInExecutor(
     return buildNonReadyProgressLeaderboard("snapshot_unavailable", request.localeHint);
   }
 
+  const friendDisplayNamesByPublicProfileId = await readViewerFriendDisplayNamesInExecutor(executor);
   const entriesBySnapshotId = await readLeaderboardSnapshotEntriesInExecutor(
     executor,
     completeHeaders.map((header) => header.snapshotId),
@@ -573,6 +632,7 @@ export async function loadProgressLeaderboardInExecutor(
     entriesBySnapshotId.get(header.snapshotId) ?? [],
     viewerProfile.publicProfileId,
     resolveName,
+    friendDisplayNamesByPublicProfileId,
     now,
   ));
   const defaultWindowKey = resolveBestLeaderboardPlacement(

--- a/apps/backend/src/routes/system.test.ts
+++ b/apps/backend/src/routes/system.test.ts
@@ -1172,6 +1172,7 @@ test("published OpenAPI documents the progress leaderboard without internal ids"
     "defaultWindowKey",
     "metricVersion",
     "anonymousDisplayName",
+    "friendDisplayName",
     "publicProfileId",
     "qualifiedReviewCount",
     "rank",
@@ -1181,7 +1182,22 @@ test("published OpenAPI documents the progress leaderboard without internal ids"
   ]) {
     assert.equal(serializedSchemas.includes(expectedField), true, `OpenAPI must document ${expectedField}`);
   }
-  for (const internalField of ["userId", "baseSort", "reviewed_by", "reviewedBy", "email"]) {
+  for (const internalField of [
+    "userId",
+    "friend_user_id",
+    "friendUserId",
+    "friend_public_profile_id",
+    "friendPublicProfileId",
+    "created_from_invitation_id",
+    "friendInvitationId",
+    "inviter_user_id",
+    "inviterUserId",
+    "createdFromInvitationId",
+    "baseSort",
+    "reviewed_by",
+    "reviewedBy",
+    "email",
+  ]) {
     assert.equal(serializedSchemas.includes(internalField), false, `OpenAPI must not expose ${internalField}`);
   }
 });

--- a/db/migrations/0064_leaderboard_friend_labels.sql
+++ b/db/migrations/0064_leaderboard_friend_labels.sql
@@ -1,0 +1,29 @@
+-- Migration status: Current / canonical.
+-- Introduces: a narrow current-viewer friend label read helper for the Progress leaderboard.
+
+CREATE OR REPLACE FUNCTION community.read_current_user_leaderboard_friend_labels()
+RETURNS TABLE (
+  friend_public_profile_id UUID,
+  friend_display_name TEXT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT
+    friendships.friend_public_profile_id,
+    friendships.friend_display_name
+  FROM community.friendships AS friendships
+  INNER JOIN community.public_profiles AS friend_profiles
+    ON friend_profiles.public_profile_id = friendships.friend_public_profile_id
+  WHERE friendships.viewer_user_id = security.current_user_id()
+    AND friend_profiles.leaderboard_participation_enabled = TRUE
+  ORDER BY friendships.friend_public_profile_id;
+$$;
+
+REVOKE ALL ON FUNCTION community.read_current_user_leaderboard_friend_labels() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION community.read_current_user_leaderboard_friend_labels() TO backend_app;
+
+COMMENT ON FUNCTION community.read_current_user_leaderboard_friend_labels() IS
+  'Returns current viewer friend public profile ids and viewer-private friend labels for friends that currently participate in the leaderboard.';


### PR DESCRIPTION
## Summary
- add viewer-scoped optional friendDisplayName metadata to backend progress leaderboard rows
- add a narrow database helper for current-viewer leaderboard friend labels
- document the optional field in OpenAPI and cover the contract with backend tests

## Validation
- node --test --import tsx src/community/leaderboard/progressLeaderboard.test.ts
- node --test --import tsx src/community/friendships.test.ts
- node --test --import tsx src/routes/system.test.ts
- npm run lint in apps/backend
- npm run lint in api