### PR TITLE
iOS progress review rating breakdown

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -238,7 +238,8 @@ extension FlashcardsStore {
 
     func handleProgressLocalMutation(
         now: Date,
-        reviewedAtClient: String
+        reviewedAtClient: String,
+        rating: ReviewRating
     ) {
         do {
             let scopeKey = try self.prepareProgressScope(now: now)
@@ -269,7 +270,8 @@ extension FlashcardsStore {
             let patchedSnapshot = try patchProgressSnapshot(
                 snapshot: progressSnapshot,
                 scopeKey: scopeKey,
-                reviewedAtClient: reviewedAtClient
+                reviewedAtClient: reviewedAtClient,
+                rating: rating
             )
             self.applyProgressSnapshot(snapshot: patchedSnapshot)
             self.clearProgressErrorMessage()

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
@@ -90,8 +90,8 @@ extension FlashcardsStore {
         renderedSeries: ProgressRenderedSeries
     ) {
         let summaryScopeKey = progressSummaryScopeKey(seriesScopeKey: scopeKey)
-        let localFallbackActiveDates = try progressActiveDatesFromReviewedAtClients(
-            reviewedAtClients: reviewedAtClientSources.canonicalReviewedAtClients,
+        let localFallbackActiveDates = try progressActiveDatesFromReviewEvents(
+            reviewEvents: reviewedAtClientSources.canonicalReviewEvents,
             timeZone: summaryScopeKey.timeZone
         )
         let localFallbackSummary = try makeProgressSummary(
@@ -102,12 +102,12 @@ extension FlashcardsStore {
                 timeZoneIdentifier: summaryScopeKey.timeZone
             )
         )
-        let localFallbackSeries = try makeProgressSeriesFromReviewedAtClients(
-            reviewedAtClients: reviewedAtClientSources.canonicalReviewedAtClients,
+        let localFallbackSeries = try makeProgressSeriesFromReviewEvents(
+            reviewEvents: reviewedAtClientSources.canonicalReviewEvents,
             requestRange: progressRequestRange(scopeKey: scopeKey)
         )
-        let pendingLocalOverlaySeries = try makeProgressSeriesFromReviewedAtClients(
-            reviewedAtClients: reviewedAtClientSources.pendingReviewedAtClients,
+        let pendingLocalOverlaySeries = try makeProgressSeriesFromReviewEvents(
+            reviewEvents: reviewedAtClientSources.pendingReviewEvents,
             requestRange: progressRequestRange(scopeKey: scopeKey)
         )
         let renderedSeries = try makeProgressRenderedSeries(
@@ -515,11 +515,17 @@ extension FlashcardsStore {
         database: LocalDatabase,
         workspaceIds: [String]
     ) throws -> ProgressReviewedAtClientSources {
-        var canonicalReviewedAtClients: [String] = []
+        var canonicalReviewEvents: [ProgressReviewEventSource] = []
         var canonicalQualifiedReviewEvents: [ProgressQualifiedReviewEventSource] = []
         for workspaceId in workspaceIds {
             for reviewEvent in try database.loadReviewEvents(workspaceId: workspaceId) {
-                canonicalReviewedAtClients.append(reviewEvent.reviewedAtClient)
+                canonicalReviewEvents.append(
+                    ProgressReviewEventSource(
+                        reviewEventId: reviewEvent.reviewEventId,
+                        reviewedAtClient: reviewEvent.reviewedAtClient,
+                        rating: reviewEvent.rating
+                    )
+                )
                 if reviewEvent.rating != .again {
                     canonicalQualifiedReviewEvents.append(
                         ProgressQualifiedReviewEventSource(
@@ -531,7 +537,7 @@ extension FlashcardsStore {
             }
         }
 
-        var pendingReviewedAtClients: [String] = []
+        var pendingReviewEvents: [ProgressReviewEventSource] = []
         var pendingQualifiedReviewEvents: [ProgressQualifiedReviewEventSource] = []
         if let installationId = self.cloudSettings?.installationId {
             for workspaceId in workspaceIds {
@@ -540,8 +546,20 @@ extension FlashcardsStore {
                     installationId: installationId
                 )
                 for pendingPayload in pendingPayloads {
-                    pendingReviewedAtClients.append(pendingPayload.reviewedAtClient)
-                    if pendingPayload.rating != ReviewRating.again.rawValue {
+                    guard let pendingRating = ReviewRating(rawValue: pendingPayload.rating) else {
+                        throw LocalStoreError.validation(
+                            "Pending review event rating is invalid: \(pendingPayload.rating)"
+                        )
+                    }
+
+                    pendingReviewEvents.append(
+                        ProgressReviewEventSource(
+                            reviewEventId: pendingPayload.reviewEventId,
+                            reviewedAtClient: pendingPayload.reviewedAtClient,
+                            rating: pendingRating
+                        )
+                    )
+                    if pendingRating != .again {
                         pendingQualifiedReviewEvents.append(
                             ProgressQualifiedReviewEventSource(
                                 reviewEventId: pendingPayload.reviewEventId,
@@ -554,8 +572,8 @@ extension FlashcardsStore {
         }
 
         return ProgressReviewedAtClientSources(
-            canonicalReviewedAtClients: canonicalReviewedAtClients,
-            pendingReviewedAtClients: pendingReviewedAtClients,
+            canonicalReviewEvents: canonicalReviewEvents,
+            pendingReviewEvents: pendingReviewEvents,
             canonicalQualifiedReviewEvents: canonicalQualifiedReviewEvents,
             pendingQualifiedReviewEvents: pendingQualifiedReviewEvents
         )

--- a/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
@@ -1,20 +1,26 @@
 import Foundation
 
 struct ProgressReviewedAtClientSources: Hashable, Sendable {
-    let canonicalReviewedAtClients: [String]
-    let pendingReviewedAtClients: [String]
+    let canonicalReviewEvents: [ProgressReviewEventSource]
+    let pendingReviewEvents: [ProgressReviewEventSource]
     /// Canonical review events rated Hard, Good, or Easy; Again is excluded.
     let canonicalQualifiedReviewEvents: [ProgressQualifiedReviewEventSource]
     /// Pending outbox review events rated Hard, Good, or Easy; Again is excluded.
     let pendingQualifiedReviewEvents: [ProgressQualifiedReviewEventSource]
 
     var pendingLocalOverlayState: ProgressPendingLocalOverlayState {
-        if self.pendingReviewedAtClients.isEmpty {
+        if self.pendingReviewEvents.isEmpty {
             return .empty
         }
 
         return .present
     }
+}
+
+struct ProgressReviewEventSource: Hashable, Sendable {
+    let reviewEventId: String
+    let reviewedAtClient: String
+    let rating: ReviewRating
 }
 
 struct ProgressQualifiedReviewEventSource: Hashable, Sendable {
@@ -479,22 +485,18 @@ private func validateProgressSeriesPairInputs(
     }
 }
 
-private func progressCountsByLocalDate(
+private func progressReviewRatingCountsByLocalDate(
     series: UserProgressSeries,
     sourceName: String
-) throws -> [String: Int] {
-    var countsByLocalDate: [String: Int] = [:]
+) throws -> [String: ProgressReviewRatingCounts] {
+    var countsByLocalDate: [String: ProgressReviewRatingCounts] = [:]
     for progressDay in series.dailyReviews {
-        guard progressDay.reviewCount >= 0 else {
-            throw LocalStoreError.validation(
-                """
-                Progress merge \(sourceName) contained a negative review count. \
-                localDate=\(progressDay.date), reviewCount=\(progressDay.reviewCount).
-                """
-            )
-        }
+        let ratingCounts = try progressReviewRatingCounts(
+            progressDay: progressDay,
+            sourceName: sourceName
+        )
 
-        guard countsByLocalDate.updateValue(progressDay.reviewCount, forKey: progressDay.date) == nil else {
+        guard countsByLocalDate.updateValue(ratingCounts, forKey: progressDay.date) == nil else {
             throw LocalStoreError.validation(
                 "Progress merge \(sourceName) contained a duplicate local date. localDate=\(progressDay.date)."
             )
@@ -504,13 +506,61 @@ private func progressCountsByLocalDate(
     return countsByLocalDate
 }
 
+private func progressReviewRatingCounts(
+    progressDay: ProgressDay,
+    sourceName: String
+) throws -> ProgressReviewRatingCounts {
+    guard progressDay.reviewCount >= 0 else {
+        throw LocalStoreError.validation(
+            """
+            Progress merge \(sourceName) contained a negative review count. \
+            localDate=\(progressDay.date), reviewCount=\(progressDay.reviewCount).
+            """
+        )
+    }
+
+    let ratingCounts = ProgressReviewRatingCounts(
+        againCount: progressDay.againCount,
+        hardCount: progressDay.hardCount,
+        goodCount: progressDay.goodCount,
+        easyCount: progressDay.easyCount
+    )
+    let values: [(rating: String, count: Int)] = [
+        ("again", ratingCounts.againCount),
+        ("hard", ratingCounts.hardCount),
+        ("good", ratingCounts.goodCount),
+        ("easy", ratingCounts.easyCount),
+    ]
+    for value in values {
+        guard value.count >= 0 else {
+            throw LocalStoreError.validation(
+                """
+                Progress merge \(sourceName) contained a negative \(value.rating) review count. \
+                localDate=\(progressDay.date), count=\(value.count).
+                """
+            )
+        }
+    }
+
+    guard progressDay.reviewCount == ratingCounts.reviewCount else {
+        throw LocalStoreError.validation(
+            """
+            Progress merge \(sourceName) review count must equal its rating-count total. \
+            localDate=\(progressDay.date), reviewCount=\(progressDay.reviewCount), ratingTotal=\(ratingCounts.reviewCount).
+            """
+        )
+    }
+
+    return ratingCounts
+}
+
 private func validateProgressCountsInRange(
-    countsByLocalDate: [String: Int],
+    localDates: Dictionary<String, ProgressReviewRatingCounts>.Keys,
     rangeLocalDates: Set<String>,
     sourceName: String,
     rangeDescription: String
 ) throws {
-    for localDate in countsByLocalDate.keys where rangeLocalDates.contains(localDate) == false {
+    for localDate in localDates where rangeLocalDates.contains(localDate) == false {
         throw LocalStoreError.validation(
             """
             Progress merge \(sourceName) contained a local date outside the merge range. \
@@ -563,9 +613,9 @@ private func makeProgressSummaryLowerBoundFromSeries(
 }
 
 private func progressActiveDatesFromSeries(series: UserProgressSeries) throws -> Set<String> {
-    let countsByLocalDate = try progressCountsByLocalDate(series: series, sourceName: "renderedSeries")
-    return Set(countsByLocalDate.compactMap { localDate, reviewCount in
-        reviewCount > 0 ? localDate : nil
+    let countsByLocalDate = try progressReviewRatingCountsByLocalDate(series: series, sourceName: "renderedSeries")
+    return Set(countsByLocalDate.compactMap { localDate, ratingCounts in
+        ratingCounts.reviewCount > 0 ? localDate : nil
     })
 }
 
@@ -578,8 +628,8 @@ private func progressActiveDatesMissingFromServerBase(
         renderedSeries: renderedSeries
     )
 
-    let serverCounts = try progressCountsByLocalDate(series: serverBase, sourceName: "serverBase")
-    let renderedCounts = try progressCountsByLocalDate(series: renderedSeries, sourceName: "renderedSeries")
+    let serverCounts = try progressReviewRatingCountsByLocalDate(series: serverBase, sourceName: "serverBase")
+    let renderedCounts = try progressReviewRatingCountsByLocalDate(series: renderedSeries, sourceName: "renderedSeries")
     let zeroFilledDays = try makeZeroFilledProgressDays(
         requestRange: ProgressRequestRange(
             timeZone: serverBase.timeZone,
@@ -590,51 +640,43 @@ private func progressActiveDatesMissingFromServerBase(
     let rangeLocalDates = Set(zeroFilledDays.map(\.date))
     let rangeDescription = "\(serverBase.from)...\(serverBase.to)"
     try validateProgressCountsInRange(
-        countsByLocalDate: serverCounts,
+        localDates: serverCounts.keys,
         rangeLocalDates: rangeLocalDates,
         sourceName: "serverBase",
         rangeDescription: rangeDescription
     )
     try validateProgressCountsInRange(
-        countsByLocalDate: renderedCounts,
+        localDates: renderedCounts.keys,
         rangeLocalDates: rangeLocalDates,
         sourceName: "renderedSeries",
         rangeDescription: rangeDescription
     )
 
     return Set(zeroFilledDays.compactMap { progressDay in
-        let serverCount = serverCounts[progressDay.date] ?? 0
-        let renderedCount = renderedCounts[progressDay.date] ?? 0
+        let serverCount = serverCounts[progressDay.date]?.reviewCount ?? 0
+        let renderedCount = renderedCounts[progressDay.date]?.reviewCount ?? 0
         return renderedCount > 0 && serverCount == 0 ? progressDay.date : nil
     })
 }
 
-func makeProgressSeriesFromReviewedAtClients(
-    reviewedAtClients: [String],
+func makeProgressSeriesFromReviewEvents(
+    reviewEvents: [ProgressReviewEventSource],
     requestRange: ProgressRequestRange
 ) throws -> UserProgressSeries {
-    let timeZone = try progressTimeZone(identifier: requestRange.timeZone)
-    let calendar = makeProgressStoreCalendar(timeZone: timeZone)
-    var reviewCountsByLocalDate: [String: Int] = [:]
-
-    for reviewedAtClient in reviewedAtClients {
-        guard let reviewedAtDate = parseIsoTimestamp(value: reviewedAtClient) else {
-            throw LocalStoreError.validation("Progress reviewedAtClient timestamp is invalid: \(reviewedAtClient)")
-        }
-
-        let localDate = progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
-        if localDate < requestRange.from || localDate > requestRange.to {
-            continue
-        }
-
-        reviewCountsByLocalDate[localDate, default: 0] += 1
-    }
-
+    let ratingCountsByLocalDate = try progressReviewRatingCountsByLocalDate(
+        reviewEvents: reviewEvents,
+        requestRange: requestRange
+    )
     let zeroFilledDays = try makeZeroFilledProgressDays(requestRange: requestRange)
     let progressDays = zeroFilledDays.map { progressDay in
+        let ratingCounts = ratingCountsByLocalDate[progressDay.date] ?? zeroProgressReviewRatingCounts()
         ProgressDay(
             date: progressDay.date,
-            reviewCount: reviewCountsByLocalDate[progressDay.date] ?? 0
+            reviewCount: ratingCounts.reviewCount,
+            againCount: ratingCounts.againCount,
+            hardCount: ratingCounts.hardCount,
+            goodCount: ratingCounts.goodCount,
+            easyCount: ratingCounts.easyCount
         )
     }
 
@@ -649,36 +691,107 @@ func makeProgressSeriesFromReviewedAtClients(
     )
 }
 
-func progressActiveDatesFromReviewedAtClients(
-    reviewedAtClients: [String],
+private func progressReviewRatingCountsByLocalDate(
+    reviewEvents: [ProgressReviewEventSource],
+    requestRange: ProgressRequestRange
+) throws -> [String: ProgressReviewRatingCounts] {
+    let timeZone = try progressTimeZone(identifier: requestRange.timeZone)
+    let calendar = makeProgressStoreCalendar(timeZone: timeZone)
+    var ratingCountsByLocalDate: [String: ProgressReviewRatingCounts] = [:]
+
+    for reviewEvent in reviewEvents {
+        guard let reviewedAtDate = parseIsoTimestamp(value: reviewEvent.reviewedAtClient) else {
+            throw LocalStoreError.validation(
+                "Progress reviewedAtClient timestamp is invalid: \(reviewEvent.reviewedAtClient)"
+            )
+        }
+
+        let localDate = progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
+        if localDate < requestRange.from || localDate > requestRange.to {
+            continue
+        }
+
+        let currentCounts = ratingCountsByLocalDate[localDate] ?? zeroProgressReviewRatingCounts()
+        ratingCountsByLocalDate[localDate] = progressReviewRatingCountsByAddingRating(
+            counts: currentCounts,
+            rating: reviewEvent.rating
+        )
+    }
+
+    return ratingCountsByLocalDate
+}
+
+func progressActiveDatesFromReviewEvents(
+    reviewEvents: [ProgressReviewEventSource],
     timeZone: String
 ) throws -> Set<String> {
     let resolvedTimeZone = try progressTimeZone(identifier: timeZone)
     let calendar = makeProgressStoreCalendar(timeZone: resolvedTimeZone)
-    return try Set(reviewedAtClients.map { reviewedAtClient in
-        guard let reviewedAtDate = parseIsoTimestamp(value: reviewedAtClient) else {
-            throw LocalStoreError.validation("Progress reviewedAtClient timestamp is invalid: \(reviewedAtClient)")
+    return try Set(reviewEvents.map { reviewEvent in
+        guard let reviewedAtDate = parseIsoTimestamp(value: reviewEvent.reviewedAtClient) else {
+            throw LocalStoreError.validation(
+                "Progress reviewedAtClient timestamp is invalid: \(reviewEvent.reviewedAtClient)"
+            )
         }
 
         return progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
     })
 }
 
-func makeProgressSummaryFromReviewedAtClients(
-    reviewedAtClients: [String],
-    timeZone: String,
-    referenceLocalDate: String
-) throws -> ProgressSummary {
-    return try makeProgressSummary(
-        reviewDates: progressActiveDatesFromReviewedAtClients(
-            reviewedAtClients: reviewedAtClients,
-            timeZone: timeZone
-        ),
-        timeZone: timeZone,
-        generatedAt: progressReferenceDate(
-            localDate: referenceLocalDate,
-            timeZoneIdentifier: timeZone
+private func zeroProgressReviewRatingCounts() -> ProgressReviewRatingCounts {
+    ProgressReviewRatingCounts(
+        againCount: 0,
+        hardCount: 0,
+        goodCount: 0,
+        easyCount: 0
+    )
+}
+
+private func progressReviewRatingCountsByAddingRating(
+    counts: ProgressReviewRatingCounts,
+    rating: ReviewRating
+) -> ProgressReviewRatingCounts {
+    switch rating {
+    case .again:
+        return ProgressReviewRatingCounts(
+            againCount: counts.againCount + 1,
+            hardCount: counts.hardCount,
+            goodCount: counts.goodCount,
+            easyCount: counts.easyCount
         )
+    case .hard:
+        return ProgressReviewRatingCounts(
+            againCount: counts.againCount,
+            hardCount: counts.hardCount + 1,
+            goodCount: counts.goodCount,
+            easyCount: counts.easyCount
+        )
+    case .good:
+        return ProgressReviewRatingCounts(
+            againCount: counts.againCount,
+            hardCount: counts.hardCount,
+            goodCount: counts.goodCount + 1,
+            easyCount: counts.easyCount
+        )
+    case .easy:
+        return ProgressReviewRatingCounts(
+            againCount: counts.againCount,
+            hardCount: counts.hardCount,
+            goodCount: counts.goodCount,
+            easyCount: counts.easyCount + 1
+        )
+    }
+}
+
+private func addProgressReviewRatingCounts(
+    left: ProgressReviewRatingCounts,
+    right: ProgressReviewRatingCounts
+) -> ProgressReviewRatingCounts {
+    ProgressReviewRatingCounts(
+        againCount: left.againCount + right.againCount,
+        hardCount: left.hardCount + right.hardCount,
+        goodCount: left.goodCount + right.goodCount,
+        easyCount: left.easyCount + right.easyCount
     )
 }
 
@@ -693,9 +806,9 @@ func mergeProgressSeries(
         localFallback: localFallback
     )
 
-    let serverCounts = try progressCountsByLocalDate(series: serverBase, sourceName: "serverBase")
-    let pendingCounts = try progressCountsByLocalDate(series: pendingLocalOverlay, sourceName: "pendingLocalOverlay")
-    let localFallbackCounts = try progressCountsByLocalDate(series: localFallback, sourceName: "localFallback")
+    let serverCounts = try progressReviewRatingCountsByLocalDate(series: serverBase, sourceName: "serverBase")
+    let pendingCounts = try progressReviewRatingCountsByLocalDate(series: pendingLocalOverlay, sourceName: "pendingLocalOverlay")
+    let localFallbackCounts = try progressReviewRatingCountsByLocalDate(series: localFallback, sourceName: "localFallback")
     let zeroFilledDays = try makeZeroFilledProgressDays(
         requestRange: ProgressRequestRange(
             timeZone: serverBase.timeZone,
@@ -706,29 +819,39 @@ func mergeProgressSeries(
     let rangeLocalDates = Set(zeroFilledDays.map(\.date))
     let rangeDescription = "\(serverBase.from)...\(serverBase.to)"
     try validateProgressCountsInRange(
-        countsByLocalDate: serverCounts,
+        localDates: serverCounts.keys,
         rangeLocalDates: rangeLocalDates,
         sourceName: "serverBase",
         rangeDescription: rangeDescription
     )
     try validateProgressCountsInRange(
-        countsByLocalDate: pendingCounts,
+        localDates: pendingCounts.keys,
         rangeLocalDates: rangeLocalDates,
         sourceName: "pendingLocalOverlay",
         rangeDescription: rangeDescription
     )
     try validateProgressCountsInRange(
-        countsByLocalDate: localFallbackCounts,
+        localDates: localFallbackCounts.keys,
         rangeLocalDates: rangeLocalDates,
         sourceName: "localFallback",
         rangeDescription: rangeDescription
     )
     let mergedDailyReviews: [ProgressDay] = zeroFilledDays.map { progressDay in
-        let serverOverlayCount = (serverCounts[progressDay.date] ?? 0) + (pendingCounts[progressDay.date] ?? 0)
-        let localFallbackCount = localFallbackCounts[progressDay.date] ?? 0
+        let serverOverlayCounts = addProgressReviewRatingCounts(
+            left: serverCounts[progressDay.date] ?? zeroProgressReviewRatingCounts(),
+            right: pendingCounts[progressDay.date] ?? zeroProgressReviewRatingCounts()
+        )
+        let localFallbackRatingCounts = localFallbackCounts[progressDay.date] ?? zeroProgressReviewRatingCounts()
+        let ratingCounts = localFallbackRatingCounts.reviewCount > serverOverlayCounts.reviewCount
+            ? localFallbackRatingCounts
+            : serverOverlayCounts
         return ProgressDay(
             date: progressDay.date,
-            reviewCount: max(serverOverlayCount, localFallbackCount)
+            reviewCount: ratingCounts.reviewCount,
+            againCount: ratingCounts.againCount,
+            hardCount: ratingCounts.hardCount,
+            goodCount: ratingCounts.goodCount,
+            easyCount: ratingCounts.easyCount
         )
     }
 
@@ -746,7 +869,8 @@ func mergeProgressSeries(
 func patchProgressSnapshot(
     snapshot: ProgressSnapshot,
     scopeKey: ProgressScopeKey,
-    reviewedAtClient: String
+    reviewedAtClient: String,
+    rating: ReviewRating
 ) throws -> ProgressSnapshot {
     guard snapshot.scopeKey.timeZone == scopeKey.timeZone else {
         return snapshot
@@ -776,9 +900,22 @@ func patchProgressSnapshot(
         progressDay.date == reviewedLocalDate
     }) {
         let progressDay = dailyReviews[dayIndex]
+        let ratingCounts = progressReviewRatingCountsByAddingRating(
+            counts: ProgressReviewRatingCounts(
+                againCount: progressDay.againCount,
+                hardCount: progressDay.hardCount,
+                goodCount: progressDay.goodCount,
+                easyCount: progressDay.easyCount
+            ),
+            rating: rating
+        )
         dailyReviews[dayIndex] = ProgressDay(
             date: progressDay.date,
-            reviewCount: progressDay.reviewCount + 1
+            reviewCount: ratingCounts.reviewCount,
+            againCount: ratingCounts.againCount,
+            hardCount: ratingCounts.hardCount,
+            goodCount: ratingCounts.goodCount,
+            easyCount: ratingCounts.easyCount
         )
     }
 
@@ -827,8 +964,8 @@ private func makeSnapshotProgressDailyReviews(
     scopeKey: ProgressScopeKey,
     calendar: Calendar
 ) throws -> [ProgressDay] {
-    let reviewCountsByLocalDate = Dictionary(uniqueKeysWithValues: snapshot.chartData.chartDays.map { chartDay in
-        (chartDay.localDate, chartDay.reviewCount)
+    let chartDaysByLocalDate = Dictionary(uniqueKeysWithValues: snapshot.chartData.chartDays.map { chartDay in
+        (chartDay.localDate, chartDay)
     })
     let startDate = try progressDateForStore(localDate: scopeKey.from, calendar: calendar)
     let endDate = try progressDateForStore(localDate: scopeKey.to, calendar: calendar)
@@ -837,10 +974,15 @@ private func makeSnapshotProgressDailyReviews(
 
     while currentDate <= endDate {
         let localDate = progressLocalDateStringForStore(date: currentDate, calendar: calendar)
+        let chartDay = chartDaysByLocalDate[localDate]
         progressDays.append(
             ProgressDay(
                 date: localDate,
-                reviewCount: reviewCountsByLocalDate[localDate] ?? 0
+                reviewCount: chartDay?.reviewCount ?? 0,
+                againCount: chartDay?.againCount ?? 0,
+                hardCount: chartDay?.hardCount ?? 0,
+                goodCount: chartDay?.goodCount ?? 0,
+                easyCount: chartDay?.easyCount ?? 0
             )
         )
         guard let nextDate = calendar.date(byAdding: .day, value: 1, to: currentDate) else {

--- a/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressDateSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressDateSupport.swift
@@ -135,7 +135,11 @@ func makeZeroFilledProgressDays(requestRange: ProgressRequestRange) throws -> [P
         progressDays.append(
             ProgressDay(
                 date: progressLocalDateStringForStore(date: currentDate, calendar: calendar),
-                reviewCount: 0
+                reviewCount: 0,
+                againCount: 0,
+                hardCount: 0,
+                goodCount: 0,
+                easyCount: 0
             )
         )
 

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressCoreTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressCoreTypes.swift
@@ -5,9 +5,24 @@ let progressDaysPerWeek: Int = 7
 struct ProgressDay: Codable, Hashable, Identifiable, Sendable {
     let date: String
     let reviewCount: Int
+    let againCount: Int
+    let hardCount: Int
+    let goodCount: Int
+    let easyCount: Int
 
     var id: String {
         self.date
+    }
+}
+
+struct ProgressReviewRatingCounts: Hashable, Sendable {
+    let againCount: Int
+    let hardCount: Int
+    let goodCount: Int
+    let easyCount: Int
+
+    var reviewCount: Int {
+        self.againCount + self.hardCount + self.goodCount + self.easyCount
     }
 }
 
@@ -278,6 +293,8 @@ enum ProgressPresentationError: LocalizedError {
     case invalidTimeZone(String)
     case invalidRange(String, String)
     case negativeReviewCount(String, Int)
+    case negativeReviewRatingCount(localDate: String, rating: String, count: Int)
+    case reviewCountBreakdownMismatch(localDate: String, reviewCount: Int, ratingTotal: Int)
     case duplicateReviewScheduleBucket(String)
     case invalidReviewScheduleBucketOrder([String])
     case negativeReviewScheduleBucketCount(String, Int)
@@ -298,6 +315,10 @@ enum ProgressPresentationError: LocalizedError {
             return "Progress contained an invalid date range from \(from) to \(to)."
         case .negativeReviewCount(let localDate, let reviewCount):
             return "Progress contained a negative review count for \(localDate): \(reviewCount)."
+        case .negativeReviewRatingCount(let localDate, let rating, let count):
+            return "Progress contained a negative \(rating) review count for \(localDate): \(count)."
+        case .reviewCountBreakdownMismatch(let localDate, let reviewCount, let ratingTotal):
+            return "Progress review count for \(localDate) must equal its rating-count total. reviewCount=\(reviewCount), ratingTotal=\(ratingTotal)."
         case .duplicateReviewScheduleBucket(let bucketKey):
             return "Review schedule contained a duplicate bucket: \(bucketKey)."
         case .invalidReviewScheduleBucketOrder(let bucketKeys):

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
@@ -29,6 +29,10 @@ struct ProgressChartDay: Hashable, Identifiable, Sendable {
     let date: Date
     let localDate: String
     let reviewCount: Int
+    let againCount: Int
+    let hardCount: Int
+    let goodCount: Int
+    let easyCount: Int
     let isToday: Bool
 
     var id: String {

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 
 let progressStringsTableName: String = "Foundation"
+let progressReviewRatingChartOrder: [ReviewRating] = [.again, .hard, .good, .easy]
 
 func progressReviewChartPageDateRange(
     page: ProgressReviewChartPage,
@@ -73,12 +74,46 @@ func progressReviewChartDayLabel(date: Date, calendar: Calendar) -> String {
     return formatter.string(from: date)
 }
 
-func progressChartBarStyle(day: ProgressChartDay) -> AnyShapeStyle {
-    if day.reviewCount > 0 {
-        return AnyShapeStyle(Color.accentColor)
+func progressReviewRatingTitle(rating: ReviewRating) -> String {
+    rating.title
+}
+
+func progressReviewRatingColor(rating: ReviewRating) -> Color {
+    switch rating {
+    case .again:
+        return Color(red: 0xD7 / 255, green: 0x26 / 255, blue: 0x3D / 255)
+    case .hard:
+        return Color(red: 0xE6 / 255, green: 0x9F / 255, blue: 0x00 / 255)
+    case .good:
+        return Color(red: 0x2B / 255, green: 0xB6 / 255, blue: 0x73 / 255)
+    case .easy:
+        return Color(red: 0x3F / 255, green: 0x7C / 255, blue: 0xC8 / 255)
+    }
+}
+
+func progressReviewRatingCount(day: ProgressChartDay, rating: ReviewRating) -> Int {
+    switch rating {
+    case .again:
+        return day.againCount
+    case .hard:
+        return day.hardCount
+    case .good:
+        return day.goodCount
+    case .easy:
+        return day.easyCount
+    }
+}
+
+func progressReviewRatingPercentage(
+    count: Int,
+    totalReviewCount: Int
+) -> String {
+    guard totalReviewCount > 0 else {
+        return Double(0).formatted(.percent.precision(.fractionLength(0)))
     }
 
-    return AnyShapeStyle(Color(uiColor: .tertiarySystemFill))
+    let ratio = Double(count) / Double(totalReviewCount)
+    return ratio.formatted(.percent.precision(.fractionLength(0)))
 }
 
 func progressReviewScheduleBucketTitle(key: ReviewScheduleBucketKey) -> String {

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressReviewChartPaging.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressReviewChartPaging.swift
@@ -125,6 +125,10 @@ private func padReviewChartPageToFullWeek(
             date: date,
             localDate: localDate,
             reviewCount: 0,
+            againCount: 0,
+            hardCount: 0,
+            goodCount: 0,
+            easyCount: 0,
             isToday: isToday
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
@@ -23,6 +23,10 @@ func makeProgressSnapshot(
             date: timelineDay.date,
             localDate: timelineDay.localDate,
             reviewCount: timelineDay.reviewCount,
+            againCount: timelineDay.againCount,
+            hardCount: timelineDay.hardCount,
+            goodCount: timelineDay.goodCount,
+            easyCount: timelineDay.easyCount,
             isToday: timelineDay.localDate == todayLocalDate
         )
     }
@@ -320,6 +324,10 @@ private struct ProgressTimelineDay: Hashable, Sendable {
     let date: Date
     let localDate: String
     let reviewCount: Int
+    let againCount: Int
+    let hardCount: Int
+    let goodCount: Int
+    let easyCount: Int
 }
 
 private func makeProgressTimeline(
@@ -333,15 +341,13 @@ private func makeProgressTimeline(
         throw ProgressPresentationError.invalidRange(series.from, series.to)
     }
 
-    var reviewCountsByLocalDate: [String: Int] = [:]
+    var reviewsByLocalDate: [String: ProgressDay] = [:]
     for day in series.dailyReviews {
         _ = try progressDate(localDate: day.date, calendar: calendar)
 
-        guard day.reviewCount >= 0 else {
-            throw ProgressPresentationError.negativeReviewCount(day.date, day.reviewCount)
-        }
+        try validateProgressDayCounts(day: day)
 
-        if reviewCountsByLocalDate.updateValue(day.reviewCount, forKey: day.date) != nil {
+        if reviewsByLocalDate.updateValue(day, forKey: day.date) != nil {
             throw ProgressPresentationError.duplicateDay(day.date)
         }
     }
@@ -354,7 +360,11 @@ private func makeProgressTimeline(
             ProgressTimelineDay(
                 date: currentDate,
                 localDate: localDate,
-                reviewCount: reviewCountsByLocalDate[localDate] ?? 0
+                reviewCount: reviewsByLocalDate[localDate]?.reviewCount ?? 0,
+                againCount: reviewsByLocalDate[localDate]?.againCount ?? 0,
+                hardCount: reviewsByLocalDate[localDate]?.hardCount ?? 0,
+                goodCount: reviewsByLocalDate[localDate]?.goodCount ?? 0,
+                easyCount: reviewsByLocalDate[localDate]?.easyCount ?? 0
             )
         )
 
@@ -365,6 +375,39 @@ private func makeProgressTimeline(
     }
 
     return timeline
+}
+
+private func validateProgressDayCounts(day: ProgressDay) throws {
+    guard day.reviewCount >= 0 else {
+        throw ProgressPresentationError.negativeReviewCount(day.date, day.reviewCount)
+    }
+
+    let ratingCounts: [(rating: String, count: Int)] = [
+        ("again", day.againCount),
+        ("hard", day.hardCount),
+        ("good", day.goodCount),
+        ("easy", day.easyCount),
+    ]
+    for ratingCount in ratingCounts {
+        guard ratingCount.count >= 0 else {
+            throw ProgressPresentationError.negativeReviewRatingCount(
+                localDate: day.date,
+                rating: ratingCount.rating,
+                count: ratingCount.count
+            )
+        }
+    }
+
+    let ratingTotal = ratingCounts.reduce(0) { total, ratingCount in
+        total + ratingCount.count
+    }
+    guard day.reviewCount == ratingTotal else {
+        throw ProgressPresentationError.reviewCountBreakdownMismatch(
+            localDate: day.date,
+            reviewCount: day.reviewCount,
+            ratingTotal: ratingTotal
+        )
+    }
 }
 
 func validateProgressSeries(

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewsSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewsSection.swift
@@ -2,12 +2,41 @@ import Charts
 import SwiftUI
 
 private let progressChartHeight: CGFloat = 220
+private let progressReviewsLegendMarkerSize: CGFloat = 10
+
+private enum ProgressReviewsSelection: Hashable {
+    case day(localDate: String)
+    case rating(ReviewRating)
+}
+
+private struct ProgressReviewChartSegment: Identifiable {
+    let day: ProgressChartDay
+    let rating: ReviewRating
+    let count: Int
+    let yStart: Int
+    let yEnd: Int
+
+    var id: String {
+        "\(self.day.localDate)-\(self.rating.rawValue)"
+    }
+}
+
+private struct ProgressReviewRatingLegendEntry: Identifiable {
+    let rating: ReviewRating
+    let count: Int
+    let totalReviewCount: Int
+
+    var id: Int {
+        self.rating.rawValue
+    }
+}
 
 struct ProgressReviewsSection: View {
     let chartDays: [ProgressChartDay]
     let chartCalendar: Calendar
     let selectionResetKey: String
     @State private var selectedPageStartLocalDate: String? = nil
+    @State private var selection: ProgressReviewsSelection? = nil
 
     private var pageSelectionResetToken: ProgressReviewChartSelectionResetToken {
         ProgressReviewChartSelectionResetToken(
@@ -50,13 +79,94 @@ struct ProgressReviewsSection: View {
         return self.chartPages[self.selectedPageIndex]
     }
 
+    private var selectedRating: ReviewRating? {
+        guard let selection = self.selection else {
+            return nil
+        }
+
+        switch selection {
+        case .day:
+            return nil
+        case .rating(let rating):
+            return rating
+        }
+    }
+
+    private var selectedDayLocalDate: String? {
+        guard let selection = self.selection else {
+            return nil
+        }
+
+        switch selection {
+        case .day(let localDate):
+            return localDate
+        case .rating:
+            return nil
+        }
+    }
+
+    private var chartDaySelectionBinding: Binding<String?> {
+        Binding(
+            get: {
+                self.selectedDayLocalDate
+            },
+            set: { newValue in
+                guard let newValue else {
+                    if let selection = self.selection, case .day = selection {
+                        self.selection = nil
+                    }
+                    return
+                }
+
+                self.selection = .day(localDate: newValue)
+            }
+        )
+    }
+
     private var visiblePageUpperBound: Int {
         guard let visiblePage else {
             return 1
         }
 
-        let maximumReviewCount = visiblePage.days.map(\.reviewCount).max() ?? 0
+        let maximumReviewCount: Int
+        if let selectedRating = self.selectedRating {
+            maximumReviewCount = visiblePage.days.map { day in
+                progressReviewRatingCount(day: day, rating: selectedRating)
+            }.max() ?? 0
+        } else {
+            maximumReviewCount = visiblePage.days.map(\.reviewCount).max() ?? 0
+        }
         return progressChartUpperBound(maximumReviewCount: maximumReviewCount)
+    }
+
+    private var visibleChartSegments: [ProgressReviewChartSegment] {
+        guard let visiblePage else {
+            return []
+        }
+
+        return makeProgressReviewChartSegments(
+            days: visiblePage.days,
+            selectedRating: self.selectedRating
+        )
+    }
+
+    private var visibleRatingLegendEntries: [ProgressReviewRatingLegendEntry] {
+        guard let visiblePage else {
+            return []
+        }
+
+        let totalReviewCount = visiblePage.days.reduce(0) { total, day in
+            total + day.reviewCount
+        }
+        return progressReviewRatingChartOrder.map { rating in
+            ProgressReviewRatingLegendEntry(
+                rating: rating,
+                count: visiblePage.days.reduce(0) { total, day in
+                    total + progressReviewRatingCount(day: day, rating: rating)
+                },
+                totalReviewCount: totalReviewCount
+            )
+        }
     }
 
     var body: some View {
@@ -134,13 +244,25 @@ struct ProgressReviewsSection: View {
                             .foregroundStyle(Color.accentColor.opacity(0.12))
                             .cornerRadius(8)
                         }
-                        BarMark(
-                            x: .value("Day", day.localDate),
-                            y: .value("Reviews", day.reviewCount)
-                        )
-                        .foregroundStyle(progressChartBarStyle(day: day))
+                    }
+                    ForEach(self.visibleChartSegments) { segment in
+                        if segment.count > 0 {
+                            BarMark(
+                                x: .value("Day", segment.day.localDate),
+                                yStart: .value("Start", segment.yStart),
+                                yEnd: .value("End", segment.yEnd)
+                            )
+                            .foregroundStyle(self.segmentForegroundStyle(segment: segment))
+                            .cornerRadius(6)
+                            .accessibilityLabel(
+                                "\(progressCompleteDateLabel(date: segment.day.date, calendar: self.chartCalendar)), \(progressReviewRatingTitle(rating: segment.rating))"
+                            )
+                            .accessibilityValue(segment.count.formatted())
+                        }
                     }
                 }
+                .chartLegend(.hidden)
+                .chartXSelection(value: self.chartDaySelectionBinding)
                 .chartYScale(domain: 0 ... self.visiblePageUpperBound)
                 .chartXAxis {
                     AxisMarks(values: visiblePage.xAxisValues) { value in
@@ -181,11 +303,32 @@ struct ProgressReviewsSection: View {
                         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                 }
                 .frame(height: progressChartHeight)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(self.visibleRatingLegendEntries) { entry in
+                        ProgressReviewsRatingLegendRow(
+                            entry: entry,
+                            isSelected: self.selectedRating == entry.rating,
+                            isAnyRatingSelected: self.selectedRating != nil,
+                            onTap: {
+                                self.toggleRatingSelection(rating: entry.rating)
+                            }
+                        )
+                    }
+                }
             }
         }
         .padding(.vertical, 4)
+        .background(
+            Color.clear
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    self.selection = nil
+                }
+        )
         .onChange(of: self.pageSelectionResetToken) { _, _ in
             self.selectedPageStartLocalDate = nil
+            self.selection = nil
         }
     }
 
@@ -195,6 +338,7 @@ struct ProgressReviewsSection: View {
         }
 
         self.selectedPageStartLocalDate = self.chartPages[self.selectedPageIndex - 1].startLocalDate
+        self.selection = nil
     }
 
     private func showNextPage() {
@@ -203,5 +347,106 @@ struct ProgressReviewsSection: View {
         }
 
         self.selectedPageStartLocalDate = self.chartPages[self.selectedPageIndex + 1].startLocalDate
+        self.selection = nil
+    }
+
+    private func segmentForegroundStyle(segment: ProgressReviewChartSegment) -> Color {
+        if let selectedDayLocalDate = self.selectedDayLocalDate,
+           segment.day.localDate != selectedDayLocalDate {
+            return Color(uiColor: .tertiarySystemFill)
+        }
+
+        return progressReviewRatingColor(rating: segment.rating)
+    }
+
+    private func toggleRatingSelection(rating: ReviewRating) {
+        if self.selectedRating == rating {
+            self.selection = nil
+        } else {
+            self.selection = .rating(rating)
+        }
+    }
+}
+
+private func makeProgressReviewChartSegments(
+    days: [ProgressChartDay],
+    selectedRating: ReviewRating?
+) -> [ProgressReviewChartSegment] {
+    days.flatMap { day in
+        var yStart: Int = 0
+        let ratings = progressReviewRatingChartOrder.filter { rating in
+            guard let selectedRating else {
+                return true
+            }
+
+            return rating == selectedRating
+        }
+        return ratings.map { rating in
+            let count = progressReviewRatingCount(day: day, rating: rating)
+            let segment = ProgressReviewChartSegment(
+                day: day,
+                rating: rating,
+                count: count,
+                yStart: yStart,
+                yEnd: yStart + count
+            )
+            yStart += count
+            return segment
+        }
+    }
+}
+
+private struct ProgressReviewsRatingLegendRow: View {
+    let entry: ProgressReviewRatingLegendEntry
+    let isSelected: Bool
+    let isAnyRatingSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(progressReviewRatingColor(rating: self.entry.rating))
+                .overlay(
+                    Circle().strokeBorder(Color.primary.opacity(0.08), lineWidth: 0.5)
+                )
+                .frame(
+                    width: progressReviewsLegendMarkerSize,
+                    height: progressReviewsLegendMarkerSize
+                )
+                .accessibilityHidden(true)
+
+            Text(progressReviewRatingTitle(rating: self.entry.rating))
+                .font(.subheadline)
+                .foregroundStyle(.primary)
+
+            Spacer(minLength: 12)
+
+            Text(self.detailText)
+                .font(.subheadline.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(self.isSelected ? Color.accentColor.opacity(0.12) : Color.clear)
+                .padding(.horizontal, -8)
+                .padding(.vertical, -4)
+        )
+        .opacity(self.isAnyRatingSelected && self.isSelected == false ? 0.35 : 1.0)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard self.entry.count > 0 else {
+                return
+            }
+
+            self.onTap()
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(self.entry.count > 0 ? .isButton : [])
+        .accessibilityLabel(progressReviewRatingTitle(rating: self.entry.rating))
+        .accessibilityValue(self.detailText)
+    }
+
+    private var detailText: String {
+        "\(self.entry.count.formatted()) · \(progressReviewRatingPercentage(count: self.entry.count, totalReviewCount: self.entry.totalReviewCount))"
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
@@ -321,7 +321,8 @@ extension FlashcardsStore {
             )
             self.handleProgressLocalMutation(
                 now: now,
-                reviewedAtClient: request.reviewedAtClient
+                reviewedAtClient: request.reviewedAtClient,
+                rating: request.rating
             )
             if bootstrapRefreshOutcome.didChange || didReconcileReviewState {
                 self.localReadVersion += 1

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalMutationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalMutationTests.swift
@@ -46,7 +46,8 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
 
         context.store.handleProgressLocalMutation(
             now: now,
-            reviewedAtClient: "2026-04-18T12:30:00.000Z"
+            reviewedAtClient: "2026-04-18T12:30:00.000Z",
+            rating: .good
         )
 
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
@@ -98,7 +99,8 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
 
         context.store.handleProgressLocalMutation(
             now: now,
-            reviewedAtClient: "2026-04-18T12:30:00.000Z"
+            reviewedAtClient: "2026-04-18T12:30:00.000Z",
+            rating: .good
         )
 
         XCTAssertNil(context.store.progressSnapshot)
@@ -172,7 +174,8 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
 
         context.store.handleProgressLocalMutation(
             now: now,
-            reviewedAtClient: formatIsoTimestamp(date: yesterdayReviewDate)
+            reviewedAtClient: formatIsoTimestamp(date: yesterdayReviewDate),
+            rating: .good
         )
 
         let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -80,7 +80,11 @@ func makeTestProgressSeries(
         dailyReviews.append(
             ProgressDay(
                 date: localDate,
-                reviewCount: reviewCountsByDate[localDate] ?? 0
+                reviewCount: reviewCountsByDate[localDate] ?? 0,
+                againCount: 0,
+                hardCount: 0,
+                goodCount: reviewCountsByDate[localDate] ?? 0,
+                easyCount: 0
             )
         )
         currentDate = calendar.date(byAdding: .day, value: 1, to: currentDate)!

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
@@ -93,7 +93,11 @@ final class ProgressServerValidationRefreshTests: ProgressStoreTestCase {
             dailyReviews: [
                 ProgressDay(
                     date: "2026-02-31",
-                    reviewCount: 1
+                    reviewCount: 1,
+                    againCount: 0,
+                    hardCount: 0,
+                    goodCount: 1,
+                    easyCount: 0
                 )
             ],
             summary: nil,

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
@@ -31,7 +31,11 @@ final class ProgressSnapshotValidationTests: XCTestCase {
           "dailyReviews": [
             {
               "date": "2026-04-01",
-              "reviewCount": 3
+              "reviewCount": 3,
+              "againCount": 1,
+              "hardCount": 1,
+              "goodCount": 1,
+              "easyCount": 0
             }
           ],
           "generatedAt": "2026-04-18T09:15:00.000Z"
@@ -118,7 +122,11 @@ final class ProgressSnapshotValidationTests: XCTestCase {
                 dailyReviews: [
                     ProgressDay(
                         date: localDate,
-                        reviewCount: 1
+                        reviewCount: 1,
+                        againCount: 0,
+                        hardCount: 0,
+                        goodCount: 1,
+                        easyCount: 0
                     )
                 ],
                 summary: nil,
@@ -159,8 +167,22 @@ final class ProgressSnapshotValidationTests: XCTestCase {
             from: scopeKey.from,
             to: scopeKey.to,
             dailyReviews: [
-                ProgressDay(date: "2026-02-03", reviewCount: 1),
-                ProgressDay(date: "2026-02-03", reviewCount: 2),
+                ProgressDay(
+                    date: "2026-02-03",
+                    reviewCount: 1,
+                    againCount: 0,
+                    hardCount: 0,
+                    goodCount: 1,
+                    easyCount: 0
+                ),
+                ProgressDay(
+                    date: "2026-02-03",
+                    reviewCount: 2,
+                    againCount: 0,
+                    hardCount: 0,
+                    goodCount: 2,
+                    easyCount: 0
+                ),
             ],
             summary: nil,
             generatedAt: nil,
@@ -199,7 +221,14 @@ final class ProgressSnapshotValidationTests: XCTestCase {
             from: scopeKey.from,
             to: scopeKey.to,
             dailyReviews: [
-                ProgressDay(date: "2026-02-03", reviewCount: -1)
+                ProgressDay(
+                    date: "2026-02-03",
+                    reviewCount: -1,
+                    againCount: 0,
+                    hardCount: 0,
+                    goodCount: 0,
+                    easyCount: 0
+                )
             ],
             summary: nil,
             generatedAt: nil,


### PR DESCRIPTION
## Summary
- Add rating-count breakdown fields to iOS progress day and chart models.
- Build local progress series from review events with ratings and merge server, pending, and local fallback count vectors.
- Render the iOS Progress Reviews chart as stacked rating bars with day and rating selection.

## Validation
- jq empty apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
- git --no-pager diff --check
- swiftc -parse over changed production Swift files
- swiftc -parse over changed progress test files

Full xcodebuild compilation could not start in this environment because the scheme had no eligible iOS 26.5 destination.