### PR TITLE
[codex] add web progress review rating breakdown

### DIFF
--- a/apps/web/src/api/endpoints/endpoints.test.ts
+++ b/apps/web/src/api/endpoints/endpoints.test.ts
@@ -208,14 +208,26 @@ describe("progress API endpoints", () => {
           {
             date: "2026-04-01",
             reviewCount: 3,
+            againCount: 1,
+            hardCount: 1,
+            goodCount: 1,
+            easyCount: 0,
           },
           {
             date: "2026-04-02",
             reviewCount: 0,
+            againCount: 0,
+            hardCount: 0,
+            goodCount: 0,
+            easyCount: 0,
           },
           {
             date: "2026-04-03",
             reviewCount: 1,
+            againCount: 0,
+            hardCount: 0,
+            goodCount: 1,
+            easyCount: 0,
           },
         ],
       }), {
@@ -242,14 +254,26 @@ describe("progress API endpoints", () => {
         {
           date: "2026-04-01",
           reviewCount: 3,
+          againCount: 1,
+          hardCount: 1,
+          goodCount: 1,
+          easyCount: 0,
         },
         {
           date: "2026-04-02",
           reviewCount: 0,
+          againCount: 0,
+          hardCount: 0,
+          goodCount: 0,
+          easyCount: 0,
         },
         {
           date: "2026-04-03",
           reviewCount: 1,
+          againCount: 0,
+          hardCount: 0,
+          goodCount: 1,
+          easyCount: 0,
         },
       ],
     });
@@ -266,14 +290,26 @@ describe("progress API endpoints", () => {
           {
             date: "2026-04-01",
             reviewCount: 3,
+            againCount: 1,
+            hardCount: 1,
+            goodCount: 1,
+            easyCount: 0,
           },
           {
             date: "2026-04-02",
             reviewCount: 0,
+            againCount: 0,
+            hardCount: 0,
+            goodCount: 0,
+            easyCount: 0,
           },
           {
             date: "2026-04-03",
             reviewCount: 1,
+            againCount: 0,
+            hardCount: 0,
+            goodCount: 1,
+            easyCount: 0,
           },
         ],
       }), {
@@ -298,17 +334,62 @@ describe("progress API endpoints", () => {
         {
           date: "2026-04-01",
           reviewCount: 3,
+          againCount: 1,
+          hardCount: 1,
+          goodCount: 1,
+          easyCount: 0,
         },
         {
           date: "2026-04-02",
           reviewCount: 0,
+          againCount: 0,
+          hardCount: 0,
+          goodCount: 0,
+          easyCount: 0,
         },
         {
           date: "2026-04-03",
           reviewCount: 1,
+          againCount: 0,
+          hardCount: 0,
+          goodCount: 1,
+          easyCount: 0,
         },
       ],
     });
+  });
+
+  it("rejects progress series responses with missing rating counts", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        timeZone: "Europe/Madrid",
+        from: "2026-04-01",
+        to: "2026-04-03",
+        generatedAt: "2026-04-18T09:15:00.000Z",
+        dailyReviews: [
+          {
+            date: "2026-04-01",
+            reviewCount: 3,
+            hardCount: 1,
+            goodCount: 1,
+            easyCount: 1,
+          },
+        ],
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressSeries({
+      timeZone: "Europe/Madrid",
+      from: "2026-04-01",
+      to: "2026-04-03",
+    })).rejects.toThrow(
+      "Invalid API response for GET /me/progress/series: dailyReviews[0].againCount must be number",
+    );
   });
 
   it("decodes review schedule responses and sends only the timezone query", async () => {
@@ -489,9 +570,9 @@ describe("progress API endpoints", () => {
         to: "2026-04-03",
         generatedAt: null,
         dailyReviews: [
-          { date: "2026-04-01", reviewCount: 0 },
-          { date: "2026-04-02", reviewCount: 0 },
-          { date: "2026-04-03", reviewCount: 0 },
+          { date: "2026-04-01", reviewCount: 0, againCount: 0, hardCount: 0, goodCount: 0, easyCount: 0 },
+          { date: "2026-04-02", reviewCount: 0, againCount: 0, hardCount: 0, goodCount: 0, easyCount: 0 },
+          { date: "2026-04-03", reviewCount: 0, againCount: 0, hardCount: 0, goodCount: 0, easyCount: 0 },
         ],
       }), {
         status: 200,

--- a/apps/web/src/apiContracts/progress.ts
+++ b/apps/web/src/apiContracts/progress.ts
@@ -36,16 +36,40 @@ import {
   parseString,
 } from "./core";
 
+function parseNonNegativeSafeInteger(value: unknown, endpoint: string, path: string): number {
+  const numberValue = parseNumber(value, endpoint, path);
+
+  if (Number.isSafeInteger(numberValue) === false || numberValue < 0) {
+    throw new ApiContractError(endpoint, describePath(path), "a non-negative safe integer");
+  }
+
+  return numberValue;
+}
+
 function parseDailyReviewPoint(
   value: unknown,
   endpoint: string,
   path: string,
 ): ProgressSeries["dailyReviews"][number] {
   const objectValue = parseObject(value, endpoint, path);
-  return {
+  const dailyReviewPoint = {
     date: parseRequiredField(objectValue, "date", endpoint, path, parseString),
-    reviewCount: parseRequiredField(objectValue, "reviewCount", endpoint, path, parseNumber),
+    reviewCount: parseRequiredField(objectValue, "reviewCount", endpoint, path, parseNonNegativeSafeInteger),
+    againCount: parseRequiredField(objectValue, "againCount", endpoint, path, parseNonNegativeSafeInteger),
+    hardCount: parseRequiredField(objectValue, "hardCount", endpoint, path, parseNonNegativeSafeInteger),
+    goodCount: parseRequiredField(objectValue, "goodCount", endpoint, path, parseNonNegativeSafeInteger),
+    easyCount: parseRequiredField(objectValue, "easyCount", endpoint, path, parseNonNegativeSafeInteger),
   };
+  const ratingCountSum = dailyReviewPoint.againCount
+    + dailyReviewPoint.hardCount
+    + dailyReviewPoint.goodCount
+    + dailyReviewPoint.easyCount;
+
+  if (dailyReviewPoint.reviewCount !== ratingCountSum) {
+    throw new ApiContractError(endpoint, describePath(joinPath(path, "reviewCount")), `rating count sum (${ratingCountSum})`);
+  }
+
+  return dailyReviewPoint;
 }
 
 function parseProgressReviewHistoryWatermarkSequenceId(
@@ -192,16 +216,6 @@ export function parseProgressSummaryResponse(value: unknown, endpoint: string): 
     ),
     summary: parseRequiredField(objectValue, "summary", endpoint, "", parseProgressSummary),
   };
-}
-
-function parseNonNegativeSafeInteger(value: unknown, endpoint: string, path: string): number {
-  const numberValue = parseNumber(value, endpoint, path);
-
-  if (Number.isSafeInteger(numberValue) === false || numberValue < 0) {
-    throw new ApiContractError(endpoint, describePath(path), "a non-negative safe integer");
-  }
-
-  return numberValue;
 }
 
 function parseLeaderboardRank(value: unknown, endpoint: string, path: string): number {

--- a/apps/web/src/appData/progress/snapshots/progressSeriesSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSeriesSnapshots.ts
@@ -25,18 +25,53 @@ export function buildDailyReviewCountMap(
   return counts;
 }
 
+function createEmptyDailyReviewPoint(date: string): DailyReviewPoint {
+  return {
+    date,
+    reviewCount: 0,
+    againCount: 0,
+    hardCount: 0,
+    goodCount: 0,
+    easyCount: 0,
+  };
+}
+
+function buildDailyReviewPointMap(
+  dailyReviews: ReadonlyArray<DailyReviewPoint>,
+): Map<string, DailyReviewPoint> {
+  const dailyReviewsByDate = new Map<string, DailyReviewPoint>();
+
+  for (const day of dailyReviews) {
+    dailyReviewsByDate.set(day.date, day);
+  }
+
+  return dailyReviewsByDate;
+}
+
+function addDailyReviewPoints(left: DailyReviewPoint, right: DailyReviewPoint): DailyReviewPoint {
+  if (left.date !== right.date) {
+    throw new Error(`Cannot merge progress days with different dates: ${left.date}, ${right.date}`);
+  }
+
+  return {
+    date: left.date,
+    reviewCount: left.reviewCount + right.reviewCount,
+    againCount: left.againCount + right.againCount,
+    hardCount: left.hardCount + right.hardCount,
+    goodCount: left.goodCount + right.goodCount,
+    easyCount: left.easyCount + right.easyCount,
+  };
+}
+
 function expandProgressDailyReviews(
   input: ProgressSeriesInput,
   dailyReviews: ReadonlyArray<DailyReviewPoint>,
 ): ReadonlyArray<DailyReviewPoint> {
-  const dailyReviewCountMap = buildDailyReviewCountMap(dailyReviews);
+  const dailyReviewPointMap = buildDailyReviewPointMap(dailyReviews);
   const expandedDailyReviews: Array<DailyReviewPoint> = [];
 
   for (let currentDate = input.from; currentDate <= input.to; currentDate = shiftLocalDate(currentDate, 1)) {
-    expandedDailyReviews.push({
-      date: currentDate,
-      reviewCount: dailyReviewCountMap.get(currentDate) ?? 0,
-    });
+    expandedDailyReviews.push(dailyReviewPointMap.get(currentDate) ?? createEmptyDailyReviewPoint(currentDate));
   }
 
   return expandedDailyReviews;
@@ -98,27 +133,26 @@ function mergeProgressSeriesWithOverlay(
   overlay: ProgressChartData | null,
   localFallback: ProgressSeriesSnapshot | null,
 ): ProgressSeriesMergeResult {
-  const pendingReviewCounts = buildDailyReviewCountMap(overlay?.dailyReviews ?? []);
+  const pendingReviewCounts = buildDailyReviewPointMap(overlay?.dailyReviews ?? []);
   const localFallbackReviewCounts = localFallback === null
-    ? new Map<string, number>()
-    : buildDailyReviewCountMap(localFallback.dailyReviews);
+    ? new Map<string, DailyReviewPoint>()
+    : buildDailyReviewPointMap(localFallback.dailyReviews);
   const normalizedServerBase = normalizeProgressSeries(serverBase);
   let hasOverlay = false;
   const dailyReviews = normalizedServerBase.dailyReviews.map((day) => {
-    const pendingReviewCount = pendingReviewCounts.get(day.date) ?? 0;
-    const localFallbackReviewCount = localFallbackReviewCounts.get(day.date) ?? 0;
-    const reviewCountWithPendingOverlay = day.reviewCount + pendingReviewCount;
-    const reviewCount = Math.max(reviewCountWithPendingOverlay, localFallbackReviewCount);
+    const pendingReviewCount = pendingReviewCounts.get(day.date) ?? createEmptyDailyReviewPoint(day.date);
+    const localFallbackReviewCount = localFallbackReviewCounts.get(day.date) ?? createEmptyDailyReviewPoint(day.date);
+    const dayWithPendingOverlay = addDailyReviewPoints(day, pendingReviewCount);
+    const reviewCount = Math.max(dayWithPendingOverlay.reviewCount, localFallbackReviewCount.reviewCount);
 
     if (reviewCount === day.reviewCount) {
       return day;
     }
 
     hasOverlay = true;
-    return {
-      date: day.date,
-      reviewCount,
-    };
+    return localFallbackReviewCount.reviewCount > dayWithPendingOverlay.reviewCount
+      ? localFallbackReviewCount
+      : dayWithPendingOverlay;
   });
 
   if (hasOverlay === false) {

--- a/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
@@ -38,7 +38,14 @@ function areDailyReviewsEqual(
     const leftDay = left[index];
     const rightDay = right[index];
 
-    if (leftDay?.date !== rightDay?.date || leftDay?.reviewCount !== rightDay?.reviewCount) {
+    if (
+      leftDay?.date !== rightDay?.date
+      || leftDay?.reviewCount !== rightDay?.reviewCount
+      || leftDay?.againCount !== rightDay?.againCount
+      || leftDay?.hardCount !== rightDay?.hardCount
+      || leftDay?.goodCount !== rightDay?.goodCount
+      || leftDay?.easyCount !== rightDay?.easyCount
+    ) {
       return false;
     }
   }

--- a/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
@@ -14,6 +14,7 @@ import {
   buildCurrentSeriesInput,
   buildCurrentSeriesScopeKey,
   buildCurrentSummaryScopeKey,
+  buildGoodDailyReviewPoint,
   buildServerReviewSchedule,
   buildServerSeries,
   buildServerSummary,
@@ -123,20 +124,20 @@ describe("useProgressSource cache", () => {
     expect(harness.getApi().progressSourceState.summary.serverBase?.generatedAt).toBe("2026-04-18T09:10:00.000Z");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(6);
     expect(harness.getApi().progressSourceState.series.serverBase?.generatedAt).toBe("2026-04-18T09:10:00.000Z");
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: buildCurrentSeriesInput().to,
       reviewCount: 6,
-    });
+    }));
 
     deferredSummary.resolve(buildServerSummary(7, "2026-04-18T09:11:00.000Z"));
     deferredSeries.resolve(buildServerSeries(7, "2026-04-18T09:11:00.000Z"));
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(7);
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: buildCurrentSeriesInput().to,
       reviewCount: 7,
-    });
+    }));
   });
 
   it("hydrates matching leaderboard cache with rankingRows before remote refresh completes", async () => {
@@ -201,7 +202,7 @@ describe("useProgressSource cache", () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     const seriesScopeKey = buildCurrentSeriesScopeKey();
     const malformedCachedSeries = {
-      version: 2,
+      version: 3,
       scopeKey: seriesScopeKey,
       savedAt: "2026-04-18T09:00:00.000Z",
       serverBase: {
@@ -213,10 +214,7 @@ describe("useProgressSource cache", () => {
           { workspaceId: "workspace-1", reviewSequenceId: 12 },
         ],
         dailyReviews: [
-          {
-            date: currentSeriesInput.to,
-            reviewCount: 12,
-          },
+          buildGoodDailyReviewPoint(currentSeriesInput.to, 12),
         ],
       },
     } as const;
@@ -238,10 +236,10 @@ describe("useProgressSource cache", () => {
     expectProgressCacheMissBreadcrumb("series", "invalid_shape");
     expect(loadProgressSeriesMock).toHaveBeenCalledWith(currentSeriesInput);
     expect(harness.getApi().progressSourceState.series.serverBase?.generatedAt).toBe("2026-04-18T09:23:00.000Z");
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 8,
-    });
+    }));
   });
 
   const invalidProgressReviewScheduleCacheCases: ReadonlyArray<Readonly<{

--- a/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
@@ -9,6 +9,7 @@ import {
   buildCurrentSeriesInput,
   buildCurrentSeriesScopeKey,
   buildCurrentSummaryScopeKey,
+  buildGoodDailyReviewPoint,
   buildServerSeries,
   buildServerSummary,
   createDeferredPromise,
@@ -78,10 +79,7 @@ describe("useProgressSource lifecycle", () => {
       activeReviewDays: 4,
     });
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
-      {
-        date: currentSeriesInput.to,
-        reviewCount: 2,
-      },
+      buildGoodDailyReviewPoint(currentSeriesInput.to, 2),
     ]);
 
     const harness = renderHarness({
@@ -115,10 +113,10 @@ describe("useProgressSource lifecycle", () => {
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("local_only");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(4);
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("local_only");
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 2,
-    });
+    }));
 
     deferredSummary.resolve(buildServerSummary(9, "2026-04-18T09:19:00.000Z"));
     deferredSeries.resolve(buildServerSeries(9, "2026-04-18T09:19:00.000Z"));
@@ -129,10 +127,10 @@ describe("useProgressSource lifecycle", () => {
     expect(harness.getApi().progressSourceState.summary.isLoading).toBe(false);
     expect(harness.getApi().progressSourceState.series.isLoading).toBe(false);
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(4);
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 2,
-    });
+    }));
   });
 
   it("ignores server responses after sections disable their scopes", async () => {
@@ -241,10 +239,10 @@ describe("useProgressSource lifecycle", () => {
     expect(loadProgressSummaryMock).toHaveBeenCalledTimes(2);
     expect(loadProgressSeriesMock).toHaveBeenCalledTimes(2);
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(1);
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 1,
-    });
+    }));
     expect(window.localStorage.getItem(summaryCacheKey)).not.toContain("2026-04-18T09:20:00.000Z");
     expect(window.localStorage.getItem(seriesCacheKey)).not.toContain("2026-04-18T09:20:00.000Z");
 
@@ -256,10 +254,10 @@ describe("useProgressSource lifecycle", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(9);
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 9,
-    });
+    }));
     expect(window.localStorage.getItem(summaryCacheKey)).toContain("2026-04-18T09:21:00.000Z");
     expect(window.localStorage.getItem(summaryCacheKey)).not.toContain("2026-04-18T09:20:00.000Z");
     expect(window.localStorage.getItem(seriesCacheKey)).toContain("2026-04-18T09:21:00.000Z");
@@ -316,10 +314,10 @@ describe("useProgressSource lifecycle", () => {
     expect(harness.getApi().progressSourceState.summary.errorMessage).toBe("");
     expect(harness.getApi().progressSourceState.series.errorMessage).toBe("");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(5);
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: buildCurrentSeriesInput().to,
       reviewCount: 5,
-    });
+    }));
   });
 
   it("refreshes only once per endpoint when the local day rolls over", async () => {

--- a/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
@@ -2,6 +2,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCurrentSeriesInput,
+  buildDailyReviewPoint,
+  buildGoodDailyReviewPoint,
   buildServerSeries,
   buildServerSummary,
   createDeferredPromise,
@@ -36,10 +38,10 @@ describe("useProgressSource summary and series", () => {
     expect(harness.getApi().progressSourceState.summary.serverBase?.source).toBe("server");
     expect(harness.getApi().progressSourceState.series.serverBase?.source).toBe("server");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(1);
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: buildCurrentSeriesInput().to,
       reviewCount: 1,
-    });
+    }));
   });
 
   it("updates summary and series independently when remote responses arrive in different orders", async () => {
@@ -58,10 +60,10 @@ describe("useProgressSource summary and series", () => {
 
     expect(harness.getApi().progressSourceState.series.serverBase?.generatedAt).toBe("2026-04-18T09:16:00.000Z");
     expect(harness.getApi().progressSourceState.summary.serverBase?.generatedAt).not.toBe("2026-04-18T09:17:00.000Z");
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: buildCurrentSeriesInput().to,
       reviewCount: 3,
-    });
+    }));
 
     deferredSummary.resolve(buildServerSummary(4, "2026-04-18T09:17:00.000Z"));
     await flushEffects();
@@ -119,10 +121,7 @@ describe("useProgressSource summary and series", () => {
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
       dailyReviews: [
-        {
-          date: currentSeriesInput.to,
-          reviewCount: 0,
-        },
+        buildGoodDailyReviewPoint(currentSeriesInput.to, 0),
       ],
     });
     loadLocalProgressSummaryMock.mockResolvedValue({
@@ -132,10 +131,7 @@ describe("useProgressSource summary and series", () => {
       activeReviewDays: 8,
     });
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
-      {
-        date: currentSeriesInput.to,
-        reviewCount: 1,
-      },
+      buildDailyReviewPoint(currentSeriesInput.to, 1, 1, 0, 0, 0),
     ]);
 
     const harness = renderHarness({
@@ -157,15 +153,19 @@ describe("useProgressSource summary and series", () => {
       lastReviewedOn: "2026-04-20",
       activeReviewDays: 8,
     });
-    expect(harness.getApi().progressSourceState.series.serverBase?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.serverBase?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 0,
-    });
+    }));
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("server");
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.isApproximate).toBe(true);
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
       date: currentSeriesInput.to,
       reviewCount: 1,
+      againCount: 1,
+      hardCount: 0,
+      goodCount: 0,
+      easyCount: 0,
     });
   });
 
@@ -193,10 +193,7 @@ describe("useProgressSource summary and series", () => {
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
       dailyReviews: [
-        {
-          date: "2026-04-19",
-          reviewCount: 1,
-        },
+        buildGoodDailyReviewPoint("2026-04-19", 1),
       ],
     });
     loadLocalProgressSummaryMock.mockResolvedValue({
@@ -207,10 +204,7 @@ describe("useProgressSource summary and series", () => {
     });
     loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-20"]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
-      {
-        date: "2026-04-20",
-        reviewCount: 1,
-      },
+      buildGoodDailyReviewPoint("2026-04-20", 1),
     ]);
 
     const harness = renderHarness({
@@ -256,10 +250,7 @@ describe("useProgressSource summary and series", () => {
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
       dailyReviews: [
-        {
-          date: "2026-04-18",
-          reviewCount: 1,
-        },
+        buildGoodDailyReviewPoint("2026-04-18", 1),
       ],
     });
     loadLocalProgressSummaryMock.mockResolvedValue({
@@ -273,14 +264,8 @@ describe("useProgressSource summary and series", () => {
       "2026-04-20",
     ]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
-      {
-        date: "2026-04-19",
-        reviewCount: 1,
-      },
-      {
-        date: "2026-04-20",
-        reviewCount: 1,
-      },
+      buildGoodDailyReviewPoint("2026-04-19", 1),
+      buildGoodDailyReviewPoint("2026-04-20", 1),
     ]);
 
     const harness = renderHarness({
@@ -375,10 +360,7 @@ describe("useProgressSource summary and series", () => {
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
       dailyReviews: [
-        {
-          date: "2026-04-20",
-          reviewCount: 1,
-        },
+        buildGoodDailyReviewPoint("2026-04-20", 1),
       ],
     });
     loadLocalProgressSummaryMock.mockResolvedValue({
@@ -389,10 +371,7 @@ describe("useProgressSource summary and series", () => {
     });
     loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-20"]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
-      {
-        date: "2026-04-20",
-        reviewCount: 1,
-      },
+      buildGoodDailyReviewPoint("2026-04-20", 1),
     ]);
 
     const harness = renderHarness({
@@ -438,10 +417,7 @@ describe("useProgressSource summary and series", () => {
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
       dailyReviews: [
-        {
-          date: "2026-04-18",
-          reviewCount: 1,
-        },
+        buildGoodDailyReviewPoint("2026-04-18", 1),
       ],
     });
     loadLocalProgressSummaryMock.mockResolvedValue({
@@ -452,10 +428,7 @@ describe("useProgressSource summary and series", () => {
     });
     loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-19"]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
-      {
-        date: "2026-04-19",
-        reviewCount: 1,
-      },
+      buildDailyReviewPoint("2026-04-19", 1, 0, 1, 0, 0),
     ]);
 
     const harness = renderHarness({
@@ -473,13 +446,17 @@ describe("useProgressSource summary and series", () => {
       lastReviewedOn: "2026-04-19",
       activeReviewDays: 201,
     });
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: "2026-04-18",
       reviewCount: 1,
-    });
+    }));
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
       date: "2026-04-19",
       reviewCount: 1,
+      againCount: 0,
+      hardCount: 1,
+      goodCount: 0,
+      easyCount: 0,
     });
   });
 
@@ -487,10 +464,7 @@ describe("useProgressSource summary and series", () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSeriesMock.mockResolvedValue(buildServerSeries(4, "2026-04-18T09:18:00.000Z"));
     loadPendingProgressDailyReviewsMock.mockResolvedValue([
-      {
-        date: currentSeriesInput.to,
-        reviewCount: 3,
-      },
+      buildDailyReviewPoint(currentSeriesInput.to, 3, 1, 1, 0, 1),
     ]);
 
     const harness = renderHarness({
@@ -502,15 +476,19 @@ describe("useProgressSource summary and series", () => {
 
     await flushEffects();
 
-    expect(harness.getApi().progressSourceState.series.serverBase?.dailyReviews).toContainEqual({
+    expect(harness.getApi().progressSourceState.series.serverBase?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 4,
-    });
+    }));
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("server");
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.isApproximate).toBe(true);
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual({
       date: currentSeriesInput.to,
       reviewCount: 7,
+      againCount: 1,
+      hardCount: 1,
+      goodCount: 4,
+      easyCount: 1,
     });
   });
 

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, vi } from "vitest";
 import type {
   CloudSettings,
+  DailyReviewPoint,
   ProgressLeaderboard,
   ProgressLeaderboardLocalViewerCounts,
   ProgressReviewSchedule,
@@ -43,8 +44,8 @@ const progressSourceMocks = vi.hoisted(() => ({
   hasPendingProgressReviewEventsMock: vi.fn<(workspaceIds: ReadonlyArray<string>) => Promise<boolean>>(),
   loadLocalProgressActiveDatesMock: vi.fn<(workspaceIds: ReadonlyArray<string>, timeZone: string) => Promise<ReadonlyArray<string>>>(),
   loadLocalProgressSummaryMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; today: string }>) => Promise<ProgressSummary>>(),
-  loadLocalProgressDailyReviewsMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; from: string; to: string }>) => Promise<ReadonlyArray<Readonly<{ date: string; reviewCount: number }>>>>(),
-  loadPendingProgressDailyReviewsMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; from: string; to: string }>) => Promise<ReadonlyArray<Readonly<{ date: string; reviewCount: number }>>>>(),
+  loadLocalProgressDailyReviewsMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; from: string; to: string }>) => Promise<ReadonlyArray<DailyReviewPoint>>>(),
+  loadPendingProgressDailyReviewsMock: vi.fn<(workspaceIds: ReadonlyArray<string>, input: Readonly<{ timeZone: string; from: string; to: string }>) => Promise<ReadonlyArray<DailyReviewPoint>>>(),
   hasCompleteLocalProgressReviewScheduleCoverageMock: vi.fn<(workspaceIds: ReadonlyArray<string>) => Promise<boolean>>(),
   hasPendingProgressReviewScheduleCardChangesMock: vi.fn<(workspaceIds: ReadonlyArray<string>) => Promise<boolean>>(),
   calculatePendingProgressReviewScheduleCardTotalDeltaMock: vi.fn<(workspaceIds: ReadonlyArray<string>) => Promise<number>>(),
@@ -367,6 +368,33 @@ export function buildServerSummary(activeReviewDays: number, generatedAt: string
   };
 }
 
+export function buildDailyReviewPoint(
+  date: string,
+  reviewCount: number,
+  againCount: number,
+  hardCount: number,
+  goodCount: number,
+  easyCount: number,
+): DailyReviewPoint {
+  const ratingCountSum = againCount + hardCount + goodCount + easyCount;
+  if (reviewCount !== ratingCountSum) {
+    throw new Error(`Invalid progress daily review test fixture for ${date}: reviewCount ${reviewCount} must equal rating count sum ${ratingCountSum}`);
+  }
+
+  return {
+    date,
+    reviewCount,
+    againCount,
+    hardCount,
+    goodCount,
+    easyCount,
+  };
+}
+
+export function buildGoodDailyReviewPoint(date: string, reviewCount: number): DailyReviewPoint {
+  return buildDailyReviewPoint(date, reviewCount, 0, 0, reviewCount, 0);
+}
+
 export function buildServerSeries(reviewCount: number, generatedAt: string): ProgressSeries {
   const input: ProgressSeriesInput = buildCurrentSeriesInput();
 
@@ -379,10 +407,7 @@ export function buildServerSeries(reviewCount: number, generatedAt: string): Pro
       { workspaceId: workspace.workspaceId, reviewSequenceId: reviewCount },
     ],
     dailyReviews: [
-      {
-        date: input.to,
-        reviewCount,
-      },
+      buildGoodDailyReviewPoint(input.to, reviewCount),
     ],
   };
 }
@@ -493,7 +518,7 @@ export function storePersistedProgressSeriesForTest(
   serverBase: ProgressSeries,
 ): void {
   window.localStorage.setItem(`flashcards-progress-server-series:${scopeKey}`, JSON.stringify({
-    version: 2,
+    version: 3,
     scopeKey,
     savedAt: "2026-04-18T09:00:00.000Z",
     serverBase,

--- a/apps/web/src/appData/progress/storage/progressStorage.ts
+++ b/apps/web/src/appData/progress/storage/progressStorage.ts
@@ -34,7 +34,7 @@ const progressReviewScheduleStorageKeyPrefix = "flashcards-progress-server-revie
 // is enough and lets settings clear it without knowing the active scope key.
 const progressLeaderboardStorageKey = "flashcards-progress-server-leaderboard";
 const progressServerSummaryVersion = 2;
-const progressServerSeriesVersion = 2;
+const progressServerSeriesVersion = 3;
 const progressServerReviewScheduleVersion = 2;
 const progressServerLeaderboardVersion = 2;
 
@@ -46,7 +46,7 @@ type PersistedProgressSummary = Readonly<{
 }>;
 
 type PersistedProgressSeries = Readonly<{
-  version: 2;
+  version: 3;
   scopeKey: ProgressScopeKey;
   savedAt: string;
   serverBase: ProgressSeries;
@@ -83,6 +83,10 @@ const localDatePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && Array.isArray(value) === false;
+}
+
+function isNonNegativeSafeIntegerValue(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
 function isValidProgressReviewHistoryWatermark(value: unknown): value is ProgressReviewHistoryWatermark {
@@ -389,13 +393,37 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
 
   const dailyReviews = parsedValue.serverBase.dailyReviews
     .map((day): DailyReviewPoint | null => {
-      if (isRecord(day) === false || typeof day.date !== "string" || typeof day.reviewCount !== "number") {
+      if (isRecord(day) === false || typeof day.date !== "string") {
+        return null;
+      }
+
+      const reviewCount = day.reviewCount;
+      const againCount = day.againCount;
+      const hardCount = day.hardCount;
+      const goodCount = day.goodCount;
+      const easyCount = day.easyCount;
+      if (
+        isNonNegativeSafeIntegerValue(reviewCount) === false
+        || isNonNegativeSafeIntegerValue(againCount) === false
+        || isNonNegativeSafeIntegerValue(hardCount) === false
+        || isNonNegativeSafeIntegerValue(goodCount) === false
+        || isNonNegativeSafeIntegerValue(easyCount) === false
+      ) {
+        return null;
+      }
+
+      const ratingCountSum = againCount + hardCount + goodCount + easyCount;
+      if (reviewCount !== ratingCountSum) {
         return null;
       }
 
       return {
         date: day.date,
-        reviewCount: day.reviewCount,
+        reviewCount,
+        againCount,
+        hardCount,
+        goodCount,
+        easyCount,
       };
     })
     .filter((day): day is DailyReviewPoint => day !== null);
@@ -435,7 +463,7 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
   return {
     status: "hit",
     value: {
-      version: 2,
+      version: progressServerSeriesVersion,
       scopeKey: parsedValue.scopeKey,
       savedAt: parsedValue.savedAt,
       serverBase: normalizedServerBase.value,
@@ -546,10 +574,6 @@ function isProgressLeaderboardStatusValue(value: unknown): value is ProgressLead
 
 function isProgressLeaderboardWindowKeyValue(value: unknown): value is ProgressLeaderboardWindowKey {
   return typeof value === "string" && progressLeaderboardWindowKeys.includes(value as ProgressLeaderboardWindowKey);
-}
-
-function isNonNegativeSafeIntegerValue(value: unknown): value is number {
-  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
 function parsePersistedProgressLeaderboardMetric(value: unknown): ProgressLeaderboardMetric | null {
@@ -895,7 +919,7 @@ export function storePersistedProgressSummary(scopeKey: ProgressScopeKey, server
 
 export function storePersistedProgressSeries(scopeKey: ProgressScopeKey, serverBase: ProgressSeries): void {
   const persistedValue: PersistedProgressSeries = {
-    version: 2,
+    version: progressServerSeriesVersion,
     scopeKey,
     savedAt: new Date().toISOString(),
     serverBase: normalizeProgressSeries(serverBase),

--- a/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
+++ b/apps/web/src/appData/sync/observation/syncLifecycleObservation.test.ts
@@ -42,6 +42,8 @@ vi.mock("../../../api", () => ({
   pushSyncOperations: apiMocks.pushSyncOperationsMock,
 }));
 
+const currentWebSyncDatabaseVersion = 14;
+
 function createRemoteSyncInput(): WorkspaceRemoteSyncInput {
   return {
     userId: "user-1",
@@ -432,7 +434,7 @@ describe("sync lifecycle observation", () => {
         storagePersistGranted: null,
         indexedDbOpenObservedAt: expect.any(String),
         indexedDbOpenOldVersion: 0,
-        indexedDbOpenNewVersion: 13,
+        indexedDbOpenNewVersion: currentWebSyncDatabaseVersion,
         indexedDbDatabaseCreated: true,
         indexedDbDatabaseUpgraded: false,
       }),
@@ -457,7 +459,7 @@ describe("sync lifecycle observation", () => {
         bootstrapPageDurationMs: [40],
         indexedDbOpenObservedAt: expect.any(String),
         indexedDbOpenOldVersion: 0,
-        indexedDbOpenNewVersion: 13,
+        indexedDbOpenNewVersion: currentWebSyncDatabaseVersion,
         indexedDbDatabaseCreated: true,
         indexedDbDatabaseUpgraded: false,
       }),

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -131,6 +131,9 @@ const arCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "الأسبوع السابق",
     nextWeek: "الأسبوع التالي",
+    reviewsBreakdown: {
+      legendLabel: "تقييمات المراجعة",
+    },
     reviewSchedule: {
       title: "جدول المراجعة",
       totalCards: "إجمالي البطاقات: {{count}}",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -131,6 +131,9 @@ const deCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Vorherige Woche",
     nextWeek: "Nächste Woche",
+    reviewsBreakdown: {
+      legendLabel: "Wiederholungsbewertungen",
+    },
     reviewSchedule: {
       title: "Wiederholungsplan",
       totalCards: "Karten gesamt: {{count}}",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -129,6 +129,9 @@ const enCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Previous week",
     nextWeek: "Next week",
+    reviewsBreakdown: {
+      legendLabel: "Review ratings",
+    },
     reviewSchedule: {
       title: "Review schedule",
       totalCards: "Total cards: {{count}}",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -131,6 +131,9 @@ const esEsCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Semana anterior",
     nextWeek: "Semana siguiente",
+    reviewsBreakdown: {
+      legendLabel: "Valoraciones de repaso",
+    },
     reviewSchedule: {
       title: "Calendario de repasos",
       totalCards: "Tarjetas totales: {{count}}",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -131,6 +131,9 @@ const esMxCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Semana anterior",
     nextWeek: "Semana siguiente",
+    reviewsBreakdown: {
+      legendLabel: "Calificaciones de repaso",
+    },
     reviewSchedule: {
       title: "Calendario de repasos",
       totalCards: "Tarjetas totales: {{count}}",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -131,6 +131,9 @@ const hiCatalog: TranslationCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "पिछला सप्ताह",
     nextWeek: "अगला सप्ताह",
+    reviewsBreakdown: {
+      legendLabel: "रिव्यू रेटिंग",
+    },
     reviewSchedule: {
       title: "रिव्यू शेड्यूल",
       totalCards: "कुल कार्ड: {{count}}",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -131,6 +131,9 @@ export const jaCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "前の週",
     nextWeek: "次の週",
+    reviewsBreakdown: {
+      legendLabel: "レビュー評価",
+    },
     reviewSchedule: {
       title: "復習スケジュール",
       totalCards: "合計カード数: {{count}}",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -131,6 +131,9 @@ export const ruCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "Предыдущая неделя",
     nextWeek: "Следующая неделя",
+    reviewsBreakdown: {
+      legendLabel: "Оценки повторений",
+    },
     reviewSchedule: {
       title: "Расписание повторений",
       totalCards: "Всего карточек: {{count}}",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -131,6 +131,9 @@ export const zhHansCatalog = {
     weekRangeValue: "{{from}} - {{to}}",
     previousWeek: "上一周",
     nextWeek: "下一周",
+    reviewsBreakdown: {
+      legendLabel: "复习评分",
+    },
     reviewSchedule: {
       title: "复习计划",
       totalCards: "卡片总数：{{count}}",

--- a/apps/web/src/localDb/core/core.migrations.test.ts
+++ b/apps/web/src/localDb/core/core.migrations.test.ts
@@ -31,6 +31,7 @@ type LegacyStoredCard = Omit<StoredCard, "dueAt" | "dueAtMillis" | "dueAtBucketM
 }>;
 
 const webSyncDatabaseName = "flashcards-web-sync";
+const currentWebSyncDatabaseVersion = 14;
 const legacyNullDueAtBucketMillis = -1;
 const legacyMalformedDueAtBucketMillis = -2;
 
@@ -277,7 +278,7 @@ describe("localDb core migrations", () => {
       await expect(openTask).rejects.toMatchObject({
         indexedDbOperation: "open",
         databaseName: webSyncDatabaseName,
-        databaseVersion: 13,
+        databaseVersion: currentWebSyncDatabaseVersion,
         indexedDbErrorName: "InvalidStateError",
       });
       expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -286,7 +287,7 @@ describe("localDb core migrations", () => {
           eventName: "indexed_db_operation_failed",
           indexedDbOperation: "open",
           databaseName: webSyncDatabaseName,
-          databaseVersion: 13,
+          databaseVersion: currentWebSyncDatabaseVersion,
           indexedDbErrorName: "InvalidStateError",
         }),
       }));
@@ -305,9 +306,9 @@ describe("localDb core migrations", () => {
     expect(readLastIndexedDbOpenLifecycleSnapshot()).toEqual(expect.objectContaining({
       observedAt: expect.any(String),
       databaseName: webSyncDatabaseName,
-      databaseVersion: 13,
+      databaseVersion: currentWebSyncDatabaseVersion,
       oldVersion: 0,
-      newVersion: 13,
+      newVersion: currentWebSyncDatabaseVersion,
       databaseCreated: true,
       databaseUpgraded: false,
     }));
@@ -316,9 +317,9 @@ describe("localDb core migrations", () => {
       details: expect.objectContaining({
         eventName: "indexed_db_open_lifecycle",
         databaseName: webSyncDatabaseName,
-        databaseVersion: 13,
+        databaseVersion: currentWebSyncDatabaseVersion,
         indexedDbOldVersion: 0,
-        indexedDbNewVersion: 13,
+        indexedDbNewVersion: currentWebSyncDatabaseVersion,
         indexedDbDatabaseCreated: true,
         indexedDbDatabaseUpgraded: false,
       }),
@@ -329,17 +330,17 @@ describe("localDb core migrations", () => {
 
     expect(readLastIndexedDbOpenLifecycleSnapshot()).toEqual(expect.objectContaining({
       databaseName: webSyncDatabaseName,
-      databaseVersion: 13,
+      databaseVersion: currentWebSyncDatabaseVersion,
       oldVersion: null,
-      newVersion: 13,
+      newVersion: currentWebSyncDatabaseVersion,
       databaseCreated: false,
       databaseUpgraded: false,
     }));
     expect(readIndexedDbOpenLifecycleSnapshotForDiagnostics()).toEqual(expect.objectContaining({
       databaseName: webSyncDatabaseName,
-      databaseVersion: 13,
+      databaseVersion: currentWebSyncDatabaseVersion,
       oldVersion: 0,
-      newVersion: 13,
+      newVersion: currentWebSyncDatabaseVersion,
       databaseCreated: true,
       databaseUpgraded: false,
     }));

--- a/apps/web/src/localDb/core/database.ts
+++ b/apps/web/src/localDb/core/database.ts
@@ -64,6 +64,10 @@ export type ProgressDailyCountRecord = Readonly<{
   workspaceId: string;
   localDate: string;
   reviewCount: number;
+  againCount: number;
+  hardCount: number;
+  goodCount: number;
+  easyCount: number;
 }>;
 
 export type ProgressCacheStateRecord = Readonly<{
@@ -95,7 +99,8 @@ export type IndexedDbOpenLifecycleSnapshot = Readonly<{
 }>;
 
 const databaseName = "flashcards-web-sync";
-const databaseVersion = 13;
+const databaseVersion = 14;
+const progressCacheStateKey = "progress_cache_state";
 const deleteDatabaseBlockedWaitMs = 3000;
 const activeDatabaseOperationPromises = new Set<Promise<unknown>>();
 let isDatabaseDeleteInProgress = false;
@@ -429,6 +434,28 @@ function upgradeToVersion13(transaction: IDBTransaction): void {
   migrateCardsDueAtDerivedFields(cardsStore, "IndexedDB fsrsLastReviewedAtMillis migration failed");
 }
 
+function upgradeToVersion14(transaction: IDBTransaction): void {
+  transaction.objectStore("progressDailyCounts").clear();
+  const metaStore = transaction.objectStore("meta");
+  const cacheStateRequest = metaStore.get(progressCacheStateKey);
+
+  cacheStateRequest.onerror = () => {
+    throw describeIndexedDbError("IndexedDB progress rating-count migration failed", cacheStateRequest.error);
+  };
+  cacheStateRequest.onsuccess = () => {
+    const cacheState = cacheStateRequest.result as ProgressCacheStateRecord | undefined;
+    if (cacheState === undefined) {
+      return;
+    }
+
+    metaStore.put({
+      ...cacheState,
+      needsRebuild: true,
+      updatedAt: new Date().toISOString(),
+    });
+  };
+}
+
 export function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.open(databaseName, databaseVersion);
@@ -512,6 +539,15 @@ export function openDatabase(): Promise<IDBDatabase> {
         }
 
         upgradeToVersion13(transaction);
+      }
+
+      if (oldVersion < 14) {
+        const transaction = request.transaction;
+        if (transaction === null) {
+          throw new Error("IndexedDB upgrade transaction is unavailable");
+        }
+
+        upgradeToVersion14(transaction);
       }
 
     };

--- a/apps/web/src/localDb/progress/progress.test.ts
+++ b/apps/web/src/localDb/progress/progress.test.ts
@@ -160,6 +160,10 @@ describe("localDb progress", () => {
       {
         date: "2025-01-08",
         reviewCount: 2,
+        againCount: 0,
+        hardCount: 1,
+        goodCount: 0,
+        easyCount: 1,
       },
     ]);
   });
@@ -226,6 +230,10 @@ describe("localDb progress", () => {
       {
         date: "2025-01-08",
         reviewCount: 2,
+        againCount: 0,
+        hardCount: 0,
+        goodCount: 1,
+        easyCount: 1,
       },
     ]);
   });

--- a/apps/web/src/localDb/progress/progress.ts
+++ b/apps/web/src/localDb/progress/progress.ts
@@ -5,6 +5,7 @@ import type {
   ProgressSeriesInput,
   ProgressSummary,
   ProgressSummaryInput,
+  ReviewRating,
   ReviewEvent,
   SyncPushOperation,
 } from "../../types";
@@ -58,18 +59,107 @@ function createEmptyProgressSummary(): ProgressSummary {
   };
 }
 
+function createEmptyDailyReviewPoint(date: string): DailyReviewPoint {
+  return {
+    date,
+    reviewCount: 0,
+    againCount: 0,
+    hardCount: 0,
+    goodCount: 0,
+    easyCount: 0,
+  };
+}
+
+export function createEmptyProgressDailyCountRecord(
+  workspaceId: string,
+  localDate: string,
+): ProgressDailyCountRecord {
+  return {
+    workspaceId,
+    localDate,
+    reviewCount: 0,
+    againCount: 0,
+    hardCount: 0,
+    goodCount: 0,
+    easyCount: 0,
+  };
+}
+
+function addReviewRatingToDailyReviewPoint(
+  dailyReviewPoint: DailyReviewPoint,
+  rating: ReviewRating,
+): DailyReviewPoint {
+  if (rating === 0) {
+    return {
+      ...dailyReviewPoint,
+      reviewCount: dailyReviewPoint.reviewCount + 1,
+      againCount: dailyReviewPoint.againCount + 1,
+    };
+  }
+
+  if (rating === 1) {
+    return {
+      ...dailyReviewPoint,
+      reviewCount: dailyReviewPoint.reviewCount + 1,
+      hardCount: dailyReviewPoint.hardCount + 1,
+    };
+  }
+
+  if (rating === 2) {
+    return {
+      ...dailyReviewPoint,
+      reviewCount: dailyReviewPoint.reviewCount + 1,
+      goodCount: dailyReviewPoint.goodCount + 1,
+    };
+  }
+
+  if (rating === 3) {
+    return {
+      ...dailyReviewPoint,
+      reviewCount: dailyReviewPoint.reviewCount + 1,
+      easyCount: dailyReviewPoint.easyCount + 1,
+    };
+  }
+
+  throw new Error(`Invalid review rating for progress aggregation: ${String(rating)}`);
+}
+
+export function addReviewRatingToProgressDailyCountRecord(
+  progressDailyCount: ProgressDailyCountRecord,
+  rating: ReviewRating,
+): ProgressDailyCountRecord {
+  const dailyReviewPoint = addReviewRatingToDailyReviewPoint({
+    date: progressDailyCount.localDate,
+    reviewCount: progressDailyCount.reviewCount,
+    againCount: progressDailyCount.againCount,
+    hardCount: progressDailyCount.hardCount,
+    goodCount: progressDailyCount.goodCount,
+    easyCount: progressDailyCount.easyCount,
+  }, rating);
+
+  return {
+    workspaceId: progressDailyCount.workspaceId,
+    localDate: progressDailyCount.localDate,
+    reviewCount: dailyReviewPoint.reviewCount,
+    againCount: dailyReviewPoint.againCount,
+    hardCount: dailyReviewPoint.hardCount,
+    goodCount: dailyReviewPoint.goodCount,
+    easyCount: dailyReviewPoint.easyCount,
+  };
+}
+
 function buildProgressActiveDates(
-  dailyReviewCounts: ReadonlyMap<string, number>,
+  dailyReviewCounts: ReadonlyMap<string, DailyReviewPoint>,
 ): ReadonlyArray<string> {
   return [...dailyReviewCounts.entries()]
-    .filter(([, reviewCount]) => reviewCount > 0)
+    .filter(([, dailyReviewPoint]) => dailyReviewPoint.reviewCount > 0)
     .map(([date]) => date)
     .sort((leftDate, rightDate) => leftDate.localeCompare(rightDate));
 }
 
 function buildProgressSummary(
   today: string,
-  dailyReviewCounts: ReadonlyMap<string, number>,
+  dailyReviewCounts: ReadonlyMap<string, DailyReviewPoint>,
 ): ProgressSummary {
   const reviewDates = buildProgressActiveDates(dailyReviewCounts);
 
@@ -111,27 +201,27 @@ function aggregateReviewEventsByWorkspaceAndLocalDate(
   reviewEvents: ReadonlyArray<ReviewEvent>,
   timeZone: string,
 ): ReadonlyArray<ProgressDailyCountRecord> {
-  const counts = new Map<string, number>();
+  const counts = new Map<string, ProgressDailyCountRecord>();
 
   for (const reviewEvent of reviewEvents) {
     const localDate = mapReviewedAtClientToLocalDate(reviewEvent.reviewedAtClient, timeZone);
     const countKey = `${reviewEvent.workspaceId}::${localDate}`;
-    counts.set(countKey, (counts.get(countKey) ?? 0) + 1);
+    const currentCount = counts.get(countKey) ?? createEmptyProgressDailyCountRecord(
+      reviewEvent.workspaceId,
+      localDate,
+    );
+    counts.set(countKey, addReviewRatingToProgressDailyCountRecord(currentCount, reviewEvent.rating));
   }
 
   return [...counts.entries()]
-    .map(([countKey, reviewCount]): ProgressDailyCountRecord => {
+    .map(([countKey, progressDailyCount]): ProgressDailyCountRecord => {
       const separatorIndex = countKey.indexOf("::");
 
       if (separatorIndex === -1) {
         throw new Error(`Invalid progress aggregate key: ${countKey}`);
       }
 
-      return {
-        workspaceId: countKey.slice(0, separatorIndex),
-        localDate: countKey.slice(separatorIndex + 2),
-        reviewCount,
-      };
+      return progressDailyCount;
     })
     .sort((leftRecord, rightRecord) => {
       const workspaceDifference = leftRecord.workspaceId.localeCompare(rightRecord.workspaceId);
@@ -175,14 +265,19 @@ async function ensureLocalProgressCacheReady(
 
 function buildMergedDailyReviewMap(
   progressDailyCounts: ReadonlyArray<ProgressDailyCountRecord>,
-): Map<string, number> {
-  const counts = new Map<string, number>();
+): Map<string, DailyReviewPoint> {
+  const counts = new Map<string, DailyReviewPoint>();
 
   for (const progressDailyCount of progressDailyCounts) {
-    counts.set(
-      progressDailyCount.localDate,
-      (counts.get(progressDailyCount.localDate) ?? 0) + progressDailyCount.reviewCount,
-    );
+    const currentCount = counts.get(progressDailyCount.localDate) ?? createEmptyDailyReviewPoint(progressDailyCount.localDate);
+    counts.set(progressDailyCount.localDate, {
+      date: progressDailyCount.localDate,
+      reviewCount: currentCount.reviewCount + progressDailyCount.reviewCount,
+      againCount: currentCount.againCount + progressDailyCount.againCount,
+      hardCount: currentCount.hardCount + progressDailyCount.hardCount,
+      goodCount: currentCount.goodCount + progressDailyCount.goodCount,
+      easyCount: currentCount.easyCount + progressDailyCount.easyCount,
+    });
   }
 
   return counts;
@@ -263,10 +358,7 @@ export async function loadLocalProgressDailyReviews(
 
     return [...mergedDailyReviewMap.entries()]
       .filter(([date]) => isDateWithinRange(date, input))
-      .map(([date, reviewCount]): DailyReviewPoint => ({
-        date,
-        reviewCount,
-      }))
+      .map(([, dailyReviewPoint]): DailyReviewPoint => dailyReviewPoint)
       .sort((leftDay, rightDay) => leftDay.date.localeCompare(rightDay.date));
   });
 }
@@ -280,7 +372,7 @@ export async function loadPendingProgressDailyReviews(
   }
 
   const outboxRecords = await listOutboxRecordsForWorkspaces(workspaceIds);
-  const counts = new Map<string, number>();
+  const counts = new Map<string, DailyReviewPoint>();
 
   for (const outboxRecord of outboxRecords) {
     if (isPendingReviewEventOperation(outboxRecord.operation) === false) {
@@ -292,14 +384,12 @@ export async function loadPendingProgressDailyReviews(
       continue;
     }
 
-    counts.set(localDate, (counts.get(localDate) ?? 0) + 1);
+    const currentCount = counts.get(localDate) ?? createEmptyDailyReviewPoint(localDate);
+    counts.set(localDate, addReviewRatingToDailyReviewPoint(currentCount, outboxRecord.operation.payload.rating));
   }
 
   return [...counts.entries()]
-    .map(([date, reviewCount]): DailyReviewPoint => ({
-      date,
-      reviewCount,
-    }))
+    .map(([, dailyReviewPoint]): DailyReviewPoint => dailyReviewPoint)
     .sort((leftDay, rightDay) => leftDay.date.localeCompare(rightDay.date));
 }
 

--- a/apps/web/src/localDb/reviews/reviews.ts
+++ b/apps/web/src/localDb/reviews/reviews.ts
@@ -37,6 +37,8 @@ import {
   loadPendingProgressDailyReviews,
   mapReviewedAtClientToLocalDate,
   markProgressCacheDirtyInTransaction,
+  addReviewRatingToProgressDailyCountRecord,
+  createEmptyProgressDailyCountRecord,
 } from "../progress/progress";
 import { decodeCursor, encodeCursor } from "../core/queryShared";
 
@@ -815,14 +817,16 @@ export async function putReviewEvent(reviewEvent: ReviewEvent): Promise<void> {
       "progressDailyCounts",
       [reviewEvent.workspaceId, localDate],
     );
+    const currentProgressDailyCount = existingProgressDailyCount ?? createEmptyProgressDailyCountRecord(
+      reviewEvent.workspaceId,
+      localDate,
+    );
 
     await runReadwrite(database, ["reviewEvents", "progressDailyCounts"], (transaction) => {
       putReviewEventInTransaction(transaction, reviewEvent);
-      transaction.objectStore("progressDailyCounts").put({
-        workspaceId: reviewEvent.workspaceId,
-        localDate,
-        reviewCount: (existingProgressDailyCount?.reviewCount ?? 0) + 1,
-      });
+      transaction.objectStore("progressDailyCounts").put(
+        addReviewRatingToProgressDailyCountRecord(currentProgressDailyCount, reviewEvent.rating),
+      );
       return null;
     });
   });

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../appData/progress/snapshots/progressSnapshots";
 import type {
   CloudSettings,
+  DailyReviewPoint,
   ProgressLeaderboard,
   ProgressLeaderboardLocalViewerCounts,
   ProgressLeaderboardRankingRow,
@@ -185,17 +186,40 @@ function createProgressSummarySnapshot(): ProgressSummarySnapshot {
   };
 }
 
+function createDailyReviewPoint(
+  date: string,
+  reviewCount: number,
+  againCount: number,
+  hardCount: number,
+  goodCount: number,
+  easyCount: number,
+): DailyReviewPoint {
+  const ratingCountSum = againCount + hardCount + goodCount + easyCount;
+  if (reviewCount !== ratingCountSum) {
+    throw new Error(`Invalid progress screen test fixture for ${date}: reviewCount ${reviewCount} must equal rating count sum ${ratingCountSum}`);
+  }
+
+  return {
+    date,
+    reviewCount,
+    againCount,
+    hardCount,
+    goodCount,
+    easyCount,
+  };
+}
+
 function createProgressSeriesSnapshot(): ProgressSeriesSnapshot {
   const dailyReviews = [
-    { date: "2026-04-13", reviewCount: 0 },
-    { date: "2026-04-14", reviewCount: 40 },
-    { date: "2026-04-15", reviewCount: 0 },
-    { date: "2026-04-16", reviewCount: 0 },
-    { date: "2026-04-17", reviewCount: 0 },
-    { date: "2026-04-18", reviewCount: 0 },
-    { date: "2026-04-19", reviewCount: 0 },
-    { date: "2026-04-20", reviewCount: 0 },
-    { date: "2026-04-21", reviewCount: 9 },
+    createDailyReviewPoint("2026-04-13", 0, 0, 0, 0, 0),
+    createDailyReviewPoint("2026-04-14", 40, 5, 10, 20, 5),
+    createDailyReviewPoint("2026-04-15", 0, 0, 0, 0, 0),
+    createDailyReviewPoint("2026-04-16", 0, 0, 0, 0, 0),
+    createDailyReviewPoint("2026-04-17", 0, 0, 0, 0, 0),
+    createDailyReviewPoint("2026-04-18", 0, 0, 0, 0, 0),
+    createDailyReviewPoint("2026-04-19", 0, 0, 0, 0, 0),
+    createDailyReviewPoint("2026-04-20", 3, 0, 3, 0, 0),
+    createDailyReviewPoint("2026-04-21", 9, 1, 2, 4, 2),
   ] as const;
 
   return {
@@ -555,6 +579,88 @@ describe("ProgressScreen", () => {
     expect(previousWeekBar.style.height).toContain("90.909");
   });
 
+  it("renders stacked review ratings and supports day and rating selection", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter>
+          <I18nProvider>
+            <ProgressScreen />
+          </I18nProvider>
+        </MemoryRouter>,
+      );
+    });
+
+    const goodSegment = container.querySelector("[data-testid='progress-chart-segment-2026-04-21-good']");
+    if (!(goodSegment instanceof HTMLSpanElement)) {
+      throw new Error("Good rating segment was not found");
+    }
+    expect(goodSegment.style.backgroundColor).toBe("rgb(43, 182, 115)");
+
+    const day20Bar = container.querySelector("[data-testid='progress-chart-bar-2026-04-20']");
+    if (!(day20Bar instanceof HTMLSpanElement)) {
+      throw new Error("Day 20 progress bar was not found");
+    }
+
+    await act(async () => {
+      day20Bar.click();
+    });
+
+    const chartRange = container.querySelector("[data-testid='progress-chart-range']");
+    if (!(chartRange instanceof HTMLParagraphElement)) {
+      throw new Error("Progress chart range was not found");
+    }
+    expect(chartRange.textContent).toBe("Apr 20, 2026");
+
+    const againButton = container.querySelector("[data-testid='progress-chart-rating-again']");
+    if (!(againButton instanceof HTMLButtonElement)) {
+      throw new Error("Again rating legend button was not found");
+    }
+    expect(againButton.disabled).toBe(true);
+    expect(againButton.textContent).toBe("Again0 (0%)");
+
+    const hardButton = container.querySelector("[data-testid='progress-chart-rating-hard']");
+    if (!(hardButton instanceof HTMLButtonElement)) {
+      throw new Error("Hard rating legend button was not found");
+    }
+    expect(hardButton.textContent).toBe("Hard3 (100%)");
+
+    const dimmedHardSegment = container.querySelector("[data-testid='progress-chart-segment-2026-04-21-hard']");
+    if (!(dimmedHardSegment instanceof HTMLSpanElement)) {
+      throw new Error("Dimmed hard rating segment was not found");
+    }
+    expect(dimmedHardSegment.style.backgroundColor).toBe("rgb(122, 128, 136)");
+
+    await act(async () => {
+      hardButton.click();
+    });
+
+    expect(hardButton.closest("li")?.className).toContain("is-selected");
+    expect(againButton.closest("li")?.className).toContain("is-dimmed");
+    expect(container.querySelector("[data-testid='progress-chart-segment-2026-04-21-good']")).toBeNull();
+
+    const filteredLatestWeekBar = container.querySelector("[data-testid='progress-chart-bar-2026-04-21']");
+    if (!(filteredLatestWeekBar instanceof HTMLSpanElement)) {
+      throw new Error("Filtered latest week bar was not found");
+    }
+    expect(filteredLatestWeekBar.style.height).toBe("50%");
+
+    const enabledAgainButton = container.querySelector("[data-testid='progress-chart-rating-again']");
+    if (!(enabledAgainButton instanceof HTMLButtonElement)) {
+      throw new Error("Enabled again rating legend button was not found");
+    }
+
+    await act(async () => {
+      enabledAgainButton.click();
+    });
+
+    const filteredDayWithoutAgainBar = container.querySelector("[data-testid='progress-chart-bar-2026-04-20']");
+    if (!(filteredDayWithoutAgainBar instanceof HTMLSpanElement)) {
+      throw new Error("Filtered day without again bar was not found");
+    }
+    expect(filteredDayWithoutAgainBar.style.height).toBe("0%");
+    expect(filteredDayWithoutAgainBar.className).not.toContain("progress-chart-bar-active");
+  });
+
   it("renders the week header with native locale interval formatting", async () => {
     await act(async () => {
       root.render(
@@ -676,24 +782,24 @@ describe("ProgressScreen", () => {
             ...createProgressSeriesSnapshot(),
             from: "2026-04-06",
             dailyReviews: [
-              { date: "2026-04-06", reviewCount: 0 },
-              { date: "2026-04-07", reviewCount: 0 },
-              { date: "2026-04-08", reviewCount: 0 },
-              { date: "2026-04-09", reviewCount: 0 },
-              { date: "2026-04-10", reviewCount: 0 },
-              { date: "2026-04-11", reviewCount: 0 },
-              { date: "2026-04-12", reviewCount: 0 },
+              createDailyReviewPoint("2026-04-06", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-07", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-08", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-09", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-10", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-11", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-12", 0, 0, 0, 0, 0),
               ...createProgressSeriesSnapshot().dailyReviews,
             ],
             chartData: {
               dailyReviews: [
-                { date: "2026-04-06", reviewCount: 0 },
-                { date: "2026-04-07", reviewCount: 0 },
-                { date: "2026-04-08", reviewCount: 0 },
-                { date: "2026-04-09", reviewCount: 0 },
-                { date: "2026-04-10", reviewCount: 0 },
-                { date: "2026-04-11", reviewCount: 0 },
-                { date: "2026-04-12", reviewCount: 0 },
+                createDailyReviewPoint("2026-04-06", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-07", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-08", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-09", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-10", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-11", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-12", 0, 0, 0, 0, 0),
                 ...createProgressSeriesSnapshot().dailyReviews,
               ],
             },
@@ -703,24 +809,24 @@ describe("ProgressScreen", () => {
             ...createProgressSeriesSnapshot(),
             from: "2026-04-06",
             dailyReviews: [
-              { date: "2026-04-06", reviewCount: 0 },
-              { date: "2026-04-07", reviewCount: 0 },
-              { date: "2026-04-08", reviewCount: 0 },
-              { date: "2026-04-09", reviewCount: 0 },
-              { date: "2026-04-10", reviewCount: 0 },
-              { date: "2026-04-11", reviewCount: 0 },
-              { date: "2026-04-12", reviewCount: 0 },
+              createDailyReviewPoint("2026-04-06", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-07", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-08", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-09", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-10", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-11", 0, 0, 0, 0, 0),
+              createDailyReviewPoint("2026-04-12", 0, 0, 0, 0, 0),
               ...createProgressSeriesSnapshot().dailyReviews,
             ],
             chartData: {
               dailyReviews: [
-                { date: "2026-04-06", reviewCount: 0 },
-                { date: "2026-04-07", reviewCount: 0 },
-                { date: "2026-04-08", reviewCount: 0 },
-                { date: "2026-04-09", reviewCount: 0 },
-                { date: "2026-04-10", reviewCount: 0 },
-                { date: "2026-04-11", reviewCount: 0 },
-                { date: "2026-04-12", reviewCount: 0 },
+                createDailyReviewPoint("2026-04-06", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-07", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-08", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-09", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-10", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-11", 0, 0, 0, 0, 0),
+                createDailyReviewPoint("2026-04-12", 0, 0, 0, 0, 0),
                 ...createProgressSeriesSnapshot().dailyReviews,
               ],
             },

--- a/apps/web/src/screens/progress/ProgressScreen.test.ts
+++ b/apps/web/src/screens/progress/ProgressScreen.test.ts
@@ -16,9 +16,9 @@ describe("ProgressScreen streak weeks", () => {
   it("marks future dates in the current locale-aligned week as placeholders", () => {
     const weeks = buildStreakWeeks(
       [
-        { date: "2026-04-18", reviewCount: 3 },
-        { date: "2026-04-20", reviewCount: 2 },
-        { date: "2026-04-21", reviewCount: 4 },
+        { date: "2026-04-18", reviewCount: 3, againCount: 0, hardCount: 0, goodCount: 3, easyCount: 0 },
+        { date: "2026-04-20", reviewCount: 2, againCount: 0, hardCount: 0, goodCount: 2, easyCount: 0 },
+        { date: "2026-04-21", reviewCount: 4, againCount: 0, hardCount: 0, goodCount: 4, easyCount: 0 },
       ],
       "2026-04-21",
       createDateFormatter("en-US"),

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -25,10 +25,14 @@ import {
   type ProgressReviewsChartNavigationState,
 } from "./reviewsChart/ProgressReviewsChartSection";
 import {
+  buildChartRatingLegendItems,
   buildChartGuideLabels,
   buildChartPages,
+  formatChartDayLabel,
   formatChartRangeLabel,
   resolveChartNavigationArrow,
+  type ProgressReviewsChartRatingKey,
+  type ProgressReviewsChartSelection,
 } from "./reviewsChart/progressReviewsChartModel";
 import { ProgressStreakSection, type ProgressStreakSummaryView } from "./streak/ProgressStreakSection";
 import { buildStreakWeeks } from "./streak/progressStreakModel";
@@ -68,6 +72,7 @@ export function ProgressScreen(): ReactElement {
   });
   const { locale, matchedBrowserLanguageTag, direction, t, formatDate, formatNumber } = useI18n();
   const [selectedPageStartLocalDate, setSelectedPageStartLocalDate] = useState<string | null>(null);
+  const [reviewsChartSelection, setReviewsChartSelection] = useState<ProgressReviewsChartSelection>({ kind: "none" });
   const [selectedReviewScheduleBucket, setSelectedReviewScheduleBucket] = useState<ProgressReviewScheduleBucketKey | null>(null);
   const [selectedLeaderboardWindowKey, setSelectedLeaderboardWindowKey] = useState<ProgressLeaderboardWindowKey | null>(null);
   const [isLeaderboardInfoVisible, setIsLeaderboardInfoVisible] = useState<boolean>(false);
@@ -88,6 +93,7 @@ export function ProgressScreen(): ReactElement {
 
   useEffect(() => {
     setSelectedPageStartLocalDate(null);
+    setReviewsChartSelection({ kind: "none" });
   }, [progressSourceState.series.renderedSnapshot]);
 
   useEffect(() => {
@@ -127,20 +133,39 @@ export function ProgressScreen(): ReactElement {
   const today = progress === null ? "" : progress.to;
   const weekContext = resolveLocaleWeekContext(matchedBrowserLanguageTag ?? locale, locale);
   const streakWeeks = progress === null ? [] : buildStreakWeeks(dailyReviews, today, formatDate, weekContext);
-  const chartPages = progress === null ? [] : buildChartPages(dailyReviews, today, formatDate, weekContext);
+  const selectedReviewsChartRatingKey = reviewsChartSelection.kind === "rating"
+    ? reviewsChartSelection.ratingKey
+    : null;
+  const chartPages = progress === null
+    ? []
+    : buildChartPages(dailyReviews, today, formatDate, weekContext, selectedReviewsChartRatingKey);
   const selectedPageIndex = chartPages.findIndex((page) => page.startLocalDate === selectedPageStartLocalDate);
   const visiblePage = chartPages.length === 0
     ? null
     : selectedPageStartLocalDate === null || selectedPageIndex === -1
       ? chartPages[chartPages.length - 1]
       : chartPages[selectedPageIndex];
+  const visiblePageHasSelectedDay = reviewsChartSelection.kind === "day"
+    && visiblePage !== null
+    && visiblePage.days.some((day) => day.date === reviewsChartSelection.date);
+  const visibleReviewsChartSelection: ProgressReviewsChartSelection = reviewsChartSelection.kind === "day" && visiblePageHasSelectedDay === false
+    ? { kind: "none" }
+    : reviewsChartSelection;
   const resolvedSelectedPageIndex = visiblePage === null
     ? 0
     : chartPages.findIndex((page) => page.startLocalDate === visiblePage.startLocalDate);
   const chartGuideLabels = buildChartGuideLabels(visiblePage?.upperBound ?? 1, formatNumber);
   const pageRangeLabel = visiblePage === null
     ? ""
+    : visibleReviewsChartSelection.kind === "day"
+      ? formatChartDayLabel(visibleReviewsChartSelection.date, locale)
     : formatChartRangeLabel(visiblePage.startDate, visiblePage.endDate, locale);
+  const chartRatingLegendItems = buildChartRatingLegendItems(
+    visiblePage,
+    visibleReviewsChartSelection,
+    t,
+    formatNumber,
+  );
   const reviewProgressBadgeTodayStatus = reviewProgressBadge.hasReviewedToday
     ? t("reviewScreen.progressBadge.reviewedToday")
     : t("reviewScreen.progressBadge.notReviewedToday");
@@ -177,6 +202,27 @@ export function ProgressScreen(): ReactElement {
     : buildReviewScheduleBucketViews(reviewSchedule, t, formatNumber);
   const reviewScheduleDonutSegments = buildReviewScheduleDonutSegments(reviewScheduleBucketViews);
   const canRenderLeaderboardServerBase = canLoadProgressServerBase(sessionVerificationState, cloudSettings);
+  const handleSelectChartPageStartLocalDate = (pageStartLocalDate: string | null): void => {
+    setSelectedPageStartLocalDate(pageStartLocalDate);
+    setReviewsChartSelection({ kind: "none" });
+  };
+  const handleSelectReviewsChartDay = (date: string): void => {
+    setReviewsChartSelection((previousSelection) => (
+      previousSelection.kind === "day" && previousSelection.date === date
+        ? { kind: "none" }
+        : { kind: "day", date }
+    ));
+  };
+  const handleSelectReviewsChartRating = (ratingKey: ProgressReviewsChartRatingKey): void => {
+    setReviewsChartSelection((previousSelection) => (
+      previousSelection.kind === "rating" && previousSelection.ratingKey === ratingKey
+        ? { kind: "none" }
+        : { kind: "rating", ratingKey }
+    ));
+  };
+  const handleClearReviewsChartSelection = (): void => {
+    setReviewsChartSelection({ kind: "none" });
+  };
   const handleSelectReviewScheduleBucket = (bucketKey: ProgressReviewScheduleBucketKey): void => {
     setSelectedReviewScheduleBucket((previous) => (previous === bucketKey ? null : bucketKey));
   };
@@ -232,8 +278,14 @@ export function ProgressScreen(): ReactElement {
               pageRangeLabel={pageRangeLabel}
               visiblePage={visiblePage}
               chartGuideLabels={chartGuideLabels}
+              legendLabel={t("progressScreen.reviewsBreakdown.legendLabel")}
+              ratingLegendItems={chartRatingLegendItems}
+              selection={visibleReviewsChartSelection}
               navigation={chartNavigation}
-              onSelectPageStartLocalDate={setSelectedPageStartLocalDate}
+              onSelectPageStartLocalDate={handleSelectChartPageStartLocalDate}
+              onSelectDay={handleSelectReviewsChartDay}
+              onSelectRating={handleSelectReviewsChartRating}
+              onClearSelection={handleClearReviewsChartSelection}
             />
 
             {reviewSchedule !== null ? (

--- a/apps/web/src/screens/progress/reviewsChart/ProgressReviewsChartSection.tsx
+++ b/apps/web/src/screens/progress/reviewsChart/ProgressReviewsChartSection.tsx
@@ -1,5 +1,10 @@
 import type { ReactElement } from "react";
-import type { ChartPage } from "./progressReviewsChartModel";
+import type {
+  ChartPage,
+  ChartRatingLegendItem,
+  ProgressReviewsChartRatingKey,
+  ProgressReviewsChartSelection,
+} from "./progressReviewsChartModel";
 
 export type ProgressReviewsChartNavigationState = Readonly<{
   previousPageStartLocalDate: string | null;
@@ -15,23 +20,36 @@ type ProgressReviewsChartSectionProps = Readonly<{
   pageRangeLabel: string;
   visiblePage: ChartPage | null;
   chartGuideLabels: ReadonlyArray<string>;
+  legendLabel: string;
+  ratingLegendItems: ReadonlyArray<ChartRatingLegendItem>;
+  selection: ProgressReviewsChartSelection;
   navigation: ProgressReviewsChartNavigationState | null;
   onSelectPageStartLocalDate: (pageStartLocalDate: string | null) => void;
+  onSelectDay: (date: string) => void;
+  onSelectRating: (ratingKey: ProgressReviewsChartRatingKey) => void;
+  onClearSelection: () => void;
 }>;
 
 function ProgressReviewsChartColumn(props: Readonly<{
   day: ChartPage["days"][number];
+  selection: ProgressReviewsChartSelection;
+  onSelectDay: (date: string) => void;
 }>): ReactElement {
-  const { day } = props;
+  const { day, selection, onSelectDay } = props;
+  const hasSelectedDay = selection.kind === "day";
+  const isSelectedDay = selection.kind === "day" && selection.date === day.date;
+  const isDimmed = hasSelectedDay && isSelectedDay === false;
   const columnClassName = [
     "progress-chart-column",
     day.isToday && day.reviewCount === 0 ? "progress-chart-column-today" : "",
+    isSelectedDay ? "is-selected" : "",
+    isDimmed ? "is-dimmed" : "",
   ]
     .filter((className) => className !== "")
     .join(" ");
   const barClassName = [
     "progress-chart-bar",
-    day.reviewCount > 0 ? "progress-chart-bar-active" : "",
+    day.displayReviewCount > 0 ? "progress-chart-bar-active" : "",
   ]
     .filter((className) => className !== "")
     .join(" ");
@@ -41,24 +59,96 @@ function ProgressReviewsChartColumn(props: Readonly<{
       className={columnClassName}
       title={day.title}
     >
-      <div className="progress-chart-bar-shell">
-        <span
-          className={barClassName}
-          style={{
-            height: `${day.barHeightPercentage}%`,
-          }}
-          aria-hidden="true"
-          data-testid={`progress-chart-bar-${day.date}`}
-        />
-      </div>
-      <div className="progress-chart-labels" aria-hidden="true">
-        <span className="progress-chart-month">
-          {day.showMonthLabel ? day.monthLabel : ""}
-        </span>
-        <span className="progress-chart-day">{day.dayLabel}</span>
-        <span className="progress-chart-weekday">{day.weekdayLabel}</span>
-      </div>
+      <button
+        type="button"
+        className="progress-chart-column-button"
+        aria-label={day.title}
+        aria-pressed={isSelectedDay}
+        onClick={(event) => {
+          event.stopPropagation();
+          onSelectDay(day.date);
+        }}
+      >
+        <div className="progress-chart-bar-shell">
+          <span
+            className={barClassName}
+            style={{
+              height: `${day.barHeightPercentage}%`,
+            }}
+            aria-hidden="true"
+            data-testid={`progress-chart-bar-${day.date}`}
+          >
+            {day.segments.map((segment) => (
+              <span
+                key={`${day.date}-${segment.ratingKey}`}
+                className="progress-chart-bar-segment"
+                style={{
+                  backgroundColor: isDimmed ? "#7A8088" : segment.color,
+                  height: `${segment.heightPercentage}%`,
+                }}
+                data-testid={`progress-chart-segment-${day.date}-${segment.ratingKey}`}
+              />
+            ))}
+          </span>
+        </div>
+        <div className="progress-chart-labels" aria-hidden="true">
+          <span className="progress-chart-month">
+            {day.showMonthLabel ? day.monthLabel : ""}
+          </span>
+          <span className="progress-chart-day">{day.dayLabel}</span>
+          <span className="progress-chart-weekday">{day.weekdayLabel}</span>
+        </div>
+      </button>
     </div>
+  );
+}
+
+function ProgressReviewsRatingLegend(props: Readonly<{
+  legendLabel: string;
+  items: ReadonlyArray<ChartRatingLegendItem>;
+  onSelectRating: (ratingKey: ProgressReviewsChartRatingKey) => void;
+}>): ReactElement {
+  const {
+    legendLabel,
+    items,
+    onSelectRating,
+  } = props;
+
+  return (
+    <ul className="progress-chart-rating-list" aria-label={legendLabel}>
+      {items.map((item) => {
+        const rowClassName = [
+          "progress-chart-rating-row",
+          item.isSelected ? "is-selected" : "",
+          item.isDimmed ? "is-dimmed" : "",
+        ]
+          .filter((className) => className !== "")
+          .join(" ");
+        return (
+          <li key={item.ratingKey} className={rowClassName}>
+            <button
+              type="button"
+              className="progress-chart-rating-row-button"
+              disabled={item.isDisabled}
+              aria-pressed={item.isDisabled ? undefined : item.isSelected}
+              data-testid={`progress-chart-rating-${item.ratingKey}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectRating(item.ratingKey);
+              }}
+            >
+              <span
+                className="progress-chart-rating-swatch"
+                style={{ backgroundColor: item.color }}
+                aria-hidden="true"
+              />
+              <span className="progress-chart-rating-label">{item.label}</span>
+              <span className="progress-chart-rating-value">{item.valueLabel}</span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 
@@ -68,12 +158,18 @@ export function ProgressReviewsChartSection(props: ProgressReviewsChartSectionPr
     pageRangeLabel,
     visiblePage,
     chartGuideLabels,
+    legendLabel,
+    ratingLegendItems,
+    selection,
     navigation,
     onSelectPageStartLocalDate,
+    onSelectDay,
+    onSelectRating,
+    onClearSelection,
   } = props;
 
   return (
-    <section className="content-card progress-section">
+    <section className="content-card progress-section" onClick={onClearSelection}>
       <div className="progress-section-head">
         <div className="progress-chart-heading">
           <h2 className="progress-section-title">{title}</h2>
@@ -89,7 +185,10 @@ export function ProgressReviewsChartSection(props: ProgressReviewsChartSectionPr
             <button
               type="button"
               className="ghost-btn progress-chart-nav-btn"
-              onClick={() => onSelectPageStartLocalDate(navigation.previousPageStartLocalDate)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectPageStartLocalDate(navigation.previousPageStartLocalDate);
+              }}
               disabled={navigation.previousPageStartLocalDate === null}
               aria-label={navigation.previousWeekLabel}
               data-testid="progress-chart-previous-week"
@@ -101,7 +200,10 @@ export function ProgressReviewsChartSection(props: ProgressReviewsChartSectionPr
             <button
               type="button"
               className="ghost-btn progress-chart-nav-btn"
-              onClick={() => onSelectPageStartLocalDate(navigation.nextPageStartLocalDate)}
+              onClick={(event) => {
+                event.stopPropagation();
+                onSelectPageStartLocalDate(navigation.nextPageStartLocalDate);
+              }}
               disabled={navigation.nextPageStartLocalDate === null}
               aria-label={navigation.nextWeekLabel}
               data-testid="progress-chart-next-week"
@@ -137,12 +239,25 @@ export function ProgressReviewsChartSection(props: ProgressReviewsChartSectionPr
 
             <div className="progress-chart-columns">
               {visiblePage.days.map((day) => (
-                <ProgressReviewsChartColumn key={day.date} day={day} />
+                <ProgressReviewsChartColumn
+                  key={day.date}
+                  day={day}
+                  selection={selection}
+                  onSelectDay={onSelectDay}
+                />
               ))}
             </div>
           </div>
         </div>
       )}
+
+      {visiblePage !== null ? (
+        <ProgressReviewsRatingLegend
+          legendLabel={legendLabel}
+          items={ratingLegendItems}
+          onSelectRating={onSelectRating}
+        />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/screens/progress/reviewsChart/progressReviewsChartModel.ts
+++ b/apps/web/src/screens/progress/reviewsChart/progressReviewsChartModel.ts
@@ -1,23 +1,57 @@
 import type { Locale, LocaleDirection, LocaleWeekContext } from "../../../i18n";
+import type { TranslationKey, TranslationValues } from "../../../i18n";
 import { parseLocalDate, shiftLocalDate } from "../../../progress/progressDates";
 import type { DailyReviewPoint } from "../../../types";
 
 const chartGuideLineCount = 3;
 const chartWeekLength = 7;
+const progressReviewsChartRatingKeys = ["again", "hard", "good", "easy"] as const;
 
 type DateFormatter = (value: Date | number | string, options?: Readonly<Intl.DateTimeFormatOptions>) => string;
 type NumberFormatter = (value: number, options?: Readonly<Intl.NumberFormatOptions>) => string;
+type Translate = (key: TranslationKey, values?: TranslationValues) => string;
 type ChartNavigationDirection = "previous" | "next";
+
+export type ProgressReviewsChartRatingKey = typeof progressReviewsChartRatingKeys[number];
+
+export type ProgressReviewsChartSelection =
+  | Readonly<{ kind: "none" }>
+  | Readonly<{ kind: "day"; date: string }>
+  | Readonly<{ kind: "rating"; ratingKey: ProgressReviewsChartRatingKey }>;
+
+export type ChartRatingSegment = Readonly<{
+  ratingKey: ProgressReviewsChartRatingKey;
+  count: number;
+  color: string;
+  heightPercentage: number;
+}>;
+
+export type ChartRatingLegendItem = Readonly<{
+  ratingKey: ProgressReviewsChartRatingKey;
+  label: string;
+  count: number;
+  valueLabel: string;
+  color: string;
+  isSelected: boolean;
+  isDimmed: boolean;
+  isDisabled: boolean;
+}>;
 
 export type ChartDay = Readonly<{
   date: string;
   reviewCount: number;
+  againCount: number;
+  hardCount: number;
+  goodCount: number;
+  easyCount: number;
+  displayReviewCount: number;
   isToday: boolean;
   weekdayLabel: string;
   dayLabel: string;
   monthLabel: string;
   showMonthLabel: boolean;
   barHeightPercentage: number;
+  segments: ReadonlyArray<ChartRatingSegment>;
   title: string;
 }>;
 
@@ -28,6 +62,13 @@ export type ChartPage = Readonly<{
   startLocalDate: string;
   upperBound: number;
 }>;
+
+export const progressReviewsChartRatingColors: Readonly<Record<ProgressReviewsChartRatingKey, string>> = {
+  again: "#D7263D",
+  hard: "#E69F00",
+  good: "#2BB673",
+  easy: "#3F7CC8",
+};
 
 function formatLocalDateForDisplay(value: string, formatDate: DateFormatter): string {
   return formatDate(parseLocalDate(value), {
@@ -59,14 +100,49 @@ function formatMonthLabel(value: string, formatDate: DateFormatter): string {
   });
 }
 
-function createDailyReviewCountMap(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyMap<string, number> {
-  const reviewCounts = new Map<string, number>();
-
-  for (const day of dailyReviews) {
-    reviewCounts.set(day.date, day.reviewCount);
+function getDailyReviewRatingCount(
+  dailyReviewPoint: DailyReviewPoint,
+  ratingKey: ProgressReviewsChartRatingKey,
+): number {
+  if (ratingKey === "again") {
+    return dailyReviewPoint.againCount;
   }
 
-  return reviewCounts;
+  if (ratingKey === "hard") {
+    return dailyReviewPoint.hardCount;
+  }
+
+  if (ratingKey === "good") {
+    return dailyReviewPoint.goodCount;
+  }
+
+  return dailyReviewPoint.easyCount;
+}
+
+function getRatingLabel(ratingKey: ProgressReviewsChartRatingKey, t: Translate): string {
+  if (ratingKey === "again") {
+    return t("reviewScreen.ratings.again");
+  }
+
+  if (ratingKey === "hard") {
+    return t("reviewScreen.ratings.hard");
+  }
+
+  if (ratingKey === "good") {
+    return t("reviewScreen.ratings.good");
+  }
+
+  return t("reviewScreen.ratings.easy");
+}
+
+function createDailyReviewPointMap(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyMap<string, DailyReviewPoint> {
+  const dailyReviewPoints = new Map<string, DailyReviewPoint>();
+
+  for (const day of dailyReviews) {
+    dailyReviewPoints.set(day.date, day);
+  }
+
+  return dailyReviewPoints;
 }
 
 function getDayOfWeek(value: string): number {
@@ -80,8 +156,25 @@ function getStartOfWeek(value: string, weekContext: LocaleWeekContext): string {
   return shiftLocalDate(value, -offsetFromWeekStart);
 }
 
-function calculateMaxReviewCount(dailyReviews: ReadonlyArray<DailyReviewPoint>): number {
-  return dailyReviews.reduce((maxReviewCount, day) => Math.max(maxReviewCount, day.reviewCount), 0);
+function calculateDailyReviewPointDisplayCount(
+  dailyReviewPoint: DailyReviewPoint,
+  selectedRatingKey: ProgressReviewsChartRatingKey | null,
+): number {
+  if (selectedRatingKey === null) {
+    return dailyReviewPoint.reviewCount;
+  }
+
+  return getDailyReviewRatingCount(dailyReviewPoint, selectedRatingKey);
+}
+
+function calculateMaxReviewCount(
+  dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  selectedRatingKey: ProgressReviewsChartRatingKey | null,
+): number {
+  return dailyReviews.reduce(
+    (maxReviewCount, day) => Math.max(maxReviewCount, calculateDailyReviewPointDisplayCount(day, selectedRatingKey)),
+    0,
+  );
 }
 
 function calculateChartUpperBound(maxReviewCount: number): number {
@@ -100,25 +193,55 @@ function calculateBarHeightPercentage(reviewCount: number, upperBound: number): 
   return (reviewCount / upperBound) * 100;
 }
 
+function buildRatingSegments(
+  dailyReviewPoint: DailyReviewPoint,
+  displayReviewCount: number,
+  selectedRatingKey: ProgressReviewsChartRatingKey | null,
+): ReadonlyArray<ChartRatingSegment> {
+  const ratingKeys = selectedRatingKey === null ? progressReviewsChartRatingKeys : [selectedRatingKey];
+
+  return ratingKeys
+    .map((ratingKey): ChartRatingSegment => {
+      const count = getDailyReviewRatingCount(dailyReviewPoint, ratingKey);
+      return {
+        ratingKey,
+        count,
+        color: progressReviewsChartRatingColors[ratingKey],
+        heightPercentage: displayReviewCount <= 0 ? 0 : (count / displayReviewCount) * 100,
+      };
+    })
+    .filter((segment) => segment.count > 0);
+}
+
 function buildChartPage(
   dailyReviews: ReadonlyArray<DailyReviewPoint>,
   today: string,
   formatDate: DateFormatter,
+  selectedRatingKey: ProgressReviewsChartRatingKey | null,
 ): ChartPage {
-  const upperBound = calculateChartUpperBound(calculateMaxReviewCount(dailyReviews));
+  const upperBound = calculateChartUpperBound(calculateMaxReviewCount(dailyReviews, selectedRatingKey));
 
   return {
-    days: dailyReviews.map((day, dayIndex): ChartDay => ({
-      date: day.date,
-      reviewCount: day.reviewCount,
-      isToday: day.date === today,
-      weekdayLabel: formatWeekdayLabel(day.date, formatDate),
-      dayLabel: formatDayLabel(day.date, formatDate),
-      monthLabel: formatMonthLabel(day.date, formatDate),
-      showMonthLabel: dayIndex === 0 || dailyReviews[dayIndex - 1]?.date.slice(0, 7) !== day.date.slice(0, 7),
-      barHeightPercentage: calculateBarHeightPercentage(day.reviewCount, upperBound),
-      title: formatLocalDateForDisplay(day.date, formatDate),
-    })),
+    days: dailyReviews.map((day, dayIndex): ChartDay => {
+      const displayReviewCount = calculateDailyReviewPointDisplayCount(day, selectedRatingKey);
+      return {
+        date: day.date,
+        reviewCount: day.reviewCount,
+        againCount: day.againCount,
+        hardCount: day.hardCount,
+        goodCount: day.goodCount,
+        easyCount: day.easyCount,
+        displayReviewCount,
+        isToday: day.date === today,
+        weekdayLabel: formatWeekdayLabel(day.date, formatDate),
+        dayLabel: formatDayLabel(day.date, formatDate),
+        monthLabel: formatMonthLabel(day.date, formatDate),
+        showMonthLabel: dayIndex === 0 || dailyReviews[dayIndex - 1]?.date.slice(0, 7) !== day.date.slice(0, 7),
+        barHeightPercentage: calculateBarHeightPercentage(displayReviewCount, upperBound),
+        segments: buildRatingSegments(day, displayReviewCount, selectedRatingKey),
+        title: formatLocalDateForDisplay(day.date, formatDate),
+      };
+    }),
     startDate: dailyReviews[0]?.date ?? "",
     endDate: dailyReviews[dailyReviews.length - 1]?.date ?? "",
     startLocalDate: dailyReviews[0]?.date ?? "",
@@ -130,14 +253,18 @@ function padPageDaysToFullWeek(
   pageDays: ReadonlyArray<DailyReviewPoint>,
   weekStart: string,
 ): ReadonlyArray<DailyReviewPoint> {
-  const reviewCounts = createDailyReviewCountMap(pageDays);
+  const reviewCounts = createDailyReviewPointMap(pageDays);
   const fullWeek: Array<DailyReviewPoint> = [];
 
   for (let dayOffset = 0; dayOffset < chartWeekLength; dayOffset += 1) {
     const date = shiftLocalDate(weekStart, dayOffset);
-    fullWeek.push({
+    fullWeek.push(reviewCounts.get(date) ?? {
       date,
-      reviewCount: reviewCounts.get(date) ?? 0,
+      reviewCount: 0,
+      againCount: 0,
+      hardCount: 0,
+      goodCount: 0,
+      easyCount: 0,
     });
   }
 
@@ -149,6 +276,7 @@ export function buildChartPages(
   today: string,
   formatDate: DateFormatter,
   weekContext: LocaleWeekContext,
+  selectedRatingKey: ProgressReviewsChartRatingKey | null,
 ): ReadonlyArray<ChartPage> {
   if (dailyReviews.length === 0) {
     return [];
@@ -162,7 +290,12 @@ export function buildChartPages(
     const weekStart = getStartOfWeek(day.date, weekContext);
 
     if (currentWeekStart !== null && currentWeekStart !== weekStart) {
-      chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
+      chartPages.push(buildChartPage(
+        padPageDaysToFullWeek(currentPageDays, currentWeekStart),
+        today,
+        formatDate,
+        selectedRatingKey,
+      ));
       currentPageDays = [day];
       currentWeekStart = weekStart;
       continue;
@@ -173,10 +306,78 @@ export function buildChartPages(
   }
 
   if (currentPageDays.length > 0 && currentWeekStart !== null) {
-    chartPages.push(buildChartPage(padPageDaysToFullWeek(currentPageDays, currentWeekStart), today, formatDate));
+    chartPages.push(buildChartPage(
+      padPageDaysToFullWeek(currentPageDays, currentWeekStart),
+      today,
+      formatDate,
+      selectedRatingKey,
+    ));
   }
 
   return chartPages;
+}
+
+function createLegendSourceDays(
+  visiblePage: ChartPage | null,
+  selection: ProgressReviewsChartSelection,
+): ReadonlyArray<ChartDay> {
+  if (visiblePage === null) {
+    return [];
+  }
+
+  if (selection.kind !== "day") {
+    return visiblePage.days;
+  }
+
+  return visiblePage.days.filter((day) => day.date === selection.date);
+}
+
+function calculateLegendRatingCount(
+  sourceDays: ReadonlyArray<ChartDay>,
+  ratingKey: ProgressReviewsChartRatingKey,
+): number {
+  return sourceDays.reduce((count, day) => count + getDailyReviewRatingCount(day, ratingKey), 0);
+}
+
+function formatRatingPercentage(count: number, totalCount: number, formatNumber: NumberFormatter): string {
+  if (count <= 0 || totalCount <= 0) {
+    return formatNumber(0, {
+      style: "percent",
+      maximumFractionDigits: 0,
+    });
+  }
+
+  return formatNumber(count / totalCount, {
+    style: "percent",
+    maximumFractionDigits: 0,
+  });
+}
+
+export function buildChartRatingLegendItems(
+  visiblePage: ChartPage | null,
+  selection: ProgressReviewsChartSelection,
+  t: Translate,
+  formatNumber: NumberFormatter,
+): ReadonlyArray<ChartRatingLegendItem> {
+  const sourceDays = createLegendSourceDays(visiblePage, selection);
+  const totalCount = sourceDays.reduce((count, day) => count + day.reviewCount, 0);
+
+  return progressReviewsChartRatingKeys.map((ratingKey): ChartRatingLegendItem => {
+    const count = calculateLegendRatingCount(sourceDays, ratingKey);
+    const countLabel = formatNumber(count);
+    const percentageLabel = formatRatingPercentage(count, totalCount, formatNumber);
+    const isSelected = selection.kind === "rating" && selection.ratingKey === ratingKey;
+    return {
+      ratingKey,
+      label: getRatingLabel(ratingKey, t),
+      count,
+      valueLabel: `${countLabel} (${percentageLabel})`,
+      color: progressReviewsChartRatingColors[ratingKey],
+      isSelected,
+      isDimmed: selection.kind === "rating" && isSelected === false,
+      isDisabled: count === 0,
+    };
+  });
 }
 
 export function buildChartGuideLabels(upperBound: number, formatNumber: NumberFormatter): ReadonlyArray<string> {
@@ -206,6 +407,15 @@ export function formatChartRangeLabel(startDate: string, endDate: string, locale
     month: "short",
     day: "numeric",
   }).formatRange(parseLocalDate(startDate), parseLocalDate(endDate));
+}
+
+export function formatChartDayLabel(date: string, locale: Locale): string {
+  return new Intl.DateTimeFormat(locale, {
+    timeZone: "UTC",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(parseLocalDate(date));
 }
 
 export function resolveChartNavigationArrow(

--- a/apps/web/src/screens/review/tests/ReviewScreen.feedback-observability.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.feedback-observability.test.tsx
@@ -61,7 +61,7 @@ describe("ReviewScreen feedback observability", () => {
     state.appData.submitReviewItem.mockImplementation(async (): Promise<Card> => card);
     progressMocks.loadLocalProgressSummaryMock.mockRejectedValue(activityLoadError);
     progressMocks.loadLocalProgressDailyReviewsMock.mockResolvedValue([
-      { date: "2026-03-10", reviewCount: 15 },
+      { date: "2026-03-10", reviewCount: 15, againCount: 0, hardCount: 0, goodCount: 15, easyCount: 0 },
     ]);
 
     await renderReviewScreen();

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -273,14 +273,37 @@
 
 .progress-chart-column {
   display: grid;
+  height: 216px;
+}
+
+.progress-chart-column-button {
+  all: unset;
+  display: grid;
   grid-template-rows: minmax(0, 1fr) auto;
   gap: 8px;
   height: 216px;
+  min-width: 0;
+  cursor: pointer;
+  border-radius: var(--content-card-inner-radius, 8px);
+}
+
+.progress-chart-column-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .progress-chart-column-today .progress-chart-bar-shell {
   border-color: var(--accent-muted);
   background: var(--accent-soft);
+}
+
+.progress-chart-column.is-selected .progress-chart-bar-shell {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.progress-chart-column.is-dimmed .progress-chart-labels {
+  opacity: 0.45;
 }
 
 .progress-chart-bar-shell {
@@ -294,21 +317,26 @@
 }
 
 .progress-chart-bar {
+  display: flex;
+  flex-direction: column-reverse;
   width: 100%;
   height: 0;
   border-radius: var(--radius-sm) var(--radius-sm) 4px 4px;
-  background: rgba(255, 255, 255, 0.12);
+  overflow: hidden;
   transition: height 180ms ease;
 }
 
 .progress-chart-bar-active {
   min-height: 8px;
-  background: var(--accent);
+  background: rgba(255, 255, 255, 0.1);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
-.progress-chart-column-today .progress-chart-bar {
-  background: var(--accent);
+.progress-chart-bar-segment {
+  display: block;
+  width: 100%;
+  min-height: 1px;
+  transition: background-color 120ms ease, height 180ms ease;
 }
 
 .progress-chart-labels {
@@ -348,6 +376,84 @@
 .progress-chart-column-today .progress-chart-weekday {
   color: var(--accent);
   font-weight: 700;
+}
+
+.progress-chart-rating-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.progress-chart-rating-row {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--content-card-inner-radius, 8px);
+  transition: background-color 120ms ease, opacity 120ms ease;
+}
+
+.progress-chart-rating-row:last-child {
+  border-bottom: 0;
+}
+
+.progress-chart-rating-row.is-selected {
+  background: var(--accent-soft);
+  border-bottom-color: transparent;
+}
+
+.progress-chart-rating-row.is-dimmed {
+  opacity: 0.35;
+}
+
+.progress-chart-rating-row-button {
+  all: unset;
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: 34px;
+  width: 100%;
+  padding: 7px 8px;
+  box-sizing: border-box;
+  border-radius: var(--content-card-inner-radius, 8px);
+  cursor: pointer;
+}
+
+.progress-chart-rating-row-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.progress-chart-rating-row-button:disabled {
+  cursor: default;
+}
+
+.progress-chart-rating-swatch {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.08);
+}
+
+.progress-chart-rating-label {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.25;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.progress-chart-rating-value {
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-align: end;
 }
 
 .progress-review-schedule {
@@ -711,6 +817,10 @@ svg.progress-review-schedule-donut {
   }
 
   .progress-chart-column {
+    height: 180px;
+  }
+
+  .progress-chart-column-button {
     height: 180px;
   }
 

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -120,9 +120,15 @@ export type ProgressReviewScheduleInput = Readonly<{
 
 export type ProgressScopeKey = string;
 
+export type ReviewRating = 0 | 1 | 2 | 3;
+
 export type DailyReviewPoint = Readonly<{
   date: string;
   reviewCount: number;
+  againCount: number;
+  hardCount: number;
+  goodCount: number;
+  easyCount: number;
 }>;
 
 export type ProgressSummary = Readonly<{
@@ -788,7 +794,7 @@ export type ReviewEvent = Readonly<{
   cardId: string;
   replicaId: string;
   clientEventId: string;
-  rating: 0 | 1 | 2 | 3;
+  rating: ReviewRating;
   reviewedAtClient: string;
   reviewedAtServer: string;
 }>;
@@ -861,7 +867,7 @@ export type SyncPushOperation =
       reviewEventId: string;
       cardId: string;
       clientEventId: string;
-      rating: 0 | 1 | 2 | 3;
+      rating: ReviewRating;
       reviewedAtClient: string;
     }>;
   }>;


### PR DESCRIPTION
## Summary
- Parse, store, and merge daily review rating counts in the web progress flow.
- Render the Progress Reviews stacked bar chart with day and rating selection.
- Update web progress tests, local DB migration expectations, and localization labels.

## Validation
- npm exec -- tsc -b
- npm exec vitest run src/api/endpoints/endpoints.test.ts src/localDb/progress/progress.test.ts src/appData/progress/source/progressSource.summarySeries.test.tsx src/screens/progress/ProgressScreen.render.test.tsx src/localDb/core/core.migrations.test.ts src/appData/sync/observation/syncLifecycleObservation.test.ts src/appData/progress/source/progressSource.cache.test.tsx src/appData/progress/source/progressSource.lifecycle.test.tsx src/screens/progress/ProgressScreen.test.ts src/screens/review/tests/ReviewScreen.feedback-observability.test.tsx
- git --no-pager diff --check