### PR TITLE
Add Android progress review rating breakdown

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -132,13 +132,43 @@ internal fun parseCloudProgressSeriesResponse(
         dailyReviews = buildList {
             for (index in 0 until dailyReviews.length()) {
                 val point = dailyReviews.requireCloudObject(index, "$fieldPath.dailyReviews[$index]")
+                val pointFieldPath = "$fieldPath.dailyReviews[$index]"
+                val reviewCount = requireNonNegativeProgressCount(
+                    value = point.requireCloudInt("reviewCount", "$pointFieldPath.reviewCount"),
+                    fieldPath = "$pointFieldPath.reviewCount"
+                )
+                val againCount = requireNonNegativeProgressCount(
+                    value = point.requireCloudInt("againCount", "$pointFieldPath.againCount"),
+                    fieldPath = "$pointFieldPath.againCount"
+                )
+                val hardCount = requireNonNegativeProgressCount(
+                    value = point.requireCloudInt("hardCount", "$pointFieldPath.hardCount"),
+                    fieldPath = "$pointFieldPath.hardCount"
+                )
+                val goodCount = requireNonNegativeProgressCount(
+                    value = point.requireCloudInt("goodCount", "$pointFieldPath.goodCount"),
+                    fieldPath = "$pointFieldPath.goodCount"
+                )
+                val easyCount = requireNonNegativeProgressCount(
+                    value = point.requireCloudInt("easyCount", "$pointFieldPath.easyCount"),
+                    fieldPath = "$pointFieldPath.easyCount"
+                )
+                requireDailyReviewCountVector(
+                    reviewCount = reviewCount,
+                    againCount = againCount,
+                    hardCount = hardCount,
+                    goodCount = goodCount,
+                    easyCount = easyCount,
+                    fieldPath = pointFieldPath
+                )
                 add(
                     CloudDailyReviewPoint(
-                        date = point.requireCloudString("date", "$fieldPath.dailyReviews[$index].date"),
-                        reviewCount = point.requireCloudInt(
-                            "reviewCount",
-                            "$fieldPath.dailyReviews[$index].reviewCount"
-                        )
+                        date = point.requireCloudString("date", "$pointFieldPath.date"),
+                        reviewCount = reviewCount,
+                        againCount = againCount,
+                        hardCount = hardCount,
+                        goodCount = goodCount,
+                        easyCount = easyCount
                     )
                 )
             }
@@ -274,6 +304,33 @@ private fun requireNonNegativeReviewScheduleInt(
     }
 
     return value
+}
+
+private fun requireNonNegativeProgressCount(
+    value: Int,
+    fieldPath: String
+): Int {
+    if (value < 0) {
+        throw CloudContractMismatchException("$fieldPath must not be negative.")
+    }
+
+    return value
+}
+
+private fun requireDailyReviewCountVector(
+    reviewCount: Int,
+    againCount: Int,
+    hardCount: Int,
+    goodCount: Int,
+    easyCount: Int,
+    fieldPath: String
+) {
+    val ratingCountTotal = againCount + hardCount + goodCount + easyCount
+    if (reviewCount != ratingCountTotal) {
+        throw CloudContractMismatchException(
+            "$fieldPath.reviewCount expected rating bucket sum $ratingCountTotal but got $reviewCount."
+        )
+    }
 }
 
 // Shared between the live response and the local payload cache so both sides of the

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -60,7 +60,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 19,
+    version = 20,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
@@ -73,7 +73,11 @@ data class ProgressLocalDayCountEntity(
     val timeZone: String,
     val workspaceId: String,
     val localDate: String,
-    val reviewCount: Int
+    val reviewCount: Int,
+    val againCount: Int,
+    val hardCount: Int,
+    val goodCount: Int,
+    val easyCount: Int
 )
 
 @Entity(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -25,7 +25,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration15To16,
         migration16To17,
         migration17To18,
-        migration18To19
+        migration18To19,
+        migration19To20
     )
 }
 
@@ -724,5 +725,23 @@ val migration18To19: Migration = object : Migration(18, 19) {
             )
             """.trimIndent()
         )
+    }
+}
+
+val migration19To20: Migration = object : Migration(19, 20) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "ALTER TABLE progress_local_day_counts ADD COLUMN againCount INTEGER NOT NULL DEFAULT 0"
+        )
+        db.execSQL(
+            "ALTER TABLE progress_local_day_counts ADD COLUMN hardCount INTEGER NOT NULL DEFAULT 0"
+        )
+        db.execSQL(
+            "ALTER TABLE progress_local_day_counts ADD COLUMN goodCount INTEGER NOT NULL DEFAULT 0"
+        )
+        db.execSQL(
+            "ALTER TABLE progress_local_day_counts ADD COLUMN easyCount INTEGER NOT NULL DEFAULT 0"
+        )
+        db.execSQL("DELETE FROM progress_local_cache_state")
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
@@ -2,8 +2,35 @@ package com.flashcardsopensourceapp.data.local.model.progress
 
 data class CloudDailyReviewPoint(
     val date: String,
-    val reviewCount: Int
-)
+    val reviewCount: Int,
+    val againCount: Int,
+    val hardCount: Int,
+    val goodCount: Int,
+    val easyCount: Int
+) {
+    init {
+        require(reviewCount >= 0) {
+            "Daily review point '$date' reviewCount must not be negative."
+        }
+        require(againCount >= 0) {
+            "Daily review point '$date' againCount must not be negative."
+        }
+        require(hardCount >= 0) {
+            "Daily review point '$date' hardCount must not be negative."
+        }
+        require(goodCount >= 0) {
+            "Daily review point '$date' goodCount must not be negative."
+        }
+        require(easyCount >= 0) {
+            "Daily review point '$date' easyCount must not be negative."
+        }
+
+        val ratingCountTotal = againCount + hardCount + goodCount + easyCount
+        require(reviewCount == ratingCountTotal) {
+            "Daily review point '$date' reviewCount must equal rating count sum $ratingCountTotal."
+        }
+    }
+}
 
 data class ProgressReviewHistoryWatermark(
     val workspaceId: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/LocalProgressCacheStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/LocalProgressCacheStore.kt
@@ -6,6 +6,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.ProgressLocalCac
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressLocalDayCountEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewHistoryStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
+import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
 import java.time.Instant
 import java.time.ZoneId
@@ -31,7 +32,7 @@ class LocalProgressCacheStore(
                 reviewedAtMillis = reviewLog.reviewedAtMillis,
                 zoneId = zoneId
             ),
-            delta = 1
+            countDelta = createProgressRatingCountDelta(rating = reviewLog.rating)
         )
         database.progressLocalCacheDao().insertProgressReviewHistoryState(
             entry = ProgressReviewHistoryStateEntity(
@@ -77,7 +78,8 @@ class LocalProgressCacheStore(
             }
             if (
                 existingReviewLog.workspaceId != reviewLog.workspaceId ||
-                existingReviewLog.reviewedAtMillis != reviewLog.reviewedAtMillis
+                existingReviewLog.reviewedAtMillis != reviewLog.reviewedAtMillis ||
+                existingReviewLog.rating != reviewLog.rating
             ) {
                 replacementWorkspaceIds.add(existingReviewLog.workspaceId)
                 replacementWorkspaceIds.add(reviewLog.workspaceId)
@@ -117,7 +119,7 @@ class LocalProgressCacheStore(
                     timeZone = timeZone,
                     workspaceId = workspaceId,
                     localDate = localDate,
-                    delta = dateReviewLogs.size
+                    countDelta = createProgressRatingCountDelta(reviewLogs = dateReviewLogs)
                 )
             }
 
@@ -281,11 +283,16 @@ class LocalProgressCacheStore(
                 zoneId = zoneId
             )
         }.map { (localDate, dateReviewLogs) ->
+            val countDelta = createProgressRatingCountDelta(reviewLogs = dateReviewLogs)
             ProgressLocalDayCountEntity(
                 timeZone = timeZone,
                 workspaceId = workspaceId,
                 localDate = localDate,
-                reviewCount = dateReviewLogs.size
+                reviewCount = countDelta.reviewCount,
+                againCount = countDelta.againCount,
+                hardCount = countDelta.hardCount,
+                goodCount = countDelta.goodCount,
+                easyCount = countDelta.easyCount
             )
         }
         database.progressLocalCacheDao().insertProgressLocalDayCounts(entries = dayCounts)
@@ -313,20 +320,24 @@ class LocalProgressCacheStore(
         timeZone: String,
         workspaceId: String,
         localDate: String,
-        delta: Int
+        countDelta: ProgressRatingCountDelta
     ) {
         val existingEntry = database.progressLocalCacheDao().loadProgressLocalDayCount(
             timeZone = timeZone,
             workspaceId = workspaceId,
             localDate = localDate
         )
-        val nextReviewCount = (existingEntry?.reviewCount ?: 0) + delta
+        val nextReviewCount = (existingEntry?.reviewCount ?: 0) + countDelta.reviewCount
         database.progressLocalCacheDao().insertProgressLocalDayCount(
             entry = ProgressLocalDayCountEntity(
                 timeZone = timeZone,
                 workspaceId = workspaceId,
                 localDate = localDate,
-                reviewCount = nextReviewCount
+                reviewCount = nextReviewCount,
+                againCount = (existingEntry?.againCount ?: 0) + countDelta.againCount,
+                hardCount = (existingEntry?.hardCount ?: 0) + countDelta.hardCount,
+                goodCount = (existingEntry?.goodCount ?: 0) + countDelta.goodCount,
+                easyCount = (existingEntry?.easyCount ?: 0) + countDelta.easyCount
             )
         )
     }
@@ -345,6 +356,39 @@ class LocalProgressCacheStore(
         )
         return cacheState?.historyVersion == previousHistoryVersion
     }
+}
+
+private data class ProgressRatingCountDelta(
+    val reviewCount: Int,
+    val againCount: Int,
+    val hardCount: Int,
+    val goodCount: Int,
+    val easyCount: Int
+)
+
+private fun createProgressRatingCountDelta(
+    reviewLogs: List<ReviewLogEntity>
+): ProgressRatingCountDelta {
+    val ratingCounts = reviewLogs.groupingBy(ReviewLogEntity::rating).eachCount()
+    return ProgressRatingCountDelta(
+        reviewCount = reviewLogs.size,
+        againCount = ratingCounts[ReviewRating.AGAIN] ?: 0,
+        hardCount = ratingCounts[ReviewRating.HARD] ?: 0,
+        goodCount = ratingCounts[ReviewRating.GOOD] ?: 0,
+        easyCount = ratingCounts[ReviewRating.EASY] ?: 0
+    )
+}
+
+private fun createProgressRatingCountDelta(
+    rating: ReviewRating
+): ProgressRatingCountDelta {
+    return ProgressRatingCountDelta(
+        reviewCount = 1,
+        againCount = if (rating == ReviewRating.AGAIN) 1 else 0,
+        hardCount = if (rating == ReviewRating.HARD) 1 else 0,
+        goodCount = if (rating == ReviewRating.GOOD) 1 else 0,
+        easyCount = if (rating == ReviewRating.EASY) 1 else 0
+    )
 }
 
 private fun toLocalDate(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
@@ -70,6 +70,10 @@ internal fun CloudProgressSeries.toCacheEntity(
                     JSONObject()
                         .put("date", point.date)
                         .put("reviewCount", point.reviewCount)
+                        .put("againCount", point.againCount)
+                        .put("hardCount", point.hardCount)
+                        .put("goodCount", point.goodCount)
+                        .put("easyCount", point.easyCount)
                 )
             }
         }.toString(),
@@ -415,7 +419,11 @@ internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgr
                     add(
                         CloudDailyReviewPoint(
                             date = date,
-                            reviewCount = point.getInt("reviewCount")
+                            reviewCount = point.getInt("reviewCount"),
+                            againCount = point.getInt("againCount"),
+                            hardCount = point.getInt("hardCount"),
+                            goodCount = point.getInt("goodCount"),
+                            easyCount = point.getInt("easyCount")
                         )
                     )
                 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressPendingReviewInputs.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressPendingReviewInputs.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.data.local.repository.progress.inputs
 
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
+import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRepositoryWarning
 import java.time.Instant
 import java.time.ZoneId
@@ -8,7 +9,8 @@ import org.json.JSONObject
 
 internal data class ProgressPendingReviewLocalDate(
     val workspaceId: String,
-    val localDate: String
+    val localDate: String,
+    val rating: ReviewRating
 )
 
 internal data class ProgressPendingReviewFingerprintEntry(
@@ -44,8 +46,8 @@ internal fun createProgressPendingReviewLocalDates(
                 return@forEach
             }
 
-            val localDate = try {
-                entry.toPendingReviewLocalDate(zoneId = zoneId)
+            val pendingReviewInput = try {
+                entry.toPendingReviewInput(zoneId = zoneId)
             } catch (error: IllegalArgumentException) {
                 logProgressRepositoryWarning(
                     event = "progress_pending_overlay_entry_skipped",
@@ -61,7 +63,8 @@ internal fun createProgressPendingReviewLocalDates(
             add(
                 ProgressPendingReviewLocalDate(
                     workspaceId = entry.workspaceId,
-                    localDate = localDate
+                    localDate = pendingReviewInput.localDate,
+                    rating = pendingReviewInput.rating
                 )
             )
         }
@@ -81,9 +84,14 @@ internal fun hasPendingProgressReviewScheduleCardChanges(
     }
 }
 
-private fun OutboxEntryEntity.toPendingReviewLocalDate(
+private data class ProgressPendingReviewInput(
+    val localDate: String,
+    val rating: ReviewRating
+)
+
+private fun OutboxEntryEntity.toPendingReviewInput(
     zoneId: ZoneId
-): String {
+): ProgressPendingReviewInput {
     val payloadJsonObject = try {
         JSONObject(payloadJson)
     } catch (error: Exception) {
@@ -100,6 +108,18 @@ private fun OutboxEntryEntity.toPendingReviewLocalDate(
             error
         )
     }
+    val ratingOrdinal = try {
+        payloadJsonObject.getInt("rating")
+    } catch (error: Exception) {
+        throw IllegalArgumentException(
+            "Missing rating in pending review-event payload for outbox entry '$outboxEntryId': $payloadJson",
+            error
+        )
+    }
+    val rating = ReviewRating.entries.getOrNull(ratingOrdinal)
+        ?: throw IllegalArgumentException(
+            "Invalid rating '$ratingOrdinal' in pending review-event payload for outbox entry '$outboxEntryId'."
+        )
     val reviewedAtInstant = try {
         Instant.parse(reviewedAtClient)
     } catch (error: Exception) {
@@ -108,5 +128,8 @@ private fun OutboxEntryEntity.toPendingReviewLocalDate(
             error
         )
     }
-    return reviewedAtInstant.atZone(zoneId).toLocalDate().toString()
+    return ProgressPendingReviewInput(
+        localDate = reviewedAtInstant.atZone(zoneId).toLocalDate().toString(),
+        rating = rating
+    )
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressLocalFallbacks.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressLocalFallbacks.kt
@@ -13,6 +13,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewSched
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
+import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.repository.progress.inputs.ProgressPendingReviewLocalDate
 import java.time.LocalDate
 import java.time.ZoneId
@@ -88,9 +89,9 @@ internal fun createLocalFallbackSeries(
         from = scopeKey.from,
         to = scopeKey.to
     )
-    val reviewCountsByDate = linkedMapOf<String, Int>()
+    val reviewPointsByDate = linkedMapOf<String, CloudDailyReviewPoint>()
     dateRange.forEach { date ->
-        reviewCountsByDate[date] = 0
+        reviewPointsByDate[date] = createEmptyDailyReviewPoint(date = date)
     }
     localDayCounts.forEach { dayCount ->
         if (dayCount.timeZone != scopeKey.timeZone) {
@@ -99,22 +100,53 @@ internal fun createLocalFallbackSeries(
         if (workspaceIdSet.contains(dayCount.workspaceId).not()) {
             return@forEach
         }
-        if (reviewCountsByDate.containsKey(dayCount.localDate).not()) {
-            return@forEach
-        }
-        reviewCountsByDate[dayCount.localDate] = (reviewCountsByDate[dayCount.localDate] ?: 0) + dayCount.reviewCount
+        val existingPoint = reviewPointsByDate[dayCount.localDate] ?: return@forEach
+        reviewPointsByDate[dayCount.localDate] = existingPoint.copy(
+            reviewCount = existingPoint.reviewCount + dayCount.reviewCount,
+            againCount = existingPoint.againCount + dayCount.againCount,
+            hardCount = existingPoint.hardCount + dayCount.hardCount,
+            goodCount = existingPoint.goodCount + dayCount.goodCount,
+            easyCount = existingPoint.easyCount + dayCount.easyCount
+        )
     }
 
     return CloudProgressSeries(
         timeZone = scopeKey.timeZone,
         from = scopeKey.from,
         to = scopeKey.to,
-        dailyReviews = reviewCountsByDate.map { (date, reviewCount) ->
-            CloudDailyReviewPoint(
-                date = date,
-                reviewCount = reviewCount
-            )
-        },
+        dailyReviews = reviewPointsByDate.values.toList(),
+        generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
+        summary = null
+    )
+}
+
+internal fun createPendingLocalOverlaySeries(
+    scopeKey: ProgressSeriesScopeKey,
+    pendingReviewLocalDates: List<ProgressPendingReviewLocalDate>,
+    workspaceIds: List<String>
+): CloudProgressSeries {
+    val workspaceIdSet = workspaceIds.toSet()
+    val reviewPointsByDate = createInclusiveLocalDateRange(
+        from = scopeKey.from,
+        to = scopeKey.to
+    ).associateWith { date -> createEmptyDailyReviewPoint(date = date) }.toMutableMap()
+
+    pendingReviewLocalDates.forEach { pendingReview ->
+        if (workspaceIdSet.contains(pendingReview.workspaceId).not()) {
+            return@forEach
+        }
+        val existingPoint = reviewPointsByDate[pendingReview.localDate] ?: return@forEach
+        reviewPointsByDate[pendingReview.localDate] = existingPoint.incrementDailyReviewPoint(
+            rating = pendingReview.rating
+        )
+    }
+
+    return CloudProgressSeries(
+        timeZone = scopeKey.timeZone,
+        from = scopeKey.from,
+        to = scopeKey.to,
+        dailyReviews = reviewPointsByDate.values.toList(),
         generatedAt = null,
         reviewHistoryWatermarks = emptyList(),
         summary = null
@@ -161,44 +193,6 @@ internal fun createLocalFallbackReviewSchedule(
     )
 }
 
-internal fun createPendingLocalOverlaySeries(
-    scopeKey: ProgressSeriesScopeKey,
-    pendingReviewLocalDates: List<ProgressPendingReviewLocalDate>,
-    workspaceIds: List<String>
-): CloudProgressSeries {
-    val workspaceIdSet = workspaceIds.toSet()
-    val reviewCountsByDate = createInclusiveLocalDateRange(
-        from = scopeKey.from,
-        to = scopeKey.to
-    ).associateWith { 0 }.toMutableMap()
-
-    pendingReviewLocalDates.forEach { pendingReview ->
-        if (workspaceIdSet.contains(pendingReview.workspaceId).not()) {
-            return@forEach
-        }
-        if (reviewCountsByDate.containsKey(pendingReview.localDate).not()) {
-            return@forEach
-        }
-
-        reviewCountsByDate[pendingReview.localDate] = (reviewCountsByDate[pendingReview.localDate] ?: 0) + 1
-    }
-
-    return CloudProgressSeries(
-        timeZone = scopeKey.timeZone,
-        from = scopeKey.from,
-        to = scopeKey.to,
-        dailyReviews = reviewCountsByDate.map { (date, reviewCount) ->
-            CloudDailyReviewPoint(
-                date = date,
-                reviewCount = reviewCount
-            )
-        },
-        generatedAt = null,
-        reviewHistoryWatermarks = emptyList(),
-        summary = null
-    )
-}
-
 internal fun createEmptyProgressSummary(): CloudProgressSummary {
     return CloudProgressSummary(
         currentStreakDays = 0,
@@ -220,14 +214,36 @@ internal fun createEmptyProgressSeries(
             from = scopeKey.from,
             to = scopeKey.to
         ).map { date ->
-            CloudDailyReviewPoint(
-                date = date,
-                reviewCount = 0
-            )
+            createEmptyDailyReviewPoint(date = date)
         },
         generatedAt = null,
         reviewHistoryWatermarks = emptyList(),
         summary = null
+    )
+}
+
+private fun createEmptyDailyReviewPoint(
+    date: String
+): CloudDailyReviewPoint {
+    return CloudDailyReviewPoint(
+        date = date,
+        reviewCount = 0,
+        againCount = 0,
+        hardCount = 0,
+        goodCount = 0,
+        easyCount = 0
+    )
+}
+
+private fun CloudDailyReviewPoint.incrementDailyReviewPoint(
+    rating: ReviewRating
+): CloudDailyReviewPoint {
+    return copy(
+        reviewCount = reviewCount + 1,
+        againCount = againCount + if (rating == ReviewRating.AGAIN) 1 else 0,
+        hardCount = hardCount + if (rating == ReviewRating.HARD) 1 else 0,
+        goodCount = goodCount + if (rating == ReviewRating.GOOD) 1 else 0,
+        easyCount = easyCount + if (rating == ReviewRating.EASY) 1 else 0
     )
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotMerging.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotMerging.kt
@@ -223,17 +223,19 @@ internal fun mergeProgressSeries(
         pendingLocalOverlay = pendingLocalOverlay,
         localFallback = localFallback
     )
-    val pendingCountsByDate = buildProgressSeriesReviewCountsByDate(series = pendingLocalOverlay)
-    val localFallbackCountsByDate = buildProgressSeriesReviewCountsByDate(series = localFallback)
+    val pendingCountsByDate = buildProgressSeriesCountVectorsByDate(series = pendingLocalOverlay)
+    val localFallbackCountsByDate = buildProgressSeriesCountVectorsByDate(series = localFallback)
     val mergedDailyReviews = base.dailyReviews.map { point ->
-        val serverPlusPending = point.reviewCount + (pendingCountsByDate[point.date] ?: 0)
-        CloudDailyReviewPoint(
-            date = point.date,
-            reviewCount = maxOf(
-                serverPlusPending,
-                localFallbackCountsByDate[point.date] ?: 0
-            )
-        )
+        val serverPlusPending = point.toProgressSeriesCountVector()
+            .plus(pendingCountsByDate[point.date] ?: createEmptyProgressSeriesCountVector())
+        val localFallbackPoint = localFallbackCountsByDate[point.date] ?: createEmptyProgressSeriesCountVector()
+        val mergedPoint = if (localFallbackPoint.reviewCount > serverPlusPending.reviewCount) {
+            localFallbackPoint
+        } else {
+            serverPlusPending
+        }
+
+        mergedPoint.toCloudDailyReviewPoint(date = point.date)
     }
     return CloudProgressSeries(
         timeZone = base.timeZone,
@@ -504,6 +506,68 @@ private fun buildProgressSeriesReviewCountsByDate(
     return reviewCountsByDate
 }
 
+private data class ProgressSeriesCountVector(
+    val reviewCount: Int,
+    val againCount: Int,
+    val hardCount: Int,
+    val goodCount: Int,
+    val easyCount: Int
+) {
+    fun plus(other: ProgressSeriesCountVector): ProgressSeriesCountVector {
+        return ProgressSeriesCountVector(
+            reviewCount = reviewCount + other.reviewCount,
+            againCount = againCount + other.againCount,
+            hardCount = hardCount + other.hardCount,
+            goodCount = goodCount + other.goodCount,
+            easyCount = easyCount + other.easyCount
+        )
+    }
+}
+
+private fun createEmptyProgressSeriesCountVector(): ProgressSeriesCountVector {
+    return ProgressSeriesCountVector(
+        reviewCount = 0,
+        againCount = 0,
+        hardCount = 0,
+        goodCount = 0,
+        easyCount = 0
+    )
+}
+
+private fun buildProgressSeriesCountVectorsByDate(
+    series: CloudProgressSeries
+): Map<String, ProgressSeriesCountVector> {
+    val countVectorsByDate = linkedMapOf<String, ProgressSeriesCountVector>()
+    series.dailyReviews.forEach { point ->
+        countVectorsByDate[point.date] = (countVectorsByDate[point.date] ?: createEmptyProgressSeriesCountVector())
+            .plus(point.toProgressSeriesCountVector())
+    }
+    return countVectorsByDate
+}
+
+private fun CloudDailyReviewPoint.toProgressSeriesCountVector(): ProgressSeriesCountVector {
+    return ProgressSeriesCountVector(
+        reviewCount = reviewCount,
+        againCount = againCount,
+        hardCount = hardCount,
+        goodCount = goodCount,
+        easyCount = easyCount
+    )
+}
+
+private fun ProgressSeriesCountVector.toCloudDailyReviewPoint(
+    date: String
+): CloudDailyReviewPoint {
+    return CloudDailyReviewPoint(
+        date = date,
+        reviewCount = reviewCount,
+        againCount = againCount,
+        hardCount = hardCount,
+        goodCount = goodCount,
+        easyCount = easyCount
+    )
+}
+
 private fun hasProgressSeriesOverlay(
     base: CloudProgressSeries,
     renderedSeries: CloudProgressSeries
@@ -514,6 +578,10 @@ private fun hasProgressSeriesOverlay(
 
     return base.dailyReviews.zip(renderedSeries.dailyReviews).any { pair ->
         pair.first.date != pair.second.date ||
-            pair.first.reviewCount != pair.second.reviewCount
+            pair.first.reviewCount != pair.second.reviewCount ||
+            pair.first.againCount != pair.second.againCount ||
+            pair.first.hardCount != pair.second.hardCount ||
+            pair.first.goodCount != pair.second.goodCount ||
+            pair.first.easyCount != pair.second.easyCount
     }
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -149,7 +149,7 @@ class CloudRemoteServiceTest {
               "from": "2026-04-01",
               "to": "2026-04-03",
               "dailyReviews": [
-                { "date": "2026-04-01", "reviewCount": 3 }
+                { "date": "2026-04-01", "reviewCount": 3, "againCount": 1, "hardCount": 1, "goodCount": 1, "easyCount": 0 }
               ],
               "reviewHistoryWatermarks": [
                 { "workspaceId": "workspace-1", "reviewSequenceId": 42 }
@@ -168,6 +168,7 @@ class CloudRemoteServiceTest {
         assertEquals("2026-04-01", series.from)
         assertEquals("2026-04-03", series.to)
         assertEquals(3, series.dailyReviews.single().reviewCount)
+        assertEquals(1, series.dailyReviews.single().againCount)
         assertEquals(42L, series.reviewHistoryWatermarks.single().reviewSequenceId)
     }
 
@@ -180,7 +181,7 @@ class CloudRemoteServiceTest {
               "from": "2026-04-01",
               "to": "2026-04-03",
               "dailyReviews": [
-                { "date": "2026-04-01", "reviewCount": 3 }
+                { "date": "2026-04-01", "reviewCount": 3, "againCount": 0, "hardCount": 1, "goodCount": 2, "easyCount": 0 }
               ],
               "generatedAt": "2026-04-18T12:00:00Z"
             }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
@@ -47,7 +47,11 @@ internal fun createProgressLocalDayCount(
         timeZone = "Europe/Madrid",
         workspaceId = workspaceId,
         localDate = localDate,
-        reviewCount = reviewCount
+        reviewCount = reviewCount,
+        againCount = 0,
+        hardCount = 0,
+        goodCount = reviewCount,
+        easyCount = 0
     )
 }
 

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
@@ -176,7 +176,11 @@ class ProgressCacheValidationTest {
             dailyReviews = listOf(
                 CloudDailyReviewPoint(
                     date = seriesScopeKey.to,
-                    reviewCount = 2
+                    reviewCount = 2,
+                    againCount = 1,
+                    hardCount = 0,
+                    goodCount = 1,
+                    easyCount = 0
                 )
             ),
             generatedAt = "2026-04-18T10:00:00Z",
@@ -188,6 +192,10 @@ class ProgressCacheValidationTest {
             newCount = 1,
             todayCount = 2
         ).copy(reviewHistoryWatermarks = watermarks)
+        val cachedSeries = series.toCacheEntity(
+            scopeKey = seriesScopeKey,
+            updatedAtMillis = 1L
+        ).toCloudProgressSeriesOrNull()
 
         assertEquals(
             watermarks,
@@ -198,10 +206,11 @@ class ProgressCacheValidationTest {
         )
         assertEquals(
             watermarks,
-            series.toCacheEntity(
-                scopeKey = seriesScopeKey,
-                updatedAtMillis = 1L
-            ).toCloudProgressSeriesOrNull()?.reviewHistoryWatermarks
+            cachedSeries?.reviewHistoryWatermarks
+        )
+        assertEquals(
+            1,
+            cachedSeries?.dailyReviews?.single()?.againCount
         )
         assertEquals(
             watermarks,

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
@@ -112,6 +112,7 @@ class ProgressSeriesSnapshotTest {
 
         assertEquals(0, overlay.dailyReviews.first().reviewCount)
         assertEquals(1, overlay.dailyReviews.last().reviewCount)
+        assertEquals(1, overlay.dailyReviews.last().goodCount)
         assertEquals(3, snapshot.renderedSeries.dailyReviews.first().reviewCount)
         assertEquals(3, snapshot.renderedSeries.dailyReviews.last().reviewCount)
         assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
@@ -124,9 +125,12 @@ class ProgressSeriesSnapshotTest {
         val localFallback = createSeries(
             scopeKey = scopeKey,
             dailyReviews = listOf(
-                createPoint(
+                createRatedPoint(
                     date = "2026-04-18",
-                    reviewCount = 1
+                    againCount = 0,
+                    hardCount = 1,
+                    goodCount = 0,
+                    easyCount = 0
                 )
             ),
             generatedAt = null
@@ -161,6 +165,8 @@ class ProgressSeriesSnapshotTest {
         )
 
         assertEquals(1, snapshot.renderedSeries.dailyReviews.single().reviewCount)
+        assertEquals(1, snapshot.renderedSeries.dailyReviews.single().hardCount)
+        assertEquals(0, snapshot.renderedSeries.dailyReviews.single().goodCount)
         assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
         assertEquals(true, snapshot.isApproximate)
         assertEquals("2026-04-18T12:00:00Z", snapshot.renderedSeries.generatedAt)
@@ -220,9 +226,12 @@ class ProgressSeriesSnapshotTest {
         val localFallback = createSeries(
             scopeKey = scopeKey,
             dailyReviews = listOf(
-                createPoint(
+                createRatedPoint(
                     date = "2026-04-18",
-                    reviewCount = 2
+                    againCount = 2,
+                    hardCount = 0,
+                    goodCount = 0,
+                    easyCount = 0
                 )
             ),
             generatedAt = null
@@ -230,9 +239,12 @@ class ProgressSeriesSnapshotTest {
         val serverBase = createSeries(
             scopeKey = scopeKey,
             dailyReviews = listOf(
-                createPoint(
+                createRatedPoint(
                     date = "2026-04-18",
-                    reviewCount = 2
+                    againCount = 0,
+                    hardCount = 1,
+                    goodCount = 1,
+                    easyCount = 0
                 )
             ),
             generatedAt = "2026-04-18T12:00:00Z"
@@ -240,9 +252,12 @@ class ProgressSeriesSnapshotTest {
         val pendingLocalOverlay = createSeries(
             scopeKey = scopeKey,
             dailyReviews = listOf(
-                createPoint(
+                createRatedPoint(
                     date = "2026-04-18",
-                    reviewCount = 1
+                    againCount = 0,
+                    hardCount = 0,
+                    goodCount = 0,
+                    easyCount = 1
                 )
             ),
             generatedAt = null
@@ -257,6 +272,10 @@ class ProgressSeriesSnapshotTest {
         )
 
         assertEquals(3, snapshot.renderedSeries.dailyReviews.single().reviewCount)
+        assertEquals(0, snapshot.renderedSeries.dailyReviews.single().againCount)
+        assertEquals(1, snapshot.renderedSeries.dailyReviews.single().hardCount)
+        assertEquals(1, snapshot.renderedSeries.dailyReviews.single().goodCount)
+        assertEquals(1, snapshot.renderedSeries.dailyReviews.single().easyCount)
         assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
         assertEquals(true, snapshot.isApproximate)
     }
@@ -422,7 +441,28 @@ class ProgressSeriesSnapshotTest {
     ): CloudDailyReviewPoint {
         return CloudDailyReviewPoint(
             date = date,
-            reviewCount = reviewCount
+            reviewCount = reviewCount,
+            againCount = 0,
+            hardCount = 0,
+            goodCount = reviewCount,
+            easyCount = 0
+        )
+    }
+
+    private fun createRatedPoint(
+        date: String,
+        againCount: Int,
+        hardCount: Int,
+        goodCount: Int,
+        easyCount: Int
+    ): CloudDailyReviewPoint {
+        return CloudDailyReviewPoint(
+            date = date,
+            reviewCount = againCount + hardCount + goodCount + easyCount,
+            againCount = againCount,
+            hardCount = hardCount,
+            goodCount = goodCount,
+            easyCount = easyCount
         )
     }
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
@@ -654,10 +654,15 @@ class ProgressSummarySnapshotTest {
         val endDate = LocalDate.parse(scopeKey.to)
         while (date <= endDate) {
             val localDate = date.toString()
+            val reviewCount = reviewCountsByDate[localDate] ?: 0
             dailyReviews.add(
                 CloudDailyReviewPoint(
                     date = localDate,
-                    reviewCount = reviewCountsByDate[localDate] ?: 0
+                    reviewCount = reviewCount,
+                    againCount = 0,
+                    hardCount = 0,
+                    goodCount = reviewCount,
+                    easyCount = 0
                 )
             )
             date = date.plusDays(1L)

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
@@ -9,6 +9,10 @@ data class ProgressHistoryDayUiState(
     val date: LocalDate,
     val dayOfMonthLabel: String,
     val reviewCount: Int,
+    val againCount: Int,
+    val hardCount: Int,
+    val goodCount: Int,
+    val easyCount: Int,
     val isToday: Boolean
 )
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -130,7 +130,11 @@ class ProgressViewModel(
 
 private data class ParsedProgressPoint(
     val date: LocalDate,
-    val reviewCount: Int
+    val reviewCount: Int,
+    val againCount: Int,
+    val hardCount: Int,
+    val goodCount: Int,
+    val easyCount: Int
 )
 
 private data class ProgressWeekContext(
@@ -325,7 +329,11 @@ private fun CloudProgressReviewSchedule.toUiState(): ProgressReviewScheduleSecti
 private fun CloudDailyReviewPoint.toParsedProgressPoint(): ParsedProgressPoint {
     return ParsedProgressPoint(
         date = parseProgressDate(rawDate = date),
-        reviewCount = reviewCount
+        reviewCount = reviewCount,
+        againCount = againCount,
+        hardCount = hardCount,
+        goodCount = goodCount,
+        easyCount = easyCount
     )
 }
 
@@ -350,6 +358,10 @@ private fun List<ParsedProgressPoint>.toReviewDays(
             date = point.date,
             dayOfMonthLabel = point.date.dayOfMonth.toString(),
             reviewCount = point.reviewCount,
+            againCount = point.againCount,
+            hardCount = point.hardCount,
+            goodCount = point.goodCount,
+            easyCount = point.easyCount,
             isToday = point.date == today
         )
     }
@@ -438,6 +450,10 @@ private fun padReviewPageDaysToFullWeek(
             date = date,
             dayOfMonthLabel = date.dayOfMonth.toString(),
             reviewCount = 0,
+            againCount = 0,
+            hardCount = 0,
+            goodCount = 0,
+            easyCount = 0,
             isToday = date == today
         )
     }

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewsSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewsSection.kt
@@ -4,6 +4,7 @@ import android.icu.text.DateIntervalFormat
 import android.icu.util.DateInterval
 import android.icu.util.TimeZone
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -39,19 +41,28 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.flashcardsopensourceapp.feature.progress.ProgressHistoryDayUiState
+import com.flashcardsopensourceapp.feature.progress.ProgressReviewPageUiState
 import com.flashcardsopensourceapp.feature.progress.ProgressReviewsSectionUiState
 import com.flashcardsopensourceapp.feature.progress.R
+import java.text.NumberFormat
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Locale
+import kotlin.math.ceil
 
 private const val reviewChartVisibleGridLines: Int = 4
 private val reviewChartColumnSpacing = 6.dp
@@ -61,6 +72,31 @@ private val reviewChartHeight = 208.dp
 private val reviewChartBarAreaHeight = reviewChartHeight - reviewChartVerticalPadding * 2
 private val reviewChartAxisWidth = 28.dp
 private val reviewChartLabelHeight = 20.dp
+private val reviewAgainColor = Color(0xFFD7263D)
+private val reviewHardColor = Color(0xFFE69F00)
+private val reviewGoodColor = Color(0xFF2BB673)
+private val reviewEasyColor = Color(0xFF3F7CC8)
+
+private enum class ReviewRatingChartKey {
+    AGAIN,
+    HARD,
+    GOOD,
+    EASY
+}
+
+private data class ReviewRatingLegendRowUiState(
+    val key: ReviewRatingChartKey,
+    val labelResId: Int,
+    val count: Int,
+    val percentageLabel: String,
+    val color: Color,
+    val isSelected: Boolean
+)
+
+private data class ReviewChartBarSegment(
+    val count: Int,
+    val color: Color
+)
 
 @Composable
 internal fun ReviewsSectionCard(
@@ -75,12 +111,19 @@ internal fun ReviewsSectionCard(
     var selectedPageStartDateKey by rememberSaveable {
         mutableStateOf<String?>(null)
     }
+    var selectedReviewDateKey by rememberSaveable {
+        mutableStateOf<String?>(null)
+    }
+    var selectedRatingKey by rememberSaveable {
+        mutableStateOf<ReviewRatingChartKey?>(null)
+    }
     val pageStartDateKeys = remember(uiState.pages) {
         uiState.pages.map { page -> page.startDateKey }
     }
     val chartGridLineColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.45f)
     val previousWeekLabel = stringResource(id = R.string.progress_reviews_previous_week)
     val nextWeekLabel = stringResource(id = R.string.progress_reviews_next_week)
+    val clearSelectionLabel = stringResource(id = R.string.progress_reviews_chart_clear_content_description)
 
     LaunchedEffect(pageStartDateKeys) {
         if (selectedPageStartDateKey == null) {
@@ -104,6 +147,43 @@ internal fun ReviewsSectionCard(
         }
     }
     val visiblePage = uiState.pages.getOrNull(selectedPageIndex)
+    val hasChartSelection = selectedReviewDateKey != null || selectedRatingKey != null
+    val legendRows = remember(visiblePage, selectedRatingKey, locale) {
+        visiblePage?.let { page ->
+            createReviewRatingLegendRows(
+                page = page,
+                selectedRatingKey = selectedRatingKey,
+                locale = locale
+            )
+        } ?: emptyList()
+    }
+    val chartUpperBound = remember(visiblePage, selectedRatingKey) {
+        visiblePage?.let { page ->
+            calculateVisibleReviewChartUpperBound(
+                page = page,
+                selectedRatingKey = selectedRatingKey
+            )
+        } ?: 1
+    }
+    val selectedRatingCount = remember(legendRows, selectedRatingKey) {
+        selectedRatingKey?.let { ratingKey ->
+            legendRows.firstOrNull { row -> row.key == ratingKey }?.count
+        }
+    }
+
+    LaunchedEffect(visiblePage?.startDateKey, selectedReviewDateKey) {
+        val activePage = visiblePage ?: return@LaunchedEffect
+        val selectedDateKey = selectedReviewDateKey ?: return@LaunchedEffect
+        if (activePage.days.none { day -> day.date.toString() == selectedDateKey }) {
+            selectedReviewDateKey = null
+        }
+    }
+
+    LaunchedEffect(visiblePage?.startDateKey, selectedRatingKey, selectedRatingCount) {
+        if (selectedRatingKey != null && (selectedRatingCount == null || selectedRatingCount == 0)) {
+            selectedRatingKey = null
+        }
+    }
 
     Card(
         modifier = Modifier
@@ -192,7 +272,7 @@ internal fun ReviewsSectionCard(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     ReviewsYAxis(
-                        upperBound = page.upperBound,
+                        upperBound = chartUpperBound,
                         modifier = Modifier
                             .padding(top = 6.dp)
                             .width(reviewChartAxisWidth)
@@ -210,6 +290,16 @@ internal fun ReviewsSectionCard(
                                 .testTag(progressReviewsActivityChartTag)
                                 .clip(RoundedCornerShape(22.dp))
                                 .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+                                .clickable(enabled = hasChartSelection) {
+                                    selectedReviewDateKey = null
+                                    selectedRatingKey = null
+                                }
+                                .semantics {
+                                    if (hasChartSelection) {
+                                        contentDescription = clearSelectionLabel
+                                        role = Role.Button
+                                    }
+                                }
                                 .drawBehind {
                                     val lineStep = size.height / reviewChartVisibleGridLines.toFloat()
 
@@ -234,9 +324,25 @@ internal fun ReviewsSectionCard(
                                 modifier = Modifier.fillMaxSize()
                             ) {
                                 page.days.forEach { day ->
+                                    val dayKey = day.date.toString()
+                                    val isSelectedDay = selectedReviewDateKey == dayKey
+                                    val dayContentDescriptionLabel = remember(day.date, locale) {
+                                        formatProgressReviewDayContentDescriptionLabel(
+                                            date = day.date,
+                                            locale = locale
+                                        )
+                                    }
                                     ReviewBarColumn(
                                         day = day,
-                                        upperBound = page.upperBound,
+                                        contentDescriptionLabel = dayContentDescriptionLabel,
+                                        upperBound = chartUpperBound,
+                                        selectedRatingKey = selectedRatingKey,
+                                        isSelected = isSelectedDay,
+                                        isDimmed = selectedReviewDateKey != null && isSelectedDay.not(),
+                                        onClick = {
+                                            selectedReviewDateKey = dayKey
+                                            selectedRatingKey = null
+                                        },
                                         modifier = Modifier
                                             .weight(1f)
                                             .fillMaxHeight()
@@ -253,14 +359,29 @@ internal fun ReviewsSectionCard(
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             page.days.forEach { day ->
+                                val dayKey = day.date.toString()
+                                val isSelectedDay = selectedReviewDateKey == dayKey
                                 ReviewChartLabel(
                                     day = day,
+                                    isSelected = isSelectedDay,
+                                    isDimmed = selectedReviewDateKey != null && isSelectedDay.not(),
                                     modifier = Modifier
                                         .weight(1f)
                                         .height(reviewChartLabelHeight)
                                 )
                             }
                         }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        ReviewRatingLegend(
+                            rows = legendRows,
+                            onSelectRating = { ratingKey ->
+                                selectedRatingKey = ratingKey
+                                selectedReviewDateKey = null
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                        )
                     }
                 }
             }
@@ -294,44 +415,104 @@ private fun ReviewsYAxis(
 @Composable
 private fun ReviewBarColumn(
     day: ProgressHistoryDayUiState,
+    contentDescriptionLabel: String,
     upperBound: Int,
+    selectedRatingKey: ReviewRatingChartKey?,
+    isSelected: Boolean,
+    isDimmed: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier
 ) {
-    val backgroundColor = if (day.isToday && day.reviewCount == 0) {
+    val dimmedBarColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.62f)
+    val segments = createReviewChartBarSegments(
+        day = day,
+        selectedRatingKey = selectedRatingKey,
+        isDimmed = isDimmed,
+        dimmedBarColor = dimmedBarColor
+    )
+    val visibleReviewCount = segments.sumOf(ReviewChartBarSegment::count)
+    val backgroundColor = if (isDimmed) {
+        Color.Transparent
+    } else if (isSelected) {
+        MaterialTheme.colorScheme.primary.copy(alpha = 0.14f)
+    } else if (day.isToday && visibleReviewCount == 0) {
         MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
     } else {
         Color.Transparent
     }
-    val barColor = when {
-        day.reviewCount > 0 -> MaterialTheme.colorScheme.primary
-        day.isToday -> MaterialTheme.colorScheme.primary
-        else -> MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.48f)
+    val zeroBarColor = if (isDimmed) {
+        dimmedBarColor
+    } else if (isSelected || day.isToday) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.48f)
     }
     val barHeight = calculateBarHeight(
-        reviewCount = day.reviewCount,
+        reviewCount = visibleReviewCount,
         upperBound = upperBound,
         maxBarHeight = reviewChartBarAreaHeight
     )
+    val contentDescriptionText = if (isSelected) {
+        pluralStringResource(
+            id = R.plurals.progress_reviews_day_selected_content_description,
+            count = visibleReviewCount,
+            contentDescriptionLabel,
+            visibleReviewCount
+        )
+    } else {
+        pluralStringResource(
+            id = R.plurals.progress_reviews_day_content_description,
+            count = visibleReviewCount,
+            contentDescriptionLabel,
+            visibleReviewCount
+        )
+    }
 
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(14.dp))
-            .background(backgroundColor),
+            .background(backgroundColor)
+            .clickable(onClick = onClick)
+            .semantics {
+                contentDescription = contentDescriptionText
+                role = Role.Button
+                selected = isSelected
+            },
         contentAlignment = Alignment.BottomCenter
     ) {
-        Box(
-            modifier = Modifier
-                .width(18.dp)
-                .height(barHeight)
-                .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp, bottomStart = 8.dp, bottomEnd = 8.dp))
-                .background(barColor)
-        )
+        if (segments.isEmpty()) {
+            Box(
+                modifier = Modifier
+                    .width(18.dp)
+                    .height(barHeight)
+                    .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp, bottomStart = 8.dp, bottomEnd = 8.dp))
+                    .background(zeroBarColor)
+            )
+        } else {
+            Column(
+                modifier = Modifier
+                    .width(18.dp)
+                    .height(barHeight)
+                    .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp, bottomStart = 8.dp, bottomEnd = 8.dp))
+            ) {
+                segments.asReversed().forEach { segment ->
+                    Box(
+                        modifier = Modifier
+                            .weight(segment.count.toFloat())
+                            .fillMaxWidth()
+                            .background(segment.color)
+                    )
+                }
+            }
+        }
     }
 }
 
 @Composable
 private fun ReviewChartLabel(
     day: ProgressHistoryDayUiState,
+    isSelected: Boolean,
+    isDimmed: Boolean,
     modifier: Modifier
 ) {
     Box(
@@ -340,14 +521,109 @@ private fun ReviewChartLabel(
     ) {
         Text(
             text = day.dayOfMonthLabel,
-            color = if (day.isToday) {
+            color = if (isDimmed) {
+                MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.56f)
+            } else if (isSelected || day.isToday) {
                 MaterialTheme.colorScheme.primary
             } else {
                 MaterialTheme.colorScheme.onSurfaceVariant
             },
-            fontWeight = if (day.isToday) FontWeight.SemiBold else FontWeight.Normal,
+            fontWeight = if (isSelected || day.isToday) FontWeight.SemiBold else FontWeight.Normal,
             style = MaterialTheme.typography.labelSmall,
             textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun ReviewRatingLegend(
+    rows: List<ReviewRatingLegendRowUiState>,
+    onSelectRating: (ReviewRatingChartKey) -> Unit,
+    modifier: Modifier
+) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = modifier
+    ) {
+        rows.forEach { row ->
+            ReviewRatingLegendItem(
+                row = row,
+                onClick = {
+                    onSelectRating(row.key)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReviewRatingLegendItem(
+    row: ReviewRatingLegendRowUiState,
+    onClick: () -> Unit
+) {
+    val rowTextColor = if (row.count == 0) {
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.56f)
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    val rowBackgroundColor = if (row.isSelected) {
+        MaterialTheme.colorScheme.surfaceVariant
+    } else {
+        Color.Transparent
+    }
+    val isInteractive = row.count > 0
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(rowBackgroundColor)
+            .clickable(
+                enabled = isInteractive,
+                onClick = onClick
+            )
+            .padding(horizontal = 8.dp, vertical = 6.dp)
+            .semantics(mergeDescendants = true) {
+                if (isInteractive) {
+                    role = Role.Button
+                    selected = row.isSelected
+                }
+            }
+    ) {
+        Box(
+            modifier = Modifier
+                .width(10.dp)
+                .height(10.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(
+                    if (row.count == 0) {
+                        row.color.copy(alpha = 0.32f)
+                    } else {
+                        row.color
+                    }
+                )
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Text(
+            text = stringResource(id = row.labelResId),
+            color = rowTextColor,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.weight(1f)
+        )
+
+        Text(
+            text = stringResource(
+                id = R.string.progress_reviews_rating_count_percentage,
+                row.count,
+                row.percentageLabel
+            ),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.End
         )
     }
 }
@@ -362,6 +638,123 @@ private fun calculateBarHeight(
     }
 
     return (maxBarHeight * (reviewCount.toFloat() / upperBound.toFloat())).coerceAtLeast(8.dp)
+}
+
+private fun createReviewChartBarSegments(
+    day: ProgressHistoryDayUiState,
+    selectedRatingKey: ReviewRatingChartKey?,
+    isDimmed: Boolean,
+    dimmedBarColor: Color
+): List<ReviewChartBarSegment> {
+    val ratingKeys = selectedRatingKey?.let { ratingKey ->
+        listOf(ratingKey)
+    } ?: ReviewRatingChartKey.entries
+
+    return ratingKeys.mapNotNull { ratingKey ->
+        val count = ratingKey.reviewCount(day = day)
+        if (count == 0) {
+            return@mapNotNull null
+        }
+
+        ReviewChartBarSegment(
+            count = count,
+            color = if (isDimmed) {
+                dimmedBarColor
+            } else {
+                ratingKey.reviewColor()
+            }
+        )
+    }
+}
+
+private fun createReviewRatingLegendRows(
+    page: ProgressReviewPageUiState,
+    selectedRatingKey: ReviewRatingChartKey?,
+    locale: Locale
+): List<ReviewRatingLegendRowUiState> {
+    val totalReviewCount = page.days.sumOf(ProgressHistoryDayUiState::reviewCount)
+    return ReviewRatingChartKey.entries.map { ratingKey ->
+        val count = page.days.sumOf { day ->
+            ratingKey.reviewCount(day = day)
+        }
+        ReviewRatingLegendRowUiState(
+            key = ratingKey,
+            labelResId = ratingKey.labelResId(),
+            count = count,
+            percentageLabel = formatProgressReviewRatingPercentage(
+                count = count,
+                totalReviewCount = totalReviewCount,
+                locale = locale
+            ),
+            color = ratingKey.reviewColor(),
+            isSelected = selectedRatingKey == ratingKey
+        )
+    }
+}
+
+private fun calculateVisibleReviewChartUpperBound(
+    page: ProgressReviewPageUiState,
+    selectedRatingKey: ReviewRatingChartKey?
+): Int {
+    val maximumReviewCount = page.days.maxOfOrNull { day ->
+        selectedRatingKey?.reviewCount(day = day) ?: day.reviewCount
+    } ?: 0
+
+    return calculateReviewChartUpperBound(maximumReviewCount = maximumReviewCount)
+}
+
+private fun calculateReviewChartUpperBound(
+    maximumReviewCount: Int
+): Int {
+    if (maximumReviewCount <= 0) {
+        return 1
+    }
+
+    return maxOf(1, ceil(maximumReviewCount * 1.1).toInt())
+}
+
+private fun formatProgressReviewRatingPercentage(
+    count: Int,
+    totalReviewCount: Int,
+    locale: Locale
+): String {
+    val percentage = if (totalReviewCount == 0) {
+        0.0
+    } else {
+        count.toDouble() / totalReviewCount.toDouble()
+    }
+    return NumberFormat.getPercentInstance(locale).apply {
+        maximumFractionDigits = 0
+    }.format(percentage)
+}
+
+private fun ReviewRatingChartKey.reviewCount(
+    day: ProgressHistoryDayUiState
+): Int {
+    return when (this) {
+        ReviewRatingChartKey.AGAIN -> day.againCount
+        ReviewRatingChartKey.HARD -> day.hardCount
+        ReviewRatingChartKey.GOOD -> day.goodCount
+        ReviewRatingChartKey.EASY -> day.easyCount
+    }
+}
+
+private fun ReviewRatingChartKey.reviewColor(): Color {
+    return when (this) {
+        ReviewRatingChartKey.AGAIN -> reviewAgainColor
+        ReviewRatingChartKey.HARD -> reviewHardColor
+        ReviewRatingChartKey.GOOD -> reviewGoodColor
+        ReviewRatingChartKey.EASY -> reviewEasyColor
+    }
+}
+
+private fun ReviewRatingChartKey.labelResId(): Int {
+    return when (this) {
+        ReviewRatingChartKey.AGAIN -> R.string.progress_reviews_rating_again
+        ReviewRatingChartKey.HARD -> R.string.progress_reviews_rating_hard
+        ReviewRatingChartKey.GOOD -> R.string.progress_reviews_rating_good
+        ReviewRatingChartKey.EASY -> R.string.progress_reviews_rating_easy
+    }
 }
 
 private fun formatProgressReviewPageRange(
@@ -379,6 +772,15 @@ private fun formatProgressReviewPageRange(
             endDate.toUtcEpochMillis()
         )
     )
+}
+
+private fun formatProgressReviewDayContentDescriptionLabel(
+    date: LocalDate,
+    locale: Locale
+): String {
+    return DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+        .withLocale(locale)
+        .format(date)
 }
 
 private fun LocalDate.toUtcEpochMillis(): Long {

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -15,6 +15,12 @@
     <string name="progress_reviews_title">Reviews</string>
     <string name="progress_reviews_previous_week">Previous week</string>
     <string name="progress_reviews_next_week">Next week</string>
+    <string name="progress_reviews_rating_again">Again</string>
+    <string name="progress_reviews_rating_hard">Hard</string>
+    <string name="progress_reviews_rating_good">Good</string>
+    <string name="progress_reviews_rating_easy">Easy</string>
+    <string name="progress_reviews_rating_count_percentage">%1$d (%2$s)</string>
+    <string name="progress_reviews_chart_clear_content_description">Clear review chart selection</string>
     <string name="progress_review_schedule_title">Review schedule</string>
     <string name="progress_review_schedule_empty">No active cards yet.</string>
     <string name="progress_review_schedule_chart_content_description">Review schedule chart</string>
@@ -52,6 +58,14 @@
     <plurals name="progress_streak_summary_content_description">
         <item quantity="one">Review streak %d day.</item>
         <item quantity="other">Review streak %d days.</item>
+    </plurals>
+    <plurals name="progress_reviews_day_content_description">
+        <item quantity="one">Select %1$s, %2$d review.</item>
+        <item quantity="other">Select %1$s, %2$d reviews.</item>
+    </plurals>
+    <plurals name="progress_reviews_day_selected_content_description">
+        <item quantity="one">%1$s selected, %2$d review.</item>
+        <item quantity="other">%1$s selected, %2$d reviews.</item>
     </plurals>
     <plurals name="progress_leaderboard_participant_count">
         <item quantity="one">%1$s participant</item>

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
@@ -265,15 +265,15 @@ class ProgressViewModelTest {
                     from = "2026-04-13",
                     to = "2026-04-21",
                     dailyReviews = listOf(
-                        CloudDailyReviewPoint(date = "2026-04-13", reviewCount = 0),
-                        CloudDailyReviewPoint(date = "2026-04-14", reviewCount = 40),
-                        CloudDailyReviewPoint(date = "2026-04-15", reviewCount = 0),
-                        CloudDailyReviewPoint(date = "2026-04-16", reviewCount = 0),
-                        CloudDailyReviewPoint(date = "2026-04-17", reviewCount = 0),
-                        CloudDailyReviewPoint(date = "2026-04-18", reviewCount = 0),
-                        CloudDailyReviewPoint(date = "2026-04-19", reviewCount = 0),
-                        CloudDailyReviewPoint(date = "2026-04-20", reviewCount = 0),
-                        CloudDailyReviewPoint(date = "2026-04-21", reviewCount = 9)
+                        createDailyReviewPoint(date = "2026-04-13", reviewCount = 0),
+                        createDailyReviewPoint(date = "2026-04-14", reviewCount = 40),
+                        createDailyReviewPoint(date = "2026-04-15", reviewCount = 0),
+                        createDailyReviewPoint(date = "2026-04-16", reviewCount = 0),
+                        createDailyReviewPoint(date = "2026-04-17", reviewCount = 0),
+                        createDailyReviewPoint(date = "2026-04-18", reviewCount = 0),
+                        createDailyReviewPoint(date = "2026-04-19", reviewCount = 0),
+                        createDailyReviewPoint(date = "2026-04-20", reviewCount = 0),
+                        createDailyReviewPoint(date = "2026-04-21", reviewCount = 9)
                     )
                 )
             )
@@ -637,7 +637,7 @@ private fun createProgressSeriesSnapshot(): ProgressSeriesSnapshot {
         from = "2026-04-18",
         to = "2026-04-18",
         dailyReviews = listOf(
-            CloudDailyReviewPoint(
+            createDailyReviewPoint(
                 date = "2026-04-18",
                 reviewCount = 3
             )
@@ -675,7 +675,10 @@ private fun createProgressSeriesSnapshot(
             from = scopeKey.from,
             to = scopeKey.to,
             dailyReviews = dailyReviews.map { point ->
-                point.copy(reviewCount = 0)
+                createDailyReviewPoint(
+                    date = point.date,
+                    reviewCount = 0
+                )
             },
             generatedAt = null,
             reviewHistoryWatermarks = emptyList(),
@@ -950,9 +953,23 @@ private fun createDailyReviewPoints(
             nextDate
         }
     }.map { date ->
-        CloudDailyReviewPoint(
+        createDailyReviewPoint(
             date = date.toString(),
             reviewCount = 1
         )
     }.toList()
+}
+
+private fun createDailyReviewPoint(
+    date: String,
+    reviewCount: Int
+): CloudDailyReviewPoint {
+    return CloudDailyReviewPoint(
+        date = date,
+        reviewCount = reviewCount,
+        againCount = 0,
+        hardCount = 0,
+        goodCount = reviewCount,
+        easyCount = 0
+    )
 }


### PR DESCRIPTION
## Summary
- carry Android progress review rating counts through cloud parsing, Room cache, local fallback, pending overlay, merge logic, and cache JSON
- render stacked Material-native Reviews chart with day/rating selection and accessible rating controls
- update Android progress/cache tests and fixtures for the rating-count contract

## Validation
- git --no-pager diff --check
- ./gradlew not run per repository instruction requiring explicit Gradle approval