### PR TITLE
Add Android progress freeze support

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingAllScreenshotsScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingAllScreenshotsScript.kt
@@ -73,7 +73,9 @@ class MarketingAllScreenshotsScript {
 
         robot.prepareOpportunityCostReviewCardForReview(
             expectedReviewStreakDays = marketingScreenshotExpectedStreakDays,
-            expectedReviewedToday = true
+            expectedReviewedToday = true,
+            expectedFreezeAvailableCredits = marketingScreenshotExpectedFreezeAvailableCredits,
+            expectedFreezeCapacity = marketingScreenshotExpectedFreezeCapacity
         )
         assertScreenshotSaved(
             robot = robot,

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingRepositorySeedScenarios.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingRepositorySeedScenarios.kt
@@ -10,6 +10,8 @@ import java.time.ZoneId
 
 internal const val marketingScreenshotExpectedStreakDays: Int = 8
 internal const val marketingScreenshotExpectedActiveReviewDays: Int = 16
+internal const val marketingScreenshotExpectedFreezeAvailableCredits: Int = 2
+internal const val marketingScreenshotExpectedFreezeCapacity: Int = 2
 
 private data class MarketingReviewTimestamp(
     val daysAgo: Long,

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
@@ -160,13 +160,17 @@ internal class MarketingScreenshotRobot(
 
     fun prepareOpportunityCostReviewCardForReview(
         expectedReviewStreakDays: Int,
-        expectedReviewedToday: Boolean
+        expectedReviewedToday: Boolean,
+        expectedFreezeAvailableCredits: Int,
+        expectedFreezeCapacity: Int
     ) {
         openReviewTab()
         waitForReviewPrompt(frontText = localeConfig.reviewCard.frontText)
         waitForReviewProgressBadge(
             expectedReviewStreakDays = expectedReviewStreakDays,
-            expectedReviewedToday = expectedReviewedToday
+            expectedReviewedToday = expectedReviewedToday,
+            expectedFreezeAvailableCredits = expectedFreezeAvailableCredits,
+            expectedFreezeCapacity = expectedFreezeCapacity
         )
     }
 
@@ -325,13 +329,25 @@ internal class MarketingScreenshotRobot(
 
     private fun waitForReviewProgressBadge(
         expectedReviewStreakDays: Int,
-        expectedReviewedToday: Boolean
+        expectedReviewedToday: Boolean,
+        expectedFreezeAvailableCredits: Int,
+        expectedFreezeCapacity: Int
     ) {
-        val expectedContentDescription = composeRule.activity.resources.getQuantityString(
+        val expectedStreakContentDescription = composeRule.activity.resources.getQuantityString(
             ReviewFeatureR.plurals.review_progress_badge_content_description,
             expectedReviewStreakDays,
             expectedReviewStreakDays
         )
+        val expectedContentDescription = if (expectedFreezeCapacity > 0) {
+            val expectedFreezeContentDescription = composeRule.activity.getString(
+                ReviewFeatureR.string.review_progress_badge_freeze_bank_content_description,
+                expectedFreezeAvailableCredits,
+                expectedFreezeCapacity
+            )
+            "$expectedStreakContentDescription $expectedFreezeContentDescription"
+        } else {
+            expectedStreakContentDescription
+        }
         val expectedStateDescription = composeRule.activity.getString(
             if (expectedReviewedToday) {
                 ReviewFeatureR.string.review_progress_badge_reviewed_today

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
@@ -57,6 +57,8 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         ),
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 0,
+                            freezeAvailableCredits = 0,
+                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),
@@ -124,6 +126,8 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         ),
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 0,
+                            freezeAvailableCredits = 0,
+                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),
@@ -177,6 +181,8 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         ),
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 0,
+                            freezeAvailableCredits = 0,
+                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -98,6 +98,8 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         emptyState = ReviewEmptyState.SESSION_COMPLETE,
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 120,
+                            freezeAvailableCredits = 0,
+                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
@@ -112,6 +112,8 @@ class RtlLayoutTest : FirebaseAppInstrumentationTimeoutTest() {
                     ),
                     reviewProgressBadge = ReviewProgressBadgeState(
                         streakDays = 0,
+                        freezeAvailableCredits = 0,
+                        freezeCapacity = 0,
                         hasReviewedToday = false,
                         isInteractive = true
                     ),

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration14To17Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration14To17Test.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.data.local.database.migrations.migration14To1
 import com.flashcardsopensourceapp.data.local.database.migrations.migration15To16
 import com.flashcardsopensourceapp.data.local.database.migrations.migration16To17
 import com.flashcardsopensourceapp.data.local.database.migrations.migration17To18
+import com.flashcardsopensourceapp.data.local.database.migrations.migration20To21
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -22,6 +23,7 @@ private const val migration14To15DatabaseName: String = "migration-14-to-15-test
 private const val migration15To16DatabaseName: String = "migration-15-to-16-test.db"
 private const val migration16To17DatabaseName: String = "migration-16-to-17-test.db"
 private const val migration17To18DatabaseName: String = "migration-17-to-18-test.db"
+private const val migration20To21DatabaseName: String = "migration-20-to-21-test.db"
 
 @RunWith(AndroidJUnit4::class)
 class AppDatabaseMigration14To17Test {
@@ -43,6 +45,10 @@ class AppDatabaseMigration14To17Test {
         deleteMigrationDatabaseFixture(
             context = context,
             databaseName = migration17To18DatabaseName
+        )
+        deleteMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration20To21DatabaseName
         )
     }
 
@@ -202,6 +208,55 @@ class AppDatabaseMigration14To17Test {
                 readMigrationSingleString(
                     database = database,
                     sql = "SELECT reviewHistoryWatermarksJson FROM progress_review_schedule_cache WHERE scopeKey = 'schedule-scope'"
+                )
+            )
+        } finally {
+            database.close()
+            openHelper.close()
+        }
+    }
+
+    @Test
+    fun migration20To21AddsFreezeCacheColumnsAndClearsStaleProgressCaches(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        createVersion20Database(context = context)
+
+        val openHelper: SupportSQLiteOpenHelper = openMigrationDatabaseAtVersion(
+            context = context,
+            databaseName = migration20To21DatabaseName,
+            version = 20
+        )
+        val database: SupportSQLiteDatabase = openHelper.writableDatabase
+
+        try {
+            migration20To21.migrate(database)
+
+            assertEquals(
+                0L,
+                readMigrationSingleLong(
+                    database = database,
+                    sql = "SELECT COUNT(*) FROM progress_summary_cache"
+                )
+            )
+            assertEquals(
+                0L,
+                readMigrationSingleLong(
+                    database = database,
+                    sql = "SELECT COUNT(*) FROM progress_series_cache"
+                )
+            )
+            assertEquals(
+                0L,
+                readMigrationSingleLong(
+                    database = database,
+                    sql = "SELECT COUNT(longestStreakDays) FROM progress_summary_cache"
+                )
+            )
+            assertEquals(
+                0L,
+                readMigrationSingleLong(
+                    database = database,
+                    sql = "SELECT COUNT(streakDaysJson) FROM progress_series_cache"
                 )
             )
         } finally {
@@ -496,6 +551,98 @@ class AppDatabaseMigration14To17Test {
                     '2026-04-18',
                     '2026-04-18T10:00:00Z',
                     0,
+                    '[]',
+                    100
+                )
+                """.trimIndent()
+            )
+        }
+    }
+
+    private fun createVersion20Database(context: Context): Unit {
+        createMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration20To21DatabaseName,
+            version = 20
+        ) { sqliteDatabase: SQLiteDatabase ->
+            sqliteDatabase.execSQL(
+                """
+                CREATE TABLE progress_summary_cache (
+                    scopeKey TEXT NOT NULL PRIMARY KEY,
+                    scopeId TEXT NOT NULL,
+                    timeZone TEXT NOT NULL,
+                    generatedAt TEXT,
+                    reviewHistoryWatermarksJson TEXT NOT NULL,
+                    currentStreakDays INTEGER NOT NULL,
+                    hasReviewedToday INTEGER NOT NULL,
+                    lastReviewedOn TEXT,
+                    activeReviewDays INTEGER NOT NULL,
+                    updatedAtMillis INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                INSERT INTO progress_summary_cache (
+                    scopeKey,
+                    scopeId,
+                    timeZone,
+                    generatedAt,
+                    reviewHistoryWatermarksJson,
+                    currentStreakDays,
+                    hasReviewedToday,
+                    lastReviewedOn,
+                    activeReviewDays,
+                    updatedAtMillis
+                ) VALUES (
+                    'summary-scope',
+                    'scope-1',
+                    'Europe/Madrid',
+                    NULL,
+                    '[]',
+                    3,
+                    1,
+                    '2026-04-18',
+                    12,
+                    100
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                CREATE TABLE progress_series_cache (
+                    scopeKey TEXT NOT NULL PRIMARY KEY,
+                    scopeId TEXT NOT NULL,
+                    timeZone TEXT NOT NULL,
+                    fromLocalDate TEXT NOT NULL,
+                    toLocalDate TEXT NOT NULL,
+                    generatedAt TEXT,
+                    reviewHistoryWatermarksJson TEXT NOT NULL,
+                    dailyReviewsJson TEXT NOT NULL,
+                    updatedAtMillis INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            sqliteDatabase.execSQL(
+                """
+                INSERT INTO progress_series_cache (
+                    scopeKey,
+                    scopeId,
+                    timeZone,
+                    fromLocalDate,
+                    toLocalDate,
+                    generatedAt,
+                    reviewHistoryWatermarksJson,
+                    dailyReviewsJson,
+                    updatedAtMillis
+                ) VALUES (
+                    'series-scope',
+                    'scope-1',
+                    'Europe/Madrid',
+                    '2026-04-12',
+                    '2026-04-18',
+                    '2026-04-18T10:00:00Z',
+                    '[]',
                     '[]',
                     100
                 )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -25,12 +25,17 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewScheduleBucket
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 import org.json.JSONObject
 
 internal class CloudProgressRemoteApi(
@@ -124,11 +129,23 @@ internal fun parseCloudProgressSeriesResponse(
     fieldPath: String
 ): CloudProgressSeries {
     val dailyReviews = response.requireCloudArray("dailyReviews", "$fieldPath.dailyReviews")
+    val from = response.requireCloudString("from", "$fieldPath.from")
+    val to = response.requireCloudString("to", "$fieldPath.to")
+    val streakDays = response.toCloudProgressStreakDays(
+        fieldPath = fieldPath
+    )
+    validateCloudProgressStreakDaysForRange(
+        streakDays = streakDays,
+        from = from,
+        to = to,
+        streakDaysFieldPath = "$fieldPath.streakDays",
+        rangeFieldPath = fieldPath
+    )
 
     return CloudProgressSeries(
         timeZone = response.requireCloudString("timeZone", "$fieldPath.timeZone"),
-        from = response.requireCloudString("from", "$fieldPath.from"),
-        to = response.requireCloudString("to", "$fieldPath.to"),
+        from = from,
+        to = to,
         dailyReviews = buildList {
             for (index in 0 until dailyReviews.length()) {
                 val point = dailyReviews.requireCloudObject(index, "$fieldPath.dailyReviews[$index]")
@@ -173,6 +190,7 @@ internal fun parseCloudProgressSeriesResponse(
                 )
             }
         },
+        streakDays = streakDays,
         generatedAt = response.optCloudStringOrNull("generatedAt", "$fieldPath.generatedAt"),
         reviewHistoryWatermarks = response.requireProgressReviewHistoryWatermarks(
             fieldPath = fieldPath
@@ -186,12 +204,132 @@ private fun JSONObject.toCloudProgressSummary(
     reviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>
 ): CloudProgressSummary {
     return CloudProgressSummary(
-        currentStreakDays = requireCloudInt("currentStreakDays", "$fieldPath.currentStreakDays"),
+        currentStreakDays = requireNonNegativeProgressInt(
+            value = requireCloudInt("currentStreakDays", "$fieldPath.currentStreakDays"),
+            fieldPath = "$fieldPath.currentStreakDays"
+        ),
+        longestStreakDays = requireNonNegativeProgressInt(
+            value = requireCloudInt("longestStreakDays", "$fieldPath.longestStreakDays"),
+            fieldPath = "$fieldPath.longestStreakDays"
+        ),
         hasReviewedToday = requireCloudBoolean("hasReviewedToday", "$fieldPath.hasReviewedToday"),
         lastReviewedOn = requireCloudNullableString("lastReviewedOn", "$fieldPath.lastReviewedOn"),
-        activeReviewDays = requireCloudInt("activeReviewDays", "$fieldPath.activeReviewDays"),
+        activeReviewDays = requireNonNegativeProgressInt(
+            value = requireCloudInt("activeReviewDays", "$fieldPath.activeReviewDays"),
+            fieldPath = "$fieldPath.activeReviewDays"
+        ),
+        streakFreeze = requireCloudObject("streakFreeze", "$fieldPath.streakFreeze").toCloudProgressStreakFreeze(
+            fieldPath = "$fieldPath.streakFreeze"
+        ),
         reviewHistoryWatermarks = reviewHistoryWatermarks
     )
+}
+
+private fun JSONObject.toCloudProgressStreakFreeze(
+    fieldPath: String
+): CloudProgressStreakFreeze {
+    return CloudProgressStreakFreeze(
+        availableCredits = requireNonNegativeProgressInt(
+            value = requireCloudInt("availableCredits", "$fieldPath.availableCredits"),
+            fieldPath = "$fieldPath.availableCredits"
+        ),
+        capacity = requireNonNegativeProgressInt(
+            value = requireCloudInt("capacity", "$fieldPath.capacity"),
+            fieldPath = "$fieldPath.capacity"
+        ),
+        balanceUnits = requireNonNegativeProgressInt(
+            value = requireCloudInt("balanceUnits", "$fieldPath.balanceUnits"),
+            fieldPath = "$fieldPath.balanceUnits"
+        ),
+        unitsPerCredit = requirePositiveProgressInt(
+            value = requireCloudInt("unitsPerCredit", "$fieldPath.unitsPerCredit"),
+            fieldPath = "$fieldPath.unitsPerCredit"
+        ),
+        nextCreditProgressUnits = requireNonNegativeProgressInt(
+            value = requireCloudInt("nextCreditProgressUnits", "$fieldPath.nextCreditProgressUnits"),
+            fieldPath = "$fieldPath.nextCreditProgressUnits"
+        ),
+        nextCreditRequiredUnits = requirePositiveProgressInt(
+            value = requireCloudInt("nextCreditRequiredUnits", "$fieldPath.nextCreditRequiredUnits"),
+            fieldPath = "$fieldPath.nextCreditRequiredUnits"
+        )
+    )
+}
+
+private fun JSONObject.toCloudProgressStreakDays(
+    fieldPath: String
+): List<CloudProgressStreakDay> {
+    val streakDays = requireCloudArray("streakDays", "$fieldPath.streakDays")
+    return buildList {
+        for (index in 0 until streakDays.length()) {
+            val day = streakDays.requireCloudObject(index, "$fieldPath.streakDays[$index]")
+            add(
+                CloudProgressStreakDay(
+                    date = day.requireCloudString("date", "$fieldPath.streakDays[$index].date"),
+                    state = CloudProgressStreakDayState.fromWireKey(
+                        wireKey = day.requireCloudString("state", "$fieldPath.streakDays[$index].state")
+                    )
+                )
+            )
+        }
+    }
+}
+
+private fun validateCloudProgressStreakDaysForRange(
+    streakDays: List<CloudProgressStreakDay>,
+    from: String,
+    to: String,
+    streakDaysFieldPath: String,
+    rangeFieldPath: String
+) {
+    val expectedDates = createCloudProgressDateRange(
+        from = from,
+        to = to,
+        fieldPath = rangeFieldPath
+    )
+    val actualDates = streakDays.map(CloudProgressStreakDay::date)
+    if (actualDates != expectedDates) {
+        throw CloudContractMismatchException(
+            "$streakDaysFieldPath must cover every date from '$from' to '$to'."
+        )
+    }
+}
+
+private fun createCloudProgressDateRange(
+    from: String,
+    to: String,
+    fieldPath: String
+): List<String> {
+    val startDate = parseCloudProgressLocalDate(
+        value = from,
+        fieldPath = "$fieldPath.from"
+    )
+    val endDate = parseCloudProgressLocalDate(
+        value = to,
+        fieldPath = "$fieldPath.to"
+    )
+    if (startDate.isAfter(endDate)) {
+        throw CloudContractMismatchException("$fieldPath range start must not be after range end.")
+    }
+
+    val dates = mutableListOf<String>()
+    var currentDate = startDate
+    while (currentDate <= endDate) {
+        dates.add(currentDate.toString())
+        currentDate = currentDate.plusDays(1L)
+    }
+    return dates
+}
+
+private fun parseCloudProgressLocalDate(
+    value: String,
+    fieldPath: String
+): LocalDate {
+    return try {
+        LocalDate.parse(value)
+    } catch (error: DateTimeParseException) {
+        throw CloudContractMismatchException("$fieldPath must be a YYYY-MM-DD date.", error)
+    }
 }
 
 internal fun parseCloudProgressReviewScheduleResponse(
@@ -317,6 +455,17 @@ private fun requireNonNegativeProgressCount(
     return value
 }
 
+private fun requireNonNegativeProgressInt(
+    value: Int,
+    fieldPath: String
+): Int {
+    if (value < 0) {
+        throw CloudContractMismatchException("$fieldPath must not be negative.")
+    }
+
+    return value
+}
+
 private fun requireDailyReviewCountVector(
     reviewCount: Int,
     againCount: Int,
@@ -331,6 +480,17 @@ private fun requireDailyReviewCountVector(
             "$fieldPath.reviewCount expected rating bucket sum $ratingCountTotal but got $reviewCount."
         )
     }
+}
+
+private fun requirePositiveProgressInt(
+    value: Int,
+    fieldPath: String
+): Int {
+    if (value <= 0) {
+        throw CloudContractMismatchException("$fieldPath must be positive.")
+    }
+
+    return value
 }
 
 // Shared between the live response and the local payload cache so both sides of the

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -60,7 +60,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 20,
+    version = 21,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
@@ -13,9 +13,16 @@ data class ProgressSummaryCacheEntity(
     val generatedAt: String?,
     val reviewHistoryWatermarksJson: String,
     val currentStreakDays: Int,
+    val longestStreakDays: Int,
     val hasReviewedToday: Boolean,
     val lastReviewedOn: String?,
     val activeReviewDays: Int,
+    val streakFreezeAvailableCredits: Int,
+    val streakFreezeCapacity: Int,
+    val streakFreezeBalanceUnits: Int,
+    val streakFreezeUnitsPerCredit: Int,
+    val streakFreezeNextCreditProgressUnits: Int,
+    val streakFreezeNextCreditRequiredUnits: Int,
     val updatedAtMillis: Long
 )
 
@@ -29,6 +36,7 @@ data class ProgressSeriesCacheEntity(
     val generatedAt: String?,
     val reviewHistoryWatermarksJson: String,
     val dailyReviewsJson: String,
+    val streakDaysJson: String,
     val updatedAtMillis: Long
 )
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -26,7 +26,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration16To17,
         migration17To18,
         migration18To19,
-        migration19To20
+        migration19To20,
+        migration20To21
     )
 }
 
@@ -743,5 +744,60 @@ val migration19To20: Migration = object : Migration(19, 20) {
             "ALTER TABLE progress_local_day_counts ADD COLUMN easyCount INTEGER NOT NULL DEFAULT 0"
         )
         db.execSQL("DELETE FROM progress_local_cache_state")
+    }
+}
+
+val migration20To21: Migration = object : Migration(20, 21) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("DELETE FROM progress_summary_cache")
+        db.execSQL("DELETE FROM progress_series_cache")
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN longestStreakDays INTEGER NOT NULL DEFAULT 0
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN streakFreezeAvailableCredits INTEGER NOT NULL DEFAULT 0
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN streakFreezeCapacity INTEGER NOT NULL DEFAULT 0
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN streakFreezeBalanceUnits INTEGER NOT NULL DEFAULT 0
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN streakFreezeUnitsPerCredit INTEGER NOT NULL DEFAULT 1
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN streakFreezeNextCreditProgressUnits INTEGER NOT NULL DEFAULT 0
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN streakFreezeNextCreditRequiredUnits INTEGER NOT NULL DEFAULT 1
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            ALTER TABLE progress_series_cache
+            ADD COLUMN streakDaysJson TEXT NOT NULL DEFAULT '[]'
+            """.trimIndent()
+        )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
@@ -32,6 +32,43 @@ data class CloudDailyReviewPoint(
     }
 }
 
+enum class CloudProgressStreakDayState(
+    val wireKey: String
+) {
+    REVIEWED("reviewed"),
+    FROZEN("frozen"),
+    MISSED("missed"),
+    PENDING("pending");
+
+    companion object {
+        private val orderedEntries: List<CloudProgressStreakDayState> = listOf(
+            REVIEWED,
+            FROZEN,
+            MISSED,
+            PENDING
+        )
+
+        fun fromWireKey(wireKey: String): CloudProgressStreakDayState {
+            return orderedEntries.firstOrNull { state -> state.wireKey == wireKey }
+                ?: throw IllegalArgumentException("Unknown progress streak day state '$wireKey'.")
+        }
+    }
+}
+
+data class CloudProgressStreakDay(
+    val date: String,
+    val state: CloudProgressStreakDayState
+)
+
+data class CloudProgressStreakFreeze(
+    val availableCredits: Int,
+    val capacity: Int,
+    val balanceUnits: Int,
+    val unitsPerCredit: Int,
+    val nextCreditProgressUnits: Int,
+    val nextCreditRequiredUnits: Int
+)
+
 data class ProgressReviewHistoryWatermark(
     val workspaceId: String,
     val reviewSequenceId: Long
@@ -39,9 +76,11 @@ data class ProgressReviewHistoryWatermark(
 
 data class CloudProgressSummary(
     val currentStreakDays: Int,
+    val longestStreakDays: Int,
     val hasReviewedToday: Boolean,
     val lastReviewedOn: String?,
     val activeReviewDays: Int,
+    val streakFreeze: CloudProgressStreakFreeze,
     val reviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>
 )
 
@@ -50,6 +89,7 @@ data class CloudProgressSeries(
     val from: String,
     val to: String,
     val dailyReviews: List<CloudDailyReviewPoint>,
+    val streakDays: List<CloudProgressStreakDay>,
     val generatedAt: String?,
     val reviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>,
     val summary: CloudProgressSummary?

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
@@ -12,6 +12,9 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewScheduleBucket
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
@@ -20,6 +23,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewSched
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRepositoryWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.createInclusiveLocalDateRange
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.parseLocalDate
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.serializeProgressReviewScheduleScopeKey
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.serializeProgressReviewScheduleServerCacheKey
@@ -43,9 +47,16 @@ internal fun CloudProgressSummary.toCacheEntity(
             watermarks = reviewHistoryWatermarks
         ),
         currentStreakDays = currentStreakDays,
+        longestStreakDays = longestStreakDays,
         hasReviewedToday = hasReviewedToday,
         lastReviewedOn = lastReviewedOn,
         activeReviewDays = activeReviewDays,
+        streakFreezeAvailableCredits = streakFreeze.availableCredits,
+        streakFreezeCapacity = streakFreeze.capacity,
+        streakFreezeBalanceUnits = streakFreeze.balanceUnits,
+        streakFreezeUnitsPerCredit = streakFreeze.unitsPerCredit,
+        streakFreezeNextCreditProgressUnits = streakFreeze.nextCreditProgressUnits,
+        streakFreezeNextCreditRequiredUnits = streakFreeze.nextCreditRequiredUnits,
         updatedAtMillis = updatedAtMillis
     )
 }
@@ -77,6 +88,7 @@ internal fun CloudProgressSeries.toCacheEntity(
                 )
             }
         }.toString(),
+        streakDaysJson = serializeProgressStreakDays(streakDays = streakDays),
         updatedAtMillis = updatedAtMillis
     )
 }
@@ -337,10 +349,46 @@ internal fun ProgressSummaryCacheEntity.toCloudProgressSummaryOrNull(): CloudPro
             rawJson = reviewHistoryWatermarksJson
         )
         CloudProgressSummary(
-            currentStreakDays = currentStreakDays,
+            currentStreakDays = requireNonNegativeProgressCacheInt(
+                value = currentStreakDays,
+                fieldPath = "progressSummaryCache.currentStreakDays"
+            ),
+            longestStreakDays = requireNonNegativeProgressCacheInt(
+                value = longestStreakDays,
+                fieldPath = "progressSummaryCache.longestStreakDays"
+            ),
             hasReviewedToday = hasReviewedToday,
             lastReviewedOn = lastReviewedOn,
-            activeReviewDays = activeReviewDays,
+            activeReviewDays = requireNonNegativeProgressCacheInt(
+                value = activeReviewDays,
+                fieldPath = "progressSummaryCache.activeReviewDays"
+            ),
+            streakFreeze = CloudProgressStreakFreeze(
+                availableCredits = requireNonNegativeProgressCacheInt(
+                    value = streakFreezeAvailableCredits,
+                    fieldPath = "progressSummaryCache.streakFreezeAvailableCredits"
+                ),
+                capacity = requireNonNegativeProgressCacheInt(
+                    value = streakFreezeCapacity,
+                    fieldPath = "progressSummaryCache.streakFreezeCapacity"
+                ),
+                balanceUnits = requireNonNegativeProgressCacheInt(
+                    value = streakFreezeBalanceUnits,
+                    fieldPath = "progressSummaryCache.streakFreezeBalanceUnits"
+                ),
+                unitsPerCredit = requirePositiveProgressCacheInt(
+                    value = streakFreezeUnitsPerCredit,
+                    fieldPath = "progressSummaryCache.streakFreezeUnitsPerCredit"
+                ),
+                nextCreditProgressUnits = requireNonNegativeProgressCacheInt(
+                    value = streakFreezeNextCreditProgressUnits,
+                    fieldPath = "progressSummaryCache.streakFreezeNextCreditProgressUnits"
+                ),
+                nextCreditRequiredUnits = requirePositiveProgressCacheInt(
+                    value = streakFreezeNextCreditRequiredUnits,
+                    fieldPath = "progressSummaryCache.streakFreezeNextCreditRequiredUnits"
+                )
+            ),
             reviewHistoryWatermarks = reviewHistoryWatermarks
         )
     }.getOrElse { error ->
@@ -413,6 +461,12 @@ internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgr
         }
 
         val dailyReviewsArray = JSONArray(dailyReviewsJson)
+        val streakDays = parseProgressStreakDays(rawJson = streakDaysJson)
+        validateProgressStreakDaysForRange(
+            streakDays = streakDays,
+            from = fromLocalDate,
+            to = toLocalDate
+        )
         val reviewHistoryWatermarks = parseProgressReviewHistoryWatermarks(
             rawJson = reviewHistoryWatermarksJson
         )
@@ -437,6 +491,7 @@ internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgr
                     )
                 }
             },
+            streakDays = streakDays,
             generatedAt = generatedAt,
             reviewHistoryWatermarks = reviewHistoryWatermarks,
             summary = null
@@ -453,6 +508,58 @@ internal fun ProgressSeriesCacheEntity.toCloudProgressSeriesOrNull(): CloudProgr
             error = error
         )
         null
+    }
+}
+
+private fun serializeProgressStreakDays(
+    streakDays: List<CloudProgressStreakDay>
+): String {
+    return JSONArray().apply {
+        streakDays.forEach { day ->
+            put(
+                JSONObject()
+                    .put("date", day.date)
+                    .put("state", day.state.wireKey)
+            )
+        }
+    }.toString()
+}
+
+private fun parseProgressStreakDays(
+    rawJson: String
+): List<CloudProgressStreakDay> {
+    val streakDaysArray = JSONArray(rawJson)
+    return buildList {
+        for (index in 0 until streakDaysArray.length()) {
+            val day = streakDaysArray.getJSONObject(index)
+            val date = day.getString("date")
+            parseLocalDate(rawDate = date)
+            add(
+                CloudProgressStreakDay(
+                    date = date,
+                    state = CloudProgressStreakDayState.fromWireKey(
+                        wireKey = day.getString("state")
+                    )
+                )
+            )
+        }
+    }
+}
+
+private fun validateProgressStreakDaysForRange(
+    streakDays: List<CloudProgressStreakDay>,
+    from: String,
+    to: String
+) {
+    val expectedDates = createInclusiveLocalDateRange(
+        from = from,
+        to = to
+    )
+    val actualDates = streakDays.map(CloudProgressStreakDay::date)
+    if (actualDates != expectedDates) {
+        throw IllegalArgumentException(
+            "Progress series cache streakDays must cover the cached range from '$from' to '$to'."
+        )
     }
 }
 
@@ -505,4 +612,26 @@ private fun parseProgressReviewHistorySequenceId(watermark: JSONObject): Long {
     }
 
     return longValue
+}
+
+private fun requireNonNegativeProgressCacheInt(
+    value: Int,
+    fieldPath: String
+): Int {
+    if (value < 0) {
+        throw IllegalArgumentException("$fieldPath must not be negative.")
+    }
+
+    return value
+}
+
+private fun requirePositiveProgressCacheInt(
+    value: Int,
+    fieldPath: String
+): Int {
+    if (value <= 0) {
+        throw IllegalArgumentException("$fieldPath must be positive.")
+    }
+
+    return value
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressLocalFallbacks.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressLocalFallbacks.kt
@@ -52,15 +52,17 @@ internal fun createLocalFallbackSummary(
     ).sorted()
     val activeReviewDateSet = activeReviewDates.toSet()
     val lastReviewedOn = activeReviewDates.lastOrNull()
-    val currentStreakDays = computeCurrentStreakDays(
-        activeReviewDateSet = activeReviewDateSet,
+    val streakEvaluation = evaluateProgressStreakFreeze(
+        sortedActiveReviewLocalDates = activeReviewDates,
         today = today
     )
     return CloudProgressSummary(
-        currentStreakDays = currentStreakDays,
+        currentStreakDays = streakEvaluation.currentStreakDays,
+        longestStreakDays = streakEvaluation.longestStreakDays,
         hasReviewedToday = activeReviewDateSet.contains(today.toString()),
         lastReviewedOn = lastReviewedOn,
         activeReviewDays = activeReviewDates.size,
+        streakFreeze = streakEvaluation.streakFreeze,
         reviewHistoryWatermarks = emptyList()
     )
 }
@@ -70,13 +72,31 @@ internal fun createLocalFallbackActiveDates(
     localDayCounts: List<ProgressLocalDayCountEntity>,
     workspaceIds: List<String>
 ): Set<String> {
+    return createActiveReviewDatesForLocalDayCounts(
+        timeZone = scopeKey.timeZone,
+        localDayCounts = localDayCounts,
+        workspaceIds = workspaceIds
+    )
+}
+
+internal fun createProgressActiveReviewDateSet(
+    timeZone: String,
+    localDayCounts: List<ProgressLocalDayCountEntity>,
+    pendingReviewLocalDates: List<ProgressPendingReviewLocalDate>,
+    workspaceIds: List<String>
+): Set<String> {
     val workspaceIdSet = workspaceIds.toSet()
-    return localDayCounts.filter { dayCount ->
-        dayCount.timeZone == scopeKey.timeZone &&
-            workspaceIdSet.contains(dayCount.workspaceId) &&
-            dayCount.reviewCount > 0
-    }.map(ProgressLocalDayCountEntity::localDate)
+    val localActiveDates = createActiveReviewDatesForLocalDayCounts(
+        timeZone = timeZone,
+        localDayCounts = localDayCounts,
+        workspaceIds = workspaceIds
+    )
+    val pendingActiveDates = pendingReviewLocalDates.filter { pendingReview ->
+        workspaceIdSet.contains(pendingReview.workspaceId)
+    }.map(ProgressPendingReviewLocalDate::localDate)
         .toSet()
+
+    return localActiveDates + pendingActiveDates
 }
 
 internal fun createLocalFallbackSeries(
@@ -109,44 +129,23 @@ internal fun createLocalFallbackSeries(
             easyCount = existingPoint.easyCount + dayCount.easyCount
         )
     }
-
-    return CloudProgressSeries(
+    val activeReviewDates = createActiveReviewDatesForLocalDayCounts(
         timeZone = scopeKey.timeZone,
-        from = scopeKey.from,
-        to = scopeKey.to,
-        dailyReviews = reviewPointsByDate.values.toList(),
-        generatedAt = null,
-        reviewHistoryWatermarks = emptyList(),
-        summary = null
+        localDayCounts = localDayCounts,
+        workspaceIds = workspaceIds
     )
-}
-
-internal fun createPendingLocalOverlaySeries(
-    scopeKey: ProgressSeriesScopeKey,
-    pendingReviewLocalDates: List<ProgressPendingReviewLocalDate>,
-    workspaceIds: List<String>
-): CloudProgressSeries {
-    val workspaceIdSet = workspaceIds.toSet()
-    val reviewPointsByDate = createInclusiveLocalDateRange(
-        from = scopeKey.from,
-        to = scopeKey.to
-    ).associateWith { date -> createEmptyDailyReviewPoint(date = date) }.toMutableMap()
-
-    pendingReviewLocalDates.forEach { pendingReview ->
-        if (workspaceIdSet.contains(pendingReview.workspaceId).not()) {
-            return@forEach
-        }
-        val existingPoint = reviewPointsByDate[pendingReview.localDate] ?: return@forEach
-        reviewPointsByDate[pendingReview.localDate] = existingPoint.incrementDailyReviewPoint(
-            rating = pendingReview.rating
-        )
-    }
 
     return CloudProgressSeries(
         timeZone = scopeKey.timeZone,
         from = scopeKey.from,
         to = scopeKey.to,
         dailyReviews = reviewPointsByDate.values.toList(),
+        streakDays = createProgressStreakDaysForRange(
+            activeReviewDateSet = activeReviewDates,
+            from = scopeKey.from,
+            to = scopeKey.to,
+            today = parseLocalDate(rawDate = scopeKey.to)
+        ),
         generatedAt = null,
         reviewHistoryWatermarks = emptyList(),
         summary = null
@@ -193,12 +192,55 @@ internal fun createLocalFallbackReviewSchedule(
     )
 }
 
+internal fun createPendingLocalOverlaySeries(
+    scopeKey: ProgressSeriesScopeKey,
+    pendingReviewLocalDates: List<ProgressPendingReviewLocalDate>,
+    workspaceIds: List<String>
+): CloudProgressSeries {
+    val workspaceIdSet = workspaceIds.toSet()
+    val reviewPointsByDate = createInclusiveLocalDateRange(
+        from = scopeKey.from,
+        to = scopeKey.to
+    ).associateWith { date -> createEmptyDailyReviewPoint(date = date) }.toMutableMap()
+
+    pendingReviewLocalDates.forEach { pendingReview ->
+        if (workspaceIdSet.contains(pendingReview.workspaceId).not()) {
+            return@forEach
+        }
+        val existingPoint = reviewPointsByDate[pendingReview.localDate] ?: return@forEach
+        reviewPointsByDate[pendingReview.localDate] = existingPoint.incrementDailyReviewPoint(
+            rating = pendingReview.rating
+        )
+    }
+    val activeReviewDates = reviewPointsByDate.filter { entry ->
+        entry.value.reviewCount > 0
+    }.keys.toSet()
+
+    return CloudProgressSeries(
+        timeZone = scopeKey.timeZone,
+        from = scopeKey.from,
+        to = scopeKey.to,
+        dailyReviews = reviewPointsByDate.values.toList(),
+        streakDays = createProgressStreakDaysForRange(
+            activeReviewDateSet = activeReviewDates,
+            from = scopeKey.from,
+            to = scopeKey.to,
+            today = parseLocalDate(rawDate = scopeKey.to)
+        ),
+        generatedAt = null,
+        reviewHistoryWatermarks = emptyList(),
+        summary = null
+    )
+}
+
 internal fun createEmptyProgressSummary(): CloudProgressSummary {
     return CloudProgressSummary(
         currentStreakDays = 0,
+        longestStreakDays = 0,
         hasReviewedToday = false,
         lastReviewedOn = null,
         activeReviewDays = 0,
+        streakFreeze = createInitialProgressStreakFreeze(),
         reviewHistoryWatermarks = emptyList()
     )
 }
@@ -216,6 +258,12 @@ internal fun createEmptyProgressSeries(
         ).map { date ->
             createEmptyDailyReviewPoint(date = date)
         },
+        streakDays = createProgressStreakDaysForRange(
+            activeReviewDateSet = emptySet(),
+            from = scopeKey.from,
+            to = scopeKey.to,
+            today = parseLocalDate(rawDate = scopeKey.to)
+        ),
         generatedAt = null,
         reviewHistoryWatermarks = emptyList(),
         summary = null
@@ -262,4 +310,18 @@ internal fun createEmptyProgressReviewSchedule(
             )
         }
     )
+}
+
+private fun createActiveReviewDatesForLocalDayCounts(
+    timeZone: String,
+    localDayCounts: List<ProgressLocalDayCountEntity>,
+    workspaceIds: List<String>
+): Set<String> {
+    val workspaceIdSet = workspaceIds.toSet()
+    return localDayCounts.filter { dayCount ->
+        dayCount.timeZone == timeZone &&
+            workspaceIdSet.contains(dayCount.workspaceId) &&
+            dayCount.reviewCount > 0
+    }.map(ProgressLocalDayCountEntity::localDate)
+        .toSet()
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotDates.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotDates.kt
@@ -1,7 +1,39 @@
 package com.flashcardsopensourceapp.data.local.repository.progress.snapshots
 
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import java.time.LocalDate
 import java.time.format.DateTimeParseException
+
+private val progressStreakFreezePolicy = ProgressStreakFreezePolicy(
+    startCapacity = 2,
+    maxCapacity = 2,
+    unitsPerCredit = 10,
+    earnedUnitsPerStreakDay = 1
+)
+
+internal data class ProgressStreakFreezeEvaluation(
+    val currentStreakDays: Int,
+    val longestStreakDays: Int,
+    val streakFreeze: CloudProgressStreakFreeze,
+    val streakDays: List<CloudProgressStreakDay>
+)
+
+private data class ProgressStreakFreezePolicy(
+    val startCapacity: Int,
+    val maxCapacity: Int,
+    val unitsPerCredit: Int,
+    val earnedUnitsPerStreakDay: Int
+)
+
+private data class ProgressStreakComputationState(
+    val balanceUnits: Int,
+    val currentStreakDays: Int,
+    val longestStreakDays: Int,
+    val hasActiveSegment: Boolean,
+    val lastEvaluatedDate: LocalDate?
+)
 
 internal fun parseLocalDate(
     rawDate: String
@@ -30,23 +62,400 @@ internal fun createInclusiveLocalDateRange(
     return dates
 }
 
-internal fun computeCurrentStreakDays(
-    activeReviewDateSet: Set<String>,
+internal fun evaluateProgressStreakFreeze(
+    sortedActiveReviewLocalDates: List<String>,
     today: LocalDate
-): Int {
-    val anchorDate: LocalDate = when {
-        activeReviewDateSet.contains(today.toString()) -> today
-        activeReviewDateSet.contains(today.minusDays(1L).toString()) -> today.minusDays(1L)
-        else -> return 0
+): ProgressStreakFreezeEvaluation {
+    validateProgressStreakFreezePolicy(policy = progressStreakFreezePolicy)
+    validateSortedActiveReviewLocalDates(sortedActiveReviewLocalDates = sortedActiveReviewLocalDates)
+
+    val statesByDate = linkedMapOf<String, CloudProgressStreakDayState>()
+    val finalState = sortedActiveReviewLocalDates
+        .filter { localDate -> localDate <= today.toString() }
+        .map { localDate -> parseLocalDate(rawDate = localDate) }
+        .fold(createInitialStreakState(policy = progressStreakFreezePolicy)) { state, reviewDate ->
+            addReviewedStreakDay(
+                state = addNonReviewedStreakDaysBeforeReview(
+                    state = state,
+                    nextReviewDate = reviewDate,
+                    policy = progressStreakFreezePolicy,
+                    statesByDate = statesByDate
+                ),
+                date = reviewDate,
+                policy = progressStreakFreezePolicy,
+                statesByDate = statesByDate
+            )
+        }.let { stateAfterReviews ->
+            addTrailingStreakDaysThroughToday(
+                state = stateAfterReviews,
+                today = today,
+                policy = progressStreakFreezePolicy,
+                statesByDate = statesByDate
+            )
+        }
+
+    return ProgressStreakFreezeEvaluation(
+        currentStreakDays = finalState.currentStreakDays,
+        longestStreakDays = finalState.longestStreakDays,
+        streakFreeze = createProgressStreakFreeze(
+            balanceUnits = finalState.balanceUnits,
+            policy = progressStreakFreezePolicy
+        ),
+        streakDays = createProgressStreakDays(statesByDate = statesByDate)
+    )
+}
+
+internal fun createProgressStreakDaysForRange(
+    activeReviewDateSet: Set<String>,
+    from: String,
+    to: String,
+    today: LocalDate
+): List<CloudProgressStreakDay> {
+    val evaluation = evaluateProgressStreakFreeze(
+        sortedActiveReviewLocalDates = activeReviewDateSet.sorted(),
+        today = today
+    )
+    val evaluatedStatesByDate = evaluation.streakDays.associate { day ->
+        day.date to day.state
     }
 
-    var streakDays = 0
-    var currentDate = anchorDate
-    while (activeReviewDateSet.contains(currentDate.toString())) {
-        streakDays += 1
-        currentDate = currentDate.minusDays(1L)
+    return createInclusiveLocalDateRange(
+        from = from,
+        to = to
+    ).map { date ->
+        val state = when {
+            activeReviewDateSet.contains(date) -> CloudProgressStreakDayState.REVIEWED
+            evaluatedStatesByDate[date] != null -> checkNotNull(evaluatedStatesByDate[date])
+            date >= today.toString() -> CloudProgressStreakDayState.PENDING
+            else -> CloudProgressStreakDayState.MISSED
+        }
+        CloudProgressStreakDay(
+            date = date,
+            state = state
+        )
     }
-    return streakDays
+}
+
+internal fun createInitialProgressStreakFreeze(): CloudProgressStreakFreeze {
+    return createProgressStreakFreeze(
+        balanceUnits = getInitialBalanceUnits(policy = progressStreakFreezePolicy),
+        policy = progressStreakFreezePolicy
+    )
+}
+
+internal fun addReviewedDayProgressStreakFreezeCredit(
+    streakFreeze: CloudProgressStreakFreeze
+): CloudProgressStreakFreeze {
+    return addProgressStreakFreezeBalanceUnits(
+        streakFreeze = streakFreeze,
+        addedBalanceUnits = progressStreakFreezePolicy.earnedUnitsPerStreakDay
+    )
+}
+
+internal fun refundSpentProgressStreakFreezeCredit(
+    streakFreeze: CloudProgressStreakFreeze
+): CloudProgressStreakFreeze {
+    return addProgressStreakFreezeBalanceUnits(
+        streakFreeze = streakFreeze,
+        addedBalanceUnits = streakFreeze.unitsPerCredit
+    )
+}
+
+private fun addProgressStreakFreezeBalanceUnits(
+    streakFreeze: CloudProgressStreakFreeze,
+    addedBalanceUnits: Int
+): CloudProgressStreakFreeze {
+    val balanceUnits = minOf(
+        streakFreeze.balanceUnits + addedBalanceUnits,
+        streakFreeze.capacity * streakFreeze.unitsPerCredit
+    )
+    val availableCredits = minOf(
+        streakFreeze.capacity,
+        balanceUnits / streakFreeze.unitsPerCredit
+    )
+
+    return streakFreeze.copy(
+        availableCredits = availableCredits,
+        balanceUnits = balanceUnits,
+        nextCreditProgressUnits = if (availableCredits >= streakFreeze.capacity) {
+            0
+        } else {
+            balanceUnits % streakFreeze.unitsPerCredit
+        },
+        nextCreditRequiredUnits = streakFreeze.unitsPerCredit
+    )
+}
+
+private fun validateProgressStreakFreezePolicy(
+    policy: ProgressStreakFreezePolicy
+) {
+    if (policy.startCapacity < 0) {
+        throw IllegalArgumentException("streak freeze startCapacity must be a non-negative integer.")
+    }
+    if (policy.maxCapacity < 0) {
+        throw IllegalArgumentException("streak freeze maxCapacity must be a non-negative integer.")
+    }
+    if (policy.unitsPerCredit <= 0) {
+        throw IllegalArgumentException("streak freeze unitsPerCredit must be a positive integer.")
+    }
+    if (policy.earnedUnitsPerStreakDay < 0) {
+        throw IllegalArgumentException("streak freeze earnedUnitsPerStreakDay must be a non-negative integer.")
+    }
+}
+
+private fun validateSortedActiveReviewLocalDates(
+    sortedActiveReviewLocalDates: List<String>
+) {
+    var previousDate: String? = null
+    sortedActiveReviewLocalDates.forEach { localDate ->
+        parseLocalDate(rawDate = localDate)
+        val previous = previousDate
+        if (previous != null && previous >= localDate) {
+            throw IllegalArgumentException("Active review local dates must be sorted ascending without duplicates.")
+        }
+        previousDate = localDate
+    }
+}
+
+private fun createInitialStreakState(
+    policy: ProgressStreakFreezePolicy
+): ProgressStreakComputationState {
+    return ProgressStreakComputationState(
+        balanceUnits = getInitialBalanceUnits(policy = policy),
+        currentStreakDays = 0,
+        longestStreakDays = 0,
+        hasActiveSegment = false,
+        lastEvaluatedDate = null
+    )
+}
+
+private fun addReviewedStreakDay(
+    state: ProgressStreakComputationState,
+    date: LocalDate,
+    policy: ProgressStreakFreezePolicy,
+    statesByDate: MutableMap<String, CloudProgressStreakDayState>
+): ProgressStreakComputationState {
+    val balanceUnits = addStreakDayEarnedUnits(
+        balanceUnits = if (state.hasActiveSegment) {
+            state.balanceUnits
+        } else {
+            getInitialBalanceUnits(policy = policy)
+        },
+        policy = policy
+    )
+    val currentStreakDays = if (state.hasActiveSegment) {
+        state.currentStreakDays + 1
+    } else {
+        1
+    }
+    statesByDate[date.toString()] = CloudProgressStreakDayState.REVIEWED
+
+    return ProgressStreakComputationState(
+        balanceUnits = balanceUnits,
+        currentStreakDays = currentStreakDays,
+        longestStreakDays = maxOf(state.longestStreakDays, currentStreakDays),
+        hasActiveSegment = true,
+        lastEvaluatedDate = date
+    )
+}
+
+private fun addFrozenStreakDay(
+    state: ProgressStreakComputationState,
+    date: LocalDate,
+    policy: ProgressStreakFreezePolicy,
+    statesByDate: MutableMap<String, CloudProgressStreakDayState>
+): ProgressStreakComputationState {
+    val balanceUnitsAfterSpend = state.balanceUnits - policy.unitsPerCredit
+    val balanceUnits = addStreakDayEarnedUnits(
+        balanceUnits = balanceUnitsAfterSpend,
+        policy = policy
+    )
+    val currentStreakDays = state.currentStreakDays + 1
+    statesByDate[date.toString()] = CloudProgressStreakDayState.FROZEN
+
+    return ProgressStreakComputationState(
+        balanceUnits = balanceUnits,
+        currentStreakDays = currentStreakDays,
+        longestStreakDays = maxOf(state.longestStreakDays, currentStreakDays),
+        hasActiveSegment = true,
+        lastEvaluatedDate = date
+    )
+}
+
+private fun addMissedStreakDay(
+    state: ProgressStreakComputationState,
+    date: LocalDate,
+    policy: ProgressStreakFreezePolicy,
+    statesByDate: MutableMap<String, CloudProgressStreakDayState>
+): ProgressStreakComputationState {
+    statesByDate[date.toString()] = CloudProgressStreakDayState.MISSED
+
+    return ProgressStreakComputationState(
+        balanceUnits = getInitialBalanceUnits(policy = policy),
+        currentStreakDays = 0,
+        longestStreakDays = state.longestStreakDays,
+        hasActiveSegment = false,
+        lastEvaluatedDate = date
+    )
+}
+
+private fun addPendingStreakDay(
+    state: ProgressStreakComputationState,
+    date: LocalDate,
+    statesByDate: MutableMap<String, CloudProgressStreakDayState>
+): ProgressStreakComputationState {
+    statesByDate[date.toString()] = CloudProgressStreakDayState.PENDING
+
+    return state.copy(lastEvaluatedDate = date)
+}
+
+private fun addNonReviewedCompletedStreakDay(
+    state: ProgressStreakComputationState,
+    date: LocalDate,
+    policy: ProgressStreakFreezePolicy,
+    statesByDate: MutableMap<String, CloudProgressStreakDayState>
+): ProgressStreakComputationState {
+    val hasFreezeCredit = getAvailableCredits(
+        balanceUnits = state.balanceUnits,
+        policy = policy
+    ) > 0
+    return if (state.hasActiveSegment && hasFreezeCredit) {
+        addFrozenStreakDay(
+            state = state,
+            date = date,
+            policy = policy,
+            statesByDate = statesByDate
+        )
+    } else {
+        addMissedStreakDay(
+            state = state,
+            date = date,
+            policy = policy,
+            statesByDate = statesByDate
+        )
+    }
+}
+
+private fun addNonReviewedStreakDaysBeforeReview(
+    state: ProgressStreakComputationState,
+    nextReviewDate: LocalDate,
+    policy: ProgressStreakFreezePolicy,
+    statesByDate: MutableMap<String, CloudProgressStreakDayState>
+): ProgressStreakComputationState {
+    var currentState = state
+    var currentDate = currentState.lastEvaluatedDate?.plusDays(1L) ?: nextReviewDate
+
+    while (currentState.lastEvaluatedDate != null && currentDate.isBefore(nextReviewDate)) {
+        currentState = addNonReviewedCompletedStreakDay(
+            state = currentState,
+            date = currentDate,
+            policy = policy,
+            statesByDate = statesByDate
+        )
+        currentDate = currentDate.plusDays(1L)
+    }
+
+    return currentState
+}
+
+private fun addTrailingStreakDaysThroughToday(
+    state: ProgressStreakComputationState,
+    today: LocalDate,
+    policy: ProgressStreakFreezePolicy,
+    statesByDate: MutableMap<String, CloudProgressStreakDayState>
+): ProgressStreakComputationState {
+    var currentState = state
+    var currentDate = currentState.lastEvaluatedDate?.plusDays(1L) ?: today
+
+    while (currentDate <= today) {
+        currentState = if (currentDate == today) {
+            addPendingStreakDay(
+                state = currentState,
+                date = currentDate,
+                statesByDate = statesByDate
+            )
+        } else {
+            addNonReviewedCompletedStreakDay(
+                state = currentState,
+                date = currentDate,
+                policy = policy,
+                statesByDate = statesByDate
+            )
+        }
+        currentDate = currentDate.plusDays(1L)
+    }
+
+    return currentState
+}
+
+private fun createProgressStreakFreeze(
+    balanceUnits: Int,
+    policy: ProgressStreakFreezePolicy
+): CloudProgressStreakFreeze {
+    val clampedBalanceUnits = clampBalanceUnits(
+        balanceUnits = balanceUnits,
+        policy = policy
+    )
+    val availableCredits = getAvailableCredits(
+        balanceUnits = clampedBalanceUnits,
+        policy = policy
+    )
+
+    return CloudProgressStreakFreeze(
+        availableCredits = availableCredits,
+        capacity = policy.maxCapacity,
+        balanceUnits = clampedBalanceUnits,
+        unitsPerCredit = policy.unitsPerCredit,
+        nextCreditProgressUnits = if (availableCredits >= policy.maxCapacity) {
+            0
+        } else {
+            clampedBalanceUnits % policy.unitsPerCredit
+        },
+        nextCreditRequiredUnits = policy.unitsPerCredit
+    )
+}
+
+private fun createProgressStreakDays(
+    statesByDate: Map<String, CloudProgressStreakDayState>
+): List<CloudProgressStreakDay> {
+    return statesByDate.entries.sortedBy { entry ->
+        entry.key
+    }.map { entry ->
+        CloudProgressStreakDay(
+            date = entry.key,
+            state = entry.value
+        )
+    }
+}
+
+private fun getInitialBalanceUnits(
+    policy: ProgressStreakFreezePolicy
+): Int {
+    return minOf(policy.startCapacity, policy.maxCapacity) * policy.unitsPerCredit
+}
+
+private fun getAvailableCredits(
+    balanceUnits: Int,
+    policy: ProgressStreakFreezePolicy
+): Int {
+    return minOf(policy.maxCapacity, balanceUnits / policy.unitsPerCredit)
+}
+
+private fun addStreakDayEarnedUnits(
+    balanceUnits: Int,
+    policy: ProgressStreakFreezePolicy
+): Int {
+    return clampBalanceUnits(
+        balanceUnits = balanceUnits + policy.earnedUnitsPerStreakDay,
+        policy = policy
+    )
+}
+
+private fun clampBalanceUnits(
+    balanceUnits: Int,
+    policy: ProgressStreakFreezePolicy
+): Int {
+    return minOf(balanceUnits, policy.maxCapacity * policy.unitsPerCredit)
 }
 
 internal fun isLocalDateAfter(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotMerging.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotMerging.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleScopeKey
@@ -14,7 +15,6 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnaps
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
-import java.time.LocalDate
 
 internal data class ProgressRenderedSeriesSummaryContext(
     val lowerBoundSummary: CloudProgressSummary,
@@ -67,6 +67,7 @@ internal fun createProgressSeriesSnapshot(
     localFallback: CloudProgressSeries,
     serverBase: CloudProgressSeries?,
     pendingLocalOverlay: CloudProgressSeries,
+    activeReviewDateSet: Set<String>,
     cloudState: CloudAccountState
 ): ProgressSeriesSnapshot {
     val renderedSeries = if (serverBase == null) {
@@ -75,7 +76,8 @@ internal fun createProgressSeriesSnapshot(
         mergeProgressSeries(
             base = serverBase,
             pendingLocalOverlay = pendingLocalOverlay,
-            localFallback = localFallback
+            localFallback = localFallback,
+            activeReviewDateSet = activeReviewDateSet
         )
     }
     val hasLocalOverlay = serverBase?.let { base ->
@@ -187,12 +189,19 @@ internal fun mergeProgressSummary(
         renderedSeriesActiveDates = renderedSeriesContext?.activeDates,
         referenceLocalDate = referenceLocalDate
     )
+    val renderedCurrentStreakDays = maxOf(
+        serverCurrentStreakDaysWithRenderedDelta,
+        localFallback.currentStreakDays,
+        renderedSeriesLowerBound?.currentStreakDays ?: 0
+    )
 
     return CloudProgressSummary(
-        currentStreakDays = maxOf(
-            serverCurrentStreakDaysWithRenderedDelta,
-            localFallback.currentStreakDays,
-            renderedSeriesLowerBound?.currentStreakDays ?: 0
+        currentStreakDays = renderedCurrentStreakDays,
+        longestStreakDays = maxOf(
+            base.longestStreakDays,
+            localFallback.longestStreakDays,
+            renderedSeriesLowerBound?.longestStreakDays ?: 0,
+            renderedCurrentStreakDays
         ),
         hasReviewedToday = base.hasReviewedToday ||
             localFallback.hasReviewedToday ||
@@ -209,6 +218,16 @@ internal fun mergeProgressSummary(
             localFallback.activeReviewDays,
             renderedSeriesLowerBound?.activeReviewDays ?: 0
         ),
+        streakFreeze = selectProgressStreakFreeze(
+            base = base,
+            localFallback = localFallback,
+            localFallbackActiveDates = localFallbackActiveDates,
+            renderedSeriesLowerBound = renderedSeriesLowerBound,
+            renderedSeriesActiveDates = renderedSeriesContext?.activeDates,
+            renderedCurrentStreakDays = renderedCurrentStreakDays,
+            serverCurrentStreakDaysWithRenderedDelta = serverCurrentStreakDaysWithRenderedDelta,
+            referenceLocalDate = referenceLocalDate
+        ),
         reviewHistoryWatermarks = base.reviewHistoryWatermarks
     )
 }
@@ -216,7 +235,8 @@ internal fun mergeProgressSummary(
 internal fun mergeProgressSeries(
     base: CloudProgressSeries,
     pendingLocalOverlay: CloudProgressSeries,
-    localFallback: CloudProgressSeries
+    localFallback: CloudProgressSeries,
+    activeReviewDateSet: Set<String>
 ): CloudProgressSeries {
     validateProgressSeriesMergeInputs(
         base = base,
@@ -237,11 +257,21 @@ internal fun mergeProgressSeries(
 
         mergedPoint.toCloudDailyReviewPoint(date = point.date)
     }
+    val visibleMergedActiveDateSet = mergedDailyReviews.filter { point ->
+        point.reviewCount > 0
+    }.map(CloudDailyReviewPoint::date).toSet()
+    val mergedStreakDays = createProgressStreakDaysForRange(
+        activeReviewDateSet = activeReviewDateSet + visibleMergedActiveDateSet,
+        from = base.from,
+        to = base.to,
+        today = parseLocalDate(rawDate = base.to)
+    )
     return CloudProgressSeries(
         timeZone = base.timeZone,
         from = base.from,
         to = base.to,
         dailyReviews = mergedDailyReviews,
+        streakDays = mergedStreakDays,
         generatedAt = base.generatedAt,
         reviewHistoryWatermarks = base.reviewHistoryWatermarks,
         summary = null
@@ -284,16 +314,91 @@ private fun createProgressSummaryLowerBoundFromSeries(
 ): CloudProgressSummary {
     val today = parseLocalDate(rawDate = series.to)
     val sortedActiveDates = activeDates.sorted()
+    val streakEvaluation = evaluateProgressStreakFreeze(
+        sortedActiveReviewLocalDates = sortedActiveDates,
+        today = today
+    )
+
     return CloudProgressSummary(
-        currentStreakDays = computeCurrentStreakDays(
-            activeReviewDateSet = activeDates,
-            today = today
-        ),
+        currentStreakDays = streakEvaluation.currentStreakDays,
+        longestStreakDays = streakEvaluation.longestStreakDays,
         hasReviewedToday = activeDates.contains(series.to),
         lastReviewedOn = sortedActiveDates.lastOrNull(),
         activeReviewDays = activeDates.size,
+        streakFreeze = streakEvaluation.streakFreeze,
         reviewHistoryWatermarks = emptyList()
     )
+}
+
+private fun selectProgressStreakFreeze(
+    base: CloudProgressSummary,
+    localFallback: CloudProgressSummary,
+    localFallbackActiveDates: Set<String>,
+    renderedSeriesLowerBound: CloudProgressSummary?,
+    renderedSeriesActiveDates: Set<String>?,
+    renderedCurrentStreakDays: Int,
+    serverCurrentStreakDaysWithRenderedDelta: Int,
+    referenceLocalDate: String
+): CloudProgressStreakFreeze {
+    val baseWithRenderedOverlay = progressStreakFreezeWithRenderedOverlay(
+        base = base,
+        localFallbackActiveDates = localFallbackActiveDates,
+        renderedSeriesActiveDates = renderedSeriesActiveDates,
+        referenceLocalDate = referenceLocalDate
+    )
+    if (serverCurrentStreakDaysWithRenderedDelta == renderedCurrentStreakDays) {
+        return baseWithRenderedOverlay
+    }
+
+    val matchingCandidate = listOfNotNull(
+        renderedSeriesLowerBound,
+        localFallback
+    ).firstOrNull { candidate ->
+        candidate.currentStreakDays == renderedCurrentStreakDays
+    }
+    if (matchingCandidate != null) {
+        return matchingCandidate.streakFreeze
+    }
+
+    return baseWithRenderedOverlay
+}
+
+private fun progressStreakFreezeWithRenderedOverlay(
+    base: CloudProgressSummary,
+    localFallbackActiveDates: Set<String>,
+    renderedSeriesActiveDates: Set<String>?,
+    referenceLocalDate: String
+): CloudProgressStreakFreeze {
+    if (base.hasReviewedToday || base.currentStreakDays <= 0) {
+        return base.streakFreeze
+    }
+
+    val activeDates = localFallbackActiveDates + (renderedSeriesActiveDates ?: emptySet())
+    val completedOverlayDates = progressCompletedOverlayDatesAfterServerLastReview(
+        activeDates = activeDates,
+        base = base,
+        referenceLocalDate = referenceLocalDate
+    )
+    val freezeAfterCompletedOverlay = completedOverlayDates.fold(base.streakFreeze) { streakFreeze, _ ->
+        refundSpentProgressStreakFreezeCredit(streakFreeze = streakFreeze)
+    }
+    if (activeDates.contains(referenceLocalDate).not()) {
+        return freezeAfterCompletedOverlay
+    }
+
+    return addReviewedDayProgressStreakFreezeCredit(streakFreeze = freezeAfterCompletedOverlay)
+}
+
+private fun progressCompletedOverlayDatesAfterServerLastReview(
+    activeDates: Set<String>,
+    base: CloudProgressSummary,
+    referenceLocalDate: String
+): List<String> {
+    val lastReviewedOn = base.lastReviewedOn ?: return emptyList()
+    return activeDates.filter { localDate ->
+        isLocalDateAfter(first = localDate, second = lastReviewedOn) &&
+            isLocalDateAfter(first = referenceLocalDate, second = localDate)
+    }.sorted()
 }
 
 private fun progressActiveDatesFromSeries(
@@ -439,18 +544,12 @@ private fun progressCurrentStreakDaysWithRenderedDelta(
     if (serverBase.currentStreakDays <= 0) {
         return serverBase.currentStreakDays
     }
-    val lastReviewedOn = serverBase.lastReviewedOn ?: return serverBase.currentStreakDays
-    val referenceDate: LocalDate = parseLocalDate(rawDate = referenceLocalDate)
     val activeDates: Set<String> = localFallbackActiveDates + (renderedSeriesActiveDates ?: emptySet())
-    var currentDate: LocalDate = parseLocalDate(rawDate = lastReviewedOn).plusDays(1L)
-    var localDelta: Int = 0
-
-    while (currentDate <= referenceDate && activeDates.contains(currentDate.toString())) {
-        localDelta += 1
-        currentDate = currentDate.plusDays(1L)
+    if (activeDates.contains(referenceLocalDate).not()) {
+        return serverBase.currentStreakDays
     }
 
-    return serverBase.currentStreakDays + localDelta
+    return serverBase.currentStreakDays + 1
 }
 
 private fun validateProgressSeriesMergeInputs(
@@ -573,6 +672,9 @@ private fun hasProgressSeriesOverlay(
     renderedSeries: CloudProgressSeries
 ): Boolean {
     if (base.dailyReviews.size != renderedSeries.dailyReviews.size) {
+        return true
+    }
+    if (base.streakDays != renderedSeries.streakDays) {
         return true
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
@@ -145,11 +145,18 @@ internal fun createProgressSummaryStoreState(
             pendingReviewLocalDates = inputs.pendingReviewLocalDates,
             workspaceIds = inputs.workspaceIds
         )
+        val activeReviewDateSet = createProgressActiveReviewDateSet(
+            timeZone = inputs.seriesScopeKey.timeZone,
+            localDayCounts = inputs.localDayCounts,
+            pendingReviewLocalDates = inputs.pendingReviewLocalDates,
+            workspaceIds = inputs.workspaceIds
+        )
         val renderedSeries = createProgressSeriesSnapshot(
             scopeKey = inputs.seriesScopeKey,
             localFallback = localFallbackSeries,
             serverBase = inputs.seriesServerBase,
             pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = activeReviewDateSet,
             cloudState = inputs.cloudState
         ).renderedSeries
         createProgressRenderedSeriesSummaryContext(
@@ -323,6 +330,16 @@ internal fun createProgressSeriesStoreState(
     } else {
         createEmptyProgressSeries(scopeKey = inputs.scopeKey)
     }
+    val activeReviewDateSet = if (inputs.isLocalCacheReady) {
+        createProgressActiveReviewDateSet(
+            timeZone = inputs.scopeKey.timeZone,
+            localDayCounts = inputs.localDayCounts,
+            pendingReviewLocalDates = inputs.pendingReviewLocalDates,
+            workspaceIds = inputs.workspaceIds
+        )
+    } else {
+        emptySet()
+    }
     return ProgressSeriesStoreState(
         scopeKey = inputs.scopeKey,
         cloudState = inputs.cloudState,
@@ -332,6 +349,7 @@ internal fun createProgressSeriesStoreState(
                 localFallback = localFallback,
                 serverBase = inputs.serverBase,
                 pendingLocalOverlay = pendingLocalOverlay,
+                activeReviewDateSet = activeReviewDateSet,
                 cloudState = inputs.cloudState
             )
         } else {

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -103,9 +103,18 @@ class CloudRemoteServiceTest {
               "timeZone": "Europe/Madrid",
               "summary": {
                 "currentStreakDays": 8,
+                "longestStreakDays": 10,
                 "hasReviewedToday": true,
                 "lastReviewedOn": "2026-04-18",
-                "activeReviewDays": 21
+                "activeReviewDays": 21,
+                "streakFreeze": {
+                  "availableCredits": 2,
+                  "capacity": 2,
+                  "balanceUnits": 20,
+                  "unitsPerCredit": 10,
+                  "nextCreditProgressUnits": 0,
+                  "nextCreditRequiredUnits": 10
+                }
               },
               "reviewHistoryWatermarks": [
                 { "workspaceId": "workspace-1", "reviewSequenceId": 42 }
@@ -121,9 +130,11 @@ class CloudRemoteServiceTest {
         )
 
         assertEquals(8, summary.currentStreakDays)
+        assertEquals(10, summary.longestStreakDays)
         assertEquals(true, summary.hasReviewedToday)
         assertEquals("2026-04-18", summary.lastReviewedOn)
         assertEquals(21, summary.activeReviewDays)
+        assertEquals(2, summary.streakFreeze.availableCredits)
         assertEquals(42L, summary.reviewHistoryWatermarks.single().reviewSequenceId)
     }
 
@@ -135,9 +146,18 @@ class CloudRemoteServiceTest {
               "timeZone": "Europe/Madrid",
               "summary": {
                 "currentStreakDays": 8,
+                "longestStreakDays": 10,
                 "hasReviewedToday": true,
                 "lastReviewedOn": "2026-04-18",
-                "activeReviewDays": 21
+                "activeReviewDays": 21,
+                "streakFreeze": {
+                  "availableCredits": 2,
+                  "capacity": 2,
+                  "balanceUnits": 20,
+                  "unitsPerCredit": 10,
+                  "nextCreditProgressUnits": 0,
+                  "nextCreditRequiredUnits": 10
+                }
               },
               "generatedAt": "2026-04-18T12:00:00Z"
             }
@@ -159,6 +179,7 @@ class CloudRemoteServiceTest {
             {
               "timeZone": "Europe/Madrid",
               "currentStreakDays": 8,
+              "longestStreakDays": 10,
               "hasReviewedToday": true,
               "lastReviewedOn": "2026-04-18",
               "activeReviewDays": 21,
@@ -187,6 +208,11 @@ class CloudRemoteServiceTest {
               "dailyReviews": [
                 { "date": "2026-04-01", "reviewCount": 3, "againCount": 1, "hardCount": 1, "goodCount": 1, "easyCount": 0 }
               ],
+              "streakDays": [
+                { "date": "2026-04-01", "state": "reviewed" },
+                { "date": "2026-04-02", "state": "frozen" },
+                { "date": "2026-04-03", "state": "pending" }
+              ],
               "reviewHistoryWatermarks": [
                 { "workspaceId": "workspace-1", "reviewSequenceId": 42 }
               ],
@@ -205,6 +231,7 @@ class CloudRemoteServiceTest {
         assertEquals("2026-04-03", series.to)
         assertEquals(3, series.dailyReviews.single().reviewCount)
         assertEquals(1, series.dailyReviews.single().againCount)
+        assertEquals("frozen", series.streakDays[1].state.wireKey)
         assertEquals(42L, series.reviewHistoryWatermarks.single().reviewSequenceId)
     }
 
@@ -218,6 +245,11 @@ class CloudRemoteServiceTest {
               "to": "2026-04-03",
               "dailyReviews": [
                 { "date": "2026-04-01", "reviewCount": 3, "againCount": 0, "hardCount": 1, "goodCount": 2, "easyCount": 0 }
+              ],
+              "streakDays": [
+                { "date": "2026-04-01", "state": "reviewed" },
+                { "date": "2026-04-02", "state": "frozen" },
+                { "date": "2026-04-03", "state": "pending" }
               ],
               "generatedAt": "2026-04-18T12:00:00Z"
             }
@@ -387,9 +419,18 @@ class CloudRemoteServiceTest {
               "timeZone": "Europe/Madrid",
               "summary": {
                 "currentStreakDays": 8,
+                "longestStreakDays": 10,
                 "hasReviewedToday": true,
                 "lastReviewedOn": "2026-04-18",
-                "activeReviewDays": 21
+                "activeReviewDays": 21,
+                "streakFreeze": {
+                  "availableCredits": 2,
+                  "capacity": 2,
+                  "balanceUnits": 20,
+                  "unitsPerCredit": 10,
+                  "nextCreditProgressUnits": 0,
+                  "nextCreditRequiredUnits": 10
+                }
               },
               "reviewHistoryWatermarks": [
                 { "workspaceId": "workspace-1", "reviewSequenceId": -1 }
@@ -417,9 +458,18 @@ class CloudRemoteServiceTest {
               "timeZone": "Europe/Madrid",
               "summary": {
                 "currentStreakDays": 8,
+                "longestStreakDays": 10,
                 "hasReviewedToday": true,
                 "lastReviewedOn": "2026-04-18",
-                "activeReviewDays": 21
+                "activeReviewDays": 21,
+                "streakFreeze": {
+                  "availableCredits": 2,
+                  "capacity": 2,
+                  "balanceUnits": 20,
+                  "unitsPerCredit": 10,
+                  "nextCreditProgressUnits": 0,
+                  "nextCreditRequiredUnits": 10
+                }
               },
               "reviewHistoryWatermarks": [
                 "not-an-object"

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
@@ -38,9 +38,16 @@ class ProgressCacheValidationTest {
             generatedAt = "2026-04-18T10:00:00Z",
             reviewHistoryWatermarksJson = """[]""",
             currentStreakDays = 2,
+            longestStreakDays = 2,
             hasReviewedToday = true,
             lastReviewedOn = "not-a-date",
             activeReviewDays = 4,
+            streakFreezeAvailableCredits = 2,
+            streakFreezeCapacity = 2,
+            streakFreezeBalanceUnits = 20,
+            streakFreezeUnitsPerCredit = 10,
+            streakFreezeNextCreditProgressUnits = 0,
+            streakFreezeNextCreditRequiredUnits = 10,
             updatedAtMillis = 1L
         )
 
@@ -58,6 +65,7 @@ class ProgressCacheValidationTest {
             generatedAt = "2026-04-18T10:00:00Z",
             reviewHistoryWatermarksJson = """[]""",
             dailyReviewsJson = "{not-json}",
+            streakDaysJson = """[]""",
             updatedAtMillis = 1L
         )
 
@@ -164,9 +172,11 @@ class ProgressCacheValidationTest {
         )
         val summary = CloudProgressSummary(
             currentStreakDays = 3,
+            longestStreakDays = 3,
             hasReviewedToday = true,
             lastReviewedOn = "2026-04-18",
             activeReviewDays = 9,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = watermarks
         )
         val series = CloudProgressSeries(
@@ -182,6 +192,12 @@ class ProgressCacheValidationTest {
                     goodCount = 1,
                     easyCount = 0
                 )
+            ),
+            streakDays = createProgressStreakDaysForRange(
+                activeReviewDateSet = setOf(seriesScopeKey.to),
+                from = seriesScopeKey.from,
+                to = seriesScopeKey.to,
+                today = LocalDate.parse(seriesScopeKey.to)
             ),
             generatedAt = "2026-04-18T10:00:00Z",
             reviewHistoryWatermarks = watermarks,
@@ -211,6 +227,13 @@ class ProgressCacheValidationTest {
         assertEquals(
             1,
             cachedSeries?.dailyReviews?.single()?.againCount
+        )
+        assertEquals(
+            series.streakDays,
+            series.toCacheEntity(
+                scopeKey = seriesScopeKey,
+                updatedAtMillis = 1L
+            ).toCloudProgressSeriesOrNull()?.streakDays
         )
         assertEquals(
             watermarks,

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
@@ -3,10 +3,12 @@ package com.flashcardsopensourceapp.data.local.repository.progress.snapshots
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
 import com.flashcardsopensourceapp.data.local.repository.progress.createCloudSettings
 import com.flashcardsopensourceapp.data.local.repository.progress.createPendingReviewOutboxEntry
+import com.flashcardsopensourceapp.data.local.repository.progress.createProgressLocalDayCount
 import com.flashcardsopensourceapp.data.local.repository.progress.inputs.createProgressPendingReviewLocalDates
 import java.time.Instant
 import java.time.LocalDate
@@ -17,6 +19,35 @@ import org.junit.Test
 
 class ProgressSeriesSnapshotTest {
     @Test
+    fun localFallbackSeriesMarksReviewedFrozenAndPendingStreakDays() {
+        val scopeKey = createProgressSeriesScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.DISCONNECTED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+
+        val localFallback = createLocalFallbackSeries(
+            scopeKey = scopeKey,
+            localDayCounts = listOf(
+                createProgressLocalDayCount(
+                    workspaceId = "workspace-1",
+                    localDate = "2026-04-15",
+                    reviewCount = 1
+                )
+            ),
+            workspaceIds = listOf("workspace-1")
+        )
+
+        val statesByDate = localFallback.streakDays.associate { day ->
+            day.date to day.state
+        }
+        assertEquals(CloudProgressStreakDayState.REVIEWED, statesByDate["2026-04-15"])
+        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-16"])
+        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-17"])
+        assertEquals(CloudProgressStreakDayState.PENDING, statesByDate["2026-04-18"])
+    }
+
+    @Test
     fun missingSeriesServerBaseRendersLocalFallbackAsApproximateLocalOnly() {
         val scopeKey = createProgressSeriesScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.DISCONNECTED),
@@ -26,7 +57,7 @@ class ProgressSeriesSnapshotTest {
         val localFallback = createLocalFallbackSeries(
             scopeKey = scopeKey,
             localDayCounts = listOf(
-                com.flashcardsopensourceapp.data.local.repository.progress.createProgressLocalDayCount(
+                createProgressLocalDayCount(
                     workspaceId = "workspace-1",
                     localDate = Instant.parse("2026-04-18T10:00:00Z")
                         .atZone(ZoneId.of("Europe/Madrid"))
@@ -46,6 +77,10 @@ class ProgressSeriesSnapshotTest {
                 scopeKey = scopeKey,
                 pendingReviewLocalDates = emptyList(),
                 workspaceIds = listOf("workspace-1")
+            ),
+            activeReviewDateSet = createActiveReviewDateSet(
+                series = localFallback,
+                additionalDates = emptySet()
             ),
             cloudState = CloudAccountState.DISCONNECTED
         )
@@ -107,6 +142,10 @@ class ProgressSeriesSnapshotTest {
             localFallback = localFallback,
             serverBase = serverBase,
             pendingLocalOverlay = overlay,
+            activeReviewDateSet = createActiveReviewDateSet(
+                series = localFallback,
+                additionalDates = setOf("2026-04-18")
+            ),
             cloudState = CloudAccountState.LINKED
         )
 
@@ -115,6 +154,103 @@ class ProgressSeriesSnapshotTest {
         assertEquals(1, overlay.dailyReviews.last().goodCount)
         assertEquals(3, snapshot.renderedSeries.dailyReviews.first().reviewCount)
         assertEquals(3, snapshot.renderedSeries.dailyReviews.last().reviewCount)
+        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(true, snapshot.isApproximate)
+    }
+
+    @Test
+    fun mergedStreakDaysUseFullActiveHistoryBeforeVisibleRange() {
+        val scopeKey = ProgressSeriesScopeKey(
+            scopeId = "local:installation-1",
+            timeZone = "Europe/Madrid",
+            from = "2026-04-16",
+            to = "2026-04-18"
+        )
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(date = "2026-04-16", reviewCount = 0),
+                createPoint(date = "2026-04-17", reviewCount = 0),
+                createPoint(date = "2026-04-18", reviewCount = 0)
+            ),
+            generatedAt = null
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = localFallback.dailyReviews,
+            generatedAt = "2026-04-18T12:00:00Z"
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(date = "2026-04-16", reviewCount = 0),
+                createPoint(date = "2026-04-17", reviewCount = 0),
+                createPoint(date = "2026-04-18", reviewCount = 1)
+            ),
+            generatedAt = null
+        )
+
+        val snapshot = createProgressSeriesSnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            serverBase = serverBase,
+            pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = setOf("2026-04-15", "2026-04-18"),
+            cloudState = CloudAccountState.LINKED
+        )
+
+        val statesByDate = snapshot.renderedSeries.streakDays.associate { day ->
+            day.date to day.state
+        }
+        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-16"])
+        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-17"])
+        assertEquals(CloudProgressStreakDayState.REVIEWED, statesByDate["2026-04-18"])
+    }
+
+    @Test
+    fun mergedStreakDaysUsePreRangeHistoryWhenVisibleCountsAreUnchanged() {
+        val scopeKey = ProgressSeriesScopeKey(
+            scopeId = "local:installation-1",
+            timeZone = "Europe/Madrid",
+            from = "2026-04-16",
+            to = "2026-04-18"
+        )
+        val dailyReviews = listOf(
+            createPoint(date = "2026-04-16", reviewCount = 0),
+            createPoint(date = "2026-04-17", reviewCount = 0),
+            createPoint(date = "2026-04-18", reviewCount = 0)
+        )
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = dailyReviews,
+            generatedAt = null
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = dailyReviews,
+            generatedAt = "2026-04-18T12:00:00Z"
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = dailyReviews,
+            generatedAt = null
+        )
+
+        val snapshot = createProgressSeriesSnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            serverBase = serverBase,
+            pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = setOf("2026-04-15"),
+            cloudState = CloudAccountState.LINKED
+        )
+
+        val statesByDate = snapshot.renderedSeries.streakDays.associate { day ->
+            day.date to day.state
+        }
+        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-16"])
+        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-17"])
+        assertEquals(CloudProgressStreakDayState.PENDING, statesByDate["2026-04-18"])
         assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
         assertEquals(true, snapshot.isApproximate)
     }
@@ -161,6 +297,10 @@ class ProgressSeriesSnapshotTest {
             localFallback = localFallback,
             serverBase = serverBase,
             pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = createActiveReviewDateSet(
+                series = localFallback,
+                additionalDates = emptySet()
+            ),
             cloudState = CloudAccountState.LINKED
         )
 
@@ -212,6 +352,10 @@ class ProgressSeriesSnapshotTest {
             localFallback = localFallback,
             serverBase = serverBase,
             pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = createActiveReviewDateSet(
+                series = localFallback,
+                additionalDates = emptySet()
+            ),
             cloudState = CloudAccountState.LINKED
         )
 
@@ -268,6 +412,10 @@ class ProgressSeriesSnapshotTest {
             localFallback = localFallback,
             serverBase = serverBase,
             pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = createActiveReviewDateSet(
+                series = localFallback,
+                additionalDates = emptySet()
+            ),
             cloudState = CloudAccountState.LINKED
         )
 
@@ -319,6 +467,10 @@ class ProgressSeriesSnapshotTest {
             localFallback = localFallback,
             serverBase = serverBase,
             pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = createActiveReviewDateSet(
+                series = localFallback,
+                additionalDates = emptySet()
+            ),
             cloudState = CloudAccountState.LINKED
         )
 
@@ -365,7 +517,11 @@ class ProgressSeriesSnapshotTest {
             mergeProgressSeries(
                 base = base,
                 pendingLocalOverlay = pendingLocalOverlay,
-                localFallback = localFallback
+                localFallback = localFallback,
+                activeReviewDateSet = createActiveReviewDateSet(
+                    series = localFallback,
+                    additionalDates = emptySet()
+                )
             )
         }
 
@@ -429,10 +585,28 @@ class ProgressSeriesSnapshotTest {
             from = scopeKey.from,
             to = scopeKey.to,
             dailyReviews = dailyReviews,
+            streakDays = createProgressStreakDaysForRange(
+                activeReviewDateSet = dailyReviews.filter { point ->
+                    point.reviewCount > 0
+                }.map(CloudDailyReviewPoint::date).toSet(),
+                from = scopeKey.from,
+                to = scopeKey.to,
+                today = LocalDate.parse(scopeKey.to)
+            ),
             generatedAt = generatedAt,
             reviewHistoryWatermarks = emptyList(),
             summary = null
         )
+    }
+
+    private fun createActiveReviewDateSet(
+        series: CloudProgressSeries,
+        additionalDates: Set<String>
+    ): Set<String> {
+        return series.dailyReviews.filter { point ->
+            point.reviewCount > 0
+        }.map(CloudDailyReviewPoint::date)
+            .toSet() + additionalDates
     }
 
     private fun createPoint(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
@@ -3,6 +3,7 @@ package com.flashcardsopensourceapp.data.local.repository.progress.snapshots
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
@@ -58,7 +59,7 @@ class ProgressSummarySnapshotTest {
     }
 
     @Test
-    fun localFallbackSummaryReturnsZeroStreakWhenLastReviewIsOlderThanYesterday() {
+    fun localFallbackSummaryFreezesCompletedMissedDaysBeforeToday() {
         val scopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.DISCONNECTED),
             today = LocalDate.parse("2026-04-18"),
@@ -83,7 +84,9 @@ class ProgressSummarySnapshotTest {
             today = LocalDate.parse("2026-04-18")
         )
 
-        assertEquals(0, localFallback.currentStreakDays)
+        assertEquals(4, localFallback.currentStreakDays)
+        assertEquals(4, localFallback.longestStreakDays)
+        assertEquals(0, localFallback.streakFreeze.availableCredits)
         assertEquals(false, localFallback.hasReviewedToday)
         assertEquals("2026-04-15", localFallback.lastReviewedOn)
     }
@@ -97,16 +100,20 @@ class ProgressSummarySnapshotTest {
         )
         val localFallback = CloudProgressSummary(
             currentStreakDays = 10,
+            longestStreakDays = 10,
             hasReviewedToday = true,
             lastReviewedOn = "2026-04-18",
             activeReviewDays = 33,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = emptyList()
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 9,
+            longestStreakDays = 9,
             hasReviewedToday = false,
             lastReviewedOn = "2026-04-17",
             activeReviewDays = 32,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = emptyList()
         )
 
@@ -125,6 +132,58 @@ class ProgressSummarySnapshotTest {
         assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
         assertEquals(33, snapshot.renderedSummary.activeReviewDays)
+    }
+
+    @Test
+    fun summaryServerBaseExtendsLocalTodayAfterFrozenGap() {
+        val scopeKey = createProgressSummaryScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val localFallback = CloudProgressSummary(
+            currentStreakDays = 1,
+            longestStreakDays = 1,
+            hasReviewedToday = true,
+            lastReviewedOn = "2026-04-18",
+            activeReviewDays = 1,
+            streakFreeze = createInitialProgressStreakFreeze(),
+            reviewHistoryWatermarks = emptyList()
+        )
+        val serverBase = CloudProgressSummary(
+            currentStreakDays = 3,
+            longestStreakDays = 3,
+            hasReviewedToday = false,
+            lastReviewedOn = "2026-04-15",
+            activeReviewDays = 30,
+            streakFreeze = CloudProgressStreakFreeze(
+                availableCredits = 0,
+                capacity = 2,
+                balanceUnits = 2,
+                unitsPerCredit = 10,
+                nextCreditProgressUnits = 2,
+                nextCreditRequiredUnits = 10
+            ),
+            reviewHistoryWatermarks = emptyList()
+        )
+
+        val snapshot = createProgressSummarySnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            localFallbackActiveDates = setOf("2026-04-18"),
+            serverBase = serverBase,
+            renderedSeriesContext = null,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(4, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(4, snapshot.renderedSummary.longestStreakDays)
+        assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
+        assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
+        assertEquals(31, snapshot.renderedSummary.activeReviewDays)
+        assertEquals(3, snapshot.renderedSummary.streakFreeze.balanceUnits)
+        assertEquals(3, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
     }
 
     @Test
@@ -175,9 +234,11 @@ class ProgressSummarySnapshotTest {
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 200,
+            longestStreakDays = 200,
             hasReviewedToday = false,
             lastReviewedOn = "2026-04-17",
             activeReviewDays = 200,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = serverWatermarks
         )
 
@@ -198,7 +259,7 @@ class ProgressSummarySnapshotTest {
     }
 
     @Test
-    fun longServerStreakExtendsThroughConsecutiveLocalDates() {
+    fun longServerStreakRefundsFrozenYesterdayAndCreditsLocalToday() {
         val summaryScopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
             today = LocalDate.parse("2026-04-20"),
@@ -250,9 +311,11 @@ class ProgressSummarySnapshotTest {
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 200,
+            longestStreakDays = 200,
             hasReviewedToday = false,
             lastReviewedOn = "2026-04-18",
             activeReviewDays = 200,
+            streakFreeze = createProgressStreakFreezeAfterOneFrozenDay(),
             reviewHistoryWatermarks = serverWatermarks
         )
 
@@ -266,14 +329,17 @@ class ProgressSummarySnapshotTest {
         )
 
         assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
-        assertEquals(202, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(201, snapshot.renderedSummary.currentStreakDays)
         assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-20", snapshot.renderedSummary.lastReviewedOn)
         assertEquals(202, snapshot.renderedSummary.activeReviewDays)
+        assertEquals(2, snapshot.renderedSummary.streakFreeze.availableCredits)
+        assertEquals(20, snapshot.renderedSummary.streakFreeze.balanceUnits)
+        assertEquals(0, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
     }
 
     @Test
-    fun longServerStreakExtendsToYesterdayWhenTodayHasNoReview() {
+    fun longServerStreakRefundsFrozenYesterdayWithoutChangingCurrentStreak() {
         val summaryScopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
             today = LocalDate.parse("2026-04-20"),
@@ -320,9 +386,11 @@ class ProgressSummarySnapshotTest {
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 200,
+            longestStreakDays = 200,
             hasReviewedToday = false,
             lastReviewedOn = "2026-04-18",
             activeReviewDays = 200,
+            streakFreeze = createProgressStreakFreezeAfterOneFrozenDay(),
             reviewHistoryWatermarks = serverWatermarks
         )
 
@@ -336,10 +404,13 @@ class ProgressSummarySnapshotTest {
         )
 
         assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
-        assertEquals(201, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(200, snapshot.renderedSummary.currentStreakDays)
         assertEquals(false, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-19", snapshot.renderedSummary.lastReviewedOn)
         assertEquals(201, snapshot.renderedSummary.activeReviewDays)
+        assertEquals(2, snapshot.renderedSummary.streakFreeze.availableCredits)
+        assertEquals(20, snapshot.renderedSummary.streakFreeze.balanceUnits)
+        assertEquals(0, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
     }
 
     @Test
@@ -390,9 +461,11 @@ class ProgressSummarySnapshotTest {
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 0,
+            longestStreakDays = 0,
             hasReviewedToday = false,
             lastReviewedOn = "2025-12-01",
             activeReviewDays = 200,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = serverWatermarks
         )
 
@@ -459,9 +532,11 @@ class ProgressSummarySnapshotTest {
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 200,
+            longestStreakDays = 200,
             hasReviewedToday = true,
             lastReviewedOn = "2026-04-18",
             activeReviewDays = 200,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = serverWatermarks
         )
 
@@ -529,9 +604,11 @@ class ProgressSummarySnapshotTest {
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 0,
+            longestStreakDays = 0,
             hasReviewedToday = false,
             lastReviewedOn = "2026-04-16",
             activeReviewDays = 1,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = serverWatermarks
         )
 
@@ -544,7 +621,7 @@ class ProgressSummarySnapshotTest {
             cloudState = CloudAccountState.LINKED
         )
 
-        assertEquals(1, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(3, snapshot.renderedSummary.currentStreakDays)
         assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
         assertEquals(2, snapshot.renderedSummary.activeReviewDays)
@@ -603,9 +680,11 @@ class ProgressSummarySnapshotTest {
         )
         val serverBase = CloudProgressSummary(
             currentStreakDays = 1,
+            longestStreakDays = 1,
             hasReviewedToday = false,
             lastReviewedOn = "2026-04-17",
             activeReviewDays = 200,
+            streakFreeze = createInitialProgressStreakFreeze(),
             reviewHistoryWatermarks = emptyList()
         )
 
@@ -618,7 +697,7 @@ class ProgressSummarySnapshotTest {
             cloudState = CloudAccountState.LINKED
         )
 
-        assertEquals(2, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(3, snapshot.renderedSummary.currentStreakDays)
         assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
         assertEquals(201, snapshot.renderedSummary.activeReviewDays)
@@ -635,6 +714,10 @@ class ProgressSummarySnapshotTest {
             localFallback = localFallback,
             serverBase = serverBase,
             pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = createActiveReviewDateSet(
+                localFallback = localFallback,
+                pendingLocalOverlay = pendingLocalOverlay
+            ),
             cloudState = CloudAccountState.LINKED
         ).renderedSeries
         return createProgressRenderedSeriesSummaryContext(
@@ -673,10 +756,28 @@ class ProgressSummarySnapshotTest {
             from = scopeKey.from,
             to = scopeKey.to,
             dailyReviews = dailyReviews,
+            streakDays = createProgressStreakDaysForRange(
+                activeReviewDateSet = reviewCountsByDate.filter { entry ->
+                    entry.value > 0
+                }.keys.toSet(),
+                from = scopeKey.from,
+                to = scopeKey.to,
+                today = LocalDate.parse(scopeKey.to)
+            ),
             generatedAt = "2026-04-18T12:00:00Z",
             reviewHistoryWatermarks = reviewHistoryWatermarks,
             summary = null
         )
+    }
+
+    private fun createActiveReviewDateSet(
+        localFallback: CloudProgressSeries,
+        pendingLocalOverlay: CloudProgressSeries
+    ): Set<String> {
+        return (localFallback.dailyReviews + pendingLocalOverlay.dailyReviews).filter { point ->
+            point.reviewCount > 0
+        }.map(CloudDailyReviewPoint::date)
+            .toSet()
     }
 
     private fun createWatermarks(
@@ -687,6 +788,17 @@ class ProgressSummarySnapshotTest {
                 workspaceId = "workspace-1",
                 reviewSequenceId = reviewSequenceId
             )
+        )
+    }
+
+    private fun createProgressStreakFreezeAfterOneFrozenDay(): CloudProgressStreakFreeze {
+        return CloudProgressStreakFreeze(
+            availableCredits = 1,
+            capacity = 2,
+            balanceUnits = 11,
+            unitsPerCredit = 10,
+            nextCreditProgressUnits = 1,
+            nextCreditRequiredUnits = 10
         )
     }
 }

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
@@ -1,6 +1,7 @@
 package com.flashcardsopensourceapp.feature.progress
 
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import java.time.LocalDate
@@ -28,6 +29,7 @@ data class ProgressStreakDayUiState(
     val date: LocalDate?,
     val dayOfMonthLabel: String?,
     val reviewCount: Int,
+    val state: CloudProgressStreakDayState?,
     val isToday: Boolean,
     val isPlaceholder: Boolean
 )
@@ -36,9 +38,17 @@ data class ProgressStreakWeekUiState(
     val days: List<ProgressStreakDayUiState>
 )
 
+data class ProgressFreezeBankUiState(
+    val availableCredits: Int,
+    val capacity: Int,
+    val nextCreditProgressUnits: Int,
+    val nextCreditRequiredUnits: Int
+)
+
 data class ProgressStreakSectionUiState(
     val weekdayLabels: List<String>,
-    val weeks: List<ProgressStreakWeekUiState>
+    val weeks: List<ProgressStreakWeekUiState>,
+    val freezeBankSummary: ProgressFreezeBankUiState?
 )
 
 data class ProgressReviewsSectionUiState(
@@ -145,7 +155,8 @@ sealed interface ProgressSummaryUiState {
     data object Loading : ProgressSummaryUiState
 
     data class Loaded(
-        val summary: CloudProgressSummary
+        val summary: CloudProgressSummary,
+        val freezeBankSummary: ProgressFreezeBankUiState
     ) : ProgressSummaryUiState
 }
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -14,6 +14,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardWindow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus
@@ -368,6 +369,9 @@ private fun CloudProgressSeries.toUiState(
         .sortedBy { point -> point.date }
         .takeLast(progressHistoryDayCount.toInt())
     val progressPointsByDate = parsedPoints.associateBy { point -> point.date }
+    val streakStatesByDate = streakDays.associate { day ->
+        parseProgressDate(rawDate = day.date) to day.state
+    }
     val weekContext = createProgressWeekContext(locale = locale)
     val reviewsSection = ProgressReviewsSectionUiState(
         pages = parsedPoints.toReviewPages(
@@ -380,8 +384,10 @@ private fun CloudProgressSeries.toUiState(
         weeks = createStreakWeeks(
             weekContext = weekContext,
             today = today,
-            progressPointsByDate = progressPointsByDate
-        )
+            progressPointsByDate = progressPointsByDate,
+            streakStatesByDate = streakStatesByDate
+        ),
+        freezeBankSummary = summary.freezeBankSummaryOrNull()
     )
 
     return ProgressUiState.Loaded(
@@ -428,7 +434,24 @@ private fun containsFriendInvitationControlCharacter(
 
 private fun ProgressSummarySnapshot.toUiState(): ProgressSummaryUiState {
     return ProgressSummaryUiState.Loaded(
-        summary = renderedSummary
+        summary = renderedSummary,
+        freezeBankSummary = renderedSummary.toFreezeBankUiState()
+    )
+}
+
+private fun ProgressSummaryUiState.freezeBankSummaryOrNull(): ProgressFreezeBankUiState? {
+    return when (this) {
+        ProgressSummaryUiState.Loading -> null
+        is ProgressSummaryUiState.Loaded -> freezeBankSummary
+    }
+}
+
+private fun CloudProgressSummary.toFreezeBankUiState(): ProgressFreezeBankUiState {
+    return ProgressFreezeBankUiState(
+        availableCredits = streakFreeze.availableCredits,
+        capacity = streakFreeze.capacity,
+        nextCreditProgressUnits = streakFreeze.nextCreditProgressUnits,
+        nextCreditRequiredUnits = streakFreeze.nextCreditRequiredUnits
     )
 }
 
@@ -613,7 +636,8 @@ private fun createProgressWeekContext(
 private fun createStreakWeeks(
     weekContext: ProgressWeekContext,
     today: LocalDate,
-    progressPointsByDate: Map<LocalDate, ParsedProgressPoint>
+    progressPointsByDate: Map<LocalDate, ParsedProgressPoint>,
+    streakStatesByDate: Map<LocalDate, CloudProgressStreakDayState>
 ): List<ProgressStreakWeekUiState> {
     val streakWindowStart = weekContext.startOfWeek(date = today)
         .minusDays(((streakWeekCount - 1) * daysPerWeek).toLong())
@@ -630,22 +654,41 @@ private fun createStreakWeeks(
                         date = null,
                         dayOfMonthLabel = null,
                         reviewCount = 0,
+                        state = null,
                         isToday = false,
                         isPlaceholder = true
                     )
                 }
 
                 val point = progressPointsByDate[date]
+                val reviewCount = point?.reviewCount ?: 0
 
                 ProgressStreakDayUiState(
                     date = date,
                     dayOfMonthLabel = date.dayOfMonth.toString(),
-                    reviewCount = point?.reviewCount ?: 0,
+                    reviewCount = reviewCount,
+                    state = streakStatesByDate[date] ?: createFallbackStreakDayState(
+                        date = date,
+                        today = today,
+                        reviewCount = reviewCount
+                    ),
                     isToday = date == today,
                     isPlaceholder = false
                 )
             }
         )
+    }
+}
+
+private fun createFallbackStreakDayState(
+    date: LocalDate,
+    today: LocalDate,
+    reviewCount: Int
+): CloudProgressStreakDayState {
+    return when {
+        reviewCount > 0 -> CloudProgressStreakDayState.REVIEWED
+        date == today -> CloudProgressStreakDayState.PENDING
+        else -> CloudProgressStreakDayState.MISSED
     }
 }
 

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AcUnit
 import androidx.compose.material.icons.outlined.LocalFireDepartment
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -33,12 +34,16 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
+import com.flashcardsopensourceapp.feature.progress.ProgressFreezeBankUiState
 import com.flashcardsopensourceapp.feature.progress.ProgressStreakDayUiState
 import com.flashcardsopensourceapp.feature.progress.ProgressStreakSectionUiState
 import com.flashcardsopensourceapp.feature.progress.ProgressSummaryUiState
 import com.flashcardsopensourceapp.feature.progress.R
 
 private const val progressStreakOverflowThreshold: Int = 99
+private val frozenStreakBorderColor = Color(0xFF90CAF9)
+private val frozenStreakContentColor = Color(0xFF1E88E5)
 
 @Composable
 internal fun StreakSectionCard(
@@ -72,7 +77,10 @@ internal fun StreakSectionCard(
                 )
             }
 
-            ProgressStreakSummary(summary = summary)
+            ProgressStreakSummary(
+                summary = summary,
+                freezeBankSummary = uiState.freezeBankSummary
+            )
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -110,58 +118,113 @@ internal fun StreakSectionCard(
 
 @Composable
 private fun ProgressStreakSummary(
-    summary: ProgressSummaryUiState
+    summary: ProgressSummaryUiState,
+    freezeBankSummary: ProgressFreezeBankUiState?
 ) {
     when (summary) {
         ProgressSummaryUiState.Loading -> Unit
 
         is ProgressSummaryUiState.Loaded -> {
-            val streakDays = summary.summary.currentStreakDays
-            val contentColor = if (summary.summary.hasReviewedToday) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.onSurfaceVariant
-            }
-            val contentDescription = pluralStringResource(
-                id = R.plurals.progress_streak_summary_content_description,
-                count = streakDays,
-                streakDays
-            )
-            val stateDescription = stringResource(
-                id = if (summary.summary.hasReviewedToday) {
-                    R.string.progress_streak_summary_reviewed_today
-                } else {
-                    R.string.progress_streak_summary_not_reviewed_today
-                }
-            )
-
             Row(
-                verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = Modifier
-                    .semantics(mergeDescendants = true) {
-                        this.contentDescription = contentDescription
-                        this.stateDescription = stateDescription
-                    }
-                    .clip(RoundedCornerShape(18.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.LocalFireDepartment,
-                    contentDescription = null,
-                    tint = contentColor
-                )
-                Text(
-                    text = formatProgressStreakValue(
-                        streakDays = streakDays
-                    ),
-                    color = contentColor,
-                    fontWeight = FontWeight.SemiBold,
-                    style = MaterialTheme.typography.titleMedium
-                )
+                ProgressStreakValueChip(summary = summary)
+                freezeBankSummary?.let { freezeBank ->
+                    ProgressFreezeBankChip(freezeBank = freezeBank)
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun ProgressStreakValueChip(
+    summary: ProgressSummaryUiState.Loaded
+) {
+    val streakDays = summary.summary.currentStreakDays
+    val contentColor = if (summary.summary.hasReviewedToday) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    val contentDescription = pluralStringResource(
+        id = R.plurals.progress_streak_summary_content_description,
+        count = streakDays,
+        streakDays
+    )
+    val stateDescription = stringResource(
+        id = if (summary.summary.hasReviewedToday) {
+            R.string.progress_streak_summary_reviewed_today
+        } else {
+            R.string.progress_streak_summary_not_reviewed_today
+        }
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .semantics(mergeDescendants = true) {
+                this.contentDescription = contentDescription
+                this.stateDescription = stateDescription
+            }
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.LocalFireDepartment,
+            contentDescription = null,
+            tint = contentColor
+        )
+        Text(
+            text = formatProgressStreakValue(
+                streakDays = streakDays
+            ),
+            color = contentColor,
+            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.titleMedium
+        )
+    }
+}
+
+@Composable
+private fun ProgressFreezeBankChip(
+    freezeBank: ProgressFreezeBankUiState
+) {
+    val contentDescription = stringResource(
+        id = R.string.progress_streak_freeze_bank_content_description,
+        freezeBank.availableCredits,
+        freezeBank.capacity
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        modifier = Modifier
+            .semantics(mergeDescendants = true) {
+                this.contentDescription = contentDescription
+            }
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainerHighest)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.AcUnit,
+            contentDescription = null,
+            tint = frozenStreakContentColor
+        )
+        Text(
+            text = stringResource(
+                id = R.string.progress_streak_freeze_bank_value,
+                freezeBank.availableCredits,
+                freezeBank.capacity
+            ),
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.titleMedium
+        )
     }
 }
 
@@ -177,9 +240,11 @@ private fun StreakDayCell(
         return
     }
 
-    val hasReviews = day.reviewCount > 0
+    val state = day.state ?: CloudProgressStreakDayState.MISSED
+    val date = checkNotNull(day.date)
     val highlightColor = when {
-        hasReviews -> Color.Transparent
+        state == CloudProgressStreakDayState.REVIEWED -> Color.Transparent
+        state == CloudProgressStreakDayState.FROZEN -> Color.Transparent
         day.isToday -> MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)
         else -> Color.Transparent
     }
@@ -189,54 +254,121 @@ private fun StreakDayCell(
         day.isToday -> MaterialTheme.colorScheme.primary
         else -> MaterialTheme.colorScheme.onSurface
     }
+    val contentDescription = when (state) {
+        CloudProgressStreakDayState.REVIEWED -> stringResource(
+            id = R.string.progress_streak_day_reviewed_content_description,
+            date.toString()
+        )
+        CloudProgressStreakDayState.FROZEN -> stringResource(
+            id = R.string.progress_streak_day_frozen_content_description,
+            date.toString()
+        )
+        CloudProgressStreakDayState.PENDING -> stringResource(
+            id = R.string.progress_streak_day_pending_content_description,
+            date.toString()
+        )
+        CloudProgressStreakDayState.MISSED -> stringResource(
+            id = R.string.progress_streak_day_missed_content_description,
+            date.toString()
+        )
+    }
 
     Box(
         modifier = modifier
             .aspectRatio(1f)
+            .semantics {
+                this.contentDescription = contentDescription
+            }
             .clip(RoundedCornerShape(18.dp))
             .background(highlightColor),
         contentAlignment = Alignment.Center
     ) {
-        if (hasReviews) {
-            Box(
-                modifier = Modifier
-                    .size(34.dp)
-                    .clip(CircleShape)
-                    .background(markerColor),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.LocalFireDepartment,
-                    contentDescription = null,
-                    tint = markerContentColor
-                )
-            }
-        } else {
-            val todayOutlineModifier = if (day.isToday) {
-                Modifier.border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                    shape = CircleShape
-                )
-            } else {
-                Modifier
-            }
+        when (state) {
+            CloudProgressStreakDayState.REVIEWED -> ReviewedStreakMarker(
+                markerColor = markerColor,
+                markerContentColor = markerContentColor
+            )
+            CloudProgressStreakDayState.FROZEN -> FrozenStreakMarker()
+            CloudProgressStreakDayState.MISSED,
+            CloudProgressStreakDayState.PENDING -> DateStreakMarker(
+                day = day,
+                dateTextColor = dateTextColor
+            )
+        }
+    }
+}
 
-            Box(
-                modifier = Modifier
-                    .size(34.dp)
-                    .then(todayOutlineModifier),
-                contentAlignment = Alignment.Center
-            ) {
-                day.dayOfMonthLabel?.let { dayOfMonthLabel ->
-                    Text(
-                        text = dayOfMonthLabel,
-                        color = dateTextColor,
-                        fontWeight = if (day.isToday) FontWeight.SemiBold else FontWeight.Normal,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
-            }
+@Composable
+private fun ReviewedStreakMarker(
+    markerColor: Color,
+    markerContentColor: Color
+) {
+    Box(
+        modifier = Modifier
+            .size(34.dp)
+            .clip(CircleShape)
+            .background(markerColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.LocalFireDepartment,
+            contentDescription = null,
+            tint = markerContentColor
+        )
+    }
+}
+
+@Composable
+private fun FrozenStreakMarker() {
+    Box(
+        modifier = Modifier
+            .size(34.dp)
+            .clip(CircleShape)
+            .background(Color.White)
+            .border(
+                width = 1.dp,
+                color = frozenStreakBorderColor,
+                shape = CircleShape
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.AcUnit,
+            contentDescription = null,
+            tint = frozenStreakContentColor,
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}
+
+@Composable
+private fun DateStreakMarker(
+    day: ProgressStreakDayUiState,
+    dateTextColor: Color
+) {
+    val todayOutlineModifier = if (day.isToday) {
+        Modifier.border(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.primary,
+            shape = CircleShape
+        )
+    } else {
+        Modifier
+    }
+
+    Box(
+        modifier = Modifier
+            .size(34.dp)
+            .then(todayOutlineModifier),
+        contentAlignment = Alignment.Center
+    ) {
+        day.dayOfMonthLabel?.let { dayOfMonthLabel ->
+            Text(
+                text = dayOfMonthLabel,
+                color = dateTextColor,
+                fontWeight = if (day.isToday) FontWeight.SemiBold else FontWeight.Normal,
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -12,6 +12,12 @@
     <string name="progress_streak_subtitle">Last 5 weeks</string>
     <string name="progress_streak_summary_reviewed_today">Reviewed today</string>
     <string name="progress_streak_summary_not_reviewed_today">Not reviewed today</string>
+    <string name="progress_streak_freeze_bank_value">%1$d/%2$d</string>
+    <string name="progress_streak_freeze_bank_content_description">Streak freezes %1$d of %2$d available.</string>
+    <string name="progress_streak_day_reviewed_content_description">%1$s reviewed.</string>
+    <string name="progress_streak_day_frozen_content_description">%1$s protected by a streak freeze.</string>
+    <string name="progress_streak_day_pending_content_description">%1$s pending.</string>
+    <string name="progress_streak_day_missed_content_description">%1$s missed.</string>
     <string name="progress_reviews_title">Reviews</string>
     <string name="progress_reviews_previous_week">Previous week</string>
     <string name="progress_reviews_next_week">Next week</string>

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
@@ -33,6 +33,9 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewScheduleBucket
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
@@ -1030,27 +1033,9 @@ private fun createProgressSummarySnapshot(): ProgressSummarySnapshot {
             timeZone = "Europe/Madrid",
             referenceLocalDate = "2026-04-18"
         ),
-        renderedSummary = CloudProgressSummary(
-            currentStreakDays = 12,
-            hasReviewedToday = true,
-            lastReviewedOn = "2026-04-18",
-            activeReviewDays = 50,
-            reviewHistoryWatermarks = emptyList()
-        ),
-        localFallback = CloudProgressSummary(
-            currentStreakDays = 12,
-            hasReviewedToday = true,
-            lastReviewedOn = "2026-04-18",
-            activeReviewDays = 50,
-            reviewHistoryWatermarks = emptyList()
-        ),
-        serverBase = CloudProgressSummary(
-            currentStreakDays = 12,
-            hasReviewedToday = true,
-            lastReviewedOn = "2026-04-18",
-            activeReviewDays = 50,
-            reviewHistoryWatermarks = emptyList()
-        ),
+        renderedSummary = createProgressSummaryForTest(),
+        localFallback = createProgressSummaryForTest(),
+        serverBase = createProgressSummaryForTest(),
         source = ProgressSnapshotSource.SERVER_BASE,
         isApproximate = false
     )
@@ -1085,6 +1070,10 @@ private fun createProgressSeriesSnapshot(
         from = scopeKey.from,
         to = scopeKey.to,
         dailyReviews = dailyReviews,
+        streakDays = createProgressStreakDaysForTest(
+            dailyReviews = dailyReviews,
+            today = to
+        ),
         generatedAt = null,
         reviewHistoryWatermarks = emptyList(),
         summary = null
@@ -1104,6 +1093,12 @@ private fun createProgressSeriesSnapshot(
                     reviewCount = 0
                 )
             },
+            streakDays = createProgressStreakDaysForTest(
+                dailyReviews = dailyReviews.map { point ->
+                    point.copy(reviewCount = 0)
+                },
+                today = to
+            ),
             generatedAt = null,
             reviewHistoryWatermarks = emptyList(),
             summary = null
@@ -1111,6 +1106,45 @@ private fun createProgressSeriesSnapshot(
         source = ProgressSnapshotSource.LOCAL_ONLY,
         isApproximate = true
     )
+}
+
+private fun createProgressSummaryForTest(): CloudProgressSummary {
+    return CloudProgressSummary(
+        currentStreakDays = 12,
+        longestStreakDays = 12,
+        hasReviewedToday = true,
+        lastReviewedOn = "2026-04-18",
+        activeReviewDays = 50,
+        streakFreeze = createProgressStreakFreezeForTest(),
+        reviewHistoryWatermarks = emptyList()
+    )
+}
+
+private fun createProgressStreakFreezeForTest(): CloudProgressStreakFreeze {
+    return CloudProgressStreakFreeze(
+        availableCredits = 2,
+        capacity = 2,
+        balanceUnits = 20,
+        unitsPerCredit = 10,
+        nextCreditProgressUnits = 0,
+        nextCreditRequiredUnits = 10
+    )
+}
+
+private fun createProgressStreakDaysForTest(
+    dailyReviews: List<CloudDailyReviewPoint>,
+    today: String
+): List<CloudProgressStreakDay> {
+    return dailyReviews.map { point ->
+        CloudProgressStreakDay(
+            date = point.date,
+            state = when {
+                point.reviewCount > 0 -> CloudProgressStreakDayState.REVIEWED
+                point.date == today -> CloudProgressStreakDayState.PENDING
+                else -> CloudProgressStreakDayState.MISSED
+            }
+        )
+    }
 }
 
 private fun createProgressReviewScheduleSnapshot(): ProgressReviewScheduleSnapshot {

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadge.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadge.kt
@@ -10,6 +10,8 @@ private const val reviewProgressBadgeOverflowThreshold: Int = 99
 internal fun createEmptyReviewProgressBadgeState(): ReviewProgressBadgeState {
     return ReviewProgressBadgeState(
         streakDays = 0,
+        freezeAvailableCredits = 0,
+        freezeCapacity = 0,
         hasReviewedToday = false,
         isInteractive = true
     )
@@ -26,6 +28,8 @@ internal fun createEmptyReviewLeaderboardBadgeState(): ReviewLeaderboardBadgeSta
 internal fun ProgressSummarySnapshot.toReviewProgressBadgeState(): ReviewProgressBadgeState {
     return ReviewProgressBadgeState(
         streakDays = renderedSummary.currentStreakDays,
+        freezeAvailableCredits = renderedSummary.streakFreeze.availableCredits,
+        freezeCapacity = renderedSummary.streakFreeze.capacity,
         hasReviewedToday = renderedSummary.hasReviewedToday,
         isInteractive = true
     )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
@@ -8,6 +8,8 @@ import com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption
 
 data class ReviewProgressBadgeState(
     val streakDays: Int,
+    val freezeAvailableCredits: Int,
+    val freezeCapacity: Int,
     val hasReviewedToday: Boolean,
     val isInteractive: Boolean
 )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AcUnit
 import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.FormatListBulleted
@@ -25,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -35,6 +37,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 private val reviewTopBarFilterMaxWidth = 160.dp
+private val reviewProgressFreezeColor = Color(0xFF90CAF9)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -55,6 +58,16 @@ internal fun ReviewTopBar(
         reviewProgressBadge.streakDays,
         reviewProgressBadge.streakDays
     )
+    val freezeBankContentDescription = stringResource(
+        id = R.string.review_progress_badge_freeze_bank_content_description,
+        reviewProgressBadge.freezeAvailableCredits,
+        reviewProgressBadge.freezeCapacity
+    )
+    val progressBadgeFullContentDescription = if (reviewProgressBadge.freezeCapacity > 0) {
+        "$progressBadgeContentDescription $freezeBankContentDescription"
+    } else {
+        progressBadgeContentDescription
+    }
     val progressBadgeStateDescription = stringResource(
         id = if (reviewProgressBadge.hasReviewedToday) {
             R.string.review_progress_badge_reviewed_today
@@ -106,7 +119,7 @@ internal fun ReviewTopBar(
                 modifier = Modifier
                     .testTag(reviewProgressBadgeTag)
                     .semantics {
-                        contentDescription = progressBadgeContentDescription
+                        contentDescription = progressBadgeFullContentDescription
                         stateDescription = progressBadgeStateDescription
                     }
                     .clip(CircleShape)
@@ -127,9 +140,35 @@ internal fun ReviewTopBar(
                     }
                 )
                 Text(text = formatReviewProgressBadgeValue(streakDays = reviewProgressBadge.streakDays))
+                ReviewProgressFreezeBankIndicator(reviewProgressBadge = reviewProgressBadge)
             }
         }
     )
+}
+
+@Composable
+private fun ReviewProgressFreezeBankIndicator(
+    reviewProgressBadge: ReviewProgressBadgeState
+) {
+    if (reviewProgressBadge.freezeCapacity <= 0) {
+        return
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.AcUnit,
+            contentDescription = null,
+            tint = reviewProgressFreezeColor,
+            modifier = Modifier.size(18.dp)
+        )
+        Text(
+            text = reviewProgressBadge.freezeAvailableCredits.toString(),
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
 }
 
 @Composable

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="review_leaderboard_shortcut_rank_content_description">Open leaderboard. Best rank %1$d.</string>
     <string name="review_progress_badge_reviewed_today">Reviewed today</string>
     <string name="review_progress_badge_not_reviewed_today">Not reviewed today</string>
+    <string name="review_progress_badge_freeze_bank_content_description">Streak freezes %1$d of %2$d available.</string>
     <string name="review_filter_title_with_count">%1$s (%2$d)</string>
     <string name="review_edit_card_content_description">Edit card</string>
     <string name="review_front_label">Front</string>

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
@@ -9,6 +9,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardViewer
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardWindow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
@@ -33,6 +34,8 @@ class ReviewProgressBadgeStateTest {
         assertEquals(
             ReviewProgressBadgeState(
                 streakDays = 14,
+                freezeAvailableCredits = 2,
+                freezeCapacity = 2,
                 hasReviewedToday = true,
                 isInteractive = true
             ),
@@ -204,9 +207,18 @@ private fun createProgressSummarySnapshot(
 ): ProgressSummarySnapshot {
     val renderedSummary = CloudProgressSummary(
         currentStreakDays = currentStreakDays,
+        longestStreakDays = currentStreakDays,
         hasReviewedToday = hasReviewedToday,
         lastReviewedOn = "2026-04-18",
         activeReviewDays = 32,
+        streakFreeze = CloudProgressStreakFreeze(
+            availableCredits = 2,
+            capacity = 2,
+            balanceUnits = 20,
+            unitsPerCredit = 10,
+            nextCreditProgressUnits = 0,
+            nextCreditRequiredUnits = 10
+        ),
         reviewHistoryWatermarks = emptyList()
     )
 


### PR DESCRIPTION
## Summary
- Parse and cache Android progress freeze fields from the backend contract.
- Add freeze-aware local/pending streak evaluation and merge behavior.
- Render frozen streak days and compact freeze-bank indicators in Progress and Review UI.

## Validation
- git --no-pager diff --check
- Gradle was not run per repository instructions for this task.