### PR TITLE
[codex] Fix web friend invite emoji name limit

### DIFF
--- a/apps/web/src/screens/invite/FriendInviteScreen.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.tsx
@@ -17,10 +17,7 @@ import type {
   FriendInvitationPreviewResponse,
   SessionInfo,
 } from "../../types";
-import {
-  friendInvitationDisplayNameMaxLength,
-  validateFriendInvitationDisplayName,
-} from "./friendInvitationDisplayName";
+import { validateFriendInvitationDisplayName } from "./friendInvitationDisplayName";
 
 type InviteLoadState = "loading" | "inactive" | "error" | "signed_out" | "ready" | "success";
 
@@ -253,7 +250,6 @@ export function FriendInviteScreen(): ReactElement {
             type="text"
             value={friendDisplayName}
             disabled={isSubmitting}
-            maxLength={friendInvitationDisplayNameMaxLength + 1}
             onChange={(event) => {
               setFriendDisplayName(event.target.value);
               setFieldErrorMessage("");

--- a/apps/web/src/screens/invite/friendInvitationDisplayName.test.tsx
+++ b/apps/web/src/screens/invite/friendInvitationDisplayName.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { validateFriendInvitationDisplayName } from "./friendInvitationDisplayName";
+
+const messages = {
+  required: "required",
+  singleLine: "singleLine",
+  tooLong: "tooLong",
+};
+
+describe("validateFriendInvitationDisplayName", () => {
+  it("counts emoji by Unicode code point instead of UTF-16 code unit length", () => {
+    expect(validateFriendInvitationDisplayName("😀".repeat(30), messages)).toBe("");
+    expect(validateFriendInvitationDisplayName("😀".repeat(31), messages)).toBe("tooLong");
+  });
+});

--- a/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
@@ -17,10 +17,7 @@ import type {
   ProgressLeaderboardWindowKey,
 } from "../../../types";
 import { progressLeaderboardWindowKeys } from "../../../types";
-import {
-  friendInvitationDisplayNameMaxLength,
-  validateFriendInvitationDisplayName,
-} from "../../invite/friendInvitationDisplayName";
+import { validateFriendInvitationDisplayName } from "../../invite/friendInvitationDisplayName";
 
 const millisecondsPerMinute = 60_000;
 
@@ -234,7 +231,6 @@ function ProgressLeaderboardInviteDialog(props: Readonly<{
                   type="text"
                   value={friendDisplayName}
                   disabled={isSubmitting}
-                  maxLength={friendInvitationDisplayNameMaxLength + 1}
                   onChange={(event) => {
                     setFriendDisplayName(event.target.value);
                     setFieldErrorMessage("");


### PR DESCRIPTION
## Summary
- remove browser-native maxlength from web friend invite name fields so emoji input is not capped by UTF-16 code units
- keep the existing Unicode-aware validation as the single source of truth
- add a focused test for 30 vs 31 emoji names

## Validation
- npx vitest run src/screens/invite/friendInvitationDisplayName.test.tsx src/screens/invite/FriendInviteScreen.test.tsx
- npm run build