### PR TITLE
[codex] Add web invite preview pages

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -38,6 +38,8 @@ import {
   cardsRoute,
   chatRoute,
   friendInviteRoutePattern,
+  friendInvitePreviewIndexRoute,
+  friendInvitePreviewRoutePattern,
   progressRoute,
   reviewRoute,
   settingsAccessRoute,
@@ -85,6 +87,9 @@ const primaryNavigationItems: ReadonlyArray<PrimaryNavigationItem> = [
 ];
 
 const ChatPanel = lazy(async () => import("./chat/ChatPanel").then((module) => ({ default: module.ChatPanel })));
+const FriendInvitePreviewScreen = lazy(async () => import("./dev/previews/invite/FriendInvitePreviewScreen").then((module) => ({
+  default: module.FriendInvitePreviewScreen,
+})));
 const AccessPermissionDetailScreen = lazy(async () => import("./screens/settings/access/AccessPermissionDetailScreen").then((module) => ({
   default: module.AccessPermissionDetailScreen,
 })));
@@ -740,6 +745,14 @@ export default function App(): ReactElement {
       <BrowserRouter>
         <TestModeProvider>
           <SentryRoutes>
+            <Route
+              path={friendInvitePreviewIndexRoute}
+              element={renderDeferredRoute(<FriendInvitePreviewScreen />, "friendInvite.loading")}
+            />
+            <Route
+              path={friendInvitePreviewRoutePattern}
+              element={renderDeferredRoute(<FriendInvitePreviewScreen />, "friendInvite.loading")}
+            />
             <Route path={friendInviteRoutePattern} element={<FriendInviteScreen />} />
             <Route path="/*" element={<AuthenticatedApp />} />
           </SentryRoutes>

--- a/apps/web/src/dev/previews/invite/FriendInvitePreviewScreen.tsx
+++ b/apps/web/src/dev/previews/invite/FriendInvitePreviewScreen.tsx
@@ -1,0 +1,172 @@
+import { useState, type ReactElement } from "react";
+import { Link, Navigate, useParams } from "react-router-dom";
+import {
+  FriendInviteErrorPanel,
+  FriendInviteInactivePanel,
+  FriendInviteLoadingPanel,
+  FriendInviteReadyPanel,
+  FriendInviteSignedOutPanel,
+  FriendInviteSuccessPanel,
+} from "../../../screens/invite/FriendInviteScreen";
+import {
+  buildFriendInvitePreviewRoute,
+  friendInvitePreviewIndexRoute,
+  reviewRoute,
+} from "../../../routes";
+import type { FriendInvitationAcceptResponse } from "../../../types";
+
+const docsPath = "docs/web-invite-previews.md";
+const previewStates = [
+  "loading",
+  "inactive",
+  "error",
+  "signed-out",
+  "ready",
+  "success",
+  "already-friends",
+] as const;
+
+type FriendInvitePreviewState = (typeof previewStates)[number];
+
+type FriendInvitePreviewChromeProps = Readonly<{
+  state: FriendInvitePreviewState;
+  children: ReactElement;
+}>;
+
+const acceptedPreviewResponse: FriendInvitationAcceptResponse = {
+  status: "accepted",
+};
+
+const alreadyFriendsPreviewResponse: FriendInvitationAcceptResponse = {
+  status: "already_friends",
+  existingFriendDisplayName: "Alex",
+};
+
+function isFriendInvitePreviewEnabled(): boolean {
+  return import.meta.env.DEV || import.meta.env.VITE_ENABLE_DEV_PREVIEWS === "true";
+}
+
+function isFriendInvitePreviewState(value: string): value is FriendInvitePreviewState {
+  return previewStates.some((state) => state === value);
+}
+
+function readFriendInvitePreviewState(routeState: string | undefined): FriendInvitePreviewState | null {
+  if (routeState === undefined || routeState === "") {
+    return null;
+  }
+
+  if (isFriendInvitePreviewState(routeState)) {
+    return routeState;
+  }
+
+  throw new Error(`Unknown friend invite preview state: ${routeState}`);
+}
+
+function handlePreviewAction(): void {
+  // Preview buttons intentionally avoid backend calls.
+}
+
+function FriendInvitePreviewIndex(): ReactElement {
+  return (
+    <main className="dev-preview-page">
+      <section className="content-card dev-preview-index-panel">
+        <p className="dev-preview-eyebrow">Non-production invite previews</p>
+        <h1 className="title">Friend invite preview pages</h1>
+        <p className="subtitle">
+          Open a specific invite state without accepting a real invite. Full manual testing instructions:
+          {" "}
+          <code>{docsPath}</code>.
+        </p>
+        <div className="dev-preview-link-list">
+          {previewStates.map((state) => (
+            <Link className="ghost-btn" key={state} to={buildFriendInvitePreviewRoute(state)}>
+              {state}
+            </Link>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+function FriendInvitePreviewChrome({ state, children }: FriendInvitePreviewChromeProps): ReactElement {
+  return (
+    <div className="dev-preview-frame">
+      <aside className="dev-preview-toolbar" aria-label="Friend invite preview instructions">
+        <Link to={friendInvitePreviewIndexRoute}>Invite previews</Link>
+        <span>
+          State: <code>{state}</code>
+        </span>
+        <span>
+          Manual testing docs: <code>{docsPath}</code>
+        </span>
+      </aside>
+      <div className="dev-preview-screen" data-testid={`friend-invite-preview-${state}`}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function renderFriendInvitePreviewState(
+  state: FriendInvitePreviewState,
+  friendDisplayName: string,
+  onFriendDisplayNameChange: (value: string) => void,
+): ReactElement {
+  if (state === "loading") {
+    return <FriendInviteLoadingPanel />;
+  }
+
+  if (state === "inactive") {
+    return <FriendInviteInactivePanel errorMessage="" onRetry={handlePreviewAction} />;
+  }
+
+  if (state === "error") {
+    return <FriendInviteErrorPanel errorMessage="Preview request failed." onRetry={handlePreviewAction} />;
+  }
+
+  if (state === "signed-out") {
+    return <FriendInviteSignedOutPanel loginHref={buildFriendInvitePreviewRoute("ready")} />;
+  }
+
+  if (state === "ready") {
+    return (
+      <FriendInviteReadyPanel
+        friendDisplayName={friendDisplayName}
+        fieldErrorMessage=""
+        errorMessage=""
+        isSubmitting={false}
+        canAccept
+        onFriendDisplayNameChange={onFriendDisplayNameChange}
+        onAccept={handlePreviewAction}
+      />
+    );
+  }
+
+  if (state === "success") {
+    return <FriendInviteSuccessPanel acceptedResponse={acceptedPreviewResponse} />;
+  }
+
+  return <FriendInviteSuccessPanel acceptedResponse={alreadyFriendsPreviewResponse} />;
+}
+
+// Non-production preview routes are documented in docs/web-invite-previews.md.
+export function FriendInvitePreviewScreen(): ReactElement {
+  const { state } = useParams();
+  const [friendDisplayName, setFriendDisplayName] = useState<string>("Alex");
+
+  if (!isFriendInvitePreviewEnabled()) {
+    return <Navigate replace to={reviewRoute} />;
+  }
+
+  const previewState = readFriendInvitePreviewState(state);
+  if (previewState === null) {
+    return <FriendInvitePreviewIndex />;
+  }
+
+  return (
+    <FriendInvitePreviewChrome state={previewState}>
+      {renderFriendInvitePreviewState(previewState, friendDisplayName, setFriendDisplayName)}
+    </FriendInvitePreviewChrome>
+  );
+}

--- a/apps/web/src/env.d.ts
+++ b/apps/web/src/env.d.ts
@@ -8,6 +8,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_DSN?: string;
   readonly VITE_SENTRY_ENVIRONMENT?: string;
   readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string;
+  readonly VITE_ENABLE_DEV_PREVIEWS?: string;
 }
 
 interface ImportMeta {

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -13,6 +13,10 @@ export const progressLeaderboardHash: string = "leaderboard";
 export const progressLeaderboardRoute: string = `${progressRoute}#${progressLeaderboardHash}`;
 export const friendInviteRoutePrefix: string = "/invite";
 export const friendInviteRoutePattern: string = `${friendInviteRoutePrefix}/:token`;
+export const devPreviewsRoutePrefix: string = "/dev/previews";
+export const friendInvitePreviewRoutePrefix: string = `${devPreviewsRoutePrefix}/invite`;
+export const friendInvitePreviewIndexRoute: string = friendInvitePreviewRoutePrefix;
+export const friendInvitePreviewRoutePattern: string = `${friendInvitePreviewRoutePrefix}/:state`;
 export const cardsRoute: string = "/cards";
 export const settingsHubRoute: string = "/settings";
 export const settingsCurrentWorkspaceRoute: string = "/settings/current-workspace";
@@ -51,6 +55,10 @@ export function buildSettingsDeckEditRoute(deckId: string): string {
 
 export function buildFriendInviteRoute(token: string): string {
   return `${friendInviteRoutePrefix}/${encodeURIComponent(token)}`;
+}
+
+export function buildFriendInvitePreviewRoute(state: string): string {
+  return `${friendInvitePreviewRoutePrefix}/${encodeURIComponent(state)}`;
 }
 
 export function buildSettingsAccessDetailRoute(accessKind: "camera" | "microphone" | "photos-and-files"): string {

--- a/apps/web/src/screens/invite/FriendInviteScreen.tsx
+++ b/apps/web/src/screens/invite/FriendInviteScreen.tsx
@@ -70,6 +70,163 @@ function InviteSuccessLinks(): ReactElement {
   );
 }
 
+type FriendInviteRetryPanelProps = Readonly<{
+  errorMessage: string;
+  onRetry: () => void;
+}>;
+
+type FriendInviteSignedOutPanelProps = Readonly<{
+  loginHref: string;
+}>;
+
+type FriendInviteSuccessPanelProps = Readonly<{
+  acceptedResponse: FriendInvitationAcceptResponse | null;
+}>;
+
+type FriendInviteReadyPanelProps = Readonly<{
+  friendDisplayName: string;
+  fieldErrorMessage: string;
+  errorMessage: string;
+  isSubmitting: boolean;
+  canAccept: boolean;
+  onFriendDisplayNameChange: (value: string) => void;
+  onAccept: () => void;
+}>;
+
+// Dev previews for these production panels are documented in docs/web-invite-previews.md.
+export function FriendInviteLoadingPanel(): ReactElement {
+  const { t } = useI18n();
+
+  return (
+    <main className="invite-page">
+      <section className="content-card invite-panel">
+        <p className="subtitle" data-testid="friend-invite-loading">{t("friendInvite.loading")}</p>
+      </section>
+    </main>
+  );
+}
+
+export function FriendInviteInactivePanel({ errorMessage, onRetry }: FriendInviteRetryPanelProps): ReactElement {
+  const { t } = useI18n();
+
+  return (
+    <main className="invite-page">
+      <section className="content-card invite-panel" data-testid="friend-invite-inactive">
+        <h1 className="title">{t("friendInvite.inactiveTitle")}</h1>
+        <p className="subtitle">{t("friendInvite.inactiveBody")}</p>
+        {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
+        <button className="ghost-btn" type="button" onClick={onRetry}>
+          {t("common.retry")}
+        </button>
+      </section>
+    </main>
+  );
+}
+
+export function FriendInviteErrorPanel({ errorMessage, onRetry }: FriendInviteRetryPanelProps): ReactElement {
+  const { t } = useI18n();
+
+  return (
+    <main className="invite-page">
+      <section className="content-card invite-panel" data-testid="friend-invite-error">
+        <h1 className="title">{t("friendInvite.errorTitle")}</h1>
+        <p className="subtitle">{t("friendInvite.errorBody")}</p>
+        {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
+        <button className="ghost-btn" type="button" onClick={onRetry}>
+          {t("common.retry")}
+        </button>
+      </section>
+    </main>
+  );
+}
+
+export function FriendInviteSignedOutPanel({ loginHref }: FriendInviteSignedOutPanelProps): ReactElement {
+  const { t } = useI18n();
+
+  return (
+    <main className="invite-page">
+      <section className="content-card invite-panel" data-testid="friend-invite-signed-out">
+        <h1 className="title">{t("friendInvite.signInTitle")}</h1>
+        <p className="subtitle">{t("friendInvite.signInBody")}</p>
+        <a className="primary-btn" href={loginHref}>
+          {t("friendInvite.signInButton")}
+        </a>
+      </section>
+    </main>
+  );
+}
+
+export function FriendInviteSuccessPanel({ acceptedResponse }: FriendInviteSuccessPanelProps): ReactElement {
+  const { t } = useI18n();
+  const isAlreadyFriends = acceptedResponse?.status === "already_friends";
+
+  return (
+    <main className="invite-page">
+      <section className="content-card invite-panel" data-testid="friend-invite-success">
+        <h1 className="title">
+          {isAlreadyFriends ? t("friendInvite.alreadyFriendsTitle") : t("friendInvite.successTitle")}
+        </h1>
+        <p className="subtitle">
+          {isAlreadyFriends && acceptedResponse?.status === "already_friends"
+            ? t("friendInvite.alreadyFriendsBody", { name: acceptedResponse.existingFriendDisplayName })
+            : t("friendInvite.successBody")}
+        </p>
+        <InviteSuccessLinks />
+        <InviteMobileLinksNotice />
+      </section>
+    </main>
+  );
+}
+
+export function FriendInviteReadyPanel({
+  friendDisplayName,
+  fieldErrorMessage,
+  errorMessage,
+  isSubmitting,
+  canAccept,
+  onFriendDisplayNameChange,
+  onAccept,
+}: FriendInviteReadyPanelProps): ReactElement {
+  const { t } = useI18n();
+
+  return (
+    <main className="invite-page">
+      <section className="content-card invite-panel" data-testid="friend-invite-ready">
+        <h1 className="title">{t("friendInvite.formTitle")}</h1>
+        <p className="subtitle">{t("friendInvite.formBody")}</p>
+        <label className="form-label invite-field">
+          <span>{t("friendInvite.displayNameLabel")}</span>
+          <input
+            className="text-input"
+            type="text"
+            value={friendDisplayName}
+            disabled={isSubmitting}
+            onChange={(event) => {
+              onFriendDisplayNameChange(event.target.value);
+            }}
+            data-testid="friend-invite-display-name-input"
+          />
+        </label>
+        {fieldErrorMessage !== "" ? (
+          <p className="error-banner" role="alert" data-testid="friend-invite-display-name-error">
+            {fieldErrorMessage}
+          </p>
+        ) : null}
+        {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
+        <button
+          className="primary-btn"
+          type="button"
+          disabled={isSubmitting || !canAccept}
+          onClick={onAccept}
+          data-testid="friend-invite-accept-button"
+        >
+          {isSubmitting ? t("friendInvite.accepting") : t("friendInvite.accept")}
+        </button>
+      </section>
+    </main>
+  );
+}
+
 export function FriendInviteScreen(): ReactElement {
   const { token } = useParams();
   const inviteToken = readInviteTokenParam(token);
@@ -163,116 +320,48 @@ export function FriendInviteScreen(): ReactElement {
     }
   }
 
+  function retryInviteLoad(): void {
+    void loadInvite();
+  }
+
+  function updateFriendDisplayName(value: string): void {
+    setFriendDisplayName(value);
+    setFieldErrorMessage("");
+  }
+
+  function acceptInvite(): void {
+    void submitInviteAcceptance();
+  }
+
   if (loadState === "loading") {
-    return (
-      <main className="invite-page">
-        <section className="content-card invite-panel">
-          <p className="subtitle" data-testid="friend-invite-loading">{t("friendInvite.loading")}</p>
-        </section>
-      </main>
-    );
+    return <FriendInviteLoadingPanel />;
   }
 
   if (loadState === "inactive") {
-    return (
-      <main className="invite-page">
-        <section className="content-card invite-panel" data-testid="friend-invite-inactive">
-          <h1 className="title">{t("friendInvite.inactiveTitle")}</h1>
-          <p className="subtitle">{t("friendInvite.inactiveBody")}</p>
-          {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
-          <button className="ghost-btn" type="button" onClick={() => void loadInvite()}>
-            {t("common.retry")}
-          </button>
-        </section>
-      </main>
-    );
+    return <FriendInviteInactivePanel errorMessage={errorMessage} onRetry={retryInviteLoad} />;
   }
 
   if (loadState === "error") {
-    return (
-      <main className="invite-page">
-        <section className="content-card invite-panel" data-testid="friend-invite-error">
-          <h1 className="title">{t("friendInvite.errorTitle")}</h1>
-          <p className="subtitle">{t("friendInvite.errorBody")}</p>
-          {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
-          <button className="ghost-btn" type="button" onClick={() => void loadInvite()}>
-            {t("common.retry")}
-          </button>
-        </section>
-      </main>
-    );
+    return <FriendInviteErrorPanel errorMessage={errorMessage} onRetry={retryInviteLoad} />;
   }
 
   if (loadState === "signed_out") {
-    return (
-      <main className="invite-page">
-        <section className="content-card invite-panel" data-testid="friend-invite-signed-out">
-          <h1 className="title">{t("friendInvite.signInTitle")}</h1>
-          <p className="subtitle">{t("friendInvite.signInBody")}</p>
-          <a className="primary-btn" href={buildLoginUrl(window.location.href, locale)}>
-            {t("friendInvite.signInButton")}
-          </a>
-        </section>
-      </main>
-    );
+    return <FriendInviteSignedOutPanel loginHref={buildLoginUrl(window.location.href, locale)} />;
   }
 
   if (loadState === "success") {
-    const isAlreadyFriends = acceptedResponse?.status === "already_friends";
-
-    return (
-      <main className="invite-page">
-        <section className="content-card invite-panel" data-testid="friend-invite-success">
-          <h1 className="title">
-            {isAlreadyFriends ? t("friendInvite.alreadyFriendsTitle") : t("friendInvite.successTitle")}
-          </h1>
-          <p className="subtitle">
-            {isAlreadyFriends && acceptedResponse?.status === "already_friends"
-              ? t("friendInvite.alreadyFriendsBody", { name: acceptedResponse.existingFriendDisplayName })
-              : t("friendInvite.successBody")}
-          </p>
-          <InviteSuccessLinks />
-          <InviteMobileLinksNotice />
-        </section>
-      </main>
-    );
+    return <FriendInviteSuccessPanel acceptedResponse={acceptedResponse} />;
   }
 
   return (
-    <main className="invite-page">
-      <section className="content-card invite-panel" data-testid="friend-invite-ready">
-        <h1 className="title">{t("friendInvite.formTitle")}</h1>
-        <p className="subtitle">{t("friendInvite.formBody")}</p>
-        <label className="form-label invite-field">
-          <span>{t("friendInvite.displayNameLabel")}</span>
-          <input
-            className="text-input"
-            type="text"
-            value={friendDisplayName}
-            disabled={isSubmitting}
-            onChange={(event) => {
-              setFriendDisplayName(event.target.value);
-              setFieldErrorMessage("");
-            }}
-            data-testid="friend-invite-display-name-input"
-          />
-        </label>
-        {fieldErrorMessage !== "" ? (
-          <p className="error-banner" role="alert" data-testid="friend-invite-display-name-error">
-            {fieldErrorMessage}
-          </p>
-        ) : null}
-        {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
-        <button
-          className="primary-btn"
-          type="button"
-          disabled={isSubmitting || preview?.status !== "active"}
-          onClick={() => void submitInviteAcceptance()}
-          data-testid="friend-invite-accept-button"
-        >
-          {isSubmitting ? t("friendInvite.accepting") : t("friendInvite.accept")}
-        </button>
-      </section>
-    </main>
+    <FriendInviteReadyPanel
+      friendDisplayName={friendDisplayName}
+      fieldErrorMessage={fieldErrorMessage}
+      errorMessage={errorMessage}
+      isSubmitting={isSubmitting}
+      canAccept={preview?.status === "active"}
+      onFriendDisplayNameChange={updateFriendDisplayName}
+      onAccept={acceptInvite}
+    />
   );
 }

--- a/apps/web/src/styles/features/dev-previews.css
+++ b/apps/web/src/styles/features/dev-previews.css
@@ -1,0 +1,70 @@
+.dev-preview-frame {
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+.dev-preview-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--divider);
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.dev-preview-toolbar a,
+.dev-preview-toolbar code {
+  color: var(--text-primary);
+}
+
+.dev-preview-screen > .invite-page {
+  min-height: calc(100vh - 42px);
+}
+
+.dev-preview-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--bg);
+}
+
+.dev-preview-index-panel {
+  width: min(100%, 680px);
+  display: grid;
+  gap: 16px;
+}
+
+.dev-preview-index-panel > .title,
+.dev-preview-index-panel > .subtitle,
+.dev-preview-eyebrow {
+  margin: 0;
+}
+
+.dev-preview-eyebrow {
+  color: var(--text-tertiary);
+  font-size: 13px;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.dev-preview-index-panel code {
+  color: var(--text-primary);
+}
+
+.dev-preview-link-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+@media (max-width: 640px) {
+  .dev-preview-page {
+    padding: 16px;
+    align-items: start;
+  }
+}

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -13,3 +13,4 @@
 @import "./features/settings.css" layer(features);
 @import "./features/progress.css" layer(features);
 @import "./features/invite.css" layer(features);
+@import "./features/dev-previews.css" layer(features);

--- a/docs/web-invite-previews.md
+++ b/docs/web-invite-previews.md
@@ -1,0 +1,45 @@
+# Web Invite Previews
+
+Use these pages to inspect friend-invite web states without creating or accepting a real invite.
+
+The preview routes are non-production tooling:
+
+- Vite dev server enables them automatically.
+- Production-style preview builds require `VITE_ENABLE_DEV_PREVIEWS=true`.
+- Do not set `VITE_ENABLE_DEV_PREVIEWS=true` for the deployed production web app.
+
+From `apps/web`:
+
+```sh
+npm run dev
+```
+
+For a production-style local preview:
+
+```sh
+VITE_ENABLE_DEV_PREVIEWS=true npm run build
+npm run preview
+```
+
+Open the index page:
+
+```text
+http://localhost:3000/dev/previews/invite
+```
+
+The index links to each state:
+
+- `/dev/previews/invite/loading`
+- `/dev/previews/invite/inactive`
+- `/dev/previews/invite/error`
+- `/dev/previews/invite/signed-out`
+- `/dev/previews/invite/ready`
+- `/dev/previews/invite/success`
+- `/dev/previews/invite/already-friends`
+
+These pages do not call the backend and do not create friendship rows. The real invite route is still `/invite/:token`.
+
+Implementation entry points:
+
+- Production panels: `apps/web/src/screens/invite/FriendInviteScreen.tsx`
+- Preview routes: `apps/web/src/dev/previews/invite/FriendInvitePreviewScreen.tsx`


### PR DESCRIPTION
## Summary
- add non-production web preview routes for friend invite states
- reuse the production invite panels from the real invite screen
- document how to open the preview pages locally

## Validation
- git --no-pager diff --check
- npx vitest run src/screens/invite/FriendInviteScreen.test.tsx src/screens/invite/friendInvitationDisplayName.test.tsx
- npx tsc --noEmit -p tsconfig.json
- npm run build
