### PR TITLE
[codex] Add web progress freeze UI

### DIFF
--- a/apps/web/src/api/endpoints/endpoints.test.ts
+++ b/apps/web/src/api/endpoints/endpoints.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ProgressReviewSchedule } from "../../types";
+import type { ProgressReviewSchedule, StreakDay } from "../../types";
 import { persistLocalePreference } from "../../i18n/runtime";
 import {
   createChatSnapshotResponse,
@@ -81,6 +81,55 @@ afterEach(() => {
   resetApiClientStateForTests();
   vi.restoreAllMocks();
 });
+
+function createFullStreakFreeze(): Readonly<{
+  availableCredits: number;
+  capacity: number;
+  balanceUnits: number;
+  unitsPerCredit: number;
+  nextCreditProgressUnits: number;
+  nextCreditRequiredUnits: number;
+}> {
+  return {
+    availableCredits: 2,
+    capacity: 2,
+    balanceUnits: 20,
+    unitsPerCredit: 10,
+    nextCreditProgressUnits: 0,
+    nextCreditRequiredUnits: 10,
+  };
+}
+
+function createProgressSummaryValue(
+  currentStreakDays: number,
+  hasReviewedToday: boolean,
+  lastReviewedOn: string | null,
+  activeReviewDays: number,
+): Readonly<{
+  currentStreakDays: number;
+  longestStreakDays: number;
+  hasReviewedToday: boolean;
+  lastReviewedOn: string | null;
+  activeReviewDays: number;
+  streakFreeze: ReturnType<typeof createFullStreakFreeze>;
+}> {
+  return {
+    currentStreakDays,
+    longestStreakDays: currentStreakDays,
+    hasReviewedToday,
+    lastReviewedOn,
+    activeReviewDays,
+    streakFreeze: createFullStreakFreeze(),
+  };
+}
+
+function createThreeDayStreakDays(): ReadonlyArray<StreakDay> {
+  return [
+    { date: "2026-04-01", state: "reviewed" },
+    { date: "2026-04-02", state: "frozen" },
+    { date: "2026-04-03", state: "reviewed" },
+  ];
+}
 
 describe("auth URL endpoints", () => {
   it("prefers the stored app locale over raw browser detection", () => {
@@ -261,12 +310,7 @@ describe("progress API endpoints", () => {
         reviewHistoryWatermarks: [
           { workspaceId: "workspace-1", reviewSequenceId: 42 },
         ],
-        summary: {
-          currentStreakDays: 1,
-          hasReviewedToday: true,
-          lastReviewedOn: "2026-04-03",
-          activeReviewDays: 2,
-        },
+        summary: createProgressSummaryValue(1, true, "2026-04-03", 2),
       }), {
         status: 200,
         headers: {
@@ -284,12 +328,7 @@ describe("progress API endpoints", () => {
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: {
-        currentStreakDays: 1,
-        hasReviewedToday: true,
-        lastReviewedOn: "2026-04-03",
-        activeReviewDays: 2,
-      },
+      summary: createProgressSummaryValue(1, true, "2026-04-03", 2),
     });
   });
 
@@ -298,12 +337,7 @@ describe("progress API endpoints", () => {
       .mockResolvedValueOnce(new Response(JSON.stringify({
         timeZone: "Europe/Madrid",
         generatedAt: "2026-04-18T09:15:00.000Z",
-        summary: {
-          currentStreakDays: 1,
-          hasReviewedToday: true,
-          lastReviewedOn: "2026-04-03",
-          activeReviewDays: 2,
-        },
+        summary: createProgressSummaryValue(1, true, "2026-04-03", 2),
       }), {
         status: 200,
         headers: {
@@ -319,12 +353,7 @@ describe("progress API endpoints", () => {
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-18T09:15:00.000Z",
       reviewHistoryWatermarks: [],
-      summary: {
-        currentStreakDays: 1,
-        hasReviewedToday: true,
-        lastReviewedOn: "2026-04-03",
-        activeReviewDays: 2,
-      },
+      summary: createProgressSummaryValue(1, true, "2026-04-03", 2),
     });
   });
 
@@ -364,6 +393,7 @@ describe("progress API endpoints", () => {
             easyCount: 0,
           },
         ],
+        streakDays: createThreeDayStreakDays(),
       }), {
         status: 200,
         headers: {
@@ -410,6 +440,7 @@ describe("progress API endpoints", () => {
           easyCount: 0,
         },
       ],
+      streakDays: createThreeDayStreakDays(),
     });
   });
 
@@ -446,6 +477,7 @@ describe("progress API endpoints", () => {
             easyCount: 0,
           },
         ],
+        streakDays: createThreeDayStreakDays(),
       }), {
         status: 200,
         headers: {
@@ -490,6 +522,7 @@ describe("progress API endpoints", () => {
           easyCount: 0,
         },
       ],
+      streakDays: createThreeDayStreakDays(),
     });
   });
 
@@ -748,6 +781,55 @@ describe("progress API endpoints", () => {
       today: "2026-04-18",
     })).rejects.toThrow(
       "Invalid API response for GET /me/progress/summary: reviewHistoryWatermarks[0].reviewSequenceId must be a non-negative safe integer",
+    );
+  });
+
+  it("rejects progress summary responses with incoherent streak freeze metadata", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        timeZone: "Europe/Madrid",
+        generatedAt: "2026-04-18T09:15:00.000Z",
+        summary: {
+          ...createProgressSummaryValue(1, true, "2026-04-03", 2),
+          streakFreeze: {
+            ...createFullStreakFreeze(),
+            balanceUnits: 19,
+          },
+        },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressSummary({
+      timeZone: "Europe/Madrid",
+      today: "2026-04-18",
+    })).rejects.toThrow(
+      "Invalid API response for GET /me/progress/summary: summary.streakFreeze must be a coherent streak freeze object",
+    );
+  });
+
+  it("rejects progress summary responses with incoherent streak length metadata", async () => {
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        timeZone: "Europe/Madrid",
+        generatedAt: "2026-04-18T09:15:00.000Z",
+        summary: {
+          ...createProgressSummaryValue(5, true, "2026-04-03", 5),
+          longestStreakDays: 4,
+        },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressSummary({
+      timeZone: "Europe/Madrid",
+      today: "2026-04-18",
+    })).rejects.toThrow(
+      "Invalid API response for GET /me/progress/summary: summary must be a coherent progress summary object",
     );
   });
 });

--- a/apps/web/src/apiContracts/progress.ts
+++ b/apps/web/src/apiContracts/progress.ts
@@ -17,8 +17,10 @@ import {
   progressLeaderboardStatuses,
   progressLeaderboardWindowKeys,
   progressReviewScheduleBucketKeys,
+  streakDayStates,
 } from "../types";
 import { findProgressReviewScheduleValidationIssue } from "../progress/progressReviewScheduleValidation";
+import { isCoherentStreakFreeze } from "../progress/streakFreeze";
 import {
   ApiContractError,
   describePath,
@@ -162,18 +164,76 @@ function parseProgressReviewScheduleBucketArray(
   return parseArray(value, endpoint, path, parseProgressReviewScheduleBucket);
 }
 
+function parseProgressStreakFreeze(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ProgressSummaryPayload["summary"]["streakFreeze"] {
+  const objectValue = parseObject(value, endpoint, path);
+  const streakFreeze = {
+    availableCredits: parseRequiredField(objectValue, "availableCredits", endpoint, path, parseNonNegativeSafeInteger),
+    capacity: parseRequiredField(objectValue, "capacity", endpoint, path, parseNonNegativeSafeInteger),
+    balanceUnits: parseRequiredField(objectValue, "balanceUnits", endpoint, path, parseNonNegativeSafeInteger),
+    unitsPerCredit: parseRequiredField(objectValue, "unitsPerCredit", endpoint, path, parseNonNegativeSafeInteger),
+    nextCreditProgressUnits: parseRequiredField(objectValue, "nextCreditProgressUnits", endpoint, path, parseNonNegativeSafeInteger),
+    nextCreditRequiredUnits: parseRequiredField(objectValue, "nextCreditRequiredUnits", endpoint, path, parseNonNegativeSafeInteger),
+  };
+
+  if (isCoherentStreakFreeze(streakFreeze) === false) {
+    throw new ApiContractError(endpoint, describePath(path), "a coherent streak freeze object");
+  }
+
+  return streakFreeze;
+}
+
 function parseProgressSummary(
   value: unknown,
   endpoint: string,
   path: string,
 ): ProgressSummaryPayload["summary"] {
   const objectValue = parseObject(value, endpoint, path);
-  return {
-    currentStreakDays: parseRequiredField(objectValue, "currentStreakDays", endpoint, path, parseNumber),
+  const summary: ProgressSummaryPayload["summary"] = {
+    currentStreakDays: parseRequiredField(objectValue, "currentStreakDays", endpoint, path, parseNonNegativeSafeInteger),
+    longestStreakDays: parseRequiredField(objectValue, "longestStreakDays", endpoint, path, parseNonNegativeSafeInteger),
     hasReviewedToday: parseRequiredField(objectValue, "hasReviewedToday", endpoint, path, parseBoolean),
     lastReviewedOn: parseRequiredField(objectValue, "lastReviewedOn", endpoint, path, parseNullableString),
-    activeReviewDays: parseRequiredField(objectValue, "activeReviewDays", endpoint, path, parseNumber),
+    activeReviewDays: parseRequiredField(objectValue, "activeReviewDays", endpoint, path, parseNonNegativeSafeInteger),
+    streakFreeze: parseRequiredField(objectValue, "streakFreeze", endpoint, path, parseProgressStreakFreeze),
   };
+
+  if (summary.longestStreakDays < summary.currentStreakDays) {
+    throw new ApiContractError(endpoint, describePath(path), "a coherent progress summary object");
+  }
+
+  return summary;
+}
+
+function parseStreakDayState(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ProgressSeries["streakDays"][number]["state"] {
+  return parseEnum(value, endpoint, path, streakDayStates);
+}
+
+function parseStreakDay(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ProgressSeries["streakDays"][number] {
+  const objectValue = parseObject(value, endpoint, path);
+  return {
+    date: parseRequiredField(objectValue, "date", endpoint, path, parseString),
+    state: parseRequiredField(objectValue, "state", endpoint, path, parseStreakDayState),
+  };
+}
+
+function parseStreakDayArray(
+  value: unknown,
+  endpoint: string,
+  path: string,
+): ProgressSeries["streakDays"] {
+  return parseArray(value, endpoint, path, parseStreakDay);
 }
 
 // Wire-shape note: the backend always emits `generatedAt` as a non-null ISO string for
@@ -200,6 +260,7 @@ export function parseProgressSeriesResponse(value: unknown, endpoint: string): P
       "",
     ),
     dailyReviews: parseRequiredField(objectValue, "dailyReviews", endpoint, "", parseDailyReviewPointArray),
+    streakDays: parseRequiredField(objectValue, "streakDays", endpoint, "", parseStreakDayArray),
   };
 }
 

--- a/apps/web/src/appData/progress/badge/reviewProgressBadge.ts
+++ b/apps/web/src/appData/progress/badge/reviewProgressBadge.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import type { ProgressSummarySnapshot, ProgressSummarySourceState, ReviewProgressBadgeState } from "../../../types";
+import { createDefaultStreakFreeze } from "../../../progress/streakFreeze";
 import { useProgressInvalidationState } from "../invalidation/progressInvalidation";
 import { useProgressSource } from "../progressSource";
 import { useAppData } from "../../context/provider";
@@ -7,6 +8,7 @@ import { useAppData } from "../../context/provider";
 const EMPTY_REVIEW_PROGRESS_BADGE_STATE: ReviewProgressBadgeState = {
   streakDays: 0,
   hasReviewedToday: false,
+  streakFreeze: createDefaultStreakFreeze(),
   isInteractive: true,
 };
 
@@ -27,6 +29,7 @@ export function buildReviewProgressBadgeStateFromSummarySnapshot(
   return {
     streakDays: summarySnapshot.summary.currentStreakDays,
     hasReviewedToday: summarySnapshot.summary.hasReviewedToday,
+    streakFreeze: summarySnapshot.summary.streakFreeze,
     isInteractive: true,
   };
 }
@@ -45,6 +48,13 @@ export function formatReviewProgressBadgeValue(streakDays: number): string {
   }
 
   return streakDays.toString();
+}
+
+export function formatReviewProgressFreezeValue(
+  streakFreeze: ReviewProgressBadgeState["streakFreeze"],
+  formatNumber: (value: number) => string,
+): string {
+  return `${formatNumber(streakFreeze.availableCredits)}/${formatNumber(streakFreeze.capacity)}`;
 }
 
 export function useReviewProgressBadge(): ReviewProgressBadgeState {

--- a/apps/web/src/appData/progress/snapshots/progressSeriesSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSeriesSnapshots.ts
@@ -4,8 +4,18 @@ import type {
   ProgressSeries,
   ProgressSeriesInput,
   ProgressSeriesSnapshot,
+  StreakDay,
+  StreakDayState,
+  StreakFreeze,
 } from "../../../types";
 import { shiftLocalDate } from "../../../progress/progressDates";
+import {
+  createDefaultStreakFreeze,
+  evaluateProgressStreakFreeze,
+  evaluateProgressStreakFreezeFromCarryState,
+  streakFreezePolicy,
+  type StreakFreezeCarryState,
+} from "../../../progress/streakFreeze";
 
 export function createProgressChartData(dailyReviews: ReadonlyArray<DailyReviewPoint>): ProgressChartData {
   return {
@@ -77,6 +87,311 @@ function expandProgressDailyReviews(
   return expandedDailyReviews;
 }
 
+function createProgressSeriesDateRange(input: ProgressSeriesInput): ReadonlyArray<string> {
+  const dates: Array<string> = [];
+
+  for (let currentDate = input.from; currentDate <= input.to; currentDate = shiftLocalDate(currentDate, 1)) {
+    dates.push(currentDate);
+  }
+
+  return dates;
+}
+
+function createStreakDayStateMap(streakDays: ReadonlyArray<StreakDay>): ReadonlyMap<string, StreakDayState> {
+  const stateMap = new Map<string, StreakDayState>();
+
+  for (const streakDay of streakDays) {
+    if (stateMap.has(streakDay.date)) {
+      throw new Error(`Progress series streakDays must not contain duplicate date: ${streakDay.date}`);
+    }
+
+    stateMap.set(streakDay.date, streakDay.state);
+  }
+
+  return stateMap;
+}
+
+function expandProgressStreakDays(
+  input: ProgressSeriesInput,
+  streakDays: ReadonlyArray<StreakDay>,
+): ReadonlyArray<StreakDay> {
+  const streakDayStateMap = createStreakDayStateMap(streakDays);
+
+  return createProgressSeriesDateRange(input).map((date): StreakDay => {
+    const state = streakDayStateMap.get(date);
+    if (state === undefined) {
+      throw new Error(`Progress series streakDays must include date: ${date}`);
+    }
+
+    return {
+      date,
+      state,
+    };
+  });
+}
+
+function activeDatesFromDailyReviews(dailyReviews: ReadonlyArray<DailyReviewPoint>): ReadonlyArray<string> {
+  const activeDates = dailyReviews
+    .filter((day) => day.reviewCount > 0)
+    .map((day) => day.date);
+
+  return uniqueSortedLocalDates(activeDates);
+}
+
+function uniqueSortedLocalDates(localDates: ReadonlyArray<string>): ReadonlyArray<string> {
+  return [...new Set(localDates)]
+    .sort((leftDate, rightDate) => leftDate.localeCompare(rightDate));
+}
+
+function createProgressStreakDays(
+  input: ProgressSeriesInput,
+  activeReviewLocalDates: ReadonlyArray<string>,
+): ReadonlyArray<StreakDay> {
+  const activeDates = uniqueSortedLocalDates(activeReviewLocalDates);
+  const activeDateSet = new Set(activeDates);
+  const evaluatedStreakDayStates = createStreakDayStateMap(
+    evaluateProgressStreakFreeze(activeDates, input.to).streakDays,
+  );
+
+  return createProgressSeriesDateRange(input).map((date): StreakDay => {
+    const state: StreakDayState = activeDateSet.has(date)
+      ? "reviewed"
+      : evaluatedStreakDayStates.get(date) ?? (date >= input.to ? "pending" : "missed");
+
+    return {
+      date,
+      state,
+    };
+  });
+}
+
+function activeDatesInRange(
+  input: ProgressSeriesInput,
+  activeReviewLocalDates: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  return uniqueSortedLocalDates(activeReviewLocalDates.filter((date) => (
+    date >= input.from && date <= input.to
+  )));
+}
+
+function createProgressStreakDaysFromCarryState(
+  input: ProgressSeriesInput,
+  activeReviewLocalDates: ReadonlyArray<string>,
+  carryState: StreakFreezeCarryState,
+): ReadonlyArray<StreakDay> {
+  return createProgressStreakCarryEvaluation(input, activeReviewLocalDates, carryState).streakDays;
+}
+
+type ProgressStreakCarryEvaluation = Readonly<{
+  streakDays: ReadonlyArray<StreakDay>;
+  streakFreeze: StreakFreeze;
+}>;
+
+function createProgressStreakCarryEvaluation(
+  input: ProgressSeriesInput,
+  activeReviewLocalDates: ReadonlyArray<string>,
+  carryState: StreakFreezeCarryState,
+): ProgressStreakCarryEvaluation {
+  const activeDates = uniqueSortedLocalDates(activeReviewLocalDates.filter((date) => (
+    date <= input.to && (carryState.lastEvaluatedDate === null || date > carryState.lastEvaluatedDate)
+  )));
+  const activeDateSet = new Set(activeDates);
+  const evaluation = evaluateProgressStreakFreezeFromCarryState(activeDates, input.to, carryState);
+  const evaluatedStreakDayStates = createStreakDayStateMap(evaluation.streakDays);
+
+  return {
+    streakFreeze: evaluation.streakFreeze,
+    streakDays: createProgressSeriesDateRange(input).map((date): StreakDay => {
+      const state: StreakDayState = activeDateSet.has(date)
+        ? "reviewed"
+        : evaluatedStreakDayStates.get(date) ?? (date >= input.to ? "pending" : "missed");
+
+      return {
+        date,
+        state,
+      };
+    }),
+  };
+}
+
+function createPossibleCarryStatesBeforeDate(firstDate: string): ReadonlyArray<StreakFreezeCarryState> {
+  const lastEvaluatedDate = shiftLocalDate(firstDate, -1);
+  const maximumBalanceUnits = streakFreezePolicy.maxCapacity * streakFreezePolicy.unitsPerCredit;
+  const inactiveCarryState: StreakFreezeCarryState = {
+    balanceUnits: createDefaultStreakFreeze().balanceUnits,
+    currentStreakDays: 0,
+    longestStreakDays: 0,
+    hasActiveSegment: false,
+    lastEvaluatedDate,
+  };
+  const activeCarryStates: Array<StreakFreezeCarryState> = [];
+
+  for (let balanceUnits = 0; balanceUnits <= maximumBalanceUnits; balanceUnits += 1) {
+    activeCarryStates.push({
+      balanceUnits,
+      currentStreakDays: 1,
+      longestStreakDays: 1,
+      hasActiveSegment: true,
+      lastEvaluatedDate,
+    });
+  }
+
+  return [
+    inactiveCarryState,
+    ...activeCarryStates,
+  ];
+}
+
+function areStreakDaysEqual(
+  left: ReadonlyArray<StreakDay>,
+  right: ReadonlyArray<StreakDay>,
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    const leftDay = left[index];
+    const rightDay = right[index];
+
+    if (leftDay?.date !== rightDay?.date || leftDay?.state !== rightDay?.state) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function selectUniqueStreakDays(
+  candidateStreakDays: ReadonlyArray<ReadonlyArray<StreakDay>>,
+): ReadonlyArray<StreakDay> | null {
+  const firstCandidate = candidateStreakDays[0];
+  if (firstCandidate === undefined) {
+    return null;
+  }
+
+  if (candidateStreakDays.every((candidate) => areStreakDaysEqual(candidate, firstCandidate)) === false) {
+    return null;
+  }
+
+  return firstCandidate;
+}
+
+function areStreakFreezesEqual(left: StreakFreeze, right: StreakFreeze): boolean {
+  return left.availableCredits === right.availableCredits
+    && left.capacity === right.capacity
+    && left.balanceUnits === right.balanceUnits
+    && left.unitsPerCredit === right.unitsPerCredit
+    && left.nextCreditProgressUnits === right.nextCreditProgressUnits
+    && left.nextCreditRequiredUnits === right.nextCreditRequiredUnits;
+}
+
+function selectUniqueStreakFreeze(streakFreezes: ReadonlyArray<StreakFreeze>): StreakFreeze | null {
+  const firstStreakFreeze = streakFreezes[0];
+  if (firstStreakFreeze === undefined) {
+    return null;
+  }
+
+  if (streakFreezes.every((streakFreeze) => areStreakFreezesEqual(streakFreeze, firstStreakFreeze)) === false) {
+    return null;
+  }
+
+  return firstStreakFreeze;
+}
+
+function validateProgressSeriesPairInputs(serverBase: ProgressSeries, renderedSeries: ProgressSeries): void {
+  if (
+    serverBase.timeZone === renderedSeries.timeZone
+    && serverBase.from === renderedSeries.from
+    && serverBase.to === renderedSeries.to
+  ) {
+    return;
+  }
+
+  throw new Error(
+    `Progress series overlay inputs must share the same range. serverBase=${serverBase.timeZone} ${serverBase.from}...${serverBase.to}, renderedSeries=${renderedSeries.timeZone} ${renderedSeries.from}...${renderedSeries.to}.`,
+  );
+}
+
+export function createExactRenderedSeriesStreakFreeze(
+  serverBase: ProgressSeries,
+  renderedSeries: ProgressSeries,
+): StreakFreeze | null {
+  validateProgressSeriesPairInputs(serverBase, renderedSeries);
+
+  const normalizedServerBase = normalizeProgressSeries(serverBase);
+  const normalizedRenderedSeries = normalizeProgressSeries(renderedSeries);
+  const input: ProgressSeriesInput = {
+    timeZone: normalizedServerBase.timeZone,
+    from: normalizedServerBase.from,
+    to: normalizedServerBase.to,
+  };
+  const serverActiveDates = activeDatesInRange(input, activeDatesFromDailyReviews(normalizedServerBase.dailyReviews));
+  const renderedActiveDates = activeDatesInRange(input, activeDatesFromDailyReviews(normalizedRenderedSeries.dailyReviews));
+  const candidateOverlayEvaluations = createPossibleCarryStatesBeforeDate(input.from)
+    .filter((carryState) => areStreakDaysEqual(
+      createProgressStreakCarryEvaluation(input, serverActiveDates, carryState).streakDays,
+      normalizedServerBase.streakDays,
+    ))
+    .map((carryState) => createProgressStreakCarryEvaluation(input, renderedActiveDates, carryState))
+    .filter((evaluation) => areStreakDaysEqual(evaluation.streakDays, normalizedRenderedSeries.streakDays));
+
+  return selectUniqueStreakFreeze(candidateOverlayEvaluations.map((evaluation) => evaluation.streakFreeze));
+}
+
+function createExactOverlayStreakDays(
+  normalizedServerBase: ProgressSeries,
+  dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  localFallbackActiveDates: ReadonlyArray<string>,
+): ReadonlyArray<StreakDay> | null {
+  const visibleInput: ProgressSeriesInput = {
+    timeZone: normalizedServerBase.timeZone,
+    from: normalizedServerBase.from,
+    to: normalizedServerBase.to,
+  };
+  const overlayActiveDates = uniqueSortedLocalDates([
+    ...localFallbackActiveDates,
+    ...activeDatesFromDailyReviews(dailyReviews),
+  ]);
+  const evaluationInput: ProgressSeriesInput = {
+    ...visibleInput,
+    from: findStreakOverlayEvaluationStartDate(visibleInput, overlayActiveDates),
+  };
+  const serverActiveDates = activeDatesInRange(
+    evaluationInput,
+    activeDatesFromDailyReviews(normalizedServerBase.dailyReviews),
+  );
+  const overlayActiveDatesInEvaluation = activeDatesInRange(evaluationInput, overlayActiveDates);
+  const candidateOverlayStreakDays = createPossibleCarryStatesBeforeDate(evaluationInput.from)
+    .filter((carryState) => areStreakDaysEqual(
+      filterStreakDaysToInput(
+        visibleInput,
+        createProgressStreakDaysFromCarryState(evaluationInput, serverActiveDates, carryState),
+      ),
+      normalizedServerBase.streakDays,
+    ))
+    .map((carryState) => filterStreakDaysToInput(
+      visibleInput,
+      createProgressStreakDaysFromCarryState(evaluationInput, overlayActiveDatesInEvaluation, carryState),
+    ));
+
+  return selectUniqueStreakDays(candidateOverlayStreakDays);
+}
+
+function findStreakOverlayEvaluationStartDate(
+  input: ProgressSeriesInput,
+  overlayActiveDates: ReadonlyArray<string>,
+): string {
+  return overlayActiveDates.find((date) => date < input.from) ?? input.from;
+}
+
+function filterStreakDaysToInput(
+  input: ProgressSeriesInput,
+  streakDays: ReadonlyArray<StreakDay>,
+): ReadonlyArray<StreakDay> {
+  return streakDays.filter((day) => day.date >= input.from && day.date <= input.to);
+}
+
 export function normalizeProgressSeries(series: ProgressSeries): ProgressSeries {
   const input: ProgressSeriesInput = {
     timeZone: series.timeZone,
@@ -91,6 +406,7 @@ export function normalizeProgressSeries(series: ProgressSeries): ProgressSeries 
     generatedAt: series.generatedAt,
     reviewHistoryWatermarks: series.reviewHistoryWatermarks,
     dailyReviews: expandProgressDailyReviews(input, series.dailyReviews),
+    streakDays: expandProgressStreakDays(input, series.streakDays),
   };
 }
 
@@ -112,7 +428,13 @@ export function createProgressSeriesSnapshot(
 export function buildLocalFallbackSeries(
   input: ProgressSeriesInput,
   dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  activeReviewLocalDates: ReadonlyArray<string>,
 ): ProgressSeries {
+  const activeDates = [
+    ...activeReviewLocalDates,
+    ...activeDatesFromDailyReviews(dailyReviews),
+  ];
+
   return {
     timeZone: input.timeZone,
     from: input.from,
@@ -120,6 +442,7 @@ export function buildLocalFallbackSeries(
     generatedAt: null,
     reviewHistoryWatermarks: [],
     dailyReviews: expandProgressDailyReviews(input, dailyReviews),
+    streakDays: createProgressStreakDays(input, activeDates),
   };
 }
 
@@ -132,6 +455,7 @@ function mergeProgressSeriesWithOverlay(
   serverBase: ProgressSeries,
   overlay: ProgressChartData | null,
   localFallback: ProgressSeriesSnapshot | null,
+  localFallbackActiveDates: ReadonlyArray<string>,
 ): ProgressSeriesMergeResult {
   const pendingReviewCounts = buildDailyReviewPointMap(overlay?.dailyReviews ?? []);
   const localFallbackReviewCounts = localFallback === null
@@ -139,6 +463,7 @@ function mergeProgressSeriesWithOverlay(
     : buildDailyReviewPointMap(localFallback.dailyReviews);
   const normalizedServerBase = normalizeProgressSeries(serverBase);
   let hasOverlay = false;
+  const reviewedOverlayDates = new Set<string>();
   const dailyReviews = normalizedServerBase.dailyReviews.map((day) => {
     const pendingReviewCount = pendingReviewCounts.get(day.date) ?? createEmptyDailyReviewPoint(day.date);
     const localFallbackReviewCount = localFallbackReviewCounts.get(day.date) ?? createEmptyDailyReviewPoint(day.date);
@@ -149,13 +474,25 @@ function mergeProgressSeriesWithOverlay(
       return day;
     }
 
+    if (reviewCount > 0) {
+      reviewedOverlayDates.add(day.date);
+    }
+
     hasOverlay = true;
     return localFallbackReviewCount.reviewCount > dayWithPendingOverlay.reviewCount
       ? localFallbackReviewCount
       : dayWithPendingOverlay;
   });
 
-  if (hasOverlay === false) {
+  const mergedStreakDays = mergeProgressStreakDaysWithOverlay(
+    normalizedServerBase,
+    dailyReviews,
+    localFallbackActiveDates,
+    reviewedOverlayDates,
+  );
+  const hasStreakDayOverlay = areStreakDaysEqual(mergedStreakDays, normalizedServerBase.streakDays) === false;
+
+  if (hasOverlay === false && hasStreakDayOverlay === false) {
     return {
       series: normalizedServerBase,
       hasOverlay: false,
@@ -166,19 +503,138 @@ function mergeProgressSeriesWithOverlay(
     series: {
       ...normalizedServerBase,
       dailyReviews,
+      streakDays: mergedStreakDays,
     },
-    hasOverlay: true,
+    hasOverlay: hasOverlay || hasStreakDayOverlay,
   };
+}
+
+function mergeProgressStreakDaysWithOverlay(
+  normalizedServerBase: ProgressSeries,
+  dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  localFallbackActiveDates: ReadonlyArray<string>,
+  reviewedOverlayDates: ReadonlySet<string>,
+): ReadonlyArray<StreakDay> {
+  const exactOverlayStreakDays = createExactOverlayStreakDays(
+    normalizedServerBase,
+    dailyReviews,
+    localFallbackActiveDates,
+  );
+  if (exactOverlayStreakDays !== null) {
+    return exactOverlayStreakDays;
+  }
+
+  const earliestReviewedOverlayDate = findEarliestLocalDate(reviewedOverlayDates);
+  const recomputeStartDate = findStreakRecomputeStartDate(
+    normalizedServerBase.streakDays,
+    earliestReviewedOverlayDate,
+  ) ?? (
+    earliestReviewedOverlayDate === null
+      ? findEarliestLocalDateBefore(localFallbackActiveDates, normalizedServerBase.from)
+      : null
+  );
+  const recomputedStreakDayMap = recomputeStartDate === null
+    ? new Map<string, StreakDay>()
+    : createStreakDayMap(createProgressStreakDays({
+      timeZone: normalizedServerBase.timeZone,
+      from: recomputeStartDate,
+      to: normalizedServerBase.to,
+    }, [
+      ...localFallbackActiveDates,
+      ...activeDatesFromDailyReviews(dailyReviews),
+    ].filter((date) => date >= recomputeStartDate)));
+
+  return normalizedServerBase.streakDays.map((day): StreakDay => {
+    const recomputedDay = recomputedStreakDayMap.get(day.date);
+    if (recomputedDay !== undefined) {
+      return recomputedDay;
+    }
+
+    if (reviewedOverlayDates.has(day.date) === false) {
+      return day;
+    }
+
+    return {
+      date: day.date,
+      state: "reviewed",
+    };
+  });
+}
+
+function createStreakDayMap(streakDays: ReadonlyArray<StreakDay>): ReadonlyMap<string, StreakDay> {
+  return new Map(streakDays.map((day) => [day.date, day]));
+}
+
+function findEarliestLocalDate(localDates: ReadonlySet<string>): string | null {
+  let earliestLocalDate: string | null = null;
+
+  for (const localDate of localDates) {
+    if (earliestLocalDate === null || localDate < earliestLocalDate) {
+      earliestLocalDate = localDate;
+    }
+  }
+
+  return earliestLocalDate;
+}
+
+function findEarliestLocalDateBefore(
+  localDates: ReadonlyArray<string>,
+  endExclusiveDate: string,
+): string | null {
+  let earliestLocalDate: string | null = null;
+
+  for (const localDate of localDates) {
+    if (localDate >= endExclusiveDate) {
+      continue;
+    }
+
+    if (earliestLocalDate === null || localDate < earliestLocalDate) {
+      earliestLocalDate = localDate;
+    }
+  }
+
+  return earliestLocalDate;
+}
+
+function findStreakRecomputeStartDate(
+  serverBaseStreakDays: ReadonlyArray<StreakDay>,
+  earliestReviewedOverlayDate: string | null,
+): string | null {
+  if (earliestReviewedOverlayDate === null) {
+    return null;
+  }
+
+  let latestMissedDateBeforeOverlay: string | null = null;
+
+  for (const day of serverBaseStreakDays) {
+    if (day.date >= earliestReviewedOverlayDate) {
+      break;
+    }
+
+    if (day.state === "missed") {
+      latestMissedDateBeforeOverlay = day.date;
+    }
+  }
+
+  return latestMissedDateBeforeOverlay === null
+    ? null
+    : shiftLocalDate(latestMissedDateBeforeOverlay, 1);
 }
 
 export function buildRenderedSeries(
   serverBase: ProgressSeriesSnapshot | null,
   localFallback: ProgressSeriesSnapshot | null,
+  localFallbackActiveDates: ReadonlyArray<string>,
   pendingLocalOverlay: ProgressChartData | null,
   canRenderServerBase: boolean,
 ): ProgressSeriesSnapshot | null {
   if (canRenderServerBase && serverBase !== null) {
-    const mergeResult = mergeProgressSeriesWithOverlay(serverBase, pendingLocalOverlay, localFallback);
+    const mergeResult = mergeProgressSeriesWithOverlay(
+      serverBase,
+      pendingLocalOverlay,
+      localFallback,
+      localFallbackActiveDates,
+    );
     return createProgressSeriesSnapshot(
       mergeResult.series,
       "server",

--- a/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
@@ -23,6 +23,8 @@ import type {
   ProgressSummaryPayload,
   ProgressSummarySnapshot,
   ProgressSummarySourceState,
+  StreakDay,
+  StreakFreeze,
 } from "../../../types";
 import { progressLeaderboardWindowKeys } from "../../../types";
 
@@ -67,9 +69,52 @@ function areProgressChartDataEqual(left: ProgressChartData | null, right: Progre
 
 export function areProgressSummariesEqual(left: ProgressSummary, right: ProgressSummary): boolean {
   return left.currentStreakDays === right.currentStreakDays
+    && left.longestStreakDays === right.longestStreakDays
     && left.hasReviewedToday === right.hasReviewedToday
     && left.lastReviewedOn === right.lastReviewedOn
-    && left.activeReviewDays === right.activeReviewDays;
+    && left.activeReviewDays === right.activeReviewDays
+    && areStreakFreezesEqual(left.streakFreeze, right.streakFreeze);
+}
+
+function areStreakFreezesEqual(left: StreakFreeze, right: StreakFreeze): boolean {
+  return left.availableCredits === right.availableCredits
+    && left.capacity === right.capacity
+    && left.balanceUnits === right.balanceUnits
+    && left.unitsPerCredit === right.unitsPerCredit
+    && left.nextCreditProgressUnits === right.nextCreditProgressUnits
+    && left.nextCreditRequiredUnits === right.nextCreditRequiredUnits;
+}
+
+function areNullableStreakFreezesEqual(left: StreakFreeze | null, right: StreakFreeze | null): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (left === null || right === null) {
+    return false;
+  }
+
+  return areStreakFreezesEqual(left, right);
+}
+
+function areStreakDaysEqual(
+  left: ReadonlyArray<StreakDay>,
+  right: ReadonlyArray<StreakDay>,
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  for (let index = 0; index < left.length; index += 1) {
+    const leftDay = left[index];
+    const rightDay = right[index];
+
+    if (leftDay?.date !== rightDay?.date || leftDay?.state !== rightDay?.state) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export function areProgressReviewHistoryWatermarksEqual(
@@ -165,6 +210,7 @@ function areProgressRenderedSeriesSummaryContextsEqual(
       );
 
   return areProgressSummariesEqual(left.lowerBoundSummary, right.lowerBoundSummary)
+    && areNullableStreakFreezesEqual(left.exactStreakFreeze, right.exactStreakFreeze)
     && areStringArraysEqual(left.activeDates, right.activeDates)
     && areStringArraysEqual(left.activeDatesMissingFromServerBase, right.activeDatesMissingFromServerBase)
     && watermarksAreEqual;
@@ -184,7 +230,8 @@ function areProgressSeriesEqual(left: ProgressSeries | null, right: ProgressSeri
     && left.to === right.to
     && left.generatedAt === right.generatedAt
     && areProgressReviewHistoryWatermarksEqual(left.reviewHistoryWatermarks, right.reviewHistoryWatermarks)
-    && areDailyReviewsEqual(left.dailyReviews, right.dailyReviews);
+    && areDailyReviewsEqual(left.dailyReviews, right.dailyReviews)
+    && areStreakDaysEqual(left.streakDays, right.streakDays);
 }
 
 function areProgressSeriesSnapshotsEqual(
@@ -458,6 +505,7 @@ function areProgressSeriesSourceStatesEqual(
   return left.scopeKey === right.scopeKey
     && left.isLoading === right.isLoading
     && left.errorMessage === right.errorMessage
+    && areStringArraysEqual(left.localFallbackActiveDates, right.localFallbackActiveDates)
     && areProgressSeriesSnapshotsEqual(left.localFallback, right.localFallback)
     && areProgressSeriesSnapshotsEqual(left.serverBase, right.serverBase)
     && areProgressChartDataEqual(left.pendingLocalOverlay, right.pendingLocalOverlay)

--- a/apps/web/src/appData/progress/snapshots/progressSourceStateSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSourceStateSnapshots.ts
@@ -29,6 +29,7 @@ export function createEmptyProgressSeriesSourceState(): ProgressSeriesSourceStat
   return {
     scopeKey: null,
     localFallback: null,
+    localFallbackActiveDates: [],
     serverBase: null,
     pendingLocalOverlay: null,
     renderedSnapshot: null,
@@ -115,6 +116,7 @@ export function createNextSeriesState(
     renderedSnapshot: buildRenderedSeries(
       nextStateWithoutRenderedSnapshot.serverBase,
       nextStateWithoutRenderedSnapshot.localFallback,
+      nextStateWithoutRenderedSnapshot.localFallbackActiveDates,
       nextStateWithoutRenderedSnapshot.pendingLocalOverlay,
       canRenderServerBase,
     ),

--- a/apps/web/src/appData/progress/snapshots/progressSummarySnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSummarySnapshots.ts
@@ -6,7 +6,16 @@ import type {
   ProgressSummary,
   ProgressSummaryPayload,
   ProgressSummarySnapshot,
+  StreakFreeze,
 } from "../../../types";
+import {
+  addReviewedDayToStreakFreeze,
+  createDefaultStreakFreeze,
+  evaluateProgressStreakFreeze,
+  evaluateProgressStreakFreezeFromCarryState,
+  streakFreezePolicy,
+  type StreakFreezeCarryState,
+} from "../../../progress/streakFreeze";
 import { shiftLocalDate } from "../../../progress/progressDates";
 import {
   areProgressReviewHistoryWatermarksEqual,
@@ -14,6 +23,7 @@ import {
 } from "./progressSnapshotEquality";
 import {
   buildDailyReviewCountMap,
+  createExactRenderedSeriesStreakFreeze,
   normalizeProgressSeries,
 } from "./progressSeriesSnapshots";
 
@@ -50,9 +60,11 @@ function maxLocalDate(
 function createEmptyProgressSummary(): ProgressSummary {
   return {
     currentStreakDays: 0,
+    longestStreakDays: 0,
     hasReviewedToday: false,
     lastReviewedOn: null,
     activeReviewDays: 0,
+    streakFreeze: createDefaultStreakFreeze(),
   };
 }
 
@@ -83,20 +95,16 @@ function summaryLowerBoundFromActiveDates(
   }
 
   const activeDateSet = new Set(sortedActiveDates);
+  const streakFreezeEvaluation = evaluateProgressStreakFreeze(sortedActiveDates, today);
   const hasReviewedToday = activeDateSet.has(today);
-  let currentDate = hasReviewedToday ? today : shiftLocalDate(today, -1);
-  let currentStreakDays = 0;
-
-  while (activeDateSet.has(currentDate)) {
-    currentStreakDays += 1;
-    currentDate = shiftLocalDate(currentDate, -1);
-  }
 
   return {
-    currentStreakDays,
+    currentStreakDays: streakFreezeEvaluation.currentStreakDays,
+    longestStreakDays: streakFreezeEvaluation.longestStreakDays,
     hasReviewedToday,
     lastReviewedOn: sortedActiveDates.at(-1) ?? null,
     activeReviewDays: sortedActiveDates.length,
+    streakFreeze: streakFreezeEvaluation.streakFreeze,
   };
 }
 
@@ -144,9 +152,13 @@ export function createProgressRenderedSeriesSummaryContext(
   const activeDatesMissingFromServerBaseResult = serverBase === null
     ? []
     : activeDatesMissingFromServerBase(serverBase, renderedSeries);
+  const exactStreakFreeze = serverBase === null
+    ? null
+    : createExactRenderedSeriesStreakFreeze(serverBase, renderedSeries);
 
   return {
     lowerBoundSummary: summaryLowerBoundFromActiveDates(activeDates, renderedSeries.to),
+    exactStreakFreeze,
     activeDates,
     activeDatesMissingFromServerBase: activeDatesMissingFromServerBaseResult,
     serverBaseReviewHistoryWatermarks: serverBase?.reviewHistoryWatermarks ?? null,
@@ -221,47 +233,160 @@ function shouldApplyActiveReviewDayDelta(
   return localDate > serverBase.lastReviewedOn;
 }
 
-function activeReviewDayDelta(
-  deltaCandidates: ReadonlyArray<string>,
-  serverBase: ProgressSummary,
-  hasSharedServerAndSeriesReviewHistoryBase: boolean,
-  referenceLocalDate: string,
-): number {
-  return deltaCandidates.filter((localDate) => shouldApplyActiveReviewDayDelta(
-    localDate,
-    serverBase,
-    hasSharedServerAndSeriesReviewHistoryBase,
-    referenceLocalDate,
-  )).length;
-}
-
 function currentStreakDaysWithLocalDelta(
   serverBase: ProgressSummary,
-  localFallbackActiveDates: ReadonlyArray<string>,
-  renderedSeriesActiveDates: ReadonlyArray<string>,
+  appliedActiveReviewDayDeltaCandidates: ReadonlyArray<string>,
   referenceLocalDate: string,
 ): number {
-  if (serverBase.hasReviewedToday || serverBase.currentStreakDays === 0) {
+  if (serverBase.hasReviewedToday) {
     return serverBase.currentStreakDays;
   }
 
-  if (serverBase.lastReviewedOn === null) {
+  if (appliedActiveReviewDayDeltaCandidates.includes(referenceLocalDate) === false) {
     return serverBase.currentStreakDays;
   }
 
-  const activeDateSet = new Set([
-    ...localFallbackActiveDates,
-    ...renderedSeriesActiveDates,
-  ]);
-  let currentDate = shiftLocalDate(serverBase.lastReviewedOn, 1);
-  let continuousLocalDelta = 0;
-
-  while (currentDate <= referenceLocalDate && activeDateSet.has(currentDate)) {
-    continuousLocalDelta += 1;
-    currentDate = shiftLocalDate(currentDate, 1);
+  if (serverBase.currentStreakDays <= 0) {
+    return 1;
   }
 
-  return serverBase.currentStreakDays + continuousLocalDelta;
+  return serverBase.currentStreakDays + 1;
+}
+
+function countCompletedNonReviewedDaysAfterLastReview(
+  lastReviewedOn: string,
+  referenceLocalDate: string,
+): number {
+  let completedDays = 0;
+
+  for (
+    let localDate = shiftLocalDate(lastReviewedOn, 1);
+    localDate < referenceLocalDate;
+    localDate = shiftLocalDate(localDate, 1)
+  ) {
+    completedDays += 1;
+  }
+
+  return completedDays;
+}
+
+function reverseFrozenDayBalanceUnits(balanceUnits: number): number | null {
+  const reversedBalanceUnits = balanceUnits
+    + streakFreezePolicy.unitsPerCredit
+    - streakFreezePolicy.earnedUnitsPerStreakDay;
+  const maximumBalanceUnits = streakFreezePolicy.maxCapacity * streakFreezePolicy.unitsPerCredit;
+
+  return reversedBalanceUnits > maximumBalanceUnits
+    ? null
+    : reversedBalanceUnits;
+}
+
+function createCarryStateAtLastReviewedDate(
+  serverBase: ProgressSummary,
+  referenceLocalDate: string,
+): StreakFreezeCarryState | null {
+  if (serverBase.lastReviewedOn === null || serverBase.lastReviewedOn >= referenceLocalDate) {
+    return null;
+  }
+
+  const completedNonReviewedDays = countCompletedNonReviewedDaysAfterLastReview(
+    serverBase.lastReviewedOn,
+    referenceLocalDate,
+  );
+  if (serverBase.currentStreakDays <= completedNonReviewedDays) {
+    return null;
+  }
+
+  let balanceUnits = serverBase.streakFreeze.balanceUnits;
+  for (let index = 0; index < completedNonReviewedDays; index += 1) {
+    const reversedBalanceUnits = reverseFrozenDayBalanceUnits(balanceUnits);
+    if (reversedBalanceUnits === null) {
+      return null;
+    }
+
+    balanceUnits = reversedBalanceUnits;
+  }
+
+  const currentStreakDays = serverBase.currentStreakDays - completedNonReviewedDays;
+
+  return {
+    balanceUnits,
+    currentStreakDays,
+    longestStreakDays: Math.max(serverBase.longestStreakDays, currentStreakDays),
+    hasActiveSegment: true,
+    lastEvaluatedDate: serverBase.lastReviewedOn,
+  };
+}
+
+function exactServerSummaryWithLocalDelta(
+  serverBase: ProgressSummary,
+  appliedActiveReviewDayDeltaCandidates: ReadonlyArray<string>,
+  referenceLocalDate: string,
+): ProgressSummary | null {
+  if (appliedActiveReviewDayDeltaCandidates.length === 0) {
+    return serverBase;
+  }
+
+  const carryState = createCarryStateAtLastReviewedDate(serverBase, referenceLocalDate);
+  if (carryState === null) {
+    return null;
+  }
+
+  const activeDates = appliedActiveReviewDayDeltaCandidates.filter((localDate) => (
+    carryState.lastEvaluatedDate !== null && localDate > carryState.lastEvaluatedDate
+  ));
+  if (activeDates.length !== appliedActiveReviewDayDeltaCandidates.length) {
+    return null;
+  }
+
+  const evaluation = evaluateProgressStreakFreezeFromCarryState(
+    activeDates,
+    referenceLocalDate,
+    carryState,
+  );
+
+  return {
+    ...serverBase,
+    currentStreakDays: evaluation.currentStreakDays,
+    longestStreakDays: Math.max(serverBase.longestStreakDays, evaluation.longestStreakDays),
+    hasReviewedToday: serverBase.hasReviewedToday || activeDates.includes(referenceLocalDate),
+    lastReviewedOn: maxLocalDate(serverBase.lastReviewedOn, activeDates.at(-1) ?? null),
+    activeReviewDays: serverBase.activeReviewDays + activeDates.length,
+    streakFreeze: evaluation.streakFreeze,
+  };
+}
+
+function streakFreezeWithLocalDelta(
+  serverBase: ProgressSummary,
+  appliedActiveReviewDayDeltaCandidates: ReadonlyArray<string>,
+  referenceLocalDate: string,
+  exactStreakFreeze: StreakFreeze | null,
+  exactServerSummary: ProgressSummary | null,
+): StreakFreeze {
+  if (appliedActiveReviewDayDeltaCandidates.length === 0) {
+    return serverBase.streakFreeze;
+  }
+
+  if (exactStreakFreeze !== null) {
+    return exactStreakFreeze;
+  }
+
+  if (exactServerSummary !== null) {
+    return exactServerSummary.streakFreeze;
+  }
+
+  if (serverBase.hasReviewedToday) {
+    return serverBase.streakFreeze;
+  }
+
+  if (
+    appliedActiveReviewDayDeltaCandidates.length === 1
+    && appliedActiveReviewDayDeltaCandidates[0] === referenceLocalDate
+  ) {
+    return addReviewedDayToStreakFreeze(serverBase.streakFreeze);
+  }
+
+  return serverBase.streakFreeze;
 }
 
 function hasProgressSummaryOverlay(
@@ -284,22 +409,54 @@ function mergeProgressSummary(
     serverBase.reviewHistoryWatermarks,
     renderedSeriesContext,
   );
-  const serverActiveReviewDaysWithLocalDelta = serverBase.summary.activeReviewDays + activeReviewDayDelta(
-    activeReviewDayDeltaCandidates(
-      renderedSeriesContext,
-      localFallbackActiveDates,
-      serverBase.summary,
-      hasSharedServerAndSeriesReviewHistoryBase,
-    ),
+  const exactStreakFreeze = hasSharedServerAndSeriesReviewHistoryBase
+    ? renderedSeriesContext?.exactStreakFreeze ?? null
+    : null;
+  const reviewDayDeltaCandidates = activeReviewDayDeltaCandidates(
+    renderedSeriesContext,
+    localFallbackActiveDates,
     serverBase.summary,
     hasSharedServerAndSeriesReviewHistoryBase,
+  );
+  const appliedActiveReviewDayDeltaCandidates = reviewDayDeltaCandidates.filter((localDate) => (
+    shouldApplyActiveReviewDayDelta(
+      localDate,
+      serverBase.summary,
+      hasSharedServerAndSeriesReviewHistoryBase,
+      referenceLocalDate,
+    )
+  ));
+  const serverActiveReviewDaysWithLocalDelta = serverBase.summary.activeReviewDays
+    + appliedActiveReviewDayDeltaCandidates.length;
+  const exactServerSummary = exactServerSummaryWithLocalDelta(
+    serverBase.summary,
+    appliedActiveReviewDayDeltaCandidates,
     referenceLocalDate,
   );
   const serverCurrentStreakDaysWithLocalDelta = currentStreakDaysWithLocalDelta(
     serverBase.summary,
-    localFallbackActiveDates,
-    renderedSeriesContext?.activeDates ?? [],
+    appliedActiveReviewDayDeltaCandidates,
     referenceLocalDate,
+  );
+  const serverSummaryWithLocalDelta: ProgressSummary = {
+    ...serverBase.summary,
+    currentStreakDays: exactServerSummary?.currentStreakDays ?? serverCurrentStreakDaysWithLocalDelta,
+    longestStreakDays: Math.max(
+      serverBase.summary.longestStreakDays,
+      exactServerSummary?.longestStreakDays ?? serverCurrentStreakDaysWithLocalDelta,
+    ),
+    streakFreeze: streakFreezeWithLocalDelta(
+      serverBase.summary,
+      appliedActiveReviewDayDeltaCandidates,
+      referenceLocalDate,
+      exactStreakFreeze,
+      exactServerSummary,
+    ),
+  };
+  const mergedCurrentStreakDays = Math.max(
+    serverSummaryWithLocalDelta.currentStreakDays,
+    localFallbackSummary.currentStreakDays,
+    renderedSeriesLowerBound?.currentStreakDays ?? 0,
   );
 
   return {
@@ -307,10 +464,12 @@ function mergeProgressSummary(
     generatedAt: serverBase.generatedAt,
     reviewHistoryWatermarks: serverBase.reviewHistoryWatermarks,
     summary: {
-      currentStreakDays: Math.max(
-        serverCurrentStreakDaysWithLocalDelta,
-        localFallbackSummary.currentStreakDays,
-        renderedSeriesLowerBound?.currentStreakDays ?? 0,
+      currentStreakDays: mergedCurrentStreakDays,
+      longestStreakDays: Math.max(
+        serverSummaryWithLocalDelta.longestStreakDays,
+        localFallbackSummary.longestStreakDays,
+        renderedSeriesLowerBound?.longestStreakDays ?? 0,
+        mergedCurrentStreakDays,
       ),
       hasReviewedToday: serverBase.summary.hasReviewedToday
         || localFallbackSummary.hasReviewedToday
@@ -327,6 +486,7 @@ function mergeProgressSummary(
         localFallbackSummary.activeReviewDays,
         renderedSeriesLowerBound?.activeReviewDays ?? 0,
       ),
+      streakFreeze: serverSummaryWithLocalDelta.streakFreeze,
     },
   };
 }

--- a/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.cache.test.tsx
@@ -6,6 +6,7 @@ import type {
   ProgressSeries,
   ProgressSummaryPayload,
 } from "../../../types";
+import type { ProgressCacheMissBreadcrumbDetails } from "../../../observability/webObservability";
 import {
   addWebBreadcrumbMock,
   buildCurrentLeaderboardScopeKey,
@@ -35,11 +36,12 @@ import {
   storePersistedProgressSeriesForTest,
   storePersistedProgressSummaryForTest,
   summaryAndSeriesSections,
+  summaryOnlySections,
   swapFirstProgressReviewScheduleBuckets,
 } from "./progressSourceTestSupport";
 
 type ExpectedProgressCacheMissSection = "summary" | "series" | "review_schedule" | "leaderboard";
-type ExpectedProgressCacheMissReason = "invalid_json" | "invalid_shape" | "scope_mismatch" | "time_zone_mismatch";
+type ExpectedProgressCacheMissReason = ProgressCacheMissBreadcrumbDetails["reason"];
 
 function expectProgressCacheMissBreadcrumb(
   section: ExpectedProgressCacheMissSection,
@@ -198,6 +200,124 @@ describe("useProgressSource cache", () => {
     expectProgressCacheMissBreadcrumb("series", "invalid_json");
   });
 
+  it("treats pre-freeze summary and series cache versions as version-mismatch misses", async () => {
+    const summaryScopeKey = buildCurrentSummaryScopeKey();
+    const seriesScopeKey = buildCurrentSeriesScopeKey();
+    const currentSeriesInput = buildCurrentSeriesInput();
+    window.localStorage.setItem(`flashcards-progress-server-summary:${summaryScopeKey}`, JSON.stringify({
+      version: 2,
+      scopeKey: summaryScopeKey,
+      savedAt: "2026-04-18T09:00:00.000Z",
+      serverBase: {
+        timeZone: "Europe/Madrid",
+        generatedAt: "2026-04-18T09:10:00.000Z",
+        reviewHistoryWatermarks: [
+          { workspaceId: "workspace-1", reviewSequenceId: 12 },
+        ],
+        summary: {
+          currentStreakDays: 12,
+          hasReviewedToday: true,
+          lastReviewedOn: currentSeriesInput.to,
+          activeReviewDays: 12,
+        },
+      },
+    }));
+    window.localStorage.setItem(`flashcards-progress-server-series:${seriesScopeKey}`, JSON.stringify({
+      version: 2,
+      scopeKey: seriesScopeKey,
+      savedAt: "2026-04-18T09:00:00.000Z",
+      serverBase: {
+        timeZone: currentSeriesInput.timeZone,
+        from: currentSeriesInput.from,
+        to: currentSeriesInput.to,
+        generatedAt: "2026-04-18T09:10:00.000Z",
+        reviewHistoryWatermarks: [
+          { workspaceId: "workspace-1", reviewSequenceId: 12 },
+        ],
+        dailyReviews: [
+          {
+            date: currentSeriesInput.to,
+            reviewCount: 12,
+          },
+        ],
+      },
+    }));
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.serverBase?.summary.activeReviewDays).toBe(1);
+    expect(harness.getApi().progressSourceState.series.serverBase?.dailyReviews).toContainEqual(expect.objectContaining({
+      date: currentSeriesInput.to,
+      reviewCount: 1,
+    }));
+    expectProgressCacheMissBreadcrumb("summary", "version_mismatch");
+    expectProgressCacheMissBreadcrumb("series", "version_mismatch");
+  });
+
+  it("treats cached summaries with incoherent streak freeze metadata as invalid-shape misses", async () => {
+    const summaryScopeKey = buildCurrentSummaryScopeKey();
+    const cachedSummary = buildServerSummary(6, "2026-04-18T09:10:00.000Z");
+    const remoteSummary = buildServerSummary(8, "2026-04-18T09:23:00.000Z");
+    storePersistedProgressSummaryForTest(summaryScopeKey, {
+      ...cachedSummary,
+      summary: {
+        ...cachedSummary.summary,
+        streakFreeze: {
+          ...cachedSummary.summary.streakFreeze,
+          balanceUnits: 19,
+        },
+      },
+    });
+    loadProgressSummaryMock.mockResolvedValueOnce(remoteSummary);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryOnlySections,
+    });
+
+    await flushEffects();
+
+    expectProgressCacheMissBreadcrumb("summary", "invalid_shape");
+    expect(harness.getApi().progressSourceState.summary.serverBase?.generatedAt).toBe("2026-04-18T09:23:00.000Z");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(8);
+  });
+
+  it("treats cached summaries with incoherent streak length metadata as invalid-shape misses", async () => {
+    const summaryScopeKey = buildCurrentSummaryScopeKey();
+    const cachedSummary = buildServerSummary(6, "2026-04-18T09:10:00.000Z");
+    const remoteSummary = buildServerSummary(8, "2026-04-18T09:23:00.000Z");
+    storePersistedProgressSummaryForTest(summaryScopeKey, {
+      ...cachedSummary,
+      summary: {
+        ...cachedSummary.summary,
+        longestStreakDays: cachedSummary.summary.currentStreakDays - 1,
+      },
+    });
+    loadProgressSummaryMock.mockResolvedValueOnce(remoteSummary);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryOnlySections,
+    });
+
+    await flushEffects();
+
+    expectProgressCacheMissBreadcrumb("summary", "invalid_shape");
+    expect(harness.getApi().progressSourceState.summary.serverBase?.generatedAt).toBe("2026-04-18T09:23:00.000Z");
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(8);
+  });
+
   it("treats malformed cached series dates as invalid-shape misses before loading remote series", async () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     const seriesScopeKey = buildCurrentSeriesScopeKey();
@@ -215,6 +335,12 @@ describe("useProgressSource cache", () => {
         ],
         dailyReviews: [
           buildGoodDailyReviewPoint(currentSeriesInput.to, 12),
+        ],
+        streakDays: [
+          {
+            date: currentSeriesInput.to,
+            state: "reviewed",
+          },
         ],
       },
     } as const;

--- a/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.lifecycle.test.tsx
@@ -5,6 +5,7 @@ import type {
   ProgressSeries,
   ProgressSummaryPayload,
 } from "../../../types";
+import { createDefaultStreakFreeze } from "../../../progress/streakFreeze";
 import {
   buildCurrentSeriesInput,
   buildCurrentSeriesScopeKey,
@@ -74,9 +75,11 @@ describe("useProgressSource lifecycle", () => {
     loadProgressSeriesMock.mockImplementation(() => deferredSeries.promise);
     loadLocalProgressSummaryMock.mockResolvedValue({
       currentStreakDays: 3,
+      longestStreakDays: 3,
       hasReviewedToday: true,
       lastReviewedOn: currentSeriesInput.to,
       activeReviewDays: 4,
+      streakFreeze: createDefaultStreakFreeze(),
     });
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
       buildGoodDailyReviewPoint(currentSeriesInput.to, 2),
@@ -174,6 +177,7 @@ describe("useProgressSource lifecycle", () => {
     expect(harness.getApi().progressSourceState.series).toEqual({
       scopeKey: null,
       localFallback: null,
+      localFallbackActiveDates: [],
       serverBase: null,
       pendingLocalOverlay: null,
       renderedSnapshot: null,

--- a/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
+import type { DailyReviewPoint, ProgressSummary, StreakFreeze } from "../../../types";
+import { shiftLocalDate } from "../../../progress/progressDates";
+import { createDefaultStreakFreeze } from "../../../progress/streakFreeze";
 import {
   buildCurrentSeriesInput,
   buildDailyReviewPoint,
   buildGoodDailyReviewPoint,
   buildServerSeries,
+  buildServerSeriesWithDailyReviews,
   buildServerSummary,
   createDeferredPromise,
   flushEffects,
@@ -21,6 +25,48 @@ import {
   summaryAndSeriesSections,
   summaryOnlySections,
 } from "./progressSourceTestSupport";
+
+function createProgressSummary(
+  currentStreakDays: number,
+  hasReviewedToday: boolean,
+  lastReviewedOn: string | null,
+  activeReviewDays: number,
+): ProgressSummary {
+  return createProgressSummaryWithFreeze(
+    currentStreakDays,
+    hasReviewedToday,
+    lastReviewedOn,
+    activeReviewDays,
+    createDefaultStreakFreeze(),
+  );
+}
+
+function createProgressSummaryWithFreeze(
+  currentStreakDays: number,
+  hasReviewedToday: boolean,
+  lastReviewedOn: string | null,
+  activeReviewDays: number,
+  streakFreeze: StreakFreeze,
+): ProgressSummary {
+  return {
+    currentStreakDays,
+    longestStreakDays: currentStreakDays,
+    hasReviewedToday,
+    lastReviewedOn,
+    activeReviewDays,
+    streakFreeze,
+  };
+}
+
+function createDailyReviewsForRange(from: string, to: string): ReadonlyArray<DailyReviewPoint> {
+  const dailyReviews: Array<DailyReviewPoint> = [];
+
+  for (let currentDate = from; currentDate <= to; currentDate = shiftLocalDate(currentDate, 1)) {
+    dailyReviews.push(buildGoodDailyReviewPoint(currentDate, 1));
+  }
+
+  return dailyReviews;
+}
 
 describe("useProgressSource summary and series", () => {
   it("loads split server summary and series for linked verified sessions", async () => {
@@ -74,12 +120,7 @@ describe("useProgressSource summary and series", () => {
 
   it("keeps rendered summary local when pending review uploads make the server summary stale", async () => {
     hasPendingProgressReviewEventsMock.mockResolvedValue(true);
-    loadLocalProgressSummaryMock.mockResolvedValue({
-      currentStreakDays: 2,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-18",
-      activeReviewDays: 8,
-    });
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-18", 8));
 
     const harness = renderHarness({
       sessionVerificationState: "verified",
@@ -105,31 +146,12 @@ describe("useProgressSource summary and series", () => {
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: {
-        currentStreakDays: 1,
-        hasReviewedToday: false,
-        lastReviewedOn: "2026-04-19",
-        activeReviewDays: 7,
-      },
+      summary: createProgressSummary(1, false, "2026-04-19", 7),
     });
-    loadProgressSeriesMock.mockResolvedValue({
-      timeZone: currentSeriesInput.timeZone,
-      from: currentSeriesInput.from,
-      to: currentSeriesInput.to,
-      generatedAt: "2026-04-20T09:15:00.000Z",
-      reviewHistoryWatermarks: [
-        { workspaceId: "workspace-1", reviewSequenceId: 42 },
-      ],
-      dailyReviews: [
-        buildGoodDailyReviewPoint(currentSeriesInput.to, 0),
-      ],
-    });
-    loadLocalProgressSummaryMock.mockResolvedValue({
-      currentStreakDays: 2,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 8,
-    });
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([
+      buildGoodDailyReviewPoint(currentSeriesInput.to, 0),
+    ], "2026-04-20T09:15:00.000Z"));
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-20", 8));
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
       buildDailyReviewPoint(currentSeriesInput.to, 1, 1, 0, 0, 0),
     ]);
@@ -147,12 +169,9 @@ describe("useProgressSource summary and series", () => {
     expect(harness.getApi().progressSourceState.summary.hasPendingLocalReviews).toBe(false);
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(true);
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
-      currentStreakDays: 2,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 8,
-    });
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
+      createProgressSummary(2, true, "2026-04-20", 8),
+    );
     expect(harness.getApi().progressSourceState.series.serverBase?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.to,
       reviewCount: 0,
@@ -170,38 +189,18 @@ describe("useProgressSource summary and series", () => {
   });
 
   it("extends a long server streak when local review history adds today", async () => {
-    const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: {
-        currentStreakDays: 200,
-        hasReviewedToday: false,
-        lastReviewedOn: "2026-04-19",
-        activeReviewDays: 200,
-      },
+      summary: createProgressSummary(200, false, "2026-04-19", 200),
     });
-    loadProgressSeriesMock.mockResolvedValue({
-      timeZone: currentSeriesInput.timeZone,
-      from: currentSeriesInput.from,
-      to: currentSeriesInput.to,
-      generatedAt: "2026-04-20T09:15:00.000Z",
-      reviewHistoryWatermarks: [
-        { workspaceId: "workspace-1", reviewSequenceId: 42 },
-      ],
-      dailyReviews: [
-        buildGoodDailyReviewPoint("2026-04-19", 1),
-      ],
-    });
-    loadLocalProgressSummaryMock.mockResolvedValue({
-      currentStreakDays: 1,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 1,
-    });
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([
+      buildGoodDailyReviewPoint("2026-04-19", 1),
+    ], "2026-04-20T09:15:00.000Z"));
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(1, true, "2026-04-20", 1));
     loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-20"]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
       buildGoodDailyReviewPoint("2026-04-20", 1),
@@ -218,47 +217,24 @@ describe("useProgressSource summary and series", () => {
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(true);
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
-      currentStreakDays: 201,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 201,
-    });
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
+      createProgressSummary(201, true, "2026-04-20", 201),
+    );
   });
 
   it("extends a long server streak through consecutive local active dates", async () => {
-    const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: {
-        currentStreakDays: 200,
-        hasReviewedToday: false,
-        lastReviewedOn: "2026-04-18",
-        activeReviewDays: 200,
-      },
+      summary: createProgressSummary(201, false, "2026-04-18", 200),
     });
-    loadProgressSeriesMock.mockResolvedValue({
-      timeZone: currentSeriesInput.timeZone,
-      from: currentSeriesInput.from,
-      to: currentSeriesInput.to,
-      generatedAt: "2026-04-20T09:15:00.000Z",
-      reviewHistoryWatermarks: [
-        { workspaceId: "workspace-1", reviewSequenceId: 42 },
-      ],
-      dailyReviews: [
-        buildGoodDailyReviewPoint("2026-04-18", 1),
-      ],
-    });
-    loadLocalProgressSummaryMock.mockResolvedValue({
-      currentStreakDays: 2,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 2,
-    });
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([
+      buildGoodDailyReviewPoint("2026-04-18", 1),
+    ], "2026-04-20T09:15:00.000Z"));
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-20", 2));
     loadLocalProgressActiveDatesMock.mockResolvedValue([
       "2026-04-19",
       "2026-04-20",
@@ -277,45 +253,22 @@ describe("useProgressSource summary and series", () => {
 
     await flushEffects();
 
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
-      currentStreakDays: 202,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 202,
-    });
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
+      createProgressSummary(202, true, "2026-04-20", 202),
+    );
   });
 
   it("adds local active dates after server last reviewed even outside the visible chart range", async () => {
-    const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: {
-        currentStreakDays: 0,
-        hasReviewedToday: false,
-        lastReviewedOn: "2025-11-15",
-        activeReviewDays: 200,
-      },
+      summary: createProgressSummary(0, false, "2025-11-15", 200),
     });
-    loadProgressSeriesMock.mockResolvedValue({
-      timeZone: currentSeriesInput.timeZone,
-      from: currentSeriesInput.from,
-      to: currentSeriesInput.to,
-      generatedAt: "2026-04-20T09:15:00.000Z",
-      reviewHistoryWatermarks: [
-        { workspaceId: "workspace-1", reviewSequenceId: 42 },
-      ],
-      dailyReviews: [],
-    });
-    loadLocalProgressSummaryMock.mockResolvedValue({
-      currentStreakDays: 0,
-      hasReviewedToday: false,
-      lastReviewedOn: "2025-11-16",
-      activeReviewDays: 1,
-    });
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([], "2026-04-20T09:15:00.000Z"));
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(0, false, "2025-11-16", 1));
     loadLocalProgressActiveDatesMock.mockResolvedValue(["2025-11-16"]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([]);
 
@@ -328,47 +281,24 @@ describe("useProgressSource summary and series", () => {
 
     await flushEffects();
 
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
-      currentStreakDays: 0,
-      hasReviewedToday: false,
-      lastReviewedOn: "2025-11-16",
-      activeReviewDays: 201,
-    });
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
+      createProgressSummary(0, false, "2025-11-16", 201),
+    );
   });
 
   it("does not double-count today when server summary already includes it", async () => {
-    const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: {
-        currentStreakDays: 200,
-        hasReviewedToday: true,
-        lastReviewedOn: "2026-04-20",
-        activeReviewDays: 200,
-      },
+      summary: createProgressSummary(200, true, "2026-04-20", 200),
     });
-    loadProgressSeriesMock.mockResolvedValue({
-      timeZone: currentSeriesInput.timeZone,
-      from: currentSeriesInput.from,
-      to: currentSeriesInput.to,
-      generatedAt: "2026-04-20T09:15:00.000Z",
-      reviewHistoryWatermarks: [
-        { workspaceId: "workspace-1", reviewSequenceId: 42 },
-      ],
-      dailyReviews: [
-        buildGoodDailyReviewPoint("2026-04-20", 1),
-      ],
-    });
-    loadLocalProgressSummaryMock.mockResolvedValue({
-      currentStreakDays: 1,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 1,
-    });
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([
+      buildGoodDailyReviewPoint("2026-04-20", 1),
+    ], "2026-04-20T09:15:00.000Z"));
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(1, true, "2026-04-20", 1));
     loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-20"]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
       buildGoodDailyReviewPoint("2026-04-20", 1),
@@ -385,47 +315,24 @@ describe("useProgressSource summary and series", () => {
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(false);
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
-      currentStreakDays: 200,
-      hasReviewedToday: true,
-      lastReviewedOn: "2026-04-20",
-      activeReviewDays: 200,
-    });
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
+      createProgressSummary(200, true, "2026-04-20", 200),
+    );
   });
 
   it("keeps disjoint visible server and local days consistent between chart and summary", async () => {
-    const currentSeriesInput = buildCurrentSeriesInput();
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: {
-        currentStreakDays: 0,
-        hasReviewedToday: false,
-        lastReviewedOn: "2026-04-18",
-        activeReviewDays: 200,
-      },
+      summary: createProgressSummary(2, false, "2026-04-18", 200),
     });
-    loadProgressSeriesMock.mockResolvedValue({
-      timeZone: currentSeriesInput.timeZone,
-      from: currentSeriesInput.from,
-      to: currentSeriesInput.to,
-      generatedAt: "2026-04-20T09:15:00.000Z",
-      reviewHistoryWatermarks: [
-        { workspaceId: "workspace-1", reviewSequenceId: 42 },
-      ],
-      dailyReviews: [
-        buildGoodDailyReviewPoint("2026-04-18", 1),
-      ],
-    });
-    loadLocalProgressSummaryMock.mockResolvedValue({
-      currentStreakDays: 1,
-      hasReviewedToday: false,
-      lastReviewedOn: "2026-04-19",
-      activeReviewDays: 1,
-    });
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([
+      buildGoodDailyReviewPoint("2026-04-18", 1),
+    ], "2026-04-20T09:15:00.000Z"));
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(1, false, "2026-04-19", 1));
     loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-19"]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
       buildDailyReviewPoint("2026-04-19", 1, 0, 1, 0, 0),
@@ -440,12 +347,9 @@ describe("useProgressSource summary and series", () => {
 
     await flushEffects();
 
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual({
-      currentStreakDays: 2,
-      hasReviewedToday: false,
-      lastReviewedOn: "2026-04-19",
-      activeReviewDays: 201,
-    });
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
+      createProgressSummary(2, false, "2026-04-19", 201),
+    );
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: "2026-04-18",
       reviewCount: 1,
@@ -492,6 +396,286 @@ describe("useProgressSource summary and series", () => {
     });
   });
 
+  it("preserves server freeze states when pending local reviews overlay a later day", async () => {
+    const serverSeries = buildServerSeriesWithDailyReviews([
+      buildGoodDailyReviewPoint("2026-04-16", 1),
+    ], "2026-04-18T09:18:00.000Z");
+    loadProgressSeriesMock.mockResolvedValue(serverSeries);
+    loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-16", "2026-04-18"]);
+    loadPendingProgressDailyReviewsMock.mockResolvedValue([
+      buildGoodDailyReviewPoint("2026-04-18", 1),
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: seriesOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: "2026-04-18",
+      state: "reviewed",
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: "2026-04-19",
+      state: "frozen",
+    });
+    expect(serverSeries.streakDays).toContainEqual({
+      date: "2026-04-19",
+      state: "missed",
+    });
+  });
+
+  it("keeps server carry-in streak states before a local review overlay", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    const localReviewDate = "2026-04-18";
+    const serverSeries = buildServerSeriesWithDailyReviews([], "2026-04-18T09:18:00.000Z");
+    loadProgressSeriesMock.mockResolvedValue({
+      ...serverSeries,
+      streakDays: serverSeries.streakDays.map((day) => (
+        day.date === currentSeriesInput.from
+          ? {
+            date: day.date,
+            state: "frozen",
+          }
+          : day
+      )),
+    });
+    loadLocalProgressActiveDatesMock.mockResolvedValue([localReviewDate]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      buildGoodDailyReviewPoint(localReviewDate, 1),
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: seriesOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: currentSeriesInput.from,
+      state: "frozen",
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: localReviewDate,
+      state: "reviewed",
+    });
+  });
+
+  it("recomputes visible carry-in streak states when a local review replaces a frozen day", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    const localReviewDate = "2026-04-17";
+    const serverSeries = buildServerSeriesWithDailyReviews(
+      createDailyReviewsForRange(currentSeriesInput.from, "2026-04-16"),
+      "2026-04-18T09:18:00.000Z",
+    );
+    loadProgressSeriesMock.mockResolvedValue(serverSeries);
+    loadLocalProgressActiveDatesMock.mockResolvedValue([localReviewDate]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      buildGoodDailyReviewPoint(localReviewDate, 1),
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: seriesOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(serverSeries.streakDays).toContainEqual({
+      date: "2026-04-19",
+      state: "missed",
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: localReviewDate,
+      state: "reviewed",
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: "2026-04-19",
+      state: "frozen",
+    });
+  });
+
+  it("builds local-only streak states from all local active dates", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    loadLocalProgressActiveDatesMock.mockResolvedValue([
+      shiftLocalDate(currentSeriesInput.from, -1),
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "unverified",
+      cloudSettings: null,
+      progressServerInvalidationVersion: 0,
+      sections: seriesOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(loadProgressSeriesMock).not.toHaveBeenCalled();
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("local_only");
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: currentSeriesInput.from,
+      state: "frozen",
+    });
+  });
+
+  it("marks server series approximate when local carry-in changes only streak states", async () => {
+    const currentSeriesInput = buildCurrentSeriesInput();
+    const localCarryInDate = shiftLocalDate(currentSeriesInput.from, -1);
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([], "2026-04-18T09:18:00.000Z"));
+    loadLocalProgressActiveDatesMock.mockResolvedValue([localCarryInDate]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: seriesOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("server");
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.isApproximate).toBe(true);
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
+      date: currentSeriesInput.from,
+      reviewCount: 0,
+    }));
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: currentSeriesInput.from,
+      state: "frozen",
+    });
+  });
+
+  it("keeps the server freeze bank when a local lower bound ties server streak length", async () => {
+    const staleServerFreeze: StreakFreeze = {
+      availableCredits: 1,
+      capacity: 2,
+      balanceUnits: 10,
+      unitsPerCredit: 10,
+      nextCreditProgressUnits: 0,
+      nextCreditRequiredUnits: 10,
+    };
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: createProgressSummaryWithFreeze(2, false, "2026-04-19", 8, staleServerFreeze),
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, false, "2026-04-19", 8));
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.streakFreeze).toEqual(
+      staleServerFreeze,
+    );
+  });
+
+  it("uses exact series freeze overlay for multi-day local review deltas", async () => {
+    const sharedWatermark = [
+      { workspaceId: "workspace-1", reviewSequenceId: 42 },
+    ];
+    const staleServerFreeze: StreakFreeze = {
+      availableCredits: 1,
+      capacity: 2,
+      balanceUnits: 11,
+      unitsPerCredit: 10,
+      nextCreditProgressUnits: 1,
+      nextCreditRequiredUnits: 10,
+    };
+    const serverSeries = {
+      ...buildServerSeriesWithDailyReviews([
+        buildGoodDailyReviewPoint("2026-04-18", 1),
+      ], "2026-04-20T09:15:00.000Z"),
+      reviewHistoryWatermarks: sharedWatermark,
+    };
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: sharedWatermark,
+      summary: createProgressSummaryWithFreeze(2, false, "2026-04-18", 200, staleServerFreeze),
+    });
+    loadProgressSeriesMock.mockResolvedValue(serverSeries);
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-20", 2));
+    loadLocalProgressActiveDatesMock.mockResolvedValue([
+      "2026-04-19",
+      "2026-04-20",
+    ]);
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+      buildGoodDailyReviewPoint("2026-04-19", 1),
+      buildGoodDailyReviewPoint("2026-04-20", 1),
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryAndSeriesSections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.currentStreakDays).toBe(3);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.streakFreeze).toEqual(
+      createDefaultStreakFreeze(),
+    );
+  });
+
+  it("uses exact summary-only freeze overlay for multi-day local review deltas", async () => {
+    const staleServerFreeze: StreakFreeze = {
+      availableCredits: 1,
+      capacity: 2,
+      balanceUnits: 10,
+      unitsPerCredit: 10,
+      nextCreditProgressUnits: 0,
+      nextCreditRequiredUnits: 10,
+    };
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: createProgressSummaryWithFreeze(200, false, "2026-04-18", 200, staleServerFreeze),
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-20", 2));
+    loadLocalProgressActiveDatesMock.mockResolvedValue([
+      "2026-04-19",
+      "2026-04-20",
+    ]);
+
+    const harness = renderHarness({
+      sessionVerificationState: "verified",
+      cloudSettings: linkedCloudSettings,
+      progressServerInvalidationVersion: 0,
+      sections: summaryOnlySections,
+    });
+
+    await flushEffects();
+
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.currentStreakDays).toBe(201);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.streakFreeze).toEqual(
+      createDefaultStreakFreeze(),
+    );
+  });
+
   it("supports summary-only ownership without loading the progress series pipeline", async () => {
     const harness = renderHarness({
       sessionVerificationState: "verified",
@@ -513,6 +697,7 @@ describe("useProgressSource summary and series", () => {
     expect(harness.getApi().progressSourceState.series).toEqual({
       scopeKey: null,
       localFallback: null,
+      localFallbackActiveDates: [],
       serverBase: null,
       pendingLocalOverlay: null,
       renderedSnapshot: null,

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -12,6 +12,8 @@ import type {
   ProgressSeriesInput,
   ProgressSummary,
   ProgressSummaryPayload,
+  StreakDay,
+  StreakDayState,
   WorkspaceSummary,
 } from "../../../types";
 import {
@@ -27,7 +29,12 @@ import {
   buildProgressDateContext,
   buildProgressSeriesInputForDateContext,
   buildProgressSummaryInputForDateContext,
+  shiftLocalDate,
 } from "../../../progress/progressDates";
+import {
+  createDefaultStreakFreeze,
+  evaluateProgressStreakFreeze,
+} from "../../../progress/streakFreeze";
 import {
   buildProgressLeaderboardScopeKey,
   buildProgressSummaryScopeKey,
@@ -361,9 +368,11 @@ export function buildServerSummary(activeReviewDays: number, generatedAt: string
     ],
     summary: {
       currentStreakDays: activeReviewDays,
+      longestStreakDays: activeReviewDays,
       hasReviewedToday: true,
       lastReviewedOn: "2026-04-18",
       activeReviewDays,
+      streakFreeze: createDefaultStreakFreeze(),
     },
   };
 }
@@ -395,8 +404,39 @@ export function buildGoodDailyReviewPoint(date: string, reviewCount: number): Da
   return buildDailyReviewPoint(date, reviewCount, 0, 0, reviewCount, 0);
 }
 
+function buildServerSeriesStreakDays(
+  input: ProgressSeriesInput,
+  dailyReviews: ProgressSeries["dailyReviews"],
+): ReadonlyArray<StreakDay> {
+  const activeDates = dailyReviews
+    .filter((day) => day.reviewCount > 0)
+    .map((day) => day.date)
+    .sort((leftDate, rightDate) => leftDate.localeCompare(rightDate));
+  const activeDateSet = new Set(activeDates);
+  const evaluatedStreakDayStates = new Map<string, StreakDayState>(
+    evaluateProgressStreakFreeze(activeDates, input.to).streakDays.map((day) => [day.date, day.state]),
+  );
+  const streakDays: Array<StreakDay> = [];
+
+  for (let currentDate = input.from; currentDate <= input.to; currentDate = shiftLocalDate(currentDate, 1)) {
+    const state: StreakDayState = activeDateSet.has(currentDate)
+      ? "reviewed"
+      : evaluatedStreakDayStates.get(currentDate) ?? (currentDate >= input.to ? "pending" : "missed");
+
+    streakDays.push({
+      date: currentDate,
+      state,
+    });
+  }
+
+  return streakDays;
+}
+
 export function buildServerSeries(reviewCount: number, generatedAt: string): ProgressSeries {
   const input: ProgressSeriesInput = buildCurrentSeriesInput();
+  const dailyReviews = [
+    buildGoodDailyReviewPoint(input.to, reviewCount),
+  ];
 
   return {
     timeZone: input.timeZone,
@@ -406,9 +446,27 @@ export function buildServerSeries(reviewCount: number, generatedAt: string): Pro
     reviewHistoryWatermarks: [
       { workspaceId: workspace.workspaceId, reviewSequenceId: reviewCount },
     ],
-    dailyReviews: [
-      buildGoodDailyReviewPoint(input.to, reviewCount),
+    dailyReviews,
+    streakDays: buildServerSeriesStreakDays(input, dailyReviews),
+  };
+}
+
+export function buildServerSeriesWithDailyReviews(
+  dailyReviews: ProgressSeries["dailyReviews"],
+  generatedAt: string,
+): ProgressSeries {
+  const input: ProgressSeriesInput = buildCurrentSeriesInput();
+
+  return {
+    timeZone: input.timeZone,
+    from: input.from,
+    to: input.to,
+    generatedAt,
+    reviewHistoryWatermarks: [
+      { workspaceId: workspace.workspaceId, reviewSequenceId: dailyReviews.length },
     ],
+    dailyReviews,
+    streakDays: buildServerSeriesStreakDays(input, dailyReviews),
   };
 }
 
@@ -506,7 +564,7 @@ export function storePersistedProgressSummaryForTest(
   serverBase: ProgressSummaryPayload,
 ): void {
   window.localStorage.setItem(`flashcards-progress-server-summary:${scopeKey}`, JSON.stringify({
-    version: 2,
+    version: 3,
     scopeKey,
     savedAt: "2026-04-18T09:00:00.000Z",
     serverBase,
@@ -609,9 +667,11 @@ beforeEach(() => {
   calculatePendingProgressReviewScheduleCardTotalDeltaMock.mockResolvedValue(0);
   loadLocalProgressSummaryMock.mockResolvedValue({
     currentStreakDays: 0,
+    longestStreakDays: 0,
     hasReviewedToday: false,
     lastReviewedOn: null,
     activeReviewDays: 0,
+    streakFreeze: createDefaultStreakFreeze(),
   });
   loadLocalProgressActiveDatesMock.mockResolvedValue([]);
   loadLocalProgressDailyReviewsMock.mockResolvedValue([]);

--- a/apps/web/src/appData/progress/source/useProgressSource.ts
+++ b/apps/web/src/appData/progress/source/useProgressSource.ts
@@ -435,8 +435,9 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
 
     void Promise.all([
       loadLocalProgressDailyReviews(accessibleWorkspaceIds, seriesInput),
+      loadLocalProgressActiveDates(accessibleWorkspaceIds, seriesInput.timeZone),
       loadPendingProgressDailyReviews(accessibleWorkspaceIds, seriesInput),
-    ]).then(([localDailyReviews, pendingLocalDailyReviews]) => {
+    ]).then(([localDailyReviews, localActiveDates, pendingLocalDailyReviews]) => {
       if (currentSeriesScopeKeyRef.current !== seriesScopeKey || seriesLocalLoadSequenceRef.current !== currentSequence) {
         return;
       }
@@ -444,7 +445,12 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
       dispatch({
         type: "series_local_load_succeeded",
         scopeKey: seriesScopeKey,
-        localFallback: createProgressSeriesSnapshot(buildLocalFallbackSeries(seriesInput, localDailyReviews), "local_only", true),
+        localFallback: createProgressSeriesSnapshot(
+          buildLocalFallbackSeries(seriesInput, localDailyReviews, localActiveDates),
+          "local_only",
+          true,
+        ),
+        localFallbackActiveDates: localActiveDates,
         pendingLocalOverlay: createProgressChartData(pendingLocalDailyReviews),
         canRenderServerBase: canLoadServerBaseRef.current,
       });

--- a/apps/web/src/appData/progress/state/progressReducer.ts
+++ b/apps/web/src/appData/progress/state/progressReducer.ts
@@ -85,6 +85,7 @@ export type ProgressSourceAction =
     type: "series_local_load_succeeded";
     scopeKey: ProgressScopeKey;
     localFallback: ProgressSeriesSnapshot;
+    localFallbackActiveDates: ReadonlyArray<string>;
     pendingLocalOverlay: ProgressChartData;
     canRenderServerBase: boolean;
   }>
@@ -243,6 +244,7 @@ function reduceProgressSourceState(
       const nextSeriesState = createNextSeriesState(state.series, {
         scopeKey: action.scopeKey,
         localFallback: null,
+        localFallbackActiveDates: [],
         serverBase: action.serverBase,
         pendingLocalOverlay: null,
         isLoading: true,
@@ -317,6 +319,7 @@ function reduceProgressSourceState(
       const nextSeriesState = createNextSeriesState(state.series, {
         scopeKey: action.scopeKey,
         localFallback: action.localFallback,
+        localFallbackActiveDates: action.localFallbackActiveDates,
         pendingLocalOverlay: action.pendingLocalOverlay,
         isLoading: false,
       }, action.canRenderServerBase);
@@ -339,6 +342,7 @@ function reduceProgressSourceState(
       const nextSeriesState = createNextSeriesState(state.series, {
         scopeKey: action.scopeKey,
         localFallback: null,
+        localFallbackActiveDates: [],
         pendingLocalOverlay: null,
         isLoading: false,
         errorMessage: action.errorMessage,

--- a/apps/web/src/appData/progress/storage/progressStorage.ts
+++ b/apps/web/src/appData/progress/storage/progressStorage.ts
@@ -14,6 +14,8 @@ import type {
   ProgressScopeKey,
   ProgressSeries,
   ProgressSummaryPayload,
+  StreakDay,
+  StreakFreeze,
 } from "../../../types";
 import { INSTALLATION_ID_STORAGE_KEY } from "../../../clientIdentity";
 import { addWebBreadcrumb, type WebObservationScope } from "../../../observability/webObservability";
@@ -23,8 +25,10 @@ import {
   progressLeaderboardStatuses,
   progressLeaderboardWindowKeys,
   progressReviewScheduleBucketKeys,
+  streakDayStates,
 } from "../../../types";
 import { findProgressReviewScheduleValidationIssue } from "../../../progress/progressReviewScheduleValidation";
+import { isCoherentStreakFreeze } from "../../../progress/streakFreeze";
 import { normalizeProgressSeries } from "../snapshots/progressSnapshots";
 
 const progressSummaryStorageKeyPrefix = "flashcards-progress-server-summary";
@@ -33,13 +37,13 @@ const progressReviewScheduleStorageKeyPrefix = "flashcards-progress-server-revie
 // Single fixed key: the leaderboard payload is account-scoped, so one cache slot
 // is enough and lets settings clear it without knowing the active scope key.
 const progressLeaderboardStorageKey = "flashcards-progress-server-leaderboard";
-const progressServerSummaryVersion = 2;
+const progressServerSummaryVersion = 3;
 const progressServerSeriesVersion = 3;
 const progressServerReviewScheduleVersion = 2;
 const progressServerLeaderboardVersion = 2;
 
 type PersistedProgressSummary = Readonly<{
-  version: 2;
+  version: 3;
   scopeKey: ProgressScopeKey;
   savedAt: string;
   serverBase: ProgressSummaryPayload;
@@ -72,7 +76,7 @@ type LocalStorageLike = Storage & Record<string, string | undefined> & Readonly<
 }>;
 
 type ProgressCacheSection = "summary" | "series" | "review_schedule" | "leaderboard";
-type ProgressCacheMissReason = "empty" | "invalid_json" | "invalid_shape" | "scope_mismatch" | "time_zone_mismatch";
+type ProgressCacheMissReason = "empty" | "invalid_json" | "invalid_shape" | "scope_mismatch" | "time_zone_mismatch" | "version_mismatch";
 
 type ProgressCacheReadResult<TValue> =
   | Readonly<{ status: "hit"; value: TValue }>
@@ -149,6 +153,7 @@ function normalizePersistedProgressSeries(
     || isValidLocalDateValue(serverBase.to) === false
     || serverBase.from > serverBase.to
     || serverBase.dailyReviews.some((day) => isValidLocalDateValue(day.date) === false)
+    || serverBase.streakDays.some((day) => isValidLocalDateValue(day.date) === false)
   ) {
     return {
       status: "miss",
@@ -162,7 +167,13 @@ function normalizePersistedProgressSeries(
       value: normalizeProgressSeries(serverBase),
     };
   } catch (error: unknown) {
-    if (error instanceof Error && error.message.startsWith("Invalid local date:")) {
+    if (
+      error instanceof Error
+      && (
+        error.message.startsWith("Invalid local date:")
+        || error.message.startsWith("Progress series streakDays")
+      )
+    ) {
       return {
         status: "miss",
         reason: "invalid_shape",
@@ -296,6 +307,68 @@ function parseJsonRecord(rawValue: string): ProgressCacheReadResult<Record<strin
   }
 }
 
+function parsePersistedStreakFreeze(value: unknown): StreakFreeze | null {
+  if (
+    isRecord(value) === false
+    || isNonNegativeSafeIntegerValue(value.availableCredits) === false
+    || isNonNegativeSafeIntegerValue(value.capacity) === false
+    || isNonNegativeSafeIntegerValue(value.balanceUnits) === false
+    || isNonNegativeSafeIntegerValue(value.unitsPerCredit) === false
+    || isNonNegativeSafeIntegerValue(value.nextCreditProgressUnits) === false
+    || isNonNegativeSafeIntegerValue(value.nextCreditRequiredUnits) === false
+  ) {
+    return null;
+  }
+
+  const streakFreeze: StreakFreeze = {
+    availableCredits: value.availableCredits,
+    capacity: value.capacity,
+    balanceUnits: value.balanceUnits,
+    unitsPerCredit: value.unitsPerCredit,
+    nextCreditProgressUnits: value.nextCreditProgressUnits,
+    nextCreditRequiredUnits: value.nextCreditRequiredUnits,
+  };
+
+  if (isCoherentStreakFreeze(streakFreeze) === false) {
+    return null;
+  }
+
+  return streakFreeze;
+}
+
+function isStreakDayStateValue(value: unknown): value is StreakDay["state"] {
+  return typeof value === "string" && streakDayStates.includes(value as StreakDay["state"]);
+}
+
+function parsePersistedStreakDays(value: unknown): ReadonlyArray<StreakDay> | null {
+  if (Array.isArray(value) === false) {
+    return null;
+  }
+
+  const streakDays = value
+    .map((day): StreakDay | null => {
+      if (
+        isRecord(day) === false
+        || typeof day.date !== "string"
+        || isStreakDayStateValue(day.state) === false
+      ) {
+        return null;
+      }
+
+      return {
+        date: day.date,
+        state: day.state,
+      };
+    })
+    .filter((day): day is StreakDay => day !== null);
+
+  if (streakDays.length !== value.length) {
+    return null;
+  }
+
+  return streakDays;
+}
+
 function parsePersistedProgressSummary(rawValue: string | null): ProgressCacheReadResult<PersistedProgressSummary> {
   if (rawValue === null) {
     return {
@@ -310,18 +383,25 @@ function parsePersistedProgressSummary(rawValue: string | null): ProgressCacheRe
   }
 
   const parsedValue = parsedRecord.value;
+  if (parsedValue.version !== progressServerSummaryVersion) {
+    return {
+      status: "miss",
+      reason: "version_mismatch",
+    };
+  }
+
   if (
-    parsedValue.version !== progressServerSummaryVersion
-    || typeof parsedValue.scopeKey !== "string"
+    typeof parsedValue.scopeKey !== "string"
     || typeof parsedValue.savedAt !== "string"
     || isRecord(parsedValue.serverBase) === false
     || typeof parsedValue.serverBase.timeZone !== "string"
     || (parsedValue.serverBase.generatedAt !== null && typeof parsedValue.serverBase.generatedAt !== "string")
     || isRecord(parsedValue.serverBase.summary) === false
-    || typeof parsedValue.serverBase.summary.currentStreakDays !== "number"
+    || isNonNegativeSafeIntegerValue(parsedValue.serverBase.summary.currentStreakDays) === false
+    || isNonNegativeSafeIntegerValue(parsedValue.serverBase.summary.longestStreakDays) === false
     || typeof parsedValue.serverBase.summary.hasReviewedToday !== "boolean"
     || (parsedValue.serverBase.summary.lastReviewedOn !== null && typeof parsedValue.serverBase.summary.lastReviewedOn !== "string")
-    || typeof parsedValue.serverBase.summary.activeReviewDays !== "number"
+    || isNonNegativeSafeIntegerValue(parsedValue.serverBase.summary.activeReviewDays) === false
   ) {
     return {
       status: "miss",
@@ -339,10 +419,25 @@ function parsePersistedProgressSummary(rawValue: string | null): ProgressCacheRe
     };
   }
 
+  const streakFreeze = parsePersistedStreakFreeze(parsedValue.serverBase.summary.streakFreeze);
+  if (streakFreeze === null) {
+    return {
+      status: "miss",
+      reason: "invalid_shape",
+    };
+  }
+
+  if (parsedValue.serverBase.summary.longestStreakDays < parsedValue.serverBase.summary.currentStreakDays) {
+    return {
+      status: "miss",
+      reason: "invalid_shape",
+    };
+  }
+
   return {
     status: "hit",
     value: {
-      version: 2,
+      version: 3,
       scopeKey: parsedValue.scopeKey,
       savedAt: parsedValue.savedAt,
       serverBase: {
@@ -351,9 +446,11 @@ function parsePersistedProgressSummary(rawValue: string | null): ProgressCacheRe
         reviewHistoryWatermarks,
         summary: {
           currentStreakDays: parsedValue.serverBase.summary.currentStreakDays,
+          longestStreakDays: parsedValue.serverBase.summary.longestStreakDays,
           hasReviewedToday: parsedValue.serverBase.summary.hasReviewedToday,
           lastReviewedOn: parsedValue.serverBase.summary.lastReviewedOn,
           activeReviewDays: parsedValue.serverBase.summary.activeReviewDays,
+          streakFreeze,
         },
       },
     },
@@ -374,9 +471,15 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
   }
 
   const parsedValue = parsedRecord.value;
+  if (parsedValue.version !== progressServerSeriesVersion) {
+    return {
+      status: "miss",
+      reason: "version_mismatch",
+    };
+  }
+
   if (
-    parsedValue.version !== progressServerSeriesVersion
-    || typeof parsedValue.scopeKey !== "string"
+    typeof parsedValue.scopeKey !== "string"
     || typeof parsedValue.savedAt !== "string"
     || isRecord(parsedValue.serverBase) === false
     || typeof parsedValue.serverBase.timeZone !== "string"
@@ -384,6 +487,7 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
     || typeof parsedValue.serverBase.to !== "string"
     || (parsedValue.serverBase.generatedAt !== null && typeof parsedValue.serverBase.generatedAt !== "string")
     || Array.isArray(parsedValue.serverBase.dailyReviews) === false
+    || Array.isArray(parsedValue.serverBase.streakDays) === false
   ) {
     return {
       status: "miss",
@@ -435,6 +539,14 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
     };
   }
 
+  const streakDays = parsePersistedStreakDays(parsedValue.serverBase.streakDays);
+  if (streakDays === null) {
+    return {
+      status: "miss",
+      reason: "invalid_shape",
+    };
+  }
+
   const reviewHistoryWatermarks = parsePersistedProgressReviewHistoryWatermarks(
     parsedValue.serverBase.reviewHistoryWatermarks,
   );
@@ -452,6 +564,7 @@ function parsePersistedProgressSeries(rawValue: string | null): ProgressCacheRea
     generatedAt: parsedValue.serverBase.generatedAt,
     reviewHistoryWatermarks,
     dailyReviews,
+    streakDays,
   });
   if (normalizedServerBase.status === "miss") {
     return {
@@ -915,7 +1028,7 @@ function assertProgressReviewScheduleTimeZone(
 
 export function storePersistedProgressSummary(scopeKey: ProgressScopeKey, serverBase: ProgressSummaryPayload): void {
   const persistedValue: PersistedProgressSummary = {
-    version: 2,
+    version: 3,
     scopeKey,
     savedAt: new Date().toISOString(),
     serverBase,

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -124,6 +124,8 @@ const arCatalog: TranslationCatalog = {
     title: "التقدم",
     subtitle: "تتبّع سلسلة الأيام الأخيرة وسجل المراجعات اليومي.",
     streakTitle: "السلسلة",
+    streakInfoToggleLabel: "حول تجميد السلسلة",
+    streakInfo: "رصيد التجميد {{available}}/{{capacity}}. الشحن التالي {{progress}}/{{required}}.",
     reviewsTitle: "المراجعات",
     lastThirtyDays: "آخر 30 يومًا",
     empty: "لم تُسجَّل أي مراجعات خلال نطاق الثلاثين يومًا هذا.",
@@ -559,7 +561,8 @@ const arCatalog: TranslationCatalog = {
       ariaLabel: "فتح لوحة المتصدرين",
     },
     progressBadge: {
-      ariaLabel: "سلسلة المراجعة {{streak}} يومًا. {{todayStatus}}.",
+      ariaLabel: "سلسلة المراجعة {{streak}} يومًا. {{todayStatus}}. {{freezeBank}}.",
+      freezeBank: "رصيد التجميد {{available}} من {{capacity}}",
       notReviewedToday: "لم تُراجع اليوم",
       reviewedToday: "راجعت اليوم",
       title: "السلسلة",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -124,6 +124,8 @@ const deCatalog: TranslationCatalog = {
     title: "Fortschritt",
     subtitle: "Verfolge deine aktuelle Serie und deinen täglichen Wiederholungsverlauf.",
     streakTitle: "Serie",
+    streakInfoToggleLabel: "Über Serien-Frost",
+    streakInfo: "Frostbank {{available}}/{{capacity}}. Nächste Aufladung {{progress}}/{{required}}.",
     reviewsTitle: "Wiederholungen",
     lastThirtyDays: "Letzte 30 Tage",
     empty: "Für diesen 30-Tage-Zeitraum wurden keine Wiederholungen erfasst.",
@@ -559,7 +561,8 @@ const deCatalog: TranslationCatalog = {
       ariaLabel: "Bestenliste öffnen",
     },
     progressBadge: {
-      ariaLabel: "Lernserie {{streak}} Tage. {{todayStatus}}.",
+      ariaLabel: "Lernserie {{streak}} Tage. {{todayStatus}}. {{freezeBank}}.",
+      freezeBank: "Frostbank {{available}} von {{capacity}}",
       notReviewedToday: "Heute noch nicht wiederholt",
       reviewedToday: "Heute wiederholt",
       title: "Serie",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -122,6 +122,8 @@ const enCatalog = {
     title: "Progress",
     subtitle: "Track your recent streak and daily review history.",
     streakTitle: "Streak",
+    streakInfoToggleLabel: "About streak freezes",
+    streakInfo: "Freeze bank {{available}}/{{capacity}}. Next recharge {{progress}}/{{required}}.",
     reviewsTitle: "Reviews",
     lastThirtyDays: "Last 30 days",
     empty: "No reviews were recorded for this 30-day range.",
@@ -557,7 +559,8 @@ const enCatalog = {
       ariaLabel: "Open leaderboard",
     },
     progressBadge: {
-      ariaLabel: "Review streak {{streak}} days. {{todayStatus}}.",
+      ariaLabel: "Review streak {{streak}} days. {{todayStatus}}. {{freezeBank}}.",
+      freezeBank: "Freeze bank {{available}} of {{capacity}}",
       notReviewedToday: "Not reviewed today",
       reviewedToday: "Reviewed today",
       title: "Streak",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -124,6 +124,8 @@ const esEsCatalog: TranslationCatalog = {
     title: "Progreso",
     subtitle: "Sigue tu racha reciente y el historial diario de repasos.",
     streakTitle: "Racha",
+    streakInfoToggleLabel: "Acerca de las congelaciones de racha",
+    streakInfo: "Banco de congelaciones {{available}}/{{capacity}}. Próxima recarga {{progress}}/{{required}}.",
     reviewsTitle: "Repasos",
     lastThirtyDays: "Últimos 30 días",
     empty: "No se registraron repasos en este rango de 30 días.",
@@ -559,7 +561,8 @@ const esEsCatalog: TranslationCatalog = {
       ariaLabel: "Abrir clasificación",
     },
     progressBadge: {
-      ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}.",
+      ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}. {{freezeBank}}.",
+      freezeBank: "Banco de congelaciones {{available}} de {{capacity}}",
       notReviewedToday: "Sin repaso hoy",
       reviewedToday: "Repasado hoy",
       title: "Racha",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -124,6 +124,8 @@ const esMxCatalog: TranslationCatalog = {
     title: "Progreso",
     subtitle: "Sigue tu racha reciente y el historial diario de repasos.",
     streakTitle: "Racha",
+    streakInfoToggleLabel: "Acerca de las congelaciones de racha",
+    streakInfo: "Banco de congelaciones {{available}}/{{capacity}}. Próxima recarga {{progress}}/{{required}}.",
     reviewsTitle: "Repasos",
     lastThirtyDays: "Últimos 30 días",
     empty: "No se registraron repasos en este rango de 30 días.",
@@ -559,7 +561,8 @@ const esMxCatalog: TranslationCatalog = {
       ariaLabel: "Abrir clasificación",
     },
     progressBadge: {
-      ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}.",
+      ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}. {{freezeBank}}.",
+      freezeBank: "Banco de congelaciones {{available}} de {{capacity}}",
       notReviewedToday: "Sin repaso hoy",
       reviewedToday: "Repasado hoy",
       title: "Racha",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -124,6 +124,8 @@ const hiCatalog: TranslationCatalog = {
     title: "प्रगति",
     subtitle: "अपनी हाल की स्ट्रीक और दैनिक रिव्यू इतिहास को ट्रैक करें।",
     streakTitle: "स्ट्रीक",
+    streakInfoToggleLabel: "स्ट्रीक फ़्रीज़ के बारे में",
+    streakInfo: "फ़्रीज़ बैंक {{available}}/{{capacity}}। अगला रीचार्ज {{progress}}/{{required}}।",
     reviewsTitle: "रिव्यू",
     lastThirtyDays: "पिछले 30 दिन",
     empty: "इन 30 दिनों की अवधि में कोई रिव्यू दर्ज नहीं किया गया।",
@@ -559,7 +561,8 @@ const hiCatalog: TranslationCatalog = {
       ariaLabel: "लीडरबोर्ड खोलें",
     },
     progressBadge: {
-      ariaLabel: "रिव्यू स्ट्रीक {{streak}} दिन। {{todayStatus}}।",
+      ariaLabel: "रिव्यू स्ट्रीक {{streak}} दिन। {{todayStatus}}। {{freezeBank}}।",
+      freezeBank: "फ़्रीज़ बैंक {{available}} में से {{capacity}}",
       notReviewedToday: "आज रिव्यू नहीं किया",
       reviewedToday: "आज रिव्यू किया",
       title: "स्ट्रीक",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -124,6 +124,8 @@ export const jaCatalog = {
     title: "進捗",
     subtitle: "直近の連続日数と日ごとの復習履歴を確認できます。",
     streakTitle: "連続日数",
+    streakInfoToggleLabel: "連続フリーズについて",
+    streakInfo: "フリーズ残数 {{available}}/{{capacity}}。次の回復 {{progress}}/{{required}}。",
     reviewsTitle: "復習回数",
     lastThirtyDays: "過去30日間",
     empty: "この30日間では復習が記録されていません。",
@@ -559,7 +561,8 @@ export const jaCatalog = {
       ariaLabel: "リーダーボードを開く",
     },
     progressBadge: {
-      ariaLabel: "復習連続 {{streak}} 日。{{todayStatus}}。",
+      ariaLabel: "復習連続 {{streak}} 日。{{todayStatus}}。{{freezeBank}}。",
+      freezeBank: "フリーズ残数 {{available}} / {{capacity}}",
       notReviewedToday: "今日はまだ復習していません",
       reviewedToday: "今日は復習済み",
       title: "連続",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -124,6 +124,8 @@ export const ruCatalog = {
     title: "Прогресс",
     subtitle: "Отслеживайте недавнюю серию и ежедневную историю повторений.",
     streakTitle: "Серия",
+    streakInfoToggleLabel: "О заморозках серии",
+    streakInfo: "Запас заморозок {{available}}/{{capacity}}. Следующее пополнение {{progress}}/{{required}}.",
     reviewsTitle: "Повторения",
     lastThirtyDays: "Последние 30 дней",
     empty: "За этот 30-дневный период повторения не были записаны.",
@@ -559,7 +561,8 @@ export const ruCatalog = {
       ariaLabel: "Открыть таблицу лидеров",
     },
     progressBadge: {
-      ariaLabel: "Серия повторений: {{streak}} дн. {{todayStatus}}.",
+      ariaLabel: "Серия повторений: {{streak}} дн. {{todayStatus}}. {{freezeBank}}.",
+      freezeBank: "Запас заморозок {{available}} из {{capacity}}",
       notReviewedToday: "Сегодня ещё не повторяли",
       reviewedToday: "Сегодня уже повторяли",
       title: "Серия",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -124,6 +124,8 @@ export const zhHansCatalog = {
     title: "进度",
     subtitle: "查看你最近的连续学习天数和每日复习记录。",
     streakTitle: "连续天数",
+    streakInfoToggleLabel: "关于连续冻结",
+    streakInfo: "冻结额度 {{available}}/{{capacity}}。下次补充 {{progress}}/{{required}}。",
     reviewsTitle: "复习次数",
     lastThirtyDays: "最近 30 天",
     empty: "在这 30 天范围内没有记录到任何复习。",
@@ -559,7 +561,8 @@ export const zhHansCatalog = {
       ariaLabel: "打开排行榜",
     },
     progressBadge: {
-      ariaLabel: "复习连续 {{streak}} 天。{{todayStatus}}。",
+      ariaLabel: "复习连续 {{streak}} 天。{{todayStatus}}。{{freezeBank}}。",
+      freezeBank: "冻结额度 {{available}} / {{capacity}}",
       notReviewedToday: "今天还没复习",
       reviewedToday: "今天已复习",
       title: "连续",

--- a/apps/web/src/localDb/progress/progress.test.ts
+++ b/apps/web/src/localDb/progress/progress.test.ts
@@ -277,9 +277,18 @@ describe("localDb progress", () => {
 
     expect(result).toEqual({
       currentStreakDays: 3,
+      longestStreakDays: 3,
       hasReviewedToday: true,
       lastReviewedOn: "2025-01-08",
       activeReviewDays: 3,
+      streakFreeze: {
+        availableCredits: 2,
+        capacity: 2,
+        balanceUnits: 20,
+        unitsPerCredit: 10,
+        nextCreditProgressUnits: 0,
+        nextCreditRequiredUnits: 10,
+      },
     });
   });
 

--- a/apps/web/src/localDb/progress/progress.ts
+++ b/apps/web/src/localDb/progress/progress.ts
@@ -24,8 +24,11 @@ import {
 import { listOutboxRecordsForWorkspaces } from "../sync/outbox";
 import {
   formatDateAsLocalDate,
-  shiftLocalDate,
 } from "../../progress/progressDates";
+import {
+  createDefaultStreakFreeze,
+  evaluateProgressStreakFreeze,
+} from "../../progress/streakFreeze";
 
 const progressCacheStateKey = "progress_cache_state";
 const progressRecordKeyHighValue = "\uffff";
@@ -53,9 +56,11 @@ function isPendingReviewEventOperation(
 function createEmptyProgressSummary(): ProgressSummary {
   return {
     currentStreakDays: 0,
+    longestStreakDays: 0,
     hasReviewedToday: false,
     lastReviewedOn: null,
     activeReviewDays: 0,
+    streakFreeze: createDefaultStreakFreeze(),
   };
 }
 
@@ -168,20 +173,16 @@ function buildProgressSummary(
   }
 
   const reviewDateSet = new Set(reviewDates);
+  const streakFreezeEvaluation = evaluateProgressStreakFreeze(reviewDates, today);
   const hasReviewedToday = reviewDateSet.has(today);
-  let currentDate = hasReviewedToday ? today : shiftLocalDate(today, -1);
-  let currentStreakDays = 0;
-
-  while (reviewDateSet.has(currentDate)) {
-    currentStreakDays += 1;
-    currentDate = shiftLocalDate(currentDate, -1);
-  }
 
   return {
-    currentStreakDays,
+    currentStreakDays: streakFreezeEvaluation.currentStreakDays,
+    longestStreakDays: streakFreezeEvaluation.longestStreakDays,
     hasReviewedToday,
     lastReviewedOn: reviewDates.at(-1) ?? null,
     activeReviewDays: reviewDates.length,
+    streakFreeze: streakFreezeEvaluation.streakFreeze,
   };
 }
 

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -98,7 +98,7 @@ export type AuthResetCleanupBreadcrumbDetails = Readonly<{
 export type ProgressCacheMissBreadcrumbDetails = Readonly<{
   eventName: "progress_cache_miss";
   section: "summary" | "series" | "review_schedule" | "leaderboard";
-  reason: "invalid_json" | "invalid_shape" | "scope_mismatch" | "time_zone_mismatch";
+  reason: "invalid_json" | "invalid_shape" | "scope_mismatch" | "time_zone_mismatch" | "version_mismatch";
   workspaceIds: ReadonlyArray<string>;
 }>;
 

--- a/apps/web/src/progress/streakFreeze.ts
+++ b/apps/web/src/progress/streakFreeze.ts
@@ -1,0 +1,418 @@
+import type {
+  StreakDay,
+  StreakDayState,
+  StreakFreeze,
+} from "../types";
+
+export const streakFreezePolicy: StreakFreezePolicy = {
+  startCapacity: 2,
+  maxCapacity: 2,
+  unitsPerCredit: 10,
+  earnedUnitsPerStreakDay: 1,
+};
+
+export type StreakFreezePolicy = Readonly<{
+  startCapacity: number;
+  maxCapacity: number;
+  unitsPerCredit: number;
+  earnedUnitsPerStreakDay: number;
+}>;
+
+export type StreakFreezeEvaluation = Readonly<{
+  currentStreakDays: number;
+  longestStreakDays: number;
+  streakFreeze: StreakFreeze;
+  streakDays: ReadonlyArray<StreakDay>;
+}>;
+
+export type StreakFreezeCarryState = Readonly<{
+  balanceUnits: number;
+  currentStreakDays: number;
+  longestStreakDays: number;
+  hasActiveSegment: boolean;
+  lastEvaluatedDate: string | null;
+}>;
+
+type StreakComputationState = StreakFreezeCarryState;
+
+const localDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseLocalDatePart(value: string, start: number, end: number): number {
+  return Number.parseInt(value.slice(start, end), 10);
+}
+
+function assertLocalDate(value: string, fieldName: string): void {
+  if (localDatePattern.test(value) === false) {
+    throw new Error(`${fieldName} must be a YYYY-MM-DD date`);
+  }
+
+  const year = parseLocalDatePart(value, 0, 4);
+  const month = parseLocalDatePart(value, 5, 7);
+  const day = parseLocalDatePart(value, 8, 10);
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    parsedDate.getUTCFullYear() !== year
+    || parsedDate.getUTCMonth() !== month - 1
+    || parsedDate.getUTCDate() !== day
+  ) {
+    throw new Error(`${fieldName} must be a YYYY-MM-DD date`);
+  }
+}
+
+function createUtcDateFromLocalDate(value: string): Date {
+  const year = parseLocalDatePart(value, 0, 4);
+  const month = parseLocalDatePart(value, 5, 7);
+  const day = parseLocalDatePart(value, 8, 10);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+function formatUtcDateAsLocalDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function shiftLocalDate(value: string, offsetDays: number): string {
+  const date = createUtcDateFromLocalDate(value);
+  date.setUTCDate(date.getUTCDate() + offsetDays);
+  return formatUtcDateAsLocalDate(date);
+}
+
+function validateStreakFreezePolicy(policy: StreakFreezePolicy): void {
+  if (Number.isInteger(policy.startCapacity) === false || policy.startCapacity < 0) {
+    throw new Error("streak freeze startCapacity must be a non-negative integer");
+  }
+
+  if (Number.isInteger(policy.maxCapacity) === false || policy.maxCapacity < 0) {
+    throw new Error("streak freeze maxCapacity must be a non-negative integer");
+  }
+
+  if (Number.isInteger(policy.unitsPerCredit) === false || policy.unitsPerCredit <= 0) {
+    throw new Error("streak freeze unitsPerCredit must be a positive integer");
+  }
+
+  if (Number.isInteger(policy.earnedUnitsPerStreakDay) === false || policy.earnedUnitsPerStreakDay < 0) {
+    throw new Error("streak freeze earnedUnitsPerStreakDay must be a non-negative integer");
+  }
+}
+
+function validateStreakFreezeCarryState(state: StreakFreezeCarryState, policy: StreakFreezePolicy): void {
+  if (Number.isInteger(state.balanceUnits) === false || state.balanceUnits < 0) {
+    throw new Error("streak freeze carry balanceUnits must be a non-negative integer");
+  }
+
+  if (state.balanceUnits > getMaximumBalanceUnits(policy)) {
+    throw new Error("streak freeze carry balanceUnits must not exceed maximum balance units");
+  }
+
+  if (Number.isInteger(state.currentStreakDays) === false || state.currentStreakDays < 0) {
+    throw new Error("streak freeze carry currentStreakDays must be a non-negative integer");
+  }
+
+  if (Number.isInteger(state.longestStreakDays) === false || state.longestStreakDays < state.currentStreakDays) {
+    throw new Error("streak freeze carry longestStreakDays must be at least currentStreakDays");
+  }
+
+  if (state.hasActiveSegment === false && state.currentStreakDays !== 0) {
+    throw new Error("streak freeze inactive carry state must have zero currentStreakDays");
+  }
+
+  if (state.lastEvaluatedDate !== null) {
+    assertLocalDate(state.lastEvaluatedDate, "streak freeze carry lastEvaluatedDate");
+  }
+}
+
+function isNonNegativeSafeInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0;
+}
+
+export function isCoherentStreakFreeze(streakFreeze: StreakFreeze): boolean {
+  if (
+    isNonNegativeSafeInteger(streakFreeze.availableCredits) === false
+    || isNonNegativeSafeInteger(streakFreeze.capacity) === false
+    || isNonNegativeSafeInteger(streakFreeze.balanceUnits) === false
+    || isNonNegativeSafeInteger(streakFreeze.unitsPerCredit) === false
+    || isNonNegativeSafeInteger(streakFreeze.nextCreditProgressUnits) === false
+    || isNonNegativeSafeInteger(streakFreeze.nextCreditRequiredUnits) === false
+    || streakFreeze.capacity !== streakFreezePolicy.maxCapacity
+    || streakFreeze.unitsPerCredit !== streakFreezePolicy.unitsPerCredit
+    || streakFreeze.nextCreditRequiredUnits !== streakFreezePolicy.unitsPerCredit
+  ) {
+    return false;
+  }
+
+  const maximumBalanceUnits = streakFreeze.capacity * streakFreeze.unitsPerCredit;
+  if (streakFreeze.balanceUnits > maximumBalanceUnits) {
+    return false;
+  }
+
+  const expectedAvailableCredits = Math.min(
+    streakFreeze.capacity,
+    Math.floor(streakFreeze.balanceUnits / streakFreeze.unitsPerCredit),
+  );
+  const expectedNextCreditProgressUnits = expectedAvailableCredits >= streakFreeze.capacity
+    ? 0
+    : streakFreeze.balanceUnits % streakFreeze.unitsPerCredit;
+
+  return streakFreeze.availableCredits === expectedAvailableCredits
+    && streakFreeze.nextCreditProgressUnits === expectedNextCreditProgressUnits;
+}
+
+function assertSortedActiveReviewLocalDates(sortedActiveReviewLocalDates: ReadonlyArray<string>): void {
+  let previousDate: string | null = null;
+
+  for (const reviewDate of sortedActiveReviewLocalDates) {
+    assertLocalDate(reviewDate, "active review local date");
+    if (previousDate !== null && previousDate >= reviewDate) {
+      throw new Error("active review local dates must be sorted ascending without duplicates");
+    }
+
+    previousDate = reviewDate;
+  }
+}
+
+function getMaximumBalanceUnits(policy: StreakFreezePolicy): number {
+  return policy.maxCapacity * policy.unitsPerCredit;
+}
+
+function getInitialBalanceUnits(policy: StreakFreezePolicy): number {
+  return Math.min(policy.startCapacity, policy.maxCapacity) * policy.unitsPerCredit;
+}
+
+function clampBalanceUnits(balanceUnits: number, policy: StreakFreezePolicy): number {
+  return Math.min(balanceUnits, getMaximumBalanceUnits(policy));
+}
+
+function addStreakDayEarnedUnits(balanceUnits: number, policy: StreakFreezePolicy): number {
+  return clampBalanceUnits(balanceUnits + policy.earnedUnitsPerStreakDay, policy);
+}
+
+function getAvailableCredits(balanceUnits: number, policy: StreakFreezePolicy): number {
+  return Math.min(policy.maxCapacity, Math.floor(balanceUnits / policy.unitsPerCredit));
+}
+
+function createStreakFreeze(balanceUnits: number, policy: StreakFreezePolicy): StreakFreeze {
+  const clampedBalanceUnits = clampBalanceUnits(balanceUnits, policy);
+  const availableCredits = getAvailableCredits(clampedBalanceUnits, policy);
+
+  return {
+    availableCredits,
+    capacity: policy.maxCapacity,
+    balanceUnits: clampedBalanceUnits,
+    unitsPerCredit: policy.unitsPerCredit,
+    nextCreditProgressUnits: availableCredits >= policy.maxCapacity ? 0 : clampedBalanceUnits % policy.unitsPerCredit,
+    nextCreditRequiredUnits: policy.unitsPerCredit,
+  };
+}
+
+function createInitialState(policy: StreakFreezePolicy): StreakComputationState {
+  return {
+    balanceUnits: getInitialBalanceUnits(policy),
+    currentStreakDays: 0,
+    longestStreakDays: 0,
+    hasActiveSegment: false,
+    lastEvaluatedDate: null,
+  };
+}
+
+function addReviewedDay(
+  state: StreakComputationState,
+  date: string,
+  policy: StreakFreezePolicy,
+  statesByDate: Map<string, StreakDayState>,
+): StreakComputationState {
+  const balanceUnits = addStreakDayEarnedUnits(
+    state.hasActiveSegment ? state.balanceUnits : getInitialBalanceUnits(policy),
+    policy,
+  );
+  const currentStreakDays = state.hasActiveSegment ? state.currentStreakDays + 1 : 1;
+  statesByDate.set(date, "reviewed");
+
+  return {
+    balanceUnits,
+    currentStreakDays,
+    longestStreakDays: Math.max(state.longestStreakDays, currentStreakDays),
+    hasActiveSegment: true,
+    lastEvaluatedDate: date,
+  };
+}
+
+function addFrozenDay(
+  state: StreakComputationState,
+  date: string,
+  policy: StreakFreezePolicy,
+  statesByDate: Map<string, StreakDayState>,
+): StreakComputationState {
+  const balanceUnitsAfterSpend = state.balanceUnits - policy.unitsPerCredit;
+  const balanceUnits = addStreakDayEarnedUnits(balanceUnitsAfterSpend, policy);
+  const currentStreakDays = state.currentStreakDays + 1;
+  statesByDate.set(date, "frozen");
+
+  return {
+    balanceUnits,
+    currentStreakDays,
+    longestStreakDays: Math.max(state.longestStreakDays, currentStreakDays),
+    hasActiveSegment: true,
+    lastEvaluatedDate: date,
+  };
+}
+
+function addMissedDay(
+  state: StreakComputationState,
+  date: string,
+  policy: StreakFreezePolicy,
+  statesByDate: Map<string, StreakDayState>,
+): StreakComputationState {
+  statesByDate.set(date, "missed");
+
+  return {
+    balanceUnits: getInitialBalanceUnits(policy),
+    currentStreakDays: 0,
+    longestStreakDays: state.longestStreakDays,
+    hasActiveSegment: false,
+    lastEvaluatedDate: date,
+  };
+}
+
+function addPendingDay(
+  state: StreakComputationState,
+  date: string,
+  statesByDate: Map<string, StreakDayState>,
+): StreakComputationState {
+  statesByDate.set(date, "pending");
+
+  return {
+    ...state,
+    lastEvaluatedDate: date,
+  };
+}
+
+function addNonReviewedCompletedDay(
+  state: StreakComputationState,
+  date: string,
+  policy: StreakFreezePolicy,
+  statesByDate: Map<string, StreakDayState>,
+): StreakComputationState {
+  if (state.hasActiveSegment && getAvailableCredits(state.balanceUnits, policy) > 0) {
+    return addFrozenDay(state, date, policy, statesByDate);
+  }
+
+  return addMissedDay(state, date, policy, statesByDate);
+}
+
+function addNonReviewedDaysBeforeReview(
+  state: StreakComputationState,
+  nextReviewDate: string,
+  policy: StreakFreezePolicy,
+  statesByDate: Map<string, StreakDayState>,
+): StreakComputationState {
+  let currentState = state;
+  let currentDate = currentState.lastEvaluatedDate === null
+    ? nextReviewDate
+    : shiftLocalDate(currentState.lastEvaluatedDate, 1);
+
+  while (currentState.lastEvaluatedDate !== null && currentDate < nextReviewDate) {
+    currentState = addNonReviewedCompletedDay(currentState, currentDate, policy, statesByDate);
+    currentDate = shiftLocalDate(currentDate, 1);
+  }
+
+  return currentState;
+}
+
+function addTrailingDaysThroughToday(
+  state: StreakComputationState,
+  today: string,
+  policy: StreakFreezePolicy,
+  statesByDate: Map<string, StreakDayState>,
+): StreakComputationState {
+  let currentState = state;
+  let currentDate = currentState.lastEvaluatedDate === null
+    ? today
+    : shiftLocalDate(currentState.lastEvaluatedDate, 1);
+
+  while (currentDate <= today) {
+    currentState = currentDate === today
+      ? addPendingDay(currentState, currentDate, statesByDate)
+      : addNonReviewedCompletedDay(currentState, currentDate, policy, statesByDate);
+    currentDate = shiftLocalDate(currentDate, 1);
+  }
+
+  return currentState;
+}
+
+function createStreakDays(statesByDate: ReadonlyMap<string, StreakDayState>): ReadonlyArray<StreakDay> {
+  return [...statesByDate.entries()]
+    .sort(([leftDate], [rightDate]) => leftDate.localeCompare(rightDate))
+    .map(([date, state]) => ({
+      date,
+      state,
+    }));
+}
+
+export function createDefaultStreakFreeze(): StreakFreeze {
+  validateStreakFreezePolicy(streakFreezePolicy);
+  return createStreakFreeze(getInitialBalanceUnits(streakFreezePolicy), streakFreezePolicy);
+}
+
+export function addReviewedDayToStreakFreeze(streakFreeze: StreakFreeze): StreakFreeze {
+  return createStreakFreeze(
+    streakFreeze.balanceUnits + streakFreezePolicy.earnedUnitsPerStreakDay,
+    streakFreezePolicy,
+  );
+}
+
+export function evaluateProgressStreakFreeze(
+  sortedActiveReviewLocalDates: ReadonlyArray<string>,
+  today: string,
+): StreakFreezeEvaluation {
+  validateStreakFreezePolicy(streakFreezePolicy);
+  assertLocalDate(today, "today");
+  assertSortedActiveReviewLocalDates(sortedActiveReviewLocalDates);
+
+  return evaluateProgressStreakFreezeFromCarryState(
+    sortedActiveReviewLocalDates,
+    today,
+    createInitialState(streakFreezePolicy),
+  );
+}
+
+export function evaluateProgressStreakFreezeFromCarryState(
+  sortedActiveReviewLocalDates: ReadonlyArray<string>,
+  today: string,
+  carryState: StreakFreezeCarryState,
+): StreakFreezeEvaluation {
+  validateStreakFreezePolicy(streakFreezePolicy);
+  validateStreakFreezeCarryState(carryState, streakFreezePolicy);
+  assertLocalDate(today, "today");
+  assertSortedActiveReviewLocalDates(sortedActiveReviewLocalDates);
+
+  if (carryState.lastEvaluatedDate !== null && carryState.lastEvaluatedDate >= today) {
+    throw new Error("streak freeze carry lastEvaluatedDate must be before today");
+  }
+
+  const staleActiveReviewDate = sortedActiveReviewLocalDates.find((reviewDate) => (
+    carryState.lastEvaluatedDate !== null && reviewDate <= carryState.lastEvaluatedDate
+  ));
+  if (staleActiveReviewDate !== undefined) {
+    throw new Error(`active review local date must be after carry lastEvaluatedDate: ${staleActiveReviewDate}`);
+  }
+
+  const statesByDate = new Map<string, StreakDayState>();
+  const activeReviewLocalDatesThroughToday = sortedActiveReviewLocalDates.filter((reviewDate) => reviewDate <= today);
+  const stateAfterReviews = activeReviewLocalDatesThroughToday.reduce<StreakComputationState>(
+    (state, reviewDate) => addReviewedDay(
+      addNonReviewedDaysBeforeReview(state, reviewDate, streakFreezePolicy, statesByDate),
+      reviewDate,
+      streakFreezePolicy,
+      statesByDate,
+    ),
+    carryState,
+  );
+  const finalState = addTrailingDaysThroughToday(stateAfterReviews, today, streakFreezePolicy, statesByDate);
+
+  return {
+    currentStreakDays: finalState.currentStreakDays,
+    longestStreakDays: finalState.longestStreakDays,
+    streakFreeze: createStreakFreeze(finalState.balanceUnits, streakFreezePolicy),
+    streakDays: createStreakDays(statesByDate),
+  };
+}

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { I18nProvider } from "../../i18n";
+import { shiftLocalDate } from "../../progress/progressDates";
 import { progressLeaderboardHash, progressStreakHash } from "../../routes";
 import type { AppDataContextValue } from "../../appData";
 import {
@@ -23,6 +24,8 @@ import type {
   ProgressReviewScheduleSnapshot,
   ProgressSeriesSnapshot,
   ProgressSummarySnapshot,
+  StreakDay,
+  StreakDayState,
 } from "../../types";
 import { progressLeaderboardWindowKeys } from "../../types";
 
@@ -170,6 +173,45 @@ function createAppData(): AppDataContextValue {
   };
 }
 
+function createPartialStreakFreeze(): Readonly<{
+  availableCredits: number;
+  capacity: number;
+  balanceUnits: number;
+  unitsPerCredit: number;
+  nextCreditProgressUnits: number;
+  nextCreditRequiredUnits: number;
+}> {
+  return {
+    availableCredits: 1,
+    capacity: 2,
+    balanceUnits: 11,
+    unitsPerCredit: 10,
+    nextCreditProgressUnits: 1,
+    nextCreditRequiredUnits: 10,
+  };
+}
+
+function createProgressStreakDaysForTest(from: string, to: string): ReadonlyArray<StreakDay> {
+  const reviewedDates = new Set(["2026-04-14", "2026-04-21"]);
+  const frozenDates = new Set(["2026-04-15", "2026-04-16"]);
+  const streakDays: Array<StreakDay> = [];
+
+  for (let currentDate = from; currentDate <= to; currentDate = shiftLocalDate(currentDate, 1)) {
+    const state: StreakDayState = reviewedDates.has(currentDate)
+      ? "reviewed"
+      : frozenDates.has(currentDate)
+        ? "frozen"
+        : "missed";
+
+    streakDays.push({
+      date: currentDate,
+      state,
+    });
+  }
+
+  return streakDays;
+}
+
 function createProgressSummarySnapshot(): ProgressSummarySnapshot {
   return {
     timeZone: "UTC",
@@ -177,9 +219,11 @@ function createProgressSummarySnapshot(): ProgressSummarySnapshot {
     reviewHistoryWatermarks: [],
     summary: {
       currentStreakDays: 2,
+      longestStreakDays: 3,
       hasReviewedToday: true,
       lastReviewedOn: "2026-04-21",
       activeReviewDays: 2,
+      streakFreeze: createPartialStreakFreeze(),
     },
     source: "server",
     isApproximate: false,
@@ -229,6 +273,7 @@ function createProgressSeriesSnapshot(): ProgressSeriesSnapshot {
     generatedAt: "2026-04-21T10:00:00.000Z",
     reviewHistoryWatermarks: [],
     dailyReviews,
+    streakDays: createProgressStreakDaysForTest("2026-03-21", "2026-04-21"),
     chartData: {
       dailyReviews,
     },
@@ -467,6 +512,7 @@ function mockProgressSourceStateWithLeaderboard(leaderboard: ProgressLeaderboard
       series: {
         scopeKey: "progress::series::UTC::2026-04-13::2026-04-21",
         localFallback: null,
+        localFallbackActiveDates: [],
         serverBase: createProgressSeriesSnapshot(),
         pendingLocalOverlay: null,
         renderedSnapshot: createProgressSeriesSnapshot(),
@@ -555,6 +601,10 @@ describe("ProgressScreen", () => {
     const streakMarkerIcons = [...container.querySelectorAll(".progress-streak-marker-flame .review-progress-badge-icon")];
     expect(streakMarkerIcons.length).toBeGreaterThan(0);
     expect(streakMarkerIcons.every((icon) => icon instanceof SVGSVGElement)).toBe(true);
+
+    const frozenMarkerIcons = [...container.querySelectorAll(".progress-streak-marker-freeze .review-progress-badge-icon")];
+    expect(frozenMarkerIcons.length).toBeGreaterThan(0);
+    expect(frozenMarkerIcons.every((icon) => icon instanceof SVGSVGElement)).toBe(true);
   });
 
   it("uses the schedule-specific progress version for review schedule refreshes", async () => {
@@ -829,6 +879,7 @@ describe("ProgressScreen", () => {
         series: {
           scopeKey: "progress::series::UTC::2026-04-06::2026-04-21",
           localFallback: null,
+          localFallbackActiveDates: [],
           serverBase: {
             ...createProgressSeriesSnapshot(),
             from: "2026-04-06",

--- a/apps/web/src/screens/progress/ProgressScreen.test.ts
+++ b/apps/web/src/screens/progress/ProgressScreen.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { shiftLocalDate } from "../../progress/progressDates";
+import type { StreakDay, StreakDayState } from "../../types";
 import { buildStreakWeeks } from "./streak/progressStreakModel";
 
 type DateFormatter = (
@@ -12,6 +14,24 @@ function createDateFormatter(locale: string): DateFormatter {
   };
 }
 
+function createStreakDays(
+  from: string,
+  to: string,
+  reviewedDates: ReadonlySet<string>,
+): ReadonlyArray<StreakDay> {
+  const days: Array<StreakDay> = [];
+
+  for (let currentDate = from; currentDate <= to; currentDate = shiftLocalDate(currentDate, 1)) {
+    const state: StreakDayState = reviewedDates.has(currentDate) ? "reviewed" : "missed";
+    days.push({
+      date: currentDate,
+      state,
+    });
+  }
+
+  return days;
+}
+
 describe("ProgressScreen streak weeks", () => {
   it("marks future dates in the current locale-aligned week as placeholders", () => {
     const weeks = buildStreakWeeks(
@@ -20,6 +40,11 @@ describe("ProgressScreen streak weeks", () => {
         { date: "2026-04-20", reviewCount: 2, againCount: 0, hardCount: 0, goodCount: 2, easyCount: 0 },
         { date: "2026-04-21", reviewCount: 4, againCount: 0, hardCount: 0, goodCount: 4, easyCount: 0 },
       ],
+      createStreakDays("2026-03-23", "2026-04-21", new Set([
+        "2026-04-18",
+        "2026-04-20",
+        "2026-04-21",
+      ])),
       "2026-04-21",
       createDateFormatter("en-US"),
       { firstDayOfWeek: 1 },

--- a/apps/web/src/screens/progress/ProgressScreen.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import { useAppData } from "../../appData";
 import {
   buildReviewProgressBadgeStateFromSummarySnapshot,
+  formatReviewProgressFreezeValue,
   formatReviewProgressBadgeValue,
 } from "../../appData/progress/badge/reviewProgressBadge";
 import { useProgressInvalidationState } from "../../appData/progress/invalidation/progressInvalidation";
@@ -75,6 +76,7 @@ export function ProgressScreen(): ReactElement {
   const [reviewsChartSelection, setReviewsChartSelection] = useState<ProgressReviewsChartSelection>({ kind: "none" });
   const [selectedReviewScheduleBucket, setSelectedReviewScheduleBucket] = useState<ProgressReviewScheduleBucketKey | null>(null);
   const [selectedLeaderboardWindowKey, setSelectedLeaderboardWindowKey] = useState<ProgressLeaderboardWindowKey | null>(null);
+  const [isStreakInfoVisible, setIsStreakInfoVisible] = useState<boolean>(false);
   const [isLeaderboardInfoVisible, setIsLeaderboardInfoVisible] = useState<boolean>(false);
   const streakSectionRef = useRef<HTMLElement | null>(null);
   const leaderboardSectionRef = useRef<HTMLElement | null>(null);
@@ -132,7 +134,7 @@ export function ProgressScreen(): ReactElement {
   const dailyReviews = progress === null ? [] : sortDailyReviews(progress.dailyReviews);
   const today = progress === null ? "" : progress.to;
   const weekContext = resolveLocaleWeekContext(matchedBrowserLanguageTag ?? locale, locale);
-  const streakWeeks = progress === null ? [] : buildStreakWeeks(dailyReviews, today, formatDate, weekContext);
+  const streakWeeks = progress === null ? [] : buildStreakWeeks(dailyReviews, progress.streakDays, today, formatDate, weekContext);
   const selectedReviewsChartRatingKey = reviewsChartSelection.kind === "rating"
     ? reviewsChartSelection.ratingKey
     : null;
@@ -169,10 +171,23 @@ export function ProgressScreen(): ReactElement {
   const reviewProgressBadgeTodayStatus = reviewProgressBadge.hasReviewedToday
     ? t("reviewScreen.progressBadge.reviewedToday")
     : t("reviewScreen.progressBadge.notReviewedToday");
+  const reviewProgressFreezeStatus = t("reviewScreen.progressBadge.freezeBank", {
+    available: formatNumber(reviewProgressBadge.streakFreeze.availableCredits),
+    capacity: formatNumber(reviewProgressBadge.streakFreeze.capacity),
+  });
   const reviewProgressBadgeAriaLabel = t("reviewScreen.progressBadge.ariaLabel", {
     streak: formatNumber(reviewProgressBadge.streakDays),
     todayStatus: reviewProgressBadgeTodayStatus,
+    freezeBank: reviewProgressFreezeStatus,
   });
+  const progressStreakInfoText = progressSummary === null
+    ? null
+    : t("progressScreen.streakInfo", {
+      available: formatNumber(progressSummary.summary.streakFreeze.availableCredits),
+      capacity: formatNumber(progressSummary.summary.streakFreeze.capacity),
+      progress: formatNumber(progressSummary.summary.streakFreeze.nextCreditProgressUnits),
+      required: formatNumber(progressSummary.summary.streakFreeze.nextCreditRequiredUnits),
+    });
   const progressStreakSummary: ProgressStreakSummaryView | null = progressSummary === null
     ? null
     : {
@@ -181,6 +196,7 @@ export function ProgressScreen(): ReactElement {
       hasReviewedToday: reviewProgressBadge.hasReviewedToday,
       ariaLabel: reviewProgressBadgeAriaLabel,
       formattedStreakValue: formatReviewProgressBadgeValue(reviewProgressBadge.streakDays),
+      formattedFreezeValue: formatReviewProgressFreezeValue(reviewProgressBadge.streakFreeze, formatNumber),
     };
   const previousWeekArrow = resolveChartNavigationArrow(direction, "previous");
   const nextWeekArrow = resolveChartNavigationArrow(direction, "next");
@@ -259,6 +275,10 @@ export function ProgressScreen(): ReactElement {
               sectionId={progressStreakHash}
               sectionRef={streakSectionRef}
               summary={progressStreakSummary}
+              infoText={progressStreakInfoText}
+              infoToggleLabel={t("progressScreen.streakInfoToggleLabel")}
+              isInfoVisible={isStreakInfoVisible}
+              onToggleInfo={() => setIsStreakInfoVisible((previous) => previous === false)}
               streakWeeks={streakWeeks}
             />
 

--- a/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
+++ b/apps/web/src/screens/progress/streak/ProgressStreakSection.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactElement, Ref } from "react";
-import { ReviewProgressBadgeIcon } from "../../shared/ReviewProgressBadgeIcon";
+import { ReviewProgressBadgeIcon, StreakFreezeIcon } from "../../shared/ReviewProgressBadgeIcon";
 import type { StreakDay } from "./progressStreakModel";
 
 const futureStreakDayStyle: Readonly<CSSProperties> = {
@@ -20,6 +20,7 @@ export type ProgressStreakSummaryView = Readonly<{
   hasReviewedToday: boolean;
   ariaLabel: string;
   formattedStreakValue: string;
+  formattedFreezeValue: string;
 }>;
 
 type ProgressStreakSectionProps = Readonly<{
@@ -27,6 +28,10 @@ type ProgressStreakSectionProps = Readonly<{
   sectionId: string;
   sectionRef: Ref<HTMLElement>;
   summary: ProgressStreakSummaryView | null;
+  infoText: string | null;
+  infoToggleLabel: string;
+  isInfoVisible: boolean;
+  onToggleInfo: () => void;
   streakWeeks: ReadonlyArray<ReadonlyArray<StreakDay>>;
 }>;
 
@@ -36,8 +41,9 @@ function ProgressStreakDay(props: Readonly<{
   const { day } = props;
   const dayClassName = [
     "progress-streak-day",
-    day.reviewCount > 0 ? "progress-streak-day-complete" : "",
-    day.isToday && day.reviewCount === 0 ? "progress-streak-day-today" : "",
+    day.state === "reviewed" ? "progress-streak-day-complete" : "",
+    day.state === "frozen" ? "progress-streak-day-frozen" : "",
+    day.isToday && day.state === "pending" ? "progress-streak-day-today" : "",
   ]
     .filter((className) => className !== "")
     .join(" ");
@@ -46,7 +52,7 @@ function ProgressStreakDay(props: Readonly<{
     <div
       className={dayClassName}
       title={day.title}
-      data-streak-state={day.isFuture ? "future" : "active"}
+      data-streak-state={day.isFuture ? "future" : day.state}
       style={day.isFuture ? futureStreakDayStyle : undefined}
     >
       <span className="progress-streak-weekday">{day.weekdayLabel}</span>
@@ -55,9 +61,13 @@ function ProgressStreakDay(props: Readonly<{
         aria-hidden="true"
         style={day.isFuture ? futureStreakMarkerStyle : undefined}
       >
-        {day.reviewCount > 0 ? (
+        {day.state === "reviewed" ? (
           <span className="progress-streak-marker-flame">
             <ReviewProgressBadgeIcon />
+          </span>
+        ) : day.state === "frozen" ? (
+          <span className="progress-streak-marker-freeze">
+            <StreakFreezeIcon />
           </span>
         ) : day.isFuture ? null : (
           <span className="progress-streak-marker-day-value">{day.dayLabel}</span>
@@ -87,13 +97,27 @@ function ProgressStreakSummary(props: Readonly<{
         <span className="review-progress-badge-value">
           {summary.formattedStreakValue}
         </span>
+        <span className="review-progress-freeze-indicator" aria-hidden="true">
+          <StreakFreezeIcon />
+          <span className="review-progress-freeze-value">{summary.formattedFreezeValue}</span>
+        </span>
       </span>
     </div>
   );
 }
 
 export function ProgressStreakSection(props: ProgressStreakSectionProps): ReactElement {
-  const { title, sectionId, sectionRef, summary, streakWeeks } = props;
+  const {
+    title,
+    sectionId,
+    sectionRef,
+    summary,
+    infoText,
+    infoToggleLabel,
+    isInfoVisible,
+    onToggleInfo,
+    streakWeeks,
+  } = props;
 
   return (
     <section
@@ -104,9 +128,27 @@ export function ProgressStreakSection(props: ProgressStreakSectionProps): ReactE
     >
       <div className="progress-section-head">
         <h2 className="progress-section-title">{title}</h2>
+        {infoText === null ? null : (
+          <button
+            type="button"
+            className="ghost-btn progress-streak-info-btn"
+            aria-expanded={isInfoVisible}
+            aria-label={infoToggleLabel}
+            onClick={onToggleInfo}
+            data-testid="progress-streak-info-toggle"
+          >
+            <span className="progress-streak-info-icon" aria-hidden="true">i</span>
+          </button>
+        )}
       </div>
 
       {summary === null ? null : <ProgressStreakSummary summary={summary} />}
+
+      {infoText !== null && isInfoVisible ? (
+        <p className="progress-streak-info" data-testid="progress-streak-info">
+          {infoText}
+        </p>
+      ) : null}
 
       <div className="progress-streak-weeks">
         {streakWeeks.map((week, weekIndex) => (

--- a/apps/web/src/screens/progress/streak/progressStreakModel.ts
+++ b/apps/web/src/screens/progress/streak/progressStreakModel.ts
@@ -1,6 +1,6 @@
 import type { LocaleWeekContext } from "../../../i18n";
 import { parseLocalDate, shiftLocalDate } from "../../../progress/progressDates";
-import type { DailyReviewPoint } from "../../../types";
+import type { DailyReviewPoint, StreakDay as ProgressStreakDay, StreakDayState } from "../../../types";
 
 const streakWeekCount = 5;
 const streakWeekLength = 7;
@@ -10,6 +10,7 @@ type DateFormatter = (value: Date | number | string, options?: Readonly<Intl.Dat
 export type StreakDay = Readonly<{
   date: string;
   reviewCount: number;
+  state: StreakDayState;
   isFuture: boolean;
   isToday: boolean;
   weekdayLabel: string;
@@ -50,6 +51,33 @@ function createDailyReviewCountMap(dailyReviews: ReadonlyArray<DailyReviewPoint>
   return reviewCounts;
 }
 
+function createStreakDayStateMap(streakDays: ReadonlyArray<ProgressStreakDay>): ReadonlyMap<string, StreakDayState> {
+  const states = new Map<string, StreakDayState>();
+
+  for (const streakDay of streakDays) {
+    states.set(streakDay.date, streakDay.state);
+  }
+
+  return states;
+}
+
+function resolveStreakDayState(
+  date: string,
+  today: string,
+  stateMap: ReadonlyMap<string, StreakDayState>,
+): StreakDayState {
+  if (date > today) {
+    return "pending";
+  }
+
+  const state = stateMap.get(date);
+  if (state === undefined) {
+    throw new Error(`Missing progress streak day state for ${date}`);
+  }
+
+  return state;
+}
+
 function getDayOfWeek(value: string): number {
   return parseLocalDate(value).getUTCDay();
 }
@@ -63,6 +91,7 @@ function getStartOfWeek(value: string, weekContext: LocaleWeekContext): string {
 
 export function buildStreakWeeks(
   dailyReviews: ReadonlyArray<DailyReviewPoint>,
+  streakDays: ReadonlyArray<ProgressStreakDay>,
   today: string,
   formatDate: DateFormatter,
   weekContext: LocaleWeekContext,
@@ -70,6 +99,7 @@ export function buildStreakWeeks(
   const currentWeekStart = getStartOfWeek(today, weekContext);
   const streakWindowStart = shiftLocalDate(currentWeekStart, -((streakWeekCount - 1) * streakWeekLength));
   const reviewCounts = createDailyReviewCountMap(dailyReviews);
+  const streakDayStates = createStreakDayStateMap(streakDays);
   const streakWeeks: Array<ReadonlyArray<StreakDay>> = [];
 
   for (let weekIndex = 0; weekIndex < streakWeekCount; weekIndex += 1) {
@@ -81,6 +111,7 @@ export function buildStreakWeeks(
       weekDays.push({
         date,
         reviewCount: reviewCounts.get(date) ?? 0,
+        state: resolveStreakDayState(date, today, streakDayStates),
         isFuture: date > today,
         isToday: date === today,
         weekdayLabel: formatWeekdayLabel(date, formatDate),

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -1,16 +1,14 @@
 import type { ComponentProps, ReactElement } from "react";
 import { Link } from "react-router-dom";
-import { formatReviewProgressBadgeValue } from "../../../appData/progress/badge/reviewProgressBadge";
+import {
+  formatReviewProgressBadgeValue,
+  formatReviewProgressFreezeValue,
+} from "../../../appData/progress/badge/reviewProgressBadge";
 import { useI18n } from "../../../i18n";
 import { progressLeaderboardRoute, progressStreakRoute } from "../../../routes";
-import { ProgressLeaderboardShortcutIcon, ReviewProgressBadgeIcon, ReviewQueueShortcutIcon } from "../../shared/ReviewProgressBadgeIcon";
+import type { ReviewProgressBadgeState } from "../../../types";
+import { ProgressLeaderboardShortcutIcon, ReviewProgressBadgeIcon, ReviewQueueShortcutIcon, StreakFreezeIcon } from "../../shared/ReviewProgressBadgeIcon";
 import { ReviewFilterMenu } from "../filters/ReviewFilterMenu";
-
-type ReviewProgressBadgeState = Readonly<{
-  hasReviewedToday: boolean;
-  isInteractive: boolean;
-  streakDays: number;
-}>;
 
 type ReviewLeaderboardBadgeState = Readonly<{
   isInteractive: boolean;
@@ -52,9 +50,15 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
   const reviewProgressBadgeTodayStatus = reviewProgressBadge.hasReviewedToday
     ? t("reviewScreen.progressBadge.reviewedToday")
     : t("reviewScreen.progressBadge.notReviewedToday");
+  const reviewProgressFreezeValue = formatReviewProgressFreezeValue(reviewProgressBadge.streakFreeze, formatNumber);
+  const reviewProgressFreezeStatus = t("reviewScreen.progressBadge.freezeBank", {
+    available: formatNumber(reviewProgressBadge.streakFreeze.availableCredits),
+    capacity: formatNumber(reviewProgressBadge.streakFreeze.capacity),
+  });
   const reviewProgressBadgeAriaLabel = t("reviewScreen.progressBadge.ariaLabel", {
     streak: formatNumber(reviewProgressBadge.streakDays),
     todayStatus: reviewProgressBadgeTodayStatus,
+    freezeBank: reviewProgressFreezeStatus,
   });
   const leaderboardShortcutRankLabel = reviewLeaderboardBadge.rank === null
     ? null
@@ -118,6 +122,10 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
             >
               <ReviewProgressBadgeIcon />
               <span className="review-progress-badge-value">{formatReviewProgressBadgeValue(reviewProgressBadge.streakDays)}</span>
+              <span className="review-progress-freeze-indicator" aria-hidden="true">
+                <StreakFreezeIcon />
+                <span className="review-progress-freeze-value">{reviewProgressFreezeValue}</span>
+              </span>
             </Link>
           </div>
         </div>

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -5,6 +5,7 @@ import ReactDOM from "react-dom/client";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, vi } from "vitest";
 import { I18nProvider } from "../../../i18n";
+import { createDefaultStreakFreeze } from "../../../progress/streakFreeze";
 import type { AppDataContextValue } from "../../../appData";
 import { clearLoadingSnapshotFallbackStorage } from "../../shared/loadingSnapshots";
 import type {
@@ -277,6 +278,7 @@ function createDefaultReviewScreenTestState(): ReviewScreenTestState {
     reviewProgressBadge: {
       streakDays: 0,
       hasReviewedToday: false,
+      streakFreeze: createDefaultStreakFreeze(),
       isInteractive: true,
     },
     reviewQueue: [],

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -160,6 +160,14 @@ describe("ReviewScreen controls", () => {
     state.reviewProgressBadge = {
       streakDays: 12,
       hasReviewedToday: true,
+      streakFreeze: {
+        availableCredits: 1,
+        capacity: 2,
+        balanceUnits: 10,
+        unitsPerCredit: 10,
+        nextCreditProgressUnits: 0,
+        nextCreditRequiredUnits: 10,
+      },
       isInteractive: true,
     };
 
@@ -186,6 +194,7 @@ describe("ReviewScreen controls", () => {
     expect(progressBadge.className).toContain("review-progress-badge-active");
     expect(progressBadge.className).not.toContain("review-progress-badge-approximate");
     expect(progressBadge.textContent).not.toContain("🔥");
+    expect(progressBadge.textContent).toContain("1/2");
     const queueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
     if (!(queueBadge instanceof HTMLButtonElement)) {
       throw new Error("Review queue badge was not found");

--- a/apps/web/src/screens/shared/ReviewProgressBadgeIcon.tsx
+++ b/apps/web/src/screens/shared/ReviewProgressBadgeIcon.tsx
@@ -47,3 +47,19 @@ export function ProgressLeaderboardShortcutIcon(): ReactElement {
     </svg>
   );
 }
+
+export function StreakFreezeIcon(): ReactElement {
+  return (
+    <svg
+      className="review-progress-badge-icon streak-freeze-icon"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M11 2h2v5.1l3.4-3.4 1.4 1.4-4.1 4.1 4.6-1.2.5 1.9-5.6 1.5 5.6 1.5-.5 1.9-4.6-1.2 4.1 4.1-1.4 1.4L13 15.7V21h-2v-5.3l-3.4 3.4-1.4-1.4 4.1-4.1-4.6 1.2-.5-1.9 5.6-1.5-5.6-1.5.5-1.9 4.6 1.2-4.1-4.1 1.4-1.4L11 7.1V2Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -114,6 +114,11 @@
   background: var(--accent-soft);
 }
 
+.progress-streak-day-frozen {
+  border-color: rgba(125, 211, 252, 0.45);
+  background: rgba(125, 211, 252, 0.08);
+}
+
 .progress-streak-weekday {
   color: var(--text-tertiary);
   font-size: 10px;
@@ -129,6 +134,10 @@
 
 .progress-streak-day-today .progress-streak-weekday {
   color: var(--accent);
+}
+
+.progress-streak-day-frozen .progress-streak-weekday {
+  color: rgba(191, 234, 255, 0.86);
 }
 
 .progress-streak-marker {
@@ -163,7 +172,17 @@
     0 0 0 3px var(--accent-soft);
 }
 
+.progress-streak-day-frozen .progress-streak-marker {
+  border-color: rgba(125, 211, 252, 0.9);
+  background: #ffffff;
+  color: #0284c7;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    0 0 0 3px rgba(125, 211, 252, 0.14);
+}
+
 .progress-streak-marker-flame,
+.progress-streak-marker-freeze,
 .progress-streak-marker-day-value {
   display: inline-flex;
   align-items: center;
@@ -173,6 +192,11 @@
 }
 
 .progress-streak-marker-flame .review-progress-badge-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.progress-streak-marker-freeze .review-progress-badge-icon {
   width: 15px;
   height: 15px;
 }
@@ -598,6 +622,7 @@ svg.progress-review-schedule-donut {
   gap: 8px;
 }
 
+.progress-streak-info-btn,
 .progress-leaderboard-info-btn,
 .progress-leaderboard-invite-btn {
   min-width: 34px;
@@ -621,6 +646,7 @@ svg.progress-review-schedule-donut {
   font-weight: 700;
 }
 
+.progress-streak-info-icon,
 .progress-leaderboard-info-icon {
   display: inline-flex;
   align-items: center;
@@ -635,6 +661,7 @@ svg.progress-review-schedule-donut {
   font-style: italic;
 }
 
+.progress-streak-info,
 .progress-leaderboard-info {
   margin: 0;
   padding: 10px 12px;
@@ -902,6 +929,11 @@ svg.progress-review-schedule-donut {
   }
 
   .progress-streak-marker-flame .review-progress-badge-icon {
+    width: 12px;
+    height: 12px;
+  }
+
+  .progress-streak-marker-freeze .review-progress-badge-icon {
     width: 12px;
     height: 12px;
   }

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -80,6 +80,32 @@
   font-variant-numeric: tabular-nums;
 }
 
+.review-progress-freeze-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding-inline-start: 2px;
+  color: #bfeaff;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.review-progress-badge-active .review-progress-freeze-indicator {
+  color: #e8f8ff;
+}
+
+.review-progress-freeze-indicator .review-progress-badge-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.review-progress-freeze-value {
+  display: inline-flex;
+  align-items: center;
+}
+
 .panel {
   --panel-padding: 16px;
   --panel-radius: var(--radius-xl);

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -131,11 +131,36 @@ export type DailyReviewPoint = Readonly<{
   easyCount: number;
 }>;
 
+export const streakDayStates = [
+  "reviewed",
+  "frozen",
+  "missed",
+  "pending",
+] as const;
+
+export type StreakDayState = typeof streakDayStates[number];
+
+export type StreakFreeze = Readonly<{
+  availableCredits: number;
+  capacity: number;
+  balanceUnits: number;
+  unitsPerCredit: number;
+  nextCreditProgressUnits: number;
+  nextCreditRequiredUnits: number;
+}>;
+
+export type StreakDay = Readonly<{
+  date: string;
+  state: StreakDayState;
+}>;
+
 export type ProgressSummary = Readonly<{
   currentStreakDays: number;
+  longestStreakDays: number;
   hasReviewedToday: boolean;
   lastReviewedOn: string | null;
   activeReviewDays: number;
+  streakFreeze: StreakFreeze;
 }>;
 
 export type ProgressReviewHistoryWatermark = Readonly<{
@@ -146,6 +171,7 @@ export type ProgressReviewHistoryWatermark = Readonly<{
 export type ReviewProgressBadgeState = Readonly<{
   streakDays: number;
   hasReviewedToday: boolean;
+  streakFreeze: StreakFreeze;
   isInteractive: boolean;
 }>;
 
@@ -173,6 +199,7 @@ export type ProgressSeries = Readonly<{
   generatedAt: string | null;
   reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark>;
   dailyReviews: ReadonlyArray<DailyReviewPoint>;
+  streakDays: ReadonlyArray<StreakDay>;
 }>;
 
 /** Canonical bucket order for the progress chart and the runtime validation set for incoming bucket keys. Reordering or removing entries is a breaking change for the UI. */
@@ -343,6 +370,7 @@ export type FriendInvitationAcceptResponse =
 
 export type ProgressRenderedSeriesSummaryContext = Readonly<{
   lowerBoundSummary: ProgressSummary;
+  exactStreakFreeze: StreakFreeze | null;
   activeDates: ReadonlyArray<string>;
   activeDatesMissingFromServerBase: ReadonlyArray<string>;
   serverBaseReviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> | null;
@@ -364,6 +392,7 @@ export type ProgressSummarySourceState = Readonly<{
 export type ProgressSeriesSourceState = Readonly<{
   scopeKey: ProgressScopeKey | null;
   localFallback: ProgressSeriesSnapshot | null;
+  localFallbackActiveDates: ReadonlyArray<string>;
   serverBase: ProgressSeriesSnapshot | null;
   pendingLocalOverlay: ProgressChartData | null;
   renderedSnapshot: ProgressSeriesSnapshot | null;


### PR DESCRIPTION
## Summary
- Parse and validate the backend progress freeze contract in the web client.
- Add freeze-aware local and pending progress overlays for summary, series, streak grid, and review badge UI.
- Update cache invalidation, local DB summaries, localization, and focused progress/review tests.

## Validation
- node_modules/.bin/tsc -b --pretty false
- node_modules/.bin/vitest run src/appData/progress/source/progressSource.summarySeries.test.tsx src/appData/progress/source/progressSource.lifecycle.test.tsx src/appData/progress/source/progressSource.cache.test.tsx src/api/endpoints/endpoints.test.ts src/localDb/progress/progress.test.ts src/screens/progress/ProgressScreen.test.ts src/screens/progress/ProgressScreen.render.test.tsx src/screens/review/tests/ReviewScreen.controls.test.tsx
- git --no-pager diff --check