### PR TITLE
[codex] Add iOS invite entry points

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -36,6 +36,7 @@ enum UITestIdentifier {
     static let progressLeaderboardOpenSettingsButton: String = "progress.leaderboard.openSettingsButton"
     static let cardsScreen: String = "cards.screen"
     static let settingsScreen: String = "settings.screen"
+    static let settingsInviteFriendButton: String = "settings.inviteFriendButton"
     static let settingsAccountStatusRow: String = "settings.accountStatusRow"
     static let settingsCurrentWorkspaceRow: String = "settings.currentWorkspaceRow"
     static let settingsReviewRemindersRow: String = "settings.reviewRemindersRow"

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
@@ -18,6 +18,7 @@ struct ProgressLeaderboardSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             self.header
+            self.friendInviteButton
 
             switch self.snapshot.state {
             case .ready(let readyState):
@@ -85,23 +86,6 @@ struct ProgressLeaderboardSection: View {
             Spacer(minLength: 12)
 
             Button {
-                self.openFriendInviteFlow()
-            } label: {
-                Image(systemName: "person.badge.plus")
-                    .font(.body)
-            }
-            .buttonStyle(.borderless)
-            .accessibilityIdentifier(UITestIdentifier.progressLeaderboardInviteFriendButton)
-            .accessibilityLabel(
-                String(
-                    localized: "progress.screen.leaderboard.invite.accessibility_label",
-                    defaultValue: "Invite a friend",
-                    table: progressStringsTableName,
-                    comment: "Accessibility label for the leaderboard friend invite button"
-                )
-            )
-
-            Button {
                 self.isInfoAlertPresented = true
             } label: {
                 Image(systemName: "info.circle")
@@ -117,6 +101,33 @@ struct ProgressLeaderboardSection: View {
                 )
             )
         }
+    }
+
+    private var friendInviteButton: some View {
+        Button {
+            self.openFriendInviteFlow()
+        } label: {
+            Label(
+                String(
+                    localized: "progress.screen.leaderboard.invite.button",
+                    defaultValue: "Invite Friend",
+                    table: progressStringsTableName,
+                    comment: "Button title for creating a leaderboard friend invite link"
+                ),
+                systemImage: "person.badge.plus"
+            )
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .accessibilityIdentifier(UITestIdentifier.progressLeaderboardInviteFriendButton)
+        .accessibilityLabel(
+            String(
+                localized: "progress.screen.leaderboard.invite.accessibility_label",
+                defaultValue: "Invite a friend",
+                table: progressStringsTableName,
+                comment: "Accessibility label for the leaderboard friend invite button"
+            )
+        )
     }
 
     @ViewBuilder

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -3364,6 +3364,65 @@
         }
       }
     },
+    "progress.screen.leaderboard.invite.button" : {
+      "comment" : "Button title for creating a leaderboard friend invite link",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "دعوة صديق"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Freund einladen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invite Friend"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invitar amigo"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invitar amigo"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "दोस्त को आमंत्रित करें"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "友達を招待"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пригласить друга"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "邀请朋友"
+          }
+        }
+      }
+    },
     "progress.screen.leaderboard.invite.accessibility_label" : {
       "comment" : "Accessibility label for the leaderboard friend invite button",
       "localizations" : {

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -15,6 +15,9 @@ struct SyncStatusPresentation: Equatable {
 struct SettingsView: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
 
+    @State private var isCloudSignInPresented: Bool = false
+    @State private var isFriendInvitePresented: Bool = false
+
     private var accountStatusValue: String {
         displayCloudAccountStateTitle(cloudState: store.cloudSettings?.cloudState ?? .disconnected)
     }
@@ -41,6 +44,10 @@ struct SettingsView: View {
 
     var body: some View {
         List {
+            Section {
+                self.friendInviteButton
+            }
+
             if store.globalErrorMessage.isEmpty == false {
                 Section {
                     CopyableErrorMessageView(message: store.globalErrorMessage)
@@ -285,6 +292,37 @@ struct SettingsView: View {
         .onAppear {
             store.triggerCloudAccountContextRefreshIfActive(surfacesGlobalErrorMessage: false)
         }
+        .sheet(isPresented: self.$isCloudSignInPresented) {
+            CloudSignInSheet(presentationContext: .standard)
+                .environment(self.store)
+        }
+        .sheet(isPresented: self.$isFriendInvitePresented) {
+            ProgressFriendInviteSheet()
+                .environment(self.store)
+        }
+    }
+
+    private var friendInviteButton: some View {
+        Button {
+            self.openFriendInviteFlow()
+        } label: {
+            Label(
+                aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"),
+                systemImage: "person.badge.plus"
+            )
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .accessibilityIdentifier(UITestIdentifier.settingsInviteFriendButton)
+    }
+
+    private func openFriendInviteFlow() {
+        guard self.store.cloudSettings?.cloudState == .linked else {
+            self.isCloudSignInPresented = true
+            return
+        }
+
+        self.isFriendInvitePresented = true
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "غير متاح";
 
 "settings.title" = "الإعدادات";
+"settings.inviteFriend.button" = "دعوة صديق";
 "settings.section.account" = "الحساب";
 "settings.section.general" = "عام";
 "settings.section.support" = "الدعم";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "Nicht verfügbar";
 
 "settings.title" = "Einstellungen";
+"settings.inviteFriend.button" = "Freund einladen";
 "settings.section.account" = "Konto";
 "settings.section.general" = "Allgemein";
 "settings.section.support" = "Support";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "No disponible";
 
 "settings.title" = "Ajustes";
+"settings.inviteFriend.button" = "Invitar amigo";
 "settings.section.account" = "Cuenta";
 "settings.section.general" = "General";
 "settings.section.support" = "Soporte";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "No disponible";
 
 "settings.title" = "Ajustes";
+"settings.inviteFriend.button" = "Invitar amigo";
 "settings.section.account" = "Cuenta";
 "settings.section.general" = "General";
 "settings.section.support" = "Soporte";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "उपलब्ध नहीं है";
 
 "settings.title" = "सेटिंग्स";
+"settings.inviteFriend.button" = "दोस्त को आमंत्रित करें";
 "settings.section.account" = "खाता";
 "settings.section.general" = "सामान्य";
 "settings.section.support" = "सहायता";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "利用できません";
 
 "settings.title" = "設定";
+"settings.inviteFriend.button" = "友達を招待";
 "settings.section.account" = "アカウント";
 "settings.section.general" = "一般";
 "settings.section.support" = "サポート";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "Недоступно";
 
 "settings.title" = "Настройки";
+"settings.inviteFriend.button" = "Пригласить друга";
 "settings.section.account" = "Аккаунт";
 "settings.section.general" = "Общие";
 "settings.section.support" = "Поддержка";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -126,6 +126,7 @@
 "common.unavailable" = "不可用";
 
 "settings.title" = "设置";
+"settings.inviteFriend.button" = "邀请朋友";
 "settings.section.account" = "账户";
 "settings.section.general" = "通用";
 "settings.section.support" = "支持";


### PR DESCRIPTION
## Summary
- move the Progress leaderboard invite action into a full-width native button
- add a top Settings invite button that reuses the friend invite/sign-in flow
- localize the new button labels and add the Settings UI test identifier

## Validation
- git --no-pager diff --check --cached
- jq empty apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
- plutil -lint apps/ios/Flashcards/Flashcards/{ar,de,es-ES,es-MX,hi,ja,ru,zh-Hans}.lproj/AISettings.strings

Simulator-backed iOS tests were not run per the task constraint.