### PR TITLE
[codex] Add web invite entry points

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -175,7 +175,7 @@ const arCatalog: TranslationCatalog = {
       unavailable: "لوحة الصدارة غير متاحة الآن. عُد لاحقًا.",
       invite: {
         actionLabel: "إنشاء دعوة صديق",
-        actionText: "دعوة",
+        actionText: "دعوة صديق",
         title: "دعوة صديق",
         body: "أنشئ رابط صديق خاصًا للوحة الصدارة.",
         friendNameLabel: "اسم الصديق في تقييماتك",
@@ -285,6 +285,10 @@ const arCatalog: TranslationCatalog = {
   settingsHome: {
     title: "الإعدادات",
     subtitle: "أدر الحساب ومساحة العمل والدعم وإعدادات الويب المتقدمة.",
+    inviteFriend: {
+      actionText: "دعوة صديق",
+      ariaLabel: "إنشاء دعوة صديق",
+    },
     groups: {
       account: "الحساب",
       general: "عام",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -175,7 +175,7 @@ const deCatalog: TranslationCatalog = {
       unavailable: "Die Bestenliste ist gerade nicht verfügbar. Schau später wieder vorbei.",
       invite: {
         actionLabel: "Freundes-Einladung erstellen",
-        actionText: "Einladen",
+        actionText: "Freund einladen",
         title: "Freund einladen",
         body: "Erstelle einen privaten Freundeslink für die Bestenliste.",
         friendNameLabel: "Freundesname in deinen Wertungen",
@@ -285,6 +285,10 @@ const deCatalog: TranslationCatalog = {
   settingsHome: {
     title: "Einstellungen",
     subtitle: "Verwalte Konto, Arbeitsbereich, Support und erweiterte Web-Einstellungen.",
+    inviteFriend: {
+      actionText: "Freund einladen",
+      ariaLabel: "Freundes-Einladung erstellen",
+    },
     groups: {
       account: "Konto",
       general: "Allgemein",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -173,7 +173,7 @@ const enCatalog = {
       unavailable: "The leaderboard is not available right now. Check back later.",
       invite: {
         actionLabel: "Create friend invite",
-        actionText: "Invite",
+        actionText: "Invite friend",
         title: "Invite a friend",
         body: "Create a private friend link for the leaderboard.",
         friendNameLabel: "Friend name in your ratings",
@@ -283,6 +283,10 @@ const enCatalog = {
   settingsHome: {
     title: "Settings",
     subtitle: "Manage account, workspace, support, and advanced web settings.",
+    inviteFriend: {
+      actionText: "Invite friend",
+      ariaLabel: "Create friend invite",
+    },
     groups: {
       account: "Account",
       general: "General",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -175,7 +175,7 @@ const esEsCatalog: TranslationCatalog = {
       unavailable: "La clasificación no está disponible ahora mismo. Vuelve más tarde.",
       invite: {
         actionLabel: "Crear invitación de amigo",
-        actionText: "Invitar",
+        actionText: "Invitar a un amigo",
         title: "Invitar a un amigo",
         body: "Crea un enlace privado de amigo para la clasificación.",
         friendNameLabel: "Nombre del amigo en tus puntuaciones",
@@ -285,6 +285,10 @@ const esEsCatalog: TranslationCatalog = {
   settingsHome: {
     title: "Ajustes",
     subtitle: "Gestiona la cuenta, el espacio de trabajo, el soporte y los ajustes web avanzados.",
+    inviteFriend: {
+      actionText: "Invitar a un amigo",
+      ariaLabel: "Crear invitación de amigo",
+    },
     groups: {
       account: "Cuenta",
       general: "General",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -175,7 +175,7 @@ const esMxCatalog: TranslationCatalog = {
       unavailable: "La tabla de posiciones no está disponible por ahora. Vuelve más tarde.",
       invite: {
         actionLabel: "Crear invitación de amigo",
-        actionText: "Invitar",
+        actionText: "Invitar a un amigo",
         title: "Invitar a un amigo",
         body: "Crea un enlace privado de amigo para la tabla de posiciones.",
         friendNameLabel: "Nombre del amigo en tus calificaciones",
@@ -285,6 +285,10 @@ const esMxCatalog: TranslationCatalog = {
   settingsHome: {
     title: "Configuración",
     subtitle: "Administra la cuenta, el espacio de trabajo, el soporte y la configuración web avanzada.",
+    inviteFriend: {
+      actionText: "Invitar a un amigo",
+      ariaLabel: "Crear invitación de amigo",
+    },
     groups: {
       account: "Cuenta",
       general: "General",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -175,7 +175,7 @@ const hiCatalog: TranslationCatalog = {
       unavailable: "लीडरबोर्ड अभी उपलब्ध नहीं है। बाद में फिर देखें।",
       invite: {
         actionLabel: "दोस्त का आमंत्रण बनाएं",
-        actionText: "आमंत्रित करें",
+        actionText: "दोस्त को आमंत्रित करें",
         title: "दोस्त को आमंत्रित करें",
         body: "लीडरबोर्ड के लिए निजी दोस्त लिंक बनाएं।",
         friendNameLabel: "आपकी रेटिंग में दोस्त का नाम",
@@ -285,6 +285,10 @@ const hiCatalog: TranslationCatalog = {
   settingsHome: {
     title: "सेटिंग्स",
     subtitle: "खाता, वर्कस्पेस, सहायता और उन्नत वेब सेटिंग्स मैनेज करें।",
+    inviteFriend: {
+      actionText: "दोस्त को आमंत्रित करें",
+      ariaLabel: "दोस्त का आमंत्रण बनाएं",
+    },
     groups: {
       account: "खाता",
       general: "सामान्य",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -175,7 +175,7 @@ export const jaCatalog = {
       unavailable: "リーダーボードは現在利用できません。しばらくしてからもう一度ご確認ください。",
       invite: {
         actionLabel: "友だち招待を作成",
-        actionText: "招待",
+        actionText: "友だちを招待",
         title: "友だちを招待",
         body: "リーダーボード用の非公開友だちリンクを作成します。",
         friendNameLabel: "自分の評価で表示する友だちの名前",
@@ -285,6 +285,10 @@ export const jaCatalog = {
   settingsHome: {
     title: "設定",
     subtitle: "アカウント、ワークスペース、サポート、詳細な Web 設定を管理します。",
+    inviteFriend: {
+      actionText: "友だちを招待",
+      ariaLabel: "友だち招待を作成",
+    },
     groups: {
       account: "アカウント",
       general: "一般",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -175,7 +175,7 @@ export const ruCatalog = {
       unavailable: "Таблица лидеров сейчас недоступна. Загляните позже.",
       invite: {
         actionLabel: "Создать приглашение для друга",
-        actionText: "Пригласить",
+        actionText: "Пригласить друга",
         title: "Пригласить друга",
         body: "Создайте приватную ссылку для таблицы лидеров.",
         friendNameLabel: "Имя друга в ваших рейтингах",
@@ -285,6 +285,10 @@ export const ruCatalog = {
   settingsHome: {
     title: "Настройки",
     subtitle: "Управляйте аккаунтом, рабочим пространством, поддержкой и расширенными веб-настройками.",
+    inviteFriend: {
+      actionText: "Пригласить друга",
+      ariaLabel: "Создать приглашение для друга",
+    },
     groups: {
       account: "Аккаунт",
       general: "Общие",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -175,7 +175,7 @@ export const zhHansCatalog = {
       unavailable: "排行榜暂时不可用。请稍后再来看看。",
       invite: {
         actionLabel: "创建好友邀请",
-        actionText: "邀请",
+        actionText: "邀请好友",
         title: "邀请好友",
         body: "为排行榜创建一个私密好友链接。",
         friendNameLabel: "你在评分中看到的好友名称",
@@ -285,6 +285,10 @@ export const zhHansCatalog = {
   settingsHome: {
     title: "设置",
     subtitle: "管理账户、工作区、支持和高级 Web 设置。",
+    inviteFriend: {
+      actionText: "邀请好友",
+      ariaLabel: "创建好友邀请",
+    },
     groups: {
       account: "账户",
       general: "通用",

--- a/apps/web/src/screens/friends/FriendInviteCreateDialog.tsx
+++ b/apps/web/src/screens/friends/FriendInviteCreateDialog.tsx
@@ -1,0 +1,214 @@
+import { useState, type ReactElement } from "react";
+import { createPortal } from "react-dom";
+import {
+  buildLoginUrl,
+  createFriendInvitation,
+  isAuthRedirectError,
+} from "../../api";
+import { useI18n } from "../../i18n";
+import type { FriendInvitationCreateResponse } from "../../types";
+import { validateFriendInvitationDisplayName } from "../invite/friendInvitationDisplayName";
+
+type FriendInviteCreateDialogProps = Readonly<{
+  canCreateInvite: boolean;
+  authRedirectUrl: string;
+  onClose: () => void;
+}>;
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function FriendInviteCreateDialog(props: FriendInviteCreateDialogProps): ReactElement {
+  const { authRedirectUrl, canCreateInvite, onClose } = props;
+  const { locale, t, formatDateTime } = useI18n();
+  const [friendDisplayName, setFriendDisplayName] = useState<string>("");
+  const [fieldErrorMessage, setFieldErrorMessage] = useState<string>("");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [statusMessage, setStatusMessage] = useState<string>("");
+  const [createdInvite, setCreatedInvite] = useState<FriendInvitationCreateResponse | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [isCopying, setIsCopying] = useState<boolean>(false);
+  const [isSharing, setIsSharing] = useState<boolean>(false);
+
+  async function submitInviteCreate(): Promise<void> {
+    const validationMessage = validateFriendInvitationDisplayName(friendDisplayName, {
+      required: t("progressScreen.leaderboard.invite.validation.required"),
+      singleLine: t("progressScreen.leaderboard.invite.validation.singleLine"),
+      tooLong: t("progressScreen.leaderboard.invite.validation.tooLong"),
+    });
+    setFieldErrorMessage(validationMessage);
+    if (validationMessage !== "") {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+    setStatusMessage("");
+
+    try {
+      const response = await createFriendInvitation({
+        inviteeDisplayName: friendDisplayName.trim(),
+      });
+      setCreatedInvite(response);
+      setStatusMessage("");
+    } catch (error) {
+      if (isAuthRedirectError(error)) {
+        return;
+      }
+
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function copyInviteLink(): Promise<void> {
+    if (createdInvite === null) {
+      throw new Error("Cannot copy a friend invite before it is created.");
+    }
+
+    setIsCopying(true);
+    setErrorMessage("");
+    setStatusMessage("");
+
+    try {
+      if (typeof navigator.clipboard?.writeText !== "function") {
+        throw new Error(t("progressScreen.leaderboard.invite.clipboardUnavailable"));
+      }
+
+      await navigator.clipboard.writeText(createdInvite.inviteUrl);
+      setStatusMessage(t("progressScreen.leaderboard.invite.copied"));
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsCopying(false);
+    }
+  }
+
+  async function shareInviteLink(): Promise<void> {
+    if (createdInvite === null) {
+      throw new Error("Cannot share a friend invite before it is created.");
+    }
+
+    setIsSharing(true);
+    setErrorMessage("");
+    setStatusMessage("");
+
+    try {
+      if (typeof navigator.share !== "function") {
+        throw new Error(t("progressScreen.leaderboard.invite.shareUnavailable"));
+      }
+
+      await navigator.share({
+        title: t("progressScreen.leaderboard.invite.shareTitle"),
+        text: t("progressScreen.leaderboard.invite.shareText"),
+        url: createdInvite.inviteUrl,
+      });
+      setStatusMessage(t("progressScreen.leaderboard.invite.shared"));
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+    } finally {
+      setIsSharing(false);
+    }
+  }
+
+  return createPortal(
+    <div className="progress-leaderboard-invite-backdrop" role="dialog" aria-modal="true" aria-labelledby="progress-leaderboard-invite-title">
+      <section className="content-card progress-leaderboard-invite-dialog">
+        <div className="progress-leaderboard-invite-dialog-head">
+          <h2 id="progress-leaderboard-invite-title" className="panel-subtitle">
+            {t("progressScreen.leaderboard.invite.title")}
+          </h2>
+          <button className="ghost-btn progress-leaderboard-invite-close" type="button" onClick={onClose}>
+            {t("common.cancel")}
+          </button>
+        </div>
+
+        {canCreateInvite ? (
+          createdInvite === null ? (
+            <>
+              <p className="subtitle">{t("progressScreen.leaderboard.invite.body")}</p>
+              <label className="form-label progress-leaderboard-invite-field">
+                <span>{t("progressScreen.leaderboard.invite.friendNameLabel")}</span>
+                <input
+                  className="text-input"
+                  type="text"
+                  value={friendDisplayName}
+                  disabled={isSubmitting}
+                  onChange={(event) => {
+                    setFriendDisplayName(event.target.value);
+                    setFieldErrorMessage("");
+                  }}
+                  data-testid="progress-leaderboard-invite-name-input"
+                />
+              </label>
+              <p className="progress-leaderboard-invite-note">{t("progressScreen.leaderboard.invite.expiryNote")}</p>
+              {fieldErrorMessage !== "" ? (
+                <p className="error-banner" role="alert" data-testid="progress-leaderboard-invite-name-error">
+                  {fieldErrorMessage}
+                </p>
+              ) : null}
+              <button
+                className="primary-btn"
+                type="button"
+                disabled={isSubmitting}
+                onClick={() => void submitInviteCreate()}
+                data-testid="progress-leaderboard-invite-create"
+              >
+                {isSubmitting ? t("progressScreen.leaderboard.invite.creating") : t("progressScreen.leaderboard.invite.create")}
+              </button>
+            </>
+          ) : (
+            <>
+              <p className="subtitle">
+                {t("progressScreen.leaderboard.invite.readyBody", {
+                  expiresAt: formatDateTime(createdInvite.expiresAt),
+                })}
+              </p>
+              <input
+                className="text-input progress-leaderboard-invite-url"
+                type="text"
+                readOnly
+                value={createdInvite.inviteUrl}
+                aria-label={t("progressScreen.leaderboard.invite.linkLabel")}
+                data-testid="progress-leaderboard-invite-url"
+              />
+              <div className="progress-leaderboard-invite-actions">
+                <button
+                  className="ghost-btn"
+                  type="button"
+                  disabled={isCopying}
+                  onClick={() => void copyInviteLink()}
+                  data-testid="progress-leaderboard-invite-copy"
+                >
+                  {isCopying ? t("progressScreen.leaderboard.invite.copying") : t("progressScreen.leaderboard.invite.copy")}
+                </button>
+                <button
+                  className="ghost-btn"
+                  type="button"
+                  disabled={isSharing}
+                  onClick={() => void shareInviteLink()}
+                  data-testid="progress-leaderboard-invite-share"
+                >
+                  {isSharing ? t("progressScreen.leaderboard.invite.sharing") : t("progressScreen.leaderboard.invite.share")}
+                </button>
+              </div>
+            </>
+          )
+        ) : (
+          <div className="progress-leaderboard-placeholder" data-testid="progress-leaderboard-invite-sign-in">
+            <p className="subtitle">{t("progressScreen.leaderboard.invite.signInBody")}</p>
+            <a className="primary-btn" href={buildLoginUrl(authRedirectUrl, locale)}>
+              {t("progressScreen.leaderboard.signIn")}
+            </a>
+          </div>
+        )}
+
+        {statusMessage !== "" ? <p className="progress-leaderboard-invite-status">{statusMessage}</p> : null}
+        {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -1174,6 +1174,30 @@ describe("ProgressScreen", () => {
       );
     });
 
+    const leaderboardCard = container.querySelector("[data-testid='progress-leaderboard-card']");
+    if (!(leaderboardCard instanceof HTMLElement)) {
+      throw new Error("Leaderboard card was not found");
+    }
+
+    const headerActions = leaderboardCard.querySelector(".progress-leaderboard-head-actions");
+    if (!(headerActions instanceof HTMLElement)) {
+      throw new Error("Leaderboard header actions were not found");
+    }
+    expect(headerActions.querySelector("[data-testid='progress-leaderboard-invite-open']")).toBeNull();
+
+    const inviteOpenButton = leaderboardCard.querySelector("[data-testid='progress-leaderboard-invite-open']");
+    if (!(inviteOpenButton instanceof HTMLButtonElement)) {
+      throw new Error("Leaderboard invite button was not found");
+    }
+    expect(inviteOpenButton.textContent).toBe("Invite friend");
+    expect(inviteOpenButton.className).toContain("primary-btn");
+
+    const periodSelector = leaderboardCard.querySelector(".progress-leaderboard-periods");
+    if (!(periodSelector instanceof HTMLElement)) {
+      throw new Error("Leaderboard period selector was not found");
+    }
+    expect(inviteOpenButton.compareDocumentPosition(periodSelector) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
     const rows = [...container.querySelectorAll(".progress-leaderboard-row")];
     expect(rows.map((row) => row.getAttribute("data-kind"))).toEqual([
       "top",

--- a/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
+++ b/apps/web/src/screens/progress/leaderboard/ProgressLeaderboardSection.tsx
@@ -1,15 +1,9 @@
 import { useState, type ReactElement, type Ref } from "react";
-import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
-import {
-  buildLoginUrl,
-  createFriendInvitation,
-  isAuthRedirectError,
-} from "../../../api";
+import { buildLoginUrl } from "../../../api";
 import { resolveBestLeaderboardPlacement } from "../../../appData/progress/leaderboardPlacement";
 import { useI18n } from "../../../i18n";
 import { settingsLeaderboardParticipationRoute } from "../../../routes";
-import type { FriendInvitationCreateResponse } from "../../../types";
 import type {
   ProgressLeaderboard,
   ProgressLeaderboardSourceState,
@@ -17,7 +11,7 @@ import type {
   ProgressLeaderboardWindowKey,
 } from "../../../types";
 import { progressLeaderboardWindowKeys } from "../../../types";
-import { validateFriendInvitationDisplayName } from "../../invite/friendInvitationDisplayName";
+import { FriendInviteCreateDialog } from "../../friends/FriendInviteCreateDialog";
 
 const millisecondsPerMinute = 60_000;
 
@@ -104,207 +98,6 @@ function ProgressLeaderboardSignInPlaceholder(): ReactElement {
         {t("progressScreen.leaderboard.signIn")}
       </a>
     </div>
-  );
-}
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function ProgressLeaderboardInviteDialog(props: Readonly<{
-  canCreateInvite: boolean;
-  onClose: () => void;
-}>): ReactElement {
-  const { canCreateInvite, onClose } = props;
-  const { locale, t, formatDateTime } = useI18n();
-  const [friendDisplayName, setFriendDisplayName] = useState<string>("");
-  const [fieldErrorMessage, setFieldErrorMessage] = useState<string>("");
-  const [errorMessage, setErrorMessage] = useState<string>("");
-  const [statusMessage, setStatusMessage] = useState<string>("");
-  const [createdInvite, setCreatedInvite] = useState<FriendInvitationCreateResponse | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [isCopying, setIsCopying] = useState<boolean>(false);
-  const [isSharing, setIsSharing] = useState<boolean>(false);
-
-  async function submitInviteCreate(): Promise<void> {
-    const validationMessage = validateFriendInvitationDisplayName(friendDisplayName, {
-      required: t("progressScreen.leaderboard.invite.validation.required"),
-      singleLine: t("progressScreen.leaderboard.invite.validation.singleLine"),
-      tooLong: t("progressScreen.leaderboard.invite.validation.tooLong"),
-    });
-    setFieldErrorMessage(validationMessage);
-    if (validationMessage !== "") {
-      return;
-    }
-
-    setIsSubmitting(true);
-    setErrorMessage("");
-    setStatusMessage("");
-
-    try {
-      const response = await createFriendInvitation({
-        inviteeDisplayName: friendDisplayName.trim(),
-      });
-      setCreatedInvite(response);
-      setStatusMessage("");
-    } catch (error) {
-      if (isAuthRedirectError(error)) {
-        return;
-      }
-
-      setErrorMessage(getErrorMessage(error));
-    } finally {
-      setIsSubmitting(false);
-    }
-  }
-
-  async function copyInviteLink(): Promise<void> {
-    if (createdInvite === null) {
-      throw new Error("Cannot copy a friend invite before it is created.");
-    }
-
-    setIsCopying(true);
-    setErrorMessage("");
-    setStatusMessage("");
-
-    try {
-      if (typeof navigator.clipboard?.writeText !== "function") {
-        throw new Error(t("progressScreen.leaderboard.invite.clipboardUnavailable"));
-      }
-
-      await navigator.clipboard.writeText(createdInvite.inviteUrl);
-      setStatusMessage(t("progressScreen.leaderboard.invite.copied"));
-    } catch (error) {
-      setErrorMessage(getErrorMessage(error));
-    } finally {
-      setIsCopying(false);
-    }
-  }
-
-  async function shareInviteLink(): Promise<void> {
-    if (createdInvite === null) {
-      throw new Error("Cannot share a friend invite before it is created.");
-    }
-
-    setIsSharing(true);
-    setErrorMessage("");
-    setStatusMessage("");
-
-    try {
-      if (typeof navigator.share !== "function") {
-        throw new Error(t("progressScreen.leaderboard.invite.shareUnavailable"));
-      }
-
-      await navigator.share({
-        title: t("progressScreen.leaderboard.invite.shareTitle"),
-        text: t("progressScreen.leaderboard.invite.shareText"),
-        url: createdInvite.inviteUrl,
-      });
-      setStatusMessage(t("progressScreen.leaderboard.invite.shared"));
-    } catch (error) {
-      setErrorMessage(getErrorMessage(error));
-    } finally {
-      setIsSharing(false);
-    }
-  }
-
-  return createPortal(
-    <div className="progress-leaderboard-invite-backdrop" role="dialog" aria-modal="true" aria-labelledby="progress-leaderboard-invite-title">
-      <section className="content-card progress-leaderboard-invite-dialog">
-        <div className="progress-leaderboard-invite-dialog-head">
-          <h2 id="progress-leaderboard-invite-title" className="panel-subtitle">
-            {t("progressScreen.leaderboard.invite.title")}
-          </h2>
-          <button className="ghost-btn progress-leaderboard-invite-close" type="button" onClick={onClose}>
-            {t("common.cancel")}
-          </button>
-        </div>
-
-        {canCreateInvite ? (
-          createdInvite === null ? (
-            <>
-              <p className="subtitle">{t("progressScreen.leaderboard.invite.body")}</p>
-              <label className="form-label progress-leaderboard-invite-field">
-                <span>{t("progressScreen.leaderboard.invite.friendNameLabel")}</span>
-                <input
-                  className="text-input"
-                  type="text"
-                  value={friendDisplayName}
-                  disabled={isSubmitting}
-                  onChange={(event) => {
-                    setFriendDisplayName(event.target.value);
-                    setFieldErrorMessage("");
-                  }}
-                  data-testid="progress-leaderboard-invite-name-input"
-                />
-              </label>
-              <p className="progress-leaderboard-invite-note">{t("progressScreen.leaderboard.invite.expiryNote")}</p>
-              {fieldErrorMessage !== "" ? (
-                <p className="error-banner" role="alert" data-testid="progress-leaderboard-invite-name-error">
-                  {fieldErrorMessage}
-                </p>
-              ) : null}
-              <button
-                className="primary-btn"
-                type="button"
-                disabled={isSubmitting}
-                onClick={() => void submitInviteCreate()}
-                data-testid="progress-leaderboard-invite-create"
-              >
-                {isSubmitting ? t("progressScreen.leaderboard.invite.creating") : t("progressScreen.leaderboard.invite.create")}
-              </button>
-            </>
-          ) : (
-            <>
-              <p className="subtitle">
-                {t("progressScreen.leaderboard.invite.readyBody", {
-                  expiresAt: formatDateTime(createdInvite.expiresAt),
-                })}
-              </p>
-              <input
-                className="text-input progress-leaderboard-invite-url"
-                type="text"
-                readOnly
-                value={createdInvite.inviteUrl}
-                aria-label={t("progressScreen.leaderboard.invite.linkLabel")}
-                data-testid="progress-leaderboard-invite-url"
-              />
-              <div className="progress-leaderboard-invite-actions">
-                <button
-                  className="ghost-btn"
-                  type="button"
-                  disabled={isCopying}
-                  onClick={() => void copyInviteLink()}
-                  data-testid="progress-leaderboard-invite-copy"
-                >
-                  {isCopying ? t("progressScreen.leaderboard.invite.copying") : t("progressScreen.leaderboard.invite.copy")}
-                </button>
-                <button
-                  className="ghost-btn"
-                  type="button"
-                  disabled={isSharing}
-                  onClick={() => void shareInviteLink()}
-                  data-testid="progress-leaderboard-invite-share"
-                >
-                  {isSharing ? t("progressScreen.leaderboard.invite.sharing") : t("progressScreen.leaderboard.invite.share")}
-                </button>
-              </div>
-            </>
-          )
-        ) : (
-          <div className="progress-leaderboard-placeholder" data-testid="progress-leaderboard-invite-sign-in">
-            <p className="subtitle">{t("progressScreen.leaderboard.invite.signInBody")}</p>
-            <a className="primary-btn" href={buildLoginUrl(window.location.href, locale)}>
-              {t("progressScreen.leaderboard.signIn")}
-            </a>
-          </div>
-        )}
-
-        {statusMessage !== "" ? <p className="progress-leaderboard-invite-status">{statusMessage}</p> : null}
-        {errorMessage !== "" ? <p className="error-banner" role="alert">{errorMessage}</p> : null}
-      </section>
-    </div>,
-    document.body,
   );
 }
 
@@ -505,17 +298,6 @@ export function ProgressLeaderboardSection(props: ProgressLeaderboardSectionProp
         <div className="progress-leaderboard-head-actions">
           <button
             type="button"
-            className="ghost-btn progress-leaderboard-invite-btn"
-            aria-label={t("progressScreen.leaderboard.invite.actionLabel")}
-            title={t("progressScreen.leaderboard.invite.actionLabel")}
-            onClick={() => setIsInviteDialogOpen(true)}
-            data-testid="progress-leaderboard-invite-open"
-          >
-            <span className="progress-leaderboard-invite-icon" aria-hidden="true">+</span>
-            <span>{t("progressScreen.leaderboard.invite.actionText")}</span>
-          </button>
-          <button
-            type="button"
             className="ghost-btn progress-leaderboard-info-btn"
             aria-expanded={isInfoVisible}
             aria-label={t("progressScreen.leaderboard.infoToggleLabel")}
@@ -540,6 +322,19 @@ export function ProgressLeaderboardSection(props: ProgressLeaderboardSectionProp
         </p>
       ) : null}
 
+      <div className="progress-leaderboard-invite-row">
+        <button
+          type="button"
+          className="primary-btn progress-leaderboard-invite-cta"
+          aria-label={t("progressScreen.leaderboard.invite.actionLabel")}
+          title={t("progressScreen.leaderboard.invite.actionLabel")}
+          onClick={() => setIsInviteDialogOpen(true)}
+          data-testid="progress-leaderboard-invite-open"
+        >
+          {t("progressScreen.leaderboard.invite.actionText")}
+        </button>
+      </div>
+
       <ProgressLeaderboardBody
         sourceState={sourceState}
         canRenderServerBase={canRenderServerBase}
@@ -548,8 +343,9 @@ export function ProgressLeaderboardSection(props: ProgressLeaderboardSectionProp
       />
 
       {isInviteDialogOpen ? (
-        <ProgressLeaderboardInviteDialog
+        <FriendInviteCreateDialog
           canCreateInvite={canRenderServerBase}
+          authRedirectUrl={window.location.href}
           onClose={() => setIsInviteDialogOpen(false)}
         />
       ) : null}

--- a/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
@@ -242,6 +242,17 @@ function expectRowVisible(testId: string): void {
   expect(getContainer().querySelector(`[data-testid='${testId}']`)).not.toBeNull();
 }
 
+async function clickButton(testId: string): Promise<void> {
+  const button = getContainer().querySelector(`[data-testid='${testId}']`);
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Settings button ${testId} was not found`);
+  }
+
+  await act(async () => {
+    clickElement(button);
+  });
+}
+
 function rowIndex(testId: string): number {
   const rows = Array.from(getContainer().querySelectorAll("[data-testid]"));
   const index = rows.findIndex((row) => row.getAttribute("data-testid") === testId);
@@ -297,6 +308,9 @@ describe("SettingsScreen navigation", () => {
       "settings-row-delete-current-workspace",
       "settings-row-delete-account",
     ].forEach(expectRowVisible);
+    expectRowVisible("settings-invite-open");
+    expect(getContainer().querySelector("[data-testid='settings-invite-open']")?.textContent).toBe("Invite friend");
+    expect(rowIndex("settings-invite-open")).toBeLessThan(rowIndex("settings-row-account-status"));
     expect(rowIndex("settings-row-review-reminders")).toBeLessThan(rowIndex("settings-row-review-animations"));
     expect(rowIndex("settings-row-review-animations")).toBeLessThan(rowIndex("settings-row-leaderboard-participation"));
     expect(rowIndex("settings-row-leaderboard-participation")).toBeLessThan(rowIndex("settings-row-language"));
@@ -310,6 +324,27 @@ describe("SettingsScreen navigation", () => {
     await renderSettingsScreen();
 
     expectRowVisible("settings-row-test");
+  });
+
+  it("opens the shared friend invite dialog from Settings", async () => {
+    await renderSettingsScreen();
+
+    await clickButton("settings-invite-open");
+
+    expect(document.body.querySelector("[data-testid='progress-leaderboard-invite-name-input']")).not.toBeNull();
+  });
+
+  it("opens the invite sign-in prompt from Settings for unlinked accounts", async () => {
+    useAppDataMock.mockReturnValue({
+      ...createAppData(),
+      cloudSettings: null,
+    });
+
+    await renderSettingsScreen();
+
+    await clickButton("settings-invite-open");
+
+    expect(document.body.querySelector("[data-testid='progress-leaderboard-invite-sign-in']")).not.toBeNull();
   });
 
   it("navigates representative root rows to their detail routes", async () => {

--- a/apps/web/src/screens/settings/SettingsScreen.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.tsx
@@ -1,6 +1,7 @@
-import { useEffect, type ReactElement } from "react";
+import { useEffect, useState, type ReactElement } from "react";
 import { isAuthRedirectError } from "../../api";
 import { useAppData } from "../../appData";
+import { canLoadProgressServerBase } from "../../appData/progress/progressSource";
 import {
   autoLocalePreference,
   type Locale,
@@ -33,6 +34,7 @@ import {
   settingsTestRoute,
 } from "../../routes";
 import { useTestMode } from "../../testMode";
+import { FriendInviteCreateDialog } from "../friends/FriendInviteCreateDialog";
 import {
   SettingsGroup,
   SettingsNavigationCard,
@@ -71,15 +73,18 @@ export function SettingsScreen(): ReactElement {
     isSessionVerified,
     refreshAccountPreferences,
     session,
+    sessionVerificationState,
     setErrorMessage,
     workspaceSettings,
   } = useAppData();
   const { localePreference, t } = useI18n();
   const { isTestModeEnabled } = useTestMode();
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState<boolean>(false);
   const currentWorkspaceName = activeWorkspace?.name ?? t("common.unavailable");
   const accountStatus = accountStatusValue(cloudSettings?.linkedEmail ?? session?.profile.email ?? null, t("common.unavailable"));
   const languagePreferenceLabel = formatLocalePreferenceLabel(localePreference, t);
   const schedulerValue = workspaceSettings === null ? t("common.unavailable") : workspaceSettings.algorithm.toUpperCase();
+  const canCreateInvite = canLoadProgressServerBase(sessionVerificationState, cloudSettings);
 
   useEffect(() => {
     if (session === null || isSessionVerified === false) {
@@ -101,6 +106,18 @@ export function SettingsScreen(): ReactElement {
       subtitle={t("settingsHome.subtitle")}
       activeTab="general"
     >
+      <div className="settings-invite-row">
+        <button
+          className="primary-btn settings-invite-btn"
+          type="button"
+          aria-label={t("settingsHome.inviteFriend.ariaLabel")}
+          onClick={() => setIsInviteDialogOpen(true)}
+          data-testid="settings-invite-open"
+        >
+          {t("settingsHome.inviteFriend.actionText")}
+        </button>
+      </div>
+
       <SettingsGroup title={t("settingsHome.groups.account")}>
         <div className="settings-nav-list">
           <SettingsNavigationCard
@@ -276,6 +293,14 @@ export function SettingsScreen(): ReactElement {
           ) : null}
         </div>
       </SettingsGroup>
+
+      {isInviteDialogOpen ? (
+        <FriendInviteCreateDialog
+          canCreateInvite={canCreateInvite}
+          authRedirectUrl={window.location.href}
+          onClose={() => setIsInviteDialogOpen(false)}
+        />
+      ) : null}
     </SettingsShell>
   );
 }

--- a/apps/web/src/styles/features/progress.css
+++ b/apps/web/src/styles/features/progress.css
@@ -623,27 +623,17 @@ svg.progress-review-schedule-donut {
 }
 
 .progress-streak-info-btn,
-.progress-leaderboard-info-btn,
-.progress-leaderboard-invite-btn {
+.progress-leaderboard-info-btn {
   min-width: 34px;
   padding: 0 10px;
 }
 
-.progress-leaderboard-invite-btn {
-  gap: 6px;
+.progress-leaderboard-invite-row {
+  display: grid;
 }
 
-.progress-leaderboard-invite-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border: 1px solid currentColor;
-  border-radius: 50%;
-  font-size: 16px;
-  line-height: 1;
-  font-weight: 700;
+.progress-leaderboard-invite-cta {
+  width: 100%;
 }
 
 .progress-streak-info-icon,

--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -111,6 +111,15 @@
   gap: 14px;
 }
 
+.settings-invite-row {
+  display: grid;
+}
+
+.settings-invite-btn {
+  width: 100%;
+  min-height: 52px;
+}
+
 .settings-nav-card {
   display: flex;
   gap: 16px;


### PR DESCRIPTION
## Summary

- Extract the web friend invite creation dialog into a shared component.
- Add full-width Invite friend entry points on Progress leaderboard and Settings.
- Localize the new CTA copy and update focused web tests.

## Validation

- npx vitest run src/screens/progress/ProgressScreen.render.test.tsx src/screens/settings/SettingsScreen.navigation.test.tsx
- npx tsc --noEmit -p tsconfig.json
