### PR TITLE
Simplify web streak freeze overlay

### DIFF
--- a/apps/web/src/api/endpoints/endpoints.test.ts
+++ b/apps/web/src/api/endpoints/endpoints.test.ts
@@ -87,6 +87,7 @@ function createFullStreakFreeze(): Readonly<{
   capacity: number;
   balanceUnits: number;
   unitsPerCredit: number;
+  earnedUnitsPerStreakDay: number;
   nextCreditProgressUnits: number;
   nextCreditRequiredUnits: number;
 }> {
@@ -95,6 +96,7 @@ function createFullStreakFreeze(): Readonly<{
     capacity: 2,
     balanceUnits: 20,
     unitsPerCredit: 10,
+    earnedUnitsPerStreakDay: 1,
     nextCreditProgressUnits: 0,
     nextCreditRequiredUnits: 10,
   };
@@ -354,6 +356,44 @@ describe("progress API endpoints", () => {
       generatedAt: "2026-04-18T09:15:00.000Z",
       reviewHistoryWatermarks: [],
       summary: createProgressSummaryValue(1, true, "2026-04-03", 2),
+    });
+  });
+
+  it("decodes progress summary streak freeze policies with capacity above the local default", async () => {
+    const streakFreeze = {
+      availableCredits: 2,
+      capacity: 3,
+      balanceUnits: 28,
+      unitsPerCredit: 10,
+      earnedUnitsPerStreakDay: 2,
+      nextCreditProgressUnits: 8,
+      nextCreditRequiredUnits: 10,
+    } as const;
+    const summary = {
+      ...createProgressSummaryValue(1, true, "2026-04-03", 2),
+      streakFreeze,
+    };
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        timeZone: "Europe/Madrid",
+        generatedAt: "2026-04-18T09:15:00.000Z",
+        summary,
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(loadProgressSummary({
+      timeZone: "Europe/Madrid",
+      today: "2026-04-18",
+    })).resolves.toEqual({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-18T09:15:00.000Z",
+      reviewHistoryWatermarks: [],
+      summary,
     });
   });
 

--- a/apps/web/src/apiContracts/progress.ts
+++ b/apps/web/src/apiContracts/progress.ts
@@ -175,6 +175,7 @@ function parseProgressStreakFreeze(
     capacity: parseRequiredField(objectValue, "capacity", endpoint, path, parseNonNegativeSafeInteger),
     balanceUnits: parseRequiredField(objectValue, "balanceUnits", endpoint, path, parseNonNegativeSafeInteger),
     unitsPerCredit: parseRequiredField(objectValue, "unitsPerCredit", endpoint, path, parseNonNegativeSafeInteger),
+    earnedUnitsPerStreakDay: parseRequiredField(objectValue, "earnedUnitsPerStreakDay", endpoint, path, parseNonNegativeSafeInteger),
     nextCreditProgressUnits: parseRequiredField(objectValue, "nextCreditProgressUnits", endpoint, path, parseNonNegativeSafeInteger),
     nextCreditRequiredUnits: parseRequiredField(objectValue, "nextCreditRequiredUnits", endpoint, path, parseNonNegativeSafeInteger),
   };

--- a/apps/web/src/appData/progress/snapshots/progressSeriesSnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSeriesSnapshots.ts
@@ -6,15 +6,10 @@ import type {
   ProgressSeriesSnapshot,
   StreakDay,
   StreakDayState,
-  StreakFreeze,
 } from "../../../types";
 import { shiftLocalDate } from "../../../progress/progressDates";
 import {
-  createDefaultStreakFreeze,
   evaluateProgressStreakFreeze,
-  evaluateProgressStreakFreezeFromCarryState,
-  streakFreezePolicy,
-  type StreakFreezeCarryState,
 } from "../../../progress/streakFreeze";
 
 export function createProgressChartData(dailyReviews: ReadonlyArray<DailyReviewPoint>): ProgressChartData {
@@ -165,83 +160,6 @@ function createProgressStreakDays(
   });
 }
 
-function activeDatesInRange(
-  input: ProgressSeriesInput,
-  activeReviewLocalDates: ReadonlyArray<string>,
-): ReadonlyArray<string> {
-  return uniqueSortedLocalDates(activeReviewLocalDates.filter((date) => (
-    date >= input.from && date <= input.to
-  )));
-}
-
-function createProgressStreakDaysFromCarryState(
-  input: ProgressSeriesInput,
-  activeReviewLocalDates: ReadonlyArray<string>,
-  carryState: StreakFreezeCarryState,
-): ReadonlyArray<StreakDay> {
-  return createProgressStreakCarryEvaluation(input, activeReviewLocalDates, carryState).streakDays;
-}
-
-type ProgressStreakCarryEvaluation = Readonly<{
-  streakDays: ReadonlyArray<StreakDay>;
-  streakFreeze: StreakFreeze;
-}>;
-
-function createProgressStreakCarryEvaluation(
-  input: ProgressSeriesInput,
-  activeReviewLocalDates: ReadonlyArray<string>,
-  carryState: StreakFreezeCarryState,
-): ProgressStreakCarryEvaluation {
-  const activeDates = uniqueSortedLocalDates(activeReviewLocalDates.filter((date) => (
-    date <= input.to && (carryState.lastEvaluatedDate === null || date > carryState.lastEvaluatedDate)
-  )));
-  const activeDateSet = new Set(activeDates);
-  const evaluation = evaluateProgressStreakFreezeFromCarryState(activeDates, input.to, carryState);
-  const evaluatedStreakDayStates = createStreakDayStateMap(evaluation.streakDays);
-
-  return {
-    streakFreeze: evaluation.streakFreeze,
-    streakDays: createProgressSeriesDateRange(input).map((date): StreakDay => {
-      const state: StreakDayState = activeDateSet.has(date)
-        ? "reviewed"
-        : evaluatedStreakDayStates.get(date) ?? (date >= input.to ? "pending" : "missed");
-
-      return {
-        date,
-        state,
-      };
-    }),
-  };
-}
-
-function createPossibleCarryStatesBeforeDate(firstDate: string): ReadonlyArray<StreakFreezeCarryState> {
-  const lastEvaluatedDate = shiftLocalDate(firstDate, -1);
-  const maximumBalanceUnits = streakFreezePolicy.maxCapacity * streakFreezePolicy.unitsPerCredit;
-  const inactiveCarryState: StreakFreezeCarryState = {
-    balanceUnits: createDefaultStreakFreeze().balanceUnits,
-    currentStreakDays: 0,
-    longestStreakDays: 0,
-    hasActiveSegment: false,
-    lastEvaluatedDate,
-  };
-  const activeCarryStates: Array<StreakFreezeCarryState> = [];
-
-  for (let balanceUnits = 0; balanceUnits <= maximumBalanceUnits; balanceUnits += 1) {
-    activeCarryStates.push({
-      balanceUnits,
-      currentStreakDays: 1,
-      longestStreakDays: 1,
-      hasActiveSegment: true,
-      lastEvaluatedDate,
-    });
-  }
-
-  return [
-    inactiveCarryState,
-    ...activeCarryStates,
-  ];
-}
-
 function areStreakDaysEqual(
   left: ReadonlyArray<StreakDay>,
   right: ReadonlyArray<StreakDay>,
@@ -260,136 +178,6 @@ function areStreakDaysEqual(
   }
 
   return true;
-}
-
-function selectUniqueStreakDays(
-  candidateStreakDays: ReadonlyArray<ReadonlyArray<StreakDay>>,
-): ReadonlyArray<StreakDay> | null {
-  const firstCandidate = candidateStreakDays[0];
-  if (firstCandidate === undefined) {
-    return null;
-  }
-
-  if (candidateStreakDays.every((candidate) => areStreakDaysEqual(candidate, firstCandidate)) === false) {
-    return null;
-  }
-
-  return firstCandidate;
-}
-
-function areStreakFreezesEqual(left: StreakFreeze, right: StreakFreeze): boolean {
-  return left.availableCredits === right.availableCredits
-    && left.capacity === right.capacity
-    && left.balanceUnits === right.balanceUnits
-    && left.unitsPerCredit === right.unitsPerCredit
-    && left.nextCreditProgressUnits === right.nextCreditProgressUnits
-    && left.nextCreditRequiredUnits === right.nextCreditRequiredUnits;
-}
-
-function selectUniqueStreakFreeze(streakFreezes: ReadonlyArray<StreakFreeze>): StreakFreeze | null {
-  const firstStreakFreeze = streakFreezes[0];
-  if (firstStreakFreeze === undefined) {
-    return null;
-  }
-
-  if (streakFreezes.every((streakFreeze) => areStreakFreezesEqual(streakFreeze, firstStreakFreeze)) === false) {
-    return null;
-  }
-
-  return firstStreakFreeze;
-}
-
-function validateProgressSeriesPairInputs(serverBase: ProgressSeries, renderedSeries: ProgressSeries): void {
-  if (
-    serverBase.timeZone === renderedSeries.timeZone
-    && serverBase.from === renderedSeries.from
-    && serverBase.to === renderedSeries.to
-  ) {
-    return;
-  }
-
-  throw new Error(
-    `Progress series overlay inputs must share the same range. serverBase=${serverBase.timeZone} ${serverBase.from}...${serverBase.to}, renderedSeries=${renderedSeries.timeZone} ${renderedSeries.from}...${renderedSeries.to}.`,
-  );
-}
-
-export function createExactRenderedSeriesStreakFreeze(
-  serverBase: ProgressSeries,
-  renderedSeries: ProgressSeries,
-): StreakFreeze | null {
-  validateProgressSeriesPairInputs(serverBase, renderedSeries);
-
-  const normalizedServerBase = normalizeProgressSeries(serverBase);
-  const normalizedRenderedSeries = normalizeProgressSeries(renderedSeries);
-  const input: ProgressSeriesInput = {
-    timeZone: normalizedServerBase.timeZone,
-    from: normalizedServerBase.from,
-    to: normalizedServerBase.to,
-  };
-  const serverActiveDates = activeDatesInRange(input, activeDatesFromDailyReviews(normalizedServerBase.dailyReviews));
-  const renderedActiveDates = activeDatesInRange(input, activeDatesFromDailyReviews(normalizedRenderedSeries.dailyReviews));
-  const candidateOverlayEvaluations = createPossibleCarryStatesBeforeDate(input.from)
-    .filter((carryState) => areStreakDaysEqual(
-      createProgressStreakCarryEvaluation(input, serverActiveDates, carryState).streakDays,
-      normalizedServerBase.streakDays,
-    ))
-    .map((carryState) => createProgressStreakCarryEvaluation(input, renderedActiveDates, carryState))
-    .filter((evaluation) => areStreakDaysEqual(evaluation.streakDays, normalizedRenderedSeries.streakDays));
-
-  return selectUniqueStreakFreeze(candidateOverlayEvaluations.map((evaluation) => evaluation.streakFreeze));
-}
-
-function createExactOverlayStreakDays(
-  normalizedServerBase: ProgressSeries,
-  dailyReviews: ReadonlyArray<DailyReviewPoint>,
-  localFallbackActiveDates: ReadonlyArray<string>,
-): ReadonlyArray<StreakDay> | null {
-  const visibleInput: ProgressSeriesInput = {
-    timeZone: normalizedServerBase.timeZone,
-    from: normalizedServerBase.from,
-    to: normalizedServerBase.to,
-  };
-  const overlayActiveDates = uniqueSortedLocalDates([
-    ...localFallbackActiveDates,
-    ...activeDatesFromDailyReviews(dailyReviews),
-  ]);
-  const evaluationInput: ProgressSeriesInput = {
-    ...visibleInput,
-    from: findStreakOverlayEvaluationStartDate(visibleInput, overlayActiveDates),
-  };
-  const serverActiveDates = activeDatesInRange(
-    evaluationInput,
-    activeDatesFromDailyReviews(normalizedServerBase.dailyReviews),
-  );
-  const overlayActiveDatesInEvaluation = activeDatesInRange(evaluationInput, overlayActiveDates);
-  const candidateOverlayStreakDays = createPossibleCarryStatesBeforeDate(evaluationInput.from)
-    .filter((carryState) => areStreakDaysEqual(
-      filterStreakDaysToInput(
-        visibleInput,
-        createProgressStreakDaysFromCarryState(evaluationInput, serverActiveDates, carryState),
-      ),
-      normalizedServerBase.streakDays,
-    ))
-    .map((carryState) => filterStreakDaysToInput(
-      visibleInput,
-      createProgressStreakDaysFromCarryState(evaluationInput, overlayActiveDatesInEvaluation, carryState),
-    ));
-
-  return selectUniqueStreakDays(candidateOverlayStreakDays);
-}
-
-function findStreakOverlayEvaluationStartDate(
-  input: ProgressSeriesInput,
-  overlayActiveDates: ReadonlyArray<string>,
-): string {
-  return overlayActiveDates.find((date) => date < input.from) ?? input.from;
-}
-
-function filterStreakDaysToInput(
-  input: ProgressSeriesInput,
-  streakDays: ReadonlyArray<StreakDay>,
-): ReadonlyArray<StreakDay> {
-  return streakDays.filter((day) => day.date >= input.from && day.date <= input.to);
 }
 
 export function normalizeProgressSeries(series: ProgressSeries): ProgressSeries {
@@ -486,7 +274,6 @@ function mergeProgressSeriesWithOverlay(
 
   const mergedStreakDays = mergeProgressStreakDaysWithOverlay(
     normalizedServerBase,
-    dailyReviews,
     localFallbackActiveDates,
     reviewedOverlayDates,
   );
@@ -511,46 +298,15 @@ function mergeProgressSeriesWithOverlay(
 
 function mergeProgressStreakDaysWithOverlay(
   normalizedServerBase: ProgressSeries,
-  dailyReviews: ReadonlyArray<DailyReviewPoint>,
   localFallbackActiveDates: ReadonlyArray<string>,
   reviewedOverlayDates: ReadonlySet<string>,
 ): ReadonlyArray<StreakDay> {
-  const exactOverlayStreakDays = createExactOverlayStreakDays(
-    normalizedServerBase,
-    dailyReviews,
-    localFallbackActiveDates,
-  );
-  if (exactOverlayStreakDays !== null) {
-    return exactOverlayStreakDays;
-  }
-
-  const earliestReviewedOverlayDate = findEarliestLocalDate(reviewedOverlayDates);
-  const recomputeStartDate = findStreakRecomputeStartDate(
-    normalizedServerBase.streakDays,
-    earliestReviewedOverlayDate,
-  ) ?? (
-    earliestReviewedOverlayDate === null
-      ? findEarliestLocalDateBefore(localFallbackActiveDates, normalizedServerBase.from)
-      : null
-  );
-  const recomputedStreakDayMap = recomputeStartDate === null
-    ? new Map<string, StreakDay>()
-    : createStreakDayMap(createProgressStreakDays({
-      timeZone: normalizedServerBase.timeZone,
-      from: recomputeStartDate,
-      to: normalizedServerBase.to,
-    }, [
-      ...localFallbackActiveDates,
-      ...activeDatesFromDailyReviews(dailyReviews),
-    ].filter((date) => date >= recomputeStartDate)));
+  const referenceLocalDate = normalizedServerBase.to;
+  const hasLocalReviewOnReferenceDate = reviewedOverlayDates.has(referenceLocalDate)
+    || localFallbackActiveDates.includes(referenceLocalDate);
 
   return normalizedServerBase.streakDays.map((day): StreakDay => {
-    const recomputedDay = recomputedStreakDayMap.get(day.date);
-    if (recomputedDay !== undefined) {
-      return recomputedDay;
-    }
-
-    if (reviewedOverlayDates.has(day.date) === false) {
+    if (day.date !== referenceLocalDate || hasLocalReviewOnReferenceDate === false) {
       return day;
     }
 
@@ -559,66 +315,6 @@ function mergeProgressStreakDaysWithOverlay(
       state: "reviewed",
     };
   });
-}
-
-function createStreakDayMap(streakDays: ReadonlyArray<StreakDay>): ReadonlyMap<string, StreakDay> {
-  return new Map(streakDays.map((day) => [day.date, day]));
-}
-
-function findEarliestLocalDate(localDates: ReadonlySet<string>): string | null {
-  let earliestLocalDate: string | null = null;
-
-  for (const localDate of localDates) {
-    if (earliestLocalDate === null || localDate < earliestLocalDate) {
-      earliestLocalDate = localDate;
-    }
-  }
-
-  return earliestLocalDate;
-}
-
-function findEarliestLocalDateBefore(
-  localDates: ReadonlyArray<string>,
-  endExclusiveDate: string,
-): string | null {
-  let earliestLocalDate: string | null = null;
-
-  for (const localDate of localDates) {
-    if (localDate >= endExclusiveDate) {
-      continue;
-    }
-
-    if (earliestLocalDate === null || localDate < earliestLocalDate) {
-      earliestLocalDate = localDate;
-    }
-  }
-
-  return earliestLocalDate;
-}
-
-function findStreakRecomputeStartDate(
-  serverBaseStreakDays: ReadonlyArray<StreakDay>,
-  earliestReviewedOverlayDate: string | null,
-): string | null {
-  if (earliestReviewedOverlayDate === null) {
-    return null;
-  }
-
-  let latestMissedDateBeforeOverlay: string | null = null;
-
-  for (const day of serverBaseStreakDays) {
-    if (day.date >= earliestReviewedOverlayDate) {
-      break;
-    }
-
-    if (day.state === "missed") {
-      latestMissedDateBeforeOverlay = day.date;
-    }
-  }
-
-  return latestMissedDateBeforeOverlay === null
-    ? null
-    : shiftLocalDate(latestMissedDateBeforeOverlay, 1);
 }
 
 export function buildRenderedSeries(

--- a/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSnapshotEquality.ts
@@ -81,20 +81,9 @@ function areStreakFreezesEqual(left: StreakFreeze, right: StreakFreeze): boolean
     && left.capacity === right.capacity
     && left.balanceUnits === right.balanceUnits
     && left.unitsPerCredit === right.unitsPerCredit
+    && left.earnedUnitsPerStreakDay === right.earnedUnitsPerStreakDay
     && left.nextCreditProgressUnits === right.nextCreditProgressUnits
     && left.nextCreditRequiredUnits === right.nextCreditRequiredUnits;
-}
-
-function areNullableStreakFreezesEqual(left: StreakFreeze | null, right: StreakFreeze | null): boolean {
-  if (left === right) {
-    return true;
-  }
-
-  if (left === null || right === null) {
-    return false;
-  }
-
-  return areStreakFreezesEqual(left, right);
 }
 
 function areStreakDaysEqual(
@@ -201,19 +190,9 @@ function areProgressRenderedSeriesSummaryContextsEqual(
     return false;
   }
 
-  const watermarksAreEqual = left.serverBaseReviewHistoryWatermarks === null
-    ? right.serverBaseReviewHistoryWatermarks === null
-    : right.serverBaseReviewHistoryWatermarks !== null
-      && areProgressReviewHistoryWatermarksEqual(
-        left.serverBaseReviewHistoryWatermarks,
-        right.serverBaseReviewHistoryWatermarks,
-      );
-
   return areProgressSummariesEqual(left.lowerBoundSummary, right.lowerBoundSummary)
-    && areNullableStreakFreezesEqual(left.exactStreakFreeze, right.exactStreakFreeze)
     && areStringArraysEqual(left.activeDates, right.activeDates)
-    && areStringArraysEqual(left.activeDatesMissingFromServerBase, right.activeDatesMissingFromServerBase)
-    && watermarksAreEqual;
+    && areStringArraysEqual(left.activeDatesMissingFromServerBase, right.activeDatesMissingFromServerBase);
 }
 
 function areProgressSeriesEqual(left: ProgressSeries | null, right: ProgressSeries | null): boolean {

--- a/apps/web/src/appData/progress/snapshots/progressSummarySnapshots.ts
+++ b/apps/web/src/appData/progress/snapshots/progressSummarySnapshots.ts
@@ -1,29 +1,21 @@
 import type {
   ProgressRenderedSeriesSummaryContext,
-  ProgressReviewHistoryWatermark,
   ProgressSeries,
   ProgressSeriesSnapshot,
   ProgressSummary,
   ProgressSummaryPayload,
   ProgressSummarySnapshot,
-  StreakFreeze,
 } from "../../../types";
 import {
   addReviewedDayToStreakFreeze,
   createDefaultStreakFreeze,
   evaluateProgressStreakFreeze,
-  evaluateProgressStreakFreezeFromCarryState,
-  streakFreezePolicy,
-  type StreakFreezeCarryState,
 } from "../../../progress/streakFreeze";
-import { shiftLocalDate } from "../../../progress/progressDates";
 import {
-  areProgressReviewHistoryWatermarksEqual,
   areProgressSummariesEqual,
 } from "./progressSnapshotEquality";
 import {
   buildDailyReviewCountMap,
-  createExactRenderedSeriesStreakFreeze,
   normalizeProgressSeries,
 } from "./progressSeriesSnapshots";
 
@@ -152,241 +144,24 @@ export function createProgressRenderedSeriesSummaryContext(
   const activeDatesMissingFromServerBaseResult = serverBase === null
     ? []
     : activeDatesMissingFromServerBase(serverBase, renderedSeries);
-  const exactStreakFreeze = serverBase === null
-    ? null
-    : createExactRenderedSeriesStreakFreeze(serverBase, renderedSeries);
 
   return {
     lowerBoundSummary: summaryLowerBoundFromActiveDates(activeDates, renderedSeries.to),
-    exactStreakFreeze,
     activeDates,
     activeDatesMissingFromServerBase: activeDatesMissingFromServerBaseResult,
-    serverBaseReviewHistoryWatermarks: serverBase?.reviewHistoryWatermarks ?? null,
   };
 }
 
-function serverAndSeriesShareReviewHistoryBase(
-  serverBaseReviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark>,
-  renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null,
-): boolean {
-  const seriesBaseReviewHistoryWatermarks = renderedSeriesContext?.serverBaseReviewHistoryWatermarks;
-
-  if (seriesBaseReviewHistoryWatermarks === null || seriesBaseReviewHistoryWatermarks === undefined) {
-    return false;
-  }
-
-  return areProgressReviewHistoryWatermarksEqual(
-    serverBaseReviewHistoryWatermarks,
-    seriesBaseReviewHistoryWatermarks,
-  );
-}
-
-function localFallbackActiveReviewDayDeltaCandidates(
+function hasLocalReferenceReview(
   localFallbackActiveDates: ReadonlyArray<string>,
-  serverBase: ProgressSummary,
-): ReadonlyArray<string> {
-  const serverLastReviewedOn = serverBase.lastReviewedOn;
-
-  if (serverLastReviewedOn === null) {
-    return localFallbackActiveDates;
-  }
-
-  return localFallbackActiveDates.filter((localDate) => localDate > serverLastReviewedOn);
-}
-
-function activeReviewDayDeltaCandidates(
   renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null,
-  localFallbackActiveDates: ReadonlyArray<string>,
-  serverBase: ProgressSummary,
-  hasSharedServerAndSeriesReviewHistoryBase: boolean,
-): ReadonlyArray<string> {
-  const renderedSeriesCandidates = renderedSeriesContext === null
-    ? []
-    : hasSharedServerAndSeriesReviewHistoryBase
-      ? renderedSeriesContext.activeDatesMissingFromServerBase
-      : renderedSeriesContext.activeDates;
-
-  return uniqueSortedLocalDates([
-    ...renderedSeriesCandidates,
-    ...localFallbackActiveReviewDayDeltaCandidates(localFallbackActiveDates, serverBase),
-  ]);
-}
-
-function shouldApplyActiveReviewDayDelta(
-  localDate: string,
-  serverBase: ProgressSummary,
-  hasSharedServerAndSeriesReviewHistoryBase: boolean,
   referenceLocalDate: string,
 ): boolean {
-  if (localDate === referenceLocalDate && serverBase.hasReviewedToday) {
-    return false;
-  }
-
-  if (hasSharedServerAndSeriesReviewHistoryBase) {
+  if (localFallbackActiveDates.includes(referenceLocalDate)) {
     return true;
   }
 
-  if (serverBase.lastReviewedOn === null) {
-    return true;
-  }
-
-  return localDate > serverBase.lastReviewedOn;
-}
-
-function currentStreakDaysWithLocalDelta(
-  serverBase: ProgressSummary,
-  appliedActiveReviewDayDeltaCandidates: ReadonlyArray<string>,
-  referenceLocalDate: string,
-): number {
-  if (serverBase.hasReviewedToday) {
-    return serverBase.currentStreakDays;
-  }
-
-  if (appliedActiveReviewDayDeltaCandidates.includes(referenceLocalDate) === false) {
-    return serverBase.currentStreakDays;
-  }
-
-  if (serverBase.currentStreakDays <= 0) {
-    return 1;
-  }
-
-  return serverBase.currentStreakDays + 1;
-}
-
-function countCompletedNonReviewedDaysAfterLastReview(
-  lastReviewedOn: string,
-  referenceLocalDate: string,
-): number {
-  let completedDays = 0;
-
-  for (
-    let localDate = shiftLocalDate(lastReviewedOn, 1);
-    localDate < referenceLocalDate;
-    localDate = shiftLocalDate(localDate, 1)
-  ) {
-    completedDays += 1;
-  }
-
-  return completedDays;
-}
-
-function reverseFrozenDayBalanceUnits(balanceUnits: number): number | null {
-  const reversedBalanceUnits = balanceUnits
-    + streakFreezePolicy.unitsPerCredit
-    - streakFreezePolicy.earnedUnitsPerStreakDay;
-  const maximumBalanceUnits = streakFreezePolicy.maxCapacity * streakFreezePolicy.unitsPerCredit;
-
-  return reversedBalanceUnits > maximumBalanceUnits
-    ? null
-    : reversedBalanceUnits;
-}
-
-function createCarryStateAtLastReviewedDate(
-  serverBase: ProgressSummary,
-  referenceLocalDate: string,
-): StreakFreezeCarryState | null {
-  if (serverBase.lastReviewedOn === null || serverBase.lastReviewedOn >= referenceLocalDate) {
-    return null;
-  }
-
-  const completedNonReviewedDays = countCompletedNonReviewedDaysAfterLastReview(
-    serverBase.lastReviewedOn,
-    referenceLocalDate,
-  );
-  if (serverBase.currentStreakDays <= completedNonReviewedDays) {
-    return null;
-  }
-
-  let balanceUnits = serverBase.streakFreeze.balanceUnits;
-  for (let index = 0; index < completedNonReviewedDays; index += 1) {
-    const reversedBalanceUnits = reverseFrozenDayBalanceUnits(balanceUnits);
-    if (reversedBalanceUnits === null) {
-      return null;
-    }
-
-    balanceUnits = reversedBalanceUnits;
-  }
-
-  const currentStreakDays = serverBase.currentStreakDays - completedNonReviewedDays;
-
-  return {
-    balanceUnits,
-    currentStreakDays,
-    longestStreakDays: Math.max(serverBase.longestStreakDays, currentStreakDays),
-    hasActiveSegment: true,
-    lastEvaluatedDate: serverBase.lastReviewedOn,
-  };
-}
-
-function exactServerSummaryWithLocalDelta(
-  serverBase: ProgressSummary,
-  appliedActiveReviewDayDeltaCandidates: ReadonlyArray<string>,
-  referenceLocalDate: string,
-): ProgressSummary | null {
-  if (appliedActiveReviewDayDeltaCandidates.length === 0) {
-    return serverBase;
-  }
-
-  const carryState = createCarryStateAtLastReviewedDate(serverBase, referenceLocalDate);
-  if (carryState === null) {
-    return null;
-  }
-
-  const activeDates = appliedActiveReviewDayDeltaCandidates.filter((localDate) => (
-    carryState.lastEvaluatedDate !== null && localDate > carryState.lastEvaluatedDate
-  ));
-  if (activeDates.length !== appliedActiveReviewDayDeltaCandidates.length) {
-    return null;
-  }
-
-  const evaluation = evaluateProgressStreakFreezeFromCarryState(
-    activeDates,
-    referenceLocalDate,
-    carryState,
-  );
-
-  return {
-    ...serverBase,
-    currentStreakDays: evaluation.currentStreakDays,
-    longestStreakDays: Math.max(serverBase.longestStreakDays, evaluation.longestStreakDays),
-    hasReviewedToday: serverBase.hasReviewedToday || activeDates.includes(referenceLocalDate),
-    lastReviewedOn: maxLocalDate(serverBase.lastReviewedOn, activeDates.at(-1) ?? null),
-    activeReviewDays: serverBase.activeReviewDays + activeDates.length,
-    streakFreeze: evaluation.streakFreeze,
-  };
-}
-
-function streakFreezeWithLocalDelta(
-  serverBase: ProgressSummary,
-  appliedActiveReviewDayDeltaCandidates: ReadonlyArray<string>,
-  referenceLocalDate: string,
-  exactStreakFreeze: StreakFreeze | null,
-  exactServerSummary: ProgressSummary | null,
-): StreakFreeze {
-  if (appliedActiveReviewDayDeltaCandidates.length === 0) {
-    return serverBase.streakFreeze;
-  }
-
-  if (exactStreakFreeze !== null) {
-    return exactStreakFreeze;
-  }
-
-  if (exactServerSummary !== null) {
-    return exactServerSummary.streakFreeze;
-  }
-
-  if (serverBase.hasReviewedToday) {
-    return serverBase.streakFreeze;
-  }
-
-  if (
-    appliedActiveReviewDayDeltaCandidates.length === 1
-    && appliedActiveReviewDayDeltaCandidates[0] === referenceLocalDate
-  ) {
-    return addReviewedDayToStreakFreeze(serverBase.streakFreeze);
-  }
-
-  return serverBase.streakFreeze;
+  return renderedSeriesContext?.activeDatesMissingFromServerBase.includes(referenceLocalDate) ?? false;
 }
 
 function hasProgressSummaryOverlay(
@@ -398,96 +173,35 @@ function hasProgressSummaryOverlay(
 
 function mergeProgressSummary(
   serverBase: ProgressSummarySnapshot,
-  localFallback: ProgressSummarySnapshot | null,
   localFallbackActiveDates: ReadonlyArray<string>,
   renderedSeriesContext: ProgressRenderedSeriesSummaryContext | null,
   referenceLocalDate: string,
 ): ProgressSummaryPayload {
-  const localFallbackSummary = localFallback?.summary ?? createEmptyProgressSummary();
-  const renderedSeriesLowerBound = renderedSeriesContext?.lowerBoundSummary;
-  const hasSharedServerAndSeriesReviewHistoryBase = serverAndSeriesShareReviewHistoryBase(
-    serverBase.reviewHistoryWatermarks,
-    renderedSeriesContext,
-  );
-  const exactStreakFreeze = hasSharedServerAndSeriesReviewHistoryBase
-    ? renderedSeriesContext?.exactStreakFreeze ?? null
-    : null;
-  const reviewDayDeltaCandidates = activeReviewDayDeltaCandidates(
-    renderedSeriesContext,
+  const hasReferenceReviewOverlay = serverBase.summary.hasReviewedToday === false && hasLocalReferenceReview(
     localFallbackActiveDates,
-    serverBase.summary,
-    hasSharedServerAndSeriesReviewHistoryBase,
-  );
-  const appliedActiveReviewDayDeltaCandidates = reviewDayDeltaCandidates.filter((localDate) => (
-    shouldApplyActiveReviewDayDelta(
-      localDate,
-      serverBase.summary,
-      hasSharedServerAndSeriesReviewHistoryBase,
-      referenceLocalDate,
-    )
-  ));
-  const serverActiveReviewDaysWithLocalDelta = serverBase.summary.activeReviewDays
-    + appliedActiveReviewDayDeltaCandidates.length;
-  const exactServerSummary = exactServerSummaryWithLocalDelta(
-    serverBase.summary,
-    appliedActiveReviewDayDeltaCandidates,
+    renderedSeriesContext,
     referenceLocalDate,
   );
-  const serverCurrentStreakDaysWithLocalDelta = currentStreakDaysWithLocalDelta(
-    serverBase.summary,
-    appliedActiveReviewDayDeltaCandidates,
-    referenceLocalDate,
-  );
-  const serverSummaryWithLocalDelta: ProgressSummary = {
-    ...serverBase.summary,
-    currentStreakDays: exactServerSummary?.currentStreakDays ?? serverCurrentStreakDaysWithLocalDelta,
-    longestStreakDays: Math.max(
-      serverBase.summary.longestStreakDays,
-      exactServerSummary?.longestStreakDays ?? serverCurrentStreakDaysWithLocalDelta,
-    ),
-    streakFreeze: streakFreezeWithLocalDelta(
-      serverBase.summary,
-      appliedActiveReviewDayDeltaCandidates,
-      referenceLocalDate,
-      exactStreakFreeze,
-      exactServerSummary,
-    ),
-  };
-  const mergedCurrentStreakDays = Math.max(
-    serverSummaryWithLocalDelta.currentStreakDays,
-    localFallbackSummary.currentStreakDays,
-    renderedSeriesLowerBound?.currentStreakDays ?? 0,
-  );
+  const currentStreakDays = hasReferenceReviewOverlay
+    ? Math.max(1, serverBase.summary.currentStreakDays + 1)
+    : serverBase.summary.currentStreakDays;
+  const summary = hasReferenceReviewOverlay
+    ? {
+      ...serverBase.summary,
+      currentStreakDays,
+      longestStreakDays: Math.max(serverBase.summary.longestStreakDays, currentStreakDays),
+      hasReviewedToday: true,
+      lastReviewedOn: maxLocalDate(serverBase.summary.lastReviewedOn, referenceLocalDate),
+      activeReviewDays: serverBase.summary.activeReviewDays + 1,
+      streakFreeze: addReviewedDayToStreakFreeze(serverBase.summary.streakFreeze),
+    }
+    : serverBase.summary;
 
   return {
     timeZone: serverBase.timeZone,
     generatedAt: serverBase.generatedAt,
     reviewHistoryWatermarks: serverBase.reviewHistoryWatermarks,
-    summary: {
-      currentStreakDays: mergedCurrentStreakDays,
-      longestStreakDays: Math.max(
-        serverSummaryWithLocalDelta.longestStreakDays,
-        localFallbackSummary.longestStreakDays,
-        renderedSeriesLowerBound?.longestStreakDays ?? 0,
-        mergedCurrentStreakDays,
-      ),
-      hasReviewedToday: serverBase.summary.hasReviewedToday
-        || localFallbackSummary.hasReviewedToday
-        || (renderedSeriesLowerBound?.hasReviewedToday ?? false),
-      lastReviewedOn: maxLocalDate(
-        maxLocalDate(
-          serverBase.summary.lastReviewedOn,
-          localFallbackSummary.lastReviewedOn,
-        ),
-        renderedSeriesLowerBound?.lastReviewedOn ?? null,
-      ),
-      activeReviewDays: Math.max(
-        serverActiveReviewDaysWithLocalDelta,
-        localFallbackSummary.activeReviewDays,
-        renderedSeriesLowerBound?.activeReviewDays ?? 0,
-      ),
-      streakFreeze: serverSummaryWithLocalDelta.streakFreeze,
-    },
+    summary,
   };
 }
 
@@ -507,7 +221,6 @@ export function buildRenderedSummary(
 
     const mergedPayload = mergeProgressSummary(
       serverBase,
-      localFallback,
       localFallbackActiveDates,
       renderedSeriesContext,
       referenceLocalDate,

--- a/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
+++ b/apps/web/src/appData/progress/source/progressSource.summarySeries.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import type { DailyReviewPoint, ProgressSummary, StreakFreeze } from "../../../types";
+import type { ProgressSummary, StreakFreeze } from "../../../types";
 import { shiftLocalDate } from "../../../progress/progressDates";
 import { createDefaultStreakFreeze } from "../../../progress/streakFreeze";
 import {
@@ -58,16 +58,6 @@ function createProgressSummaryWithFreeze(
   };
 }
 
-function createDailyReviewsForRange(from: string, to: string): ReadonlyArray<DailyReviewPoint> {
-  const dailyReviews: Array<DailyReviewPoint> = [];
-
-  for (let currentDate = from; currentDate <= to; currentDate = shiftLocalDate(currentDate, 1)) {
-    dailyReviews.push(buildGoodDailyReviewPoint(currentDate, 1));
-  }
-
-  return dailyReviews;
-}
-
 describe("useProgressSource summary and series", () => {
   it("loads split server summary and series for linked verified sessions", async () => {
     const harness = renderHarness({
@@ -118,9 +108,18 @@ describe("useProgressSource summary and series", () => {
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(4);
   });
 
-  it("keeps rendered summary local when pending review uploads make the server summary stale", async () => {
+  it("marks server summary approximate without replacing it for non-today pending uploads", async () => {
     hasPendingProgressReviewEventsMock.mockResolvedValue(true);
-    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-18", 8));
+    loadProgressSummaryMock.mockResolvedValue({
+      timeZone: "Europe/Madrid",
+      generatedAt: "2026-04-20T09:15:00.000Z",
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: createProgressSummary(2, false, "2026-04-19", 7),
+    });
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, false, "2026-04-19", 8));
+    loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-19"]);
 
     const harness = renderHarness({
       sessionVerificationState: "verified",
@@ -134,7 +133,9 @@ describe("useProgressSource summary and series", () => {
     expect(harness.getApi().progressSourceState.summary.serverBase?.source).toBe("server");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.source).toBe("server");
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.isApproximate).toBe(true);
-    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(8);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
+      createProgressSummary(2, false, "2026-04-19", 7),
+    );
   });
 
   it("keeps reviewed-today summary visible after pending uploads clear before the server summary catches up", async () => {
@@ -185,6 +186,10 @@ describe("useProgressSource summary and series", () => {
       hardCount: 0,
       goodCount: 0,
       easyCount: 0,
+    });
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
+      date: currentSeriesInput.to,
+      state: "reviewed",
     });
   });
 
@@ -254,11 +259,11 @@ describe("useProgressSource summary and series", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
-      createProgressSummary(202, true, "2026-04-20", 202),
+      createProgressSummary(202, true, "2026-04-20", 201),
     );
   });
 
-  it("adds local active dates after server last reviewed even outside the visible chart range", async () => {
+  it("does not apply non-today local active dates to server summary", async () => {
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
@@ -282,7 +287,7 @@ describe("useProgressSource summary and series", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
-      createProgressSummary(0, false, "2025-11-16", 201),
+      createProgressSummary(0, false, "2025-11-15", 200),
     );
   });
 
@@ -348,7 +353,7 @@ describe("useProgressSource summary and series", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary).toEqual(
-      createProgressSummary(2, false, "2026-04-19", 201),
+      createProgressSummary(2, false, "2026-04-18", 200),
     );
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: "2026-04-18",
@@ -396,7 +401,7 @@ describe("useProgressSource summary and series", () => {
     });
   });
 
-  it("preserves server freeze states when pending local reviews overlay a later day", async () => {
+  it("does not recompute historical streak states when pending local reviews overlay a non-today day", async () => {
     const serverSeries = buildServerSeriesWithDailyReviews([
       buildGoodDailyReviewPoint("2026-04-16", 1),
     ], "2026-04-18T09:18:00.000Z");
@@ -415,13 +420,17 @@ describe("useProgressSource summary and series", () => {
 
     await flushEffects();
 
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
+      date: "2026-04-18",
+      reviewCount: 1,
+    }));
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
       date: "2026-04-18",
-      state: "reviewed",
+      state: "frozen",
     });
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
       date: "2026-04-19",
-      state: "frozen",
+      state: "missed",
     });
     expect(serverSeries.streakDays).toContainEqual({
       date: "2026-04-19",
@@ -429,7 +438,7 @@ describe("useProgressSource summary and series", () => {
     });
   });
 
-  it("keeps server carry-in streak states before a local review overlay", async () => {
+  it("keeps server streak states before a non-today local review overlay", async () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     const localReviewDate = "2026-04-18";
     const serverSeries = buildServerSeriesWithDailyReviews([], "2026-04-18T09:18:00.000Z");
@@ -464,17 +473,15 @@ describe("useProgressSource summary and series", () => {
     });
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
       date: localReviewDate,
-      state: "reviewed",
+      state: "missed",
     });
   });
 
-  it("recomputes visible carry-in streak states when a local review replaces a frozen day", async () => {
-    const currentSeriesInput = buildCurrentSeriesInput();
+  it("keeps future historical server streak states when a local review replaces a frozen day", async () => {
     const localReviewDate = "2026-04-17";
-    const serverSeries = buildServerSeriesWithDailyReviews(
-      createDailyReviewsForRange(currentSeriesInput.from, "2026-04-16"),
-      "2026-04-18T09:18:00.000Z",
-    );
+    const serverSeries = buildServerSeriesWithDailyReviews([
+      buildGoodDailyReviewPoint("2026-04-16", 1),
+    ], "2026-04-18T09:18:00.000Z");
     loadProgressSeriesMock.mockResolvedValue(serverSeries);
     loadLocalProgressActiveDatesMock.mockResolvedValue([localReviewDate]);
     loadLocalProgressDailyReviewsMock.mockResolvedValue([
@@ -496,11 +503,11 @@ describe("useProgressSource summary and series", () => {
     });
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
       date: localReviewDate,
-      state: "reviewed",
+      state: "frozen",
     });
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
       date: "2026-04-19",
-      state: "frozen",
+      state: "missed",
     });
   });
 
@@ -527,7 +534,7 @@ describe("useProgressSource summary and series", () => {
     });
   });
 
-  it("marks server series approximate when local carry-in changes only streak states", async () => {
+  it("keeps server series exact when local carry-in only changes local-only streak evaluation", async () => {
     const currentSeriesInput = buildCurrentSeriesInput();
     const localCarryInDate = shiftLocalDate(currentSeriesInput.from, -1);
     loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([], "2026-04-18T09:18:00.000Z"));
@@ -544,14 +551,14 @@ describe("useProgressSource summary and series", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.source).toBe("server");
-    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.isApproximate).toBe(true);
+    expect(harness.getApi().progressSourceState.series.renderedSnapshot?.isApproximate).toBe(false);
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.dailyReviews).toContainEqual(expect.objectContaining({
       date: currentSeriesInput.from,
       reviewCount: 0,
     }));
     expect(harness.getApi().progressSourceState.series.renderedSnapshot?.streakDays).toContainEqual({
       date: currentSeriesInput.from,
-      state: "frozen",
+      state: "missed",
     });
   });
 
@@ -561,6 +568,7 @@ describe("useProgressSource summary and series", () => {
       capacity: 2,
       balanceUnits: 10,
       unitsPerCredit: 10,
+      earnedUnitsPerStreakDay: 1,
       nextCreditProgressUnits: 0,
       nextCreditRequiredUnits: 10,
     };
@@ -588,38 +596,29 @@ describe("useProgressSource summary and series", () => {
     );
   });
 
-  it("uses exact series freeze overlay for multi-day local review deltas", async () => {
-    const sharedWatermark = [
-      { workspaceId: "workspace-1", reviewSequenceId: 42 },
-    ];
-    const staleServerFreeze: StreakFreeze = {
+  it("recharges server freeze with only today's local review from series overlay", async () => {
+    const serverFreeze: StreakFreeze = {
       availableCredits: 1,
-      capacity: 2,
-      balanceUnits: 11,
+      capacity: 3,
+      balanceUnits: 18,
       unitsPerCredit: 10,
-      nextCreditProgressUnits: 1,
+      earnedUnitsPerStreakDay: 2,
+      nextCreditProgressUnits: 8,
       nextCreditRequiredUnits: 10,
-    };
-    const serverSeries = {
-      ...buildServerSeriesWithDailyReviews([
-        buildGoodDailyReviewPoint("2026-04-18", 1),
-      ], "2026-04-20T09:15:00.000Z"),
-      reviewHistoryWatermarks: sharedWatermark,
     };
     loadProgressSummaryMock.mockResolvedValue({
       timeZone: "Europe/Madrid",
       generatedAt: "2026-04-20T09:15:00.000Z",
-      reviewHistoryWatermarks: sharedWatermark,
-      summary: createProgressSummaryWithFreeze(2, false, "2026-04-18", 200, staleServerFreeze),
+      reviewHistoryWatermarks: [
+        { workspaceId: "workspace-1", reviewSequenceId: 42 },
+      ],
+      summary: createProgressSummaryWithFreeze(2, false, "2026-04-19", 200, serverFreeze),
     });
-    loadProgressSeriesMock.mockResolvedValue(serverSeries);
-    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-20", 2));
-    loadLocalProgressActiveDatesMock.mockResolvedValue([
-      "2026-04-19",
-      "2026-04-20",
-    ]);
-    loadLocalProgressDailyReviewsMock.mockResolvedValue([
+    loadProgressSeriesMock.mockResolvedValue(buildServerSeriesWithDailyReviews([
       buildGoodDailyReviewPoint("2026-04-19", 1),
+    ], "2026-04-20T09:15:00.000Z"));
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(1, true, "2026-04-20", 1));
+    loadLocalProgressDailyReviewsMock.mockResolvedValue([
       buildGoodDailyReviewPoint("2026-04-20", 1),
     ]);
 
@@ -633,18 +632,28 @@ describe("useProgressSource summary and series", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.currentStreakDays).toBe(3);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(201);
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.streakFreeze).toEqual(
-      createDefaultStreakFreeze(),
+      {
+        availableCredits: 2,
+        capacity: 3,
+        balanceUnits: 20,
+        unitsPerCredit: 10,
+        earnedUnitsPerStreakDay: 2,
+        nextCreditProgressUnits: 0,
+        nextCreditRequiredUnits: 10,
+      },
     );
   });
 
-  it("uses exact summary-only freeze overlay for multi-day local review deltas", async () => {
-    const staleServerFreeze: StreakFreeze = {
-      availableCredits: 1,
-      capacity: 2,
-      balanceUnits: 10,
+  it("recharges server freeze with only today's local review in summary-only mode", async () => {
+    const serverFreeze: StreakFreeze = {
+      availableCredits: 2,
+      capacity: 3,
+      balanceUnits: 28,
       unitsPerCredit: 10,
-      nextCreditProgressUnits: 0,
+      earnedUnitsPerStreakDay: 2,
+      nextCreditProgressUnits: 8,
       nextCreditRequiredUnits: 10,
     };
     loadProgressSummaryMock.mockResolvedValue({
@@ -653,13 +662,10 @@ describe("useProgressSource summary and series", () => {
       reviewHistoryWatermarks: [
         { workspaceId: "workspace-1", reviewSequenceId: 42 },
       ],
-      summary: createProgressSummaryWithFreeze(200, false, "2026-04-18", 200, staleServerFreeze),
+      summary: createProgressSummaryWithFreeze(200, false, "2026-04-19", 200, serverFreeze),
     });
-    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(2, true, "2026-04-20", 2));
-    loadLocalProgressActiveDatesMock.mockResolvedValue([
-      "2026-04-19",
-      "2026-04-20",
-    ]);
+    loadLocalProgressSummaryMock.mockResolvedValue(createProgressSummary(1, true, "2026-04-20", 1));
+    loadLocalProgressActiveDatesMock.mockResolvedValue(["2026-04-20"]);
 
     const harness = renderHarness({
       sessionVerificationState: "verified",
@@ -671,8 +677,17 @@ describe("useProgressSource summary and series", () => {
     await flushEffects();
 
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.currentStreakDays).toBe(201);
+    expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.activeReviewDays).toBe(201);
     expect(harness.getApi().progressSourceState.summary.renderedSnapshot?.summary.streakFreeze).toEqual(
-      createDefaultStreakFreeze(),
+      {
+        availableCredits: 3,
+        capacity: 3,
+        balanceUnits: 30,
+        unitsPerCredit: 10,
+        earnedUnitsPerStreakDay: 2,
+        nextCreditProgressUnits: 0,
+        nextCreditRequiredUnits: 10,
+      },
     );
   });
 

--- a/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
+++ b/apps/web/src/appData/progress/source/progressSourceTestSupport.tsx
@@ -564,7 +564,7 @@ export function storePersistedProgressSummaryForTest(
   serverBase: ProgressSummaryPayload,
 ): void {
   window.localStorage.setItem(`flashcards-progress-server-summary:${scopeKey}`, JSON.stringify({
-    version: 3,
+    version: 4,
     scopeKey,
     savedAt: "2026-04-18T09:00:00.000Z",
     serverBase,

--- a/apps/web/src/appData/progress/storage/progressStorage.ts
+++ b/apps/web/src/appData/progress/storage/progressStorage.ts
@@ -37,13 +37,13 @@ const progressReviewScheduleStorageKeyPrefix = "flashcards-progress-server-revie
 // Single fixed key: the leaderboard payload is account-scoped, so one cache slot
 // is enough and lets settings clear it without knowing the active scope key.
 const progressLeaderboardStorageKey = "flashcards-progress-server-leaderboard";
-const progressServerSummaryVersion = 3;
+const progressServerSummaryVersion = 4;
 const progressServerSeriesVersion = 3;
 const progressServerReviewScheduleVersion = 2;
 const progressServerLeaderboardVersion = 2;
 
 type PersistedProgressSummary = Readonly<{
-  version: 3;
+  version: 4;
   scopeKey: ProgressScopeKey;
   savedAt: string;
   serverBase: ProgressSummaryPayload;
@@ -314,6 +314,7 @@ function parsePersistedStreakFreeze(value: unknown): StreakFreeze | null {
     || isNonNegativeSafeIntegerValue(value.capacity) === false
     || isNonNegativeSafeIntegerValue(value.balanceUnits) === false
     || isNonNegativeSafeIntegerValue(value.unitsPerCredit) === false
+    || isNonNegativeSafeIntegerValue(value.earnedUnitsPerStreakDay) === false
     || isNonNegativeSafeIntegerValue(value.nextCreditProgressUnits) === false
     || isNonNegativeSafeIntegerValue(value.nextCreditRequiredUnits) === false
   ) {
@@ -325,6 +326,7 @@ function parsePersistedStreakFreeze(value: unknown): StreakFreeze | null {
     capacity: value.capacity,
     balanceUnits: value.balanceUnits,
     unitsPerCredit: value.unitsPerCredit,
+    earnedUnitsPerStreakDay: value.earnedUnitsPerStreakDay,
     nextCreditProgressUnits: value.nextCreditProgressUnits,
     nextCreditRequiredUnits: value.nextCreditRequiredUnits,
   };
@@ -437,7 +439,7 @@ function parsePersistedProgressSummary(rawValue: string | null): ProgressCacheRe
   return {
     status: "hit",
     value: {
-      version: 3,
+      version: progressServerSummaryVersion,
       scopeKey: parsedValue.scopeKey,
       savedAt: parsedValue.savedAt,
       serverBase: {
@@ -1028,7 +1030,7 @@ function assertProgressReviewScheduleTimeZone(
 
 export function storePersistedProgressSummary(scopeKey: ProgressScopeKey, serverBase: ProgressSummaryPayload): void {
   const persistedValue: PersistedProgressSummary = {
-    version: 3,
+    version: progressServerSummaryVersion,
     scopeKey,
     savedAt: new Date().toISOString(),
     serverBase,

--- a/apps/web/src/localDb/progress/progress.test.ts
+++ b/apps/web/src/localDb/progress/progress.test.ts
@@ -286,6 +286,7 @@ describe("localDb progress", () => {
         capacity: 2,
         balanceUnits: 20,
         unitsPerCredit: 10,
+        earnedUnitsPerStreakDay: 1,
         nextCreditProgressUnits: 0,
         nextCreditRequiredUnits: 10,
       },

--- a/apps/web/src/progress/streakFreeze.ts
+++ b/apps/web/src/progress/streakFreeze.ts
@@ -25,15 +25,13 @@ export type StreakFreezeEvaluation = Readonly<{
   streakDays: ReadonlyArray<StreakDay>;
 }>;
 
-export type StreakFreezeCarryState = Readonly<{
+type StreakComputationState = Readonly<{
   balanceUnits: number;
   currentStreakDays: number;
   longestStreakDays: number;
   hasActiveSegment: boolean;
   lastEvaluatedDate: string | null;
 }>;
-
-type StreakComputationState = StreakFreezeCarryState;
 
 const localDatePattern = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -95,32 +93,6 @@ function validateStreakFreezePolicy(policy: StreakFreezePolicy): void {
   }
 }
 
-function validateStreakFreezeCarryState(state: StreakFreezeCarryState, policy: StreakFreezePolicy): void {
-  if (Number.isInteger(state.balanceUnits) === false || state.balanceUnits < 0) {
-    throw new Error("streak freeze carry balanceUnits must be a non-negative integer");
-  }
-
-  if (state.balanceUnits > getMaximumBalanceUnits(policy)) {
-    throw new Error("streak freeze carry balanceUnits must not exceed maximum balance units");
-  }
-
-  if (Number.isInteger(state.currentStreakDays) === false || state.currentStreakDays < 0) {
-    throw new Error("streak freeze carry currentStreakDays must be a non-negative integer");
-  }
-
-  if (Number.isInteger(state.longestStreakDays) === false || state.longestStreakDays < state.currentStreakDays) {
-    throw new Error("streak freeze carry longestStreakDays must be at least currentStreakDays");
-  }
-
-  if (state.hasActiveSegment === false && state.currentStreakDays !== 0) {
-    throw new Error("streak freeze inactive carry state must have zero currentStreakDays");
-  }
-
-  if (state.lastEvaluatedDate !== null) {
-    assertLocalDate(state.lastEvaluatedDate, "streak freeze carry lastEvaluatedDate");
-  }
-}
-
 function isNonNegativeSafeInteger(value: number): boolean {
   return Number.isSafeInteger(value) && value >= 0;
 }
@@ -131,17 +103,17 @@ export function isCoherentStreakFreeze(streakFreeze: StreakFreeze): boolean {
     || isNonNegativeSafeInteger(streakFreeze.capacity) === false
     || isNonNegativeSafeInteger(streakFreeze.balanceUnits) === false
     || isNonNegativeSafeInteger(streakFreeze.unitsPerCredit) === false
+    || isNonNegativeSafeInteger(streakFreeze.earnedUnitsPerStreakDay) === false
     || isNonNegativeSafeInteger(streakFreeze.nextCreditProgressUnits) === false
     || isNonNegativeSafeInteger(streakFreeze.nextCreditRequiredUnits) === false
-    || streakFreeze.capacity !== streakFreezePolicy.maxCapacity
-    || streakFreeze.unitsPerCredit !== streakFreezePolicy.unitsPerCredit
-    || streakFreeze.nextCreditRequiredUnits !== streakFreezePolicy.unitsPerCredit
+    || streakFreeze.unitsPerCredit <= 0
+    || streakFreeze.nextCreditRequiredUnits !== streakFreeze.unitsPerCredit
   ) {
     return false;
   }
 
   const maximumBalanceUnits = streakFreeze.capacity * streakFreeze.unitsPerCredit;
-  if (streakFreeze.balanceUnits > maximumBalanceUnits) {
+  if (Number.isSafeInteger(maximumBalanceUnits) === false || streakFreeze.balanceUnits > maximumBalanceUnits) {
     return false;
   }
 
@@ -190,18 +162,34 @@ function getAvailableCredits(balanceUnits: number, policy: StreakFreezePolicy): 
   return Math.min(policy.maxCapacity, Math.floor(balanceUnits / policy.unitsPerCredit));
 }
 
-function createStreakFreeze(balanceUnits: number, policy: StreakFreezePolicy): StreakFreeze {
-  const clampedBalanceUnits = clampBalanceUnits(balanceUnits, policy);
-  const availableCredits = getAvailableCredits(clampedBalanceUnits, policy);
+function createStreakFreezeFromFields(
+  balanceUnits: number,
+  capacity: number,
+  unitsPerCredit: number,
+  earnedUnitsPerStreakDay: number,
+): StreakFreeze {
+  const maximumBalanceUnits = capacity * unitsPerCredit;
+  const clampedBalanceUnits = Math.min(balanceUnits, maximumBalanceUnits);
+  const availableCredits = Math.min(capacity, Math.floor(clampedBalanceUnits / unitsPerCredit));
 
   return {
     availableCredits,
-    capacity: policy.maxCapacity,
+    capacity,
     balanceUnits: clampedBalanceUnits,
-    unitsPerCredit: policy.unitsPerCredit,
-    nextCreditProgressUnits: availableCredits >= policy.maxCapacity ? 0 : clampedBalanceUnits % policy.unitsPerCredit,
-    nextCreditRequiredUnits: policy.unitsPerCredit,
+    unitsPerCredit,
+    earnedUnitsPerStreakDay,
+    nextCreditProgressUnits: availableCredits >= capacity ? 0 : clampedBalanceUnits % unitsPerCredit,
+    nextCreditRequiredUnits: unitsPerCredit,
   };
+}
+
+function createStreakFreeze(balanceUnits: number, policy: StreakFreezePolicy): StreakFreeze {
+  return createStreakFreezeFromFields(
+    clampBalanceUnits(balanceUnits, policy),
+    policy.maxCapacity,
+    policy.unitsPerCredit,
+    policy.earnedUnitsPerStreakDay,
+  );
 }
 
 function createInitialState(policy: StreakFreezePolicy): StreakComputationState {
@@ -354,9 +342,15 @@ export function createDefaultStreakFreeze(): StreakFreeze {
 }
 
 export function addReviewedDayToStreakFreeze(streakFreeze: StreakFreeze): StreakFreeze {
-  return createStreakFreeze(
-    streakFreeze.balanceUnits + streakFreezePolicy.earnedUnitsPerStreakDay,
-    streakFreezePolicy,
+  if (isCoherentStreakFreeze(streakFreeze) === false) {
+    throw new Error("Cannot add reviewed day to incoherent streak freeze object");
+  }
+
+  return createStreakFreezeFromFields(
+    streakFreeze.balanceUnits + streakFreeze.earnedUnitsPerStreakDay,
+    streakFreeze.capacity,
+    streakFreeze.unitsPerCredit,
+    streakFreeze.earnedUnitsPerStreakDay,
   );
 }
 
@@ -368,34 +362,6 @@ export function evaluateProgressStreakFreeze(
   assertLocalDate(today, "today");
   assertSortedActiveReviewLocalDates(sortedActiveReviewLocalDates);
 
-  return evaluateProgressStreakFreezeFromCarryState(
-    sortedActiveReviewLocalDates,
-    today,
-    createInitialState(streakFreezePolicy),
-  );
-}
-
-export function evaluateProgressStreakFreezeFromCarryState(
-  sortedActiveReviewLocalDates: ReadonlyArray<string>,
-  today: string,
-  carryState: StreakFreezeCarryState,
-): StreakFreezeEvaluation {
-  validateStreakFreezePolicy(streakFreezePolicy);
-  validateStreakFreezeCarryState(carryState, streakFreezePolicy);
-  assertLocalDate(today, "today");
-  assertSortedActiveReviewLocalDates(sortedActiveReviewLocalDates);
-
-  if (carryState.lastEvaluatedDate !== null && carryState.lastEvaluatedDate >= today) {
-    throw new Error("streak freeze carry lastEvaluatedDate must be before today");
-  }
-
-  const staleActiveReviewDate = sortedActiveReviewLocalDates.find((reviewDate) => (
-    carryState.lastEvaluatedDate !== null && reviewDate <= carryState.lastEvaluatedDate
-  ));
-  if (staleActiveReviewDate !== undefined) {
-    throw new Error(`active review local date must be after carry lastEvaluatedDate: ${staleActiveReviewDate}`);
-  }
-
   const statesByDate = new Map<string, StreakDayState>();
   const activeReviewLocalDatesThroughToday = sortedActiveReviewLocalDates.filter((reviewDate) => reviewDate <= today);
   const stateAfterReviews = activeReviewLocalDatesThroughToday.reduce<StreakComputationState>(
@@ -405,7 +371,7 @@ export function evaluateProgressStreakFreezeFromCarryState(
       streakFreezePolicy,
       statesByDate,
     ),
-    carryState,
+    createInitialState(streakFreezePolicy),
   );
   const finalState = addTrailingDaysThroughToday(stateAfterReviews, today, streakFreezePolicy, statesByDate);
 

--- a/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
+++ b/apps/web/src/screens/progress/ProgressScreen.render.test.tsx
@@ -178,14 +178,16 @@ function createPartialStreakFreeze(): Readonly<{
   capacity: number;
   balanceUnits: number;
   unitsPerCredit: number;
+  earnedUnitsPerStreakDay: number;
   nextCreditProgressUnits: number;
   nextCreditRequiredUnits: number;
 }> {
   return {
     availableCredits: 1,
-    capacity: 2,
+    capacity: 3,
     balanceUnits: 11,
     unitsPerCredit: 10,
+    earnedUnitsPerStreakDay: 1,
     nextCreditProgressUnits: 1,
     nextCreditRequiredUnits: 10,
   };
@@ -592,6 +594,7 @@ describe("ProgressScreen", () => {
     });
 
     expect(container.textContent).not.toContain("🔥");
+    expect(container.textContent).toContain("1/3");
 
     const summaryBadgeIcon = container.querySelector(".progress-streak-summary .review-progress-badge-icon");
     if (!(summaryBadgeIcon instanceof SVGSVGElement)) {

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -165,6 +165,7 @@ describe("ReviewScreen controls", () => {
         capacity: 2,
         balanceUnits: 10,
         unitsPerCredit: 10,
+        earnedUnitsPerStreakDay: 1,
         nextCreditProgressUnits: 0,
         nextCreditRequiredUnits: 10,
       },

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -145,6 +145,7 @@ export type StreakFreeze = Readonly<{
   capacity: number;
   balanceUnits: number;
   unitsPerCredit: number;
+  earnedUnitsPerStreakDay: number;
   nextCreditProgressUnits: number;
   nextCreditRequiredUnits: number;
 }>;
@@ -370,10 +371,8 @@ export type FriendInvitationAcceptResponse =
 
 export type ProgressRenderedSeriesSummaryContext = Readonly<{
   lowerBoundSummary: ProgressSummary;
-  exactStreakFreeze: StreakFreeze | null;
   activeDates: ReadonlyArray<string>;
   activeDatesMissingFromServerBase: ReadonlyArray<string>;
-  serverBaseReviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> | null;
 }>;
 
 export type ProgressSummarySourceState = Readonly<{


### PR DESCRIPTION
## Summary
- Treat server streak freeze and streak days as authoritative for web serverBase snapshots
- Keep local-only evaluator behavior while limiting serverBase overlays to today
- Parse and render server-provided earnedUnitsPerStreakDay and non-default freeze capacity

## Validation
- npm exec -- vitest run src/appData/progress/source/progressSource.summarySeries.test.tsx src/appData/progress/source/progressSource.cache.test.tsx src/screens/progress/ProgressScreen.render.test.tsx src/screens/review/tests/ReviewScreen.controls.test.tsx src/api/endpoints/endpoints.test.ts src/localDb/progress/progress.test.ts
- npm exec -- tsc -b --pretty false
- git --no-pager diff --check