### PR TITLE
[codex] Suppress guest link timeout telemetry

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -706,12 +706,14 @@ extension FlashcardsStore {
                 installationId: self.cloudSettings?.installationId,
                 errorMessage: Flashcards.errorMessage(error: error)
             )
-            self.captureCloudSyncFailure(
-                error: error,
-                linkedSession: linkedSession,
-                fallbackCloudState: self.cloudSettings?.cloudState,
-                action: "guest_cloud_link_sync"
-            )
+            if isRetryableNetworkTransportFailure(error: error) == false {
+                self.captureCloudSyncFailure(
+                    error: error,
+                    linkedSession: linkedSession,
+                    fallbackCloudState: self.cloudSettings?.cloudState,
+                    action: "guest_cloud_link_sync"
+                )
+            }
             self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
             if trigger.surfacesGlobalErrorMessage {
                 self.globalErrorMessage = Flashcards.errorMessage(error: error)


### PR DESCRIPTION
## Summary
- Suppress Sentry exception capture for retryable network transport failures during iOS guest cloud link final sync.
- Keep non-retryable guest link sync failures reported.

## Impact
- Reduces noisy production telemetry for transient iOS guest upgrade timeouts without changing user-visible sync failure handling or pending upgrade recovery state.

## Validation
- git --no-pager diff --check
- Review of related cloud link and retryable network classification paths

Simulator-backed iOS tests were not run because this repository requires explicit approval for local simulator runs.