### PR TITLE
[codex] Simplify Android freeze overlay

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -228,32 +228,43 @@ private fun JSONObject.toCloudProgressSummary(
 private fun JSONObject.toCloudProgressStreakFreeze(
     fieldPath: String
 ): CloudProgressStreakFreeze {
-    return CloudProgressStreakFreeze(
-        availableCredits = requireNonNegativeProgressInt(
-            value = requireCloudInt("availableCredits", "$fieldPath.availableCredits"),
-            fieldPath = "$fieldPath.availableCredits"
-        ),
-        capacity = requireNonNegativeProgressInt(
-            value = requireCloudInt("capacity", "$fieldPath.capacity"),
-            fieldPath = "$fieldPath.capacity"
-        ),
-        balanceUnits = requireNonNegativeProgressInt(
-            value = requireCloudInt("balanceUnits", "$fieldPath.balanceUnits"),
-            fieldPath = "$fieldPath.balanceUnits"
-        ),
-        unitsPerCredit = requirePositiveProgressInt(
-            value = requireCloudInt("unitsPerCredit", "$fieldPath.unitsPerCredit"),
-            fieldPath = "$fieldPath.unitsPerCredit"
-        ),
-        nextCreditProgressUnits = requireNonNegativeProgressInt(
-            value = requireCloudInt("nextCreditProgressUnits", "$fieldPath.nextCreditProgressUnits"),
-            fieldPath = "$fieldPath.nextCreditProgressUnits"
-        ),
-        nextCreditRequiredUnits = requirePositiveProgressInt(
-            value = requireCloudInt("nextCreditRequiredUnits", "$fieldPath.nextCreditRequiredUnits"),
-            fieldPath = "$fieldPath.nextCreditRequiredUnits"
+    try {
+        return CloudProgressStreakFreeze(
+            availableCredits = requireNonNegativeProgressInt(
+                value = requireCloudInt("availableCredits", "$fieldPath.availableCredits"),
+                fieldPath = "$fieldPath.availableCredits"
+            ),
+            capacity = requireNonNegativeProgressInt(
+                value = requireCloudInt("capacity", "$fieldPath.capacity"),
+                fieldPath = "$fieldPath.capacity"
+            ),
+            balanceUnits = requireNonNegativeProgressInt(
+                value = requireCloudInt("balanceUnits", "$fieldPath.balanceUnits"),
+                fieldPath = "$fieldPath.balanceUnits"
+            ),
+            unitsPerCredit = requirePositiveProgressInt(
+                value = requireCloudInt("unitsPerCredit", "$fieldPath.unitsPerCredit"),
+                fieldPath = "$fieldPath.unitsPerCredit"
+            ),
+            earnedUnitsPerStreakDay = requireNonNegativeProgressInt(
+                value = requireCloudInt("earnedUnitsPerStreakDay", "$fieldPath.earnedUnitsPerStreakDay"),
+                fieldPath = "$fieldPath.earnedUnitsPerStreakDay"
+            ),
+            nextCreditProgressUnits = requireNonNegativeProgressInt(
+                value = requireCloudInt("nextCreditProgressUnits", "$fieldPath.nextCreditProgressUnits"),
+                fieldPath = "$fieldPath.nextCreditProgressUnits"
+            ),
+            nextCreditRequiredUnits = requirePositiveProgressInt(
+                value = requireCloudInt("nextCreditRequiredUnits", "$fieldPath.nextCreditRequiredUnits"),
+                fieldPath = "$fieldPath.nextCreditRequiredUnits"
+            )
         )
-    )
+    } catch (error: IllegalArgumentException) {
+        throw CloudContractMismatchException(
+            "$fieldPath is not a coherent streak freeze payload: ${error.message}",
+            error
+        )
+    }
 }
 
 private fun JSONObject.toCloudProgressStreakDays(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -60,7 +60,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 21,
+    version = 22,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
@@ -21,6 +21,7 @@ data class ProgressSummaryCacheEntity(
     val streakFreezeCapacity: Int,
     val streakFreezeBalanceUnits: Int,
     val streakFreezeUnitsPerCredit: Int,
+    val streakFreezeEarnedUnitsPerStreakDay: Int,
     val streakFreezeNextCreditProgressUnits: Int,
     val streakFreezeNextCreditRequiredUnits: Int,
     val updatedAtMillis: Long

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -27,7 +27,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration17To18,
         migration18To19,
         migration19To20,
-        migration20To21
+        migration20To21,
+        migration21To22
     )
 }
 
@@ -797,6 +798,18 @@ val migration20To21: Migration = object : Migration(20, 21) {
             """
             ALTER TABLE progress_series_cache
             ADD COLUMN streakDaysJson TEXT NOT NULL DEFAULT '[]'
+            """.trimIndent()
+        )
+    }
+}
+
+val migration21To22: Migration = object : Migration(21, 22) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("DELETE FROM progress_summary_cache")
+        db.execSQL(
+            """
+            ALTER TABLE progress_summary_cache
+            ADD COLUMN streakFreezeEarnedUnitsPerStreakDay INTEGER NOT NULL DEFAULT 1
             """.trimIndent()
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressModels.kt
@@ -65,9 +65,56 @@ data class CloudProgressStreakFreeze(
     val capacity: Int,
     val balanceUnits: Int,
     val unitsPerCredit: Int,
+    val earnedUnitsPerStreakDay: Int,
     val nextCreditProgressUnits: Int,
     val nextCreditRequiredUnits: Int
-)
+) {
+    init {
+        require(availableCredits >= 0) {
+            "Progress streak freeze availableCredits must not be negative."
+        }
+        require(capacity >= 0) {
+            "Progress streak freeze capacity must not be negative."
+        }
+        require(balanceUnits >= 0) {
+            "Progress streak freeze balanceUnits must not be negative."
+        }
+        require(unitsPerCredit > 0) {
+            "Progress streak freeze unitsPerCredit must be positive."
+        }
+        require(earnedUnitsPerStreakDay >= 0) {
+            "Progress streak freeze earnedUnitsPerStreakDay must not be negative."
+        }
+        require(nextCreditProgressUnits >= 0) {
+            "Progress streak freeze nextCreditProgressUnits must not be negative."
+        }
+        require(nextCreditRequiredUnits > 0) {
+            "Progress streak freeze nextCreditRequiredUnits must be positive."
+        }
+
+        val capacityBalanceUnits: Long = capacity.toLong() * unitsPerCredit.toLong()
+        require(balanceUnits.toLong() <= capacityBalanceUnits) {
+            "Progress streak freeze balanceUnits must not exceed capacity * unitsPerCredit."
+        }
+
+        val expectedAvailableCredits = minOf(capacity, balanceUnits / unitsPerCredit)
+        require(availableCredits == expectedAvailableCredits) {
+            "Progress streak freeze availableCredits must match balanceUnits and unitsPerCredit."
+        }
+
+        val expectedNextCreditProgressUnits = if (availableCredits >= capacity) {
+            0
+        } else {
+            balanceUnits % unitsPerCredit
+        }
+        require(nextCreditProgressUnits == expectedNextCreditProgressUnits) {
+            "Progress streak freeze nextCreditProgressUnits must match balanceUnits and capacity."
+        }
+        require(nextCreditRequiredUnits == unitsPerCredit) {
+            "Progress streak freeze nextCreditRequiredUnits must equal unitsPerCredit."
+        }
+    }
+}
 
 data class ProgressReviewHistoryWatermark(
     val workspaceId: String,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
@@ -55,6 +55,7 @@ internal fun CloudProgressSummary.toCacheEntity(
         streakFreezeCapacity = streakFreeze.capacity,
         streakFreezeBalanceUnits = streakFreeze.balanceUnits,
         streakFreezeUnitsPerCredit = streakFreeze.unitsPerCredit,
+        streakFreezeEarnedUnitsPerStreakDay = streakFreeze.earnedUnitsPerStreakDay,
         streakFreezeNextCreditProgressUnits = streakFreeze.nextCreditProgressUnits,
         streakFreezeNextCreditRequiredUnits = streakFreeze.nextCreditRequiredUnits,
         updatedAtMillis = updatedAtMillis
@@ -379,6 +380,10 @@ internal fun ProgressSummaryCacheEntity.toCloudProgressSummaryOrNull(): CloudPro
                 unitsPerCredit = requirePositiveProgressCacheInt(
                     value = streakFreezeUnitsPerCredit,
                     fieldPath = "progressSummaryCache.streakFreezeUnitsPerCredit"
+                ),
+                earnedUnitsPerStreakDay = requireNonNegativeProgressCacheInt(
+                    value = streakFreezeEarnedUnitsPerStreakDay,
+                    fieldPath = "progressSummaryCache.streakFreezeEarnedUnitsPerStreakDay"
                 ),
                 nextCreditProgressUnits = requireNonNegativeProgressCacheInt(
                     value = streakFreezeNextCreditProgressUnits,

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotDates.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotDates.kt
@@ -143,49 +143,6 @@ internal fun createInitialProgressStreakFreeze(): CloudProgressStreakFreeze {
     )
 }
 
-internal fun addReviewedDayProgressStreakFreezeCredit(
-    streakFreeze: CloudProgressStreakFreeze
-): CloudProgressStreakFreeze {
-    return addProgressStreakFreezeBalanceUnits(
-        streakFreeze = streakFreeze,
-        addedBalanceUnits = progressStreakFreezePolicy.earnedUnitsPerStreakDay
-    )
-}
-
-internal fun refundSpentProgressStreakFreezeCredit(
-    streakFreeze: CloudProgressStreakFreeze
-): CloudProgressStreakFreeze {
-    return addProgressStreakFreezeBalanceUnits(
-        streakFreeze = streakFreeze,
-        addedBalanceUnits = streakFreeze.unitsPerCredit
-    )
-}
-
-private fun addProgressStreakFreezeBalanceUnits(
-    streakFreeze: CloudProgressStreakFreeze,
-    addedBalanceUnits: Int
-): CloudProgressStreakFreeze {
-    val balanceUnits = minOf(
-        streakFreeze.balanceUnits + addedBalanceUnits,
-        streakFreeze.capacity * streakFreeze.unitsPerCredit
-    )
-    val availableCredits = minOf(
-        streakFreeze.capacity,
-        balanceUnits / streakFreeze.unitsPerCredit
-    )
-
-    return streakFreeze.copy(
-        availableCredits = availableCredits,
-        balanceUnits = balanceUnits,
-        nextCreditProgressUnits = if (availableCredits >= streakFreeze.capacity) {
-            0
-        } else {
-            balanceUnits % streakFreeze.unitsPerCredit
-        },
-        nextCreditRequiredUnits = streakFreeze.unitsPerCredit
-    )
-}
-
 private fun validateProgressStreakFreezePolicy(
     policy: ProgressStreakFreezePolicy
 ) {
@@ -406,6 +363,7 @@ private fun createProgressStreakFreeze(
         capacity = policy.maxCapacity,
         balanceUnits = clampedBalanceUnits,
         unitsPerCredit = policy.unitsPerCredit,
+        earnedUnitsPerStreakDay = policy.earnedUnitsPerStreakDay,
         nextCreditProgressUnits = if (availableCredits >= policy.maxCapacity) {
             0
         } else {
@@ -456,27 +414,4 @@ private fun clampBalanceUnits(
     policy: ProgressStreakFreezePolicy
 ): Int {
     return minOf(balanceUnits, policy.maxCapacity * policy.unitsPerCredit)
-}
-
-internal fun isLocalDateAfter(
-    first: String?,
-    second: String?
-): Boolean {
-    return when {
-        first == null -> false
-        second == null -> true
-        else -> parseLocalDate(rawDate = first).isAfter(parseLocalDate(rawDate = second))
-    }
-}
-
-internal fun maxLocalDate(
-    first: String?,
-    second: String?
-): String? {
-    return when {
-        first == null -> second
-        second == null -> first
-        parseLocalDate(rawDate = first).isAfter(parseLocalDate(rawDate = second)) -> first
-        else -> second
-    }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotMerging.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSnapshotMerging.kt
@@ -5,9 +5,10 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
-import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
@@ -17,10 +18,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScop
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 
 internal data class ProgressRenderedSeriesSummaryContext(
-    val lowerBoundSummary: CloudProgressSummary,
-    val activeDates: Set<String>,
-    val activeDatesMissingFromServerBase: Set<String>,
-    val serverBaseReviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>?
+    val activeDates: Set<String>
 )
 
 internal fun createProgressSummarySnapshot(
@@ -35,7 +33,6 @@ internal fun createProgressSummarySnapshot(
         serverBase == null -> localFallback
         else -> mergeProgressSummary(
             base = serverBase,
-            localFallback = localFallback,
             localFallbackActiveDates = localFallbackActiveDates,
             renderedSeriesContext = renderedSeriesContext,
             referenceLocalDate = scopeKey.referenceLocalDate
@@ -161,72 +158,35 @@ internal fun createProgressReviewScheduleSnapshot(
 
 internal fun mergeProgressSummary(
     base: CloudProgressSummary,
-    localFallback: CloudProgressSummary,
     localFallbackActiveDates: Set<String>,
     renderedSeriesContext: ProgressRenderedSeriesSummaryContext?,
     referenceLocalDate: String
 ): CloudProgressSummary {
-    val renderedSeriesLowerBound = renderedSeriesContext?.lowerBoundSummary
-    val serverAndSeriesShareReviewHistoryBase = progressServerAndSeriesShareReviewHistoryBase(
-        serverBaseReviewHistoryWatermarks = base.reviewHistoryWatermarks,
-        renderedSeriesContext = renderedSeriesContext
-    )
-    val serverActiveReviewDaysWithRenderedDelta = base.activeReviewDays +
-        progressActiveReviewDayDelta(
-            activeReviewDayDeltaCandidates = progressActiveReviewDayDeltaCandidates(
-                renderedSeriesContext = renderedSeriesContext,
-                localFallbackActiveDates = localFallbackActiveDates,
-                serverBase = base,
-                serverAndSeriesShareReviewHistoryBase = serverAndSeriesShareReviewHistoryBase
-            ),
-            serverBase = base,
-            serverAndSeriesShareReviewHistoryBase = serverAndSeriesShareReviewHistoryBase,
-            referenceLocalDate = referenceLocalDate
-        )
-    val serverCurrentStreakDaysWithRenderedDelta = progressCurrentStreakDaysWithRenderedDelta(
+    val hasReferenceDateReviewOverlay = progressHasReferenceDateReviewOverlay(
         serverBase = base,
         localFallbackActiveDates = localFallbackActiveDates,
         renderedSeriesActiveDates = renderedSeriesContext?.activeDates,
         referenceLocalDate = referenceLocalDate
     )
-    val renderedCurrentStreakDays = maxOf(
-        serverCurrentStreakDaysWithRenderedDelta,
-        localFallback.currentStreakDays,
-        renderedSeriesLowerBound?.currentStreakDays ?: 0
-    )
+    val referenceDateReviewDelta = if (hasReferenceDateReviewOverlay) 1 else 0
+    val renderedCurrentStreakDays = base.currentStreakDays + referenceDateReviewDelta
 
     return CloudProgressSummary(
         currentStreakDays = renderedCurrentStreakDays,
         longestStreakDays = maxOf(
             base.longestStreakDays,
-            localFallback.longestStreakDays,
-            renderedSeriesLowerBound?.longestStreakDays ?: 0,
             renderedCurrentStreakDays
         ),
-        hasReviewedToday = base.hasReviewedToday ||
-            localFallback.hasReviewedToday ||
-            (renderedSeriesLowerBound?.hasReviewedToday == true),
-        lastReviewedOn = maxLocalDate(
-            first = maxLocalDate(
-                first = base.lastReviewedOn,
-                second = localFallback.lastReviewedOn
-            ),
-            second = renderedSeriesLowerBound?.lastReviewedOn
-        ),
-        activeReviewDays = maxOf(
-            serverActiveReviewDaysWithRenderedDelta,
-            localFallback.activeReviewDays,
-            renderedSeriesLowerBound?.activeReviewDays ?: 0
-        ),
-        streakFreeze = selectProgressStreakFreeze(
+        hasReviewedToday = base.hasReviewedToday || hasReferenceDateReviewOverlay,
+        lastReviewedOn = if (hasReferenceDateReviewOverlay) {
+            referenceLocalDate
+        } else {
+            base.lastReviewedOn
+        },
+        activeReviewDays = base.activeReviewDays + referenceDateReviewDelta,
+        streakFreeze = progressStreakFreezeWithReferenceDateOverlay(
             base = base,
-            localFallback = localFallback,
-            localFallbackActiveDates = localFallbackActiveDates,
-            renderedSeriesLowerBound = renderedSeriesLowerBound,
-            renderedSeriesActiveDates = renderedSeriesContext?.activeDates,
-            renderedCurrentStreakDays = renderedCurrentStreakDays,
-            serverCurrentStreakDaysWithRenderedDelta = serverCurrentStreakDaysWithRenderedDelta,
-            referenceLocalDate = referenceLocalDate
+            hasReferenceDateReviewOverlay = hasReferenceDateReviewOverlay
         ),
         reviewHistoryWatermarks = base.reviewHistoryWatermarks
     )
@@ -260,11 +220,9 @@ internal fun mergeProgressSeries(
     val visibleMergedActiveDateSet = mergedDailyReviews.filter { point ->
         point.reviewCount > 0
     }.map(CloudDailyReviewPoint::date).toSet()
-    val mergedStreakDays = createProgressStreakDaysForRange(
-        activeReviewDateSet = activeReviewDateSet + visibleMergedActiveDateSet,
-        from = base.from,
-        to = base.to,
-        today = parseLocalDate(rawDate = base.to)
+    val mergedStreakDays = patchProgressSeriesTodayStreakDay(
+        base = base,
+        mergedActiveDateSet = activeReviewDateSet + visibleMergedActiveDateSet
     )
     return CloudProgressSeries(
         timeZone = base.timeZone,
@@ -279,126 +237,22 @@ internal fun mergeProgressSeries(
 }
 
 internal fun createProgressRenderedSeriesSummaryContext(
-    serverBase: CloudProgressSeries?,
-    scopeKey: ProgressSeriesScopeKey,
     renderedSeries: CloudProgressSeries
 ): ProgressRenderedSeriesSummaryContext {
-    val activeDates = progressActiveDatesFromSeries(series = renderedSeries)
-    val activeDatesMissingFromServerBase: Set<String>
-    val serverBaseReviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>?
-    if (serverBase != null && isProgressSeriesInScope(series = serverBase, scopeKey = scopeKey)) {
-        activeDatesMissingFromServerBase = progressActiveDatesMissingFromServerBase(
-            serverBase = serverBase,
-            renderedSeries = renderedSeries
-        )
-        serverBaseReviewHistoryWatermarks = serverBase.reviewHistoryWatermarks
-    } else {
-        activeDatesMissingFromServerBase = emptySet()
-        serverBaseReviewHistoryWatermarks = null
-    }
-
     return ProgressRenderedSeriesSummaryContext(
-        lowerBoundSummary = createProgressSummaryLowerBoundFromSeries(
-            series = renderedSeries,
-            activeDates = activeDates
-        ),
-        activeDates = activeDates,
-        activeDatesMissingFromServerBase = activeDatesMissingFromServerBase,
-        serverBaseReviewHistoryWatermarks = serverBaseReviewHistoryWatermarks
+        activeDates = progressActiveDatesFromSeries(series = renderedSeries)
     )
 }
 
-private fun createProgressSummaryLowerBoundFromSeries(
-    series: CloudProgressSeries,
-    activeDates: Set<String>
-): CloudProgressSummary {
-    val today = parseLocalDate(rawDate = series.to)
-    val sortedActiveDates = activeDates.sorted()
-    val streakEvaluation = evaluateProgressStreakFreeze(
-        sortedActiveReviewLocalDates = sortedActiveDates,
-        today = today
-    )
-
-    return CloudProgressSummary(
-        currentStreakDays = streakEvaluation.currentStreakDays,
-        longestStreakDays = streakEvaluation.longestStreakDays,
-        hasReviewedToday = activeDates.contains(series.to),
-        lastReviewedOn = sortedActiveDates.lastOrNull(),
-        activeReviewDays = activeDates.size,
-        streakFreeze = streakEvaluation.streakFreeze,
-        reviewHistoryWatermarks = emptyList()
-    )
-}
-
-private fun selectProgressStreakFreeze(
+private fun progressStreakFreezeWithReferenceDateOverlay(
     base: CloudProgressSummary,
-    localFallback: CloudProgressSummary,
-    localFallbackActiveDates: Set<String>,
-    renderedSeriesLowerBound: CloudProgressSummary?,
-    renderedSeriesActiveDates: Set<String>?,
-    renderedCurrentStreakDays: Int,
-    serverCurrentStreakDaysWithRenderedDelta: Int,
-    referenceLocalDate: String
+    hasReferenceDateReviewOverlay: Boolean
 ): CloudProgressStreakFreeze {
-    val baseWithRenderedOverlay = progressStreakFreezeWithRenderedOverlay(
-        base = base,
-        localFallbackActiveDates = localFallbackActiveDates,
-        renderedSeriesActiveDates = renderedSeriesActiveDates,
-        referenceLocalDate = referenceLocalDate
-    )
-    if (serverCurrentStreakDaysWithRenderedDelta == renderedCurrentStreakDays) {
-        return baseWithRenderedOverlay
-    }
-
-    val matchingCandidate = listOfNotNull(
-        renderedSeriesLowerBound,
-        localFallback
-    ).firstOrNull { candidate ->
-        candidate.currentStreakDays == renderedCurrentStreakDays
-    }
-    if (matchingCandidate != null) {
-        return matchingCandidate.streakFreeze
-    }
-
-    return baseWithRenderedOverlay
-}
-
-private fun progressStreakFreezeWithRenderedOverlay(
-    base: CloudProgressSummary,
-    localFallbackActiveDates: Set<String>,
-    renderedSeriesActiveDates: Set<String>?,
-    referenceLocalDate: String
-): CloudProgressStreakFreeze {
-    if (base.hasReviewedToday || base.currentStreakDays <= 0) {
+    if (hasReferenceDateReviewOverlay.not()) {
         return base.streakFreeze
     }
 
-    val activeDates = localFallbackActiveDates + (renderedSeriesActiveDates ?: emptySet())
-    val completedOverlayDates = progressCompletedOverlayDatesAfterServerLastReview(
-        activeDates = activeDates,
-        base = base,
-        referenceLocalDate = referenceLocalDate
-    )
-    val freezeAfterCompletedOverlay = completedOverlayDates.fold(base.streakFreeze) { streakFreeze, _ ->
-        refundSpentProgressStreakFreezeCredit(streakFreeze = streakFreeze)
-    }
-    if (activeDates.contains(referenceLocalDate).not()) {
-        return freezeAfterCompletedOverlay
-    }
-
-    return addReviewedDayProgressStreakFreezeCredit(streakFreeze = freezeAfterCompletedOverlay)
-}
-
-private fun progressCompletedOverlayDatesAfterServerLastReview(
-    activeDates: Set<String>,
-    base: CloudProgressSummary,
-    referenceLocalDate: String
-): List<String> {
-    val lastReviewedOn = base.lastReviewedOn ?: return emptyList()
-    return activeDates.filter { localDate ->
-        isLocalDateAfter(first = localDate, second = lastReviewedOn) &&
-            isLocalDateAfter(first = referenceLocalDate, second = localDate)
-    }.sorted()
+    return addProgressStreakFreezeEarnedUnits(streakFreeze = base.streakFreeze)
 }
 
 private fun progressActiveDatesFromSeries(
@@ -410,146 +264,64 @@ private fun progressActiveDatesFromSeries(
     }.keys.toSet()
 }
 
-private fun progressActiveDatesMissingFromServerBase(
-    serverBase: CloudProgressSeries,
-    renderedSeries: CloudProgressSeries
-): Set<String> {
-    validateProgressSeriesPairInputs(
-        base = serverBase,
-        renderedSeries = renderedSeries
-    )
-
-    val serverCountsByDate = buildProgressSeriesReviewCountsByDate(series = serverBase)
-    val renderedCountsByDate = buildProgressSeriesReviewCountsByDate(series = renderedSeries)
-    return createInclusiveLocalDateRange(
-        from = serverBase.from,
-        to = serverBase.to
-    ).filter { date ->
-        (renderedCountsByDate[date] ?: 0) > 0 &&
-            (serverCountsByDate[date] ?: 0) == 0
-    }.toSet()
-}
-
-private fun validateProgressSeriesPairInputs(
-    base: CloudProgressSeries,
-    renderedSeries: CloudProgressSeries
-) {
-    validateProgressSeriesMergeInput(
-        base = base,
-        candidate = renderedSeries,
-        candidateName = "renderedSeries"
-    )
-}
-
-private fun isProgressSeriesInScope(
-    series: CloudProgressSeries,
-    scopeKey: ProgressSeriesScopeKey
-): Boolean {
-    return series.timeZone == scopeKey.timeZone &&
-        series.from == scopeKey.from &&
-        series.to == scopeKey.to
-}
-
-private fun progressServerAndSeriesShareReviewHistoryBase(
-    serverBaseReviewHistoryWatermarks: List<ProgressReviewHistoryWatermark>,
-    renderedSeriesContext: ProgressRenderedSeriesSummaryContext?
-): Boolean {
-    val seriesBaseReviewHistoryWatermarks = renderedSeriesContext?.serverBaseReviewHistoryWatermarks ?: return false
-    if (serverBaseReviewHistoryWatermarks.isEmpty() || seriesBaseReviewHistoryWatermarks.isEmpty()) {
-        return false
-    }
-    return seriesBaseReviewHistoryWatermarks == serverBaseReviewHistoryWatermarks
-}
-
-private fun progressActiveReviewDayDeltaCandidates(
-    renderedSeriesContext: ProgressRenderedSeriesSummaryContext?,
-    localFallbackActiveDates: Set<String>,
-    serverBase: CloudProgressSummary,
-    serverAndSeriesShareReviewHistoryBase: Boolean
-): Set<String> {
-    val renderedSeriesCandidates: Set<String> = if (renderedSeriesContext != null) {
-        if (serverAndSeriesShareReviewHistoryBase) {
-            renderedSeriesContext.activeDatesMissingFromServerBase
-        } else {
-            renderedSeriesContext.activeDates
-        }
-    } else {
-        emptySet()
-    }
-
-    return renderedSeriesCandidates + progressLocalFallbackActiveReviewDayDeltaCandidates(
-        localFallbackActiveDates = localFallbackActiveDates,
-        serverBase = serverBase
-    )
-}
-
-private fun progressLocalFallbackActiveReviewDayDeltaCandidates(
-    localFallbackActiveDates: Set<String>,
-    serverBase: CloudProgressSummary
-): Set<String> {
-    val lastReviewedOn = serverBase.lastReviewedOn ?: return localFallbackActiveDates
-    return localFallbackActiveDates.filter { localDate ->
-        isLocalDateAfter(
-            first = localDate,
-            second = lastReviewedOn
-        )
-    }.toSet()
-}
-
-private fun progressActiveReviewDayDelta(
-    activeReviewDayDeltaCandidates: Set<String>,
-    serverBase: CloudProgressSummary,
-    serverAndSeriesShareReviewHistoryBase: Boolean,
-    referenceLocalDate: String
-): Int {
-    return activeReviewDayDeltaCandidates.count { localDate ->
-        progressShouldApplyActiveReviewDayDelta(
-            localDate = localDate,
-            serverBase = serverBase,
-            serverAndSeriesShareReviewHistoryBase = serverAndSeriesShareReviewHistoryBase,
-            referenceLocalDate = referenceLocalDate
-        )
-    }
-}
-
-private fun progressShouldApplyActiveReviewDayDelta(
-    localDate: String,
-    serverBase: CloudProgressSummary,
-    serverAndSeriesShareReviewHistoryBase: Boolean,
-    referenceLocalDate: String
-): Boolean {
-    if (localDate == referenceLocalDate && serverBase.hasReviewedToday) {
-        return false
-    }
-    if (serverAndSeriesShareReviewHistoryBase) {
-        return true
-    }
-
-    val lastReviewedOn = serverBase.lastReviewedOn ?: return true
-    return isLocalDateAfter(
-        first = localDate,
-        second = lastReviewedOn
-    )
-}
-
-private fun progressCurrentStreakDaysWithRenderedDelta(
+private fun progressHasReferenceDateReviewOverlay(
     serverBase: CloudProgressSummary,
     localFallbackActiveDates: Set<String>,
     renderedSeriesActiveDates: Set<String>?,
     referenceLocalDate: String
-): Int {
+): Boolean {
     if (serverBase.hasReviewedToday) {
-        return serverBase.currentStreakDays
-    }
-    if (serverBase.currentStreakDays <= 0) {
-        return serverBase.currentStreakDays
-    }
-    val activeDates: Set<String> = localFallbackActiveDates + (renderedSeriesActiveDates ?: emptySet())
-    if (activeDates.contains(referenceLocalDate).not()) {
-        return serverBase.currentStreakDays
+        return false
     }
 
-    return serverBase.currentStreakDays + 1
+    val activeDates: Set<String> = localFallbackActiveDates + (renderedSeriesActiveDates ?: emptySet())
+    return activeDates.contains(referenceLocalDate)
+}
+
+private fun addProgressStreakFreezeEarnedUnits(
+    streakFreeze: CloudProgressStreakFreeze
+): CloudProgressStreakFreeze {
+    val balanceUnits = minOf(
+        streakFreeze.balanceUnits.toLong() + streakFreeze.earnedUnitsPerStreakDay.toLong(),
+        streakFreeze.capacity.toLong() * streakFreeze.unitsPerCredit.toLong(),
+        Int.MAX_VALUE.toLong()
+    ).toInt()
+    val availableCredits = minOf(
+        streakFreeze.capacity,
+        balanceUnits / streakFreeze.unitsPerCredit
+    )
+
+    return streakFreeze.copy(
+        availableCredits = availableCredits,
+        balanceUnits = balanceUnits,
+        nextCreditProgressUnits = if (availableCredits >= streakFreeze.capacity) {
+            0
+        } else {
+            balanceUnits % streakFreeze.unitsPerCredit
+        },
+        nextCreditRequiredUnits = streakFreeze.unitsPerCredit
+    )
+}
+
+private fun patchProgressSeriesTodayStreakDay(
+    base: CloudProgressSeries,
+    mergedActiveDateSet: Set<String>
+): List<CloudProgressStreakDay> {
+    if (mergedActiveDateSet.contains(base.to).not()) {
+        return base.streakDays
+    }
+    val serverTodayReviewCount = buildProgressSeriesReviewCountsByDate(series = base)[base.to] ?: 0
+    if (serverTodayReviewCount > 0) {
+        return base.streakDays
+    }
+
+    return base.streakDays.map { day ->
+        if (day.date == base.to) {
+            day.copy(state = CloudProgressStreakDayState.REVIEWED)
+        } else {
+            day
+        }
+    }
 }
 
 private fun validateProgressSeriesMergeInputs(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
@@ -160,8 +160,6 @@ internal fun createProgressSummaryStoreState(
             cloudState = inputs.cloudState
         ).renderedSeries
         createProgressRenderedSeriesSummaryContext(
-            serverBase = inputs.seriesServerBase,
-            scopeKey = inputs.seriesScopeKey,
             renderedSeries = renderedSeries
         )
     } else {

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -109,10 +109,11 @@ class CloudRemoteServiceTest {
                 "activeReviewDays": 21,
                 "streakFreeze": {
                   "availableCredits": 2,
-                  "capacity": 2,
-                  "balanceUnits": 20,
+                  "capacity": 3,
+                  "balanceUnits": 25,
                   "unitsPerCredit": 10,
-                  "nextCreditProgressUnits": 0,
+                  "earnedUnitsPerStreakDay": 2,
+                  "nextCreditProgressUnits": 5,
                   "nextCreditRequiredUnits": 10
                 }
               },
@@ -135,6 +136,9 @@ class CloudRemoteServiceTest {
         assertEquals("2026-04-18", summary.lastReviewedOn)
         assertEquals(21, summary.activeReviewDays)
         assertEquals(2, summary.streakFreeze.availableCredits)
+        assertEquals(3, summary.streakFreeze.capacity)
+        assertEquals(2, summary.streakFreeze.earnedUnitsPerStreakDay)
+        assertEquals(5, summary.streakFreeze.nextCreditProgressUnits)
         assertEquals(42L, summary.reviewHistoryWatermarks.single().reviewSequenceId)
     }
 
@@ -155,6 +159,7 @@ class CloudRemoteServiceTest {
                   "capacity": 2,
                   "balanceUnits": 20,
                   "unitsPerCredit": 10,
+                  "earnedUnitsPerStreakDay": 1,
                   "nextCreditProgressUnits": 0,
                   "nextCreditRequiredUnits": 10
                 }
@@ -170,6 +175,44 @@ class CloudRemoteServiceTest {
         )
 
         assertTrue(summary.reviewHistoryWatermarks.isEmpty())
+    }
+
+    @Test
+    fun parseCloudProgressSummaryResponseRejectsIncoherentStreakFreezePayload() {
+        val response = JSONObject(
+            """
+            {
+              "timeZone": "Europe/Madrid",
+              "summary": {
+                "currentStreakDays": 8,
+                "longestStreakDays": 10,
+                "hasReviewedToday": true,
+                "lastReviewedOn": "2026-04-18",
+                "activeReviewDays": 21,
+                "streakFreeze": {
+                  "availableCredits": 1,
+                  "capacity": 3,
+                  "balanceUnits": 25,
+                  "unitsPerCredit": 10,
+                  "earnedUnitsPerStreakDay": 2,
+                  "nextCreditProgressUnits": 5,
+                  "nextCreditRequiredUnits": 10
+                }
+              },
+              "generatedAt": "2026-04-18T12:00:00Z"
+            }
+            """.trimIndent()
+        )
+
+        val error = assertThrows(CloudContractMismatchException::class.java) {
+            parseCloudProgressSummaryResponse(
+                response = response,
+                fieldPath = "progressSummary"
+            )
+        }
+
+        assertTrue(error.message.orEmpty().contains("progressSummary.summary.streakFreeze"))
+        assertTrue(error.message.orEmpty().contains("availableCredits"))
     }
 
     @Test(expected = CloudContractMismatchException::class)
@@ -428,6 +471,7 @@ class CloudRemoteServiceTest {
                   "capacity": 2,
                   "balanceUnits": 20,
                   "unitsPerCredit": 10,
+                  "earnedUnitsPerStreakDay": 1,
                   "nextCreditProgressUnits": 0,
                   "nextCreditRequiredUnits": 10
                 }
@@ -467,6 +511,7 @@ class CloudRemoteServiceTest {
                   "capacity": 2,
                   "balanceUnits": 20,
                   "unitsPerCredit": 10,
+                  "earnedUnitsPerStreakDay": 1,
                   "nextCreditProgressUnits": 0,
                   "nextCreditRequiredUnits": 10
                 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
@@ -7,6 +7,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
@@ -46,6 +47,7 @@ class ProgressCacheValidationTest {
             streakFreezeCapacity = 2,
             streakFreezeBalanceUnits = 20,
             streakFreezeUnitsPerCredit = 10,
+            streakFreezeEarnedUnitsPerStreakDay = 1,
             streakFreezeNextCreditProgressUnits = 0,
             streakFreezeNextCreditRequiredUnits = 10,
             updatedAtMillis = 1L
@@ -87,6 +89,42 @@ class ProgressCacheValidationTest {
         )
 
         assertEquals(null, cacheEntity.toCloudProgressReviewScheduleOrNull())
+    }
+
+    @Test
+    fun progressSummaryCachePreservesServerStreakFreezePolicy(): Unit {
+        val scopeKey = createProgressSummaryScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val summary = CloudProgressSummary(
+            currentStreakDays = 4,
+            longestStreakDays = 4,
+            hasReviewedToday = false,
+            lastReviewedOn = "2026-04-17",
+            activeReviewDays = 9,
+            streakFreeze = CloudProgressStreakFreeze(
+                availableCredits = 2,
+                capacity = 3,
+                balanceUnits = 25,
+                unitsPerCredit = 10,
+                earnedUnitsPerStreakDay = 2,
+                nextCreditProgressUnits = 5,
+                nextCreditRequiredUnits = 10
+            ),
+            reviewHistoryWatermarks = emptyList()
+        )
+
+        val restoredSummary = summary.toCacheEntity(
+            scopeKey = scopeKey,
+            updatedAtMillis = 1L
+        ).toCloudProgressSummaryOrNull()
+
+        assertEquals(3, restoredSummary?.streakFreeze?.capacity)
+        assertEquals(25, restoredSummary?.streakFreeze?.balanceUnits)
+        assertEquals(2, restoredSummary?.streakFreeze?.earnedUnitsPerStreakDay)
+        assertEquals(5, restoredSummary?.streakFreeze?.nextCreditProgressUnits)
     }
 
     @Test

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSeriesSnapshotTest.kt
@@ -3,6 +3,7 @@ package com.flashcardsopensourceapp.data.local.repository.progress.snapshots
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
@@ -154,12 +155,13 @@ class ProgressSeriesSnapshotTest {
         assertEquals(1, overlay.dailyReviews.last().goodCount)
         assertEquals(3, snapshot.renderedSeries.dailyReviews.first().reviewCount)
         assertEquals(3, snapshot.renderedSeries.dailyReviews.last().reviewCount)
+        assertEquals(CloudProgressStreakDayState.REVIEWED, snapshot.renderedSeries.streakDays.last().state)
         assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
         assertEquals(true, snapshot.isApproximate)
     }
 
     @Test
-    fun mergedStreakDaysUseFullActiveHistoryBeforeVisibleRange() {
+    fun serverBaseSeriesPatchesOnlyTodayStreakDayForLocalOverlay() {
         val scopeKey = ProgressSeriesScopeKey(
             scopeId = "local:installation-1",
             timeZone = "Europe/Madrid",
@@ -202,13 +204,13 @@ class ProgressSeriesSnapshotTest {
         val statesByDate = snapshot.renderedSeries.streakDays.associate { day ->
             day.date to day.state
         }
-        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-16"])
-        assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-17"])
+        assertEquals(CloudProgressStreakDayState.MISSED, statesByDate["2026-04-16"])
+        assertEquals(CloudProgressStreakDayState.MISSED, statesByDate["2026-04-17"])
         assertEquals(CloudProgressStreakDayState.REVIEWED, statesByDate["2026-04-18"])
     }
 
     @Test
-    fun mergedStreakDaysUsePreRangeHistoryWhenVisibleCountsAreUnchanged() {
+    fun serverBaseSeriesIgnoresPreRangeHistoryWhenVisibleCountsAreUnchanged() {
         val scopeKey = ProgressSeriesScopeKey(
             scopeId = "local:installation-1",
             timeZone = "Europe/Madrid",
@@ -248,6 +250,80 @@ class ProgressSeriesSnapshotTest {
         val statesByDate = snapshot.renderedSeries.streakDays.associate { day ->
             day.date to day.state
         }
+        assertEquals(CloudProgressStreakDayState.MISSED, statesByDate["2026-04-16"])
+        assertEquals(CloudProgressStreakDayState.MISSED, statesByDate["2026-04-17"])
+        assertEquals(CloudProgressStreakDayState.PENDING, statesByDate["2026-04-18"])
+        assertEquals(ProgressSnapshotSource.SERVER_BASE, snapshot.source)
+        assertEquals(false, snapshot.isApproximate)
+    }
+
+    @Test
+    fun olderLocalActiveDateDoesNotRewriteHistoricalServerStreakDays() {
+        val scopeKey = ProgressSeriesScopeKey(
+            scopeId = "local:installation-1",
+            timeZone = "Europe/Madrid",
+            from = "2026-04-16",
+            to = "2026-04-18"
+        )
+        val serverBase = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(date = "2026-04-16", reviewCount = 0),
+                createPoint(date = "2026-04-17", reviewCount = 0),
+                createPoint(date = "2026-04-18", reviewCount = 0)
+            ),
+            generatedAt = "2026-04-18T12:00:00Z"
+        ).copy(
+            streakDays = listOf(
+                CloudProgressStreakDay(
+                    date = "2026-04-16",
+                    state = CloudProgressStreakDayState.FROZEN
+                ),
+                CloudProgressStreakDay(
+                    date = "2026-04-17",
+                    state = CloudProgressStreakDayState.FROZEN
+                ),
+                CloudProgressStreakDay(
+                    date = "2026-04-18",
+                    state = CloudProgressStreakDayState.PENDING
+                )
+            )
+        )
+        val localFallback = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(date = "2026-04-16", reviewCount = 0),
+                createPoint(date = "2026-04-17", reviewCount = 1),
+                createPoint(date = "2026-04-18", reviewCount = 0)
+            ),
+            generatedAt = null
+        )
+        val pendingLocalOverlay = createSeries(
+            scopeKey = scopeKey,
+            dailyReviews = listOf(
+                createPoint(date = "2026-04-16", reviewCount = 0),
+                createPoint(date = "2026-04-17", reviewCount = 0),
+                createPoint(date = "2026-04-18", reviewCount = 0)
+            ),
+            generatedAt = null
+        )
+
+        val snapshot = createProgressSeriesSnapshot(
+            scopeKey = scopeKey,
+            localFallback = localFallback,
+            serverBase = serverBase,
+            pendingLocalOverlay = pendingLocalOverlay,
+            activeReviewDateSet = createActiveReviewDateSet(
+                series = localFallback,
+                additionalDates = emptySet()
+            ),
+            cloudState = CloudAccountState.LINKED
+        )
+
+        val statesByDate = snapshot.renderedSeries.streakDays.associate { day ->
+            day.date to day.state
+        }
+        assertEquals(1, snapshot.renderedSeries.dailyReviews[1].reviewCount)
         assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-16"])
         assertEquals(CloudProgressStreakDayState.FROZEN, statesByDate["2026-04-17"])
         assertEquals(CloudProgressStreakDayState.PENDING, statesByDate["2026-04-18"])

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressSummarySnapshotTest.kt
@@ -8,8 +8,10 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummar
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
+import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.repository.progress.createCloudSettings
 import com.flashcardsopensourceapp.data.local.repository.progress.createProgressLocalDayCount
+import com.flashcardsopensourceapp.data.local.repository.progress.inputs.ProgressPendingReviewLocalDate
 import java.time.LocalDate
 import java.time.ZoneId
 import org.junit.Assert.assertEquals
@@ -161,6 +163,7 @@ class ProgressSummarySnapshotTest {
                 capacity = 2,
                 balanceUnits = 2,
                 unitsPerCredit = 10,
+                earnedUnitsPerStreakDay = 1,
                 nextCreditProgressUnits = 2,
                 nextCreditRequiredUnits = 10
             ),
@@ -259,7 +262,90 @@ class ProgressSummarySnapshotTest {
     }
 
     @Test
-    fun longServerStreakRefundsFrozenYesterdayAndCreditsLocalToday() {
+    fun pendingTodayReviewUpdatesServerBaseSummaryAndClampsFreezeCapacity() {
+        val summaryScopeKey = createProgressSummaryScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val seriesScopeKey = createProgressSeriesScopeKey(
+            cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
+            today = LocalDate.parse("2026-04-18"),
+            zoneId = ZoneId.of("Europe/Madrid")
+        )
+        val localFallback = createLocalFallbackSummary(
+            scopeKey = summaryScopeKey,
+            localDayCounts = emptyList(),
+            workspaceIds = listOf("workspace-1"),
+            today = LocalDate.parse("2026-04-18")
+        )
+        val serverWatermarks = createWatermarks(reviewSequenceId = 42L)
+        val serverSeries = createSeries(
+            scopeKey = seriesScopeKey,
+            reviewCountsByDate = emptyMap(),
+            reviewHistoryWatermarks = serverWatermarks
+        )
+        val renderedSeriesContext = createRenderedSeriesContext(
+            scopeKey = seriesScopeKey,
+            serverBase = serverSeries,
+            localFallback = createLocalFallbackSeries(
+                scopeKey = seriesScopeKey,
+                localDayCounts = emptyList(),
+                workspaceIds = listOf("workspace-1")
+            ),
+            pendingLocalOverlay = createPendingLocalOverlaySeries(
+                scopeKey = seriesScopeKey,
+                pendingReviewLocalDates = listOf(
+                    ProgressPendingReviewLocalDate(
+                        workspaceId = "workspace-1",
+                        localDate = "2026-04-18",
+                        rating = ReviewRating.GOOD
+                    )
+                ),
+                workspaceIds = listOf("workspace-1")
+            )
+        )
+        val serverBase = CloudProgressSummary(
+            currentStreakDays = 0,
+            longestStreakDays = 0,
+            hasReviewedToday = false,
+            lastReviewedOn = null,
+            activeReviewDays = 0,
+            streakFreeze = CloudProgressStreakFreeze(
+                availableCredits = 2,
+                capacity = 3,
+                balanceUnits = 29,
+                unitsPerCredit = 10,
+                earnedUnitsPerStreakDay = 2,
+                nextCreditProgressUnits = 9,
+                nextCreditRequiredUnits = 10
+            ),
+            reviewHistoryWatermarks = serverWatermarks
+        )
+
+        val snapshot = createProgressSummarySnapshot(
+            scopeKey = summaryScopeKey,
+            localFallback = localFallback,
+            localFallbackActiveDates = emptySet(),
+            serverBase = serverBase,
+            renderedSeriesContext = renderedSeriesContext,
+            cloudState = CloudAccountState.LINKED
+        )
+
+        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(1, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(1, snapshot.renderedSummary.longestStreakDays)
+        assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
+        assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
+        assertEquals(1, snapshot.renderedSummary.activeReviewDays)
+        assertEquals(3, snapshot.renderedSummary.streakFreeze.capacity)
+        assertEquals(3, snapshot.renderedSummary.streakFreeze.availableCredits)
+        assertEquals(30, snapshot.renderedSummary.streakFreeze.balanceUnits)
+        assertEquals(0, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
+    }
+
+    @Test
+    fun longServerStreakCreditsLocalTodayWithoutRefundingFrozenYesterday() {
         val summaryScopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
             today = LocalDate.parse("2026-04-20"),
@@ -332,14 +418,14 @@ class ProgressSummarySnapshotTest {
         assertEquals(201, snapshot.renderedSummary.currentStreakDays)
         assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-20", snapshot.renderedSummary.lastReviewedOn)
-        assertEquals(202, snapshot.renderedSummary.activeReviewDays)
-        assertEquals(2, snapshot.renderedSummary.streakFreeze.availableCredits)
-        assertEquals(20, snapshot.renderedSummary.streakFreeze.balanceUnits)
-        assertEquals(0, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
+        assertEquals(201, snapshot.renderedSummary.activeReviewDays)
+        assertEquals(1, snapshot.renderedSummary.streakFreeze.availableCredits)
+        assertEquals(12, snapshot.renderedSummary.streakFreeze.balanceUnits)
+        assertEquals(2, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
     }
 
     @Test
-    fun longServerStreakRefundsFrozenYesterdayWithoutChangingCurrentStreak() {
+    fun olderLocalActiveDateDoesNotChangeServerBaseSummary() {
         val summaryScopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
             today = LocalDate.parse("2026-04-20"),
@@ -403,18 +489,18 @@ class ProgressSummarySnapshotTest {
             cloudState = CloudAccountState.LINKED
         )
 
-        assertEquals(ProgressSnapshotSource.SERVER_BASE_WITH_LOCAL_OVERLAY, snapshot.source)
+        assertEquals(ProgressSnapshotSource.SERVER_BASE, snapshot.source)
         assertEquals(200, snapshot.renderedSummary.currentStreakDays)
         assertEquals(false, snapshot.renderedSummary.hasReviewedToday)
-        assertEquals("2026-04-19", snapshot.renderedSummary.lastReviewedOn)
-        assertEquals(201, snapshot.renderedSummary.activeReviewDays)
-        assertEquals(2, snapshot.renderedSummary.streakFreeze.availableCredits)
-        assertEquals(20, snapshot.renderedSummary.streakFreeze.balanceUnits)
-        assertEquals(0, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
+        assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
+        assertEquals(200, snapshot.renderedSummary.activeReviewDays)
+        assertEquals(1, snapshot.renderedSummary.streakFreeze.availableCredits)
+        assertEquals(11, snapshot.renderedSummary.streakFreeze.balanceUnits)
+        assertEquals(1, snapshot.renderedSummary.streakFreeze.nextCreditProgressUnits)
     }
 
     @Test
-    fun localActiveDateOutsideVisibleChartRangeExtendsActiveDays() {
+    fun localActiveDateOutsideVisibleChartRangeDoesNotChangeServerBaseSummary() {
         val summaryScopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
             today = LocalDate.parse("2026-04-18"),
@@ -478,10 +564,11 @@ class ProgressSummarySnapshotTest {
             cloudState = CloudAccountState.LINKED
         )
 
+        assertEquals(ProgressSnapshotSource.SERVER_BASE, snapshot.source)
         assertEquals(0, snapshot.renderedSummary.currentStreakDays)
         assertEquals(false, snapshot.renderedSummary.hasReviewedToday)
-        assertEquals("2025-12-02", snapshot.renderedSummary.lastReviewedOn)
-        assertEquals(201, snapshot.renderedSummary.activeReviewDays)
+        assertEquals("2025-12-01", snapshot.renderedSummary.lastReviewedOn)
+        assertEquals(200, snapshot.renderedSummary.activeReviewDays)
     }
 
     @Test
@@ -557,7 +644,7 @@ class ProgressSummarySnapshotTest {
     }
 
     @Test
-    fun disjointVisibleServerAndLocalDatesKeepSummaryConsistentWithRenderedSeries() {
+    fun disjointVisibleServerAndLocalDatesOnlyApplyTodayStreakDelta() {
         val summaryScopeKey = createProgressSummaryScopeKey(
             cloudSettings = createCloudSettings(cloudState = CloudAccountState.LINKED),
             today = LocalDate.parse("2026-04-18"),
@@ -621,7 +708,7 @@ class ProgressSummarySnapshotTest {
             cloudState = CloudAccountState.LINKED
         )
 
-        assertEquals(3, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(1, snapshot.renderedSummary.currentStreakDays)
         assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
         assertEquals(2, snapshot.renderedSummary.activeReviewDays)
@@ -697,7 +784,7 @@ class ProgressSummarySnapshotTest {
             cloudState = CloudAccountState.LINKED
         )
 
-        assertEquals(3, snapshot.renderedSummary.currentStreakDays)
+        assertEquals(2, snapshot.renderedSummary.currentStreakDays)
         assertEquals(true, snapshot.renderedSummary.hasReviewedToday)
         assertEquals("2026-04-18", snapshot.renderedSummary.lastReviewedOn)
         assertEquals(201, snapshot.renderedSummary.activeReviewDays)
@@ -721,8 +808,6 @@ class ProgressSummarySnapshotTest {
             cloudState = CloudAccountState.LINKED
         ).renderedSeries
         return createProgressRenderedSeriesSummaryContext(
-            serverBase = serverBase,
-            scopeKey = scopeKey,
             renderedSeries = renderedSeries
         )
     }
@@ -797,6 +882,7 @@ class ProgressSummarySnapshotTest {
             capacity = 2,
             balanceUnits = 11,
             unitsPerCredit = 10,
+            earnedUnitsPerStreakDay = 1,
             nextCreditProgressUnits = 1,
             nextCreditRequiredUnits = 10
         )

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTest.kt
@@ -751,6 +751,7 @@ private fun createProgressStreakFreezeForTest(): CloudProgressStreakFreeze {
         capacity = 2,
         balanceUnits = 20,
         unitsPerCredit = 10,
+        earnedUnitsPerStreakDay = 1,
         nextCreditProgressUnits = 0,
         nextCreditRequiredUnits = 10
     )

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
@@ -216,6 +216,7 @@ private fun createProgressSummarySnapshot(
             capacity = 2,
             balanceUnits = 20,
             unitsPerCredit = 10,
+            earnedUnitsPerStreakDay = 1,
             nextCreditProgressUnits = 0,
             nextCreditRequiredUnits = 10
         ),


### PR DESCRIPTION
## Summary
- Trust server-provided Android streak freeze policy fields, including earnedUnitsPerStreakDay
- Reduce serverBase overlay to today-only summary and streak-day patches
- Preserve local-only fallback evaluator and update cache/parser/tests

## Validation
- git --no-pager diff --cached --check
- Static review only; ./gradlew was not run per repository instruction