### PR TITLE
[codex] Suppress transient progress refresh warnings

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
@@ -3,10 +3,14 @@ package com.flashcardsopensourceapp.data.local.repository.progress.runtime
 import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
 import com.flashcardsopensourceapp.core.observability.AndroidWarningIssueEvent
 import com.flashcardsopensourceapp.core.observability.AppObservability
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.network.isLikelyTransientNetworkIoException
+import com.flashcardsopensourceapp.data.local.network.isRetryableHttpStatusCode
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressReviewScheduleStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSeriesStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreState
+import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -91,25 +95,64 @@ internal fun logProgressRefreshWarning(
     fields: List<Pair<String, String?>>,
     error: Throwable
 ) {
-    observability.captureWarning(
-        event = AndroidWarningIssueEvent.ProgressRefreshWarning(
-            workspaceId = extractProgressWorkspaceId(
-                fields = fields,
-                scopeId = scopeId
-            ),
-            refreshAction = event,
-            scopeId = scopeId,
-            source = source,
-            appVersion = observationVersions.appVersion,
-            clientVersion = observationVersions.clientVersion,
-            versionCode = observationVersions.versionCode
+    if (shouldCaptureProgressRefreshWarning(error = error)) {
+        observability.captureWarning(
+            event = AndroidWarningIssueEvent.ProgressRefreshWarning(
+                workspaceId = extractProgressWorkspaceId(
+                    fields = fields,
+                    scopeId = scopeId
+                ),
+                refreshAction = event,
+                scopeId = scopeId,
+                source = source,
+                appVersion = observationVersions.appVersion,
+                clientVersion = observationVersions.clientVersion,
+                versionCode = observationVersions.versionCode
+            )
         )
-    )
+    }
     logProgressRepositoryWarning(
         event = event,
         fields = fields,
         error = error
     )
+}
+
+internal fun shouldCaptureProgressRefreshWarning(error: Throwable): Boolean {
+    return isTransientProgressRefreshFailure(error = error).not()
+}
+
+private fun isTransientProgressRefreshFailure(error: Throwable): Boolean {
+    val cloudRemoteError: CloudRemoteException? = error as? CloudRemoteException
+        ?: findProgressCloudRemoteCause(error = error)
+    if (cloudRemoteError != null) {
+        return isRetryableHttpStatusCode(statusCode = cloudRemoteError.statusCode)
+    }
+
+    val ioError: IOException? = error as? IOException ?: findProgressIoCause(error = error)
+    return ioError != null && isLikelyTransientNetworkIoException(error = ioError)
+}
+
+private fun findProgressCloudRemoteCause(error: Throwable): CloudRemoteException? {
+    var currentCause: Throwable? = error.cause
+    while (currentCause != null) {
+        if (currentCause is CloudRemoteException) {
+            return currentCause
+        }
+        currentCause = currentCause.cause
+    }
+    return null
+}
+
+private fun findProgressIoCause(error: Throwable): IOException? {
+    var currentCause: Throwable? = error.cause
+    while (currentCause != null) {
+        if (currentCause is IOException) {
+            return currentCause
+        }
+        currentCause = currentCause.cause
+    }
+    return null
 }
 
 internal fun supportsServerRefresh(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
@@ -1,5 +1,6 @@
 package com.flashcardsopensourceapp.data.local.repository.progress
 
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleScopeKey
@@ -9,12 +10,14 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSou
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldCaptureProgressRefreshWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressReviewScheduleRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSeriesRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSummaryRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressReviewScheduleStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSeriesStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreState
+import java.net.UnknownHostException
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -213,6 +216,40 @@ class ProgressRemoteLoadWarningSuppressionTest {
             shouldSuppressProgressReviewScheduleRemoteLoadWarning(
                 latestStoreState = disconnectedStoreState,
                 refreshStoreState = refreshStoreState
+            )
+        )
+    }
+
+    @Test
+    fun progressRefreshWarningIsNotCapturedForTransientNetworkFailure(): Unit {
+        assertFalse(
+            shouldCaptureProgressRefreshWarning(
+                error = UnknownHostException("Unable to resolve host api.flashcards-open-source-app.com")
+            )
+        )
+    }
+
+    @Test
+    fun progressRefreshWarningIsNotCapturedForRetryableHttpFailure(): Unit {
+        assertFalse(
+            shouldCaptureProgressRefreshWarning(
+                error = CloudRemoteException(
+                    message = "Gateway timeout.",
+                    statusCode = 504,
+                    responseBody = "",
+                    errorCode = null,
+                    requestId = "request-1",
+                    syncConflict = null
+                )
+            )
+        )
+    }
+
+    @Test
+    fun progressRefreshWarningIsCapturedForNonTransientFailure(): Unit {
+        assertTrue(
+            shouldCaptureProgressRefreshWarning(
+                error = IllegalStateException("Progress response is invalid.")
             )
         )
     }


### PR DESCRIPTION
## Summary
- suppress progress refresh Sentry warnings for transient network and retryable HTTP failures
- keep local logging and preserve warning capture for non-transient progress refresh failures
- add focused suppression coverage for DNS, retryable HTTP, and non-transient errors

## Validation
- git --no-pager diff --check
- static review of affected progress warning call sites

Gradle was not run locally because this repository requires explicit permission before local Gradle runs.