### PR TITLE
[codex] Suppress transient progress sync warnings

### DIFF
--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
@@ -17,6 +17,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.should
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressReviewScheduleStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSeriesStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreState
+import java.net.MalformedURLException
 import java.net.UnknownHostException
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -230,6 +231,18 @@ class ProgressRemoteLoadWarningSuppressionTest {
     }
 
     @Test
+    fun progressRefreshWarningIsNotCapturedForNestedTransientNetworkFailure(): Unit {
+        assertFalse(
+            shouldCaptureProgressRefreshWarning(
+                error = IllegalStateException(
+                    "Cloud sync failed.",
+                    UnknownHostException("Unable to resolve host api.flashcards-open-source-app.com")
+                )
+            )
+        )
+    }
+
+    @Test
     fun progressRefreshWarningIsNotCapturedForRetryableHttpFailure(): Unit {
         assertFalse(
             shouldCaptureProgressRefreshWarning(
@@ -241,6 +254,31 @@ class ProgressRemoteLoadWarningSuppressionTest {
                     requestId = "request-1",
                     syncConflict = null
                 )
+            )
+        )
+    }
+
+    @Test
+    fun progressRefreshWarningIsCapturedForNonRetryableHttpFailure(): Unit {
+        assertTrue(
+            shouldCaptureProgressRefreshWarning(
+                error = CloudRemoteException(
+                    message = "Bad request.",
+                    statusCode = 400,
+                    responseBody = "",
+                    errorCode = null,
+                    requestId = "request-1",
+                    syncConflict = null
+                )
+            )
+        )
+    }
+
+    @Test
+    fun progressRefreshWarningIsCapturedForNonTransientIoFailure(): Unit {
+        assertTrue(
+            shouldCaptureProgressRefreshWarning(
+                error = MalformedURLException("bad://url")
             )
         )
     }


### PR DESCRIPTION
## Summary
- suppress Sentry progress refresh warning issues for transient sync-before-remote-load network failures
- keep local progress repository logging for those transient failures
- cover retryable HTTP and transient IO classification in progress suppression tests

## Validation
- git --no-pager diff --check
- Android Gradle tests not run locally because repository instructions require explicit approval for ./gradlew runs