### PR TITLE
[codex] Suppress transient progress sync warnings

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressReviewScheduleOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressReviewScheduleOrchestration.kt
@@ -20,6 +20,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.Progre
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressSyncBeforeRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressReviewScheduleRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.supportsServerRefresh
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressReviewScheduleStoreInputs
@@ -229,7 +230,7 @@ internal class ProgressReviewScheduleOrchestration(
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Exception) {
-                logProgressRefreshWarning(
+                logProgressSyncBeforeRemoteLoadFailure(
                     observability = observability,
                     observationVersions = observationVersions,
                     event = "progress_review_schedule_sync_before_remote_load_failed",

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSeriesOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSeriesOrchestration.kt
@@ -22,6 +22,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.Progre
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressSyncBeforeRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSeriesRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.supportsServerRefresh
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSeriesStoreInputs
@@ -239,7 +240,7 @@ internal class ProgressSeriesOrchestration(
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Exception) {
-                logProgressRefreshWarning(
+                logProgressSyncBeforeRemoteLoadFailure(
                     observability = observability,
                     observationVersions = observationVersions,
                     event = "progress_series_sync_before_remote_load_failed",

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSummaryOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSummaryOrchestration.kt
@@ -23,6 +23,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.Progre
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressSyncBeforeRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSummaryRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.supportsServerRefresh
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreInputs
@@ -242,7 +243,7 @@ internal class ProgressSummaryOrchestration(
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Exception) {
-                logProgressRefreshWarning(
+                logProgressSyncBeforeRemoteLoadFailure(
                     observability = observability,
                     observationVersions = observationVersions,
                     event = "progress_summary_sync_before_remote_load_failed",

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
@@ -94,23 +94,21 @@ internal fun logProgressRefreshWarning(
     source: String,
     fields: List<Pair<String, String?>>,
     error: Throwable
-) {
-    if (shouldCaptureProgressRefreshWarning(error = error)) {
-        observability.captureWarning(
-            event = AndroidWarningIssueEvent.ProgressRefreshWarning(
-                workspaceId = extractProgressWorkspaceId(
-                    fields = fields,
-                    scopeId = scopeId
-                ),
-                refreshAction = event,
-                scopeId = scopeId,
-                source = source,
-                appVersion = observationVersions.appVersion,
-                clientVersion = observationVersions.clientVersion,
-                versionCode = observationVersions.versionCode
-            )
+): Unit {
+    observability.captureWarning(
+        event = AndroidWarningIssueEvent.ProgressRefreshWarning(
+            workspaceId = extractProgressWorkspaceId(
+                fields = fields,
+                scopeId = scopeId
+            ),
+            refreshAction = event,
+            scopeId = scopeId,
+            source = source,
+            appVersion = observationVersions.appVersion,
+            clientVersion = observationVersions.clientVersion,
+            versionCode = observationVersions.versionCode
         )
-    }
+    )
     logProgressRepositoryWarning(
         event = event,
         fields = fields,
@@ -118,41 +116,57 @@ internal fun logProgressRefreshWarning(
     )
 }
 
-internal fun shouldCaptureProgressRefreshWarning(error: Throwable): Boolean {
-    return isTransientProgressRefreshFailure(error = error).not()
-}
-
-private fun isTransientProgressRefreshFailure(error: Throwable): Boolean {
-    val cloudRemoteError: CloudRemoteException? = error as? CloudRemoteException
-        ?: findProgressCloudRemoteCause(error = error)
-    if (cloudRemoteError != null) {
-        return isRetryableHttpStatusCode(statusCode = cloudRemoteError.statusCode)
+internal fun logProgressSyncBeforeRemoteLoadFailure(
+    observability: AppObservability,
+    observationVersions: ProgressObservationVersions,
+    event: String,
+    scopeId: String,
+    source: String,
+    fields: List<Pair<String, String?>>,
+    error: Throwable
+): Unit {
+    if (isExpectedTransientProgressSyncBeforeRemoteLoadError(error = error)) {
+        logProgressRepositoryWarning(
+            event = event,
+            fields = fields + listOf(
+                "sentryWarningSuppressed" to "true",
+                "suppressionReason" to "transient_sync_before_remote_load_failure"
+            ),
+            error = error
+        )
+        return
     }
 
-    val ioError: IOException? = error as? IOException ?: findProgressIoCause(error = error)
-    return ioError != null && isLikelyTransientNetworkIoException(error = ioError)
+    logProgressRefreshWarning(
+        observability = observability,
+        observationVersions = observationVersions,
+        event = event,
+        scopeId = scopeId,
+        source = source,
+        fields = fields,
+        error = error
+    )
 }
 
-private fun findProgressCloudRemoteCause(error: Throwable): CloudRemoteException? {
-    var currentCause: Throwable? = error.cause
-    while (currentCause != null) {
-        if (currentCause is CloudRemoteException) {
-            return currentCause
+internal fun isExpectedTransientProgressSyncBeforeRemoteLoadError(error: Throwable): Boolean {
+    var currentError: Throwable? = error
+    while (currentError != null) {
+        if (
+            currentError is CloudRemoteException &&
+            isRetryableHttpStatusCode(statusCode = currentError.statusCode)
+        ) {
+            return true
         }
-        currentCause = currentCause.cause
-    }
-    return null
-}
-
-private fun findProgressIoCause(error: Throwable): IOException? {
-    var currentCause: Throwable? = error.cause
-    while (currentCause != null) {
-        if (currentCause is IOException) {
-            return currentCause
+        if (
+            currentError is IOException &&
+            isLikelyTransientNetworkIoException(error = currentError)
+        ) {
+            return true
         }
-        currentCause = currentCause.cause
+        currentError = currentError.cause
     }
-    return null
+
+    return false
 }
 
 internal fun supportsServerRefresh(

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
@@ -10,20 +10,60 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSou
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
-import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldCaptureProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.isExpectedTransientProgressSyncBeforeRemoteLoadError
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressReviewScheduleRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSeriesRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSummaryRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressReviewScheduleStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSeriesStoreState
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressSummaryStoreState
-import java.net.MalformedURLException
 import java.net.UnknownHostException
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ProgressRemoteLoadWarningSuppressionTest {
+    @Test
+    fun syncBeforeRemoteLoadWarningIsSuppressedOnlyForExpectedTransientFailures(): Unit {
+        assertTrue(
+            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+                error = CloudRemoteException(
+                    message = "Gateway timeout",
+                    statusCode = 504,
+                    responseBody = "",
+                    errorCode = null,
+                    requestId = "request-1",
+                    syncConflict = null
+                )
+            )
+        )
+        assertTrue(
+            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+                error = IllegalStateException(
+                    "Wrapped network error",
+                    UnknownHostException("Unable to resolve host")
+                )
+            )
+        )
+        assertFalse(
+            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+                error = CloudRemoteException(
+                    message = "Invalid sync request",
+                    statusCode = 400,
+                    responseBody = """{"code":"SYNC_INVALID_INPUT"}""",
+                    errorCode = "SYNC_INVALID_INPUT",
+                    requestId = "request-2",
+                    syncConflict = null
+                )
+            )
+        )
+        assertFalse(
+            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+                error = IllegalStateException("Progress sync invariant failed.")
+            )
+        )
+    }
+
     @Test
     fun summaryRemoteLoadWarningIsSuppressedOnlyForStaleState(): Unit {
         val refreshStoreState: ProgressSummaryStoreState = createSummaryStoreState(
@@ -221,76 +261,6 @@ class ProgressRemoteLoadWarningSuppressionTest {
         )
     }
 
-    @Test
-    fun progressRefreshWarningIsNotCapturedForTransientNetworkFailure(): Unit {
-        assertFalse(
-            shouldCaptureProgressRefreshWarning(
-                error = UnknownHostException("Unable to resolve host api.flashcards-open-source-app.com")
-            )
-        )
-    }
-
-    @Test
-    fun progressRefreshWarningIsNotCapturedForNestedTransientNetworkFailure(): Unit {
-        assertFalse(
-            shouldCaptureProgressRefreshWarning(
-                error = IllegalStateException(
-                    "Cloud sync failed.",
-                    UnknownHostException("Unable to resolve host api.flashcards-open-source-app.com")
-                )
-            )
-        )
-    }
-
-    @Test
-    fun progressRefreshWarningIsNotCapturedForRetryableHttpFailure(): Unit {
-        assertFalse(
-            shouldCaptureProgressRefreshWarning(
-                error = CloudRemoteException(
-                    message = "Gateway timeout.",
-                    statusCode = 504,
-                    responseBody = "",
-                    errorCode = null,
-                    requestId = "request-1",
-                    syncConflict = null
-                )
-            )
-        )
-    }
-
-    @Test
-    fun progressRefreshWarningIsCapturedForNonRetryableHttpFailure(): Unit {
-        assertTrue(
-            shouldCaptureProgressRefreshWarning(
-                error = CloudRemoteException(
-                    message = "Bad request.",
-                    statusCode = 400,
-                    responseBody = "",
-                    errorCode = null,
-                    requestId = "request-1",
-                    syncConflict = null
-                )
-            )
-        )
-    }
-
-    @Test
-    fun progressRefreshWarningIsCapturedForNonTransientIoFailure(): Unit {
-        assertTrue(
-            shouldCaptureProgressRefreshWarning(
-                error = MalformedURLException("bad://url")
-            )
-        )
-    }
-
-    @Test
-    fun progressRefreshWarningIsCapturedForNonTransientFailure(): Unit {
-        assertTrue(
-            shouldCaptureProgressRefreshWarning(
-                error = IllegalStateException("Progress response is invalid.")
-            )
-        )
-    }
 }
 
 private fun createSummaryStoreState(


### PR DESCRIPTION
## Summary
- suppress duplicate Android progress refresh Sentry warnings for expected transient sync-before-remote-load failures
- keep non-transient sync failures on the existing progress warning path
- add focused runtime coverage for transient HTTP/DNS classification

## Validation
- git --no-pager diff --check
- Gradle not run locally per repository policy without explicit approval