### PR TITLE
[codex] Remove Review freeze badge state

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingAllScreenshotsScript.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingAllScreenshotsScript.kt
@@ -73,9 +73,7 @@ class MarketingAllScreenshotsScript {
 
         robot.prepareOpportunityCostReviewCardForReview(
             expectedReviewStreakDays = marketingScreenshotExpectedStreakDays,
-            expectedReviewedToday = true,
-            expectedFreezeAvailableCredits = marketingScreenshotExpectedFreezeAvailableCredits,
-            expectedFreezeCapacity = marketingScreenshotExpectedFreezeCapacity
+            expectedReviewedToday = true
         )
         assertScreenshotSaved(
             robot = robot,

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingRepositorySeedScenarios.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingRepositorySeedScenarios.kt
@@ -10,8 +10,6 @@ import java.time.ZoneId
 
 internal const val marketingScreenshotExpectedStreakDays: Int = 8
 internal const val marketingScreenshotExpectedActiveReviewDays: Int = 16
-internal const val marketingScreenshotExpectedFreezeAvailableCredits: Int = 2
-internal const val marketingScreenshotExpectedFreezeCapacity: Int = 2
 
 private data class MarketingReviewTimestamp(
     val daysAgo: Long,

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/marketing/screenshots/MarketingScreenshotTestSupport.kt
@@ -160,17 +160,13 @@ internal class MarketingScreenshotRobot(
 
     fun prepareOpportunityCostReviewCardForReview(
         expectedReviewStreakDays: Int,
-        expectedReviewedToday: Boolean,
-        expectedFreezeAvailableCredits: Int,
-        expectedFreezeCapacity: Int
+        expectedReviewedToday: Boolean
     ) {
         openReviewTab()
         waitForReviewPrompt(frontText = localeConfig.reviewCard.frontText)
         waitForReviewProgressBadge(
             expectedReviewStreakDays = expectedReviewStreakDays,
-            expectedReviewedToday = expectedReviewedToday,
-            expectedFreezeAvailableCredits = expectedFreezeAvailableCredits,
-            expectedFreezeCapacity = expectedFreezeCapacity
+            expectedReviewedToday = expectedReviewedToday
         )
     }
 
@@ -329,25 +325,13 @@ internal class MarketingScreenshotRobot(
 
     private fun waitForReviewProgressBadge(
         expectedReviewStreakDays: Int,
-        expectedReviewedToday: Boolean,
-        expectedFreezeAvailableCredits: Int,
-        expectedFreezeCapacity: Int
+        expectedReviewedToday: Boolean
     ) {
-        val expectedStreakContentDescription = composeRule.activity.resources.getQuantityString(
+        val expectedContentDescription = composeRule.activity.resources.getQuantityString(
             ReviewFeatureR.plurals.review_progress_badge_content_description,
             expectedReviewStreakDays,
             expectedReviewStreakDays
         )
-        val expectedContentDescription = if (expectedFreezeCapacity > 0) {
-            val expectedFreezeContentDescription = composeRule.activity.getString(
-                ReviewFeatureR.string.review_progress_badge_freeze_bank_content_description,
-                expectedFreezeAvailableCredits,
-                expectedFreezeCapacity
-            )
-            "$expectedStreakContentDescription $expectedFreezeContentDescription"
-        } else {
-            expectedStreakContentDescription
-        }
         val expectedStateDescription = composeRule.activity.getString(
             if (expectedReviewedToday) {
                 ReviewFeatureR.string.review_progress_badge_reviewed_today

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewPreviewRouteTest.kt
@@ -57,8 +57,6 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         ),
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 0,
-                            freezeAvailableCredits = 0,
-                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),
@@ -126,8 +124,6 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         ),
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 0,
-                            freezeAvailableCredits = 0,
-                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),
@@ -181,8 +177,6 @@ class ReviewPreviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         ),
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 0,
-                            freezeAvailableCredits = 0,
-                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/ReviewRouteTest.kt
@@ -98,8 +98,6 @@ class ReviewRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         emptyState = ReviewEmptyState.SESSION_COMPLETE,
                         reviewProgressBadge = ReviewProgressBadgeState(
                             streakDays = 120,
-                            freezeAvailableCredits = 0,
-                            freezeCapacity = 0,
                             hasReviewedToday = false,
                             isInteractive = true
                         ),

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
@@ -112,8 +112,6 @@ class RtlLayoutTest : FirebaseAppInstrumentationTimeoutTest() {
                     ),
                     reviewProgressBadge = ReviewProgressBadgeState(
                         streakDays = 0,
-                        freezeAvailableCredits = 0,
-                        freezeCapacity = 0,
                         hasReviewedToday = false,
                         isInteractive = true
                     ),

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadge.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadge.kt
@@ -10,8 +10,6 @@ private const val reviewProgressBadgeOverflowThreshold: Int = 99
 internal fun createEmptyReviewProgressBadgeState(): ReviewProgressBadgeState {
     return ReviewProgressBadgeState(
         streakDays = 0,
-        freezeAvailableCredits = 0,
-        freezeCapacity = 0,
         hasReviewedToday = false,
         isInteractive = true
     )
@@ -28,8 +26,6 @@ internal fun createEmptyReviewLeaderboardBadgeState(): ReviewLeaderboardBadgeSta
 internal fun ProgressSummarySnapshot.toReviewProgressBadgeState(): ReviewProgressBadgeState {
     return ReviewProgressBadgeState(
         streakDays = renderedSummary.currentStreakDays,
-        freezeAvailableCredits = renderedSummary.streakFreeze.availableCredits,
-        freezeCapacity = renderedSummary.streakFreeze.capacity,
         hasReviewedToday = renderedSummary.hasReviewedToday,
         isInteractive = true
     )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/ReviewUiState.kt
@@ -8,8 +8,6 @@ import com.flashcardsopensourceapp.data.local.model.review.ReviewTagFilterOption
 
 data class ReviewProgressBadgeState(
     val streakDays: Int,
-    val freezeAvailableCredits: Int,
-    val freezeCapacity: Int,
     val hasReviewedToday: Boolean,
     val isInteractive: Boolean
 )

--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewTopBar.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.AcUnit
 import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.FormatListBulleted
@@ -37,7 +36,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 private val reviewTopBarFilterMaxWidth = 160.dp
-private val reviewProgressFreezeColor = Color(0xFF90CAF9)
+private val reviewLeaderboardTrophyColor = Color(0xFFFFD60A)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -58,16 +57,6 @@ internal fun ReviewTopBar(
         reviewProgressBadge.streakDays,
         reviewProgressBadge.streakDays
     )
-    val freezeBankContentDescription = stringResource(
-        id = R.string.review_progress_badge_freeze_bank_content_description,
-        reviewProgressBadge.freezeAvailableCredits,
-        reviewProgressBadge.freezeCapacity
-    )
-    val progressBadgeFullContentDescription = if (reviewProgressBadge.freezeCapacity > 0) {
-        "$progressBadgeContentDescription $freezeBankContentDescription"
-    } else {
-        progressBadgeContentDescription
-    }
     val progressBadgeStateDescription = stringResource(
         id = if (reviewProgressBadge.hasReviewedToday) {
             R.string.review_progress_badge_reviewed_today
@@ -119,7 +108,7 @@ internal fun ReviewTopBar(
                 modifier = Modifier
                     .testTag(reviewProgressBadgeTag)
                     .semantics {
-                        contentDescription = progressBadgeFullContentDescription
+                        contentDescription = progressBadgeContentDescription
                         stateDescription = progressBadgeStateDescription
                     }
                     .clip(CircleShape)
@@ -140,35 +129,9 @@ internal fun ReviewTopBar(
                     }
                 )
                 Text(text = formatReviewProgressBadgeValue(streakDays = reviewProgressBadge.streakDays))
-                ReviewProgressFreezeBankIndicator(reviewProgressBadge = reviewProgressBadge)
             }
         }
     )
-}
-
-@Composable
-private fun ReviewProgressFreezeBankIndicator(
-    reviewProgressBadge: ReviewProgressBadgeState
-) {
-    if (reviewProgressBadge.freezeCapacity <= 0) {
-        return
-    }
-
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(2.dp)
-    ) {
-        Icon(
-            imageVector = Icons.Outlined.AcUnit,
-            contentDescription = null,
-            tint = reviewProgressFreezeColor,
-            modifier = Modifier.size(18.dp)
-        )
-        Text(
-            text = reviewProgressBadge.freezeAvailableCredits.toString(),
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
 }
 
 @Composable
@@ -205,7 +168,8 @@ private fun ReviewLeaderboardAction(
     ) {
         Icon(
             imageVector = Icons.Outlined.EmojiEvents,
-            contentDescription = null
+            contentDescription = null,
+            tint = reviewLeaderboardTrophyColor
         )
         if (rank != null) {
             Text(text = rank.toString())

--- a/apps/android/feature/review/src/main/res/values/strings.xml
+++ b/apps/android/feature/review/src/main/res/values/strings.xml
@@ -30,7 +30,6 @@
     <string name="review_leaderboard_shortcut_rank_content_description">Open leaderboard. Best rank %1$d.</string>
     <string name="review_progress_badge_reviewed_today">Reviewed today</string>
     <string name="review_progress_badge_not_reviewed_today">Not reviewed today</string>
-    <string name="review_progress_badge_freeze_bank_content_description">Streak freezes %1$d of %2$d available.</string>
     <string name="review_filter_title_with_count">%1$s (%2$d)</string>
     <string name="review_edit_card_content_description">Edit card</string>
     <string name="review_front_label">Front</string>

--- a/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
+++ b/apps/android/feature/review/src/test/java/com/flashcardsopensourceapp/feature/review/ReviewProgressBadgeStateTest.kt
@@ -25,7 +25,7 @@ import org.junit.Test
 
 class ReviewProgressBadgeStateTest {
     @Test
-    fun reviewProgressBadgeStateUsesRenderedSummaryFields() {
+    fun reviewProgressBadgeStateUsesRenderedStreakAndIgnoresFreezeBank() {
         val badgeState = createProgressSummarySnapshot(
             currentStreakDays = 14,
             hasReviewedToday = true
@@ -34,8 +34,6 @@ class ReviewProgressBadgeStateTest {
         assertEquals(
             ReviewProgressBadgeState(
                 streakDays = 14,
-                freezeAvailableCredits = 2,
-                freezeCapacity = 2,
                 hasReviewedToday = true,
                 isInteractive = true
             ),


### PR DESCRIPTION
## Summary
- remove Review badge freeze-bank state, rendering, and semantics
- keep Review streak mapping based on the rendered summary streak
- tint the Review leaderboard trophy yellow and update dependent Android tests/screenshot support

## Validation
- git diff --check
- rg -n "AcUnit|freezeAvailableCredits|freezeCapacity" apps/android/feature/review returned no matches

Gradle was not run because the Android task instructions require explicit approval before running ./gradlew.