### PR TITLE
[codex] hide review freeze bank

### DIFF
--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -567,6 +567,7 @@ const arCatalog: TranslationCatalog = {
     },
     progressBadge: {
       ariaLabel: "سلسلة المراجعة {{streak}} يومًا. {{todayStatus}}. {{freezeBank}}.",
+      reviewAriaLabel: "سلسلة المراجعة {{streak}} يومًا. {{todayStatus}}.",
       freezeBank: "رصيد التجميد {{available}} من {{capacity}}",
       notReviewedToday: "لم تُراجع اليوم",
       reviewedToday: "راجعت اليوم",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -567,6 +567,7 @@ const deCatalog: TranslationCatalog = {
     },
     progressBadge: {
       ariaLabel: "Lernserie {{streak}} Tage. {{todayStatus}}. {{freezeBank}}.",
+      reviewAriaLabel: "Lernserie {{streak}} Tage. {{todayStatus}}.",
       freezeBank: "Frostbank {{available}} von {{capacity}}",
       notReviewedToday: "Heute noch nicht wiederholt",
       reviewedToday: "Heute wiederholt",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -565,6 +565,7 @@ const enCatalog = {
     },
     progressBadge: {
       ariaLabel: "Review streak {{streak}} days. {{todayStatus}}. {{freezeBank}}.",
+      reviewAriaLabel: "Review streak {{streak}} days. {{todayStatus}}.",
       freezeBank: "Freeze bank {{available}} of {{capacity}}",
       notReviewedToday: "Not reviewed today",
       reviewedToday: "Reviewed today",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -567,6 +567,7 @@ const esEsCatalog: TranslationCatalog = {
     },
     progressBadge: {
       ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}. {{freezeBank}}.",
+      reviewAriaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}.",
       freezeBank: "Banco de congelaciones {{available}} de {{capacity}}",
       notReviewedToday: "Sin repaso hoy",
       reviewedToday: "Repasado hoy",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -567,6 +567,7 @@ const esMxCatalog: TranslationCatalog = {
     },
     progressBadge: {
       ariaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}. {{freezeBank}}.",
+      reviewAriaLabel: "Racha de repaso de {{streak}} días. {{todayStatus}}.",
       freezeBank: "Banco de congelaciones {{available}} de {{capacity}}",
       notReviewedToday: "Sin repaso hoy",
       reviewedToday: "Repasado hoy",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -567,6 +567,7 @@ const hiCatalog: TranslationCatalog = {
     },
     progressBadge: {
       ariaLabel: "रिव्यू स्ट्रीक {{streak}} दिन। {{todayStatus}}। {{freezeBank}}।",
+      reviewAriaLabel: "रिव्यू स्ट्रीक {{streak}} दिन। {{todayStatus}}।",
       freezeBank: "फ़्रीज़ बैंक {{available}} में से {{capacity}}",
       notReviewedToday: "आज रिव्यू नहीं किया",
       reviewedToday: "आज रिव्यू किया",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -567,6 +567,7 @@ export const jaCatalog = {
     },
     progressBadge: {
       ariaLabel: "復習連続 {{streak}} 日。{{todayStatus}}。{{freezeBank}}。",
+      reviewAriaLabel: "復習連続 {{streak}} 日。{{todayStatus}}。",
       freezeBank: "フリーズ残数 {{available}} / {{capacity}}",
       notReviewedToday: "今日はまだ復習していません",
       reviewedToday: "今日は復習済み",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -567,6 +567,7 @@ export const ruCatalog = {
     },
     progressBadge: {
       ariaLabel: "Серия повторений: {{streak}} дн. {{todayStatus}}. {{freezeBank}}.",
+      reviewAriaLabel: "Серия повторений: {{streak}} дн. {{todayStatus}}.",
       freezeBank: "Запас заморозок {{available}} из {{capacity}}",
       notReviewedToday: "Сегодня ещё не повторяли",
       reviewedToday: "Сегодня уже повторяли",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -567,6 +567,7 @@ export const zhHansCatalog = {
     },
     progressBadge: {
       ariaLabel: "复习连续 {{streak}} 天。{{todayStatus}}。{{freezeBank}}。",
+      reviewAriaLabel: "复习连续 {{streak}} 天。{{todayStatus}}。",
       freezeBank: "冻结额度 {{available}} / {{capacity}}",
       notReviewedToday: "今天还没复习",
       reviewedToday: "今天已复习",

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -1,13 +1,10 @@
 import type { ComponentProps, ReactElement } from "react";
 import { Link } from "react-router-dom";
-import {
-  formatReviewProgressBadgeValue,
-  formatReviewProgressFreezeValue,
-} from "../../../appData/progress/badge/reviewProgressBadge";
+import { formatReviewProgressBadgeValue } from "../../../appData/progress/badge/reviewProgressBadge";
 import { useI18n } from "../../../i18n";
 import { progressLeaderboardRoute, progressStreakRoute } from "../../../routes";
 import type { ReviewProgressBadgeState } from "../../../types";
-import { ProgressLeaderboardShortcutIcon, ReviewProgressBadgeIcon, ReviewQueueShortcutIcon, StreakFreezeIcon } from "../../shared/ReviewProgressBadgeIcon";
+import { ProgressLeaderboardShortcutIcon, ReviewProgressBadgeIcon, ReviewQueueShortcutIcon } from "../../shared/ReviewProgressBadgeIcon";
 import { ReviewFilterMenu } from "../filters/ReviewFilterMenu";
 
 type ReviewLeaderboardBadgeState = Readonly<{
@@ -50,15 +47,9 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
   const reviewProgressBadgeTodayStatus = reviewProgressBadge.hasReviewedToday
     ? t("reviewScreen.progressBadge.reviewedToday")
     : t("reviewScreen.progressBadge.notReviewedToday");
-  const reviewProgressFreezeValue = formatReviewProgressFreezeValue(reviewProgressBadge.streakFreeze, formatNumber);
-  const reviewProgressFreezeStatus = t("reviewScreen.progressBadge.freezeBank", {
-    available: formatNumber(reviewProgressBadge.streakFreeze.availableCredits),
-    capacity: formatNumber(reviewProgressBadge.streakFreeze.capacity),
-  });
-  const reviewProgressBadgeAriaLabel = t("reviewScreen.progressBadge.ariaLabel", {
+  const reviewProgressBadgeAriaLabel = t("reviewScreen.progressBadge.reviewAriaLabel", {
     streak: formatNumber(reviewProgressBadge.streakDays),
     todayStatus: reviewProgressBadgeTodayStatus,
-    freezeBank: reviewProgressFreezeStatus,
   });
   const leaderboardShortcutRankLabel = reviewLeaderboardBadge.rank === null
     ? null
@@ -122,10 +113,6 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
             >
               <ReviewProgressBadgeIcon />
               <span className="review-progress-badge-value">{formatReviewProgressBadgeValue(reviewProgressBadge.streakDays)}</span>
-              <span className="review-progress-freeze-indicator" aria-hidden="true">
-                <StreakFreezeIcon />
-                <span className="review-progress-freeze-value">{reviewProgressFreezeValue}</span>
-              </span>
             </Link>
           </div>
         </div>

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -195,7 +195,11 @@ describe("ReviewScreen controls", () => {
     expect(progressBadge.className).toContain("review-progress-badge-active");
     expect(progressBadge.className).not.toContain("review-progress-badge-approximate");
     expect(progressBadge.textContent).not.toContain("🔥");
-    expect(progressBadge.textContent).toContain("1/2");
+    expect(progressBadge.textContent).toContain("12");
+    expect(progressBadge.textContent).not.toContain("1/2");
+    expect(progressBadge.querySelector(".review-progress-freeze-indicator")).toBeNull();
+    expect(progressBadge.getAttribute("aria-label")).toBe("Review streak 12 days. Reviewed today.");
+    expect(progressBadge.getAttribute("title")).toBe("Review streak 12 days. Reviewed today.");
     const queueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
     if (!(queueBadge instanceof HTMLButtonElement)) {
       throw new Error("Review queue badge was not found");
@@ -211,6 +215,10 @@ describe("ReviewScreen controls", () => {
     expect(leaderboardShortcut.querySelector(".review-progress-badge-value")).toBeNull();
     expect(leaderboardShortcut.getAttribute("aria-label")).toBe("Open leaderboard");
     expect(leaderboardShortcut.getAttribute("href")).toBe("/progress#leaderboard");
+    expect(reviewStylesContain(
+      ".review-leaderboard-shortcut .review-progress-badge-icon",
+      "color: #fbbf24",
+    )).toBe(true);
     const queuePanel = getContainer().querySelector("#review-queue-panel");
     if (!(queuePanel instanceof HTMLElement)) {
       throw new Error("Review queue panel was not found");

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -64,6 +64,10 @@
   padding-inline: 12px 14px;
 }
 
+.review-leaderboard-shortcut .review-progress-badge-icon {
+  color: #fbbf24;
+}
+
 .review-progress-shortcuts {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- hide Review header freeze-bank text from visible, title, and aria output
- keep the Review streak value sourced from the freeze-aware streak days
- make the Review leaderboard trophy yellow and update direct Review coverage

## Validation
- npm exec vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx
- npm exec -- tsc -b