### PR TITLE
[codex] Hide review freeze badge details

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -563,23 +563,11 @@ struct ReviewView: View {
             self.navigation.openProgress(target: .streak)
         } label: {
             HStack(spacing: reviewToolbarBadgeSpacing) {
-                HStack(spacing: 3) {
-                    Image(systemName: badgePresentation.iconSystemName)
-                        .foregroundStyle(self.reviewProgressBadgeToolbarIconColor(badgeState: badgeState))
-                    Text(formatReviewProgressBadgeValue(badgeState: badgeState))
-                        .monospacedDigit()
-                        .lineLimit(1)
-                }
-
-                if badgeState.showsStreakFreezeBank {
-                    HStack(spacing: 3) {
-                        Image(systemName: reviewProgressFreezeBankSystemImageName())
-                            .foregroundStyle(Color(red: 0x2A / 255, green: 0x7F / 255, blue: 0xC2 / 255))
-                        Text(formatReviewProgressFreezeBankValue(badgeState: badgeState))
-                            .monospacedDigit()
-                            .lineLimit(1)
-                    }
-                }
+                Image(systemName: badgePresentation.iconSystemName)
+                    .foregroundStyle(self.reviewProgressBadgeToolbarIconColor(badgeState: badgeState))
+                Text(formatReviewProgressBadgeValue(badgeState: badgeState))
+                    .monospacedDigit()
+                    .lineLimit(1)
             }
             .fixedSize(horizontal: true, vertical: false)
         }
@@ -681,39 +669,15 @@ struct ReviewView: View {
             locale: Locale.current,
             badgeState.streakDays.formatted()
         )
-        guard badgeState.showsStreakFreezeBank else {
-            return streakLabel
-        }
-
-        return "\(streakLabel) \(self.reviewProgressFreezeBankAccessibilityLabel(badgeState: badgeState))"
+        return streakLabel
     }
 
     private func reviewProgressBadgeAccessibilityValue(badgeState: ReviewProgressBadgeState) -> String {
-        var components: [String] = [
+        let components: [String] = [
             "streakDays=\(badgeState.streakDays)",
             "hasReviewedToday=\(badgeState.hasReviewedToday ? "true" : "false")"
         ]
-        if badgeState.showsStreakFreezeBank {
-            components.append("streakFreezeAvailableCredits=\(badgeState.streakFreezeAvailableCredits)")
-            components.append("streakFreezeCapacity=\(badgeState.streakFreezeCapacity)")
-        }
-
         return components.joined(separator: ";")
-    }
-
-    private func reviewProgressFreezeBankAccessibilityLabel(badgeState: ReviewProgressBadgeState) -> String {
-        let localizedFormat = String(
-            localized: "progress.freeze_bank.accessibility",
-            defaultValue: "Freeze bank %@ of %@ available.",
-            table: progressStringsTableName,
-            comment: "Accessibility label for the current streak freeze credit bank"
-        )
-        return String(
-            format: localizedFormat,
-            locale: Locale.current,
-            badgeState.streakFreezeAvailableCredits.formatted(),
-            badgeState.streakFreezeCapacity.formatted()
-        )
     }
 
     private func reviewBottomBarContainer<Content: View>(

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Assertions/LiveSmokeAssertions.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Assertions/LiveSmokeAssertions.swift
@@ -321,6 +321,41 @@ extension LiveSmokeTestCase {
         expectedValue: String,
         timeout: TimeInterval
     ) throws -> Bool {
+        return try self.waitForElementValueMatching(
+            element,
+            identifier: identifier,
+            expectedValue: expectedValue,
+            timeout: timeout
+        ) { currentValue in
+            currentValue == expectedValue || currentValue.contains(expectedValue)
+        }
+    }
+
+    @MainActor
+    func waitForElementValue(
+        _ element: XCUIElement,
+        identifier: String,
+        expectedValue: String,
+        timeout: TimeInterval
+    ) throws -> Bool {
+        return try self.waitForElementValueMatching(
+            element,
+            identifier: identifier,
+            expectedValue: expectedValue,
+            timeout: timeout
+        ) { currentValue in
+            currentValue == expectedValue
+        }
+    }
+
+    @MainActor
+    private func waitForElementValueMatching(
+        _ element: XCUIElement,
+        identifier: String,
+        expectedValue: String,
+        timeout: TimeInterval,
+        matchesExpectedValue: (String) -> Bool
+    ) throws -> Bool {
         self.logSmokeBreadcrumb(
             event: "wait_start",
             action: "wait_for_element_value",
@@ -335,7 +370,7 @@ extension LiveSmokeTestCase {
 
         while Date() < deadline {
             let currentValue = self.elementValue(element: element)
-            if currentValue == expectedValue || currentValue.contains(expectedValue) {
+            if matchesExpectedValue(currentValue) {
                 let durationSeconds = Date().timeIntervalSince(startedAt)
                 self.logSmokeBreadcrumb(
                     event: "wait_end",

--- a/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/MarketingScreenshots/MarketingManualScreenshotTestCase.swift
@@ -55,9 +55,7 @@ private let marketingExpectedProgressSummaryValue: String = [
 
 private let marketingExpectedReviewProgressBadgeValue: String = [
     "streakDays=12",
-    "hasReviewedToday=true",
-    "streakFreezeAvailableCredits=1",
-    "streakFreezeCapacity=2"
+    "hasReviewedToday=true"
 ].joined(separator: ";")
 
 private let marketingAiHandoffFirstCardValue: String = "first_card"
@@ -208,7 +206,7 @@ class MarketingManualScreenshotTestCase: LiveSmokeTestCase {
     @MainActor
     func assertReviewProgressBadge() throws {
         let reviewProgressBadge = self.app.buttons[LiveSmokeIdentifier.reviewProgressBadge]
-        if try self.waitForElementValueContaining(
+        if try self.waitForElementValue(
             reviewProgressBadge,
             identifier: LiveSmokeIdentifier.reviewProgressBadge,
             expectedValue: marketingExpectedReviewProgressBadgeValue,


### PR DESCRIPTION
## Summary

- Hide streak freeze details from the iOS Review toolbar badge UI and accessibility payload.
- Keep the Review streak number freeze-aware through the existing shared progress badge state.
- Tighten the marketing screenshot Review badge assertion to require the exact accessibility value while leaving Progress freeze expectations unchanged.

## Validation

- Ran `git --no-pager diff --check`.
- Verified `ReviewView.swift` no longer references the Review freeze formatter/accessibility helper or freeze fields.
- Did not run simulator-backed iOS tests per repository instructions.