### PR TITLE
[codex] Add progress freeze bank info

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakSection.kt
@@ -14,13 +14,21 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AcUnit
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.LocalFireDepartment
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -193,6 +201,7 @@ private fun ProgressStreakValueChip(
 private fun ProgressFreezeBankChip(
     freezeBank: ProgressFreezeBankUiState
 ) {
+    var isInfoDialogVisible by rememberSaveable { mutableStateOf(false) }
     val contentDescription = stringResource(
         id = R.string.progress_streak_freeze_bank_content_description,
         freezeBank.availableCredits,
@@ -203,27 +212,71 @@ private fun ProgressFreezeBankChip(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         modifier = Modifier
-            .semantics(mergeDescendants = true) {
-                this.contentDescription = contentDescription
-            }
             .clip(RoundedCornerShape(18.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHighest)
-            .padding(horizontal = 12.dp, vertical = 8.dp)
     ) {
-        Icon(
-            imageVector = Icons.Outlined.AcUnit,
-            contentDescription = null,
-            tint = frozenStreakContentColor
-        )
-        Text(
-            text = stringResource(
-                id = R.string.progress_streak_freeze_bank_value,
-                freezeBank.availableCredits,
-                freezeBank.capacity
-            ),
-            color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.SemiBold,
-            style = MaterialTheme.typography.titleMedium
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier
+                .semantics(mergeDescendants = true) {
+                    this.contentDescription = contentDescription
+                }
+                .padding(start = 12.dp, top = 8.dp, bottom = 8.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.AcUnit,
+                contentDescription = null,
+                tint = frozenStreakContentColor
+            )
+            Text(
+                text = stringResource(
+                    id = R.string.progress_streak_freeze_bank_value,
+                    freezeBank.availableCredits,
+                    freezeBank.capacity
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.titleMedium
+            )
+        }
+        IconButton(
+            onClick = { isInfoDialogVisible = true },
+            modifier = Modifier.size(36.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Info,
+                contentDescription = stringResource(
+                    id = R.string.progress_streak_freeze_bank_info_button_content_description
+                ),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+
+    if (isInfoDialogVisible) {
+        AlertDialog(
+            onDismissRequest = { isInfoDialogVisible = false },
+            confirmButton = {
+                TextButton(onClick = { isInfoDialogVisible = false }) {
+                    Text(stringResource(id = R.string.progress_streak_freeze_bank_info_dismiss))
+                }
+            },
+            title = {
+                Text(stringResource(id = R.string.progress_streak_freeze_bank_info_title))
+            },
+            text = {
+                Text(
+                    stringResource(
+                        id = R.string.progress_streak_freeze_bank_info_body,
+                        freezeBank.availableCredits,
+                        freezeBank.capacity,
+                        freezeBank.nextCreditProgressUnits,
+                        freezeBank.nextCreditRequiredUnits
+                    )
+                )
+            }
         )
     }
 }

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -14,6 +14,10 @@
     <string name="progress_streak_summary_not_reviewed_today">Not reviewed today</string>
     <string name="progress_streak_freeze_bank_value">%1$d/%2$d</string>
     <string name="progress_streak_freeze_bank_content_description">Streak freezes %1$d of %2$d available.</string>
+    <string name="progress_streak_freeze_bank_info_button_content_description">About streak freezes</string>
+    <string name="progress_streak_freeze_bank_info_title">Streak freezes</string>
+    <string name="progress_streak_freeze_bank_info_body">Available: %1$d/%2$d. Recharge: %3$d/%4$d. Freezes protect missed days and recharge as your streak continues.</string>
+    <string name="progress_streak_freeze_bank_info_dismiss">OK</string>
     <string name="progress_streak_day_reviewed_content_description">%1$s reviewed.</string>
     <string name="progress_streak_day_frozen_content_description">%1$s protected by a streak freeze.</string>
     <string name="progress_streak_day_pending_content_description">%1$s pending.</string>

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -64,6 +64,7 @@ struct ProgressScreen: View {
                             ProgressStreakSection(
                                 weeks: streakWeeks,
                                 badgeState: makeReviewProgressBadgeState(summary: progressSnapshot.summary),
+                                streakFreeze: progressSnapshot.summary.streakFreeze,
                                 calendar: presentationCalendar
                             )
                         }

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressStreakSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressStreakSection.swift
@@ -4,11 +4,16 @@ private let progressCalendarColumnCount: Int = 7
 private let progressReviewCardsStringsTableName: String = "ReviewCards"
 private let progressStreakBadgeSize: CGFloat = 34
 private let progressStreakBadgeHorizontalPadding: CGFloat = 8
+private let progressFrozenStreakBorderColor = Color(red: 0x9D / 255, green: 0xD8 / 255, blue: 0xFF / 255)
+private let progressFrozenStreakContentColor = Color(red: 0x2A / 255, green: 0x7F / 255, blue: 0xC2 / 255)
 
 struct ProgressStreakSection: View {
     let weeks: [ProgressCalendarWeek]
     let badgeState: ReviewProgressBadgeState
+    let streakFreeze: ProgressStreakFreeze
     let calendar: Calendar
+
+    @State private var isFreezeInfoAlertPresented: Bool = false
 
     private var columns: [GridItem] {
         Array(repeating: GridItem(.flexible(), spacing: 10, alignment: .center), count: progressCalendarColumnCount)
@@ -26,6 +31,12 @@ struct ProgressStreakSection: View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 ProgressStreakSummaryBadge(badgeState: self.badgeState)
+                if self.badgeState.showsStreakFreezeBank {
+                    ProgressFreezeBankChip(
+                        badgeState: self.badgeState,
+                        onShowInfo: { self.isFreezeInfoAlertPresented = true }
+                    )
+                }
                 Spacer(minLength: 0)
             }
 
@@ -45,6 +56,47 @@ struct ProgressStreakSection: View {
             }
         }
         .padding(.vertical, 4)
+        .alert(
+            self.freezeInfoTitle,
+            isPresented: self.$isFreezeInfoAlertPresented
+        ) {
+            Button(
+                String(
+                    localized: "shared.ok",
+                    table: progressStringsTableName,
+                    comment: "Confirmation button title"
+                ),
+                role: .cancel
+            ) {}
+        } message: {
+            Text(self.freezeInfoMessage)
+        }
+    }
+
+    private var freezeInfoTitle: String {
+        String(
+            localized: "progress.freeze_bank.info.title",
+            defaultValue: "Streak freezes",
+            table: progressStringsTableName,
+            comment: "Title for the streak freeze bank explanation alert"
+        )
+    }
+
+    private var freezeInfoMessage: String {
+        let localizedFormat = String(
+            localized: "progress.freeze_bank.info.message",
+            defaultValue: "Available: %@/%@. Recharge: %@/%@. Freezes protect missed days and recharge as your streak continues.",
+            table: progressStringsTableName,
+            comment: "Body for the streak freeze bank explanation alert. Parameters are available credits, capacity, next credit progress, and next credit required units."
+        )
+        return String(
+            format: localizedFormat,
+            locale: Locale.current,
+            self.streakFreeze.availableCredits.formatted(),
+            self.streakFreeze.capacity.formatted(),
+            self.streakFreeze.nextCreditProgressUnits.formatted(),
+            self.streakFreeze.nextCreditRequiredUnits.formatted()
+        )
     }
 }
 
@@ -100,19 +152,62 @@ private struct ProgressStreakSummaryBadge: View {
             )
         }
 
-        let streakLabel = String(
+        return String(
             format: localizedFormat,
             locale: Locale.current,
             self.badgeState.streakDays.formatted()
         )
-        guard self.badgeState.showsStreakFreezeBank else {
-            return streakLabel
-        }
+    }
+}
 
-        return "\(streakLabel) \(self.freezeBankAccessibilityLabel)"
+private struct ProgressFreezeBankChip: View {
+    let badgeState: ReviewProgressBadgeState
+    let onShowInfo: () -> Void
+
+    var body: some View {
+        Button {
+            self.onShowInfo()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: reviewProgressFreezeBankSystemImageName())
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(progressFrozenStreakContentColor)
+
+                Text(formatReviewProgressFreezeBankValue(badgeState: self.badgeState))
+                    .font(.caption2.weight(.semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(.primary)
+                    .minimumScaleFactor(0.65)
+
+                Image(systemName: "info.circle")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, progressStreakBadgeHorizontalPadding)
+            .frame(minHeight: progressStreakBadgeSize)
+            .background {
+                Capsule()
+                    .fill(Color(uiColor: .secondarySystemBackground))
+            }
+            .overlay {
+                Capsule()
+                    .strokeBorder(progressFrozenStreakBorderColor, lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .fixedSize(horizontal: true, vertical: false)
+        .accessibilityLabel(self.accessibilityLabel)
+        .accessibilityHint(
+            String(
+                localized: "progress.freeze_bank.info.accessibility_hint",
+                defaultValue: "Shows how streak freezes work.",
+                table: progressStringsTableName,
+                comment: "Accessibility hint for the streak freeze bank info button"
+            )
+        )
     }
 
-    private var freezeBankAccessibilityLabel: String {
+    private var accessibilityLabel: String {
         let localizedFormat = String(
             localized: "progress.freeze_bank.accessibility",
             defaultValue: "Freeze bank %@ of %@ available.",
@@ -191,7 +286,7 @@ private struct ProgressStreakDayCell: View {
         }
 
         if self.isFrozenDay {
-            return Color(red: 0x9D / 255, green: 0xD8 / 255, blue: 0xFF / 255)
+            return progressFrozenStreakBorderColor
         }
 
         if self.day.isToday {
@@ -211,7 +306,7 @@ private struct ProgressStreakDayCell: View {
         }
 
         if self.isFrozenDay {
-            return Color(red: 0x2A / 255, green: 0x7F / 255, blue: 0xC2 / 255)
+            return progressFrozenStreakContentColor
         }
 
         if self.day.isToday {

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -6609,6 +6609,183 @@
         }
       }
     },
+    "progress.freeze_bank.info.accessibility_hint" : {
+      "comment" : "Accessibility hint for the streak freeze bank info button",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "يعرض كيفية عمل تجميدات السلسلة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt, wie Serien-Freezes funktionieren."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shows how streak freezes work."
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra cómo funcionan las congelaciones de racha."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra cómo funcionan las congelaciones de racha."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "दिखाता है कि स्ट्रीक फ़्रीज़ कैसे काम करते हैं."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストリークフリーズの仕組みを表示します。"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывает, как работают заморозки серии."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示连续记录冻结的工作方式。"
+          }
+        }
+      }
+    },
+    "progress.freeze_bank.info.message" : {
+      "comment" : "Body for the streak freeze bank explanation alert. Parameters are available credits, capacity, next credit progress, and next credit required units.",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المتاح: %@/%@. إعادة الشحن: %@/%@. تحمي التجميدات الأيام الفائتة وتُعاد شحنها مع استمرار سلسلتك."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verfügbar: %@/%@. Aufladung: %@/%@. Freezes schützen verpasste Tage und laden sich auf, während deine Serie weiterläuft."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Available: %@/%@. Recharge: %@/%@. Freezes protect missed days and recharge as your streak continues."
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disponibles: %@/%@. Recarga: %@/%@. Las congelaciones protegen días perdidos y se recargan a medida que continúa tu racha."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disponibles: %@/%@. Recarga: %@/%@. Las congelaciones protegen días perdidos y se recargan a medida que continúa tu racha."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "उपलब्ध: %@/%@. रीचार्ज: %@/%@. फ़्रीज़ छूटे हुए दिनों की रक्षा करते हैं और आपकी श्रृंखला जारी रहने पर रीचार्ज होते हैं."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能: %@/%@。リチャージ: %@/%@。フリーズは逃した日を保護し、連続記録が続くと回復します。"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Доступно: %@/%@. Перезарядка: %@/%@. Заморозки защищают пропущенные дни и восстанавливаются по мере продолжения серии."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用：%@/%@。恢复进度：%@/%@。冻结可保护错过的日期，并会随着连续记录继续而恢复。"
+          }
+        }
+      }
+    },
+    "progress.freeze_bank.info.title" : {
+      "comment" : "Title for the streak freeze bank explanation alert",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تجميدات السلسلة"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Serien-Freezes"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streak freezes"
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Congelaciones de racha"
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Congelaciones de racha"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "स्ट्रीक फ़्रीज़"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストリークフリーズ"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заморозки серии"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连续记录冻结"
+          }
+        }
+      }
+    },
     "progress.screen.streak.section_title" : {
       "comment" : "Progress streak section title",
       "localizations" : {


### PR DESCRIPTION
## Summary
- Add an Android Progress freeze-bank info affordance with the current balance and recharge progress.
- Add an iOS Progress freeze-bank chip and localized info alert.
- Keep freeze bank visibility on Progress without changing Review.

## Validation
- `python3 -m json.tool apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings >/dev/null`
- `xmllint --noout apps/android/feature/progress/src/main/res/values/strings.xml`
- `git --no-pager diff --check`

Android Gradle and iOS simulator-backed tests were not run per repository instructions.