### PR TITLE
[codex] Center settings page

### DIFF
--- a/apps/web/src/styles/features/settings.css
+++ b/apps/web/src/styles/features/settings.css
@@ -4,7 +4,9 @@
 }
 
 .settings-panel {
+  width: 100%;
   max-width: 980px;
+  justify-self: center;
   align-content: start;
   border: 0;
   border-radius: 0;


### PR DESCRIPTION
## Summary

Centers the web settings panel within the main content area while keeping the existing 980px maximum width.

## Impact

The settings screen now aligns with the centered fullscreen AI chat layout on wide screens without changing settings content, routing, or behavior.

## Validation

- npm run build
- git --no-pager diff --check