### PR TITLE
[codex] Fix Android progress summary import

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -13,6 +13,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus


### PR DESCRIPTION
## Summary

Adds the missing `CloudProgressSummary` import in the Android progress ViewModel.

## Root cause

Android Release failed at `:feature:progress:compileDebugKotlin` because `ProgressViewModel.kt` declared an extension on `CloudProgressSummary` without importing the model type. The unresolved type also made the `streakFreeze` member references fail.

## Validation

- `git --no-pager diff --check`
- `git --no-pager diff --cached --check`

I did not run local `./gradlew`; repository instructions require explicit approval before local Gradle runs.