### PR TITLE
[codex] Split web progress source pipelines

### DIFF
--- a/apps/web/src/appData/progress/source/pipelines/leaderboardSource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/leaderboardSource.ts
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+  ApiNetworkError,
+  loadProgressLeaderboard,
+} from "../../../../api";
+import {
+  loadLocalLeaderboardViewerCounts,
+} from "../../../../localDb/progress/progress";
+import type {
+  ProgressLeaderboard,
+  ProgressScopeKey,
+} from "../../../../types";
+import {
+  createProgressLeaderboardSnapshot,
+} from "../../snapshots/progressSnapshots";
+import {
+  loadPersistedProgressLeaderboard,
+  storePersistedProgressLeaderboard,
+} from "../../storage/progressStorage";
+import {
+  captureProgressServerLoadError,
+  getErrorMessage,
+  type ProgressCanLoadServerBaseRef,
+  type ProgressScopeKeyRef,
+  type ProgressSourceDispatch,
+} from "./progressSourcePipelineHelpers";
+
+export type RefreshProgressLeaderboard = (
+  targetScopeKey: ProgressScopeKey,
+  nextRefreshKey: string,
+  bypassFreshnessGate: boolean,
+) => Promise<void>;
+
+export type ProgressLeaderboardSourcePipeline = Readonly<{
+  refreshProgressLeaderboard: RefreshProgressLeaderboard;
+}>;
+
+type ProgressLeaderboardRefreshRequest = Readonly<{
+  refreshKey: string;
+  bypassFreshnessGate: boolean;
+}>;
+
+type ProgressLeaderboardSourcePipelineParams = Readonly<{
+  accessibleWorkspaceIds: ReadonlyArray<string>;
+  activeWorkspaceId: string | null;
+  autoRefreshEnabled: boolean;
+  canLoadServerBase: boolean;
+  canLoadServerBaseRef: ProgressCanLoadServerBaseRef;
+  currentScopeKeyRef: ProgressScopeKeyRef;
+  dispatch: ProgressSourceDispatch;
+  installationId: string | null;
+  manualRefreshVersion: number;
+  progressLocalVersion: number;
+  refreshKey: string | null;
+  scopeKey: ProgressScopeKey | null;
+}>;
+
+/**
+ * The compact leaderboard snapshot regenerates hourly on the server, so
+ * automatic refreshes are skipped while every cached window's
+ * `nextRefreshAfter` is still in the future. Manual Progress refreshes bypass
+ * this gate, and non-ready payloads (no windows) are never considered fresh so
+ * participation changes propagate on the next automatic load.
+ */
+function isProgressLeaderboardFresh(leaderboard: ProgressLeaderboard | null, nowTimestamp: number): boolean {
+  if (leaderboard === null || leaderboard.windows.length === 0) {
+    return false;
+  }
+
+  return leaderboard.windows.every((window) => {
+    const nextRefreshAfterTimestamp = Date.parse(window.nextRefreshAfter);
+    return Number.isNaN(nextRefreshAfterTimestamp) === false && nextRefreshAfterTimestamp > nowTimestamp;
+  });
+}
+
+export function useProgressLeaderboardSourcePipeline(
+  params: ProgressLeaderboardSourcePipelineParams,
+): ProgressLeaderboardSourcePipeline {
+  const {
+    accessibleWorkspaceIds,
+    activeWorkspaceId,
+    autoRefreshEnabled,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    installationId,
+    manualRefreshVersion,
+    progressLocalVersion,
+    refreshKey,
+    scopeKey,
+  } = params;
+  const localLoadSequenceRef = useRef<number>(0);
+  const serverRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
+  const requestedRefreshRequestsRef = useRef<Map<ProgressScopeKey, ProgressLeaderboardRefreshRequest>>(new Map());
+
+  useEffect(() => {
+    currentScopeKeyRef.current = scopeKey;
+
+    if (scopeKey === null) {
+      dispatch({ type: "leaderboard_scope_reset" });
+      return;
+    }
+
+    const persistedLeaderboard = canLoadServerBase
+      ? loadPersistedProgressLeaderboard(scopeKey)
+      : null;
+
+    dispatch({
+      type: "leaderboard_scope_initialized",
+      scopeKey,
+      serverBase: persistedLeaderboard === null ? null : createProgressLeaderboardSnapshot(persistedLeaderboard, false),
+      canRenderServerBase: canLoadServerBaseRef.current,
+    });
+  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, scopeKey]);
+
+  useEffect(() => {
+    if (scopeKey === null) {
+      return;
+    }
+
+    // The viewer counts only overlay a rendered server snapshot, so skip the
+    // review-event scan entirely while the session cannot load one; the effect
+    // re-runs when `canLoadServerBase` flips after sign-in.
+    if (canLoadServerBase === false) {
+      return;
+    }
+
+    const currentSequence = localLoadSequenceRef.current + 1;
+    localLoadSequenceRef.current = currentSequence;
+
+    void loadLocalLeaderboardViewerCounts(accessibleWorkspaceIds, new Date()).then((localViewerCounts) => {
+      if (
+        currentScopeKeyRef.current !== scopeKey
+        || localLoadSequenceRef.current !== currentSequence
+      ) {
+        return;
+      }
+
+      dispatch({
+        type: "leaderboard_local_load_succeeded",
+        scopeKey,
+        localViewerCounts,
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    }).catch((error: unknown) => {
+      if (
+        currentScopeKeyRef.current !== scopeKey
+        || localLoadSequenceRef.current !== currentSequence
+      ) {
+        return;
+      }
+
+      dispatch({
+        type: "leaderboard_local_load_failed",
+        scopeKey,
+        errorMessage: getErrorMessage(error),
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    });
+  }, [
+    accessibleWorkspaceIds,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    manualRefreshVersion,
+    progressLocalVersion,
+    scopeKey,
+  ]);
+
+  const refreshProgressLeaderboard = useCallback<RefreshProgressLeaderboard>(async function refreshProgressLeaderboard(
+    targetScopeKey: ProgressScopeKey,
+    nextRefreshKey: string,
+    bypassFreshnessGate: boolean,
+  ): Promise<void> {
+    requestedRefreshRequestsRef.current.set(targetScopeKey, {
+      refreshKey: nextRefreshKey,
+      bypassFreshnessGate,
+    });
+
+    const inFlightRefresh = serverRefreshPromisesRef.current.get(targetScopeKey);
+    if (inFlightRefresh !== undefined) {
+      return inFlightRefresh;
+    }
+
+    const refreshPromise = (async (): Promise<void> => {
+      try {
+        while (true) {
+          const requestedRefresh = requestedRefreshRequestsRef.current.get(targetScopeKey);
+
+          if (requestedRefresh === undefined) {
+            throw new Error(`Missing requested progress leaderboard refresh key for scope ${targetScopeKey}`);
+          }
+
+          if (currentScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
+            requestedRefreshRequestsRef.current.delete(targetScopeKey);
+            return;
+          }
+
+          if (
+            requestedRefresh.bypassFreshnessGate === false
+            && isProgressLeaderboardFresh(loadPersistedProgressLeaderboard(targetScopeKey), Date.now())
+          ) {
+            if (requestedRefreshRequestsRef.current.get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey) {
+              dispatch({
+                type: "leaderboard_server_load_skipped",
+                scopeKey: targetScopeKey,
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+              requestedRefreshRequestsRef.current.delete(targetScopeKey);
+              return;
+            }
+
+            continue;
+          }
+
+          try {
+            const serverLeaderboard = await loadProgressLeaderboard();
+            const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
+              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              storePersistedProgressLeaderboard(targetScopeKey, serverLeaderboard);
+              dispatch({
+                type: "leaderboard_server_load_succeeded",
+                scopeKey: targetScopeKey,
+                serverBase: createProgressLeaderboardSnapshot(serverLeaderboard, false),
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+            }
+          } catch (error: unknown) {
+            const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
+              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              dispatch({
+                type: "leaderboard_server_load_failed",
+                scopeKey: targetScopeKey,
+                errorMessage: getErrorMessage(error),
+                isNetworkError: error instanceof ApiNetworkError,
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+              captureProgressServerLoadError(error, {
+                operation: "progress_leaderboard_server_load",
+                workspaceId: activeWorkspaceId,
+                installationId,
+              });
+            }
+          }
+
+          if (requestedRefreshRequestsRef.current.get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey) {
+            requestedRefreshRequestsRef.current.delete(targetScopeKey);
+            return;
+          }
+        }
+      } finally {
+        serverRefreshPromisesRef.current.delete(targetScopeKey);
+      }
+    })();
+
+    serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
+    return refreshPromise;
+  }, [activeWorkspaceId, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+
+  useEffect(() => {
+    if (autoRefreshEnabled === false) {
+      return;
+    }
+
+    if (scopeKey === null || refreshKey === null) {
+      return;
+    }
+
+    if (requestedRefreshRequestsRef.current.get(scopeKey)?.refreshKey === refreshKey) {
+      return;
+    }
+
+    void refreshProgressLeaderboard(scopeKey, refreshKey, false);
+  }, [
+    autoRefreshEnabled,
+    refreshKey,
+    refreshProgressLeaderboard,
+    scopeKey,
+  ]);
+
+  return {
+    refreshProgressLeaderboard,
+  };
+}

--- a/apps/web/src/appData/progress/source/pipelines/progressSourcePipelineHelpers.ts
+++ b/apps/web/src/appData/progress/source/pipelines/progressSourcePipelineHelpers.ts
@@ -1,0 +1,82 @@
+import type { Dispatch, MutableRefObject } from "react";
+import { ApiNetworkError } from "../../../../api";
+import { captureApiContractError } from "../../../../observability/apiContractObservation";
+import {
+  captureWebException,
+  type ProgressServerLoadFailureDetails,
+  type WebObservationScope,
+} from "../../../../observability/webObservability";
+import type { ProgressScopeKey } from "../../../../types";
+import type { ProgressSourceAction } from "../../state/progressReducer";
+
+export type ProgressSourceDispatch = Dispatch<ProgressSourceAction>;
+
+export type ProgressCanLoadServerBaseRef = MutableRefObject<boolean>;
+
+export type ProgressScopeKeyRef = MutableRefObject<ProgressScopeKey | null>;
+
+export type ProgressNumberRef = MutableRefObject<number>;
+
+export type ProgressServerLoadOperation = ProgressServerLoadFailureDetails["operation"];
+
+export type ProgressServerLoadObservationContext = Readonly<{
+  operation: ProgressServerLoadOperation;
+  workspaceId: string | null;
+  installationId: string | null;
+}>;
+
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function getCurrentRoute(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function buildProgressNetworkErrorScope(
+  error: ApiNetworkError,
+  context: ProgressServerLoadObservationContext,
+): WebObservationScope {
+  return {
+    app: "web",
+    feature: "progress",
+    userId: null,
+    workspaceId: context.workspaceId,
+    installationId: context.installationId,
+    route: getCurrentRoute(),
+    requestId: error.requestId,
+    statusCode: error.statusCode,
+    code: error.code,
+  };
+}
+
+function captureProgressNetworkError(error: unknown, context: ProgressServerLoadObservationContext): void {
+  if (error instanceof ApiNetworkError === false) {
+    return;
+  }
+
+  captureWebException({
+    action: "progress_server_load_failed",
+    error,
+    scope: buildProgressNetworkErrorScope(error, context),
+    details: {
+      operation: context.operation,
+      workspaceId: context.workspaceId,
+    },
+  });
+}
+
+export function captureProgressServerLoadError(error: unknown, context: ProgressServerLoadObservationContext): void {
+  captureApiContractError(error, {
+    feature: "progress",
+    sourceAction: context.operation,
+    userId: null,
+    workspaceId: context.workspaceId,
+    installationId: context.installationId,
+  });
+  captureProgressNetworkError(error, context);
+}

--- a/apps/web/src/appData/progress/source/pipelines/reviewScheduleSource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/reviewScheduleSource.ts
@@ -1,0 +1,294 @@
+import { useCallback, useEffect, useRef } from "react";
+import { loadProgressReviewSchedule } from "../../../../api";
+import {
+  calculatePendingProgressReviewScheduleCardTotalDelta,
+  hasCompleteLocalProgressReviewScheduleCoverage,
+  hasPendingProgressReviewScheduleCardChanges,
+  loadLocalProgressReviewSchedule,
+} from "../../../../localDb/reviews/reviewSchedule";
+import type {
+  ProgressReviewScheduleInput,
+  ProgressScopeKey,
+} from "../../../../types";
+import {
+  createProgressReviewScheduleSnapshot,
+} from "../../snapshots/progressSnapshots";
+import {
+  loadPersistedProgressReviewSchedule,
+  storePersistedProgressReviewSchedule,
+} from "../../storage/progressStorage";
+import {
+  captureProgressServerLoadError,
+  getErrorMessage,
+  type ProgressCanLoadServerBaseRef,
+  type ProgressNumberRef,
+  type ProgressScopeKeyRef,
+  type ProgressSourceDispatch,
+} from "./progressSourcePipelineHelpers";
+
+export type RefreshProgressReviewSchedule = (
+  targetScopeKey: ProgressScopeKey,
+  input: ProgressReviewScheduleInput,
+  nextRefreshKey: string,
+  nextProgressScheduleLocalVersion: number,
+) => Promise<void>;
+
+export type ProgressReviewScheduleSourcePipeline = Readonly<{
+  refreshProgressReviewSchedule: RefreshProgressReviewSchedule;
+}>;
+
+type ProgressReviewScheduleRefreshRequest = Readonly<{
+  refreshKey: string;
+  progressScheduleLocalVersion: number;
+}>;
+
+type ProgressReviewScheduleSourcePipelineParams = Readonly<{
+  accessibleWorkspaceIds: ReadonlyArray<string>;
+  activeWorkspaceId: string | null;
+  canLoadServerBase: boolean;
+  canLoadServerBaseRef: ProgressCanLoadServerBaseRef;
+  currentScopeKeyRef: ProgressScopeKeyRef;
+  dispatch: ProgressSourceDispatch;
+  input: ProgressReviewScheduleInput;
+  installationId: string | null;
+  manualRefreshVersion: number;
+  progressScheduleLocalVersion: number;
+  progressScheduleLocalVersionRef: ProgressNumberRef;
+  refreshKey: string | null;
+  scopeKey: ProgressScopeKey | null;
+}>;
+
+export function useProgressReviewScheduleSourcePipeline(
+  params: ProgressReviewScheduleSourcePipelineParams,
+): ProgressReviewScheduleSourcePipeline {
+  const {
+    accessibleWorkspaceIds,
+    activeWorkspaceId,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    input,
+    installationId,
+    manualRefreshVersion,
+    progressScheduleLocalVersion,
+    progressScheduleLocalVersionRef,
+    refreshKey,
+    scopeKey,
+  } = params;
+  const localLoadSequenceRef = useRef<number>(0);
+  const serverRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
+  const requestedRefreshRequestsRef = useRef<Map<ProgressScopeKey, ProgressReviewScheduleRefreshRequest>>(new Map());
+
+  useEffect(() => {
+    currentScopeKeyRef.current = scopeKey;
+
+    if (scopeKey === null) {
+      dispatch({ type: "review_schedule_scope_reset" });
+      return;
+    }
+
+    const persistedReviewSchedule = canLoadServerBase
+      ? loadPersistedProgressReviewSchedule(scopeKey, input.timeZone)
+      : null;
+
+    dispatch({
+      type: "review_schedule_scope_initialized",
+      scopeKey,
+      serverBase: persistedReviewSchedule === null
+        ? null
+        : createProgressReviewScheduleSnapshot(persistedReviewSchedule, "server", false),
+      progressScheduleLocalVersion: progressScheduleLocalVersionRef.current,
+      canRenderServerBase: canLoadServerBaseRef.current,
+    });
+  }, [
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    input.timeZone,
+    progressScheduleLocalVersionRef,
+    scopeKey,
+  ]);
+
+  useEffect(() => {
+    if (scopeKey === null) {
+      return;
+    }
+
+    const currentSequence = localLoadSequenceRef.current + 1;
+    localLoadSequenceRef.current = currentSequence;
+
+    void Promise.all([
+      loadLocalProgressReviewSchedule(accessibleWorkspaceIds, input),
+      hasPendingProgressReviewScheduleCardChanges(accessibleWorkspaceIds),
+      hasCompleteLocalProgressReviewScheduleCoverage(accessibleWorkspaceIds),
+      calculatePendingProgressReviewScheduleCardTotalDelta(accessibleWorkspaceIds),
+    ]).then(([
+      localReviewSchedule,
+      hasPendingLocalCardChanges,
+      hasCompleteLocalCardState,
+      pendingLocalCardTotalDelta,
+    ]) => {
+      if (
+        currentScopeKeyRef.current !== scopeKey
+        || localLoadSequenceRef.current !== currentSequence
+      ) {
+        return;
+      }
+
+      dispatch({
+        type: "review_schedule_local_load_succeeded",
+        scopeKey,
+        localFallback: createProgressReviewScheduleSnapshot(localReviewSchedule, "local_only", true),
+        hasPendingLocalCardChanges,
+        hasCompleteLocalCardState,
+        pendingLocalCardTotalDelta,
+        progressScheduleLocalVersion,
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    }).catch((error: unknown) => {
+      if (
+        currentScopeKeyRef.current !== scopeKey
+        || localLoadSequenceRef.current !== currentSequence
+      ) {
+        return;
+      }
+
+      dispatch({
+        type: "review_schedule_local_load_failed",
+        scopeKey,
+        errorMessage: getErrorMessage(error),
+        progressScheduleLocalVersion,
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    });
+  }, [
+    accessibleWorkspaceIds,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    input,
+    manualRefreshVersion,
+    progressScheduleLocalVersion,
+    scopeKey,
+  ]);
+
+  const refreshProgressReviewSchedule = useCallback<RefreshProgressReviewSchedule>(async function refreshProgressReviewSchedule(
+    targetScopeKey: ProgressScopeKey,
+    refreshInput: ProgressReviewScheduleInput,
+    nextRefreshKey: string,
+    nextProgressScheduleLocalVersion: number,
+  ): Promise<void> {
+    requestedRefreshRequestsRef.current.set(targetScopeKey, {
+      refreshKey: nextRefreshKey,
+      progressScheduleLocalVersion: nextProgressScheduleLocalVersion,
+    });
+
+    const inFlightRefresh = serverRefreshPromisesRef.current.get(targetScopeKey);
+    if (inFlightRefresh !== undefined) {
+      return inFlightRefresh;
+    }
+
+    const refreshPromise = (async (): Promise<void> => {
+      try {
+        while (true) {
+          const requestedRefresh = requestedRefreshRequestsRef.current.get(targetScopeKey);
+
+          if (requestedRefresh === undefined) {
+            throw new Error(`Missing requested progress review schedule refresh key for scope ${targetScopeKey}`);
+          }
+
+          if (currentScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
+            requestedRefreshRequestsRef.current.delete(targetScopeKey);
+            return;
+          }
+
+          try {
+            const serverReviewSchedule = await loadProgressReviewSchedule(refreshInput);
+            const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
+              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              storePersistedProgressReviewSchedule(targetScopeKey, serverReviewSchedule, refreshInput.timeZone);
+              dispatch({
+                type: "review_schedule_server_load_succeeded",
+                scopeKey: targetScopeKey,
+                serverBase: createProgressReviewScheduleSnapshot(serverReviewSchedule, "server", false),
+                progressScheduleLocalVersion: requestedRefresh.progressScheduleLocalVersion,
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+            }
+          } catch (error: unknown) {
+            const isCurrentRefreshRequest: boolean = requestedRefreshRequestsRef.current
+              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              dispatch({
+                type: "review_schedule_server_load_failed",
+                scopeKey: targetScopeKey,
+                errorMessage: getErrorMessage(error),
+                progressScheduleLocalVersion: requestedRefresh.progressScheduleLocalVersion,
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+              captureProgressServerLoadError(error, {
+                operation: "progress_review_schedule_server_load",
+                workspaceId: activeWorkspaceId,
+                installationId,
+              });
+            }
+          }
+
+          if (
+            requestedRefreshRequestsRef.current.get(targetScopeKey)?.refreshKey
+              === requestedRefresh.refreshKey
+          ) {
+            requestedRefreshRequestsRef.current.delete(targetScopeKey);
+            return;
+          }
+        }
+      } finally {
+        serverRefreshPromisesRef.current.delete(targetScopeKey);
+      }
+    })();
+
+    serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
+    return refreshPromise;
+  }, [activeWorkspaceId, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+
+  useEffect(() => {
+    if (scopeKey === null || refreshKey === null) {
+      return;
+    }
+
+    if (requestedRefreshRequestsRef.current.get(scopeKey)?.refreshKey === refreshKey) {
+      return;
+    }
+
+    void refreshProgressReviewSchedule(
+      scopeKey,
+      input,
+      refreshKey,
+      progressScheduleLocalVersion,
+    );
+  }, [
+    input,
+    progressScheduleLocalVersion,
+    refreshKey,
+    refreshProgressReviewSchedule,
+    scopeKey,
+  ]);
+
+  return {
+    refreshProgressReviewSchedule,
+  };
+}

--- a/apps/web/src/appData/progress/source/pipelines/seriesSource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/seriesSource.ts
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useRef } from "react";
+import { loadProgressSeries } from "../../../../api";
+import {
+  loadLocalProgressActiveDates,
+  loadLocalProgressDailyReviews,
+  loadPendingProgressDailyReviews,
+} from "../../../../localDb/progress/progress";
+import type {
+  ProgressScopeKey,
+  ProgressSeriesInput,
+} from "../../../../types";
+import {
+  buildLocalFallbackSeries,
+  createProgressChartData,
+  createProgressSeriesSnapshot,
+  normalizeProgressSeries,
+} from "../../snapshots/progressSnapshots";
+import {
+  loadPersistedProgressSeries,
+  storePersistedProgressSeries,
+} from "../../storage/progressStorage";
+import {
+  captureProgressServerLoadError,
+  getErrorMessage,
+  type ProgressCanLoadServerBaseRef,
+  type ProgressScopeKeyRef,
+  type ProgressSourceDispatch,
+} from "./progressSourcePipelineHelpers";
+
+export type RefreshProgressSeries = (
+  targetScopeKey: ProgressScopeKey,
+  input: ProgressSeriesInput,
+  nextRefreshKey: string,
+) => Promise<void>;
+
+export type ProgressSeriesSourcePipeline = Readonly<{
+  refreshProgressSeries: RefreshProgressSeries;
+}>;
+
+type ProgressSeriesSourcePipelineParams = Readonly<{
+  accessibleWorkspaceIds: ReadonlyArray<string>;
+  activeWorkspaceId: string | null;
+  canLoadServerBase: boolean;
+  canLoadServerBaseRef: ProgressCanLoadServerBaseRef;
+  currentScopeKeyRef: ProgressScopeKeyRef;
+  dispatch: ProgressSourceDispatch;
+  input: ProgressSeriesInput;
+  installationId: string | null;
+  manualRefreshVersion: number;
+  progressLocalVersion: number;
+  refreshKey: string | null;
+  scopeKey: ProgressScopeKey | null;
+}>;
+
+export function useProgressSeriesSourcePipeline(
+  params: ProgressSeriesSourcePipelineParams,
+): ProgressSeriesSourcePipeline {
+  const {
+    accessibleWorkspaceIds,
+    activeWorkspaceId,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    input,
+    installationId,
+    manualRefreshVersion,
+    progressLocalVersion,
+    refreshKey,
+    scopeKey,
+  } = params;
+  const localLoadSequenceRef = useRef<number>(0);
+  const serverRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
+  const requestedRefreshKeysRef = useRef<Map<ProgressScopeKey, string>>(new Map());
+
+  useEffect(() => {
+    currentScopeKeyRef.current = scopeKey;
+
+    if (scopeKey === null) {
+      dispatch({
+        type: "series_scope_reset",
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+      return;
+    }
+
+    const persistedSeries = canLoadServerBase
+      ? loadPersistedProgressSeries(scopeKey)
+      : null;
+
+    dispatch({
+      type: "series_scope_initialized",
+      scopeKey,
+      serverBase: persistedSeries === null ? null : createProgressSeriesSnapshot(persistedSeries, "server", false),
+      canRenderServerBase: canLoadServerBaseRef.current,
+    });
+  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, scopeKey]);
+
+  useEffect(() => {
+    if (scopeKey === null) {
+      return;
+    }
+
+    const currentSequence = localLoadSequenceRef.current + 1;
+    localLoadSequenceRef.current = currentSequence;
+
+    void Promise.all([
+      loadLocalProgressDailyReviews(accessibleWorkspaceIds, input),
+      loadLocalProgressActiveDates(accessibleWorkspaceIds, input.timeZone),
+      loadPendingProgressDailyReviews(accessibleWorkspaceIds, input),
+    ]).then(([localDailyReviews, localActiveDates, pendingLocalDailyReviews]) => {
+      if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
+        return;
+      }
+
+      dispatch({
+        type: "series_local_load_succeeded",
+        scopeKey,
+        localFallback: createProgressSeriesSnapshot(
+          buildLocalFallbackSeries(input, localDailyReviews, localActiveDates),
+          "local_only",
+          true,
+        ),
+        localFallbackActiveDates: localActiveDates,
+        pendingLocalOverlay: createProgressChartData(pendingLocalDailyReviews),
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    }).catch((error: unknown) => {
+      if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
+        return;
+      }
+
+      dispatch({
+        type: "series_local_load_failed",
+        scopeKey,
+        errorMessage: getErrorMessage(error),
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    });
+  }, [
+    accessibleWorkspaceIds,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    input,
+    manualRefreshVersion,
+    progressLocalVersion,
+    scopeKey,
+  ]);
+
+  const refreshProgressSeries = useCallback<RefreshProgressSeries>(async function refreshProgressSeries(
+    targetScopeKey: ProgressScopeKey,
+    refreshInput: ProgressSeriesInput,
+    nextRefreshKey: string,
+  ): Promise<void> {
+    requestedRefreshKeysRef.current.set(targetScopeKey, nextRefreshKey);
+
+    const inFlightRefresh = serverRefreshPromisesRef.current.get(targetScopeKey);
+    if (inFlightRefresh !== undefined) {
+      return inFlightRefresh;
+    }
+
+    const refreshPromise = (async (): Promise<void> => {
+      try {
+        while (true) {
+          const requestedRefreshKey = requestedRefreshKeysRef.current.get(targetScopeKey);
+
+          if (requestedRefreshKey === undefined) {
+            throw new Error(`Missing requested progress series refresh key for scope ${targetScopeKey}`);
+          }
+
+          if (currentScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
+            requestedRefreshKeysRef.current.delete(targetScopeKey);
+            return;
+          }
+
+          try {
+            const serverSeries = normalizeProgressSeries(await loadProgressSeries(refreshInput));
+            const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
+              === requestedRefreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              storePersistedProgressSeries(targetScopeKey, serverSeries);
+              dispatch({
+                type: "series_server_load_succeeded",
+                scopeKey: targetScopeKey,
+                serverBase: createProgressSeriesSnapshot(serverSeries, "server", false),
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+            }
+          } catch (error: unknown) {
+            const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
+              === requestedRefreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              dispatch({
+                type: "series_server_load_failed",
+                scopeKey: targetScopeKey,
+                errorMessage: getErrorMessage(error),
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+              captureProgressServerLoadError(error, {
+                operation: "progress_series_server_load",
+                workspaceId: activeWorkspaceId,
+                installationId,
+              });
+            }
+          }
+
+          if (requestedRefreshKeysRef.current.get(targetScopeKey) === requestedRefreshKey) {
+            requestedRefreshKeysRef.current.delete(targetScopeKey);
+            return;
+          }
+        }
+      } finally {
+        serverRefreshPromisesRef.current.delete(targetScopeKey);
+      }
+    })();
+
+    serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
+    return refreshPromise;
+  }, [activeWorkspaceId, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+
+  useEffect(() => {
+    if (scopeKey === null || refreshKey === null) {
+      return;
+    }
+
+    if (requestedRefreshKeysRef.current.get(scopeKey) === refreshKey) {
+      return;
+    }
+
+    void refreshProgressSeries(scopeKey, input, refreshKey);
+  }, [input, refreshKey, refreshProgressSeries, scopeKey]);
+
+  return {
+    refreshProgressSeries,
+  };
+}

--- a/apps/web/src/appData/progress/source/pipelines/summarySource.ts
+++ b/apps/web/src/appData/progress/source/pipelines/summarySource.ts
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useRef } from "react";
+import { loadProgressSummary } from "../../../../api";
+import {
+  hasPendingProgressReviewEvents,
+  loadLocalProgressActiveDates,
+  loadLocalProgressSummary,
+} from "../../../../localDb/progress/progress";
+import type {
+  ProgressScopeKey,
+  ProgressSummaryInput,
+} from "../../../../types";
+import {
+  createProgressSummarySnapshot,
+} from "../../snapshots/progressSnapshots";
+import {
+  loadPersistedProgressSummary,
+  storePersistedProgressSummary,
+} from "../../storage/progressStorage";
+import {
+  captureProgressServerLoadError,
+  getErrorMessage,
+  type ProgressCanLoadServerBaseRef,
+  type ProgressScopeKeyRef,
+  type ProgressSourceDispatch,
+} from "./progressSourcePipelineHelpers";
+
+export type RefreshProgressSummary = (
+  targetScopeKey: ProgressScopeKey,
+  input: ProgressSummaryInput,
+  nextRefreshKey: string,
+) => Promise<void>;
+
+export type ProgressSummarySourcePipeline = Readonly<{
+  refreshProgressSummary: RefreshProgressSummary;
+}>;
+
+type ProgressSummarySourcePipelineParams = Readonly<{
+  accessibleWorkspaceIds: ReadonlyArray<string>;
+  activeWorkspaceId: string | null;
+  canLoadServerBase: boolean;
+  canLoadServerBaseRef: ProgressCanLoadServerBaseRef;
+  currentScopeKeyRef: ProgressScopeKeyRef;
+  dispatch: ProgressSourceDispatch;
+  input: ProgressSummaryInput;
+  installationId: string | null;
+  manualRefreshVersion: number;
+  progressLocalVersion: number;
+  refreshKey: string | null;
+  scopeKey: ProgressScopeKey | null;
+}>;
+
+export function useProgressSummarySourcePipeline(
+  params: ProgressSummarySourcePipelineParams,
+): ProgressSummarySourcePipeline {
+  const {
+    accessibleWorkspaceIds,
+    activeWorkspaceId,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    input,
+    installationId,
+    manualRefreshVersion,
+    progressLocalVersion,
+    refreshKey,
+    scopeKey,
+  } = params;
+  const localLoadSequenceRef = useRef<number>(0);
+  const serverRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
+  const requestedRefreshKeysRef = useRef<Map<ProgressScopeKey, string>>(new Map());
+
+  useEffect(() => {
+    currentScopeKeyRef.current = scopeKey;
+
+    if (scopeKey === null) {
+      dispatch({ type: "summary_scope_reset" });
+      return;
+    }
+
+    const persistedSummary = canLoadServerBase
+      ? loadPersistedProgressSummary(scopeKey)
+      : null;
+
+    dispatch({
+      type: "summary_scope_initialized",
+      scopeKey,
+      referenceLocalDate: input.today,
+      serverBase: persistedSummary === null ? null : createProgressSummarySnapshot(persistedSummary, "server", false),
+      canRenderServerBase: canLoadServerBaseRef.current,
+    });
+  }, [canLoadServerBase, canLoadServerBaseRef, currentScopeKeyRef, dispatch, input.today, scopeKey]);
+
+  useEffect(() => {
+    if (scopeKey === null) {
+      return;
+    }
+
+    const currentSequence = localLoadSequenceRef.current + 1;
+    localLoadSequenceRef.current = currentSequence;
+
+    void Promise.all([
+      loadLocalProgressSummary(accessibleWorkspaceIds, input),
+      loadLocalProgressActiveDates(accessibleWorkspaceIds, input.timeZone),
+      hasPendingProgressReviewEvents(accessibleWorkspaceIds),
+    ]).then(([localSummary, localFallbackActiveDates, hasPendingLocalReviews]) => {
+      if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
+        return;
+      }
+
+      dispatch({
+        type: "summary_local_load_succeeded",
+        scopeKey,
+        localFallback: createProgressSummarySnapshot({
+          timeZone: input.timeZone,
+          generatedAt: null,
+          reviewHistoryWatermarks: [],
+          summary: localSummary,
+        }, "local_only", true),
+        localFallbackActiveDates,
+        hasPendingLocalReviews,
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    }).catch((error: unknown) => {
+      if (currentScopeKeyRef.current !== scopeKey || localLoadSequenceRef.current !== currentSequence) {
+        return;
+      }
+
+      dispatch({
+        type: "summary_local_load_failed",
+        scopeKey,
+        errorMessage: getErrorMessage(error),
+        canRenderServerBase: canLoadServerBaseRef.current,
+      });
+    });
+  }, [
+    accessibleWorkspaceIds,
+    canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef,
+    dispatch,
+    input,
+    manualRefreshVersion,
+    progressLocalVersion,
+    scopeKey,
+  ]);
+
+  const refreshProgressSummary = useCallback<RefreshProgressSummary>(async function refreshProgressSummary(
+    targetScopeKey: ProgressScopeKey,
+    refreshInput: ProgressSummaryInput,
+    nextRefreshKey: string,
+  ): Promise<void> {
+    requestedRefreshKeysRef.current.set(targetScopeKey, nextRefreshKey);
+
+    const inFlightRefresh = serverRefreshPromisesRef.current.get(targetScopeKey);
+    if (inFlightRefresh !== undefined) {
+      return inFlightRefresh;
+    }
+
+    const refreshPromise = (async (): Promise<void> => {
+      try {
+        while (true) {
+          const requestedRefreshKey = requestedRefreshKeysRef.current.get(targetScopeKey);
+
+          if (requestedRefreshKey === undefined) {
+            throw new Error(`Missing requested progress summary refresh key for scope ${targetScopeKey}`);
+          }
+
+          if (currentScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
+            requestedRefreshKeysRef.current.delete(targetScopeKey);
+            return;
+          }
+
+          try {
+            const serverSummary = await loadProgressSummary(refreshInput);
+            const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
+              === requestedRefreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              storePersistedProgressSummary(targetScopeKey, serverSummary);
+              dispatch({
+                type: "summary_server_load_succeeded",
+                scopeKey: targetScopeKey,
+                serverBase: createProgressSummarySnapshot(serverSummary, "server", false),
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+            }
+          } catch (error: unknown) {
+            const isCurrentRefreshRequest: boolean = requestedRefreshKeysRef.current.get(targetScopeKey)
+              === requestedRefreshKey;
+
+            if (
+              currentScopeKeyRef.current === targetScopeKey
+              && canLoadServerBaseRef.current
+              && isCurrentRefreshRequest
+            ) {
+              dispatch({
+                type: "summary_server_load_failed",
+                scopeKey: targetScopeKey,
+                errorMessage: getErrorMessage(error),
+                canRenderServerBase: canLoadServerBaseRef.current,
+              });
+              captureProgressServerLoadError(error, {
+                operation: "progress_summary_server_load",
+                workspaceId: activeWorkspaceId,
+                installationId,
+              });
+            }
+          }
+
+          if (requestedRefreshKeysRef.current.get(targetScopeKey) === requestedRefreshKey) {
+            requestedRefreshKeysRef.current.delete(targetScopeKey);
+            return;
+          }
+        }
+      } finally {
+        serverRefreshPromisesRef.current.delete(targetScopeKey);
+      }
+    })();
+
+    serverRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
+    return refreshPromise;
+  }, [activeWorkspaceId, canLoadServerBaseRef, currentScopeKeyRef, dispatch, installationId]);
+
+  useEffect(() => {
+    if (scopeKey === null || refreshKey === null) {
+      return;
+    }
+
+    if (requestedRefreshKeysRef.current.get(scopeKey) === refreshKey) {
+      return;
+    }
+
+    void refreshProgressSummary(scopeKey, input, refreshKey);
+  }, [input, refreshKey, refreshProgressSummary, scopeKey]);
+
+  return {
+    refreshProgressSummary,
+  };
+}

--- a/apps/web/src/appData/progress/source/useProgressSource.ts
+++ b/apps/web/src/appData/progress/source/useProgressSource.ts
@@ -1,41 +1,12 @@
 import {
   useCallback,
-  useEffect,
   useMemo,
   useReducer,
   useRef,
   useState,
 } from "react";
-import {
-  ApiNetworkError,
-  loadProgressLeaderboard,
-  loadProgressReviewSchedule,
-  loadProgressSeries,
-  loadProgressSummary,
-} from "../../../api";
-import { captureApiContractError } from "../../../observability/apiContractObservation";
-import {
-  captureWebException,
-  type ProgressServerLoadFailureDetails,
-  type WebObservationScope,
-} from "../../../observability/webObservability";
-import {
-  hasPendingProgressReviewEvents,
-  loadLocalLeaderboardViewerCounts,
-  loadLocalProgressActiveDates,
-  loadLocalProgressDailyReviews,
-  loadLocalProgressSummary,
-  loadPendingProgressDailyReviews,
-} from "../../../localDb/progress/progress";
-import {
-  calculatePendingProgressReviewScheduleCardTotalDelta,
-  hasCompleteLocalProgressReviewScheduleCoverage,
-  hasPendingProgressReviewScheduleCardChanges,
-  loadLocalProgressReviewSchedule,
-} from "../../../localDb/reviews/reviewSchedule";
 import type {
   CloudSettings,
-  ProgressLeaderboard,
   ProgressReviewScheduleInput,
   ProgressScopeKey,
   ProgressSeriesInput,
@@ -67,25 +38,10 @@ import {
   resolveProgressSummaryScopeKey,
   type ProgressSourceSections,
 } from "../state/progressScope";
-import {
-  buildLocalFallbackSeries,
-  createProgressChartData,
-  createProgressLeaderboardSnapshot,
-  createProgressReviewScheduleSnapshot,
-  createProgressSeriesSnapshot,
-  createProgressSummarySnapshot,
-  normalizeProgressSeries,
-} from "../snapshots/progressSnapshots";
-import {
-  loadPersistedProgressLeaderboard,
-  loadPersistedProgressReviewSchedule,
-  loadPersistedProgressSeries,
-  loadPersistedProgressSummary,
-  storePersistedProgressLeaderboard,
-  storePersistedProgressReviewSchedule,
-  storePersistedProgressSeries,
-  storePersistedProgressSummary,
-} from "../storage/progressStorage";
+import { useProgressLeaderboardSourcePipeline } from "./pipelines/leaderboardSource";
+import { useProgressReviewScheduleSourcePipeline } from "./pipelines/reviewScheduleSource";
+import { useProgressSeriesSourcePipeline } from "./pipelines/seriesSource";
+import { useProgressSummarySourcePipeline } from "./pipelines/summarySource";
 
 type UseProgressSourceParams = Readonly<{
   activeWorkspace: WorkspaceSummary | null;
@@ -103,98 +59,6 @@ type UseProgressSourceResult = Readonly<{
   progressSourceState: ProgressSourceState;
   refreshProgress: () => Promise<void>;
 }>;
-
-type ProgressReviewScheduleRefreshRequest = Readonly<{
-  refreshKey: string;
-  progressScheduleLocalVersion: number;
-}>;
-
-type ProgressLeaderboardRefreshRequest = Readonly<{
-  refreshKey: string;
-  bypassFreshnessGate: boolean;
-}>;
-
-/**
- * The compact leaderboard snapshot regenerates hourly on the server, so
- * automatic refreshes are skipped while every cached window's
- * `nextRefreshAfter` is still in the future. Manual Progress refreshes bypass
- * this gate, and non-ready payloads (no windows) are never considered fresh so
- * participation changes propagate on the next automatic load.
- */
-function isProgressLeaderboardFresh(leaderboard: ProgressLeaderboard | null, nowTimestamp: number): boolean {
-  if (leaderboard === null || leaderboard.windows.length === 0) {
-    return false;
-  }
-
-  return leaderboard.windows.every((window) => {
-    const nextRefreshAfterTimestamp = Date.parse(window.nextRefreshAfter);
-    return Number.isNaN(nextRefreshAfterTimestamp) === false && nextRefreshAfterTimestamp > nowTimestamp;
-  });
-}
-
-type ProgressServerLoadOperation = ProgressServerLoadFailureDetails["operation"];
-
-type ProgressServerLoadObservationContext = Readonly<{
-  operation: ProgressServerLoadOperation;
-  workspaceId: string | null;
-  installationId: string | null;
-}>;
-
-function getErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function getCurrentRoute(): string | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-
-  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
-}
-
-function buildProgressNetworkErrorScope(
-  error: ApiNetworkError,
-  context: ProgressServerLoadObservationContext,
-): WebObservationScope {
-  return {
-    app: "web",
-    feature: "progress",
-    userId: null,
-    workspaceId: context.workspaceId,
-    installationId: context.installationId,
-    route: getCurrentRoute(),
-    requestId: error.requestId,
-    statusCode: error.statusCode,
-    code: error.code,
-  };
-}
-
-function captureProgressNetworkError(error: unknown, context: ProgressServerLoadObservationContext): void {
-  if (error instanceof ApiNetworkError === false) {
-    return;
-  }
-
-  captureWebException({
-    action: "progress_server_load_failed",
-    error,
-    scope: buildProgressNetworkErrorScope(error, context),
-    details: {
-      operation: context.operation,
-      workspaceId: context.workspaceId,
-    },
-  });
-}
-
-function captureProgressServerLoadError(error: unknown, context: ProgressServerLoadObservationContext): void {
-  captureApiContractError(error, {
-    feature: "progress",
-    sourceAction: context.operation,
-    userId: null,
-    workspaceId: context.workspaceId,
-    installationId: context.installationId,
-  });
-  captureProgressNetworkError(error, context);
-}
 
 export function useProgressSource(params: UseProgressSourceParams): UseProgressSourceResult {
   const {
@@ -218,21 +82,10 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
   const currentReviewScheduleScopeKeyRef = useRef<ProgressScopeKey | null>(null);
   const currentLeaderboardScopeKeyRef = useRef<ProgressScopeKey | null>(null);
   const canLoadServerBaseRef = useRef<boolean>(false);
-  const summaryLocalLoadSequenceRef = useRef<number>(0);
-  const seriesLocalLoadSequenceRef = useRef<number>(0);
-  const reviewScheduleLocalLoadSequenceRef = useRef<number>(0);
-  const leaderboardLocalLoadSequenceRef = useRef<number>(0);
-  const summaryServerRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
-  const seriesServerRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
-  const reviewScheduleServerRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
-  const leaderboardServerRefreshPromisesRef = useRef<Map<ProgressScopeKey, Promise<void>>>(new Map());
-  const requestedSummaryRefreshKeysRef = useRef<Map<ProgressScopeKey, string>>(new Map());
-  const requestedSeriesRefreshKeysRef = useRef<Map<ProgressScopeKey, string>>(new Map());
-  const requestedReviewScheduleRefreshRequestsRef = useRef<Map<ProgressScopeKey, ProgressReviewScheduleRefreshRequest>>(new Map());
-  const requestedLeaderboardRefreshRequestsRef = useRef<Map<ProgressScopeKey, ProgressLeaderboardRefreshRequest>>(new Map());
   const progressScheduleLocalVersionRef = useRef<number>(0);
 
   const activeWorkspaceId = activeWorkspace?.workspaceId ?? null;
+  const installationId = cloudSettings?.installationId ?? null;
   const accessibleWorkspaceIds = useMemo(
     () => collectAccessibleWorkspaceIds(activeWorkspaceId, availableWorkspaces),
     [activeWorkspaceId, availableWorkspaces],
@@ -287,731 +140,63 @@ export function useProgressSource(params: UseProgressSourceParams): UseProgressS
   canLoadServerBaseRef.current = canLoadServerBase;
   progressScheduleLocalVersionRef.current = progressScheduleLocalVersion;
 
-  useEffect(() => {
-    currentSummaryScopeKeyRef.current = summaryScopeKey;
-
-    if (summaryScopeKey === null) {
-      dispatch({ type: "summary_scope_reset" });
-      return;
-    }
-
-    const persistedSummary = canLoadServerBase
-      ? loadPersistedProgressSummary(summaryScopeKey)
-      : null;
-
-    dispatch({
-      type: "summary_scope_initialized",
-      scopeKey: summaryScopeKey,
-      referenceLocalDate: summaryInput.today,
-      serverBase: persistedSummary === null ? null : createProgressSummarySnapshot(persistedSummary, "server", false),
-      canRenderServerBase: canLoadServerBaseRef.current,
-    });
-  }, [canLoadServerBase, summaryInput.today, summaryScopeKey]);
-
-  useEffect(() => {
-    currentSeriesScopeKeyRef.current = seriesScopeKey;
-
-    if (seriesScopeKey === null) {
-      dispatch({
-        type: "series_scope_reset",
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-      return;
-    }
-
-    const persistedSeries = canLoadServerBase
-      ? loadPersistedProgressSeries(seriesScopeKey)
-      : null;
-
-    dispatch({
-      type: "series_scope_initialized",
-      scopeKey: seriesScopeKey,
-      serverBase: persistedSeries === null ? null : createProgressSeriesSnapshot(persistedSeries, "server", false),
-      canRenderServerBase: canLoadServerBaseRef.current,
-    });
-  }, [canLoadServerBase, seriesScopeKey]);
-
-  useEffect(() => {
-    currentReviewScheduleScopeKeyRef.current = reviewScheduleScopeKey;
-
-    if (reviewScheduleScopeKey === null) {
-      dispatch({ type: "review_schedule_scope_reset" });
-      return;
-    }
-
-    const persistedReviewSchedule = canLoadServerBase
-      ? loadPersistedProgressReviewSchedule(reviewScheduleScopeKey, reviewScheduleInput.timeZone)
-      : null;
-
-    dispatch({
-      type: "review_schedule_scope_initialized",
-      scopeKey: reviewScheduleScopeKey,
-      serverBase: persistedReviewSchedule === null
-        ? null
-        : createProgressReviewScheduleSnapshot(persistedReviewSchedule, "server", false),
-      progressScheduleLocalVersion: progressScheduleLocalVersionRef.current,
-      canRenderServerBase: canLoadServerBaseRef.current,
-    });
-  }, [canLoadServerBase, reviewScheduleInput.timeZone, reviewScheduleScopeKey]);
-
-  useEffect(() => {
-    currentLeaderboardScopeKeyRef.current = leaderboardScopeKey;
-
-    if (leaderboardScopeKey === null) {
-      dispatch({ type: "leaderboard_scope_reset" });
-      return;
-    }
-
-    const persistedLeaderboard = canLoadServerBase
-      ? loadPersistedProgressLeaderboard(leaderboardScopeKey)
-      : null;
-
-    dispatch({
-      type: "leaderboard_scope_initialized",
-      scopeKey: leaderboardScopeKey,
-      serverBase: persistedLeaderboard === null ? null : createProgressLeaderboardSnapshot(persistedLeaderboard, false),
-      canRenderServerBase: canLoadServerBaseRef.current,
-    });
-  }, [canLoadServerBase, leaderboardScopeKey]);
-
-  useEffect(() => {
-    if (summaryScopeKey === null) {
-      return;
-    }
-
-    const currentSequence = summaryLocalLoadSequenceRef.current + 1;
-    summaryLocalLoadSequenceRef.current = currentSequence;
-
-    void Promise.all([
-      loadLocalProgressSummary(accessibleWorkspaceIds, summaryInput),
-      loadLocalProgressActiveDates(accessibleWorkspaceIds, summaryInput.timeZone),
-      hasPendingProgressReviewEvents(accessibleWorkspaceIds),
-    ]).then(([localSummary, localFallbackActiveDates, hasPendingLocalReviews]) => {
-      if (currentSummaryScopeKeyRef.current !== summaryScopeKey || summaryLocalLoadSequenceRef.current !== currentSequence) {
-        return;
-      }
-
-      dispatch({
-        type: "summary_local_load_succeeded",
-        scopeKey: summaryScopeKey,
-        localFallback: createProgressSummarySnapshot({
-          timeZone: summaryInput.timeZone,
-          generatedAt: null,
-          reviewHistoryWatermarks: [],
-          summary: localSummary,
-        }, "local_only", true),
-        localFallbackActiveDates,
-        hasPendingLocalReviews,
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    }).catch((error: unknown) => {
-      if (currentSummaryScopeKeyRef.current !== summaryScopeKey || summaryLocalLoadSequenceRef.current !== currentSequence) {
-        return;
-      }
-
-      dispatch({
-        type: "summary_local_load_failed",
-        scopeKey: summaryScopeKey,
-        errorMessage: getErrorMessage(error),
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    });
-  }, [
+  const { refreshProgressSummary } = useProgressSummarySourcePipeline({
     accessibleWorkspaceIds,
+    activeWorkspaceId,
     canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef: currentSummaryScopeKeyRef,
+    dispatch,
+    input: summaryInput,
+    installationId,
     manualRefreshVersion,
     progressLocalVersion,
-    summaryInput,
-    summaryScopeKey,
-  ]);
-
-  useEffect(() => {
-    if (seriesScopeKey === null) {
-      return;
-    }
-
-    const currentSequence = seriesLocalLoadSequenceRef.current + 1;
-    seriesLocalLoadSequenceRef.current = currentSequence;
-
-    void Promise.all([
-      loadLocalProgressDailyReviews(accessibleWorkspaceIds, seriesInput),
-      loadLocalProgressActiveDates(accessibleWorkspaceIds, seriesInput.timeZone),
-      loadPendingProgressDailyReviews(accessibleWorkspaceIds, seriesInput),
-    ]).then(([localDailyReviews, localActiveDates, pendingLocalDailyReviews]) => {
-      if (currentSeriesScopeKeyRef.current !== seriesScopeKey || seriesLocalLoadSequenceRef.current !== currentSequence) {
-        return;
-      }
-
-      dispatch({
-        type: "series_local_load_succeeded",
-        scopeKey: seriesScopeKey,
-        localFallback: createProgressSeriesSnapshot(
-          buildLocalFallbackSeries(seriesInput, localDailyReviews, localActiveDates),
-          "local_only",
-          true,
-        ),
-        localFallbackActiveDates: localActiveDates,
-        pendingLocalOverlay: createProgressChartData(pendingLocalDailyReviews),
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    }).catch((error: unknown) => {
-      if (currentSeriesScopeKeyRef.current !== seriesScopeKey || seriesLocalLoadSequenceRef.current !== currentSequence) {
-        return;
-      }
-
-      dispatch({
-        type: "series_local_load_failed",
-        scopeKey: seriesScopeKey,
-        errorMessage: getErrorMessage(error),
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    });
-  }, [
+    refreshKey: summaryRefreshKey,
+    scopeKey: summaryScopeKey,
+  });
+  const { refreshProgressSeries } = useProgressSeriesSourcePipeline({
     accessibleWorkspaceIds,
+    activeWorkspaceId,
     canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef: currentSeriesScopeKeyRef,
+    dispatch,
+    input: seriesInput,
+    installationId,
     manualRefreshVersion,
     progressLocalVersion,
-    seriesInput,
-    seriesScopeKey,
-  ]);
-
-  useEffect(() => {
-    if (reviewScheduleScopeKey === null) {
-      return;
-    }
-
-    const currentSequence = reviewScheduleLocalLoadSequenceRef.current + 1;
-    reviewScheduleLocalLoadSequenceRef.current = currentSequence;
-
-    void Promise.all([
-      loadLocalProgressReviewSchedule(accessibleWorkspaceIds, reviewScheduleInput),
-      hasPendingProgressReviewScheduleCardChanges(accessibleWorkspaceIds),
-      hasCompleteLocalProgressReviewScheduleCoverage(accessibleWorkspaceIds),
-      calculatePendingProgressReviewScheduleCardTotalDelta(accessibleWorkspaceIds),
-    ]).then(([
-      localReviewSchedule,
-      hasPendingLocalCardChanges,
-      hasCompleteLocalCardState,
-      pendingLocalCardTotalDelta,
-    ]) => {
-      if (
-        currentReviewScheduleScopeKeyRef.current !== reviewScheduleScopeKey
-        || reviewScheduleLocalLoadSequenceRef.current !== currentSequence
-      ) {
-        return;
-      }
-
-      dispatch({
-        type: "review_schedule_local_load_succeeded",
-        scopeKey: reviewScheduleScopeKey,
-        localFallback: createProgressReviewScheduleSnapshot(localReviewSchedule, "local_only", true),
-        hasPendingLocalCardChanges,
-        hasCompleteLocalCardState,
-        pendingLocalCardTotalDelta,
-        progressScheduleLocalVersion,
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    }).catch((error: unknown) => {
-      if (
-        currentReviewScheduleScopeKeyRef.current !== reviewScheduleScopeKey
-        || reviewScheduleLocalLoadSequenceRef.current !== currentSequence
-      ) {
-        return;
-      }
-
-      dispatch({
-        type: "review_schedule_local_load_failed",
-        scopeKey: reviewScheduleScopeKey,
-        errorMessage: getErrorMessage(error),
-        progressScheduleLocalVersion,
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    });
-  }, [
+    refreshKey: seriesRefreshKey,
+    scopeKey: seriesScopeKey,
+  });
+  const { refreshProgressReviewSchedule } = useProgressReviewScheduleSourcePipeline({
     accessibleWorkspaceIds,
+    activeWorkspaceId,
     canLoadServerBase,
+    canLoadServerBaseRef,
+    currentScopeKeyRef: currentReviewScheduleScopeKeyRef,
+    dispatch,
+    input: reviewScheduleInput,
+    installationId,
     manualRefreshVersion,
     progressScheduleLocalVersion,
-    reviewScheduleInput,
-    reviewScheduleScopeKey,
-  ]);
-
-  useEffect(() => {
-    if (leaderboardScopeKey === null) {
-      return;
-    }
-
-    // The viewer counts only overlay a rendered server snapshot, so skip the
-    // review-event scan entirely while the session cannot load one; the effect
-    // re-runs when `canLoadServerBase` flips after sign-in.
-    if (canLoadServerBase === false) {
-      return;
-    }
-
-    const currentSequence = leaderboardLocalLoadSequenceRef.current + 1;
-    leaderboardLocalLoadSequenceRef.current = currentSequence;
-
-    void loadLocalLeaderboardViewerCounts(accessibleWorkspaceIds, new Date()).then((localViewerCounts) => {
-      if (
-        currentLeaderboardScopeKeyRef.current !== leaderboardScopeKey
-        || leaderboardLocalLoadSequenceRef.current !== currentSequence
-      ) {
-        return;
-      }
-
-      dispatch({
-        type: "leaderboard_local_load_succeeded",
-        scopeKey: leaderboardScopeKey,
-        localViewerCounts,
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    }).catch((error: unknown) => {
-      if (
-        currentLeaderboardScopeKeyRef.current !== leaderboardScopeKey
-        || leaderboardLocalLoadSequenceRef.current !== currentSequence
-      ) {
-        return;
-      }
-
-      dispatch({
-        type: "leaderboard_local_load_failed",
-        scopeKey: leaderboardScopeKey,
-        errorMessage: getErrorMessage(error),
-        canRenderServerBase: canLoadServerBaseRef.current,
-      });
-    });
-  }, [
+    progressScheduleLocalVersionRef,
+    refreshKey: reviewScheduleRefreshKey,
+    scopeKey: reviewScheduleScopeKey,
+  });
+  const { refreshProgressLeaderboard } = useProgressLeaderboardSourcePipeline({
     accessibleWorkspaceIds,
+    activeWorkspaceId,
+    autoRefreshEnabled: leaderboardAutoRefreshEnabled,
     canLoadServerBase,
-    leaderboardScopeKey,
+    canLoadServerBaseRef,
+    currentScopeKeyRef: currentLeaderboardScopeKeyRef,
+    dispatch,
+    installationId,
     manualRefreshVersion,
     progressLocalVersion,
-  ]);
-
-  const refreshProgressSummary = useCallback(async function refreshProgressSummary(
-    targetScopeKey: ProgressScopeKey,
-    input: ProgressSummaryInput,
-    nextRefreshKey: string,
-  ): Promise<void> {
-    requestedSummaryRefreshKeysRef.current.set(targetScopeKey, nextRefreshKey);
-
-    const inFlightRefresh = summaryServerRefreshPromisesRef.current.get(targetScopeKey);
-    if (inFlightRefresh !== undefined) {
-      return inFlightRefresh;
-    }
-
-    const refreshPromise = (async (): Promise<void> => {
-      try {
-        while (true) {
-          const requestedRefreshKey = requestedSummaryRefreshKeysRef.current.get(targetScopeKey);
-
-          if (requestedRefreshKey === undefined) {
-            throw new Error(`Missing requested progress summary refresh key for scope ${targetScopeKey}`);
-          }
-
-          if (currentSummaryScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
-            requestedSummaryRefreshKeysRef.current.delete(targetScopeKey);
-            return;
-          }
-
-          try {
-            const serverSummary = await loadProgressSummary(input);
-            const isCurrentRefreshRequest: boolean = requestedSummaryRefreshKeysRef.current.get(targetScopeKey)
-              === requestedRefreshKey;
-
-            if (
-              currentSummaryScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              storePersistedProgressSummary(targetScopeKey, serverSummary);
-              dispatch({
-                type: "summary_server_load_succeeded",
-                scopeKey: targetScopeKey,
-                serverBase: createProgressSummarySnapshot(serverSummary, "server", false),
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-            }
-          } catch (error: unknown) {
-            const isCurrentRefreshRequest: boolean = requestedSummaryRefreshKeysRef.current.get(targetScopeKey)
-              === requestedRefreshKey;
-
-            if (
-              currentSummaryScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              dispatch({
-                type: "summary_server_load_failed",
-                scopeKey: targetScopeKey,
-                errorMessage: getErrorMessage(error),
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-              captureProgressServerLoadError(error, {
-                operation: "progress_summary_server_load",
-                workspaceId: activeWorkspaceId,
-                installationId: cloudSettings?.installationId ?? null,
-              });
-            }
-          }
-
-          if (requestedSummaryRefreshKeysRef.current.get(targetScopeKey) === requestedRefreshKey) {
-            requestedSummaryRefreshKeysRef.current.delete(targetScopeKey);
-            return;
-          }
-        }
-      } finally {
-        summaryServerRefreshPromisesRef.current.delete(targetScopeKey);
-      }
-    })();
-
-    summaryServerRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
-    return refreshPromise;
-  }, [activeWorkspaceId, cloudSettings?.installationId]);
-
-  const refreshProgressSeries = useCallback(async function refreshProgressSeries(
-    targetScopeKey: ProgressScopeKey,
-    input: ProgressSeriesInput,
-    nextRefreshKey: string,
-  ): Promise<void> {
-    requestedSeriesRefreshKeysRef.current.set(targetScopeKey, nextRefreshKey);
-
-    const inFlightRefresh = seriesServerRefreshPromisesRef.current.get(targetScopeKey);
-    if (inFlightRefresh !== undefined) {
-      return inFlightRefresh;
-    }
-
-    const refreshPromise = (async (): Promise<void> => {
-      try {
-        while (true) {
-          const requestedRefreshKey = requestedSeriesRefreshKeysRef.current.get(targetScopeKey);
-
-          if (requestedRefreshKey === undefined) {
-            throw new Error(`Missing requested progress series refresh key for scope ${targetScopeKey}`);
-          }
-
-          if (currentSeriesScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
-            requestedSeriesRefreshKeysRef.current.delete(targetScopeKey);
-            return;
-          }
-
-          try {
-            const serverSeries = normalizeProgressSeries(await loadProgressSeries(input));
-            const isCurrentRefreshRequest: boolean = requestedSeriesRefreshKeysRef.current.get(targetScopeKey)
-              === requestedRefreshKey;
-
-            if (
-              currentSeriesScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              storePersistedProgressSeries(targetScopeKey, serverSeries);
-              dispatch({
-                type: "series_server_load_succeeded",
-                scopeKey: targetScopeKey,
-                serverBase: createProgressSeriesSnapshot(serverSeries, "server", false),
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-            }
-          } catch (error: unknown) {
-            const isCurrentRefreshRequest: boolean = requestedSeriesRefreshKeysRef.current.get(targetScopeKey)
-              === requestedRefreshKey;
-
-            if (
-              currentSeriesScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              dispatch({
-                type: "series_server_load_failed",
-                scopeKey: targetScopeKey,
-                errorMessage: getErrorMessage(error),
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-              captureProgressServerLoadError(error, {
-                operation: "progress_series_server_load",
-                workspaceId: activeWorkspaceId,
-                installationId: cloudSettings?.installationId ?? null,
-              });
-            }
-          }
-
-          if (requestedSeriesRefreshKeysRef.current.get(targetScopeKey) === requestedRefreshKey) {
-            requestedSeriesRefreshKeysRef.current.delete(targetScopeKey);
-            return;
-          }
-        }
-      } finally {
-        seriesServerRefreshPromisesRef.current.delete(targetScopeKey);
-      }
-    })();
-
-    seriesServerRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
-    return refreshPromise;
-  }, [activeWorkspaceId, cloudSettings?.installationId]);
-
-  const refreshProgressReviewSchedule = useCallback(async function refreshProgressReviewSchedule(
-    targetScopeKey: ProgressScopeKey,
-    input: ProgressReviewScheduleInput,
-    nextRefreshKey: string,
-    nextProgressScheduleLocalVersion: number,
-  ): Promise<void> {
-    requestedReviewScheduleRefreshRequestsRef.current.set(targetScopeKey, {
-      refreshKey: nextRefreshKey,
-      progressScheduleLocalVersion: nextProgressScheduleLocalVersion,
-    });
-
-    const inFlightRefresh = reviewScheduleServerRefreshPromisesRef.current.get(targetScopeKey);
-    if (inFlightRefresh !== undefined) {
-      return inFlightRefresh;
-    }
-
-    const refreshPromise = (async (): Promise<void> => {
-      try {
-        while (true) {
-          const requestedRefresh = requestedReviewScheduleRefreshRequestsRef.current.get(targetScopeKey);
-
-          if (requestedRefresh === undefined) {
-            throw new Error(`Missing requested progress review schedule refresh key for scope ${targetScopeKey}`);
-          }
-
-          if (currentReviewScheduleScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
-            requestedReviewScheduleRefreshRequestsRef.current.delete(targetScopeKey);
-            return;
-          }
-
-          try {
-            const serverReviewSchedule = await loadProgressReviewSchedule(input);
-            const isCurrentRefreshRequest: boolean = requestedReviewScheduleRefreshRequestsRef.current
-              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
-
-            if (
-              currentReviewScheduleScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              storePersistedProgressReviewSchedule(targetScopeKey, serverReviewSchedule, input.timeZone);
-              dispatch({
-                type: "review_schedule_server_load_succeeded",
-                scopeKey: targetScopeKey,
-                serverBase: createProgressReviewScheduleSnapshot(serverReviewSchedule, "server", false),
-                progressScheduleLocalVersion: requestedRefresh.progressScheduleLocalVersion,
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-            }
-          } catch (error: unknown) {
-            const isCurrentRefreshRequest: boolean = requestedReviewScheduleRefreshRequestsRef.current
-              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
-
-            if (
-              currentReviewScheduleScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              dispatch({
-                type: "review_schedule_server_load_failed",
-                scopeKey: targetScopeKey,
-                errorMessage: getErrorMessage(error),
-                progressScheduleLocalVersion: requestedRefresh.progressScheduleLocalVersion,
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-              captureProgressServerLoadError(error, {
-                operation: "progress_review_schedule_server_load",
-                workspaceId: activeWorkspaceId,
-                installationId: cloudSettings?.installationId ?? null,
-              });
-            }
-          }
-
-          if (
-            requestedReviewScheduleRefreshRequestsRef.current.get(targetScopeKey)?.refreshKey
-              === requestedRefresh.refreshKey
-          ) {
-            requestedReviewScheduleRefreshRequestsRef.current.delete(targetScopeKey);
-            return;
-          }
-        }
-      } finally {
-        reviewScheduleServerRefreshPromisesRef.current.delete(targetScopeKey);
-      }
-    })();
-
-    reviewScheduleServerRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
-    return refreshPromise;
-  }, [activeWorkspaceId, cloudSettings?.installationId]);
-
-  const refreshProgressLeaderboard = useCallback(async function refreshProgressLeaderboard(
-    targetScopeKey: ProgressScopeKey,
-    nextRefreshKey: string,
-    bypassFreshnessGate: boolean,
-  ): Promise<void> {
-    requestedLeaderboardRefreshRequestsRef.current.set(targetScopeKey, {
-      refreshKey: nextRefreshKey,
-      bypassFreshnessGate,
-    });
-
-    const inFlightRefresh = leaderboardServerRefreshPromisesRef.current.get(targetScopeKey);
-    if (inFlightRefresh !== undefined) {
-      return inFlightRefresh;
-    }
-
-    const refreshPromise = (async (): Promise<void> => {
-      try {
-        while (true) {
-          const requestedRefresh = requestedLeaderboardRefreshRequestsRef.current.get(targetScopeKey);
-
-          if (requestedRefresh === undefined) {
-            throw new Error(`Missing requested progress leaderboard refresh key for scope ${targetScopeKey}`);
-          }
-
-          if (currentLeaderboardScopeKeyRef.current !== targetScopeKey || canLoadServerBaseRef.current === false) {
-            requestedLeaderboardRefreshRequestsRef.current.delete(targetScopeKey);
-            return;
-          }
-
-          if (
-            requestedRefresh.bypassFreshnessGate === false
-            && isProgressLeaderboardFresh(loadPersistedProgressLeaderboard(targetScopeKey), Date.now())
-          ) {
-            if (requestedLeaderboardRefreshRequestsRef.current.get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey) {
-              dispatch({
-                type: "leaderboard_server_load_skipped",
-                scopeKey: targetScopeKey,
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-              requestedLeaderboardRefreshRequestsRef.current.delete(targetScopeKey);
-              return;
-            }
-
-            continue;
-          }
-
-          try {
-            const serverLeaderboard = await loadProgressLeaderboard();
-            const isCurrentRefreshRequest: boolean = requestedLeaderboardRefreshRequestsRef.current
-              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
-
-            if (
-              currentLeaderboardScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              storePersistedProgressLeaderboard(targetScopeKey, serverLeaderboard);
-              dispatch({
-                type: "leaderboard_server_load_succeeded",
-                scopeKey: targetScopeKey,
-                serverBase: createProgressLeaderboardSnapshot(serverLeaderboard, false),
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-            }
-          } catch (error: unknown) {
-            const isCurrentRefreshRequest: boolean = requestedLeaderboardRefreshRequestsRef.current
-              .get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey;
-
-            if (
-              currentLeaderboardScopeKeyRef.current === targetScopeKey
-              && canLoadServerBaseRef.current
-              && isCurrentRefreshRequest
-            ) {
-              dispatch({
-                type: "leaderboard_server_load_failed",
-                scopeKey: targetScopeKey,
-                errorMessage: getErrorMessage(error),
-                isNetworkError: error instanceof ApiNetworkError,
-                canRenderServerBase: canLoadServerBaseRef.current,
-              });
-              captureProgressServerLoadError(error, {
-                operation: "progress_leaderboard_server_load",
-                workspaceId: activeWorkspaceId,
-                installationId: cloudSettings?.installationId ?? null,
-              });
-            }
-          }
-
-          if (requestedLeaderboardRefreshRequestsRef.current.get(targetScopeKey)?.refreshKey === requestedRefresh.refreshKey) {
-            requestedLeaderboardRefreshRequestsRef.current.delete(targetScopeKey);
-            return;
-          }
-        }
-      } finally {
-        leaderboardServerRefreshPromisesRef.current.delete(targetScopeKey);
-      }
-    })();
-
-    leaderboardServerRefreshPromisesRef.current.set(targetScopeKey, refreshPromise);
-    return refreshPromise;
-  }, [activeWorkspaceId, cloudSettings?.installationId]);
-
-  useEffect(() => {
-    if (summaryScopeKey === null || summaryRefreshKey === null) {
-      return;
-    }
-
-    if (requestedSummaryRefreshKeysRef.current.get(summaryScopeKey) === summaryRefreshKey) {
-      return;
-    }
-
-    void refreshProgressSummary(summaryScopeKey, summaryInput, summaryRefreshKey);
-  }, [refreshProgressSummary, summaryInput, summaryRefreshKey, summaryScopeKey]);
-
-  useEffect(() => {
-    if (seriesScopeKey === null || seriesRefreshKey === null) {
-      return;
-    }
-
-    if (requestedSeriesRefreshKeysRef.current.get(seriesScopeKey) === seriesRefreshKey) {
-      return;
-    }
-
-    void refreshProgressSeries(seriesScopeKey, seriesInput, seriesRefreshKey);
-  }, [refreshProgressSeries, seriesInput, seriesRefreshKey, seriesScopeKey]);
-
-  useEffect(() => {
-    if (reviewScheduleScopeKey === null || reviewScheduleRefreshKey === null) {
-      return;
-    }
-
-    if (
-      requestedReviewScheduleRefreshRequestsRef.current.get(reviewScheduleScopeKey)?.refreshKey
-        === reviewScheduleRefreshKey
-    ) {
-      return;
-    }
-
-    void refreshProgressReviewSchedule(
-      reviewScheduleScopeKey,
-      reviewScheduleInput,
-      reviewScheduleRefreshKey,
-      progressScheduleLocalVersion,
-    );
-  }, [
-    progressScheduleLocalVersion,
-    refreshProgressReviewSchedule,
-    reviewScheduleInput,
-    reviewScheduleRefreshKey,
-    reviewScheduleScopeKey,
-  ]);
-
-  useEffect(() => {
-    if (leaderboardAutoRefreshEnabled === false) {
-      return;
-    }
-
-    if (leaderboardScopeKey === null || leaderboardRefreshKey === null) {
-      return;
-    }
-
-    if (requestedLeaderboardRefreshRequestsRef.current.get(leaderboardScopeKey)?.refreshKey === leaderboardRefreshKey) {
-      return;
-    }
-
-    void refreshProgressLeaderboard(leaderboardScopeKey, leaderboardRefreshKey, false);
-  }, [
-    leaderboardAutoRefreshEnabled,
-    leaderboardRefreshKey,
-    leaderboardScopeKey,
-    refreshProgressLeaderboard,
-  ]);
+    refreshKey: leaderboardRefreshKey,
+    scopeKey: leaderboardScopeKey,
+  });
 
   const refreshProgress = useCallback(async function refreshProgress(): Promise<void> {
     if (


### PR DESCRIPTION
## Summary
- split the web progress source hook into summary, series, review schedule, and leaderboard source pipelines
- kept useProgressSource as the orchestrator for scope resolution, refs, reducer wiring, manual refresh, and return shape
- moved shared progress source dispatch/ref/error observation helpers into a small pipeline helper module

## Validation
- cd apps/web && npx vitest run src/appData/progress/source/progressSource.summarySeries.test.tsx src/appData/progress/source/progressSource.cache.test.tsx src/appData/progress/source/progressSource.reviewSchedule.test.tsx src/appData/progress/source/progressSource.lifecycle.test.tsx
- cd apps/web && npm run build
- git --no-pager diff --check