### PR TITLE
[codex] Make review queue manually rendered

### DIFF
--- a/apps/web/e2e/live-smoke/flows/cards-review.ts
+++ b/apps/web/e2e/live-smoke/flows/cards-review.ts
@@ -67,6 +67,7 @@ async function reviewSeededCardFromQueue(session: LiveSmokeSession): Promise<voi
   if (reviewedCardId === null || reviewedCardId === "") {
     throw new Error(`Review current card id is unavailable for ${scenario.seededFrontText}`);
   }
+  await trackedClick(diagnostics, "open review queue for post-review observation", page.getByTestId("review-queue-badge"));
   await trackedClick(diagnostics, "reveal review answer", page.getByTestId("review-reveal-answer"));
   await trackedClick(diagnostics, "submit Good review answer", page.getByTestId("review-rate-good"));
   await session.diagnostics.runAction(`confirm review pane and queue update after reviewing ${scenario.seededFrontText}`, async () => {

--- a/apps/web/src/screens/review/ReviewScreen.tsx
+++ b/apps/web/src/screens/review/ReviewScreen.tsx
@@ -38,12 +38,16 @@ export function ReviewScreen(): ReactElement {
     dismissReviewReactions();
   }, [dismissReviewReactions, reviewReactionAnimationsEnabled]);
 
+  const reviewLayoutClassName = queuePanelProps.isReviewQueuePanelOpen
+    ? "review-layout review-layout-queue-open"
+    : "review-layout";
+
   return (
     <main className="container" data-testid="review-screen" onPointerDownCapture={dismissReviewReactions}>
       <section className="panel review-screen-panel">
         <ReviewScreenHeader {...headerProps} />
 
-        <div className="review-layout">
+        <div className={reviewLayoutClassName}>
           <div className="review-pane-reaction-frame">
             <ReviewPane {...paneProps} />
             <ReviewRatingReactionLayer
@@ -51,7 +55,7 @@ export function ReviewScreen(): ReactElement {
               onReactionEventFallback={reviewReactionFallbackHandler}
             />
           </div>
-          <ReviewQueuePanel {...queuePanelProps} />
+          {queuePanelProps.isReviewQueuePanelOpen ? <ReviewQueuePanel {...queuePanelProps} /> : null}
         </div>
       </section>
 

--- a/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
+++ b/apps/web/src/screens/review/components/ReviewScreenHeader.tsx
@@ -57,7 +57,7 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
   const leaderboardShortcutAriaLabel = leaderboardShortcutRankLabel === null
     ? t("reviewScreen.leaderboardShortcut.ariaLabel")
     : `${t("reviewScreen.leaderboardShortcut.ariaLabel")}. ${leaderboardShortcutRankLabel}`;
-  const isReviewQueueShortcutDisabled = reviewQueueTotalCount === 0;
+  const isReviewQueueShortcutDisabled = reviewQueueTotalCount === 0 && isReviewQueuePanelOpen === false;
 
   return (
     <div className="screen-head review-screen-head">
@@ -80,7 +80,7 @@ export function ReviewScreenHeader(props: ReviewScreenHeaderProps): ReactElement
             <button
               className="badge review-progress-badge review-screen-head-badge review-queue-shortcut"
               type="button"
-              aria-controls="review-queue-panel"
+              aria-controls={isReviewQueuePanelOpen ? "review-queue-panel" : undefined}
               aria-expanded={isReviewQueueShortcutDisabled ? undefined : isReviewQueuePanelOpen}
               aria-label={reviewQueueAriaLabel}
               title={reviewQueueAriaLabel}

--- a/apps/web/src/screens/review/data/useReviewScreenData.submit.test.tsx
+++ b/apps/web/src/screens/review/data/useReviewScreenData.submit.test.tsx
@@ -20,6 +20,7 @@ const {
   dispatchDocumentKeydown,
   getContainer,
   getState,
+  openReviewQueue,
   renderReviewScreen,
   rerenderReviewScreen,
   revealAnswer,
@@ -714,6 +715,7 @@ describe("useReviewScreenData submit", () => {
       await Promise.resolve();
     });
 
+    await openReviewQueue();
     const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
     expect(getContainer().textContent).toContain("Race next front");
     expect(getContainer().textContent).not.toContain("Race current original front");

--- a/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
+++ b/apps/web/src/screens/review/testSupport/ReviewScreenTestSupport.tsx
@@ -124,6 +124,7 @@ type ReviewScreenTestHarness = Readonly<{
   dispatchDocumentKeydown: (key: string) => Promise<void>;
   getContainer: () => HTMLDivElement;
   getState: () => ReviewScreenTestState;
+  openReviewQueue: () => Promise<void>;
   openReviewFilterMenu: () => Promise<void>;
   renderReviewScreen: () => Promise<void>;
   rerenderReviewScreen: () => Promise<void>;
@@ -619,6 +620,21 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     });
   }
 
+  async function openReviewQueue(): Promise<void> {
+    const queueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
+    if (!(queueBadge instanceof HTMLButtonElement)) {
+      throw new Error("Review queue badge was not found");
+    }
+
+    if (queueBadge.getAttribute("aria-expanded") === "true") {
+      return;
+    }
+
+    await act(async () => {
+      clickElement(queueBadge);
+    });
+  }
+
   async function revealAnswer(): Promise<void> {
     const revealButton = getContainer().querySelector(".review-reveal-btn");
     if (!(revealButton instanceof HTMLButtonElement)) {
@@ -640,6 +656,7 @@ export function setupReviewScreenTest(): ReviewScreenTestHarness {
     dispatchDocumentKeydown,
     getContainer,
     getState: (): ReviewScreenTestState => state,
+    openReviewQueue,
     openReviewFilterMenu,
     renderReviewScreen,
     rerenderReviewScreen: renderReviewScreen,

--- a/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.controls.test.tsx
@@ -25,6 +25,7 @@ const {
   getState,
   openReviewFilterMenu,
   renderReviewScreen,
+  rerenderReviewScreen,
   revealAnswer,
 } = setupReviewScreenTest();
 
@@ -206,7 +207,7 @@ describe("ReviewScreen controls", () => {
     }
     expect(queueBadge.querySelector(".review-progress-badge-value")).toBeNull();
     expect(queueBadge.getAttribute("aria-label")).toContain("1 card");
-    expect(queueBadge.getAttribute("aria-controls")).toBe("review-queue-panel");
+    expect(queueBadge.getAttribute("aria-controls")).toBeNull();
     expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
     expect(queueBadge.getAttribute("href")).toBeNull();
     expect(queueBadge.disabled).toBe(false);
@@ -219,16 +220,13 @@ describe("ReviewScreen controls", () => {
       ".review-leaderboard-shortcut .review-progress-badge-icon",
       "color: #fbbf24",
     )).toBe(true);
-    const queuePanel = getContainer().querySelector("#review-queue-panel");
-    if (!(queuePanel instanceof HTMLElement)) {
-      throw new Error("Review queue panel was not found");
+    const reviewLayout = getContainer().querySelector(".review-layout");
+    if (!(reviewLayout instanceof HTMLElement)) {
+      throw new Error("Review layout was not found");
     }
-    const queueCloseButton = getContainer().querySelector("[data-testid='review-queue-close']");
-    if (!(queueCloseButton instanceof HTMLButtonElement)) {
-      throw new Error("Review queue close button was not found");
-    }
-    expect(queuePanel.className).not.toContain("review-queue-panel-open");
-    expect(queueCloseButton.getAttribute("aria-label")).toBe("Close queue");
+    expect(reviewLayout.className).not.toContain("review-layout-queue-open");
+    expect(getContainer().querySelector("#review-queue-panel")).toBeNull();
+    expect(getContainer().querySelectorAll("[data-testid='review-queue-card']")).toHaveLength(0);
     expect(getContainer().querySelector("[data-testid='review-screen-toolbar']")).toBeNull();
     expect(headerActions.contains(scopeTrigger)).toBe(true);
     expect(headerActions.contains(queueBadge)).toBe(true);
@@ -243,22 +241,39 @@ describe("ReviewScreen controls", () => {
     expect(progressBadgeIcon.getAttribute("aria-hidden")).toBe("true");
 
     await clickElementAsync(queueBadge);
+    expect(queueBadge.getAttribute("aria-controls")).toBe("review-queue-panel");
     expect(queueBadge.getAttribute("aria-expanded")).toBe("true");
-    expect(queuePanel.className).toContain("review-queue-panel-open");
+    expect(reviewLayout.className).toContain("review-layout-queue-open");
+    const queuePanelAfterOpen = getContainer().querySelector("#review-queue-panel");
+    if (!(queuePanelAfterOpen instanceof HTMLElement)) {
+      throw new Error("Review queue panel was not found after opening");
+    }
+    const queueCloseButton = getContainer().querySelector("[data-testid='review-queue-close']");
+    if (!(queueCloseButton instanceof HTMLButtonElement)) {
+      throw new Error("Review queue close button was not found");
+    }
+    expect(queuePanelAfterOpen.className).toContain("review-queue-panel-open");
+    expect(queueCloseButton.getAttribute("aria-label")).toBe("Close queue");
+    expect(getContainer().querySelectorAll("[data-testid='review-queue-card']")).toHaveLength(1);
     expect(window.location.hash).toBe("");
 
     await clickElementAsync(queueCloseButton);
+    expect(queueBadge.getAttribute("aria-controls")).toBeNull();
     expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
-    expect(queuePanel.className).not.toContain("review-queue-panel-open");
+    expect(reviewLayout.className).not.toContain("review-layout-queue-open");
+    expect(getContainer().querySelector("#review-queue-panel")).toBeNull();
+    expect(getContainer().querySelectorAll("[data-testid='review-queue-card']")).toHaveLength(0);
     expect(window.location.hash).toBe("");
 
     await clickElementAsync(queueBadge);
     expect(queueBadge.getAttribute("aria-expanded")).toBe("true");
+    expect(getContainer().querySelector("#review-queue-panel")).not.toBeNull();
     expect(window.location.hash).toBe("");
 
     await clickElementAsync(queueBadge);
     expect(queueBadge.getAttribute("aria-expanded")).toBe("false");
-    expect(queuePanel.className).not.toContain("review-queue-panel-open");
+    expect(getContainer().querySelector("#review-queue-panel")).toBeNull();
+    expect(getContainer().querySelectorAll("[data-testid='review-queue-card']")).toHaveLength(0);
     expect(window.location.hash).toBe("");
   });
 
@@ -292,6 +307,71 @@ describe("ReviewScreen controls", () => {
     expect(leaderboardShortcut.className).toContain("review-leaderboard-shortcut-ranked");
     expect(leaderboardShortcutValue.textContent).toBe("3");
     expect(leaderboardShortcut.getAttribute("aria-label")).toContain("#3");
+  });
+
+  it("keeps an open empty queue closable from the header shortcut", async () => {
+    const state = getState();
+    const card = createCard({
+      cardId: "card-empty-open-queue",
+      frontText: "Question",
+      backText: "Answer",
+    });
+    state.cards = [card];
+    state.reviewQueue = [card];
+    state.reviewTimeline = [card];
+
+    await renderReviewScreen();
+
+    const queueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
+    if (!(queueBadge instanceof HTMLButtonElement)) {
+      throw new Error("Review queue badge was not found");
+    }
+
+    await clickElementAsync(queueBadge);
+    expect(queueBadge.disabled).toBe(false);
+    expect(queueBadge.getAttribute("aria-expanded")).toBe("true");
+    expect(getContainer().querySelector("#review-queue-panel")).not.toBeNull();
+
+    state.reviewQueue = [];
+    state.reviewTimeline = [];
+    state.appData.selectedReviewFilter = {
+      kind: "tag",
+      tag: "empty",
+    };
+    state.appData.localReadVersion = 1;
+
+    await rerenderReviewScreen();
+    await flushReviewScreenPromises();
+    await vi.waitFor(() => {
+      const refreshedQueueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
+      if (!(refreshedQueueBadge instanceof HTMLButtonElement)) {
+        throw new Error("Review queue badge was not found while waiting for empty queue");
+      }
+
+      expect(refreshedQueueBadge.getAttribute("aria-label")).toContain("0 cards");
+    });
+
+    const emptyQueueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
+    if (!(emptyQueueBadge instanceof HTMLButtonElement)) {
+      throw new Error("Review queue badge was not found after queue emptied");
+    }
+
+    expect(emptyQueueBadge.disabled).toBe(false);
+    expect(emptyQueueBadge.getAttribute("aria-controls")).toBe("review-queue-panel");
+    expect(emptyQueueBadge.getAttribute("aria-expanded")).toBe("true");
+    expect(getContainer().querySelector("#review-queue-panel")).not.toBeNull();
+
+    await clickElementAsync(emptyQueueBadge);
+
+    const closedEmptyQueueBadge = getContainer().querySelector("[data-testid='review-queue-badge']");
+    if (!(closedEmptyQueueBadge instanceof HTMLButtonElement)) {
+      throw new Error("Review queue badge was not found after closing empty queue");
+    }
+
+    expect(closedEmptyQueueBadge.disabled).toBe(true);
+    expect(closedEmptyQueueBadge.getAttribute("aria-controls")).toBeNull();
+    expect(closedEmptyQueueBadge.getAttribute("aria-expanded")).toBeNull();
+    expect(getContainer().querySelector("#review-queue-panel")).toBeNull();
   });
 
   it("reveals the answer with Space and submits the selected rating shortcut", async () => {

--- a/apps/web/src/screens/review/tests/ReviewScreen.presented-card.test.tsx
+++ b/apps/web/src/screens/review/tests/ReviewScreen.presented-card.test.tsx
@@ -10,6 +10,7 @@ const {
   dispatchDocumentKeydown,
   getContainer,
   getState,
+  openReviewQueue,
   renderReviewScreen,
   rerenderReviewScreen,
   revealAnswer,
@@ -65,6 +66,7 @@ describe("ReviewScreen presented card preservation", () => {
 
     expect(state.appData.getCardById).toHaveBeenCalledWith("card-current");
     expect(getContainer().textContent).toContain("Current front");
+    await openReviewQueue();
     const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
     expect(queueTitlesAfterRefresh).toEqual([
       "Current front",
@@ -85,6 +87,7 @@ describe("ReviewScreen presented card preservation", () => {
 
     await rerenderReviewScreen();
 
+    await openReviewQueue();
     const queueTitlesAfterReappearance = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
     expect(queueTitlesAfterReappearance).toEqual([
       "Recent due 1 front",
@@ -146,6 +149,7 @@ describe("ReviewScreen presented card preservation", () => {
     expect(state.appData.getCardById).toHaveBeenCalledWith("card-current-filter");
     expect(getContainer().textContent).toContain("Filter head 1 front");
     expect(getContainer().textContent).not.toContain("Current filter front");
+    await openReviewQueue();
     const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
     expect(queueTitlesAfterRefresh).toEqual(canonicalCards.map((card) => card.frontText));
   });
@@ -201,6 +205,7 @@ describe("ReviewScreen presented card preservation", () => {
     expect(state.appData.getCardById).toHaveBeenCalledWith("card-current-not-due");
     expect(reviewPane.textContent).toContain("Not due head 1 front");
     expect(reviewPane.textContent).not.toContain("Current not due front");
+    await openReviewQueue();
     const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
     expect(queueTitlesAfterRefresh).toEqual([
       ...canonicalCards.map((card) => card.frontText),
@@ -247,6 +252,7 @@ describe("ReviewScreen presented card preservation", () => {
     expect(getContainer().textContent).toContain("Missing head 1 front");
     expect(getContainer().textContent).not.toContain("Current missing front");
     expect(getContainer().textContent).not.toContain("Card not found: card-current-missing");
+    await openReviewQueue();
     const queueTitlesAfterRefresh = [...getContainer().querySelectorAll(".review-queue-card-title")].map((element) => element.textContent);
     expect(queueTitlesAfterRefresh).toEqual(canonicalCards.map((card) => card.frontText));
   });

--- a/apps/web/src/styles/features/review/review-screen.css
+++ b/apps/web/src/styles/features/review/review-screen.css
@@ -20,10 +20,16 @@
 
 .review-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  grid-template-columns: minmax(0, calc((100% - 10px) * 0.6));
   gap: 10px;
   align-items: stretch;
+  justify-content: center;
   min-height: 0;
+}
+
+.review-layout-queue-open {
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  justify-content: stretch;
 }
 
 .review-pane-reaction-frame {


### PR DESCRIPTION
## Summary
- Keep the review queue closed and unmounted until the user opens it from the header shortcut.
- Center the review pane when the queue is closed, while preserving the existing two-column queue layout when open.
- Update review tests and live smoke expectations for explicit queue opening.

## Validation
- `npm exec -- vitest run src/screens/review/tests/ReviewScreen.controls.test.tsx`
- `npm exec -- vitest run src/screens/review/**/*.test.ts src/screens/review/**/*.test.tsx`
- `npm run build`
- `git --no-pager diff --check`