### PR TITLE
[codex] Fix Android progress leaderboard fixture

### DIFF
--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
@@ -533,6 +533,11 @@ private fun createLeaderboardCompactRows(
     if (totalRowCount > topRowCount) {
         shownRanks.add(totalRowCount)
     }
+    rankingRows.forEach { row ->
+        if (row.friendDisplayName != null) {
+            shownRanks.add(row.rank)
+        }
+    }
 
     val rowsByRank = rankingRows.associateBy { row -> row.rank }
     return buildList {
@@ -563,7 +568,7 @@ private fun CloudProgressLeaderboardRankingRow.toLeaderboardParticipantRow(
         },
         publicProfileId = publicProfileId,
         anonymousDisplayName = anonymousDisplayName,
-        friendDisplayName = null,
+        friendDisplayName = friendDisplayName,
         qualifiedReviewCount = qualifiedReviewCount,
         rank = rank
     )
@@ -573,6 +578,7 @@ private fun createLeaderboardParticipantRow(
     kind: ProgressLeaderboardParticipantRowKind,
     publicProfileId: String,
     anonymousDisplayName: String,
+    friendDisplayName: String?,
     qualifiedReviewCount: Int,
     rank: Int
 ): CloudProgressLeaderboardRow.Participant {
@@ -580,7 +586,7 @@ private fun createLeaderboardParticipantRow(
         kind = kind,
         publicProfileId = publicProfileId,
         anonymousDisplayName = anonymousDisplayName,
-        friendDisplayName = null,
+        friendDisplayName = friendDisplayName,
         qualifiedReviewCount = qualifiedReviewCount,
         rank = rank
     )


### PR DESCRIPTION
## Summary

Fix the Android progress ViewModel test fixture so compact leaderboard rows preserve friend display names.

## Root cause

The split progress ViewModel test support passed `friendDisplayName` into `createLeaderboardParticipantRow`, but the helper signature did not accept that parameter and always wrote `null`. That caused `:feature:progress:compileDebugUnitTestKotlin` to fail in Android Release.

## Validation

- `git --no-pager diff --check`

I did not run local Gradle because this repository requires explicit permission before running `./gradlew`.