### PR TITLE
[codex] Fix Android progress fixture invariant

### DIFF
--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
@@ -213,7 +213,10 @@ internal fun createProgressSeriesSnapshot(
             },
             streakDays = createProgressStreakDaysForTest(
                 dailyReviews = dailyReviews.map { point ->
-                    point.copy(reviewCount = 0)
+                    createDailyReviewPoint(
+                        date = point.date,
+                        reviewCount = 0
+                    )
                 },
                 today = to
             ),


### PR DESCRIPTION
## Summary

Fix the Android progress ViewModel test fixture so pending overlay streak days use valid zero-count review points.

## Root cause

The shared progress fixture created zero-count overlay streak inputs with `point.copy(reviewCount = 0)`, which left the rating sub-counts unchanged. `CloudDailyReviewPoint` requires `reviewCount` to equal the sum of `againCount`, `hardCount`, `goodCount`, and `easyCount`, so the fixture threw `IllegalArgumentException` before the affected ViewModel tests could run.

## Validation

- `git --no-pager diff --check`

I did not run local Gradle because this repository requires explicit permission before running `./gradlew`.