### PR TITLE
Fix progress aggregation day mapping

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
@@ -432,9 +432,9 @@ func makeProgressSeriesFromReviewEvents(
         timeZone: requestRange.timeZone
     )
     let zeroFilledDays = try makeZeroFilledProgressDays(requestRange: requestRange)
-    let progressDays = zeroFilledDays.map { progressDay in
+    let progressDays: [ProgressDay] = zeroFilledDays.map { progressDay in
         let ratingCounts = ratingCountsByLocalDate[progressDay.date] ?? zeroProgressReviewRatingCounts()
-        ProgressDay(
+        return ProgressDay(
             date: progressDay.date,
             reviewCount: ratingCounts.reviewCount,
             againCount: ratingCounts.againCount,


### PR DESCRIPTION
## Summary
- Fix Swift progress day mapping to return ProgressDay values from the zero-filled day map.
- Keep the iOS progress series dailyReviews argument typed as [ProgressDay].

## Root Cause
The map closure introduced an intermediate ratingCounts binding but did not explicitly return ProgressDay, so Swift inferred the closure result as Void and produced [()].

## Validation
- git --no-pager diff --check
- xcodebuild build was attempted, but local package artifact extraction failed before compilation because the machine volume is out of space.