### PR TITLE
[codex] Fix progress reviews chart selection

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewsSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressReviewsSection.kt
@@ -148,11 +148,12 @@ internal fun ReviewsSectionCard(
     }
     val visiblePage = uiState.pages.getOrNull(selectedPageIndex)
     val hasChartSelection = selectedReviewDateKey != null || selectedRatingKey != null
-    val legendRows = remember(visiblePage, selectedRatingKey, locale) {
+    val legendRows = remember(visiblePage, selectedRatingKey, selectedReviewDateKey, locale) {
         visiblePage?.let { page ->
             createReviewRatingLegendRows(
                 page = page,
                 selectedRatingKey = selectedRatingKey,
+                selectedReviewDateKey = selectedReviewDateKey,
                 locale = locale
             )
         } ?: emptyList()
@@ -213,10 +214,10 @@ internal fun ReviewsSectionCard(
                         style = MaterialTheme.typography.titleLarge
                     )
                     visiblePage?.let { page ->
-                        val pageRangeLabel = remember(page.startDate, page.endDate, locale) {
-                            formatProgressReviewPageRange(
-                                startDate = page.startDate,
-                                endDate = page.endDate,
+                        val pageRangeLabel = remember(page, selectedReviewDateKey, locale) {
+                            formatProgressReviewVisibleDateLabel(
+                                page = page,
+                                selectedReviewDateKey = selectedReviewDateKey,
                                 locale = locale
                             )
                         }
@@ -238,6 +239,8 @@ internal fun ReviewsSectionCard(
                             onClick = {
                                 if (selectedPageIndex > 0) {
                                     selectedPageStartDateKey = uiState.pages[selectedPageIndex - 1].startDateKey
+                                    selectedReviewDateKey = null
+                                    selectedRatingKey = null
                                 }
                             }
                         ) {
@@ -254,6 +257,8 @@ internal fun ReviewsSectionCard(
                             onClick = {
                                 if (selectedPageIndex < uiState.pages.lastIndex) {
                                     selectedPageStartDateKey = uiState.pages[selectedPageIndex + 1].startDateKey
+                                    selectedReviewDateKey = null
+                                    selectedRatingKey = null
                                 }
                             }
                         ) {
@@ -340,7 +345,11 @@ internal fun ReviewsSectionCard(
                                         isSelected = isSelectedDay,
                                         isDimmed = selectedReviewDateKey != null && isSelectedDay.not(),
                                         onClick = {
-                                            selectedReviewDateKey = dayKey
+                                            selectedReviewDateKey = if (isSelectedDay) {
+                                                null
+                                            } else {
+                                                dayKey
+                                            }
                                             selectedRatingKey = null
                                         },
                                         modifier = Modifier
@@ -377,7 +386,11 @@ internal fun ReviewsSectionCard(
                         ReviewRatingLegend(
                             rows = legendRows,
                             onSelectRating = { ratingKey ->
-                                selectedRatingKey = ratingKey
+                                selectedRatingKey = if (selectedRatingKey == ratingKey) {
+                                    null
+                                } else {
+                                    ratingKey
+                                }
                                 selectedReviewDateKey = null
                             },
                             modifier = Modifier.fillMaxWidth()
@@ -670,11 +683,20 @@ private fun createReviewChartBarSegments(
 private fun createReviewRatingLegendRows(
     page: ProgressReviewPageUiState,
     selectedRatingKey: ReviewRatingChartKey?,
+    selectedReviewDateKey: String?,
     locale: Locale
 ): List<ReviewRatingLegendRowUiState> {
-    val totalReviewCount = page.days.sumOf(ProgressHistoryDayUiState::reviewCount)
+    val selectedDay = selectedReviewDateKey?.let { dateKey ->
+        page.days.firstOrNull { day -> day.date.toString() == dateKey }
+    }
+    val legendDays = if (selectedDay == null) {
+        page.days
+    } else {
+        listOf(selectedDay)
+    }
+    val totalReviewCount = legendDays.sumOf(ProgressHistoryDayUiState::reviewCount)
     return ReviewRatingChartKey.entries.map { ratingKey ->
-        val count = page.days.sumOf { day ->
+        val count = legendDays.sumOf { day ->
             ratingKey.reviewCount(day = day)
         }
         ReviewRatingLegendRowUiState(
@@ -690,6 +712,29 @@ private fun createReviewRatingLegendRows(
             isSelected = selectedRatingKey == ratingKey
         )
     }
+}
+
+private fun formatProgressReviewVisibleDateLabel(
+    page: ProgressReviewPageUiState,
+    selectedReviewDateKey: String?,
+    locale: Locale
+): String {
+    val selectedDay = selectedReviewDateKey?.let { dateKey ->
+        page.days.firstOrNull { day -> day.date.toString() == dateKey }
+    }
+
+    if (selectedDay != null) {
+        return formatProgressReviewDayContentDescriptionLabel(
+            date = selectedDay.date,
+            locale = locale
+        )
+    }
+
+    return formatProgressReviewPageRange(
+        startDate = page.startDate,
+        endDate = page.endDate,
+        locale = locale
+    )
 }
 
 private fun calculateVisibleReviewChartUpperBound(

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressFormatting.swift
@@ -17,6 +17,16 @@ func progressReviewChartPageDateRange(
     return formatter.string(from: page.startDate, to: page.endDate)
 }
 
+func progressReviewChartDateLabel(date: Date, calendar: Calendar) -> String {
+    let formatter = DateFormatter()
+    formatter.calendar = calendar
+    formatter.locale = Locale.autoupdatingCurrent
+    formatter.timeZone = calendar.timeZone
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .none
+    return formatter.string(from: date)
+}
+
 func requiredProgressPresentationCalendar(
     timeZoneIdentifier: String
 ) -> Calendar {

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewsSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressReviewsSection.swift
@@ -123,6 +123,25 @@ struct ProgressReviewsSection: View {
         )
     }
 
+    private var visibleDateLabel: String? {
+        guard let visiblePage else {
+            return nil
+        }
+
+        if let selectedDayLocalDate,
+           let selectedDay = visiblePage.day(localDate: selectedDayLocalDate) {
+            return progressReviewChartDateLabel(
+                date: selectedDay.date,
+                calendar: self.chartCalendar
+            )
+        }
+
+        return progressReviewChartPageDateRange(
+            page: visiblePage,
+            calendar: self.chartCalendar
+        )
+    }
+
     private var visiblePageUpperBound: Int {
         guard let visiblePage else {
             return 1
@@ -155,13 +174,21 @@ struct ProgressReviewsSection: View {
             return []
         }
 
-        let totalReviewCount = visiblePage.days.reduce(0) { total, day in
+        let legendDays: [ProgressChartDay]
+        if let selectedDayLocalDate,
+           let selectedDay = visiblePage.day(localDate: selectedDayLocalDate) {
+            legendDays = [selectedDay]
+        } else {
+            legendDays = visiblePage.days
+        }
+
+        let totalReviewCount = legendDays.reduce(0) { total, day in
             total + day.reviewCount
         }
         return progressReviewRatingChartOrder.map { rating in
             ProgressReviewRatingLegendEntry(
                 rating: rating,
-                count: visiblePage.days.reduce(0) { total, day in
+                count: legendDays.reduce(0) { total, day in
                     total + progressReviewRatingCount(day: day, rating: rating)
                 },
                 totalReviewCount: totalReviewCount
@@ -183,12 +210,9 @@ struct ProgressReviewsSection: View {
                     )
                     .font(.headline)
 
-                    if let visiblePage = self.visiblePage {
+                    if let visibleDateLabel = self.visibleDateLabel {
                         Text(
-                            progressReviewChartPageDateRange(
-                                page: visiblePage,
-                                calendar: self.chartCalendar
-                            )
+                            visibleDateLabel
                         )
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
@@ -263,6 +287,7 @@ struct ProgressReviewsSection: View {
                 }
                 .chartLegend(.hidden)
                 .chartXSelection(value: self.chartDaySelectionBinding)
+                .chartXScale(domain: visiblePage.xAxisValues)
                 .chartYScale(domain: 0 ... self.visiblePageUpperBound)
                 .chartXAxis {
                     AxisMarks(values: visiblePage.xAxisValues) { value in
@@ -319,13 +344,6 @@ struct ProgressReviewsSection: View {
             }
         }
         .padding(.vertical, 4)
-        .background(
-            Color.clear
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    self.selection = nil
-                }
-        )
         .onChange(of: self.pageSelectionResetToken) { _, _ in
             self.selectedPageStartLocalDate = nil
             self.selection = nil


### PR DESCRIPTION
## Summary
- keep the iOS reviews chart on a full seven-day week domain
- make iOS day selection update the date label and rating breakdown
- align Android reviews chart day and rating selection behavior with the web flow

## Validation
- git --no-pager diff --check
- git --no-pager diff --cached --check
- xcrun swift -e typecheck for the Swift Charts categorical x-domain call

Gradle and iOS simulator tests were not run because this repository requires explicit permission for those heavier local runs.