### PR TITLE
[codex] Fix invite friend flow

### DIFF
--- a/apps/android/feature/friendinvite/src/main/java/com/flashcardsopensourceapp/feature/friendinvite/FriendInvitationDialog.kt
+++ b/apps/android/feature/friendinvite/src/main/java/com/flashcardsopensourceapp/feature/friendinvite/FriendInvitationDialog.kt
@@ -94,6 +94,11 @@ fun FriendInvitationDialog(
         },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text(
+                    text = stringResource(id = R.string.friend_invite_dialog_body),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    style = MaterialTheme.typography.bodyMedium
+                )
                 OutlinedTextField(
                     value = displayName,
                     onValueChange = { updatedDisplayName ->

--- a/apps/android/feature/friendinvite/src/main/res/values/strings.xml
+++ b/apps/android/feature/friendinvite/src/main/res/values/strings.xml
@@ -1,8 +1,9 @@
 <resources>
     <string name="friend_invite_button">Invite friend</string>
     <string name="friend_invite_dialog_title">Invite a friend</string>
-    <string name="friend_invite_display_name_label">Friend display name</string>
-    <string name="friend_invite_expiry_note">Invite links expire in 2 days.</string>
+    <string name="friend_invite_dialog_body">Create a private friend link for the leaderboard.</string>
+    <string name="friend_invite_display_name_label">Friend name on your leaderboard</string>
+    <string name="friend_invite_expiry_note">Only you see this name on your leaderboard. Your friend chooses what to call you when accepting. Invite links expire in 2 days.</string>
     <string name="friend_invite_create_button">Create link</string>
     <string name="friend_invite_cancel_button">Cancel</string>
     <string name="friend_invite_share_title">Send this link to your friend</string>

--- a/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/ProgressScreen.swift
@@ -16,6 +16,8 @@ struct ProgressScreen: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
     @State private var selectedLeaderboardWindowKey: LeaderboardWindowKey?
+    @State private var isCloudSignInPresented: Bool = false
+    @State private var isFriendInvitePresented: Bool = false
 
     private var isLeaderboardSectionAvailable: Bool {
         self.store.progressSnapshot != nil && self.store.progressLeaderboardSnapshot != nil
@@ -78,7 +80,10 @@ struct ProgressScreen: View {
                                 ProgressLeaderboardSection(
                                     snapshot: leaderboardSnapshot,
                                     isRefreshing: self.store.isProgressRefreshing,
-                                    selectedWindowKey: self.$selectedLeaderboardWindowKey
+                                    leaderboardRefreshMessage: self.store.progressErrorState.leaderboardRefreshMessage,
+                                    selectedWindowKey: self.$selectedLeaderboardWindowKey,
+                                    onOpenCloudSignIn: self.openCloudSignInFlow,
+                                    onOpenFriendInvite: self.openFriendInviteFlow
                                 )
                             }
                             .id(ProgressScreenSectionID.leaderboard)
@@ -147,6 +152,27 @@ struct ProgressScreen: View {
                 await self.handleProgressPresentationRequest(proxy: proxy)
             }
         }
+        .sheet(isPresented: self.$isCloudSignInPresented) {
+            CloudSignInSheet(presentationContext: .standard)
+                .environment(self.store)
+        }
+        .sheet(isPresented: self.$isFriendInvitePresented) {
+            ProgressFriendInviteSheet()
+                .environment(self.store)
+        }
+    }
+
+    private func openCloudSignInFlow() {
+        self.isCloudSignInPresented = true
+    }
+
+    private func openFriendInviteFlow() {
+        guard self.store.cloudSettings?.cloudState == .linked else {
+            self.isCloudSignInPresented = true
+            return
+        }
+
+        self.isFriendInvitePresented = true
     }
 
     @MainActor

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressFriendInviteSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressFriendInviteSheet.swift
@@ -48,11 +48,25 @@ struct ProgressFriendInviteSheet: View {
                     }
                 }
 
+                if self.invitation == nil {
+                    Section {
+                        Text(
+                            String(
+                                localized: "progress.friend_invite.description",
+                                defaultValue: "Create a private friend link for the leaderboard.",
+                                table: progressStringsTableName,
+                                comment: "Body text explaining friend invite creation before the display name field"
+                            )
+                        )
+                        .foregroundStyle(.secondary)
+                    }
+                }
+
                 Section {
                     TextField(
                         String(
                             localized: "progress.friend_invite.display_name.label",
-                            defaultValue: "Friend name",
+                            defaultValue: "Friend name on your leaderboard",
                             table: progressStringsTableName,
                             comment: "Text field label for the private friend invite display name"
                         ),
@@ -60,7 +74,7 @@ struct ProgressFriendInviteSheet: View {
                         prompt: Text(
                             String(
                                 localized: "progress.friend_invite.display_name.prompt",
-                                defaultValue: "Required",
+                                defaultValue: "Your friend's name",
                                 table: progressStringsTableName,
                                 comment: "Prompt for an empty friend invite display name field"
                             )
@@ -81,7 +95,7 @@ struct ProgressFriendInviteSheet: View {
                     Text(
                         String(
                             localized: "progress.friend_invite.display_name.footer",
-                            defaultValue: "This private name appears only on your leaderboard. Invite links expire in 2 days.",
+                            defaultValue: "Only you see this name in your leaderboard. Your friend chooses what to call you when accepting. Invite links expire in 2 days.",
                             table: progressStringsTableName,
                             comment: "Footer explaining private friend invite display names and expiration"
                         )

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressLeaderboardSection.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct ProgressLeaderboardSection: View {
-    @Environment(FlashcardsStore.self) private var store: FlashcardsStore
     @Environment(AppNavigationModel.self) private var navigation: AppNavigationModel
 
     let snapshot: ProgressLeaderboardSnapshot
@@ -9,11 +8,12 @@ struct ProgressLeaderboardSection: View {
     /// first leaderboard fetch starts only after summary and series complete, and
     /// the offline placeholder must stay hidden while any of them is in flight.
     let isRefreshing: Bool
+    let leaderboardRefreshMessage: String
     @Binding var selectedWindowKey: LeaderboardWindowKey?
+    let onOpenCloudSignIn: () -> Void
+    let onOpenFriendInvite: () -> Void
 
     @State private var isInfoAlertPresented: Bool = false
-    @State private var isCloudSignInPresented: Bool = false
-    @State private var isFriendInvitePresented: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -51,14 +51,6 @@ struct ProgressLeaderboardSection: View {
             ) {}
         } message: {
             Text(self.infoMessage)
-        }
-        .sheet(isPresented: self.$isCloudSignInPresented) {
-            CloudSignInSheet(presentationContext: .standard)
-                .environment(self.store)
-        }
-        .sheet(isPresented: self.$isFriendInvitePresented) {
-            ProgressFriendInviteSheet()
-                .environment(self.store)
         }
     }
 
@@ -105,18 +97,21 @@ struct ProgressLeaderboardSection: View {
 
     private var friendInviteButton: some View {
         Button {
-            self.openFriendInviteFlow()
+            self.onOpenFriendInvite()
         } label: {
-            Label(
-                String(
-                    localized: "progress.screen.leaderboard.invite.button",
-                    defaultValue: "Invite Friend",
-                    table: progressStringsTableName,
-                    comment: "Button title for creating a leaderboard friend invite link"
-                ),
-                systemImage: "person.badge.plus"
-            )
-            .frame(maxWidth: .infinity)
+            HStack(spacing: 8) {
+                Image(systemName: "person.crop.circle.badge.plus")
+                    .accessibilityHidden(true)
+                Text(
+                    String(
+                        localized: "progress.screen.leaderboard.invite.button",
+                        defaultValue: "Invite Friend",
+                        table: progressStringsTableName,
+                        comment: "Button title for creating a leaderboard friend invite link"
+                    )
+                )
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .buttonStyle(.borderedProminent)
         .accessibilityIdentifier(UITestIdentifier.progressLeaderboardInviteFriendButton)
@@ -187,15 +182,6 @@ struct ProgressLeaderboardSection: View {
         }
     }
 
-    private func openFriendInviteFlow() {
-        guard self.store.cloudSettings?.cloudState == .linked else {
-            self.isCloudSignInPresented = true
-            return
-        }
-
-        self.isFriendInvitePresented = true
-    }
-
     private func resolveSelectedWindowKey(readyState: ProgressLeaderboardReadyState) -> LeaderboardWindowKey {
         self.selectedWindowKey
             ?? resolveBestLeaderboardPlacement(readyState: readyState)?.windowKey
@@ -231,7 +217,7 @@ struct ProgressLeaderboardSection: View {
                     comment: "Progress leaderboard sign-in placeholder button"
                 )
             ) {
-                self.isCloudSignInPresented = true
+                self.onOpenCloudSignIn()
             }
             .accessibilityIdentifier(UITestIdentifier.progressLeaderboardSignInButton)
         }
@@ -304,7 +290,7 @@ struct ProgressLeaderboardSection: View {
                 Spacer(minLength: 0)
             }
             .padding(.vertical, 24)
-        } else if self.store.progressErrorState.leaderboardRefreshMessage.isEmpty == false {
+        } else if self.leaderboardRefreshMessage.isEmpty == false {
             // The fetch failed for a non-connectivity reason; the offline copy
             // would be misleading. The exact error renders in the Progress error
             // banner, so this placeholder stays generic.

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -2892,61 +2892,120 @@
         }
       }
     },
+    "progress.friend_invite.description" : {
+      "comment" : "Body text explaining friend invite creation before the display name field",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أنشئ رابط صديق خاصًا للوحة الصدارة."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstelle einen privaten Freundeslink für die Bestenliste."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create a private friend link for the leaderboard."
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea un enlace privado de amigo para la tabla de clasificación."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crea un enlace privado de amigo para la tabla de posiciones."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "लीडरबोर्ड के लिए एक निजी दोस्त लिंक बनाएं।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リーダーボード用の非公開の友だちリンクを作成します。"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Создайте личную ссылку для друга для таблицы лидеров."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为排行榜创建一个私密好友链接。"
+          }
+        }
+      }
+    },
     "progress.friend_invite.display_name.footer" : {
       "comment" : "Footer explaining private friend invite display names and expiration",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يظهر هذا الاسم الخاص في لوحة الصدارة لديك فقط. تنتهي صلاحية روابط الدعوة خلال يومين."
+            "value" : "أنت فقط ترى هذا الاسم في لوحة الصدارة لديك. يختار صديقك اسمك عند قبول الدعوة. تنتهي صلاحية روابط الدعوة خلال يومين."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dieser private Name erscheint nur auf deiner Bestenliste. Einladungslinks laufen in 2 Tagen ab."
+            "value" : "Nur du siehst diesen Namen in deiner Bestenliste. Dein Freund wählt beim Annehmen aus, wie er dich nennt. Einladungslinks laufen in 2 Tagen ab."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "This private name appears only on your leaderboard. Invite links expire in 2 days."
+            "value" : "Only you see this name in your leaderboard. Your friend chooses what to call you when accepting. Invite links expire in 2 days."
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este nombre privado aparece solo en tu tabla de clasificación. Los enlaces de invitación caducan en 2 días."
+            "value" : "Solo tú ves este nombre en tu tabla de clasificación. Tu amigo elige cómo llamarte al aceptar. Los enlaces de invitación caducan en 2 días."
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Este nombre privado aparece solo en tu tabla de posiciones. Los enlaces de invitación vencen en 2 días."
+            "value" : "Solo tú ves este nombre en tu tabla de posiciones. Tu amigo elige cómo llamarte al aceptar. Los enlaces de invitación vencen en 2 días."
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "यह निजी नाम केवल आपके लीडरबोर्ड पर दिखता है। आमंत्रण लिंक 2 दिनों में समाप्त हो जाते हैं।"
+            "value" : "यह नाम केवल आपको अपने लीडरबोर्ड में दिखता है। स्वीकार करते समय आपका दोस्त चुनता है कि आपको क्या नाम देना है। आमंत्रण लिंक 2 दिनों में समाप्त हो जाते हैं।"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "この非公開名はあなたのリーダーボードにのみ表示されます。招待リンクは2日で期限切れになります。"
+            "value" : "この名前はあなたのリーダーボードにだけ表示されます。友だちは承認時にあなたの呼び名を選びます。招待リンクは2日で期限切れになります。"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Это личное имя видно только в вашей таблице лидеров. Ссылки-приглашения истекают через 2 дня."
+            "value" : "Только вы видите это имя в своей таблице лидеров. Друг выберет ваше имя у себя при принятии приглашения. Ссылки-приглашения истекают через 2 дня."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "这个私密名称只会显示在你的排行榜中。邀请链接将在 2 天后过期。"
+            "value" : "只有你会在自己的排行榜中看到这个名称。你的朋友接受邀请时会选择如何称呼你。邀请链接将在 2 天后过期。"
           }
         }
       }
@@ -2957,55 +3016,55 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "اسم الصديق"
+            "value" : "اسم الصديق في لوحة الصدارة لديك"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Name des Freundes"
+            "value" : "Name des Freundes in deiner Bestenliste"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Friend name"
+            "value" : "Friend name on your leaderboard"
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nombre del amigo"
+            "value" : "Nombre del amigo en tu tabla de clasificación"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nombre del amigo"
+            "value" : "Nombre del amigo en tu tabla de posiciones"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "दोस्त का नाम"
+            "value" : "आपके लीडरबोर्ड पर दोस्त का नाम"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "友達の名前"
+            "value" : "自分のリーダーボードで表示する友だちの名前"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Имя друга"
+            "value" : "Имя друга в вашей таблице лидеров"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "朋友名称"
+            "value" : "你的排行榜上的好友名称"
           }
         }
       }
@@ -3016,55 +3075,55 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مطلوب"
+            "value" : "اسم صديقك"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erforderlich"
+            "value" : "Name deines Freundes"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Required"
+            "value" : "Your friend's name"
           }
         },
         "es-ES" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obligatorio"
+            "value" : "Nombre de tu amigo"
           }
         },
         "es-MX" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obligatorio"
+            "value" : "Nombre de tu amigo"
           }
         },
         "hi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "आवश्यक"
+            "value" : "आपके दोस्त का नाम"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "必須"
+            "value" : "友だちの名前"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Обязательно"
+            "value" : "Имя вашего друга"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "必填"
+            "value" : "你朋友的名字"
           }
         }
       }

--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -306,14 +306,16 @@ struct SettingsView: View {
         Button {
             self.openFriendInviteFlow()
         } label: {
-            Label(
-                aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"),
-                systemImage: "person.badge.plus"
-            )
-            .frame(maxWidth: .infinity)
+            HStack(spacing: 8) {
+                Image(systemName: "person.crop.circle.badge.plus")
+                    .accessibilityHidden(true)
+                Text(aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"))
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .buttonStyle(.borderedProminent)
         .accessibilityIdentifier(UITestIdentifier.settingsInviteFriendButton)
+        .accessibilityLabel(aiSettingsLocalized("settings.inviteFriend.button", "Invite Friend"))
     }
 
     private func openFriendInviteFlow() {


### PR DESCRIPTION
## Summary

- stabilize iOS Progress friend invite sheet presentation so created links remain visible
- improve invite field copy and localization on iOS and Android
- center iOS invite buttons with explicit icon accessibility handling

## Validation

- git diff --check --cached
- jq empty apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
- xmllint --noout apps/android/feature/friendinvite/src/main/res/values/strings.xml
