### PR TITLE
[codex] Fix iOS progress test fixtures

### DIFF
--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressServerValidationRefreshTests.swift
@@ -131,7 +131,14 @@ final class ProgressServerValidationRefreshTests: ProgressStoreTestCase {
                 from: requestRange.from,
                 to: requestRange.to,
                 dailyReviews: [
-                    ProgressDay(date: requestRange.to, reviewCount: 1)
+                    ProgressDay(
+                        date: requestRange.to,
+                        reviewCount: 1,
+                        againCount: 0,
+                        hardCount: 0,
+                        goodCount: 1,
+                        easyCount: 0
+                    )
                 ],
                 summary: nil,
                 generatedAt: "2026-04-18T10:00:00.000Z",

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Validation/ProgressSnapshotValidationTests.swift
@@ -419,7 +419,14 @@ final class ProgressSnapshotValidationTests: XCTestCase {
             from: scopeKey.from,
             to: scopeKey.to,
             dailyReviews: [
-                ProgressDay(date: "2026-02-03", reviewCount: 1)
+                ProgressDay(
+                    date: "2026-02-03",
+                    reviewCount: 1,
+                    againCount: 0,
+                    hardCount: 0,
+                    goodCount: 1,
+                    easyCount: 0
+                )
             ],
             streakDays: [
                 ProgressStreakDay(date: "2026-02-03", state: .frozen)
@@ -467,7 +474,14 @@ final class ProgressSnapshotValidationTests: XCTestCase {
             from: scopeKey.from,
             to: scopeKey.to,
             dailyReviews: [
-                ProgressDay(date: "2026-02-03", reviewCount: 0)
+                ProgressDay(
+                    date: "2026-02-03",
+                    reviewCount: 0,
+                    againCount: 0,
+                    hardCount: 0,
+                    goodCount: 0,
+                    easyCount: 0
+                )
             ],
             streakDays: [
                 ProgressStreakDay(date: "2026-02-03", state: .reviewed)


### PR DESCRIPTION
## Summary
- pass explicit rating-count breakdowns to the remaining ProgressDay test fixtures
- keep the existing validation intent by making reviewCount match again/hard/good/easy totals

## Root Cause
ProgressDay now requires rating-count fields, but three test fixtures still used the old constructor shape. Xcode Cloud failed while compiling the iOS test target.

## Validation
- git --no-pager diff --cached --check
- git --no-pager diff --check
- rg confirmed no remaining short ProgressDay(date:, reviewCount:) calls in the iOS app/tests

Full local xcodebuild build-for-testing did not run because this machine has no eligible iOS 26.5 destination installed.