### PR TITLE
[codex] Add iOS progress reviewed-at test helper

### DIFF
--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -63,6 +63,24 @@ func makeReviewedAtClientForTests(
     return formatIsoTimestamp(date: reviewedAt)
 }
 
+func makeProgressSeriesFromReviewedAtClients(
+    reviewedAtClients: [String],
+    requestRange: ProgressRequestRange
+) throws -> UserProgressSeries {
+    let reviewEvents: [ProgressReviewEventSource] = reviewedAtClients.enumerated().map { index, reviewedAtClient in
+        ProgressReviewEventSource(
+            reviewEventId: "test-review-event-\(index + 1)",
+            reviewedAtClient: reviewedAtClient,
+            rating: .good
+        )
+    }
+
+    return try makeProgressSeriesFromReviewEvents(
+        reviewEvents: reviewEvents,
+        requestRange: requestRange
+    )
+}
+
 func makeTestProgressSeries(
     requestRange: ProgressSeriesLoadRequest,
     reviewCountsByDate: [String: Int],


### PR DESCRIPTION
## Summary
- add the missing shared iOS test helper `makeProgressSeriesFromReviewedAtClients`
- route reviewed-at timestamp fixtures through the existing progress review-event aggregation path

## Root Cause
Two test cloud sync services called a helper that did not exist in the iOS test target, so Xcode Cloud failed while compiling `GuestCloudUpgradeTestSupport.swift`.

## Validation
- `git --no-pager diff --cached --check`
- `rg` confirmed one helper definition and the two existing call sites

Full local `xcodebuild build-for-testing` could not run because this machine has no eligible iOS destination for the scheme.