### PR TITLE
[codex] Return progress streak freeze fixture

### DIFF
--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -205,7 +205,7 @@ func makeTestProgressStreakFreeze(
         nextCreditProgressUnits = balanceUnits % progressStreakFreezePolicy.unitsPerCredit
     }
 
-    ProgressStreakFreeze(
+    return ProgressStreakFreeze(
         availableCredits: availableCredits,
         capacity: progressStreakFreezePolicy.maxCapacity,
         balanceUnits: balanceUnits,


### PR DESCRIPTION
## Summary
- add the missing explicit return in `makeTestProgressStreakFreeze`
- fix the iOS test target compile error and matching unused initializer warning

## Root Cause
`makeTestProgressStreakFreeze` computes `nextCreditProgressUnits` before constructing `ProgressStreakFreeze`, so Swift does not allow implicit return from the initializer expression.

## Validation
- `git --no-pager diff --cached --check`
- `xcodebuild -showdestinations` confirms local full compile is blocked by missing eligible iOS 26.5 destination on this machine.