### PR TITLE
Fix Android core KTX compile SDK compatibility

### DIFF
--- a/apps/android/gradle/libs.versions.toml
+++ b/apps/android/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "9.2.1"
 kotlin = "2.3.21"
 ksp = "2.3.9"
-coreKtx = "1.19.0"
+coreKtx = "1.18.0"
 splashscreen = "1.2.0"
 activityCompose = "1.13.0"
 lifecycle = "2.10.0"


### PR DESCRIPTION
## Summary
- revert AndroidX Core KTX to 1.18.0 so the Android build remains compatible with compileSdk 36

## Validation
- not run: local Gradle checks are resource-heavy in this repository and were not explicitly allowed for this task