### PR TITLE
[codex] Handle cloud cancellation during sign-in sync

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/CloudAccountDeletionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/CloudAccountDeletionCoordinator.kt
@@ -61,6 +61,8 @@ internal class CloudAccountDeletionCoordinator(
                     bearerToken = authenticatedSession.credentials.idToken,
                     confirmationText = confirmationText
                 )
+            } catch (error: CancellationException) {
+                throw error
             } catch (error: Exception) {
                 if (isRemoteAccountDeletedError(error = error)) {
                     resetCoordinator.resetLocalStateForCloudIdentityChange()
@@ -86,6 +88,8 @@ internal class CloudAccountDeletionCoordinator(
                     bearerToken = authenticatedSession.credentials.idToken,
                     confirmationText = accountDeletionConfirmationTextForCloudApi
                 )
+            } catch (error: CancellationException) {
+                throw error
             } catch (error: Exception) {
                 if (isRemoteAccountDeletedError(error = error).not()) {
                     preferencesStore.markAccountDeletionFailed(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/guest/CloudGuestSessionCoordinator.kt
@@ -327,6 +327,8 @@ class CloudGuestSessionCoordinator(
                 apiBaseUrl = storedGuestSession.apiBaseUrl,
                 guestToken = storedGuestSession.guestToken
             )
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             if (isGuestSessionInvalidError(error = error).not()) {
                 throw error

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/runtime/CloudSessionProvider.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/runtime/CloudSessionProvider.kt
@@ -10,6 +10,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.cloud.shouldRefreshCloudIdToken
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.account.CloudIdentityResetCoordinator
+import kotlinx.coroutines.CancellationException
 
 internal data class AuthenticatedCloudSession(
     val configuration: CloudServiceConfiguration,
@@ -55,6 +56,8 @@ internal class CloudSessionProvider(
                 credentials = refreshedCredentials,
                 accountSnapshot = accountSnapshot
             )
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             if (isRemoteAccountDeletedError(error = error)) {
                 resetLocalStateForDeletedAccount()
@@ -93,6 +96,8 @@ internal class CloudSessionProvider(
                 credentials = refreshedCredentials,
                 accountSnapshot = accountSnapshot
             )
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             if (isRemoteAccountDeletedError(error = error)) {
                 resetLocalStateForDeletedAccount()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
@@ -81,6 +81,8 @@ internal suspend fun runCloudSyncCore(
                         )
                     }
                     syncLocalStore.deleteOutboxEntries(acknowledgedOperationIds)
+                } catch (error: CancellationException) {
+                    throw error
                 } catch (error: Exception) {
                     val recoveredState = recoverWorkspaceForkConflictIfNeeded(
                         workspaceId = workspaceId,
@@ -259,6 +261,8 @@ private suspend fun runBootstrapHydrationWithForkRecovery(
                                 .put("entries", bootstrapEntries)
                         )
                         lastHotCursor = bootstrapPushResponse.bootstrapHotChangeId ?: lastHotCursor
+                    } catch (error: CancellationException) {
+                        throw error
                     } catch (error: Exception) {
                         val recoveredState = recoverWorkspaceForkConflictIfNeeded(
                             workspaceId = workspaceId,
@@ -403,6 +407,8 @@ private suspend fun importReviewHistoryWithForkRecovery(
                 lastReviewSequenceId = lastReviewSequenceId,
                 workspaceForkRecoveryState = recoveryState
             )
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             val recoveredState = recoverWorkspaceForkConflictIfNeeded(
                 workspaceId = workspaceId,
@@ -453,6 +459,9 @@ private suspend fun pullAndApplyReviewHistoryBatch(
         }
         syncLocalStore.flushReviewHistoryChangeBatch()
         return lastReviewSequenceId
+    } catch (error: CancellationException) {
+        syncLocalStore.discardReviewHistoryChangeBatch()
+        throw error
     } catch (error: Exception) {
         syncLocalStore.discardReviewHistoryChangeBatch()
         throw error

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudLinkedWorkspaceTransitionCoordinator.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/workspace/CloudLinkedWorkspaceTransitionCoordinator.kt
@@ -18,6 +18,7 @@ import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.CloudSyn
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.CloudWorkspaceForkRecoveryMode
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.androidClientPlatform
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.runCloudSyncCore
+import kotlinx.coroutines.CancellationException
 import org.json.JSONObject
 
 internal class CloudLinkedWorkspaceTransitionCoordinator(
@@ -150,6 +151,8 @@ internal class CloudLinkedWorkspaceTransitionCoordinator(
                 syncLocalStore = syncLocalStore,
                 workspaceForkRecoveryMode = CloudWorkspaceForkRecoveryMode.ENABLED
             )
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             val preservesBlockedSyncState: Boolean = error is CloudSyncBlockedException || isCloudIdentityConflictError(
                 error = error

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInStateReducers.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInStateReducers.kt
@@ -131,6 +131,16 @@ internal fun failCloudSendCode(
     )
 }
 
+internal fun cancelCloudSendCodeAttempt(
+    state: CloudSignInDraftState,
+    authAttemptId: Long
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(isSendingCode = false)
+}
+
 internal fun startCloudVerifyCodeAttempt(
     state: CloudSignInDraftState,
     authAttemptId: Long
@@ -166,6 +176,16 @@ internal fun failCloudVerifyCode(
         errorMessage = errorPresentation.message,
         errorTechnicalDetails = errorPresentation.technicalDetails
     )
+}
+
+internal fun cancelCloudVerifyCodeAttempt(
+    state: CloudSignInDraftState,
+    authAttemptId: Long
+): CloudSignInDraftState {
+    if (state.authAttemptId != authAttemptId) {
+        return state
+    }
+    return state.copy(isVerifyingCode = false)
 }
 
 internal fun publishCloudVerifiedLinkContext(

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -40,6 +40,7 @@ import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.requiresCloud
 import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.resolveCloudPostAuthFailureAction
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
 import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -240,6 +241,11 @@ class CloudSignInViewModel(
                     }
                 }
             }
+        } catch (error: CancellationException) {
+            draftState.update { state ->
+                cancelCloudSendCodeAttempt(state = state, authAttemptId = authAttemptId)
+            }
+            throw error
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return CloudSendCodeNavigationOutcome.NoNavigation
@@ -275,6 +281,11 @@ class CloudSignInViewModel(
                 isSendingCode = false,
                 isVerifyingCode = false
             )
+        } catch (error: CancellationException) {
+            draftState.update { state ->
+                cancelCloudVerifyCodeAttempt(state = state, authAttemptId = authAttemptId)
+            }
+            throw error
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return false
@@ -463,6 +474,16 @@ class CloudSignInViewModel(
                     workspaceTitle = completion.workspaceTitle
                 )
             }
+        } catch (error: CancellationException) {
+            failPostAuthCancellationIfStillProcessing(
+                authAttemptId = authAttemptId,
+                errorMessage = if (requiresCloudGuestUpgrade(linkContext = linkContext)) {
+                    strings.get(R.string.settings_post_auth_guest_upgrade_failed)
+                } else {
+                    strings.get(R.string.settings_post_auth_setup_failed)
+                }
+            )
+            throw error
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
@@ -524,6 +545,12 @@ class CloudSignInViewModel(
                 authAttemptId = authAttemptId,
                 workspaceTitle = completion.workspaceTitle
             )
+        } catch (error: CancellationException) {
+            failPostAuthCancellationIfStillProcessing(
+                authAttemptId = authAttemptId,
+                errorMessage = strings.get(R.string.settings_post_auth_guest_local_recovery_failed)
+            )
+            throw error
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
@@ -583,6 +610,12 @@ class CloudSignInViewModel(
                 authAttemptId = authAttemptId,
                 workspaceTitle = workspaceTitle
             )
+        } catch (error: CancellationException) {
+            failPostAuthCancellationIfStillProcessing(
+                authAttemptId = authAttemptId,
+                errorMessage = strings.get(R.string.settings_post_auth_sync_failed)
+            )
+            throw error
         } catch (error: Exception) {
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return
@@ -600,6 +633,25 @@ class CloudSignInViewModel(
                     errorMessage = errorMessage,
                     recoveryErrorBlocked = recoveryError != null,
                     postAuthResetAllowed = isInvalidCloudCredentialRecovery(error = recoveryError)
+                )
+            }
+        }
+    }
+
+    private fun failPostAuthCancellationIfStillProcessing(
+        authAttemptId: Long,
+        errorMessage: String
+    ) {
+        draftState.update { state ->
+            if (state.authAttemptId != authAttemptId || state.processingTitle.isEmpty()) {
+                state
+            } else {
+                failCloudPostAuth(
+                    state = state,
+                    authAttemptId = authAttemptId,
+                    errorMessage = errorMessage,
+                    recoveryErrorBlocked = false,
+                    postAuthResetAllowed = false
                 )
             }
         }

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -13,6 +13,7 @@ import com.flashcardsopensourceapp.feature.settings.cloud.postAuth.CloudPostAuth
 import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSendCodeNavigationOutcome
 import com.flashcardsopensourceapp.feature.settings.cloud.signIn.CloudSignInViewModel
 import java.io.IOException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -571,6 +572,181 @@ class CloudSignInViewModelTest {
         assertEquals(false, viewModel.postAuthUiState.value.canLogout)
 
         postAuthCollection.cancel()
+    }
+
+    @Test
+    fun postAuthWorkspaceSetupCancellationRethrowsWithRetryState() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueCompleteCloudLinkError(CancellationException("Cloud request was cancelled."))
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-setup-cancelled")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-recovered",
+                    workspaceName = "Recovered",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.LINKED_CREDENTIAL_RESTORE,
+                    preferredWorkspaceId = "workspace-recovered"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, viewModel.sendCode())
+        advanceUntilIdle()
+
+        val error = try {
+            viewModel.completePendingPostAuthIfNeeded()
+            null
+        } catch (caught: CancellationException) {
+            caught
+        }
+
+        assertNotNull(error)
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals("Cloud workspace setup failed.", viewModel.postAuthUiState.value.errorMessage)
+        assertEquals("", viewModel.postAuthUiState.value.processingTitle)
+        assertEquals(true, viewModel.postAuthUiState.value.canRetry)
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun postAuthInitialSyncCancellationRethrowsWithRetryState() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        val syncRepository = FakeSyncRepository()
+        syncRepository.enqueueSyncError(CancellationException("Cloud request was cancelled."))
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = syncRepository,
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val postAuthCollection = backgroundScope.async {
+            viewModel.postAuthUiState.collect()
+        }
+        val credentials = makeCredentials(idToken = "id-token-sync-cancelled")
+        repository.enqueueSendCodeResult(CloudSendCodeResult.Verified(credentials = credentials))
+        repository.enqueuePreparedLinkContext(
+            idToken = credentials.idToken,
+            result = CompletableDeferred(
+                makeLinkContext(
+                    credentials = credentials,
+                    email = "person@example.com",
+                    workspaceId = "workspace-remote",
+                    workspaceName = "Remote",
+                    postAuthRoute = CloudWorkspacePostAuthRoute.NONE,
+                    preferredWorkspaceId = "workspace-remote"
+                )
+            )
+        )
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.Verified, viewModel.sendCode())
+        advanceUntilIdle()
+
+        val error = try {
+            viewModel.completePendingPostAuthIfNeeded()
+            null
+        } catch (caught: CancellationException) {
+            caught
+        }
+
+        assertNotNull(error)
+        assertEquals(1, syncRepository.syncNowCalls)
+        assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
+        assertEquals("", viewModel.postAuthUiState.value.processingTitle)
+        assertEquals("Initial sync failed.", viewModel.postAuthUiState.value.errorMessage)
+        assertEquals(true, viewModel.postAuthUiState.value.canRetry)
+
+        postAuthCollection.cancel()
+    }
+
+    @Test
+    fun sendCodeCancellationRethrowsWithoutLoadingState() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueSendCodeError(CancellationException("Cloud request was cancelled."))
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val uiStateCollection = backgroundScope.async {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.updateEmail("person@example.com")
+        val error = try {
+            viewModel.sendCode()
+            null
+        } catch (caught: CancellationException) {
+            caught
+        }
+        advanceUntilIdle()
+
+        assertNotNull(error)
+        assertEquals(false, viewModel.uiState.value.isSendingCode)
+        assertEquals("", viewModel.uiState.value.errorMessage)
+
+        uiStateCollection.cancel()
+    }
+
+    @Test
+    fun verifyCodeCancellationRethrowsWithoutLoadingState() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueSendCodeResult(
+            CloudSendCodeResult.OtpRequired(
+                challenge = CloudOtpChallenge(
+                    email = "person@example.com",
+                    csrfToken = "csrf-token",
+                    otpSessionToken = "otp-session-token"
+                )
+            )
+        )
+        repository.enqueueVerifyCodeError(CancellationException("Cloud request was cancelled."))
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val uiStateCollection = backgroundScope.async {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.OtpRequired, viewModel.sendCode())
+        viewModel.updateCode("12345678")
+        val error = try {
+            viewModel.verifyCode()
+            null
+        } catch (caught: CancellationException) {
+            caught
+        }
+        advanceUntilIdle()
+
+        assertNotNull(error)
+        assertEquals(false, viewModel.uiState.value.isVerifyingCode)
+        assertEquals("", viewModel.uiState.value.errorMessage)
+
+        uiStateCollection.cancel()
     }
 
     @Test

--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -688,6 +688,10 @@ extension FlashcardsStore {
             )
             try self.reload()
         } catch {
+            if isRequestCancellationError(error: error) {
+                self.syncStatus = .idle
+                throw error
+            }
             if didCompleteLocalLink == false {
                 logCloudFlowPhase(
                     phase: .linkLocalWorkspace,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -414,6 +414,10 @@ final class CloudSessionRuntime {
             do {
                 _ = try await activeCloudSyncTask.task.value
             } catch {
+                if isRequestCancellationError(error: error) {
+                    self.clearActiveCloudSyncTaskIfCurrent(id: activeCloudSyncTask.id)
+                    continue
+                }
                 FlashcardsObservability.captureWarning(
                     .cloudRetry(
                         CloudRetryWarning(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudLink.swift
@@ -20,6 +20,9 @@ extension FlashcardsStore {
             self.globalErrorMessage = ""
             return result
         } catch {
+            if isRequestCancellationError(error: error) {
+                throw error
+            }
             self.captureCloudAuthFailure(
                 error: error,
                 configuration: configuration,
@@ -40,6 +43,9 @@ extension FlashcardsStore {
             self.globalErrorMessage = ""
             return context
         } catch {
+            if isRequestCancellationError(error: error) {
+                throw error
+            }
             self.captureCloudAuthFailure(
                 error: error,
                 configuration: configuration,
@@ -746,6 +752,10 @@ extension FlashcardsStore {
             )
             try self.reload()
         } catch {
+            if isRequestCancellationError(error: error) {
+                self.syncStatus = .idle
+                throw error
+            }
             if didCompleteLocalLink == false {
                 logCloudFlowPhase(
                     phase: .linkLocalWorkspace,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudRestore.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudRestore.swift
@@ -23,6 +23,10 @@ extension FlashcardsStore {
             )
             self.userDefaults.removeObject(forKey: pendingCloudServerBootstrapUserDefaultsKey)
         } catch {
+            if isRequestCancellationError(error: error) {
+                self.syncStatus = .idle
+                throw error
+            }
             self.cloudRuntime.clearActiveCloudSessionIfMatchingStableContext(linkedSession: linkedSession)
             logCloudFlowPhase(
                 phase: .linkedSync,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -80,6 +80,10 @@ extension FlashcardsStore {
                 trigger: trigger
             )
         } catch {
+            if isRequestCancellationError(error: error) {
+                self.syncStatus = .idle
+                throw error
+            }
             try self.throwIfCloudCredentialRecoveryRequired()
             let failureError: Error
             do {
@@ -167,6 +171,9 @@ extension FlashcardsStore {
 
             try await self.syncCloudNow(trigger: trigger)
         } catch {
+            if isRequestCancellationError(error: error) {
+                return
+            }
             if self.isCloudAccountDeletedError(error) {
                 self.handleRemoteAccountDeletedCleanup()
                 return
@@ -488,6 +495,9 @@ extension FlashcardsStore {
     }
 
     private func shouldCaptureCloudSyncFailure(error: Error, trigger: CloudSyncTrigger) -> Bool {
+        if isRequestCancellationError(error: error) {
+            return false
+        }
         if isRetryableNetworkTransportFailure(error: error) {
             return false
         }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
@@ -141,6 +141,9 @@ struct CloudSyncTransport {
                 allowsRetry: self.allowsRetry(path: path, method: method, body: body)
             )
         } catch {
+            if isRequestCancellationError(error: error) {
+                throw error
+            }
             logCloudFlowPhase(
                 phase: phase,
                 outcome: "failure",
@@ -212,6 +215,9 @@ struct CloudSyncTransport {
             } catch let error as CancellationError {
                 throw error
             } catch {
+                if isRequestCancellationError(error: error) {
+                    throw error
+                }
                 lastError = error
                 guard allowsRetry
                     && isRetryableNetworkTransportFailure(error: error)

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
@@ -182,6 +182,9 @@ struct CloudOtpVerificationSheet: View {
                 self.authErrorPresentation = nil
                 self.onVerified(verifiedContext)
             } catch {
+                if isRequestCancellationError(error: error) {
+                    return
+                }
                 self.applyOtpErrorState(error: error)
                 self.authErrorPresentation = makeCloudAuthInlineErrorPresentation(
                     error: error,
@@ -212,6 +215,9 @@ struct CloudOtpVerificationSheet: View {
                     throw LocalStoreError.validation("Demo review sign-in cannot resend an OTP challenge")
                 }
             } catch {
+                if isRequestCancellationError(error: error) {
+                    return
+                }
                 self.authErrorPresentation = makeCloudAuthInlineErrorPresentation(
                     error: error,
                     context: .sendCode

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 
+private struct CloudSignInPostAuthTaskHandle {
+    let stateId: String
+    let task: Task<Void, Never>
+}
+
 struct CloudSignInSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
@@ -19,6 +24,9 @@ struct CloudSignInSheet: View {
     @State private var isSendingCode: Bool = false
     @State private var isLogoutConfirmationPresented: Bool = false
     @State private var hasRecordedActivePresentation: Bool = false
+    @State private var postAuthLoadingTask: CloudSignInPostAuthTaskHandle?
+    @State private var postAuthGuestLocalRecoveryPreparationTask: CloudSignInPostAuthTaskHandle?
+    @State private var postAuthSyncTask: CloudSignInPostAuthTaskHandle?
 
     init(presentationContext: CloudSignInPresentationContext) {
         self.presentationContext = presentationContext
@@ -89,10 +97,8 @@ struct CloudSignInSheet: View {
                         self.handleVerifiedAuthContext(verifiedContext)
                     },
                     onReturnToEmail: {
+                        self.cancelPostAuthTasksAndClearInFlightState()
                         self.otpSheetState = nil
-                        self.postAuthLoadingState = nil
-                        self.postAuthGuestLocalRecoveryPreparationState = nil
-                        self.postAuthSyncState = nil
                         self.workspaceLinkContext = nil
                         self.postAuthRecoveryNeededState = nil
                         self.postAuthFailureState = nil
@@ -104,23 +110,14 @@ struct CloudSignInSheet: View {
             .sheet(item: self.$postAuthLoadingState) { loadingState in
                 CloudPostAuthLoadingSheet()
                     .interactiveDismissDisabled(true)
-                    .task(id: loadingState.id) {
-                        await self.prepareCloudLink(verifiedContext: loadingState.verifiedContext)
-                    }
             }
             .sheet(item: self.$postAuthGuestLocalRecoveryPreparationState) { recoveryState in
                 CloudPostAuthGuestLocalRecoveryPreparationSheet()
                     .interactiveDismissDisabled(true)
-                    .task(id: recoveryState.id) {
-                        await self.runGuestLocalRecoveryPreparation(recoveryState)
-                    }
             }
             .sheet(item: self.$postAuthSyncState) { syncState in
                 CloudPostAuthSyncSheet(operation: syncState.operation)
                     .interactiveDismissDisabled(true)
-                    .task(id: syncState.id) {
-                        await self.runPostAuthSync(syncState)
-                    }
             }
             .sheet(item: self.$workspaceLinkContext) { linkContext in
                 CloudWorkspaceSelectionSheet(
@@ -183,6 +180,7 @@ struct CloudSignInSheet: View {
                 self.scheduleEmailFieldFocus()
             }
             .onDisappear {
+                self.cancelPostAuthTasksAndClearInFlightState()
                 self.clearActivePresentationIfNeeded()
             }
         }
@@ -193,6 +191,76 @@ struct CloudSignInSheet: View {
         self.postAuthLoadingState != nil
             || self.postAuthGuestLocalRecoveryPreparationState != nil
             || self.postAuthSyncState != nil
+    }
+
+    private func cancelPostAuthTasks() {
+        self.postAuthLoadingTask?.task.cancel()
+        self.postAuthLoadingTask = nil
+        self.postAuthGuestLocalRecoveryPreparationTask?.task.cancel()
+        self.postAuthGuestLocalRecoveryPreparationTask = nil
+        self.postAuthSyncTask?.task.cancel()
+        self.postAuthSyncTask = nil
+    }
+
+    private func cancelPostAuthTasksAndClearInFlightState() {
+        self.cancelPostAuthTasks()
+        self.postAuthLoadingState = nil
+        self.postAuthGuestLocalRecoveryPreparationState = nil
+        self.postAuthSyncState = nil
+    }
+
+    private func clearPostAuthLoadingTaskIfCurrent(stateId: String) {
+        guard self.postAuthLoadingTask?.stateId == stateId else {
+            return
+        }
+        self.postAuthLoadingTask = nil
+    }
+
+    private func clearPostAuthGuestLocalRecoveryPreparationTaskIfCurrent(stateId: String) {
+        guard self.postAuthGuestLocalRecoveryPreparationTask?.stateId == stateId else {
+            return
+        }
+        self.postAuthGuestLocalRecoveryPreparationTask = nil
+    }
+
+    private func clearPostAuthSyncTaskIfCurrent(stateId: String) {
+        guard self.postAuthSyncTask?.stateId == stateId else {
+            return
+        }
+        self.postAuthSyncTask = nil
+    }
+
+    private func startPostAuthLoadingTask(_ loadingState: CloudPostAuthLoadingState) {
+        self.postAuthLoadingTask?.task.cancel()
+        let task = Task { @MainActor in
+            await self.prepareCloudLink(loadingState)
+            self.clearPostAuthLoadingTaskIfCurrent(stateId: loadingState.id)
+        }
+        self.postAuthLoadingTask = CloudSignInPostAuthTaskHandle(stateId: loadingState.id, task: task)
+    }
+
+    private func startPostAuthGuestLocalRecoveryPreparationTask(
+        _ recoveryState: CloudPostAuthGuestLocalRecoveryPreparationState
+    ) {
+        self.postAuthGuestLocalRecoveryPreparationTask?.task.cancel()
+        let task = Task { @MainActor in
+            await Task.yield()
+            await self.runGuestLocalRecoveryPreparation(recoveryState)
+            self.clearPostAuthGuestLocalRecoveryPreparationTaskIfCurrent(stateId: recoveryState.id)
+        }
+        self.postAuthGuestLocalRecoveryPreparationTask = CloudSignInPostAuthTaskHandle(
+            stateId: recoveryState.id,
+            task: task
+        )
+    }
+
+    private func startPostAuthSyncTask(_ syncState: CloudPostAuthSyncState) {
+        self.postAuthSyncTask?.task.cancel()
+        let task = Task { @MainActor in
+            await self.runPostAuthSync(syncState)
+            self.clearPostAuthSyncTaskIfCurrent(stateId: syncState.id)
+        }
+        self.postAuthSyncTask = CloudSignInPostAuthTaskHandle(stateId: syncState.id, task: task)
     }
 
     private func scheduleEmailFieldFocus() {
@@ -265,6 +333,12 @@ struct CloudSignInSheet: View {
                     )
                 }
             } catch {
+                if isRequestCancellationError(error: error) {
+                    if self.otpSheetState?.id == nextOtpSheetState.id {
+                        self.otpSheetState = nil
+                    }
+                    return
+                }
                 if self.otpSheetState?.id == nextOtpSheetState.id {
                     self.otpSheetState = nil
                 }
@@ -286,10 +360,12 @@ struct CloudSignInSheet: View {
         switch makeCloudWorkspacePostAuthRoute(linkContext: linkContext) {
         case .autoLink(let selection):
             if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
-                self.postAuthGuestLocalRecoveryPreparationState = CloudPostAuthGuestLocalRecoveryPreparationState(
+                let nextState = CloudPostAuthGuestLocalRecoveryPreparationState(
                     linkContext: linkContext,
                     selection: selection
                 )
+                self.postAuthGuestLocalRecoveryPreparationState = nextState
+                self.startPostAuthGuestLocalRecoveryPreparationTask(nextState)
             } else {
                 self.completeLink(linkContext: linkContext, selection: selection)
             }
@@ -305,27 +381,36 @@ struct CloudSignInSheet: View {
     }
 
     private func handleVerifiedAuthContext(_ verifiedContext: CloudVerifiedAuthContext) {
+        let loadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
         self.otpSheetState = nil
-        self.postAuthLoadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
+        self.postAuthLoadingState = loadingState
         self.postAuthGuestLocalRecoveryPreparationState = nil
         self.postAuthSyncState = nil
         self.workspaceLinkContext = nil
         self.postAuthRecoveryNeededState = nil
         self.authErrorPresentation = nil
+
+        self.startPostAuthLoadingTask(loadingState)
     }
 
-    private func prepareCloudLink(verifiedContext: CloudVerifiedAuthContext) async {
+    private func prepareCloudLink(_ loadingState: CloudPostAuthLoadingState) async {
         do {
-            let linkContext = try await self.store.prepareCloudLink(verifiedContext: verifiedContext)
+            let linkContext = try await self.store.prepareCloudLink(verifiedContext: loadingState.verifiedContext)
+            guard self.postAuthLoadingState?.id == loadingState.id else {
+                return
+            }
             self.postAuthFailureState = nil
             self.handlePreparedLinkContext(linkContext)
         } catch {
+            guard self.postAuthLoadingState?.id == loadingState.id else {
+                return
+            }
             self.postAuthLoadingState = nil
             self.postAuthGuestLocalRecoveryPreparationState = nil
             self.postAuthSyncState = nil
             if self.store.cloudCredentialRecoveryState?.reason == .guestSessionMissing {
                 let failurePresentation = makeGuestLocalRecoveryPostAuthFailurePresentation(
-                    retryAction: .prepareLink(verifiedContext: verifiedContext)
+                    retryAction: .prepareLink(verifiedContext: loadingState.verifiedContext)
                 )
                 self.presentPostAuthFailure(
                     title: failurePresentation.title,
@@ -339,7 +424,7 @@ struct CloudSignInSheet: View {
                     title: aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
                     message: Flashcards.errorMessage(error: error),
                     technicalDetails: nil,
-                    retryAction: .prepareLink(verifiedContext: verifiedContext),
+                    retryAction: .prepareLink(verifiedContext: loadingState.verifiedContext),
                     kind: .standard
                 )
             }
@@ -377,7 +462,9 @@ struct CloudSignInSheet: View {
 
         switch failureState.retryAction {
         case .prepareLink(let verifiedContext):
-            self.postAuthLoadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
+            let loadingState = CloudPostAuthLoadingState(verifiedContext: verifiedContext)
+            self.postAuthLoadingState = loadingState
+            self.startPostAuthLoadingTask(loadingState)
         case .completeLink(let linkContext, let selection):
             self.completeLink(linkContext: linkContext, selection: selection)
         case .completeGuestLink(let linkContext, let selection):
@@ -398,6 +485,8 @@ struct CloudSignInSheet: View {
         self.postAuthRecoveryNeededState = nil
         self.postAuthFailureState = nil
         self.postAuthSyncState = nextState
+
+        self.startPostAuthSyncTask(nextState)
     }
 
     private func runPostAuthSync(_ syncState: CloudPostAuthSyncState) async {
@@ -462,6 +551,7 @@ struct CloudSignInSheet: View {
         retryAction: CloudPostAuthRetryAction,
         kind: CloudPostAuthFailureKind
     ) {
+        self.cancelPostAuthTasks()
         self.authErrorPresentation = nil
         self.postAuthLoadingState = nil
         self.postAuthGuestLocalRecoveryPreparationState = nil
@@ -477,6 +567,7 @@ struct CloudSignInSheet: View {
     }
 
     private func logoutAndDismiss() {
+        self.cancelPostAuthTasksAndClearInFlightState()
         do {
             try self.store.logoutCloudAccount()
         } catch {
@@ -486,9 +577,6 @@ struct CloudSignInSheet: View {
             )
         }
 
-        self.postAuthLoadingState = nil
-        self.postAuthGuestLocalRecoveryPreparationState = nil
-        self.postAuthSyncState = nil
         self.postAuthFailureState = nil
         self.workspaceLinkContext = nil
         self.postAuthRecoveryNeededState = nil


### PR DESCRIPTION
## Summary
- keep iOS post-auth cloud sync work outside transient SwiftUI sheet tasks
- stop reporting request cancellation as cloud sync/auth failures
- align Android cloud cancellation handling with coroutine cancellation semantics and retryable post-auth state

## Validation
- git --no-pager diff --check
- review pass with one fresh subagent

Gradle and iOS simulator-backed tests were not run because project instructions require explicit approval for those heavy checks.