### PR TITLE
[codex] Fix Android post-auth cancellation tests

### DIFF
--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -614,6 +614,7 @@ class CloudSignInViewModelTest {
         } catch (caught: CancellationException) {
             caught
         }
+        advanceUntilIdle()
 
         assertNotNull(error)
         assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
@@ -665,6 +666,7 @@ class CloudSignInViewModelTest {
         } catch (caught: CancellationException) {
             caught
         }
+        advanceUntilIdle()
 
         assertNotNull(error)
         assertEquals(1, syncRepository.syncNowCalls)


### PR DESCRIPTION
## Summary

- advance the coroutine test scheduler after post-auth cancellation exceptions
- keep the retry-state assertions aligned with the derived StateFlow update timing

## Validation

- git diff --check
- Gradle not run by request