### PR TITLE
[codex] Stabilize Android live smoke cloud waits

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceLifecycleFlows.kt
@@ -30,6 +30,7 @@ import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceErrorMe
 import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceNameOrNull
 import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceOperationMessageOrNull
 import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceSummaryOrNull
+import com.flashcardsopensourceapp.app.livesmoke.support.externalCloudWorkspaceTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.externalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.selectedWorkspaceSummary
@@ -61,8 +62,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 
-private const val linkedWorkspaceMutationTimeoutMillis: Long = 120_000L
-
 private enum class DeletePreviewResolution {
     PREVIEW_READY,
     ERROR_VISIBLE
@@ -83,7 +82,7 @@ internal data class EphemeralWorkspaceHandle(
 
 internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): EphemeralWorkspaceHandle {
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
-    waitForCurrentWorkspaceScreenToSettle()
+    waitForCurrentWorkspaceScreenToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
     waitUntilAtLeastOneExistsOrFail(
         matcher = hasText("Create new workspace"),
         timeoutMillis = internalUiTimeoutMillis
@@ -104,16 +103,16 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
     clickTag(tag = currentWorkspaceCreateButtonTag, label = "Create new workspace")
     val createdWorkspaceSelection: LinkedWorkspaceSelectionSnapshot = waitForLinkedWorkspaceSelectionToChange(
         previousWorkspaceId = selectedWorkspaceIdBeforeCreate,
-        timeoutMillis = linkedWorkspaceMutationTimeoutMillis,
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis,
         context = "after creating a linked workspace"
     )
     waitForSelectedWorkspaceSummaryToChange(
         beforeSummary = selectedWorkspaceSummaryBeforeCreate,
         context = "after creating a linked workspace",
-        timeoutMillis = linkedWorkspaceMutationTimeoutMillis
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
     waitForCurrentWorkspaceOperationToFinish(
-        timeoutMillis = linkedWorkspaceMutationTimeoutMillis
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
     waitForCurrentWorkspaceRenameReady(
         expectedWorkspaceName = workspaceName,
@@ -124,16 +123,16 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
     clickTag(tag = currentWorkspaceSaveNameButtonTag, label = "Save workspace name")
     waitForCurrentWorkspaceRenameOutcome(
         expectedWorkspaceName = workspaceName,
-        timeoutMillis = linkedWorkspaceMutationTimeoutMillis
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
     val renamedWorkspaceSelection: LinkedWorkspaceSelectionSnapshot = waitForLinkedWorkspaceName(
         expectedWorkspaceName = workspaceName,
-        timeoutMillis = linkedWorkspaceMutationTimeoutMillis,
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis,
         context = "after renaming the linked workspace"
     )
     tapBackIcon()
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
-    waitForCurrentWorkspaceScreenToSettle()
+    waitForCurrentWorkspaceScreenToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
     waitForCurrentWorkspaceName(expectedWorkspaceName = workspaceName)
     tapBackIcon()
 
@@ -151,10 +150,10 @@ internal fun LiveSmokeContext.createEphemeralWorkspace(workspaceName: String): E
 internal fun LiveSmokeContext.deleteEphemeralWorkspace(workspaceHandle: EphemeralWorkspaceHandle) {
     forceLinkedSyncAndWaitForWorkspace(
         workspaceHandle = workspaceHandle,
-        timeoutMillis = externalUiTimeoutMillis
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
-    waitForCurrentWorkspaceScreenToSettle()
+    waitForCurrentWorkspaceScreenToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
     waitUntilAtLeastOneExistsOrFail(
         matcher = hasText("Create new workspace"),
         timeoutMillis = internalUiTimeoutMillis
@@ -189,15 +188,15 @@ internal fun LiveSmokeContext.deleteEphemeralWorkspace(workspaceHandle: Ephemera
     tapDeleteWorkspaceConfirmation(workspaceName = workspaceHandle.workspaceName)
     waitForLinkedWorkspaceSelectionToChange(
         previousWorkspaceId = workspaceHandle.workspaceId,
-        timeoutMillis = externalUiTimeoutMillis,
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis,
         context = "after deleting the isolated linked workspace"
     )
     tapBackIcon()
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
-    waitForCurrentWorkspaceScreenToSettle()
+    waitForCurrentWorkspaceScreenToSettle(timeoutMillis = externalCloudWorkspaceTimeoutMillis)
     try {
         waitUntilWithMitigation(
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = externalCloudWorkspaceTimeoutMillis,
             context = "while waiting for workspace deletion to finish"
         ) {
             val currentWorkspaceName: String? = currentWorkspaceNameOrNull()
@@ -220,7 +219,7 @@ internal fun LiveSmokeContext.deleteEphemeralWorkspace(workspaceHandle: Ephemera
     }
     waitForSelectedWorkspaceSummary(
         context = "after deleting the isolated linked workspace",
-        timeoutMillis = externalUiTimeoutMillis
+        timeoutMillis = externalCloudWorkspaceTimeoutMillis
     )
     tapBackIcon()
 }
@@ -256,7 +255,7 @@ internal fun LiveSmokeContext.forceLinkedSyncAndWaitForWorkspace(
     )
 
     openSettingsRow(rowTag = settingsCurrentWorkspaceRowTag, rowLabel = "Workspace")
-    waitForCurrentWorkspaceScreenToSettle()
+    waitForCurrentWorkspaceScreenToSettle(timeoutMillis = timeoutMillis)
     waitForCurrentWorkspaceName(expectedWorkspaceName = workspaceHandle.workspaceName)
     waitForSelectedWorkspaceSummary(
         context = "after forcing linked sync before cleanup",
@@ -300,7 +299,7 @@ private fun LiveSmokeContext.waitForDeletePreviewResolution(
 ): DeletePreviewResolution {
     try {
         waitUntilWithMitigation(
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = externalCloudWorkspaceTimeoutMillis,
             context = "while waiting for delete preview resolution for '$workspaceName'"
         ) {
             isDeletePreviewDialogVisible() || deleteCurrentWorkspaceErrorMessageOrNull() != null
@@ -358,7 +357,7 @@ private fun LiveSmokeContext.tapDeleteWorkspaceConfirmation(workspaceName: Strin
     composeRule.waitForIdle()
     try {
         waitUntilWithMitigation(
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = externalCloudWorkspaceTimeoutMillis,
             context = "while waiting for delete confirmation completion for '$workspaceName'"
         ) {
             val confirmationError: String? = deleteConfirmationErrorOrNull()

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceProgressFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeWorkspaceProgressFlows.kt
@@ -7,12 +7,12 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextReplacement
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.clickTag
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.nodeSummary
-import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTagToDisappear
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTagToExist
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilWithMitigation
 import com.flashcardsopensourceapp.app.livesmoke.support.LiveSmokeContext
 import com.flashcardsopensourceapp.app.livesmoke.support.currentCloudSettingsSummary
 import com.flashcardsopensourceapp.app.livesmoke.support.currentWorkspaceSummaryOrNull
+import com.flashcardsopensourceapp.app.livesmoke.support.externalCloudWorkspaceTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.externalUiTimeoutMillis
 import com.flashcardsopensourceapp.feature.settings.settingsResetStudyProgressRowTag
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressButtonTag
@@ -20,6 +20,7 @@ import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSet
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressConfirmationDialogTag
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressConfirmationFieldTag
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressConfirmationPhraseTag
+import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressDialogErrorTag
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressErrorTag
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressPreviewBodyTag
 import com.flashcardsopensourceapp.feature.settings.workspace.reset.workspaceSettingsResetProgressPreviewButtonTag
@@ -43,11 +44,7 @@ internal fun LiveSmokeContext.resetWorkspaceProgressFromSettings(expectedCardsTo
 
     waitForResetProgressPreviewReady(expectedCardsToResetCount = expectedCardsToResetCount)
     clickTag(tag = workspaceSettingsResetProgressPreviewButtonTag, label = "Confirm reset progress")
-    waitForTagToDisappear(
-        tag = workspaceSettingsResetProgressPreviewDialogTag,
-        timeoutMillis = externalUiTimeoutMillis,
-        context = "while waiting for reset progress to complete"
-    )
+    waitForResetProgressCompletion()
 }
 
 private fun LiveSmokeContext.waitForResetProgressConfirmationReady() {
@@ -84,11 +81,11 @@ private fun LiveSmokeContext.waitForResetProgressPreviewReady(expectedCardsToRes
     try {
         waitForTagToExist(
             tag = workspaceSettingsResetProgressPreviewDialogTag,
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = externalCloudWorkspaceTimeoutMillis,
             context = "while waiting for reset progress preview dialog"
         )
         waitUntilWithMitigation(
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = externalCloudWorkspaceTimeoutMillis,
             context = "while waiting for reset progress preview body"
         ) {
             val previewBodyText = readTaggedTextOrNull(workspaceSettingsResetProgressPreviewBodyTag)
@@ -100,6 +97,33 @@ private fun LiveSmokeContext.waitForResetProgressPreviewReady(expectedCardsToRes
             "Reset progress preview did not become ready. " +
                 "PreviewBody=${readTaggedTextOrNull(workspaceSettingsResetProgressPreviewBodyTag)} " +
                 "PreviewError=${workspaceSettingsResetProgressErrorTextOrNull()} " +
+                "CloudSettings=${currentCloudSettingsSummary()} " +
+                "CurrentWorkspace=${currentWorkspaceSummaryOrNull()}",
+            error
+        )
+    }
+}
+
+private fun LiveSmokeContext.waitForResetProgressCompletion() {
+    try {
+        waitUntilWithMitigation(
+            timeoutMillis = externalCloudWorkspaceTimeoutMillis,
+            context = "while waiting for reset progress to complete"
+        ) {
+            val resetDialogErrorText: String? = workspaceSettingsResetProgressDialogErrorTextOrNull()
+            if (resetDialogErrorText != null) {
+                throw AssertionError("Reset progress failed: $resetDialogErrorText")
+            }
+            composeRule.onAllNodesWithTag(workspaceSettingsResetProgressPreviewDialogTag)
+                .fetchSemanticsNodes()
+                .isEmpty()
+        }
+    } catch (error: Throwable) {
+        throw AssertionError(
+            "Reset progress did not complete. " +
+                "PreviewDialogVisible=${isResetProgressPreviewDialogVisible()} " +
+                "PreviewError=${workspaceSettingsResetProgressDialogErrorTextOrNull()} " +
+                "ScreenError=${workspaceSettingsResetProgressErrorTextOrNull()} " +
                 "CloudSettings=${currentCloudSettingsSummary()} " +
                 "CurrentWorkspace=${currentWorkspaceSummaryOrNull()}",
             error
@@ -129,12 +153,26 @@ private fun LiveSmokeContext.readTaggedTextOrNull(tag: String): String? {
         ?.takeIf { text -> text.isNotBlank() }
 }
 
+private fun LiveSmokeContext.workspaceSettingsResetProgressDialogErrorTextOrNull(): String? {
+    return composeRule.onAllNodesWithTag(workspaceSettingsResetProgressDialogErrorTag).fetchSemanticsNodes()
+        .singleOrNull()
+        ?.let(::nodeSummary)
+        ?.trim()
+        ?.takeIf { text -> text.isNotBlank() }
+}
+
 private fun LiveSmokeContext.workspaceSettingsResetProgressErrorTextOrNull(): String? {
     return composeRule.onAllNodesWithTag(workspaceSettingsResetProgressErrorTag).fetchSemanticsNodes()
         .singleOrNull()
         ?.let(::nodeSummary)
         ?.trim()
         ?.takeIf { text -> text.isNotBlank() }
+}
+
+private fun LiveSmokeContext.isResetProgressPreviewDialogVisible(): Boolean {
+    return composeRule.onAllNodesWithTag(workspaceSettingsResetProgressPreviewDialogTag)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
 }
 
 private fun extractResetProgressCount(previewBodyText: String): Int {

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeContext.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeContext.kt
@@ -8,6 +8,7 @@ import com.flashcardsopensourceapp.app.livesmoke.diagnostics.emitInlineRawScreen
 import org.junit.rules.TestName
 
 internal const val externalUiTimeoutMillis: Long = 30_000L
+internal const val externalCloudWorkspaceTimeoutMillis: Long = 120_000L
 internal const val externalAiRunTimeoutMillis: Long = 60_000L
 internal const val internalUiTimeoutMillis: Long = 10_000L
 internal const val reviewEmailArgumentKey: String = "FLASHCARDS_LIVE_REVIEW_EMAIL"

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeWorkspaceStateSupport.kt
@@ -68,10 +68,10 @@ internal fun LiveSmokeContext.waitForSelectedWorkspaceSummaryToChange(
     }
 }
 
-internal fun LiveSmokeContext.waitForCurrentWorkspaceScreenToSettle() {
+internal fun LiveSmokeContext.waitForCurrentWorkspaceScreenToSettle(timeoutMillis: Long) {
     try {
         waitUntilWithMitigation(
-            timeoutMillis = externalUiTimeoutMillis,
+            timeoutMillis = timeoutMillis,
             context = "while waiting for the Workspace screen to settle"
         ) {
             val visibleError: String? = currentWorkspaceVisibleErrorMessageOrNull()


### PR DESCRIPTION
## Summary
- add a dedicated Android live smoke cloud workspace timeout
- apply it to linked workspace create/delete/reset waits
- fail fast when reset progress surfaces a dialog error

## Validation
- git --no-pager diff --check
- Gradle/instrumentation not run per repository policy requiring explicit approval