### PR TITLE
Fix iOS AI guest session preparation race

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatStore.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Core/AIChatStore.swift
@@ -163,6 +163,7 @@ final class AIChatStore {
     @ObservationIgnored var activeDictationTask: Task<Void, Never>?
     @ObservationIgnored var activeWarmUpTask: Task<Void, Never>?
     @ObservationIgnored var activeBootstrapTask: Task<Void, Never>?
+    @ObservationIgnored var activePassiveSnapshotRefreshTask: Task<Void, Never>?
     @ObservationIgnored var activeNewSessionTask: Task<Void, Never>?
     @ObservationIgnored var activeRemoteSessionProvisionRequest: AIChatRemoteSessionProvisionRequest?
     @ObservationIgnored var activePersistTask: Task<Void, Never>?
@@ -180,6 +181,7 @@ final class AIChatStore {
     @ObservationIgnored var activeToolRunPostSyncTask: Task<Void, Never>?
     @ObservationIgnored var nextResumeAttemptSequence: Int
     @ObservationIgnored var nextBootstrapRequestSequence: Int
+    @ObservationIgnored var nextPassiveSnapshotRefreshSequence: Int
     @ObservationIgnored var nextNewSessionRequestSequence: Int
     @ObservationIgnored var activeResumeErrorAttemptSequence: Int?
     @ObservationIgnored var activeLiveResumeAttemptSequence: Int?
@@ -640,6 +642,7 @@ final class AIChatStore {
         self.activeDictationTask = nil
         self.activeWarmUpTask = nil
         self.activeBootstrapTask = nil
+        self.activePassiveSnapshotRefreshTask = nil
         self.activeNewSessionTask = nil
         self.activeRemoteSessionProvisionRequest = nil
         self.activePersistTask = nil
@@ -656,6 +659,7 @@ final class AIChatStore {
         self.activeToolRunPostSyncTask = nil
         self.nextResumeAttemptSequence = 0
         self.nextBootstrapRequestSequence = 0
+        self.nextPassiveSnapshotRefreshSequence = 0
         self.nextNewSessionRequestSequence = 0
         self.activeResumeErrorAttemptSequence = nil
         self.activeLiveResumeAttemptSequence = nil

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Run/AIChatStore+RunLifecycle.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Run/AIChatStore+RunLifecycle.swift
@@ -142,6 +142,7 @@ extension AIChatStore {
 
     func shutdownForTests() {
         self.invalidateActiveBootstrapTask()
+        self.invalidateActivePassiveSnapshotRefreshTask()
         self.activeWarmUpTask?.cancel()
         self.activeWarmUpTask = nil
         self.invalidatePendingNewSessionRequest()

--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+Surface.swift
@@ -240,6 +240,7 @@ extension AIChatStore {
 
         if self.shouldPreserveActiveGuestSendDuringAccessContextChange(nextAccessContext: nextAccessContext) {
             self.surfaceState.activeAccessContext = nextAccessContext
+            self.invalidateActivePassiveSnapshotRefreshTask()
             self.historyStore.activateWorkspace(workspaceId: self.historyWorkspaceId())
             self.schedulePersistCurrentState()
             return
@@ -247,6 +248,7 @@ extension AIChatStore {
 
         self.surfaceState.activeAccessContext = nextAccessContext
         self.invalidatePendingNewSessionRequest()
+        self.invalidateActivePassiveSnapshotRefreshTask()
         self.invalidatePendingRemoteSessionProvisionRequest()
         self.invalidateActiveBootstrapTask()
         self.cancelStreaming()
@@ -400,8 +402,33 @@ extension AIChatStore {
         self.nextBootstrapRequestSequence += 1
     }
 
+    func beginPassiveSnapshotRefreshSequence() -> Int {
+        self.activePassiveSnapshotRefreshTask?.cancel()
+        self.activePassiveSnapshotRefreshTask = nil
+        self.nextPassiveSnapshotRefreshSequence += 1
+        return self.nextPassiveSnapshotRefreshSequence
+    }
+
+    func invalidateActivePassiveSnapshotRefreshTask() {
+        self.activePassiveSnapshotRefreshTask?.cancel()
+        self.activePassiveSnapshotRefreshTask = nil
+        self.nextPassiveSnapshotRefreshSequence += 1
+    }
+
     func isCurrentBootstrapRequest(sequence: Int) -> Bool {
         self.nextBootstrapRequestSequence == sequence
+    }
+
+    func isCurrentPassiveSnapshotRefresh(sequence: Int) -> Bool {
+        self.nextPassiveSnapshotRefreshSequence == sequence
+    }
+
+    func isCurrentPassiveSnapshotRefreshRequest(
+        sequence: Int,
+        accessContext: AIChatAccessContext
+    ) -> Bool {
+        self.isCurrentPassiveSnapshotRefresh(sequence: sequence)
+            && self.surfaceState.activeAccessContext == accessContext
     }
 
     func isCurrentLinkedBootstrapRequest(
@@ -466,6 +493,7 @@ extension AIChatStore {
 
     private func prepareLocalHistoryStateReset() {
         self.invalidateActiveBootstrapTask()
+        self.invalidateActivePassiveSnapshotRefreshTask()
         self.activeWarmUpTask?.cancel()
         self.activeWarmUpTask = nil
         self.invalidatePendingRemoteSessionProvisionRequest()
@@ -506,6 +534,7 @@ extension AIChatStore {
         pendingAttachments: [AIChatAttachment]
     ) {
         self.invalidateActiveBootstrapTask()
+        self.invalidateActivePassiveSnapshotRefreshTask()
         self.activeWarmUpTask?.cancel()
         self.activeWarmUpTask = nil
         self.activeSendTask?.cancel()
@@ -687,12 +716,41 @@ extension AIChatStore {
             return
         }
 
-        Task {
+        let requestSequence = self.beginPassiveSnapshotRefreshSequence()
+        let refreshAccessContext = self.surfaceState.activeAccessContext ?? self.currentAccessContext()
+        let task = Task {
+            defer {
+                if self.isCurrentPassiveSnapshotRefresh(sequence: requestSequence) {
+                    self.activePassiveSnapshotRefreshTask = nil
+                }
+            }
+
             var refreshedSessionId: String?
             do {
+                guard self.isCurrentPassiveSnapshotRefreshRequest(
+                    sequence: requestSequence,
+                    accessContext: refreshAccessContext
+                ) else {
+                    throw CancellationError()
+                }
+
                 let session = try await self.flashcardsStore.cloudSessionForAI()
+                guard self.isCurrentPassiveSnapshotRefreshRequest(
+                    sequence: requestSequence,
+                    accessContext: refreshAccessContext
+                ) else {
+                    throw CancellationError()
+                }
+
                 let sessionId = try await self.ensureRemoteSessionIfNeeded(session: session)
                 refreshedSessionId = sessionId
+                guard self.isCurrentPassiveSnapshotRefreshRequest(
+                    sequence: requestSequence,
+                    accessContext: refreshAccessContext
+                ), self.chatSessionId == sessionId else {
+                    throw CancellationError()
+                }
+
                 let refreshedBaselineState = self.currentPersistedState()
                 let bootstrap = try await self.chatService.loadBootstrap(
                     session: session,
@@ -700,7 +758,11 @@ extension AIChatStore {
                     limit: aiChatBootstrapPageLimit,
                     resumeAttemptDiagnostics: nil
                 )
-                guard self.currentPersistedState() == refreshedBaselineState else {
+                guard self.isCurrentPassiveSnapshotRefreshRequest(
+                    sequence: requestSequence,
+                    accessContext: refreshAccessContext
+                ), self.chatSessionId == sessionId,
+                    self.currentPersistedState() == refreshedBaselineState else {
                     return
                 }
                 self.applyBootstrap(bootstrap)
@@ -712,6 +774,13 @@ extension AIChatStore {
             } catch is CancellationError {
                 return
             } catch {
+                guard self.isCurrentPassiveSnapshotRefreshRequest(
+                    sequence: requestSequence,
+                    accessContext: refreshAccessContext
+                ) else {
+                    return
+                }
+
                 if self.shouldIgnoreAIChatPassiveSnapshotRefreshFailure(error: error) {
                     return
                 }
@@ -737,6 +806,7 @@ extension AIChatStore {
                 )
             }
         }
+        self.activePassiveSnapshotRefreshTask = task
     }
 
     private func shouldIgnoreAIChatPassiveSnapshotRefreshFailure(error: Error) -> Bool {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -14,6 +14,7 @@ struct CloudSessionRuntimeState {
     var activeCloudLinkTask: CloudLinkTransitionState?
     var activeWorkspaceCompletionTask: CloudWorkspaceCompletionState?
     var activeAIChatSessionPreparation: AIChatSessionPreparationState?
+    var activeGuestCloudSessionPreparation: GuestCloudSessionPreparationState?
 }
 
 @MainActor
@@ -37,7 +38,8 @@ final class CloudSessionRuntime {
             pendingCloudResync: false,
             activeCloudLinkTask: nil,
             activeWorkspaceCompletionTask: nil,
-            activeAIChatSessionPreparation: nil
+            activeAIChatSessionPreparation: nil,
+            activeGuestCloudSessionPreparation: nil
         )
     }
 
@@ -161,7 +163,6 @@ final class CloudSessionRuntime {
         }
 
         let needsRestore = self.state.activeCloudSession == nil
-
         let preparation = AIChatSessionPreparationState(
             id: UUID().uuidString.lowercased(),
             task: Task { @MainActor in
@@ -183,6 +184,35 @@ final class CloudSessionRuntime {
         } catch {
             if self.state.activeAIChatSessionPreparation?.id == preparation.id {
                 self.state.activeAIChatSessionPreparation = nil
+            }
+            throw error
+        }
+    }
+
+    func prepareGuestCloudSession(
+        operation: @escaping @MainActor () async throws -> GuestCloudSessionRestoreResult
+    ) async throws -> GuestCloudSessionRestoreResult {
+        if let activePreparation = self.state.activeGuestCloudSessionPreparation {
+            return try await activePreparation.task.value
+        }
+
+        let preparation = GuestCloudSessionPreparationState(
+            id: UUID().uuidString.lowercased(),
+            task: Task { @MainActor in
+                try await operation()
+            }
+        )
+        self.state.activeGuestCloudSessionPreparation = preparation
+
+        do {
+            let result = try await preparation.task.value
+            if self.state.activeGuestCloudSessionPreparation?.id == preparation.id {
+                self.state.activeGuestCloudSessionPreparation = nil
+            }
+            return result
+        } catch {
+            if self.state.activeGuestCloudSessionPreparation?.id == preparation.id {
+                self.state.activeGuestCloudSessionPreparation = nil
             }
             throw error
         }
@@ -490,6 +520,8 @@ final class CloudSessionRuntime {
         self.state.pendingCloudResync = false
         self.state.activeAIChatSessionPreparation?.task.cancel()
         self.state.activeAIChatSessionPreparation = nil
+        self.state.activeGuestCloudSessionPreparation?.task.cancel()
+        self.state.activeGuestCloudSessionPreparation = nil
     }
 
     func cancelForAccountDeletion() {
@@ -500,6 +532,8 @@ final class CloudSessionRuntime {
         self.state.pendingCloudResync = false
         self.state.activeAIChatSessionPreparation?.task.cancel()
         self.state.activeAIChatSessionPreparation = nil
+        self.state.activeGuestCloudSessionPreparation?.task.cancel()
+        self.state.activeGuestCloudSessionPreparation = nil
         self.state.activeCloudSession = nil
         self.cloudAuthService.resetChallengeSession()
         FlashcardsObservability.setIdentity(nil)

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudAccount.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudAccount.swift
@@ -227,7 +227,19 @@ extension FlashcardsStore {
 
     func restoreGuestCloudSessionIfNeeded(
         trigger: CloudSyncTrigger
-    ) async throws -> (session: CloudLinkedSession, didRunSync: Bool) {
+    ) async throws -> GuestCloudSessionRestoreResult {
+        try await self.cloudRuntime.prepareGuestCloudSession { [weak self] in
+            guard let self else {
+                throw LocalStoreError.uninitialized("Flashcards store is unavailable")
+            }
+
+            return try await self.performRestoreGuestCloudSessionIfNeeded(trigger: trigger)
+        }
+    }
+
+    private func performRestoreGuestCloudSessionIfNeeded(
+        trigger: CloudSyncTrigger
+    ) async throws -> GuestCloudSessionRestoreResult {
         let guestSession = try await self.loadOrCreateGuestCloudSession()
         let isAlreadyGuestLinked = self.cloudSettings?.cloudState == .guest
             && self.workspace?.workspaceId == guestSession.workspaceId
@@ -237,13 +249,13 @@ extension FlashcardsStore {
             self.cloudRuntime.setActiveCloudSession(linkedSession: guestSession)
             if case .failed = self.syncStatus {
                 try await self.performSameWorkspaceCloudRestore(linkedSession: guestSession, trigger: trigger)
-                return (guestSession, true)
+                return GuestCloudSessionRestoreResult(session: guestSession, didRunSync: true)
             }
-            return (guestSession, false)
+            return GuestCloudSessionRestoreResult(session: guestSession, didRunSync: false)
         }
 
         try await self.finishCloudLink(linkedSession: guestSession, trigger: trigger)
-        return (guestSession, true)
+        return GuestCloudSessionRestoreResult(session: guestSession, didRunSync: true)
     }
 
     func prepareAuthenticatedCloudSessionForAI() async throws -> CloudLinkedSession {

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
@@ -250,6 +250,16 @@ struct AIChatSessionPreparationState {
     let task: Task<CloudLinkedSession, Error>
 }
 
+struct GuestCloudSessionRestoreResult {
+    let session: CloudLinkedSession
+    let didRunSync: Bool
+}
+
+struct GuestCloudSessionPreparationState {
+    let id: String
+    let task: Task<GuestCloudSessionRestoreResult, Error>
+}
+
 struct CloudLinkTransitionState {
     let id: String
     let task: Task<Void, Error>


### PR DESCRIPTION
## Summary
- single-flight guest cloud session restore across AI, sync, and feedback callers
- guard passive AI snapshot refreshes against stale access context/session updates
- cancel passive refresh tasks during AI test shutdown

## Validation
- xcrun swiftc -parse on changed Swift files
- git --no-pager diff --check