### PR TITLE
Grant reporting readonly analytics access

### DIFF
--- a/apps/backend/src/community/friendships.test.ts
+++ b/apps/backend/src/community/friendships.test.ts
@@ -103,3 +103,33 @@ test("0064 migration exposes only current viewer leaderboard friend labels", () 
   assert.equal(sql.includes("inviter_user_id"), false);
   assert.equal(sql.includes("email"), false);
 });
+
+test("0065 migration grants reporting access to community analytics without invite token hashes", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "../../db/migrations/0065_reporting_readonly_community_analytics.sql",
+  );
+  const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
+
+  assert.match(sql, /GRANT USAGE ON SCHEMA community TO reporting_readonly/);
+  assert.match(sql, /REVOKE SELECT ON ALL TABLES IN SCHEMA community FROM reporting_readonly/);
+  assert.match(sql, /ALTER DEFAULT PRIVILEGES IN SCHEMA community REVOKE SELECT ON TABLES FROM reporting_readonly/);
+
+  assert.match(sql, /GRANT SELECT \([^)]*user_id,[^)]*public_profile_id,[^)]*leaderboard_participation_enabled[^)]*\) ON TABLE community\.public_profiles TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*review_event_id,[^)]*metric_version,[^)]*public_profile_id,[^)]*reviewed_by_user_id[^)]*\) ON TABLE community\.public_review_activity_facts TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*snapshot_id,[^)]*metric_version,[^)]*window_key[^)]*\) ON TABLE community\.leaderboard_snapshots TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*snapshot_id,[^)]*public_profile_id,[^)]*qualified_review_count[^)]*\) ON TABLE community\.leaderboard_snapshot_entries TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*friend_invitation_id,[^)]*inviter_user_id,[^)]*accepted_at,[^)]*accepted_by_user_id[^)]*\) ON TABLE community\.friend_invitations TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*viewer_user_id,[^)]*friend_user_id,[^)]*friend_public_profile_id,[^)]*created_from_invitation_id[^)]*\) ON TABLE community\.friendships TO reporting_readonly/);
+
+  assert.match(sql, /CREATE POLICY public_profiles_reporting_readonly_select ON community\.public_profiles FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY public_review_activity_facts_reporting_readonly_select ON community\.public_review_activity_facts FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY leaderboard_snapshots_reporting_readonly_select ON community\.leaderboard_snapshots FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY leaderboard_snapshot_entries_reporting_readonly_select ON community\.leaderboard_snapshot_entries FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY friend_invitations_reporting_readonly_select ON community\.friend_invitations FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY friendships_reporting_readonly_select ON community\.friendships FOR SELECT TO reporting_readonly USING \(true\)/);
+
+  assert.equal(sql.includes("invite_token_hash"), false);
+  assert.equal(sql.includes("invitee_display_name_for_inviter"), false);
+  assert.equal(sql.includes("friend_display_name"), false);
+});

--- a/apps/backend/src/database/reportingReadonlyOperationalAnalytics.test.ts
+++ b/apps/backend/src/database/reportingReadonlyOperationalAnalytics.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+test("0066 migration grants reporting access to operational analytics metadata only", () => {
+  const migrationPath = resolve(
+    process.cwd(),
+    "../../db/migrations/0066_reporting_readonly_operational_analytics.sql",
+  );
+  const sql = readFileSync(migrationPath, "utf8").replace(/\s+/g, " ");
+
+  assert.match(sql, /GRANT USAGE ON SCHEMA auth TO reporting_readonly/);
+  assert.match(sql, /GRANT USAGE ON SCHEMA ai TO reporting_readonly/);
+  assert.match(sql, /REVOKE SELECT ON ALL TABLES IN SCHEMA auth FROM reporting_readonly/);
+  assert.match(sql, /REVOKE SELECT ON ALL TABLES IN SCHEMA ai FROM reporting_readonly/);
+
+  assert.match(sql, /GRANT SELECT \([^)]*provider_type,[^)]*user_id,[^)]*created_at[^)]*\) ON TABLE auth\.user_identities TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*session_id,[^)]*user_id,[^)]*last_seen_at,[^)]*platform[^)]*\) ON TABLE auth\.guest_sessions TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*user_id,[^)]*usage_month,[^)]*weighted_tokens,[^)]*updated_at[^)]*\) ON TABLE auth\.guest_ai_monthly_usage TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*upgrade_id,[^)]*source_guest_user_id,[^)]*target_user_id,[^)]*selection_type,[^)]*merged_at[^)]*\) ON TABLE auth\.guest_upgrade_history TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*source_guest_replica_id,[^)]*upgrade_id,[^)]*target_replica_id,[^)]*merged_at[^)]*\) ON TABLE auth\.guest_replica_aliases TO reporting_readonly/);
+
+  assert.match(sql, /GRANT SELECT \([^)]*session_id,[^)]*user_id,[^)]*workspace_id,[^)]*status,[^)]*active_run_id[^)]*\) ON TABLE ai\.chat_sessions TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*run_id,[^)]*session_id,[^)]*status,[^)]*request_id,[^)]*model_id,[^)]*ai_cost_mode[^)]*\) ON TABLE ai\.chat_runs TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*generation_id,[^)]*session_id,[^)]*source,[^)]*invalidated_reason,[^)]*created_at[^)]*\) ON TABLE ai\.chat_composer_suggestion_generations TO reporting_readonly/);
+
+  assert.match(sql, /GRANT SELECT \([^)]*workspace_id,[^)]*min_available_hot_change_id,[^)]*updated_at[^)]*\) ON TABLE sync\.workspace_sync_metadata TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*change_id,[^)]*workspace_id,[^)]*entity_type,[^)]*operation_id,[^)]*replica_id[^)]*\) ON TABLE sync\.hot_changes TO reporting_readonly/);
+  assert.match(sql, /GRANT SELECT \([^)]*workspace_id,[^)]*operation_id,[^)]*operation_type,[^)]*resulting_hot_change_id,[^)]*replica_id[^)]*\) ON TABLE sync\.applied_operations_current TO reporting_readonly/);
+
+  assert.match(sql, /CREATE POLICY chat_sessions_reporting_readonly_select ON ai\.chat_sessions FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY chat_runs_reporting_readonly_select ON ai\.chat_runs FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY chat_composer_suggestion_generations_reporting_readonly_select ON ai\.chat_composer_suggestion_generations FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY workspace_sync_metadata_reporting_readonly_select ON sync\.workspace_sync_metadata FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY hot_changes_reporting_readonly_select ON sync\.hot_changes FOR SELECT TO reporting_readonly USING \(true\)/);
+  assert.match(sql, /CREATE POLICY applied_operations_current_reporting_readonly_select ON sync\.applied_operations_current FOR SELECT TO reporting_readonly USING \(true\)/);
+
+  assert.equal(sql.includes("session_secret_hash"), false);
+  assert.equal(sql.includes("source_guest_session_secret_hash"), false);
+  assert.equal(sql.includes("provider_subject"), false);
+  assert.equal(sql.includes("auth.admin_users"), false);
+  assert.equal(sql.includes("auth.agent_api_keys"), false);
+  assert.equal(sql.includes("auth.agent_otp_challenges"), false);
+  assert.equal(sql.includes("ai.chat_items"), false);
+  assert.equal(sql.includes("turn_input"), false);
+  assert.equal(sql.includes("last_error_message"), false);
+  assert.equal(sql.includes("composer_suggestions"), false);
+  assert.doesNotMatch(sql, /GRANT SELECT \([^)]*suggestions[^)]*\) ON TABLE ai\.chat_composer_suggestion_generations/);
+  assert.equal(sql.includes("sync.changes"), false);
+});

--- a/db/migrations/0065_reporting_readonly_community_analytics.sql
+++ b/db/migrations/0065_reporting_readonly_community_analytics.sql
@@ -1,0 +1,106 @@
+-- Migration status: Current / canonical.
+-- Introduces: read-only reporting access to community analytics tables.
+-- Current guidance: reporting_readonly may inspect community participation,
+--   leaderboard facts, friend invitation audit fields, and directed friendship
+--   rows for operator analytics. Friend invite token hashes remain hidden.
+
+GRANT USAGE ON SCHEMA community TO reporting_readonly;
+
+REVOKE SELECT ON ALL TABLES IN SCHEMA community FROM reporting_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA community
+  REVOKE SELECT ON TABLES FROM reporting_readonly;
+
+GRANT SELECT (
+  user_id,
+  public_profile_id,
+  leaderboard_participation_enabled,
+  created_at,
+  updated_at
+) ON TABLE community.public_profiles TO reporting_readonly;
+
+GRANT SELECT (
+  review_event_id,
+  metric_version,
+  public_profile_id,
+  reviewed_by_user_id,
+  rating,
+  reviewed_at_client,
+  reviewed_at_server,
+  is_countable,
+  exclusion_reason,
+  created_at
+) ON TABLE community.public_review_activity_facts TO reporting_readonly;
+
+GRANT SELECT (
+  snapshot_id,
+  metric_version,
+  window_key,
+  generated_at,
+  as_of_server_hour
+) ON TABLE community.leaderboard_snapshots TO reporting_readonly;
+
+GRANT SELECT (
+  snapshot_id,
+  public_profile_id,
+  qualified_review_count,
+  base_sort_position
+) ON TABLE community.leaderboard_snapshot_entries TO reporting_readonly;
+
+GRANT SELECT (
+  friend_invitation_id,
+  inviter_user_id,
+  created_at,
+  expires_at,
+  accepted_at,
+  accepted_by_user_id
+) ON TABLE community.friend_invitations TO reporting_readonly;
+
+GRANT SELECT (
+  viewer_user_id,
+  friend_user_id,
+  friend_public_profile_id,
+  created_from_invitation_id,
+  created_at
+) ON TABLE community.friendships TO reporting_readonly;
+
+DROP POLICY IF EXISTS public_profiles_reporting_readonly_select ON community.public_profiles;
+CREATE POLICY public_profiles_reporting_readonly_select
+  ON community.public_profiles
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS public_review_activity_facts_reporting_readonly_select ON community.public_review_activity_facts;
+CREATE POLICY public_review_activity_facts_reporting_readonly_select
+  ON community.public_review_activity_facts
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS leaderboard_snapshots_reporting_readonly_select ON community.leaderboard_snapshots;
+CREATE POLICY leaderboard_snapshots_reporting_readonly_select
+  ON community.leaderboard_snapshots
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS leaderboard_snapshot_entries_reporting_readonly_select ON community.leaderboard_snapshot_entries;
+CREATE POLICY leaderboard_snapshot_entries_reporting_readonly_select
+  ON community.leaderboard_snapshot_entries
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS friend_invitations_reporting_readonly_select ON community.friend_invitations;
+CREATE POLICY friend_invitations_reporting_readonly_select
+  ON community.friend_invitations
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS friendships_reporting_readonly_select ON community.friendships;
+CREATE POLICY friendships_reporting_readonly_select
+  ON community.friendships
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);

--- a/db/migrations/0066_reporting_readonly_operational_analytics.sql
+++ b/db/migrations/0066_reporting_readonly_operational_analytics.sql
@@ -1,0 +1,173 @@
+-- Migration status: Current / canonical.
+-- Introduces: read-only reporting access to operational analytics metadata.
+-- Current guidance: reporting_readonly may inspect guest conversion, AI run
+--   health, and current sync diagnostics. Secret hashes, raw chat payloads,
+--   prompts, suggestions, and legacy payload-heavy sync feeds remain hidden.
+
+GRANT USAGE ON SCHEMA auth TO reporting_readonly;
+GRANT USAGE ON SCHEMA ai TO reporting_readonly;
+
+REVOKE SELECT ON ALL TABLES IN SCHEMA auth FROM reporting_readonly;
+REVOKE SELECT ON ALL TABLES IN SCHEMA ai FROM reporting_readonly;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA auth
+  REVOKE SELECT ON TABLES FROM reporting_readonly;
+ALTER DEFAULT PRIVILEGES IN SCHEMA ai
+  REVOKE SELECT ON TABLES FROM reporting_readonly;
+
+GRANT SELECT (
+  provider_type,
+  user_id,
+  created_at
+) ON TABLE auth.user_identities TO reporting_readonly;
+
+GRANT SELECT (
+  session_id,
+  user_id,
+  created_at,
+  last_seen_at,
+  revoked_at,
+  platform
+) ON TABLE auth.guest_sessions TO reporting_readonly;
+
+GRANT SELECT (
+  user_id,
+  usage_month,
+  weighted_tokens,
+  updated_at
+) ON TABLE auth.guest_ai_monthly_usage TO reporting_readonly;
+
+GRANT SELECT (
+  upgrade_id,
+  source_guest_user_id,
+  source_guest_workspace_id,
+  source_guest_session_id,
+  target_user_id,
+  target_workspace_id,
+  selection_type,
+  merged_at
+) ON TABLE auth.guest_upgrade_history TO reporting_readonly;
+
+GRANT SELECT (
+  source_guest_replica_id,
+  upgrade_id,
+  target_replica_id,
+  merged_at
+) ON TABLE auth.guest_replica_aliases TO reporting_readonly;
+
+GRANT SELECT (
+  session_id,
+  user_id,
+  workspace_id,
+  status,
+  active_run_heartbeat_at,
+  main_content_invalidation_version,
+  active_run_id,
+  active_composer_suggestion_generation_id,
+  created_at,
+  updated_at
+) ON TABLE ai.chat_sessions TO reporting_readonly;
+
+GRANT SELECT (
+  run_id,
+  session_id,
+  assistant_item_id,
+  status,
+  request_id,
+  model_id,
+  reasoning_effort,
+  timezone,
+  worker_claimed_at,
+  worker_heartbeat_at,
+  cancel_requested_at,
+  started_at,
+  finished_at,
+  created_at,
+  updated_at,
+  ui_locale,
+  ai_cost_mode,
+  chat_turns_last_7d,
+  good_review_days_last_7d
+) ON TABLE ai.chat_runs TO reporting_readonly;
+
+GRANT SELECT (
+  generation_id,
+  session_id,
+  assistant_item_id,
+  source,
+  invalidated_at,
+  invalidated_reason,
+  created_at
+) ON TABLE ai.chat_composer_suggestion_generations TO reporting_readonly;
+
+GRANT SELECT (
+  workspace_id,
+  min_available_hot_change_id,
+  updated_at
+) ON TABLE sync.workspace_sync_metadata TO reporting_readonly;
+
+GRANT SELECT (
+  change_id,
+  workspace_id,
+  entity_type,
+  entity_id,
+  action,
+  operation_id,
+  client_updated_at,
+  recorded_at,
+  replica_id
+) ON TABLE sync.hot_changes TO reporting_readonly;
+
+GRANT SELECT (
+  workspace_id,
+  operation_id,
+  operation_type,
+  entity_type,
+  entity_id,
+  client_updated_at,
+  resulting_hot_change_id,
+  applied_at,
+  replica_id
+) ON TABLE sync.applied_operations_current TO reporting_readonly;
+
+DROP POLICY IF EXISTS chat_sessions_reporting_readonly_select ON ai.chat_sessions;
+CREATE POLICY chat_sessions_reporting_readonly_select
+  ON ai.chat_sessions
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS chat_runs_reporting_readonly_select ON ai.chat_runs;
+CREATE POLICY chat_runs_reporting_readonly_select
+  ON ai.chat_runs
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS chat_composer_suggestion_generations_reporting_readonly_select ON ai.chat_composer_suggestion_generations;
+CREATE POLICY chat_composer_suggestion_generations_reporting_readonly_select
+  ON ai.chat_composer_suggestion_generations
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS workspace_sync_metadata_reporting_readonly_select ON sync.workspace_sync_metadata;
+CREATE POLICY workspace_sync_metadata_reporting_readonly_select
+  ON sync.workspace_sync_metadata
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS hot_changes_reporting_readonly_select ON sync.hot_changes;
+CREATE POLICY hot_changes_reporting_readonly_select
+  ON sync.hot_changes
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);
+
+DROP POLICY IF EXISTS applied_operations_current_reporting_readonly_select ON sync.applied_operations_current;
+CREATE POLICY applied_operations_current_reporting_readonly_select
+  ON sync.applied_operations_current
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);

--- a/docs/analytics-db-access.md
+++ b/docs/analytics-db-access.md
@@ -105,7 +105,7 @@ The baseline schema migration creates a dedicated login role and its read-only g
 - role name: `reporting_readonly`
 - login enabled
 - `CONNECT` on database `flashcards`
-- `USAGE` on schemas `org`, `content`, `sync`, `support`
+- `USAGE` on schemas `org`, `content`, `sync`, `support`, `community`, `auth`, `ai`
 - `SELECT` only on the allowed tables listed below
 
 The baseline schema migration also enforces the persistent runtime policy for this role:
@@ -131,6 +131,9 @@ The role gets `USAGE` on these schemas:
 - `content`
 - `sync`
 - `support`
+- `community`
+- `auth`
+- `ai`
 
 ## Granted tables
 
@@ -146,14 +149,33 @@ The role gets `SELECT` on these tables only:
 - `sync.installations`
 - `support.feedback_submissions`
 - `support.feedback_prompt_events`
+- `community.public_profiles`
+- `community.public_review_activity_facts`
+- `community.leaderboard_snapshots`
+- `community.leaderboard_snapshot_entries`
+- selected audit columns on `community.friend_invitations`
+- selected audit columns on `community.friendships`
+- selected operational columns on `auth.user_identities`
+- selected operational columns on `auth.guest_sessions`
+- `auth.guest_ai_monthly_usage`
+- selected audit columns on `auth.guest_upgrade_history`
+- `auth.guest_replica_aliases`
+- selected metadata columns on `ai.chat_sessions`
+- selected metadata columns on `ai.chat_runs`
+- selected metadata columns on `ai.chat_composer_suggestion_generations`
+- `sync.workspace_sync_metadata`
+- selected metadata columns on `sync.hot_changes`
+- selected metadata columns on `sync.applied_operations_current`
 
 No write access is granted.
 
 ## Row-level security behavior
 
-The baseline schema migration creates explicit `FOR SELECT` policies for `reporting_readonly` on the same tables listed above.
+For granted tables that have row-level security enabled, migrations create explicit `FOR SELECT` policies for `reporting_readonly`.
 
 Those policies currently use `USING (true)`, which means the role is allowed to read all rows from those allowed tables. This is intentional for manual operator analytics.
+
+The granted `auth` analytics tables currently do not have row-level security enabled. Their `reporting_readonly` access is limited by explicit read-only column grants instead.
 
 ## Manual local workflow
 
@@ -255,3 +277,42 @@ Use support tables when the investigation needs submitted product feedback or au
 
 - `support.feedback_submissions`
 - `support.feedback_prompt_events`
+
+Use community tables when the investigation needs leaderboard participation, public community activity, friend invitation status, or friendship counts:
+
+- `community.public_profiles`
+- `community.public_review_activity_facts`
+- `community.leaderboard_snapshots`
+- `community.leaderboard_snapshot_entries`
+- `community.friend_invitations`
+- `community.friendships`
+
+Friend invitation analytics intentionally expose invitation ids, inviter ids, created/expiry timestamps, acceptance timestamps, and accepted-by user ids. They do not expose `community.friend_invitations.invite_token_hash`.
+
+Friendship analytics intentionally expose directed relationship ids and creation metadata. One accepted friendship normally creates two `community.friendships` rows, one per viewer, so aggregate reports should count unordered pairs or divide symmetric directed rows by two when they need a human friendship count.
+
+Use guest and account-conversion tables when the investigation needs guest activity, guest AI quota usage, or guest-to-account upgrade funnel data:
+
+- `auth.user_identities`
+- `auth.guest_sessions`
+- `auth.guest_ai_monthly_usage`
+- `auth.guest_upgrade_history`
+- `auth.guest_replica_aliases`
+
+Guest analytics intentionally do not expose guest session secret hashes, replay secret hashes, raw provider subjects, OTP challenge state, API key hashes, or admin entitlement rows.
+
+Use AI operational tables when the investigation needs chat session volume, run health, model/cost-policy distribution, or stuck/failed run timing:
+
+- `ai.chat_sessions`
+- `ai.chat_runs`
+- `ai.chat_composer_suggestion_generations`
+
+AI operational analytics intentionally expose metadata only. They do not expose `ai.chat_items`, `ai.chat_items.payload`, `ai.chat_runs.turn_input`, `ai.chat_runs.last_error_message`, `ai.chat_sessions.composer_suggestions`, or `ai.chat_composer_suggestion_generations.suggestions`.
+
+Use current sync diagnostic tables when the investigation needs sync retention metadata, hot-state mutation volume, or idempotency ledger diagnostics:
+
+- `sync.workspace_sync_metadata`
+- `sync.hot_changes`
+- `sync.applied_operations_current`
+
+Sync diagnostics intentionally do not expose the superseded `sync.changes` payload feed or legacy `sync.applied_operations` table.


### PR DESCRIPTION
## Summary
- add reporting_readonly grants for community analytics tables
- add reporting_readonly grants for operational guest, AI, and sync metadata
- document the granted reporting surface and add migration contract tests

## Tests
- git --no-pager diff --cached --check
- node --test src/community/friendships.test.ts src/database/reportingReadonlyOperationalAnalytics.test.ts