### PR TITLE
Add community metrics to admin dashboard

### DIFF
--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -53,14 +53,16 @@ v1 includes one dashboard page only:
 
 - `review-events-by-date`
 
-The dashboard shows four review charts:
+The dashboard shows six charts:
 
 - daily unique users
 - stacked review events by user
 - daily active users by platform
 - daily review events by platform
+- daily friend invite links created
+- existing friend connections at the end of each day
 
-The default chart range starts on the first calendar day with any `content.review_events.reviewed_at_server` row and ends on today, inclusive, in the dashboard timezone. The dashboard includes date range filters that can narrow the chart range and reset back to that default.
-The filter panel keeps date, user, new/returning cohort, and platform filters in one compact row. User emails and user IDs are shown only inside the user filter popup and chart tooltips, not as a persistent page list.
+The default chart range starts on the first calendar day with any review event, friend invite link, or friendship row and ends on today, inclusive, in the dashboard timezone. The dashboard includes date range filters that can narrow the chart range and reset back to that default.
+The filter panel keeps date, user, new/returning cohort, and platform filters in one compact row. Date filters apply to all charts. User, cohort, and platform filters apply to review-event charts only; friend invite and friend connection charts stay all-user date-range metrics. User emails and user IDs are shown only inside the user filter popup and chart tooltips, not as a persistent page list.
 
 Its SQL lives in the admin frontend as a chart-owned query and runs through the generic admin reporting endpoint.

--- a/apps/admin/src/adminApi.ts
+++ b/apps/admin/src/adminApi.ts
@@ -58,6 +58,16 @@ export type ReviewEventsByDateUniqueUserCohort = Readonly<{
   returningReviewingUsers: number;
 }>;
 
+export type ReviewEventsByDateFriendInvitationTotal = Readonly<{
+  date: string;
+  friendInvitationCount: number;
+}>;
+
+export type ReviewEventsByDateFriendshipTotal = Readonly<{
+  date: string;
+  friendshipCount: number;
+}>;
+
 export type ReviewEventsByDatePlatformActiveUserTotal = Readonly<{
   date: string;
   platform: ReviewEventPlatform;
@@ -87,6 +97,8 @@ export type ReviewEventsByDateReport = Readonly<{
   users: ReadonlyArray<ReviewEventsByDateUser>;
   dateTotals: ReadonlyArray<ReviewEventsByDateTotal>;
   dailyUniqueUserCohorts: ReadonlyArray<ReviewEventsByDateUniqueUserCohort>;
+  friendInvitationTotals: ReadonlyArray<ReviewEventsByDateFriendInvitationTotal>;
+  friendshipTotals: ReadonlyArray<ReviewEventsByDateFriendshipTotal>;
   platformActiveUserTotals: ReadonlyArray<ReviewEventsByDatePlatformActiveUserTotal>;
   platformReviewEventTotals: ReadonlyArray<ReviewEventsByDatePlatformReviewEventTotal>;
   rows: ReadonlyArray<ReviewEventsByDateRow>;

--- a/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/ReviewEventsByDateDashboard.tsx
@@ -208,17 +208,21 @@ export function ReviewEventsByDateDashboard(
     [matchingUserFilterOptions],
   );
   const hiddenUserFilterOptionCount = matchingUserFilterOptions.length - visibleUserFilterOptions.length;
-  const chartModel = useMemo(
+  const reviewChartModel = useMemo(
     () => buildReviewEventsByDateChartModel(filteredReport, props.report.users),
     [filteredReport, props.report.users],
+  );
+  const communityChartModel = useMemo(
+    () => buildReviewEventsByDateChartModel(props.report, props.report.users),
+    [props.report],
   );
   const summaryCards = useMemo(
     () => buildReviewEventsByDateSummaryCards(
       filteredReport,
-      chartModel.peakDailyVolume,
-      chartModel.peakDailyUniqueUsers,
+      reviewChartModel.peakDailyVolume,
+      reviewChartModel.peakDailyUniqueUsers,
     ),
-    [chartModel.peakDailyUniqueUsers, chartModel.peakDailyVolume, filteredReport],
+    [reviewChartModel.peakDailyUniqueUsers, reviewChartModel.peakDailyVolume, filteredReport],
   );
 
   return (
@@ -229,7 +233,7 @@ export function ReviewEventsByDateDashboard(
           <h1>Review Events By Date</h1>
         </div>
         <p className="subhead">
-          Daily unique reviewers and stacked review-event volume by calendar date. The first two charts show overall user activity and per-user event volume. The two platform charts below compare active users and review events across <strong>web</strong>, <strong>android</strong>, and <strong>ios</strong>. Dates are grouped in <strong>UTC</strong>.
+          Daily unique reviewers, stacked review-event volume, platform activity, friend invite links, and existing friend connections by calendar date. Dates are grouped in <strong>UTC</strong>.
         </p>
         <div className="hero-meta">
           <span className="hero-badge">Signed in as {props.adminEmail}</span>
@@ -259,7 +263,7 @@ export function ReviewEventsByDateDashboard(
         matchingUserFilterOptionCount={matchingUserFilterOptions.length}
         hiddenUserFilterOptionCount={hiddenUserFilterOptionCount}
         activeUserFilters={activeUserFilters}
-        userColorScale={chartModel.userColorScale}
+        userColorScale={reviewChartModel.userColorScale}
         onFromDateChange={handleFromDateChange}
         onToDateChange={handleToDateChange}
         onDateRangeSubmit={handleDateRangeSubmit}
@@ -276,7 +280,8 @@ export function ReviewEventsByDateDashboard(
       <ReviewEventsByDateSummary cards={summaryCards} />
 
       <ReviewEventsByDateCharts
-        chartModel={chartModel}
+        reviewChartModel={reviewChartModel}
+        communityChartModel={communityChartModel}
         generatedAtUtc={props.report.generatedAtUtc}
         isReportLoading={props.isReportLoading}
         userById={filteredUserById}

--- a/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/ReviewEventsByDateCharts.tsx
@@ -10,6 +10,8 @@ import {
   type ReviewEventsByDateChartModel,
 } from "./chartModel";
 import {
+  renderDailyFriendInvitationsChart,
+  renderDailyFriendshipsChart,
   renderDailyUniqueUsersChart,
   renderPlatformActiveUsersChart,
   renderPlatformReviewEventsChart,
@@ -18,7 +20,8 @@ import {
 import { formatGeneratedAt } from "../formatting";
 
 type ReviewEventsByDateChartsProps = Readonly<{
-  chartModel: ReviewEventsByDateChartModel;
+  reviewChartModel: ReviewEventsByDateChartModel;
+  communityChartModel: ReviewEventsByDateChartModel;
   generatedAtUtc: string;
   isReportLoading: boolean;
   userById: ReadonlyMap<string, ReviewEventsByDateUser>;
@@ -66,6 +69,8 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
   const userReviewEventsChartRef = useRef<SVGSVGElement | null>(null);
   const platformUsersChartRef = useRef<SVGSVGElement | null>(null);
   const platformReviewEventsChartRef = useRef<SVGSVGElement | null>(null);
+  const friendInvitationsChartRef = useRef<SVGSVGElement | null>(null);
+  const friendshipsChartRef = useRef<SVGSVGElement | null>(null);
   const [tooltipState, setTooltipState] = useState<ChartTooltipState>({
     visible: false,
     html: "",
@@ -86,11 +91,15 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
     const userReviewEventsSvgElement = userReviewEventsChartRef.current;
     const platformUsersSvgElement = platformUsersChartRef.current;
     const platformReviewEventsSvgElement = platformReviewEventsChartRef.current;
+    const friendInvitationsSvgElement = friendInvitationsChartRef.current;
+    const friendshipsSvgElement = friendshipsChartRef.current;
     if (
       uniqueUsersSvgElement === null
       || userReviewEventsSvgElement === null
       || platformUsersSvgElement === null
       || platformReviewEventsSvgElement === null
+      || friendInvitationsSvgElement === null
+      || friendshipsSvgElement === null
     ) {
       return;
     }
@@ -121,48 +130,65 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
 
     renderDailyUniqueUsersChart({
       svgElement: uniqueUsersSvgElement,
-      dates: props.chartModel.dates,
-      tickDates: props.chartModel.tickDates,
-      dailyUniqueUserCohortMatrix: props.chartModel.dailyUniqueUserCohortMatrix,
-      dailyUniqueUsersByDate: props.chartModel.dailyUniqueUsersByDate,
-      totalReviewEventsByDate: props.chartModel.totalReviewEventsByDate,
-      peakDailyUniqueUsers: props.chartModel.peakDailyUniqueUsers,
+      dates: props.reviewChartModel.dates,
+      tickDates: props.reviewChartModel.tickDates,
+      dailyUniqueUserCohortMatrix: props.reviewChartModel.dailyUniqueUserCohortMatrix,
+      dailyUniqueUsersByDate: props.reviewChartModel.dailyUniqueUsersByDate,
+      totalReviewEventsByDate: props.reviewChartModel.totalReviewEventsByDate,
+      peakDailyUniqueUsers: props.reviewChartModel.peakDailyUniqueUsers,
       tooltipHandlers,
     });
     renderUserReviewEventsChart({
       svgElement: userReviewEventsSvgElement,
-      dates: props.chartModel.dates,
-      tickDates: props.chartModel.tickDates,
-      userMatrix: props.chartModel.userMatrix,
-      userIds: props.chartModel.userIds,
-      userColorScale: props.chartModel.userColorScale,
+      dates: props.reviewChartModel.dates,
+      tickDates: props.reviewChartModel.tickDates,
+      userMatrix: props.reviewChartModel.userMatrix,
+      userIds: props.reviewChartModel.userIds,
+      userColorScale: props.reviewChartModel.userColorScale,
       userById: props.userById,
-      totalReviewEventsByDate: props.chartModel.totalReviewEventsByDate,
-      peakDailyVolume: props.chartModel.peakDailyVolume,
+      totalReviewEventsByDate: props.reviewChartModel.totalReviewEventsByDate,
+      peakDailyVolume: props.reviewChartModel.peakDailyVolume,
       isReportLoading: props.isReportLoading,
       onUserFilterApply: handleUserFilterApply,
       tooltipHandlers,
     });
     renderPlatformActiveUsersChart({
       svgElement: platformUsersSvgElement,
-      dates: props.chartModel.dates,
-      tickDates: props.chartModel.tickDates,
-      platformActiveUsersMatrix: props.chartModel.platformActiveUsersMatrix,
-      dailyUniqueUsersByDate: props.chartModel.dailyUniqueUsersByDate,
-      peakDailyPlatformUsers: props.chartModel.peakDailyPlatformUsers,
+      dates: props.reviewChartModel.dates,
+      tickDates: props.reviewChartModel.tickDates,
+      platformActiveUsersMatrix: props.reviewChartModel.platformActiveUsersMatrix,
+      dailyUniqueUsersByDate: props.reviewChartModel.dailyUniqueUsersByDate,
+      peakDailyPlatformUsers: props.reviewChartModel.peakDailyPlatformUsers,
       tooltipHandlers,
     });
     renderPlatformReviewEventsChart({
       svgElement: platformReviewEventsSvgElement,
-      dates: props.chartModel.dates,
-      tickDates: props.chartModel.tickDates,
-      platformReviewEventsMatrix: props.chartModel.platformReviewEventsMatrix,
-      totalPlatformReviewEventsByDate: props.chartModel.totalPlatformReviewEventsByDate,
-      peakDailyPlatformReviewEvents: props.chartModel.peakDailyPlatformReviewEvents,
+      dates: props.reviewChartModel.dates,
+      tickDates: props.reviewChartModel.tickDates,
+      platformReviewEventsMatrix: props.reviewChartModel.platformReviewEventsMatrix,
+      totalPlatformReviewEventsByDate: props.reviewChartModel.totalPlatformReviewEventsByDate,
+      peakDailyPlatformReviewEvents: props.reviewChartModel.peakDailyPlatformReviewEvents,
+      tooltipHandlers,
+    });
+    renderDailyFriendInvitationsChart({
+      svgElement: friendInvitationsSvgElement,
+      dates: props.communityChartModel.dates,
+      tickDates: props.communityChartModel.tickDates,
+      friendInvitationCounts: props.communityChartModel.friendInvitationCounts,
+      peakDailyFriendInvitations: props.communityChartModel.peakDailyFriendInvitations,
+      tooltipHandlers,
+    });
+    renderDailyFriendshipsChart({
+      svgElement: friendshipsSvgElement,
+      dates: props.communityChartModel.dates,
+      tickDates: props.communityChartModel.tickDates,
+      friendshipCounts: props.communityChartModel.friendshipCounts,
+      peakDailyFriendships: props.communityChartModel.peakDailyFriendships,
       tooltipHandlers,
     });
   }, [
-    props.chartModel,
+    props.reviewChartModel,
+    props.communityChartModel,
     props.isReportLoading,
     props.userById,
     handleUserFilterApply,
@@ -216,6 +242,30 @@ export function ReviewEventsByDateCharts(props: ReviewEventsByDateChartsProps): 
           </div>
           <div className="chart-scroll">
             <svg ref={platformReviewEventsChartRef} />
+          </div>
+        </div>
+
+        <div className="chart-shell">
+          <div className="chart-meta">
+            <span>Friend invite links created</span>
+            <div className="chart-meta-right">
+              <span>All users - date filter only</span>
+            </div>
+          </div>
+          <div className="chart-scroll">
+            <svg ref={friendInvitationsChartRef} />
+          </div>
+        </div>
+
+        <div className="chart-shell">
+          <div className="chart-meta">
+            <span>Existing friend connections by day</span>
+            <div className="chart-meta-right">
+              <span>All users - date filter only</span>
+            </div>
+          </div>
+          <div className="chart-scroll">
+            <svg ref={friendshipsChartRef} />
           </div>
         </div>
       </section>

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartModel.ts
@@ -4,6 +4,8 @@ import {
   reviewEventPlatforms,
   type ReviewEventCohort,
   type ReviewEventPlatform,
+  type ReviewEventsByDateFriendInvitationTotal,
+  type ReviewEventsByDateFriendshipTotal,
   type ReviewEventsByDateReport,
   type ReviewEventsByDateUniqueUserCohort,
   type ReviewEventsByDateUser,
@@ -46,6 +48,8 @@ export type ReviewEventsByDateChartModel = Readonly<{
   userIds: ReadonlyArray<string>;
   userColorScale: d3.ScaleOrdinal<string, string>;
   dailyUniqueUserCohortMatrix: ReadonlyArray<MatrixChartEntry>;
+  friendInvitationCounts: ReadonlyArray<DailyValueEntry>;
+  friendshipCounts: ReadonlyArray<DailyValueEntry>;
   userMatrix: ReadonlyArray<MatrixChartEntry>;
   platformActiveUsersMatrix: ReadonlyArray<MatrixChartEntry>;
   platformReviewEventsMatrix: ReadonlyArray<MatrixChartEntry>;
@@ -53,6 +57,8 @@ export type ReviewEventsByDateChartModel = Readonly<{
   dailyUniqueUsersByDate: ReadonlyMap<string, number>;
   totalPlatformReviewEventsByDate: ReadonlyMap<string, number>;
   peakDailyUniqueUsers: number;
+  peakDailyFriendInvitations: number;
+  peakDailyFriendships: number;
   peakDailyVolume: number;
   peakDailyPlatformUsers: number;
   peakDailyPlatformReviewEvents: number;
@@ -88,6 +94,11 @@ export const uniqueUserCohortColors: Readonly<Record<UniqueUserCohortKey, string
   new: "#2e6f95",
 };
 
+export const communityMetricColors = {
+  friendInvitations: "#76b7b2",
+  friendships: "#edc948",
+} as const;
+
 const userColorPalette: ReadonlyArray<string> = [
   ...d3.schemeTableau10,
   ...d3.schemeSet2,
@@ -112,6 +123,8 @@ export function buildReviewEventsByDateChartModel(
     date: item.date,
     value: item.newReviewingUsers + item.returningReviewingUsers,
   }));
+  const friendInvitationCounts = buildFriendInvitationCounts(report.friendInvitationTotals);
+  const friendshipCounts = buildFriendshipCounts(report.friendshipTotals);
   const userMatrix = buildUserMatrix(report);
   const platformActiveUsersMatrix = buildPlatformMatrix(
     report.platformActiveUserTotals,
@@ -127,6 +140,8 @@ export function buildReviewEventsByDateChartModel(
   const dailyUniqueUsersByDate = new Map(dailyUniqueUserTotals.map((item) => [item.date, item.value]));
   const totalPlatformReviewEventsByDate = buildTotalsByDate(platformReviewEventsMatrix);
   const peakDailyUniqueUsers = getPeakDailyValue(dailyUniqueUserTotals);
+  const peakDailyFriendInvitations = getPeakDailyValue(friendInvitationCounts);
+  const peakDailyFriendships = getPeakDailyValue(friendshipCounts);
   const peakDailyVolume = d3.max(report.dateTotals, (item) => item.totalReviewEvents) ?? 0;
   const peakDailyPlatformUsers = getPeakGroupedValue(platformActiveUsersMatrix);
   const peakDailyPlatformReviewEvents = getPeakStackedValue(platformReviewEventsMatrix);
@@ -137,6 +152,8 @@ export function buildReviewEventsByDateChartModel(
     userIds,
     userColorScale,
     dailyUniqueUserCohortMatrix,
+    friendInvitationCounts,
+    friendshipCounts,
     userMatrix,
     platformActiveUsersMatrix,
     platformReviewEventsMatrix,
@@ -144,6 +161,8 @@ export function buildReviewEventsByDateChartModel(
     dailyUniqueUsersByDate,
     totalPlatformReviewEventsByDate,
     peakDailyUniqueUsers,
+    peakDailyFriendInvitations,
+    peakDailyFriendships,
     peakDailyVolume,
     peakDailyPlatformUsers,
     peakDailyPlatformReviewEvents,
@@ -167,6 +186,24 @@ function buildDailyUniqueUserCohortMatrix(
       returning: cohort.returningReviewingUsers,
       new: cohort.newReviewingUsers,
     },
+  }));
+}
+
+function buildFriendInvitationCounts(
+  totals: ReadonlyArray<ReviewEventsByDateFriendInvitationTotal>,
+): ReadonlyArray<DailyValueEntry> {
+  return totals.map((total) => ({
+    date: total.date,
+    value: total.friendInvitationCount,
+  }));
+}
+
+function buildFriendshipCounts(
+  totals: ReadonlyArray<ReviewEventsByDateFriendshipTotal>,
+): ReadonlyArray<DailyValueEntry> {
+  return totals.map((total) => ({
+    date: total.date,
+    value: total.friendshipCount,
   }));
 }
 

--- a/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/charts/chartRenderers.ts
@@ -7,6 +7,7 @@ import {
 import {
   chartMargin,
   chartWidth,
+  communityMetricColors,
   getPlatformColor,
   platformLabels,
   simpleChartHeight,
@@ -14,6 +15,7 @@ import {
   uniqueUserCohortColors,
   uniqueUserCohortKeys,
   uniqueUserCohortLabels,
+  type DailyValueEntry,
   type GroupedChartRectEntry,
   type MatrixChartEntry,
   type StackedChartRectEntry,
@@ -27,11 +29,25 @@ type ChartFrameParams = Readonly<{
   y: d3.ScaleLinear<number, number>;
   tickDates: ReadonlyArray<string>;
   yAxisLabel: string;
+  xAxisLabel: string;
 }>;
 
 type ChartTooltipHandlers = Readonly<{
   showTooltip: (html: string, clientX: number, clientY: number) => void;
   hideTooltip: () => void;
+}>;
+
+type RenderDailyValueBarChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  values: ReadonlyArray<DailyValueEntry>;
+  peakValue: number;
+  color: string;
+  yAxisLabel: string;
+  tooltipSubtitle: string;
+  tooltipMetricLabel: string;
+  tooltipHandlers: ChartTooltipHandlers;
 }>;
 
 export type RenderDailyUniqueUsersChartParams = Readonly<{
@@ -57,6 +73,24 @@ export type RenderUserReviewEventsChartParams = Readonly<{
   peakDailyVolume: number;
   isReportLoading: boolean;
   onUserFilterApply: (userId: string) => void;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+export type RenderDailyFriendInvitationsChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  friendInvitationCounts: ReadonlyArray<DailyValueEntry>;
+  peakDailyFriendInvitations: number;
+  tooltipHandlers: ChartTooltipHandlers;
+}>;
+
+export type RenderDailyFriendshipsChartParams = Readonly<{
+  svgElement: SVGSVGElement;
+  dates: ReadonlyArray<string>;
+  tickDates: ReadonlyArray<string>;
+  friendshipCounts: ReadonlyArray<DailyValueEntry>;
+  peakDailyFriendships: number;
   tooltipHandlers: ChartTooltipHandlers;
 }>;
 
@@ -164,9 +198,52 @@ function renderChartFrame(
     .attr("x", innerWidth / 2)
     .attr("y", innerHeight + 74)
     .attr("text-anchor", "middle")
-    .text("Review date");
+    .text(params.xAxisLabel);
 
   return group;
+}
+
+function renderDailyValueBarChart(params: RenderDailyValueBarChartParams): void {
+  const svg = d3.select(params.svgElement);
+  const x = createDateScale(params.dates);
+  const innerHeight = getInnerHeight(simpleChartHeight);
+  const y = d3.scaleLinear()
+    .domain([0, Math.max(1, params.peakValue)])
+    .nice()
+    .range([innerHeight, 0]);
+  const group = renderChartFrame(svg, {
+    chartHeight: simpleChartHeight,
+    x,
+    y,
+    tickDates: params.tickDates,
+    yAxisLabel: params.yAxisLabel,
+    xAxisLabel: "Date",
+  });
+
+  group.selectAll<SVGRectElement, DailyValueEntry>(".bar-segment")
+    .data(params.values.filter((entry) => entry.value > 0))
+    .join("rect")
+    .attr("class", "bar-segment")
+    .attr("fill", params.color)
+    .attr("x", (entry) => x(entry.date) ?? 0)
+    .attr("y", (entry) => y(entry.value))
+    .attr("width", x.bandwidth())
+    .attr("height", (entry) => Math.max(0, innerHeight - y(entry.value)))
+    .attr("rx", 3)
+    .attr("stroke", "rgba(255, 255, 255, 0.18)")
+    .attr("stroke-width", 1)
+    .on("mousemove", (event, entry: DailyValueEntry) => {
+      params.tooltipHandlers.showTooltip(
+        [
+          `<p class="tooltip-title">${escapeHtml(formatDateRangeLabel(entry.date))}</p>`,
+          `<p class="tooltip-subtitle">${escapeHtml(params.tooltipSubtitle)}</p>`,
+          `<div class="tooltip-metric"><span>${escapeHtml(params.tooltipMetricLabel)}</span><strong>${numberFormatter(entry.value)}</strong></div>`,
+        ].join(""),
+        event.clientX,
+        event.clientY,
+      );
+    })
+    .on("mouseleave", params.tooltipHandlers.hideTooltip);
 }
 
 export function renderDailyUniqueUsersChart(params: RenderDailyUniqueUsersChartParams): void {
@@ -183,6 +260,7 @@ export function renderDailyUniqueUsersChart(params: RenderDailyUniqueUsersChartP
     y,
     tickDates: params.tickDates,
     yAxisLabel: "Unique users",
+    xAxisLabel: "Review date",
   });
   const series = d3.stack<MatrixChartEntry>()
     .keys(uniqueUserCohortKeys)
@@ -242,6 +320,7 @@ export function renderUserReviewEventsChart(params: RenderUserReviewEventsChartP
     y,
     tickDates: params.tickDates,
     yAxisLabel: "Review events",
+    xAxisLabel: "Review date",
   });
   const series = d3.stack<MatrixChartEntry>()
     .keys(params.userIds)
@@ -296,6 +375,36 @@ export function renderUserReviewEventsChart(params: RenderUserReviewEventsChartP
   }
 }
 
+export function renderDailyFriendInvitationsChart(params: RenderDailyFriendInvitationsChartParams): void {
+  renderDailyValueBarChart({
+    svgElement: params.svgElement,
+    dates: params.dates,
+    tickDates: params.tickDates,
+    values: params.friendInvitationCounts,
+    peakValue: params.peakDailyFriendInvitations,
+    color: communityMetricColors.friendInvitations,
+    yAxisLabel: "Invite links",
+    tooltipSubtitle: "Invite links",
+    tooltipMetricLabel: "Created invite links",
+    tooltipHandlers: params.tooltipHandlers,
+  });
+}
+
+export function renderDailyFriendshipsChart(params: RenderDailyFriendshipsChartParams): void {
+  renderDailyValueBarChart({
+    svgElement: params.svgElement,
+    dates: params.dates,
+    tickDates: params.tickDates,
+    values: params.friendshipCounts,
+    peakValue: params.peakDailyFriendships,
+    color: communityMetricColors.friendships,
+    yAxisLabel: "Friendships",
+    tooltipSubtitle: "Friendships",
+    tooltipMetricLabel: "Existing friendships at end of day",
+    tooltipHandlers: params.tooltipHandlers,
+  });
+}
+
 export function renderPlatformActiveUsersChart(params: RenderPlatformActiveUsersChartParams): void {
   const svg = d3.select(params.svgElement);
   const x = createDateScale(params.dates);
@@ -315,6 +424,7 @@ export function renderPlatformActiveUsersChart(params: RenderPlatformActiveUsers
     y,
     tickDates: params.tickDates,
     yAxisLabel: "Active users",
+    xAxisLabel: "Review date",
   });
   const bars = params.platformActiveUsersMatrix.flatMap((entry) => reviewEventPlatforms.map((platform) => ({
     key: platform,
@@ -361,6 +471,7 @@ export function renderPlatformReviewEventsChart(params: RenderPlatformReviewEven
     y,
     tickDates: params.tickDates,
     yAxisLabel: "Review events",
+    xAxisLabel: "Review date",
   });
   const series = d3.stack<MatrixChartEntry>()
     .keys(reviewEventPlatforms)

--- a/apps/admin/src/reports/reviewEventsByDate/query.ts
+++ b/apps/admin/src/reports/reviewEventsByDate/query.ts
@@ -8,6 +8,8 @@ import type {
   AdminQueryValue,
   ReviewEventCohort,
   ReviewEventPlatform,
+  ReviewEventsByDateFriendInvitationTotal,
+  ReviewEventsByDateFriendshipTotal,
   ReviewEventsByDatePlatformActiveUserTotal,
   ReviewEventsByDatePlatformReviewEventTotal,
   ReviewEventsByDateReport,
@@ -26,6 +28,12 @@ type ReviewEventsByDateQueryRow = Readonly<{
   platform: ReviewEventPlatform;
   review_event_count: string | number;
   user_first_review_date: string;
+}>;
+
+type ReviewEventsByDateCommunityQueryRow = Readonly<{
+  report_date: string;
+  friend_invitation_count: string | number;
+  friendship_count: string | number;
 }>;
 
 export type ReviewEventsByDateRange = Readonly<{
@@ -138,6 +146,16 @@ function toReviewEventsByDateQueryRow(resultSetRow: Readonly<Record<string, Admi
     platform: assertPlatform(resultSetRow.platform ?? null, "platform"),
     review_event_count: toInteger(resultSetRow.review_event_count ?? null, "review_event_count"),
     user_first_review_date: assertIsString(resultSetRow.user_first_review_date ?? null, "user_first_review_date"),
+  };
+}
+
+function toReviewEventsByDateCommunityQueryRow(
+  resultSetRow: Readonly<Record<string, AdminQueryValue>>,
+): ReviewEventsByDateCommunityQueryRow {
+  return {
+    report_date: assertIsString(resultSetRow.report_date ?? null, "report_date"),
+    friend_invitation_count: toInteger(resultSetRow.friend_invitation_count ?? null, "friend_invitation_count"),
+    friendship_count: toInteger(resultSetRow.friendship_count ?? null, "friendship_count"),
   };
 }
 
@@ -257,6 +275,52 @@ function buildDailyUniqueUserCohorts(
   }));
 }
 
+function buildCommunityRowsByDate(
+  rows: ReadonlyArray<ReviewEventsByDateCommunityQueryRow>,
+  dates: ReadonlyArray<string>,
+): ReadonlyMap<string, ReviewEventsByDateCommunityQueryRow> {
+  const dateSet = new Set(dates);
+  const rowsByDate = new Map<string, ReviewEventsByDateCommunityQueryRow>();
+
+  for (const row of rows) {
+    if (dateSet.has(row.report_date) === false) {
+      throw new Error(`Community report returned a date outside the requested range: ${row.report_date}`);
+    }
+
+    if (rowsByDate.has(row.report_date)) {
+      throw new Error(`Community report returned duplicate rows for date: ${row.report_date}`);
+    }
+
+    rowsByDate.set(row.report_date, row);
+  }
+
+  return rowsByDate;
+}
+
+function buildFriendInvitationTotals(
+  rows: ReadonlyArray<ReviewEventsByDateCommunityQueryRow>,
+  dates: ReadonlyArray<string>,
+): ReadonlyArray<ReviewEventsByDateFriendInvitationTotal> {
+  const rowsByDate = buildCommunityRowsByDate(rows, dates);
+
+  return dates.map((date) => ({
+    date,
+    friendInvitationCount: toInteger(rowsByDate.get(date)?.friend_invitation_count ?? 0, "friend_invitation_count"),
+  }));
+}
+
+function buildFriendshipTotals(
+  rows: ReadonlyArray<ReviewEventsByDateCommunityQueryRow>,
+  dates: ReadonlyArray<string>,
+): ReadonlyArray<ReviewEventsByDateFriendshipTotal> {
+  const rowsByDate = buildCommunityRowsByDate(rows, dates);
+
+  return dates.map((date) => ({
+    date,
+    friendshipCount: toInteger(rowsByDate.get(date)?.friendship_count ?? 0, "friendship_count"),
+  }));
+}
+
 function buildReviewEventsByDateAggregateFields(
   rows: ReadonlyArray<ReviewEventsByDateRow>,
   dates: ReadonlyArray<string>,
@@ -273,6 +337,7 @@ function buildReviewEventsByDateAggregateFields(
 
 function buildReviewEventsByDateReport(
   resultSet: AdminQueryResultSet,
+  communityResultSet: AdminQueryResultSet,
   executedAtUtc: string,
   from: string,
   to: string,
@@ -305,12 +370,17 @@ function buildReviewEventsByDateReport(
 
   const dates = buildRequestedDateRange(from, to);
   const aggregateFields = buildReviewEventsByDateAggregateFields(rows, dates);
+  const communityRows = communityResultSet.rows
+    .map(toReviewEventsByDateCommunityQueryRow)
+    .sort((left, right) => left.report_date.localeCompare(right.report_date));
 
   return {
     generatedAtUtc: executedAtUtc,
     from,
     to,
     ...aggregateFields,
+    friendInvitationTotals: buildFriendInvitationTotals(communityRows, dates),
+    friendshipTotals: buildFriendshipTotals(communityRows, dates),
     rows,
   };
 }
@@ -371,13 +441,23 @@ export function filterReviewEventsByDateReport(
 
 export function buildReviewEventsByDateDefaultRangeSql(): string {
   return [
+    "WITH activity_dates AS (",
+    "  SELECT (review_events.reviewed_at_server AT TIME ZONE 'UTC')::date AS activity_date",
+    "  FROM content.review_events AS review_events",
+    "  UNION ALL",
+    "  SELECT (friend_invitations.created_at AT TIME ZONE 'UTC')::date AS activity_date",
+    "  FROM community.friend_invitations AS friend_invitations",
+    "  UNION ALL",
+    "  SELECT (friendships.created_at AT TIME ZONE 'UTC')::date AS activity_date",
+    "  FROM community.friendships AS friendships",
+    ")",
     "SELECT",
     "  COALESCE(",
-    "    to_char(MIN((review_events.reviewed_at_server AT TIME ZONE 'UTC')::date), 'YYYY-MM-DD'),",
+    "    to_char(MIN(activity_dates.activity_date), 'YYYY-MM-DD'),",
     "    to_char((now() AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD')",
     "  ) AS from_date,",
     "  to_char((now() AT TIME ZONE 'UTC')::date, 'YYYY-MM-DD') AS to_date",
-    "FROM content.review_events AS review_events",
+    "FROM activity_dates",
   ].join("\n");
 }
 
@@ -456,6 +536,76 @@ export function buildReviewEventsByDateSql(from: string, to: string): string {
   ].join("\n");
 }
 
+export function buildReviewEventsByDateCommunitySql(from: string, to: string): string {
+  assertValidDateRange({ from, to }, "community report");
+
+  return [
+    "WITH requested_dates AS (",
+    "  SELECT generate_series(",
+    `    ${escapeSqlStringLiteral(from)}::date,`,
+    `    ${escapeSqlStringLiteral(to)}::date,`,
+    "    INTERVAL '1 day'",
+    "  )::date AS report_date",
+    "),",
+    "real_friend_invitations AS (",
+    "  SELECT",
+    "    (friend_invitations.created_at AT TIME ZONE 'UTC')::date AS created_date",
+    "  FROM community.friend_invitations AS friend_invitations",
+    "  LEFT JOIN org.user_settings AS inviter_user_settings",
+    "    ON inviter_user_settings.user_id = friend_invitations.inviter_user_id",
+    "  WHERE (",
+    "    inviter_user_settings.email IS NULL",
+    "    OR LOWER(btrim(inviter_user_settings.email)) NOT LIKE '%@example.com'",
+    "  )",
+    "),",
+    "daily_friend_invitations AS (",
+    "  SELECT",
+    "    real_friend_invitations.created_date,",
+    "    COUNT(*)::int AS friend_invitation_count",
+    "  FROM real_friend_invitations",
+    "  WHERE real_friend_invitations.created_date >= " + escapeSqlStringLiteral(from) + "::date",
+    "    AND real_friend_invitations.created_date <= " + escapeSqlStringLiteral(to) + "::date",
+    "  GROUP BY real_friend_invitations.created_date",
+    "),",
+    "real_friendship_pairs AS (",
+    "  SELECT",
+    "    LEAST(friendships.viewer_user_id, friendships.friend_user_id) AS first_user_id,",
+    "    GREATEST(friendships.viewer_user_id, friendships.friend_user_id) AS second_user_id,",
+    "    MIN(friendships.created_at) AS created_at",
+    "  FROM community.friendships AS friendships",
+    "  LEFT JOIN org.user_settings AS viewer_user_settings",
+    "    ON viewer_user_settings.user_id = friendships.viewer_user_id",
+    "  LEFT JOIN org.user_settings AS friend_user_settings",
+    "    ON friend_user_settings.user_id = friendships.friend_user_id",
+    "  WHERE (",
+    "    viewer_user_settings.email IS NULL",
+    "    OR LOWER(btrim(viewer_user_settings.email)) NOT LIKE '%@example.com'",
+    "  )",
+    "    AND (",
+    "      friend_user_settings.email IS NULL",
+    "      OR LOWER(btrim(friend_user_settings.email)) NOT LIKE '%@example.com'",
+    "    )",
+    "  GROUP BY",
+    "    LEAST(friendships.viewer_user_id, friendships.friend_user_id),",
+    "    GREATEST(friendships.viewer_user_id, friendships.friend_user_id)",
+    ")",
+    "SELECT",
+    "  to_char(requested_dates.report_date, 'YYYY-MM-DD') AS report_date,",
+    "  COALESCE(daily_friend_invitations.friend_invitation_count, 0)::int AS friend_invitation_count,",
+    "  COALESCE((",
+    "    SELECT COUNT(*)",
+    "    FROM real_friendship_pairs",
+    "    WHERE real_friendship_pairs.created_at < (",
+    "      (requested_dates.report_date + INTERVAL '1 day')::timestamp AT TIME ZONE 'UTC'",
+    "    )",
+    "  ), 0)::int AS friendship_count",
+    "FROM requested_dates",
+    "LEFT JOIN daily_friend_invitations",
+    "  ON daily_friend_invitations.created_date = requested_dates.report_date",
+    "ORDER BY requested_dates.report_date ASC",
+  ].join("\n");
+}
+
 export async function loadReviewEventsByDateDefaultRange(
   config: AdminAppConfig,
 ): Promise<ReviewEventsByDateRange> {
@@ -490,9 +640,12 @@ export async function loadReviewEventsByDateReport(
   from: string,
   to: string,
 ): Promise<ReviewEventsByDateReport> {
-  const response = await runAdminQuery(config, buildReviewEventsByDateSql(from, to));
-  if (response.resultSets.length !== 1) {
-    throw new Error("Review events report must return exactly one result set.");
+  const response = await runAdminQuery(config, [
+    buildReviewEventsByDateSql(from, to),
+    buildReviewEventsByDateCommunitySql(from, to),
+  ].join(";\n"));
+  if (response.resultSets.length !== 2) {
+    throw new Error(`Review events report must return exactly two result sets. Got ${response.resultSets.length}.`);
   }
 
   const resultSet = response.resultSets[0];
@@ -500,5 +653,10 @@ export async function loadReviewEventsByDateReport(
     throw new Error("Review events report result set is missing.");
   }
 
-  return buildReviewEventsByDateReport(resultSet, response.executedAtUtc, from, to);
+  const communityResultSet = response.resultSets[1];
+  if (communityResultSet === undefined) {
+    throw new Error("Review events community report result set is missing.");
+  }
+
+  return buildReviewEventsByDateReport(resultSet, communityResultSet, response.executedAtUtc, from, to);
 }

--- a/docs/admin-app.md
+++ b/docs/admin-app.md
@@ -68,10 +68,12 @@ The query payload includes:
 Current v1 attribution contract for `review-events-by-date`:
 
 - the report is intended for the current single-effective-learner workspace model
-- the default chart range starts on the first calendar day with any `content.review_events.reviewed_at_server` row and ends on today, inclusive, in the report timezone
-- dashboard filters can narrow date range, user, new/returning cohort, and platform; Reset all returns date range to the same first-review-day-through-today default and restores all local filters
+- the default chart range starts on the first calendar day with any `content.review_events.reviewed_at_server`, `community.friend_invitations.created_at`, or `community.friendships.created_at` row and ends on today, inclusive, in the report timezone
+- dashboard filters can narrow date range, user, new/returning cohort, and platform; date filters apply to every chart, while user, cohort, and platform filters apply only to review-event charts; Reset all returns date range to the same first-activity-day-through-today default and restores all local filters
 - `users[]` and `rows[].userId` are derived from the current `sync.workspace_replicas.user_id` label for stacked per-user event volume
 - platform charts derive `web` / `android` / `ios` from `content.review_events.replica_id -> sync.workspace_replicas.platform`
+- friend invite charts count `community.friend_invitations` rows created on each UTC date
+- friend connection charts count friendship pairs that exist at the end of each UTC date; directed `community.friendships` rows are not double-counted
 - that label is acceptable for today's product shape, but it is not a durable historical review-author field
 - do not interpret this report as collaborative per-user analytics unless review authorship is stored immutably on each review event
 
@@ -143,10 +145,10 @@ The admin frontend fails fast on any other non-local hostname. Do not serve the 
 - a listed admin email loads the dashboard
 - a signed-in non-admin sees the access denied page
 - network traces show `POST /v1/admin/reports/query` for dashboard data
-- the default date filter starts on the first review-event day and ends on today
+- the default date filter starts on the first review, friend invite, or friendship day and ends on today
 - date, user, new/returning cohort, and platform filters open as popups from the compact filter row
 - the dashboard does not show a persistent email or user list outside the user filter popup
-- unique-users, stacked-by-user, platform-users, and platform-events charts all render
+- unique-users, stacked-by-user, platform-users, platform-events, friend-invite-links, and friend-connections charts all render
 - narrowing the date filter reloads all charts, and Reset all restores the default range and all local filters
 - stacked-by-user hover tooltips may reveal the current email and user ID for the hovered segment
 - backend logs do not show writes through the reporting path


### PR DESCRIPTION
## Summary
- add admin report metrics for created friend invite links and cumulative friendships by day
- render two matching community metric charts in the review events dashboard
- document the expanded admin chart set and filter scope

## Checks
- npm --prefix apps/admin run build
- git --no-pager diff --check