### PR TITLE
Add web chat send button busy state

### DIFF
--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -203,6 +203,7 @@ export function ChatPanel(props: Props): ReactElement {
     isStopping,
     sendPhase,
   });
+  const isSendButtonBusy = sendPhase === "preparingSend" || sendPhase === "startingRun";
   const canShowComposerSuggestions = getCanShowComposerSuggestions({
     composerAction,
     composerSuggestionsCount: composerSuggestions.length,
@@ -467,10 +468,18 @@ export function ChatPanel(props: Props): ReactElement {
                 type="button"
                 className="chat-send-btn"
                 aria-label={t("chatPanel.actions.sendAriaLabel")}
+                aria-busy={isSendButtonBusy ? "true" : "false"}
                 onClick={() => void sendPendingMessage()}
                 disabled={!canSendPendingMessage}
                 data-testid="chat-send-button"
               >
+                {isSendButtonBusy ? (
+                  <span
+                    className="chat-send-btn-spinner"
+                    aria-hidden="true"
+                    data-testid="chat-send-button-busy-indicator"
+                  />
+                ) : null}
                 {t("chatPanel.actions.send")}
               </button>
             )}

--- a/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx
@@ -16,6 +16,7 @@ import {
   queryChatComposerState,
   queryChatMicrophoneButton,
   queryChatSendButton,
+  queryChatSendButtonBusyIndicator,
   queryChatStopButton,
   readStoredDraftPendingAttachmentCount,
   setTextareaValue,
@@ -288,9 +289,14 @@ describe("ChatPanel composer controls", () => {
 
     const composerState = queryChatComposerState(getContainer());
     const attachButton = queryChatAttachButton(getContainer());
+    const sendButton = queryChatSendButton(getContainer());
     expect(composerState?.getAttribute("data-send-phase")).toBe("preparingSend");
     expect(attachButton).not.toBeNull();
     expect(attachButton?.disabled).toBe(true);
+    expect(sendButton).not.toBeNull();
+    expect(sendButton?.disabled).toBe(true);
+    expect(sendButton?.getAttribute("aria-busy")).toBe("true");
+    expect(queryChatSendButtonBusyIndicator(getContainer())).not.toBeNull();
 
     await dispatchChatPanelDragEvent(getContainer(), createDropEvent(new File(["pending"], "pending.txt", { type: "text/plain" })));
     await flushAsync();
@@ -331,7 +337,11 @@ describe("ChatPanel composer controls", () => {
     await flushAsync();
 
     const composerState = queryChatComposerState(getContainer());
+    const sendButton = queryChatSendButton(getContainer());
     expect(composerState?.getAttribute("data-send-phase")).toBe("preparingSend");
+    expect(sendButton).not.toBeNull();
+    expect(sendButton?.getAttribute("aria-busy")).toBe("true");
+    expect(queryChatSendButtonBusyIndicator(getContainer())).not.toBeNull();
     expect(resolveDelayedAttachment).not.toBeNull();
 
     await act(async () => {

--- a/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx
@@ -9,6 +9,7 @@ import {
   createNewChatSessionMock,
   queryChatComposerInput,
   queryChatSendButton,
+  queryChatSendButtonBusyIndicator,
   readStoredDraftPendingAttachmentCount,
   readStoredDraftInputText,
   setTextareaValue,
@@ -297,6 +298,8 @@ describe("ChatPanel send recovered drafts", () => {
     expect(composerStateAfterReopen?.getAttribute("data-send-phase")).toBe("startingRun");
     expect(textareaAfterReopen?.value).toBe("keep this draft after closing panel");
     expect(sendButtonAfterReopen?.disabled).toBe(true);
+    expect(sendButtonAfterReopen?.getAttribute("aria-busy")).toBe("true");
+    expect(queryChatSendButtonBusyIndicator(getContainer())).not.toBeNull();
     expect(readStoredDraftInputText("workspace-1", staleSessionId as string)).toBeNull();
     expect(readStoredDraftInputText("workspace-1", recoveredSessionId as string)).toBe("keep this draft after closing panel");
 
@@ -308,6 +311,8 @@ describe("ChatPanel send recovered drafts", () => {
     const sendButtonAfterRetryFailure = queryChatSendButton(getContainer());
     expect(composerStateAfterRetryFailure?.getAttribute("data-send-phase")).toBe("idle");
     expect(sendButtonAfterRetryFailure?.disabled).toBe(false);
+    expect(sendButtonAfterRetryFailure?.getAttribute("aria-busy")).toBe("false");
+    expect(queryChatSendButtonBusyIndicator(getContainer())).toBeNull();
     expect(readStoredDraftInputText("workspace-1", recoveredSessionId as string)).toBe("keep this draft after closing panel");
   });
 

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -385,6 +385,10 @@ export function queryChatSendButton(container: ParentNode): HTMLButtonElement | 
   return container.querySelector('.chat-send-btn[aria-label="Send message"]') as HTMLButtonElement | null;
 }
 
+export function queryChatSendButtonBusyIndicator(container: ParentNode): HTMLSpanElement | null {
+  return container.querySelector('[data-testid="chat-send-button-busy-indicator"]') as HTMLSpanElement | null;
+}
+
 export function queryChatStopButton(container: ParentNode): HTMLButtonElement | null {
   return container.querySelector('.chat-stop-btn[aria-label="Stop response"]') as HTMLButtonElement | null;
 }

--- a/apps/web/src/styles/features/chat.css
+++ b/apps/web/src/styles/features/chat.css
@@ -510,9 +510,33 @@
 }
 
 .chat-send-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   background: var(--accent);
   color: #fff4ef;
   border-color: transparent;
+}
+
+.chat-send-btn-spinner {
+  inline-size: 12px;
+  block-size: 12px;
+  flex: 0 0 12px;
+  border: 1.5px solid rgba(255, 255, 255, 0.24);
+  border-block-start-color: currentColor;
+  border-radius: 999px;
+  animation: chat-send-btn-spin 0.8s linear infinite;
+}
+
+@keyframes chat-send-btn-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .chat-send-btn:hover {


### PR DESCRIPTION
## Summary
- show a compact busy spinner on the web chat send button during preparingSend and startingRun
- expose the send button busy state with aria-busy
- extend existing ChatPanel tests for the busy indicator in both send phases

## Validation
- npm ci (passed; Node engine warning because package wants Node 24.x and shell has Node v25.6.1; npm audit reports 1 high severity issue)
- npm exec vitest run src/chat/ChatPanel/tests/ChatPanel.composer-controls.test.tsx src/chat/ChatPanel/tests/send/ChatPanel.send-recovered-drafts.test.tsx (passed: 2 files, 18 tests)
- git --no-pager diff --check (passed)