### PR TITLE
Keep Android chat visible during warm loading

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
@@ -11,12 +11,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasProgressBarRangeInfo
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
@@ -385,7 +387,7 @@ class AiRouteTest : FirebaseAppInstrumentationTimeoutTest() {
     }
 
     @Test
-    fun loadingStateDoesNotExposeConversationOrComposerSemantics() {
+    fun coldStartLoadingStateDoesNotExposeConversationOrComposerSemantics() {
         val loadingTitle = composeRule.activity.getString(AiFeatureR.string.ai_loading_chat_title)
         val loadingBody = composeRule.activity.getString(AiFeatureR.string.ai_loading_chat_body)
 
@@ -393,7 +395,7 @@ class AiRouteTest : FirebaseAppInstrumentationTimeoutTest() {
             FlashcardsTheme {
                 AiRoute(
                     uiState = makeAiUiState(
-                        isConversationReady = true,
+                        isConversationReady = false,
                         isConversationLoading = true
                     ),
                     onAcceptConsent = {},
@@ -427,6 +429,67 @@ class AiRouteTest : FirebaseAppInstrumentationTimeoutTest() {
         assertTrue(composeRule.onAllNodesWithTag(aiConversationSurfaceTag).fetchSemanticsNodes().isEmpty())
         assertTrue(composeRule.onAllNodesWithTag(aiComposerMessageFieldTag).fetchSemanticsNodes().isEmpty())
         assertTrue(composeRule.onAllNodesWithTag(aiComposerSendButtonTag).fetchSemanticsNodes().isEmpty())
+    }
+
+    @Test
+    fun warmLoadingStatePreservesConversationAndDisablesComposerSend() {
+        composeRule.setContent {
+            FlashcardsTheme {
+                AiRoute(
+                    uiState = makeAiUiState(
+                        messages = listOf(
+                            AiChatMessage(
+                                messageId = "user-warm-loading",
+                                role = AiChatRole.USER,
+                                content = listOf(AiChatContentPart.Text(text = "Build a deck from this note.")),
+                                timestampMillis = 1L,
+                                isError = false,
+                                isStopped = false,
+                                cursor = null,
+                                itemId = null
+                            )
+                        ),
+                        draftMessage = "Add examples.",
+                        isConversationReady = false,
+                        isConversationLoading = true
+                    ),
+                    onAcceptConsent = {},
+                    onDraftMessageChange = {},
+                    onApplyComposerSuggestion = {},
+                    onSendMessage = {},
+                    onCancelStreaming = {},
+                    onNewChat = {},
+                    onOpenAccountStatus = {},
+                    onDismissErrorMessage = {},
+                    onDismissAlert = {},
+                    onAddPendingAttachment = {},
+                    onRemovePendingAttachment = {},
+                    onStartDictationPermissionRequest = {},
+                    onStartDictationRecording = {},
+                    onTranscribeRecordedAudio = { _, _, _ -> },
+                    onCancelDictation = {},
+                    onScreenVisible = {},
+                    onScreenHidden = {},
+                    onWarmUpSessionIfNeeded = {},
+                    onRetryConversationLoad = {},
+                    onShowAlert = {},
+                    onShowErrorMessage = {}
+                )
+            }
+        }
+
+        assertTrue(composeRule.onAllNodesWithTag(aiConversationLoadingTag).fetchSemanticsNodes().isEmpty())
+        composeRule.onNodeWithTag(aiConversationSurfaceTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(aiUserMessageBubbleTag, useUnmergedTree = true).assertIsDisplayed()
+        composeRule.onNodeWithTag(aiComposerMessageFieldTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(aiComposerSendButtonTag).assertIsDisplayed()
+        composeRule.onNodeWithTag(aiComposerSendButtonTag).assertIsNotEnabled()
+        assertTrue(
+            composeRule.onAllNodes(
+                matcher = hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate),
+                useUnmergedTree = true
+            ).fetchSemanticsNodes().isNotEmpty()
+        )
     }
 
     @Test

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiComposerContent.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiComposerContent.kt
@@ -87,6 +87,8 @@ internal fun AiComposer(
             R.string.ai_send
         }
     )
+    val showPrimaryActionProgress = (uiState.isConversationLoading || uiState.isComposerBusy) &&
+        uiState.canStopStreaming.not()
     val dictationActionLabel = stringResource(
         id = if (uiState.dictationState == AiChatDictationState.RECORDING) {
             R.string.ai_stop
@@ -244,14 +246,21 @@ internal fun AiComposer(
                             }
                             .testTag(tag = aiComposerSendButtonTag)
                     ) {
-                        Icon(
-                            imageVector = if (uiState.canStopStreaming) {
-                                Icons.Outlined.Stop
-                            } else {
-                                Icons.AutoMirrored.Outlined.Send
-                            },
-                            contentDescription = null
-                        )
+                        if (showPrimaryActionProgress) {
+                            CircularProgressIndicator(
+                                strokeWidth = 2.dp,
+                                modifier = Modifier.size(aiComposerProgressSize)
+                            )
+                        } else {
+                            Icon(
+                                imageVector = if (uiState.canStopStreaming) {
+                                    Icons.Outlined.Stop
+                                } else {
+                                    Icons.AutoMirrored.Outlined.Send
+                                },
+                                contentDescription = null
+                            )
+                        }
                     }
                 },
                 modifier = Modifier

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
@@ -125,9 +125,14 @@ internal fun AiRouteContent(
     val dismissComposerFocus: () -> Unit = {
         focusManager.clearFocus(force = true)
     }
-    val showInteractiveConversation = uiState.isConsentRequired.not() &&
-        uiState.isConversationReady &&
-        uiState.isConversationLoading.not()
+    val hasLocalConversationContent = uiState.messages.isNotEmpty() ||
+        uiState.draftMessage.isNotEmpty() ||
+        uiState.pendingAttachments.isNotEmpty()
+    val isColdConversationLoading = uiState.isConversationLoading &&
+        hasLocalConversationContent.not()
+    val showConversation = uiState.isConversationReady ||
+        (uiState.isConversationLoading && hasLocalConversationContent)
+    val showComposer = uiState.isConsentRequired.not() && showConversation
 
     val takePictureLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.TakePicturePreview()
@@ -359,11 +364,11 @@ internal fun AiRouteContent(
                 onAcceptConsent = onAcceptConsent,
                 modifier = contentModifier
             )
-        } else if (uiState.isConversationLoading) {
+        } else if (isColdConversationLoading) {
             AiConversationLoading(
                 modifier = contentModifier
             )
-        } else if (uiState.isConversationReady.not()) {
+        } else if (showConversation.not()) {
             Box(
                 modifier = contentModifier
             ) {
@@ -409,7 +414,7 @@ internal fun AiRouteContent(
                         .weight(weight = 1f)
                 )
 
-                if (showInteractiveConversation) {
+                if (showComposer) {
                     AiComposer(
                         uiState = uiState,
                         onDraftMessageChange = onDraftMessageChange,


### PR DESCRIPTION
## Summary
- keep Android AI transcript and composer visible during warm conversation loading when local content exists
- show a small progress indicator in the send button while loading/preparing
- split route coverage between cold-start and warm-loading behavior

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff --check
- Android Gradle/instrumentation tests not run because ./gradlew was not authorized