### PR TITLE
Fix iOS chat bootstrap loading surface

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+ComposerUIState.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Store/Surface/AIChatStore+ComposerUIState.swift
@@ -74,6 +74,14 @@ extension AIChatStore {
             || self.isStreaming
     }
 
+    var hasLocalTranscriptDuringBootstrap: Bool {
+        self.bootstrapPhase == .loading && self.messages.isEmpty == false
+    }
+
+    var shouldShowComposerAccessory: Bool {
+        self.isChatInteractive || self.bootstrapPhase == .loading
+    }
+
     var isComposerBusy: Bool {
         self.bootstrapPhase == .loading || self.composerPhase != .idle
     }

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatComposerAccessoryView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatComposerAccessoryView.swift
@@ -147,7 +147,8 @@ extension AIChatView {
                     Button {
                         self.handlePrimaryComposerAction()
                     } label: {
-                        if self.chatStore.composerPhase == .preparingSend {
+                        if self.chatStore.bootstrapPhase == .loading
+                            || self.chatStore.composerPhase == .preparingSend {
                             ProgressView()
                                 .controlSize(.small)
                                 .frame(
@@ -166,11 +167,7 @@ extension AIChatView {
                     }
                     .buttonStyle(.plain)
                     .disabled(self.primaryComposerButtonDisabled)
-                    .accessibilityLabel(
-                        self.chatStore.canStopResponse
-                            ? aiSettingsLocalized("ai.composer.stopResponse", "Stop response")
-                            : aiSettingsLocalized("ai.composer.sendMessage", "Send message")
-                    )
+                    .accessibilityLabel(self.primaryComposerButtonAccessibilityLabel)
                     .accessibilityIdentifier(UITestIdentifier.aiComposerSendButton)
                     .padding(.trailing, aiChatComposerSendButtonInset)
                     .padding(.bottom, aiChatComposerSendButtonInset)
@@ -254,6 +251,16 @@ extension AIChatView {
 
     var primaryComposerButtonDisabled: Bool {
         self.chatStore.canStopResponse == false && self.chatStore.canSendMessage == false
+    }
+
+    var primaryComposerButtonAccessibilityLabel: String {
+        guard self.chatStore.bootstrapPhase != .loading else {
+            return aiSettingsLocalized("ai.loading.title", "Loading chat")
+        }
+
+        return self.chatStore.canStopResponse
+            ? aiSettingsLocalized("ai.composer.stopResponse", "Stop response")
+            : aiSettingsLocalized("ai.composer.sendMessage", "Send message")
     }
 
     var composerTextFieldDisabled: Bool {

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -252,7 +252,7 @@ struct AIChatView: View {
 
     @ViewBuilder
     var bottomBarContent: some View {
-        if self.accessState == .ready && self.chatStore.isChatInteractive {
+        if self.accessState == .ready && self.chatStore.shouldShowComposerAccessory {
             self.composerAccessory
         }
     }
@@ -353,7 +353,11 @@ struct AIChatView: View {
         Group {
             switch self.chatStore.bootstrapPhase {
             case .loading:
-                self.loadingChatState
+                if self.chatStore.hasLocalTranscriptDuringBootstrap {
+                    self.chatScrollSurface
+                } else {
+                    self.loadingChatState
+                }
             case .failed:
                 self.failedChatState
             case .ready:

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Flows/LiveSmokeAiFlows.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Flows/LiveSmokeAiFlows.swift
@@ -143,14 +143,14 @@ extension LiveSmokeTestCase {
     @MainActor
     func waitForAiComposerAfterConsent() throws {
         let consentButton = self.app.buttons[LiveSmokeIdentifier.aiConsentAcceptButton]
-        let composerTextField = self.app.descendants(matching: .any)
-            .matching(identifier: LiveSmokeIdentifier.aiComposerTextField)
-            .firstMatch
         let deadline = Date().addingTimeInterval(LiveSmokeConfiguration.longUiTimeoutSeconds)
         var nextConsentRetryTapAt = Date()
 
         while Date() < deadline {
-            if consentButton.exists == false && composerTextField.exists {
+            if consentButton.exists == false {
+                _ = try self.waitForAiComposerUsable(
+                    timeout: deadline.timeIntervalSinceNow
+                )
                 return
             }
 
@@ -170,11 +170,8 @@ extension LiveSmokeTestCase {
             )
         }
 
-        throw LiveSmokeFailure.missingElement(
-            identifier: LiveSmokeIdentifier.aiComposerTextField,
-            timeoutSeconds: LiveSmokeConfiguration.longUiTimeoutSeconds,
-            screen: self.currentScreenSummary(),
-            step: self.currentStepTitle
+        _ = try self.waitForAiComposerUsable(
+            timeout: LiveSmokeConfiguration.optionalProbeTimeoutSeconds
         )
     }
 
@@ -243,7 +240,7 @@ extension LiveSmokeTestCase {
 
     @MainActor
     func replaceAiComposerText(_ text: String, timeout: TimeInterval) throws {
-        let element = self.aiComposerTextFieldElement()
+        let element = try self.waitForAiComposerUsable(timeout: timeout)
         try self.replaceTextSafely(
             text,
             inElement: element,
@@ -255,12 +252,9 @@ extension LiveSmokeTestCase {
 
     @MainActor
     func prepareAiComposerForResetConversation(timeout: TimeInterval) throws {
-        let element = self.aiComposerTextFieldElement()
-
         for _ in 1...aiResetPromptMaximumAttempts {
             try self.clearAndTypeAiComposerTextWithoutExactValueAssertion(
                 aiResetPromptText,
-                element: element,
                 timeout: timeout
             )
 
@@ -284,14 +278,71 @@ extension LiveSmokeTestCase {
     }
 
     @MainActor
+    func waitForAiComposerUsable(timeout: TimeInterval) throws -> XCUIElement {
+        let element = self.aiComposerTextFieldElement()
+        let startedAt = Date()
+        let deadline = startedAt.addingTimeInterval(timeout)
+        self.logSmokeBreadcrumb(
+            event: "wait_start",
+            action: "wait_for_ai_composer_usable",
+            identifier: LiveSmokeIdentifier.aiComposerTextField,
+            timeoutSeconds: formatDuration(seconds: timeout),
+            durationSeconds: "-",
+            result: "start",
+            note: "waiting for composer text input to become usable"
+        )
+
+        while Date() < deadline {
+            if element.exists && element.isEnabled && element.isHittable {
+                let durationSeconds = Date().timeIntervalSince(startedAt)
+                self.logSmokeBreadcrumb(
+                    event: "wait_end",
+                    action: "wait_for_ai_composer_usable",
+                    identifier: LiveSmokeIdentifier.aiComposerTextField,
+                    timeoutSeconds: formatDuration(seconds: timeout),
+                    durationSeconds: formatDuration(seconds: durationSeconds),
+                    result: "success",
+                    note: "composer text input is enabled and hittable"
+                )
+                return element
+            }
+
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: liveSmokeFocusPollIntervalSeconds))
+        }
+
+        let durationSeconds = Date().timeIntervalSince(startedAt)
+        self.logSmokeBreadcrumb(
+            event: "wait_end",
+            action: "wait_for_ai_composer_usable",
+            identifier: LiveSmokeIdentifier.aiComposerTextField,
+            timeoutSeconds: formatDuration(seconds: timeout),
+            durationSeconds: formatDuration(seconds: durationSeconds),
+            result: "failure",
+            note: "enabled=\(element.isEnabled) \(self.textInputFailureNote(element: element))"
+        )
+        throw LiveSmokeFailure.textInputNotReady(
+            identifier: LiveSmokeIdentifier.aiComposerTextField,
+            timeoutSeconds: timeout,
+            screen: self.currentScreenSummary(),
+            step: self.currentStepTitle,
+            exists: element.exists,
+            hittable: element.isHittable,
+            hasKeyboardFocus: self.elementHasKeyboardFocus(element: element),
+            softwareKeyboardVisible: self.softwareKeyboardIsVisible(),
+            elementLabel: element.label,
+            elementValue: self.elementValue(element: element)
+        )
+    }
+
+    @MainActor
     func clearAndTypeAiComposerTextWithoutExactValueAssertion(
         _ text: String,
-        element: XCUIElement,
         timeout: TimeInterval
     ) throws {
         try self.runWithInlineRawScreenStateOnFailure(
             action: "replace_text_without_exact_match.\(LiveSmokeIdentifier.aiComposerTextField)"
         ) {
+            let element = try self.waitForAiComposerUsable(timeout: timeout)
             try self.focusElementForTextInput(
                 element,
                 identifier: LiveSmokeIdentifier.aiComposerTextField,
@@ -405,10 +456,8 @@ extension LiveSmokeTestCase {
 
     @MainActor
     func clearAiComposerText(timeout: TimeInterval) throws {
-        let element = self.aiComposerTextFieldElement()
         try self.clearAndTypeAiComposerTextWithoutExactValueAssertion(
             "",
-            element: element,
             timeout: timeout
         )
     }


### PR DESCRIPTION
## Summary
- keep existing iOS AI chat transcript visible during linked bootstrap when local messages exist
- keep the composer visible during bootstrap while existing computed permissions keep it disabled
- show bootstrap loading state in the composer send button and update AI smoke readiness waits

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff --check
- fresh read-only worker review: no P0-P4 findings

Simulator-backed iOS tests were not run because they were not explicitly authorized.