### PR TITLE
Fix iOS AI chat scroll follow behavior

### DIFF
--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView+Scrolling.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView+Scrolling.swift
@@ -27,10 +27,65 @@ func aiChatScrollState(
     )
 }
 
+func aiChatScrollStateAllowsDeferredBottomSync(
+    scrollState: AIChatScrollState?,
+    messages: [AIChatMessage]
+) -> Bool {
+    guard messages.isEmpty == false else {
+        return true
+    }
+    guard let scrollState else {
+        return false
+    }
+
+    return scrollState.isNearBottom
+}
+
+func aiChatMessageListUpdateAppendsTail(
+    previousMessages: [AIChatMessage],
+    nextMessages: [AIChatMessage]
+) -> Bool {
+    guard nextMessages.count > previousMessages.count else {
+        return false
+    }
+
+    return zip(previousMessages, nextMessages).allSatisfy { previousMessage, nextMessage in
+        previousMessage == nextMessage
+    }
+}
+
+func aiChatMessageListUpdateChangesExistingTail(
+    previousMessages: [AIChatMessage],
+    nextMessages: [AIChatMessage]
+) -> Bool {
+    guard previousMessages.isEmpty == false else {
+        return false
+    }
+    guard previousMessages.count == nextMessages.count else {
+        return false
+    }
+    guard let previousTail = previousMessages.last,
+          let nextTail = nextMessages.last else {
+        return false
+    }
+    guard previousTail.id == nextTail.id, previousTail != nextTail else {
+        return false
+    }
+
+    return zip(previousMessages.dropLast(), nextMessages.dropLast())
+        .allSatisfy { previousMessage, nextMessage in
+            previousMessage == nextMessage
+        }
+}
+
 extension AIChatView {
-    func detachAutoFollowForExpandedContent() {
+    func detachAutoFollow() {
         self.isAutoFollowEnabled = false
         self.cancelDeferredBottomSync()
+    }
+
+    func detachAutoFollowForExpandedContent() {
+        self.detachAutoFollow()
     }
 
     func scheduleDeferredBottomSyncIfNeeded() {
@@ -44,6 +99,12 @@ extension AIChatView {
             return
         }
         guard self.isAutoFollowEnabled else {
+            return
+        }
+        guard aiChatScrollStateAllowsDeferredBottomSync(
+            scrollState: self.currentScrollState,
+            messages: self.chatStore.messages
+        ) else {
             return
         }
 
@@ -63,6 +124,17 @@ extension AIChatView {
                 return
             }
             guard self.chatStore.bootstrapPhase == .ready else {
+                self.deferredBottomSyncTask = nil
+                return
+            }
+            guard self.isAutoFollowEnabled else {
+                self.deferredBottomSyncTask = nil
+                return
+            }
+            guard aiChatScrollStateAllowsDeferredBottomSync(
+                scrollState: self.currentScrollState,
+                messages: self.chatStore.messages
+            ) else {
                 self.deferredBottomSyncTask = nil
                 return
             }

--- a/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
+++ b/apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift
@@ -103,6 +103,8 @@ struct AIChatView: View {
     @State var isPhotoPickerPresented: Bool
     @State var selectedPhotoItem: PhotosPickerItem?
     @State var isAutoFollowEnabled: Bool
+    @State var currentScrollState: AIChatScrollState?
+    @State var hasActiveUserScrollGesture: Bool
     @State var scrollPosition: ScrollPosition
     @State var autoScrollTask: Task<Void, Never>?
     @State var deferredBottomSyncTask: Task<Void, Never>?
@@ -118,6 +120,8 @@ struct AIChatView: View {
         self.isPhotoPickerPresented = false
         self.selectedPhotoItem = nil
         self.isAutoFollowEnabled = true
+        self.currentScrollState = nil
+        self.hasActiveUserScrollGesture = false
         self.scrollPosition = ScrollPosition(idType: String.self)
         self.autoScrollTask = nil
         self.deferredBottomSyncTask = nil
@@ -463,30 +467,44 @@ struct AIChatView: View {
             self.dismissComposerFocus()
         }
         .onScrollPhaseChange { _, nextPhase, context in
-            let nextScrollState = aiChatScrollState(
+            let nextScrollState: AIChatScrollState = aiChatScrollState(
                 scrollPhase: nextPhase,
                 scrollGeometry: context.geometry,
                 bottomThreshold: aiChatAutoScrollBottomThreshold
             )
+            self.currentScrollState = nextScrollState
 
-            // Only user-driven scroll phases can detach auto-follow. Animated scrolls
-            // are app-driven and should not flip the latch while the assistant content grows.
-            if nextScrollState.isUserInitiatedScroll && nextScrollState.isNearBottom == false {
-                self.isAutoFollowEnabled = false
-                return
+            // Only user-driven scrolls can detach auto-follow. Animated scrolls are
+            // app-driven and should not flip the latch while assistant content grows.
+            if nextScrollState.isUserInitiatedScroll {
+                self.hasActiveUserScrollGesture = true
+                if nextScrollState.isNearBottom == false {
+                    self.detachAutoFollow()
+                    return
+                }
             }
 
-            if nextPhase == .idle && nextScrollState.isNearBottom {
+            if nextPhase == .idle {
+                let didCompleteUserScrollGesture: Bool = self.hasActiveUserScrollGesture
+                self.hasActiveUserScrollGesture = false
+                guard nextScrollState.isNearBottom else {
+                    if didCompleteUserScrollGesture {
+                        self.detachAutoFollow()
+                    }
+                    return
+                }
+
                 self.isAutoFollowEnabled = true
                 if self.chatStore.isStreaming {
                     self.scrollToBottomIfNeeded(isAnimated: false)
                 }
+                return
             }
         }
         .onAppear {
-            // Keep the one-shot deferred sync for initial presentation and tab re-entry.
-            // That fixes the earlier first-layout gap without fighting keyboard-driven
-            // size changes or overriding a deliberate manual scroll-away later.
+            // Keep the one-shot deferred sync only when the previous geometry already
+            // proved the reader was at the bottom, so tab return cannot override a
+            // deliberate manual scroll-away.
             self.scheduleDeferredBottomSyncIfNeeded()
             if self.chatStore.isStreaming {
                 self.startAutoScrollTask()
@@ -496,13 +514,27 @@ struct AIChatView: View {
             self.cancelDeferredBottomSync()
             self.stopAutoScrollTask()
         }
-        .onChange(of: self.chatStore.messages) { _, messages in
+        .onChange(of: self.chatStore.messages) { previousMessages, messages in
             guard messages.isEmpty == false else {
                 self.isAutoFollowEnabled = true
+                self.currentScrollState = nil
+                self.hasActiveUserScrollGesture = false
                 self.scrollToBottom(isAnimated: false)
                 return
             }
 
+            let didAppendTail: Bool = aiChatMessageListUpdateAppendsTail(
+                previousMessages: previousMessages,
+                nextMessages: messages
+            )
+            let didChangeStreamingTail: Bool = self.chatStore.isStreaming
+                && aiChatMessageListUpdateChangesExistingTail(
+                    previousMessages: previousMessages,
+                    nextMessages: messages
+                )
+            guard didAppendTail || didChangeStreamingTail else {
+                return
+            }
             self.scrollToBottomIfNeeded(isAnimated: self.chatStore.isStreaming == false)
         }
         .onChange(of: self.chatStore.isStreaming) { _, isStreaming in


### PR DESCRIPTION
## Summary
- preserve manual scroll-away in the iOS AI chat through tab return and lifecycle changes
- guard deferred bottom sync behind known near-bottom scroll state
- auto-follow only tail appends or active streaming tail updates instead of bootstrap replacements

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/AI/Views/AIChatView+Scrolling.swift apps/ios/Flashcards/Flashcards/AI/Views/AIChatView.swift

Generic iOS build was attempted earlier and blocked before compile by local disk exhaustion while extracting packages. No simulator-backed tests were run per repository instructions.