### PR TITLE
Preserve Android AI chat scroll position

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AiRouteTest.kt
@@ -756,6 +756,7 @@ private fun makeAiUiState(
         isStreaming.not()
     return AiUiState(
         currentWorkspaceName = "Personal",
+        conversationScrollStateKey = "test-conversation",
         messages = messages,
         pendingAttachments = emptyList(),
         draftMessage = draftMessage,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiUiState.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/AiUiState.kt
@@ -22,6 +22,7 @@ fun emptyAiBootstrapErrorPresentation(): AiBootstrapErrorPresentation {
 
 data class AiUiState(
     val currentWorkspaceName: String,
+    val conversationScrollStateKey: String,
     val messages: List<AiChatMessage>,
     val pendingAttachments: List<AiChatAttachment>,
     val draftMessage: String,

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapper.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/runtime/AiUiStateMapper.kt
@@ -1,15 +1,16 @@
 package com.flashcardsopensourceapp.feature.ai.runtime
 
-import com.flashcardsopensourceapp.data.local.model.sync.AppMetadataSummary
-import com.flashcardsopensourceapp.data.local.model.sync.AppMetadataStorage
-import com.flashcardsopensourceapp.data.local.model.sync.AppMetadataSyncStatus
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatDictationState
+import com.flashcardsopensourceapp.data.local.model.ai.AiChatMessage
 import com.flashcardsopensourceapp.data.local.model.ai.AiChatServerConfig
-import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
-import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.ai.defaultAiChatServerConfig
 import com.flashcardsopensourceapp.data.local.model.ai.effectiveAiChatServerConfig
 import com.flashcardsopensourceapp.data.local.model.ai.isSendableAiChatAttachment
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
+import com.flashcardsopensourceapp.data.local.model.sync.AppMetadataSummary
+import com.flashcardsopensourceapp.data.local.model.sync.AppMetadataStorage
+import com.flashcardsopensourceapp.data.local.model.sync.AppMetadataSyncStatus
 import com.flashcardsopensourceapp.feature.ai.AiUiState
 import com.flashcardsopensourceapp.feature.ai.emptyAiBootstrapErrorPresentation
 import com.flashcardsopensourceapp.feature.ai.runtime.conversation.AiAccessContext
@@ -100,6 +101,7 @@ internal fun mapToAiUiState(
 
     return AiUiState(
         currentWorkspaceName = metadata.currentWorkspaceName ?: textProvider.unavailableLabel,
+        conversationScrollStateKey = aiConversationScrollStateKey(runtimeState = runtimeState),
         messages = runtimeState.persistedState.messages,
         pendingAttachments = runtimeState.pendingAttachments,
         draftMessage = runtimeState.draftMessage,
@@ -143,6 +145,7 @@ internal fun mapToAiUiState(
 internal fun makeInitialAiUiState(hasConsent: Boolean, textProvider: AiTextProvider): AiUiState {
     return AiUiState(
         currentWorkspaceName = textProvider.loadingLabel,
+        conversationScrollStateKey = emptyAiConversationScrollStateKey(),
         messages = emptyList(),
         pendingAttachments = emptyList(),
         draftMessage = "",
@@ -187,4 +190,27 @@ private fun canToggleDictation(
     return chatConfig.features.dictationEnabled && canPrepareAiDraftInComposerPhase(
         composerPhase = runtimeState.composerPhase
     ) && runtimeState.conversationBootstrapState == AiConversationBootstrapState.READY
+}
+
+private fun aiConversationScrollStateKey(runtimeState: AiChatRuntimeState): String {
+    val chatSessionId: String = runtimeState.persistedState.chatSessionId.trim()
+    if (chatSessionId.isNotEmpty()) {
+        return "session:$chatSessionId"
+    }
+
+    val conversationScopeId: String? = runtimeState.conversationScopeId?.trim()
+    if (conversationScopeId != null && conversationScopeId.isNotEmpty()) {
+        return "scope:$conversationScopeId"
+    }
+
+    return aiConversationMessageSetScrollStateKey(messages = runtimeState.persistedState.messages)
+}
+
+private fun aiConversationMessageSetScrollStateKey(messages: List<AiChatMessage>): String {
+    val firstMessage: AiChatMessage = messages.firstOrNull() ?: return emptyAiConversationScrollStateKey()
+    return "messages:${firstMessage.messageId}:${firstMessage.timestampMillis}"
+}
+
+private fun emptyAiConversationScrollStateKey(): String {
+    return "empty"
 }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiConversationContent.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiConversationContent.kt
@@ -10,13 +10,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -47,6 +48,7 @@ private val aiEmptyStateMaxWidth = 420.dp
 
 @Composable
 internal fun AiConversation(
+    conversationScrollStateKey: String,
     messages: List<AiChatMessage>,
     currentWorkspaceName: String,
     isStreaming: Boolean,
@@ -55,7 +57,37 @@ internal fun AiConversation(
     contentPadding: PaddingValues,
     modifier: Modifier
 ) {
-    val listState = rememberLazyListState()
+    key(conversationScrollStateKey) {
+        AiConversationStatefulContent(
+            messages = messages,
+            currentWorkspaceName = currentWorkspaceName,
+            isStreaming = isStreaming,
+            onOpenAccountStatus = onOpenAccountStatus,
+            onDismissComposerFocus = onDismissComposerFocus,
+            contentPadding = contentPadding,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun AiConversationStatefulContent(
+    messages: List<AiChatMessage>,
+    currentWorkspaceName: String,
+    isStreaming: Boolean,
+    onOpenAccountStatus: () -> Unit,
+    onDismissComposerFocus: () -> Unit,
+    contentPadding: PaddingValues,
+    modifier: Modifier
+) {
+    val listState = rememberSaveable(
+        saver = LazyListState.Saver
+    ) {
+        LazyListState(
+            firstVisibleItemIndex = 0,
+            firstVisibleItemScrollOffset = 0
+        )
+    }
     val currentMessages by rememberUpdatedState(messages)
     val currentStreamingState by rememberUpdatedState(isStreaming)
     val interactionSource = remember { MutableInteractionSource() }

--- a/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
+++ b/apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai/ui/AiScreen.kt
@@ -400,6 +400,7 @@ internal fun AiRouteContent(
                 modifier = contentModifier
             ) {
                 AiConversation(
+                    conversationScrollStateKey = uiState.conversationScrollStateKey,
                     messages = uiState.messages,
                     currentWorkspaceName = uiState.currentWorkspaceName,
                     isStreaming = uiState.isStreaming,


### PR DESCRIPTION
## Summary
- add a stable conversation scroll key to Android AI UI state
- preserve AI chat LazyListState and bottom-detach latch across remounts using conversation-keyed saveable state
- keep auto-follow behavior scoped to near-bottom chat state

## Validation
- worker refreshed cleanly to origin/main commit 6e201b10 after iOS PR #631
- git --no-pager diff --check
- rg "rememberLazyListState" apps/android/feature/ai/src/main/java/com/flashcardsopensourceapp/feature/ai -n: no matches
- direct AiUiState(...) and AiConversation(...) call sites accounted for after signature changes
- fresh post-fix review: no P0-P1 issues; one P3 instrumentation coverage suggestion only

Gradle/instrumentation tests were not run because ./gradlew was not authorized by repository instructions.