### PR TITLE
Preserve web chat scroll position

### DIFF
--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -81,6 +81,7 @@ export function ChatPanel(props: Props): ReactElement {
     messages,
     messagesRef,
     messagesContentRef,
+    scrollKey: currentSessionId,
   });
   const isInitialHistoryLoading = !isHistoryLoaded && messages.length === 0;
   const attachmentLimitMessage = t("chatPanel.alerts.attachmentLimit", {
@@ -280,7 +281,7 @@ export function ChatPanel(props: Props): ReactElement {
         </div>
       </div>
 
-      <div className="chat-messages" ref={messagesRef} onScroll={handleMessagesScroll}>
+      <div className="chat-messages" ref={messagesRef} onScroll={handleMessagesScroll} data-testid="chat-messages">
         <div className="chat-messages-content" ref={messagesContentRef}>
           {isInitialHistoryLoading ? (
             <div className="chat-empty chat-empty-loading" aria-live="polite">

--- a/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx
+++ b/apps/web/src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx
@@ -1,8 +1,13 @@
 // @vitest-environment jsdom
+import { act, createElement, useLayoutEffect, useRef, type ReactElement } from "react";
+import ReactDOM from "react-dom/client";
 import { describe, expect, it, vi } from "vitest";
 import {
   ApiErrorMock,
+  configureMessagesScroller,
   captureWebExceptionMock,
+  consumeChatLiveStreamMock,
+  createChatActiveRun,
   createChatSnapshot,
   createNewChatSessionMock,
   getChatSnapshotMock,
@@ -15,13 +20,88 @@ import {
   createUnverifiedWorkspaceAppDataMock,
   createVerifiedWorkspaceAppDataMock,
 } from "../support/ChatPanelTestFixtures";
+import { useChatAutoScroll } from "../../../history/useChatAutoScroll";
+import type { StoredMessage } from "../../../history/useChatHistory";
 import { storeChatSessionWarmStartSnapshot } from "../../../sessionController/lifecycle/warmStart";
+import type { ChatLiveEvent } from "../../../streaming/liveStream";
 
 const {
   flushAsync,
   getContainer,
+  hideChatPanel,
   renderChatPanel,
+  setMessagesScrollerMetrics,
 } = setupChatPanelTest();
+
+function queryMessagesScroller(container: ParentNode): HTMLDivElement {
+  const scroller = container.querySelector('[data-testid="chat-messages"]') as HTMLDivElement | null;
+  expect(scroller).not.toBeNull();
+  if (scroller === null) {
+    throw new Error("Expected chat messages scroller");
+  }
+
+  return scroller;
+}
+
+async function finishProgrammaticScrollSuppression(): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(1_000);
+    await Promise.resolve();
+  });
+}
+
+async function detachMessagesScroller(scroller: HTMLDivElement, scrollTop: number): Promise<void> {
+  await act(async () => {
+    scroller.dispatchEvent(new Event("wheel", { bubbles: true }));
+    scroller.scrollTop = scrollTop;
+    scroller.dispatchEvent(new Event("scroll", { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+const emptyStoredMessages: ReadonlyArray<StoredMessage> = [];
+
+type AutoScrollHarnessProps = Readonly<{
+  metrics: Readonly<{
+    scrollTop: number;
+    scrollHeight: number;
+    clientHeight: number;
+  }>;
+  scrollKey: string;
+}>;
+
+function AutoScrollHarness(props: AutoScrollHarnessProps): ReactElement {
+  const { metrics, scrollKey } = props;
+  const messagesRef = useRef<HTMLDivElement>(null);
+  const messagesContentRef = useRef<HTMLDivElement>(null);
+  const { handleMessagesScroll } = useChatAutoScroll({
+    isHydrated: true,
+    isStreaming: false,
+    messages: emptyStoredMessages,
+    messagesRef,
+    messagesContentRef,
+    scrollKey,
+  });
+
+  useLayoutEffect(() => {
+    const element = messagesRef.current;
+    if (element === null) {
+      return;
+    }
+
+    configureMessagesScroller(element, metrics);
+  }, [metrics]);
+
+  return createElement(
+    "div",
+    {
+      "data-testid": "auto-scroll-harness",
+      onScroll: handleMessagesScroll,
+      ref: messagesRef,
+    },
+    createElement("div", { ref: messagesContentRef }),
+  );
+}
 
 describe("ChatPanel hydration lifecycle", () => {
   it("shows loading UI instead of empty suggestions while the initial chat history is unresolved", async () => {
@@ -319,6 +399,479 @@ describe("ChatPanel hydration lifecycle", () => {
 
     expect(getChatSnapshotMock).toHaveBeenCalledTimes(1);
     expect(getContainer().textContent).toContain("Existing response");
+  });
+
+  it("preserves detached middle scroll when a hydrated session remounts", async () => {
+    const sessionId = "session-scroll-remount";
+    const freshTimestamp = Date.now();
+    getChatSnapshotMock.mockImplementation(() => new Promise(() => undefined));
+    storeChatSessionWarmStartSnapshot("workspace-1", createChatSnapshot({
+      sessionId,
+      conversationScopeId: sessionId,
+      conversation: {
+        updatedAt: freshTimestamp,
+        mainContentInvalidationVersion: 0,
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Older question" }],
+            timestamp: freshTimestamp,
+            isError: false,
+            isStopped: false,
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Older answer" }],
+            timestamp: freshTimestamp + 1,
+            isError: false,
+            isStopped: false,
+          },
+        ],
+      },
+    }), false);
+
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_000,
+      clientHeight: 400,
+    });
+    await renderChatPanel();
+    await flushAsync();
+
+    const scroller = queryMessagesScroller(getContainer());
+    await finishProgrammaticScrollSuppression();
+    await detachMessagesScroller(scroller, 320);
+
+    expect(scroller.scrollTop).toBe(320);
+
+    await hideChatPanel();
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_000,
+      clientHeight: 400,
+    });
+    await renderChatPanel();
+    await flushAsync();
+
+    const remountedScroller = queryMessagesScroller(getContainer());
+    expect(remountedScroller.scrollTop).toBe(320);
+  });
+
+  it("keeps detached scroll state attached to the previous key when the scroll key changes", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const root = ReactDOM.createRoot(host);
+
+    async function renderHarness(scrollKey: string, scrollTop: number): Promise<HTMLDivElement> {
+      await act(async () => {
+        root.render(createElement(AutoScrollHarness, {
+          metrics: {
+            scrollTop,
+            scrollHeight: 1_000,
+            clientHeight: 400,
+          },
+          scrollKey,
+        }));
+        await Promise.resolve();
+      });
+
+      const scroller = host.querySelector('[data-testid="auto-scroll-harness"]') as HTMLDivElement | null;
+      expect(scroller).not.toBeNull();
+      if (scroller === null) {
+        throw new Error("Expected auto-scroll harness scroller");
+      }
+
+      return scroller;
+    }
+
+    try {
+      const firstScroller = await renderHarness("session-key-a", 600);
+      await finishProgrammaticScrollSuppression();
+      await detachMessagesScroller(firstScroller, 320);
+
+      const secondScroller = await renderHarness("session-key-b", 600);
+      expect(secondScroller.scrollTop).toBe(1_000);
+
+      const restoredFirstScroller = await renderHarness("session-key-a", 600);
+      expect(restoredFirstScroller.scrollTop).toBe(320);
+    } finally {
+      await act(async () => {
+        root.unmount();
+        await Promise.resolve();
+      });
+      host.remove();
+    }
+  });
+
+  it("preserves detached scroll anchor when hydration replaces the visible snapshot", async () => {
+    const sessionId = "session-scroll-snapshot";
+    const freshTimestamp = Date.now();
+    let resolveHydrationSnapshot: ((snapshot: ReturnType<typeof createChatSnapshot>) => void) | null = null;
+    getChatSnapshotMock.mockImplementation(() => new Promise((resolve) => {
+      resolveHydrationSnapshot = resolve;
+    }));
+    storeChatSessionWarmStartSnapshot("workspace-1", createChatSnapshot({
+      sessionId,
+      conversationScopeId: sessionId,
+      conversation: {
+        updatedAt: freshTimestamp,
+        mainContentInvalidationVersion: 0,
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Warm question" }],
+            timestamp: freshTimestamp,
+            isError: false,
+            isStopped: false,
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Warm answer" }],
+            timestamp: freshTimestamp + 1,
+            isError: false,
+            isStopped: false,
+          },
+        ],
+      },
+    }), false);
+
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_000,
+      clientHeight: 400,
+    });
+    await renderChatPanel();
+    await flushAsync();
+
+    const scroller = queryMessagesScroller(getContainer());
+    await finishProgrammaticScrollSuppression();
+    await detachMessagesScroller(scroller, 300);
+    setMessagesScrollerMetrics({
+      scrollTop: scroller.scrollTop,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+    configureMessagesScroller(scroller, {
+      scrollTop: scroller.scrollTop,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+
+    expect(resolveHydrationSnapshot).not.toBeNull();
+    if (resolveHydrationSnapshot === null) {
+      throw new Error("Expected pending hydration snapshot request");
+    }
+
+    await act(async () => {
+      resolveHydrationSnapshot(createChatSnapshot({
+        sessionId,
+        conversationScopeId: sessionId,
+        conversation: {
+          updatedAt: freshTimestamp + 2,
+          mainContentInvalidationVersion: 0,
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "Warm question" }],
+              timestamp: freshTimestamp,
+              isError: false,
+              isStopped: false,
+            },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Warm answer with refreshed details" }],
+              timestamp: freshTimestamp + 1,
+              isError: false,
+              isStopped: false,
+            },
+          ],
+        },
+      }));
+      await Promise.resolve();
+    });
+    await flushAsync();
+    await flushAsync();
+
+    expect(scroller.scrollTop).toBe(600);
+  });
+
+  it("keeps detached scroll fixed when a fresh-object snapshot only appends messages", async () => {
+    const sessionId = "session-scroll-append-snapshot";
+    const freshTimestamp = Date.now();
+    let resolveHydrationSnapshot: ((snapshot: ReturnType<typeof createChatSnapshot>) => void) | null = null;
+    getChatSnapshotMock.mockImplementation(() => new Promise((resolve) => {
+      resolveHydrationSnapshot = resolve;
+    }));
+    storeChatSessionWarmStartSnapshot("workspace-1", createChatSnapshot({
+      sessionId,
+      conversationScopeId: sessionId,
+      conversation: {
+        updatedAt: freshTimestamp,
+        mainContentInvalidationVersion: 0,
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Warm question" }],
+            timestamp: freshTimestamp,
+            isError: false,
+            isStopped: false,
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Warm answer" }],
+            timestamp: freshTimestamp + 1,
+            isError: false,
+            isStopped: false,
+          },
+        ],
+      },
+    }), false);
+
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_000,
+      clientHeight: 400,
+    });
+    await renderChatPanel();
+    await flushAsync();
+
+    const scroller = queryMessagesScroller(getContainer());
+    await finishProgrammaticScrollSuppression();
+    await detachMessagesScroller(scroller, 300);
+    setMessagesScrollerMetrics({
+      scrollTop: scroller.scrollTop,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+    configureMessagesScroller(scroller, {
+      scrollTop: scroller.scrollTop,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+
+    expect(resolveHydrationSnapshot).not.toBeNull();
+    if (resolveHydrationSnapshot === null) {
+      throw new Error("Expected pending hydration snapshot request");
+    }
+
+    await act(async () => {
+      resolveHydrationSnapshot(createChatSnapshot({
+        sessionId,
+        conversationScopeId: sessionId,
+        conversation: {
+          updatedAt: freshTimestamp + 2,
+          mainContentInvalidationVersion: 0,
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "Warm question" }],
+              timestamp: freshTimestamp,
+              isError: false,
+              isStopped: false,
+            },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Warm answer" }],
+              timestamp: freshTimestamp + 1,
+              isError: false,
+              isStopped: false,
+            },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "Appended answer detail" }],
+              timestamp: freshTimestamp + 2,
+              isError: false,
+              isStopped: false,
+            },
+          ],
+        },
+      }));
+      await Promise.resolve();
+    });
+    await flushAsync();
+    await flushAsync();
+
+    expect(scroller.scrollTop).toBe(300);
+  });
+
+  it("keeps detached scroll fixed while an active stream advances the assistant cursor", async () => {
+    const sessionId = "session-streaming-detached";
+    const freshTimestamp = Date.now();
+    let emitLiveEvent: ((event: ChatLiveEvent) => void) | null = null;
+    consumeChatLiveStreamMock.mockImplementation((params: Readonly<{
+      onEvent: (event: ChatLiveEvent) => void;
+    }>) => {
+      emitLiveEvent = params.onEvent;
+      return new Promise(() => undefined);
+    });
+    getChatSnapshotMock.mockResolvedValue(createChatSnapshot({
+      sessionId,
+      conversationScopeId: sessionId,
+      activeRun: createChatActiveRun(),
+      conversation: {
+        updatedAt: freshTimestamp,
+        mainContentInvalidationVersion: 0,
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Streaming question" }],
+            timestamp: freshTimestamp,
+            isError: false,
+            isStopped: false,
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Streaming answer" }],
+            timestamp: freshTimestamp + 1,
+            isError: false,
+            isStopped: false,
+            cursor: "cursor-0",
+            itemId: "item-1",
+          },
+        ],
+      },
+    }));
+
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_000,
+      clientHeight: 400,
+    });
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    const scroller = queryMessagesScroller(getContainer());
+    await finishProgrammaticScrollSuppression();
+    await detachMessagesScroller(scroller, 300);
+    setMessagesScrollerMetrics({
+      scrollTop: scroller.scrollTop,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+    configureMessagesScroller(scroller, {
+      scrollTop: scroller.scrollTop,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+
+    expect(emitLiveEvent).not.toBeNull();
+    if (emitLiveEvent === null) {
+      throw new Error("Expected active chat live stream");
+    }
+
+    await act(async () => {
+      emitLiveEvent({
+        type: "assistant_delta",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId: "run-1",
+        sequenceNumber: 1,
+        streamEpoch: "epoch-1",
+        text: " with more content",
+        cursor: "cursor-1",
+        itemId: "item-1",
+      });
+      await Promise.resolve();
+    });
+    await flushAsync();
+
+    expect(scroller.scrollTop).toBe(300);
+  });
+
+  it("keeps bottom follow when a streaming session remounts before pending scroll flushes", async () => {
+    const sessionId = "session-streaming-remount";
+    const freshTimestamp = Date.now();
+    let emitLiveEvent: ((event: ChatLiveEvent) => void) | null = null;
+    consumeChatLiveStreamMock.mockImplementation((params: Readonly<{
+      onEvent: (event: ChatLiveEvent) => void;
+    }>) => {
+      emitLiveEvent = params.onEvent;
+      return new Promise(() => undefined);
+    });
+    getChatSnapshotMock.mockResolvedValue(createChatSnapshot({
+      sessionId,
+      conversationScopeId: sessionId,
+      activeRun: createChatActiveRun(),
+      conversation: {
+        updatedAt: freshTimestamp,
+        mainContentInvalidationVersion: 0,
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Streaming question" }],
+            timestamp: freshTimestamp,
+            isError: false,
+            isStopped: false,
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Streaming answer" }],
+            timestamp: freshTimestamp + 1,
+            isError: false,
+            isStopped: false,
+            cursor: "cursor-0",
+            itemId: "item-1",
+          },
+        ],
+      },
+    }));
+
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_000,
+      clientHeight: 400,
+    });
+    await renderChatPanel();
+    await flushAsync();
+    await flushAsync();
+
+    const scroller = queryMessagesScroller(getContainer());
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+    configureMessagesScroller(scroller, {
+      scrollTop: 600,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+
+    expect(emitLiveEvent).not.toBeNull();
+    if (emitLiveEvent === null) {
+      throw new Error("Expected active chat live stream");
+    }
+
+    await act(async () => {
+      emitLiveEvent({
+        type: "assistant_delta",
+        sessionId,
+        conversationScopeId: sessionId,
+        runId: "run-1",
+        sequenceNumber: 1,
+        streamEpoch: "epoch-1",
+        text: " with more content",
+        cursor: "cursor-1",
+        itemId: "item-1",
+      });
+      await Promise.resolve();
+    });
+    await flushAsync();
+
+    expect(scroller.scrollTop).toBe(600);
+
+    await hideChatPanel();
+    setMessagesScrollerMetrics({
+      scrollTop: 600,
+      scrollHeight: 1_300,
+      clientHeight: 400,
+    });
+    await renderChatPanel();
+    await flushAsync();
+
+    const remountedScroller = queryMessagesScroller(getContainer());
+    expect(remountedScroller.scrollTop).toBe(1_300);
   });
 
   it("does not reuse the previous workspace session id when hydrating a new workspace", async () => {

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -1,4 +1,4 @@
-import { StrictMode, act, createElement, useEffect, type ReactNode } from "react";
+import { StrictMode, act, createElement, useEffect, useLayoutEffect, type ReactNode } from "react";
 import ReactDOM from "react-dom/client";
 import { afterEach, beforeEach, expect, vi } from "vitest";
 import { I18nProvider, useI18n } from "../../../../i18n";
@@ -190,6 +190,7 @@ type ChatPanelTestHarness = Readonly<{
   getScrollToMock: () => ReturnType<typeof vi.fn>;
   getClipboardWriteTextMock: () => ReturnType<typeof vi.fn>;
   getAlertMock: () => ReturnType<typeof vi.fn>;
+  setMessagesScrollerMetrics: (metrics: MessagesScrollerMetrics) => void;
   setMobileViewport: (isMobile: boolean) => void;
   flushAsync: () => Promise<void>;
   renderChatPanel: (mode?: "sidebar" | "fullscreen") => Promise<void>;
@@ -208,6 +209,12 @@ type TextareaKeyboardParams = Readonly<{
   key: string;
   shiftKey: boolean;
   repeat: boolean;
+}>;
+
+export type MessagesScrollerMetrics = Readonly<{
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
 }>;
 
 export {
@@ -318,16 +325,16 @@ export function pressTextareaKey(
   return keyboardEvent;
 }
 
-export function configureMessagesScroller(element: HTMLDivElement): void {
-  let scrollTop = 600;
+export function configureMessagesScroller(element: HTMLDivElement, metrics: MessagesScrollerMetrics): void {
+  let scrollTop = metrics.scrollTop;
 
   Object.defineProperty(element, "scrollHeight", {
     configurable: true,
-    get: () => 1_000,
+    get: () => metrics.scrollHeight,
   });
   Object.defineProperty(element, "clientHeight", {
     configurable: true,
-    get: () => 400,
+    get: () => metrics.clientHeight,
   });
   Object.defineProperty(element, "scrollTop", {
     configurable: true,
@@ -470,12 +477,14 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
   let scrollToMock: ReturnType<typeof vi.fn> | null = null;
   let clipboardWriteTextMock: ReturnType<typeof vi.fn> | null = null;
   let alertMock: ReturnType<typeof vi.fn> | null = null;
+  let messagesScrollerMetrics: MessagesScrollerMetrics | null = null;
   let setLocalePreferenceRef: ((localePreference: LocalePreference) => void) | null = null;
   let isMobileViewport = false;
   const matchMediaListeners = new Set<(event: MediaQueryListEvent) => void>();
 
   beforeEach(() => {
     isMobileViewport = false;
+    messagesScrollerMetrics = null;
     matchMediaListeners.clear();
     const localStorageState = new Map<string, string>();
     const localStorageMock: Storage = {
@@ -743,6 +752,10 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
     return alertMock;
   }
 
+  function setMessagesScrollerMetrics(metrics: MessagesScrollerMetrics): void {
+    messagesScrollerMetrics = metrics;
+  }
+
   function setMobileViewport(nextIsMobile: boolean): void {
     isMobileViewport = nextIsMobile;
     const changeEvent = { matches: isMobileViewport, media: "(max-width: 768px)" } as MediaQueryListEvent;
@@ -770,6 +783,22 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
     return null;
   }
 
+  function MessagesScrollerMetricsConfigurator(): null {
+    useLayoutEffect(() => {
+      const mountedContainer = container;
+      if (mountedContainer === null || messagesScrollerMetrics === null) {
+        return;
+      }
+
+      const messagesScroller = mountedContainer.querySelector('[data-testid="chat-messages"]') as HTMLDivElement | null;
+      if (messagesScroller !== null) {
+        configureMessagesScroller(messagesScroller, messagesScrollerMetrics);
+      }
+    });
+
+    return null;
+  }
+
   async function renderChatPanelShell(panel: ReactNode, shouldUseStrictMode: boolean): Promise<void> {
     expect(root).not.toBeNull();
     await act(async () => {
@@ -782,6 +811,7 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
           createElement(
             ChatDraftProvider,
             null,
+            createElement(MessagesScrollerMetricsConfigurator),
             createElement(LocalePreferenceProbe),
             panel,
           ),
@@ -897,6 +927,7 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
     getScrollToMock,
     getClipboardWriteTextMock,
     getAlertMock,
+    setMessagesScrollerMetrics,
     setMobileViewport,
     flushAsync,
     renderChatPanel,

--- a/apps/web/src/chat/history/useChatAutoScroll.ts
+++ b/apps/web/src/chat/history/useChatAutoScroll.ts
@@ -3,10 +3,22 @@ import {
   AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
   AUTO_SCROLL_INTERVAL_MS,
 } from "../shared/chatHelpers";
+import type { ToolCallContentPart } from "../../types";
 import type { StoredMessage } from "./useChatHistory";
 
 const PROGRAMMATIC_SCROLL_SUPPRESSION_MS = 750;
 const USER_SCROLL_INTENT_TIMEOUT_MS = 750;
+
+type ChatScrollState = Readonly<{
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  wasNearBottom: boolean;
+}>;
+
+const savedScrollStatesByKey = new Map<string, ChatScrollState>();
+
+type StreamPosition = NonNullable<ToolCallContentPart["streamPosition"]>;
 
 export type UseChatAutoScrollParams = Readonly<{
   isHydrated: boolean;
@@ -14,6 +26,7 @@ export type UseChatAutoScrollParams = Readonly<{
   messages: ReadonlyArray<StoredMessage>;
   messagesRef: RefObject<HTMLDivElement | null>;
   messagesContentRef: RefObject<HTMLDivElement | null>;
+  scrollKey: string | null;
 }>;
 
 export type UseChatAutoScrollResult = Readonly<{
@@ -32,22 +45,248 @@ function scrollToBottomSmooth(element: HTMLDivElement): void {
   element.scrollTo({ top: element.scrollHeight, behavior: "smooth" });
 }
 
+function readScrollState(element: HTMLDivElement): ChatScrollState {
+  return {
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+    wasNearBottom: isNearBottom(element),
+  };
+}
+
+function readSavedScrollState(scrollKey: string | null): ChatScrollState | null {
+  return scrollKey === null ? null : savedScrollStatesByKey.get(scrollKey) ?? null;
+}
+
+function saveScrollState(scrollKey: string | null, scrollState: ChatScrollState): void {
+  if (scrollKey === null) {
+    return;
+  }
+
+  savedScrollStatesByKey.set(scrollKey, scrollState);
+}
+
+function areStreamPositionsEqual(
+  previousPosition: StreamPosition | undefined,
+  nextPosition: StreamPosition | undefined,
+): boolean {
+  if (previousPosition === nextPosition) {
+    return true;
+  }
+
+  if (previousPosition === undefined || nextPosition === undefined) {
+    return false;
+  }
+
+  return previousPosition.itemId === nextPosition.itemId
+    && previousPosition.responseIndex === nextPosition.responseIndex
+    && previousPosition.outputIndex === nextPosition.outputIndex
+    && previousPosition.contentIndex === nextPosition.contentIndex
+    && previousPosition.sequenceNumber === nextPosition.sequenceNumber;
+}
+
+function areContentPartsEqual(
+  previousParts: StoredMessage["content"],
+  nextParts: StoredMessage["content"],
+): boolean {
+  if (previousParts === nextParts) {
+    return true;
+  }
+
+  if (previousParts.length !== nextParts.length) {
+    return false;
+  }
+
+  for (let index = 0; index < previousParts.length; index += 1) {
+    const previousPart = previousParts[index];
+    const nextPart = nextParts[index];
+    if (previousPart?.type !== nextPart?.type) {
+      return false;
+    }
+
+    switch (previousPart?.type) {
+      case "text":
+        if (nextPart.type !== "text" || previousPart.text !== nextPart.text) {
+          return false;
+        }
+        break;
+      case "image":
+        if (
+          nextPart.type !== "image"
+          || previousPart.mediaType !== nextPart.mediaType
+          || previousPart.base64Data !== nextPart.base64Data
+        ) {
+          return false;
+        }
+        break;
+      case "file":
+        if (
+          nextPart.type !== "file"
+          || previousPart.mediaType !== nextPart.mediaType
+          || previousPart.base64Data !== nextPart.base64Data
+          || previousPart.fileName !== nextPart.fileName
+        ) {
+          return false;
+        }
+        break;
+      case "card":
+        if (
+          nextPart.type !== "card"
+          || previousPart.cardId !== nextPart.cardId
+          || previousPart.frontText !== nextPart.frontText
+          || previousPart.backText !== nextPart.backText
+          || previousPart.effortLevel !== nextPart.effortLevel
+          || previousPart.tags.length !== nextPart.tags.length
+          || previousPart.tags.some((tag, tagIndex) => tag !== nextPart.tags[tagIndex])
+        ) {
+          return false;
+        }
+        break;
+      case "tool_call":
+        if (
+          nextPart.type !== "tool_call"
+          || previousPart.id !== nextPart.id
+          || previousPart.name !== nextPart.name
+          || previousPart.status !== nextPart.status
+          || previousPart.providerStatus !== nextPart.providerStatus
+          || previousPart.input !== nextPart.input
+          || previousPart.output !== nextPart.output
+          || areStreamPositionsEqual(previousPart.streamPosition, nextPart.streamPosition) === false
+        ) {
+          return false;
+        }
+        break;
+      case "reasoning_summary":
+        if (
+          nextPart.type !== "reasoning_summary"
+          || previousPart.reasoningId !== nextPart.reasoningId
+          || previousPart.summary !== nextPart.summary
+          || previousPart.status !== nextPart.status
+          || areStreamPositionsEqual(previousPart.streamPosition, nextPart.streamPosition) === false
+        ) {
+          return false;
+        }
+        break;
+      default:
+        return false;
+    }
+  }
+
+  return true;
+}
+
+function areMessagesEqual(
+  previousMessage: StoredMessage,
+  nextMessage: StoredMessage,
+): boolean {
+  return previousMessage === nextMessage
+    || (
+      previousMessage.role === nextMessage.role
+      && previousMessage.timestamp === nextMessage.timestamp
+      && previousMessage.isError === nextMessage.isError
+      && previousMessage.isStopped === nextMessage.isStopped
+      && (previousMessage.itemId ?? null) === (nextMessage.itemId ?? null)
+      && (previousMessage.cursor ?? null) === (nextMessage.cursor ?? null)
+      && areContentPartsEqual(previousMessage.content, nextMessage.content)
+    );
+}
+
+function hasSameIncrementalMessageIdentity(
+  previousMessage: StoredMessage,
+  nextMessage: StoredMessage,
+): boolean {
+  const previousItemId = previousMessage.itemId ?? null;
+  const nextItemId = nextMessage.itemId ?? null;
+  return previousMessage.role === nextMessage.role
+    && previousMessage.timestamp === nextMessage.timestamp
+    && previousMessage.role === "assistant"
+    && nextItemId !== null
+    && (previousItemId === nextItemId || previousItemId === null);
+}
+
+function isIncrementalMessageUpdate(
+  previousMessages: ReadonlyArray<StoredMessage>,
+  nextMessages: ReadonlyArray<StoredMessage>,
+): boolean {
+  if (nextMessages.length < previousMessages.length) {
+    return false;
+  }
+
+  if (nextMessages.length > previousMessages.length) {
+    return previousMessages.every((message, index) => {
+      const nextMessage = nextMessages[index];
+      return nextMessage !== undefined && areMessagesEqual(message, nextMessage);
+    });
+  }
+
+  if (previousMessages.length === 0) {
+    return true;
+  }
+
+  const lastIndex = previousMessages.length - 1;
+  for (let index = 0; index < lastIndex; index += 1) {
+    const previousMessage = previousMessages[index];
+    const nextMessage = nextMessages[index];
+    if (previousMessage === undefined || nextMessage === undefined || areMessagesEqual(previousMessage, nextMessage) === false) {
+      return false;
+    }
+  }
+
+  const previousLastMessage = previousMessages[lastIndex];
+  const nextLastMessage = nextMessages[lastIndex];
+  if (previousLastMessage === undefined || nextLastMessage === undefined) {
+    return false;
+  }
+
+  return previousLastMessage === nextLastMessage
+    || hasSameIncrementalMessageIdentity(previousLastMessage, nextLastMessage);
+}
+
 /**
  * Keeps the messages pane snapped to the latest content while preserving the
  * current UX contract for persisted history, streamed batching, and manual
  * scroll overrides.
  */
 export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoScrollResult {
-  const { isHydrated, isStreaming, messages, messagesRef, messagesContentRef } = params;
+  const { isHydrated, isStreaming, messages, messagesRef, messagesContentRef, scrollKey } = params;
   // Follow stays enabled until a user-driven scroll gesture detaches the view from the bottom.
   const isAutoFollowEnabledRef = useRef<boolean>(true);
   const hasPendingScrollRef = useRef<boolean>(false);
   const autoScrollIntervalIdRef = useRef<number | null>(null);
-  const hasInitialBottomSnapRef = useRef<boolean>(false);
+  const hasRestoredScrollKeyRef = useRef<boolean>(false);
+  const restoredScrollKeyRef = useRef<string | null>(null);
+  const lastScrollStateRef = useRef<ChatScrollState | null>(null);
+  const previousMessagesRef = useRef<ReadonlyArray<StoredMessage> | null>(null);
   const programmaticScrollTimeoutIdRef = useRef<number | null>(null);
   const userScrollIntentTimeoutIdRef = useRef<number | null>(null);
   const isProgrammaticScrollActiveRef = useRef<boolean>(false);
   const isUserScrollIntentActiveRef = useRef<boolean>(false);
+
+  function getPersistedScrollState(scrollState: ChatScrollState): ChatScrollState {
+    if (isAutoFollowEnabledRef.current || hasPendingScrollRef.current) {
+      return {
+        ...scrollState,
+        wasNearBottom: true,
+      };
+    }
+
+    return scrollState;
+  }
+
+  function saveRememberedScrollStateForKey(key: string | null, scrollState: ChatScrollState): void {
+    saveScrollState(key, getPersistedScrollState(scrollState));
+  }
+
+  function saveRememberedScrollState(scrollState: ChatScrollState): void {
+    saveRememberedScrollStateForKey(scrollKey, scrollState);
+  }
+
+  function rememberScrollState(element: HTMLDivElement): ChatScrollState {
+    const scrollState = readScrollState(element);
+    lastScrollStateRef.current = scrollState;
+    saveRememberedScrollState(scrollState);
+    return scrollState;
+  }
 
   function flushPendingAutoScroll(): void {
     const element = messagesRef.current;
@@ -65,6 +304,7 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
 
     scrollToBottomSmooth(element);
     hasPendingScrollRef.current = false;
+    rememberScrollState(element);
   }
 
   function clearProgrammaticScrollSuppression(): void {
@@ -126,8 +366,26 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
     element.scrollTo({ top: element.scrollHeight, behavior: "auto" });
   }
 
+  function restoreScrollTop(element: HTMLDivElement, scrollTop: number): void {
+    startProgrammaticScrollSuppression(element);
+    element.scrollTo({ top: Math.max(0, scrollTop), behavior: "auto" });
+  }
+
+  function preserveDetachedAnchor(element: HTMLDivElement, previousScrollState: ChatScrollState): void {
+    const scrollHeightDelta = element.scrollHeight - previousScrollState.scrollHeight;
+    if (scrollHeightDelta === 0) {
+      return;
+    }
+
+    restoreScrollTop(element, previousScrollState.scrollTop + scrollHeightDelta);
+  }
+
   useEffect(() => {
-    if (!isHydrated || hasInitialBottomSnapRef.current) {
+    if (!isHydrated) {
+      return;
+    }
+
+    if (hasRestoredScrollKeyRef.current && restoredScrollKeyRef.current === scrollKey) {
       return;
     }
 
@@ -136,11 +394,21 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
       return;
     }
 
-    scrollToBottom(element, false);
-    hasInitialBottomSnapRef.current = true;
-    isAutoFollowEnabledRef.current = true;
+    const savedScrollState = readSavedScrollState(scrollKey);
+    if (savedScrollState !== null && savedScrollState.wasNearBottom === false) {
+      restoreScrollTop(element, savedScrollState.scrollTop);
+      isAutoFollowEnabledRef.current = false;
+    } else {
+      scrollToBottom(element, false);
+      isAutoFollowEnabledRef.current = true;
+    }
+
+    hasRestoredScrollKeyRef.current = true;
+    restoredScrollKeyRef.current = scrollKey;
     hasPendingScrollRef.current = false;
-  }, [isHydrated, messagesRef]);
+    previousMessagesRef.current = messages;
+    rememberScrollState(element);
+  }, [isHydrated, messages, messagesRef, scrollKey]);
 
   useEffect(() => {
     if (!isHydrated) {
@@ -176,7 +444,29 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
   }, [isHydrated, messagesRef]);
 
   useEffect(() => {
-    if (!isHydrated || hasInitialBottomSnapRef.current === false) {
+    if (!isHydrated || hasRestoredScrollKeyRef.current === false) {
+      return;
+    }
+
+    const element = messagesRef.current;
+    if (element === null) {
+      return;
+    }
+
+    const previousMessages = previousMessagesRef.current;
+    const previousScrollState = lastScrollStateRef.current;
+    if (
+      previousMessages !== null
+      && previousScrollState !== null
+      && isAutoFollowEnabledRef.current === false
+    ) {
+      if (isIncrementalMessageUpdate(previousMessages, messages) === false) {
+        preserveDetachedAnchor(element, previousScrollState);
+      }
+
+      hasPendingScrollRef.current = false;
+      previousMessagesRef.current = messages;
+      rememberScrollState(element);
       return;
     }
 
@@ -184,7 +474,9 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
     if (isStreaming === false) {
       flushPendingAutoScroll();
     }
-  }, [isHydrated, isStreaming, messages]);
+    previousMessagesRef.current = messages;
+    rememberScrollState(element);
+  }, [isHydrated, isStreaming, messages, messagesRef]);
 
   useEffect(() => {
     if (!isHydrated) {
@@ -210,10 +502,10 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
     }
 
     flushPendingAutoScroll();
-  }, [isHydrated, isStreaming]);
+  }, [isHydrated, isStreaming, scrollKey]);
 
   useEffect(() => {
-    if (!isHydrated || hasInitialBottomSnapRef.current === false) {
+    if (!isHydrated || hasRestoredScrollKeyRef.current === false) {
       return;
     }
 
@@ -237,6 +529,18 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
       resizeObserver.disconnect();
     };
   }, [isHydrated, messagesContentRef]);
+
+  useEffect(() => {
+    const keyForCleanup = scrollKey;
+    return () => {
+      const scrollState = lastScrollStateRef.current;
+      if (scrollState === null) {
+        return;
+      }
+
+      saveRememberedScrollStateForKey(keyForCleanup, scrollState);
+    };
+  }, [scrollKey]);
 
   useEffect(() => {
     return () => {
@@ -265,9 +569,15 @@ export function useChatAutoScroll(params: UseChatAutoScrollParams): UseChatAutoS
       return;
     }
 
+    const scrollState = readScrollState(element);
+    lastScrollStateRef.current = scrollState;
     if (isUserScrollIntentActiveRef.current) {
-      isAutoFollowEnabledRef.current = isNearBottom(element);
+      isAutoFollowEnabledRef.current = scrollState.wasNearBottom;
+      if (scrollState.wasNearBottom === false) {
+        hasPendingScrollRef.current = false;
+      }
     }
+    saveRememberedScrollState(scrollState);
 
     if (isAutoFollowEnabledRef.current && !isStreaming) {
       flushPendingAutoScroll();


### PR DESCRIPTION
## Summary
- preserve web chat scroll state by stable session key across remount/hydration
- keep bottom auto-follow for near-bottom and active streaming states
- preserve detached reader anchors for snapshot replacement and append-only refreshes

## Validation
- git --no-pager diff --check
- npm exec vitest -- run src/chat/ChatPanel/tests/lifecycle/ChatPanel.hydration-lifecycle.test.tsx (19/19)
- npm exec vitest -- run src/chat/ChatPanel/tests/*.test.tsx src/chat/ChatPanel/tests/*/*.test.tsx (116/116)
- npm run build (passed with existing Vite large chunk warnings)
- fresh worker-owned read-only review: no findings, pass