### PR TITLE
Add Android review reminder tab badge

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.Badge
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -64,6 +65,7 @@ import com.flashcardsopensourceapp.app.navigation.TopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.currentVisibleAppScreen
 import com.flashcardsopensourceapp.app.navigation.currentTopLevelDestination
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
+import com.flashcardsopensourceapp.app.navigation.reviewReminderAttentionBadgeTag
 import com.flashcardsopensourceapp.app.navigation.settings.SettingsAccountSignInEmailDestination
 import com.flashcardsopensourceapp.app.navigation.topLevelDestinations
 import com.flashcardsopensourceapp.app.prompts.feedback.FeedbackPromptContext
@@ -255,6 +257,9 @@ fun FlashcardsApp(
         val settingsAttentionSummary: SettingsAttentionSummary = makeSettingsAttentionSummary(
             issues = makeSettingsAttentionIssues(cloudState = cloudSettings.cloudState)
         )
+        val reviewReminderAttentionState by appGraph.reviewReminderAttentionController.attentionState.collectAsStateWithLifecycle(
+            initialValue = appGraph.reviewReminderAttentionController.attentionState.value
+        )
         val currentCanRunImmediateAutoSync by rememberUpdatedState(newValue = canRunImmediateAutoSync)
         val currentCanRefreshCloudAccountContext by rememberUpdatedState(newValue = canRefreshCloudAccountContext)
         val currentVisibleAppScreenState by rememberUpdatedState(newValue = currentVisibleAppScreen)
@@ -278,6 +283,15 @@ fun FlashcardsApp(
             appGraph.visibleAppScreenController.updateVisibleAppScreen(
                 screen = currentVisibleAppScreen
             )
+        }
+
+        LaunchedEffect(isAppResumed, appGraph.reviewReminderAttentionController) {
+            if (isAppResumed.not()) {
+                return@LaunchedEffect
+            }
+
+            appGraph.reviewReminderAttentionController.reloadFromStore()
+            appGraph.reviewReminderAttentionController.reconcileWithReviewHistory()
         }
 
         LaunchedEffect(
@@ -465,14 +479,19 @@ fun FlashcardsApp(
             layoutType = navigationSuiteType,
             navigationSuiteItems = {
                 topLevelDestinations.forEach { destination ->
-                    val settingsBadge: (@Composable () -> Unit)? =
-                        if (destination == SettingsDestination && settingsAttentionSummary.settingsTabCount > 0) {
+                    val destinationBadge: (@Composable () -> Unit)? = when {
+                        destination == ReviewDestination && reviewReminderAttentionState != null -> {
+                            {
+                                ReviewReminderAttentionBadge()
+                            }
+                        }
+                        destination == SettingsDestination && settingsAttentionSummary.settingsTabCount > 0 -> {
                             {
                                 SettingsAttentionBadge(count = settingsAttentionSummary.settingsTabCount)
                             }
-                        } else {
-                            null
                         }
+                        else -> null
+                    }
 
                     item(
                         selected = currentDestination.route == destination.route,
@@ -511,7 +530,7 @@ fun FlashcardsApp(
                         label = {
                             Text(stringResource(destination.labelResId))
                         },
-                        badge = settingsBadge
+                        badge = destinationBadge
                     )
                 }
             }
@@ -593,6 +612,17 @@ private fun shouldHideNavigationSuite(
     return destination == AiDestination &&
         navigationSuiteType == NavigationSuiteType.NavigationBar &&
         isImeVisible
+}
+
+@Composable
+private fun ReviewReminderAttentionBadge() {
+    Badge(
+        modifier = Modifier.testTag(reviewReminderAttentionBadgeTag),
+        containerColor = MaterialTheme.colorScheme.error,
+        contentColor = MaterialTheme.colorScheme.onError
+    ) {
+        Text(text = "1")
+    }
 }
 
 private fun shouldRefreshCloudAccountContext(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -24,6 +24,7 @@ import com.flashcardsopensourceapp.core.ui.AppMessageBus
 import com.flashcardsopensourceapp.core.ui.TestModeStore
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreenController
 import com.flashcardsopensourceapp.app.navigation.AppHandoffCoordinator
+import com.flashcardsopensourceapp.app.notifications.review.ReviewReminderAttentionController
 import com.flashcardsopensourceapp.app.notifications.review.ReviewNotificationsManager
 import com.flashcardsopensourceapp.app.notifications.strict.AndroidStrictRemindersScheduler
 import com.flashcardsopensourceapp.app.notifications.strict.StrictRemindersManager
@@ -162,6 +163,10 @@ class AppGraph(
     private val notificationsStore = SharedPreferencesReviewNotificationsStore(context = context)
     val reviewNotificationsStore: ReviewNotificationsStore = notificationsStore
     val strictRemindersStore: StrictRemindersStore = notificationsStore
+    val reviewReminderAttentionController = ReviewReminderAttentionController(
+        reviewNotificationsStore = reviewNotificationsStore,
+        reviewLogDao = database.reviewLogDao()
+    )
     private val aiCoroutineDispatchers = AiCoroutineDispatchers(io = Dispatchers.IO)
     private val localProgressCacheStore = LocalProgressCacheStore(
         database = database,
@@ -388,6 +393,7 @@ class AppGraph(
                         importedReviewAtMillis = latestReviewedAtMillis,
                         nowMillis = nowMillis
                     )
+                    reviewReminderAttentionController.reconcileWithReviewHistory()
                 } else {
                     strictRemindersManager.reconcileStrictReminders(
                         trigger = StrictRemindersReconcileTrigger.REVIEW_HISTORY_IMPORTED,

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/TopLevelDestinations.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/TopLevelDestinations.kt
@@ -29,6 +29,8 @@ fun topLevelDestinationTestTag(route: String): String {
     return "top_level_destination_$route"
 }
 
+const val reviewReminderAttentionBadgeTag: String = "top_level_destination_review_reminder_badge"
+
 data object ReviewDestination : TopLevelDestination {
     override val route: String = "review"
     override val labelResId: Int = R.string.top_level_review

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/review/ReviewNavGraph.kt
@@ -86,6 +86,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                         )
                     },
                     onSuccessfulReviewRecorded = { reviewedAtMillis ->
+                        appGraph.reviewReminderAttentionController.clearAfterSuccessfulReview()
                         appGraph.strictRemindersManager.recordSuccessfulReview(
                             reviewedAtMillis = reviewedAtMillis,
                             nowMillis = System.currentTimeMillis()
@@ -239,6 +240,7 @@ internal fun NavGraphBuilder.registerReviewNavGraph(
                         )
                     },
                     onSuccessfulReviewRecorded = { reviewedAtMillis ->
+                        appGraph.reviewReminderAttentionController.clearAfterSuccessfulReview()
                         appGraph.strictRemindersManager.recordSuccessfulReview(
                             reviewedAtMillis = reviewedAtMillis,
                             nowMillis = System.currentTimeMillis()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationWorker.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewNotificationWorker.kt
@@ -8,6 +8,7 @@ import com.flashcardsopensourceapp.app.notifications.addNotificationWorkerBreadc
 import com.flashcardsopensourceapp.app.notifications.hasNotificationPermission
 import com.flashcardsopensourceapp.app.notifications.reviewReminderNotificationKind
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
+import com.flashcardsopensourceapp.data.local.notifications.ReviewReminderAttentionState
 import com.flashcardsopensourceapp.data.local.notifications.SharedPreferencesReviewNotificationsStore
 
 open class ReviewNotificationWorker(
@@ -56,6 +57,11 @@ open class ReviewNotificationWorker(
             requestId = requestId,
             showAppIconBadge = showAppIconBadge
         )
+        markDeliveredReviewReminder(
+            workspaceId = workspaceId,
+            requestId = requestId,
+            deliveredAtMillis = System.currentTimeMillis()
+        )
         addWorkerBreadcrumb(
             stage = "worker_notification_posted",
             requestId = requestId,
@@ -74,6 +80,30 @@ open class ReviewNotificationWorker(
         }
         // Cold-start fallback: the worker can fire before Application.onCreate has published the graph.
         return SharedPreferencesReviewNotificationsStore(context = applicationContext)
+    }
+
+    private fun markDeliveredReviewReminder(
+        workspaceId: String,
+        requestId: String,
+        deliveredAtMillis: Long
+    ) {
+        val appGraph = (applicationContext as? FlashcardsApplication)?.appGraphOrNull
+        if (appGraph != null) {
+            appGraph.reviewReminderAttentionController.markDeliveredReviewReminder(
+                workspaceId = workspaceId,
+                requestId = requestId,
+                deliveredAtMillis = deliveredAtMillis
+            )
+            return
+        }
+
+        SharedPreferencesReviewNotificationsStore(context = applicationContext).markReviewReminderAttention(
+            state = ReviewReminderAttentionState(
+                workspaceId = workspaceId,
+                requestId = requestId,
+                deliveredAtMillis = deliveredAtMillis
+            )
+        )
     }
 
     private fun addWorkerBreadcrumb(

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewReminderAttentionController.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/notifications/review/ReviewReminderAttentionController.kt
@@ -1,0 +1,68 @@
+package com.flashcardsopensourceapp.app.notifications.review
+
+import com.flashcardsopensourceapp.data.local.database.review.ReviewLogDao
+import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationsStore
+import com.flashcardsopensourceapp.data.local.notifications.ReviewReminderAttentionState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class ReviewReminderAttentionController(
+    private val reviewNotificationsStore: ReviewNotificationsStore,
+    private val reviewLogDao: ReviewLogDao
+) {
+    private val attentionStateMutable = MutableStateFlow(
+        value = reviewNotificationsStore.loadReviewReminderAttentionState()
+    )
+
+    val attentionState: StateFlow<ReviewReminderAttentionState?> =
+        attentionStateMutable.asStateFlow()
+
+    fun markDeliveredReviewReminder(
+        workspaceId: String,
+        requestId: String,
+        deliveredAtMillis: Long
+    ) {
+        val state = ReviewReminderAttentionState(
+            workspaceId = workspaceId,
+            requestId = requestId,
+            deliveredAtMillis = deliveredAtMillis
+        )
+        reviewNotificationsStore.markReviewReminderAttention(state = state)
+        attentionStateMutable.value = state
+    }
+
+    fun clearAfterSuccessfulReview() {
+        reviewNotificationsStore.clearReviewReminderAttention()
+        attentionStateMutable.value = null
+    }
+
+    fun reloadFromStore() {
+        attentionStateMutable.value = reviewNotificationsStore.loadReviewReminderAttentionState()
+    }
+
+    suspend fun reconcileWithReviewHistory() {
+        val storedState = reviewNotificationsStore.loadReviewReminderAttentionState()
+        if (storedState == null) {
+            attentionStateMutable.value = null
+            return
+        }
+
+        val hasNewerReview = reviewLogDao.hasReviewLogsAfter(
+            workspaceId = storedState.workspaceId,
+            afterMillis = storedState.deliveredAtMillis
+        )
+        val currentState = reviewNotificationsStore.loadReviewReminderAttentionState()
+        if (currentState != storedState) {
+            attentionStateMutable.value = currentState
+            return
+        }
+        if (hasNewerReview.not()) {
+            attentionStateMutable.value = storedState
+            return
+        }
+
+        reviewNotificationsStore.clearReviewReminderAttention()
+        attentionStateMutable.value = null
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewLogDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/review/ReviewLogDao.kt
@@ -63,6 +63,19 @@ interface ReviewLogDao {
         SELECT EXISTS(
             SELECT 1
             FROM review_logs
+            WHERE workspaceId = :workspaceId
+                AND reviewedAtMillis > :afterMillis
+            LIMIT 1
+        )
+        """
+    )
+    suspend fun hasReviewLogsAfter(workspaceId: String, afterMillis: Long): Boolean
+
+    @Query(
+        """
+        SELECT EXISTS(
+            SELECT 1
+            FROM review_logs
             WHERE reviewedAtMillis < :endMillis
             LIMIT 1
         )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/notifications/ReviewNotificationsStore.kt
@@ -30,6 +30,7 @@ private const val strictRemindersLastCompletedReviewAtKey: String = "strict-remi
 private const val reviewNotificationsPromptStateKey: String = "review-notifications-prompt-state"
 private const val reviewNotificationsSuccessfulReviewCountKey: String = "review-notifications-successful-review-count"
 private const val reviewNotificationsLastActiveAtKey: String = "review-notifications-last-active-at"
+private const val reviewReminderAttentionStateKey: String = "review-reminder-attention-state"
 private const val reviewNotificationsModeDaily: String = "daily"
 private const val reviewNotificationsModeInactivity: String = "inactivity"
 private const val reviewFilterKindKey: String = "kind"
@@ -95,6 +96,24 @@ data class CurrentReviewNotificationCard(
     val frontText: String
 )
 
+data class ReviewReminderAttentionState(
+    val workspaceId: String,
+    val requestId: String,
+    val deliveredAtMillis: Long
+) {
+    init {
+        require(workspaceId.isNotBlank()) {
+            "Review reminder attention state requires a workspaceId."
+        }
+        require(requestId.isNotBlank()) {
+            "Review reminder attention state requires a requestId."
+        }
+        require(deliveredAtMillis >= 0L) {
+            "Review reminder attention state requires a non-negative deliveredAtMillis."
+        }
+    }
+}
+
 fun defaultReviewNotificationsSettings(): ReviewNotificationsSettings {
     return ReviewNotificationsSettings(
         isEnabled = true,
@@ -140,6 +159,9 @@ interface ReviewNotificationsStore {
     fun loadLastActiveAtMillis(): Long?
     fun saveLastActiveAtMillis(timestampMillis: Long)
     fun clearLastActiveAtMillis()
+    fun loadReviewReminderAttentionState(): ReviewReminderAttentionState?
+    fun markReviewReminderAttention(state: ReviewReminderAttentionState)
+    fun clearReviewReminderAttention()
     fun loadScheduledPayloads(workspaceId: String): List<ScheduledReviewNotificationPayload>
     fun saveScheduledPayloads(workspaceId: String, payloads: List<ScheduledReviewNotificationPayload>)
 }
@@ -276,6 +298,35 @@ class SharedPreferencesReviewNotificationsStore(
     override fun clearLastActiveAtMillis() {
         preferences.edit(commit = true) {
             remove(reviewNotificationsLastActiveAtKey)
+        }
+    }
+
+    override fun loadReviewReminderAttentionState(): ReviewReminderAttentionState? {
+        val rawValue = preferences.getString(reviewReminderAttentionStateKey, null)
+            ?: return null
+
+        return try {
+            decodeReviewReminderAttentionState(rawValue = rawValue)
+        } catch (_: Exception) {
+            preferences.edit(commit = true) {
+                remove(reviewReminderAttentionStateKey)
+            }
+            null
+        }
+    }
+
+    override fun markReviewReminderAttention(state: ReviewReminderAttentionState) {
+        preferences.edit(commit = true) {
+            putString(
+                reviewReminderAttentionStateKey,
+                encodeReviewReminderAttentionState(state = state)
+            )
+        }
+    }
+
+    override fun clearReviewReminderAttention() {
+        preferences.edit(commit = true) {
+            remove(reviewReminderAttentionStateKey)
         }
     }
 
@@ -790,6 +841,23 @@ private fun decodePromptState(rawValue: String): NotificationPermissionPromptSta
         hasShownPrePrompt = payload.getBoolean("hasShownPrePrompt"),
         hasRequestedSystemPermission = payload.getBoolean("hasRequestedSystemPermission"),
         hasDismissedPrePrompt = payload.getBoolean("hasDismissedPrePrompt")
+    )
+}
+
+private fun encodeReviewReminderAttentionState(state: ReviewReminderAttentionState): String {
+    return JSONObject().apply {
+        put("workspaceId", state.workspaceId)
+        put("requestId", state.requestId)
+        put("deliveredAtMillis", state.deliveredAtMillis)
+    }.toString()
+}
+
+private fun decodeReviewReminderAttentionState(rawValue: String): ReviewReminderAttentionState {
+    val payload = JSONObject(rawValue)
+    return ReviewReminderAttentionState(
+        workspaceId = payload.getString("workspaceId"),
+        requestId = payload.getString("requestId"),
+        deliveredAtMillis = payload.getLong("deliveredAtMillis")
     )
 }
 


### PR DESCRIPTION
## Summary
- persist delivered review reminder attention state for Android
- mark the Review top-level destination with a native Material badge when reminder attention is active
- clear attention after successful review recording and reconcile stale state from local review history

## Validation
- git fetch origin main + git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff --check
- direct trailing-whitespace scan on the new controller file
- read-only review subagent: no P0-P4 findings

Gradle was not run because local ./gradlew runs were not explicitly authorized for this task.