### PR TITLE
Add iOS review reminder tab badge

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -251,6 +251,11 @@ struct FlashcardsApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: .NSSystemTimeZoneDidChange)) { _ in
                     self.handleProgressContextSystemChange()
                 }
+                .onReceive(NotificationCenter.default.publisher(for: reviewReminderAttentionStateDidChangeNotificationName)) { _ in
+                    let now = Date()
+                    self.store.reloadReviewReminderAttentionState()
+                    self.store.reconcileReviewReminderAttentionAfterReviewLogs(now: now)
+                }
                 .task(id: self.isAppNotificationTapConsumptionReady) {
                     await self.consumePendingAppNotificationTapIfNeeded()
                 }

--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -63,6 +63,13 @@ struct RootTabView: View {
         )
     }
 
+    private var reviewReminderAttentionBadgeCount: Int {
+        isReviewReminderAttentionVisible(
+            state: store.reviewReminderAttentionState,
+            workspaceId: store.workspace?.workspaceId
+        ) ? 1 : 0
+    }
+
     private var guestSignInAfterReviewPromptPresentation: Binding<Bool> {
         Binding<Bool>(
             get: {
@@ -472,6 +479,7 @@ struct RootTabView: View {
             )
             .accessibilityIdentifier(UITestIdentifier.rootTabReviewItem)
         }
+        .badge(self.reviewReminderAttentionBadgeCount)
         .tag(AppTab.review)
     }
 

--- a/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
@@ -102,17 +102,23 @@ extension FlashcardsStore {
     func submitReview(cardId: String, rating: ReviewRating) throws {
         let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
+        let reviewedAtClient = nowIsoTimestamp()
         _ = try context.database.submitReview(
             workspaceId: context.workspaceId,
             reviewSubmission: ReviewSubmission(
                 cardId: cardId,
                 rating: rating,
-                reviewedAtClient: nowIsoTimestamp()
+                reviewedAtClient: reviewedAtClient
             )
+        )
+        let reviewedAt = parseIsoTimestamp(value: reviewedAtClient) ?? now
+        _ = self.recordSuccessfulReviewNotificationEffects(
+            reviewedAt: reviewedAt,
+            workspaceId: context.workspaceId,
+            now: now
         )
         self.handleReviewScheduleLocalCardStateDidChange(now: now)
         self.refreshLocalReadModels(now: now)
-        self.recordSuccessfulStrictReminderReview(reviewedAt: now, now: now)
         self.triggerCloudSyncIfLinked(trigger: self.localMutationCloudSyncTrigger(now: now))
     }
 

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Read.swift
@@ -44,6 +44,22 @@ extension LocalDatabase {
         try self.core.scalarInt(sql: "SELECT COUNT(*) FROM review_events", values: [])
     }
 
+    func hasReviewEvent(workspaceId: String, after date: Date) throws -> Bool {
+        try self.core.scalarInt(
+            sql: """
+            SELECT EXISTS(
+                SELECT 1
+                FROM review_events
+                WHERE workspace_id = ? AND reviewed_at_client > ?
+            )
+            """,
+            values: [
+                .text(workspaceId),
+                .text(formatIsoTimestamp(date: date))
+            ]
+        ) == 1
+    }
+
     func loadFeedbackReviewActivitySummary(
         workspaceId: String,
         now: Date,

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -101,6 +101,85 @@ extension FlashcardsStore {
         }
     }
 
+    func markReviewReminderAttention(
+        workspaceId: String,
+        requestId: String,
+        deliveredAtMillis: Int64
+    ) {
+        let state = makeReviewReminderAttentionState(
+            workspaceId: workspaceId,
+            requestId: requestId,
+            deliveredAtMillis: deliveredAtMillis
+        )
+        self.reviewReminderAttentionState = state
+        saveReviewReminderAttentionState(
+            state: state,
+            userDefaults: self.userDefaults,
+            encoder: self.encoder
+        )
+    }
+
+    func clearReviewReminderAttention(workspaceId: String) {
+        guard self.reviewReminderAttentionState?.workspaceId == workspaceId else {
+            return
+        }
+
+        self.reviewReminderAttentionState = nil
+        clearReviewReminderAttentionState(userDefaults: self.userDefaults)
+    }
+
+    func reloadReviewReminderAttentionState() {
+        self.reviewReminderAttentionState = loadReviewReminderAttentionState(
+            userDefaults: self.userDefaults,
+            decoder: self.decoder
+        )
+    }
+
+    func reconcileReviewReminderAttentionAfterReviewLogs(now _: Date) {
+        guard let state = self.reviewReminderAttentionState else {
+            return
+        }
+        guard isReviewReminderAttentionVisible(
+            state: state,
+            workspaceId: self.workspace?.workspaceId
+        ) else {
+            return
+        }
+        guard let database = self.database else {
+            return
+        }
+
+        do {
+            let deliveredAt = Date(timeIntervalSince1970: TimeInterval(state.deliveredAtMillis) / 1_000)
+            if try database.hasReviewEvent(workspaceId: state.workspaceId, after: deliveredAt) {
+                self.clearReviewReminderAttention(workspaceId: state.workspaceId)
+            }
+        } catch {
+            FlashcardsObservability.captureWarning(
+                .localDataRepair(
+                    LocalDataRepairWarning(
+                        action: "review_reminder_attention_reconcile_failed",
+                        scope: IOSObservationScope(
+                            feature: .notifications,
+                            userId: nil,
+                            workspaceId: state.workspaceId,
+                            requestId: nil,
+                            clientRequestId: nil,
+                            sessionId: nil,
+                            runId: nil,
+                            cloudState: self.cloudSettings?.cloudState,
+                            configurationMode: nil
+                        ),
+                        workspaceId: state.workspaceId,
+                        cardId: nil,
+                        reason: Flashcards.errorMessage(error: error),
+                        repair: "keep_review_reminder_attention_state"
+                    )
+                )
+            )
+        }
+    }
+
     func dismissReviewNotificationPrePrompt(markDismissed: Bool) {
         self.isReviewNotificationPrePromptPresented = false
         if markDismissed {
@@ -184,20 +263,30 @@ extension FlashcardsStore {
         switch request {
         case .fallback(let fallback):
             logAppNotificationTapFallback(fallback: fallback)
-        case .openReviewReminder, .openStrictReminder:
+        case .openReviewReminder:
+            self.reloadReviewReminderAttentionState()
+            navigation.selectTab(.review)
+        case .openStrictReminder:
             navigation.selectTab(.review)
         }
     }
 
-    func resolveSuccessfulReviewNotificationPrePromptDecision(reviewedAt: Date, now: Date) async -> Bool {
+    func recordSuccessfulReviewNotificationEffects(
+        reviewedAt: Date,
+        workspaceId: String,
+        now: Date
+    ) -> Int {
         let nextCount = self.userDefaults.integer(forKey: reviewNotificationSuccessfulReviewCountUserDefaultsKey) + 1
         self.userDefaults.set(nextCount, forKey: reviewNotificationSuccessfulReviewCountUserDefaultsKey)
         self.userDefaults.set(now.timeIntervalSince1970, forKey: reviewNotificationLastActiveAtUserDefaultsKey)
         self.reconcileReviewNotifications(trigger: .reviewRecorded, now: now)
+        self.clearReviewReminderAttention(workspaceId: workspaceId)
         self.clearAppIconBadge()
         self.recordSuccessfulStrictReminderReview(reviewedAt: reviewedAt, now: now)
-        let reviewCount = self.loadReviewNotificationPromptReviewCount(persistedReviewCount: nextCount)
+        return self.loadReviewNotificationPromptReviewCount(persistedReviewCount: nextCount)
+    }
 
+    func resolveSuccessfulReviewNotificationPrePromptDecision(reviewCount: Int) async -> Bool {
         defer {
             self.requestGuestSignInAfterReviewPromptReconciliation()
         }
@@ -336,6 +425,14 @@ extension FlashcardsStore {
 
         let center = UNUserNotificationCenter.current()
         let pendingRequestIdentifiers = await pendingReviewNotificationRequestIdentifiers(center: center)
+        if trigger.shouldClearDeliveredReviewNotifications {
+            let deliveredReviewNotifications = await deliveredReviewReminderNotifications(center: center)
+            self.markReviewReminderAttentionFromDeliveredNotifications(
+                notifications: deliveredReviewNotifications,
+                workspaceId: workspaceId
+            )
+            self.reconcileReviewReminderAttentionAfterReviewLogs(now: now)
+        }
         if pendingRequestIdentifiers.isEmpty == false {
             center.removePendingNotificationRequests(withIdentifiers: pendingRequestIdentifiers)
         }
@@ -581,6 +678,31 @@ extension FlashcardsStore {
             )
         }
         self.persistScheduledReviewNotifications(payloads: acceptedPayloads)
+    }
+
+    private func markReviewReminderAttentionFromDeliveredNotifications(
+        notifications: [UNNotification],
+        workspaceId: String
+    ) {
+        let states = notifications.compactMap { notification in
+            makeReviewReminderAttentionState(
+                notification: notification
+            )
+        }
+        let currentWorkspaceStates = states.filter { state in
+            state.workspaceId == workspaceId
+        }
+        guard let latestState = currentWorkspaceStates.max(by: { lhs, rhs in
+            lhs.deliveredAtMillis < rhs.deliveredAtMillis
+        }) else {
+            return
+        }
+
+        self.markReviewReminderAttention(
+            workspaceId: latestState.workspaceId,
+            requestId: latestState.requestId,
+            deliveredAtMillis: latestState.deliveredAtMillis
+        )
     }
 
     private func persistScheduledReviewNotifications(payloads: [ScheduledReviewNotificationPayload]) {

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationDiagnosticsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationDiagnosticsSupport.swift
@@ -122,6 +122,21 @@ func deliveredReviewNotificationRequestIdentifiers(
     }
 }
 
+func deliveredReviewReminderNotifications(
+    center: UNUserNotificationCenter
+) async -> [UNNotification] {
+    await withCheckedContinuation { continuation in
+        center.getDeliveredNotifications { notifications in
+            continuation.resume(
+                returning: notifications.filter { notification in
+                    isReviewNotificationRequestIdentifier(identifier: notification.request.identifier)
+                        && parseAppNotificationTapRequest(userInfo: notification.request.content.userInfo) == .openReviewReminder
+                }
+            )
+        }
+    }
+}
+
 /// Removes delivered review reminders from Notification Center.
 func removeDeliveredReviewNotifications(
     center: UNUserNotificationCenter

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPayloadSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPayloadSupport.swift
@@ -7,6 +7,7 @@ let reviewNotificationFallbackBodyText: String = String(
 )
 
 let reviewNotificationScheduledPayloadsUserDefaultsKeyPrefix: String = "review-notification-scheduled-payloads::"
+let reviewNotificationRequestIdentifierPrefix: String = "review-notification::"
 
 struct ScheduledReviewNotificationPayload: Hashable, Sendable, Identifiable {
     let workspaceId: String
@@ -166,12 +167,34 @@ func loadScheduledReviewNotifications(
 }
 
 func makeReviewNotificationRequestIdentifier(workspaceId: String, kind: String, suffix: String) -> String {
-    "review-notification::\(workspaceId)::\(kind)::\(suffix)"
+    "\(reviewNotificationRequestIdentifierPrefix)\(workspaceId)::\(kind)::\(suffix)"
 }
 
 /// Review reminders are identified by the shared `review-notification::` identifier prefix.
 func isReviewNotificationRequestIdentifier(identifier: String) -> Bool {
-    identifier.hasPrefix("review-notification::")
+    identifier.hasPrefix(reviewNotificationRequestIdentifierPrefix)
+}
+
+func reviewNotificationRequestWorkspaceId(identifier: String) -> String? {
+    guard identifier.hasPrefix(reviewNotificationRequestIdentifierPrefix) else {
+        return nil
+    }
+
+    let prefixEndIndex = identifier.index(
+        identifier.startIndex,
+        offsetBy: reviewNotificationRequestIdentifierPrefix.count
+    )
+    let suffix = identifier[prefixEndIndex...]
+    guard let separatorRange = suffix.range(of: "::") else {
+        return nil
+    }
+
+    let workspaceId = String(suffix[..<separatorRange.lowerBound])
+    guard workspaceId.isEmpty == false else {
+        return nil
+    }
+
+    return workspaceId
 }
 
 /// Keeps only identifiers that belong to review reminders.

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsAppDelegate.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationsAppDelegate.swift
@@ -15,7 +15,12 @@ final class ReviewNotificationsAppDelegate: NSObject, UIApplicationDelegate, UNU
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        [.banner, .sound]
+        persistReviewReminderAttentionState(
+            notification: notification,
+            userDefaults: .standard,
+            encoder: JSONEncoder()
+        )
+        return [.banner, .sound]
     }
 
     nonisolated func userNotificationCenter(
@@ -45,6 +50,13 @@ final class ReviewNotificationsAppDelegate: NSObject, UIApplicationDelegate, UNU
             logAppNotificationTapEvent(action: "notification_tap_dropped", metadata: droppedMetadata)
             completionHandler()
             return
+        }
+        if request == .openReviewReminder {
+            persistReviewReminderAttentionState(
+                notification: response.notification,
+                userDefaults: .standard,
+                encoder: JSONEncoder()
+            )
         }
 
         let receivedMetadata = makeAppNotificationTapLogMetadata(

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewReminderAttentionSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewReminderAttentionSupport.swift
@@ -1,0 +1,130 @@
+import Foundation
+import UserNotifications
+
+let reviewReminderAttentionStateUserDefaultsKey: String = "review-reminder-attention-state"
+let reviewReminderAttentionStateDidChangeNotificationName: Notification.Name = Notification.Name(
+    "reviewReminderAttentionStateDidChange"
+)
+
+struct ReviewReminderAttentionState: Codable, Hashable, Sendable {
+    let workspaceId: String
+    let requestId: String
+    let deliveredAtMillis: Int64
+}
+
+func makeReviewReminderAttentionState(
+    workspaceId: String,
+    requestId: String,
+    deliveredAtMillis: Int64
+) -> ReviewReminderAttentionState {
+    ReviewReminderAttentionState(
+        workspaceId: workspaceId,
+        requestId: requestId,
+        deliveredAtMillis: deliveredAtMillis
+    )
+}
+
+func isReviewReminderAttentionVisible(
+    state: ReviewReminderAttentionState?,
+    workspaceId: String?
+) -> Bool {
+    guard let state, let workspaceId else {
+        return false
+    }
+
+    return state.workspaceId == workspaceId
+}
+
+func loadReviewReminderAttentionState(
+    userDefaults: UserDefaults,
+    decoder: JSONDecoder
+) -> ReviewReminderAttentionState? {
+    guard let data = userDefaults.data(forKey: reviewReminderAttentionStateUserDefaultsKey) else {
+        return nil
+    }
+
+    do {
+        return try decoder.decode(ReviewReminderAttentionState.self, from: data)
+    } catch {
+        captureReviewNotificationsSilentFailure(
+            error: error,
+            action: "review_reminder_attention_state_load",
+            stage: "decode",
+            cloudSettings: nil,
+            workspaceId: nil,
+            configurationMode: nil
+        )
+        userDefaults.removeObject(forKey: reviewReminderAttentionStateUserDefaultsKey)
+        return nil
+    }
+}
+
+func saveReviewReminderAttentionState(
+    state: ReviewReminderAttentionState,
+    userDefaults: UserDefaults,
+    encoder: JSONEncoder
+) {
+    do {
+        let data = try encoder.encode(state)
+        userDefaults.set(data, forKey: reviewReminderAttentionStateUserDefaultsKey)
+    } catch {
+        captureReviewNotificationsSilentFailure(
+            error: error,
+            action: "review_reminder_attention_state_save",
+            stage: "encode",
+            cloudSettings: nil,
+            workspaceId: state.workspaceId,
+            configurationMode: nil
+        )
+        userDefaults.removeObject(forKey: reviewReminderAttentionStateUserDefaultsKey)
+    }
+}
+
+func clearReviewReminderAttentionState(userDefaults: UserDefaults) {
+    userDefaults.removeObject(forKey: reviewReminderAttentionStateUserDefaultsKey)
+}
+
+func makeReviewReminderAttentionState(
+    notification: UNNotification
+) -> ReviewReminderAttentionState? {
+    guard parseAppNotificationTapRequest(userInfo: notification.request.content.userInfo) == .openReviewReminder else {
+        return nil
+    }
+
+    let requestId = notification.request.identifier
+    guard let workspaceId = reviewNotificationRequestWorkspaceId(identifier: requestId) else {
+        return nil
+    }
+
+    return makeReviewReminderAttentionState(
+        workspaceId: workspaceId,
+        requestId: requestId,
+        deliveredAtMillis: epochMillis(date: notification.date)
+    )
+}
+
+@discardableResult
+func persistReviewReminderAttentionState(
+    notification: UNNotification,
+    userDefaults: UserDefaults,
+    encoder: JSONEncoder
+) -> ReviewReminderAttentionState? {
+    guard let state = makeReviewReminderAttentionState(
+        notification: notification
+    ) else {
+        return nil
+    }
+
+    saveReviewReminderAttentionState(
+        state: state,
+        userDefaults: userDefaults,
+        encoder: encoder
+    )
+    Task { @MainActor in
+        NotificationCenter.default.post(
+            name: reviewReminderAttentionStateDidChangeNotificationName,
+            object: nil
+        )
+    }
+    return state
+}

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
@@ -293,6 +293,12 @@ extension FlashcardsStore {
                 )
             )
             let now = Date()
+            let reviewedAt = parseIsoTimestamp(value: request.reviewedAtClient) ?? now
+            let reviewCount = self.recordSuccessfulReviewNotificationEffects(
+                reviewedAt: reviewedAt,
+                workspaceId: request.workspaceId,
+                now: now
+            )
             guard self.reviewSubmissionRequestMatchesCurrentContext(request: request, now: now) else {
                 self.applyStaleReviewSubmissionCompletion(request: request)
                 return
@@ -339,10 +345,8 @@ extension FlashcardsStore {
                 )
             }
 
-            let reviewedAt = parseIsoTimestamp(value: request.reviewedAtClient) ?? now
             let shouldShowReviewNotificationPrePrompt = await self.resolveSuccessfulReviewNotificationPrePromptDecision(
-                reviewedAt: reviewedAt,
-                now: now
+                reviewCount: reviewCount
             )
             guard self.successfulReviewSubmissionPromptContextMatchesCurrentState(
                 request: request,

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore+Bootstrap.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore+Bootstrap.swift
@@ -133,6 +133,8 @@ extension FlashcardsStore {
         self.globalErrorMessage = ""
         self.reloadReviewNotificationsSettings()
         self.reloadStrictRemindersSettings()
+        self.reloadReviewReminderAttentionState()
+        self.reconcileReviewReminderAttentionAfterReviewLogs(now: now)
         self.localReadVersion += 1
         if refreshVisibleProgress {
             self.prepareProgressForCurrentVisibleTabAndRefreshIfNeeded(now: now)
@@ -202,6 +204,8 @@ extension FlashcardsStore {
         self.globalErrorMessage = ""
         self.reloadReviewNotificationsSettings()
         self.reloadStrictRemindersSettings()
+        self.reloadReviewReminderAttentionState()
+        self.reconcileReviewReminderAttentionAfterReviewLogs(now: now)
         if workspaceChanged {
             self.resetReviewHardReminderSession()
         }

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -95,6 +95,7 @@ final class FlashcardsStore {
     var isTestModeEnabled: Bool
     var reviewNotificationsSettings: ReviewNotificationsSettings
     var strictRemindersSettings: StrictRemindersSettings
+    var reviewReminderAttentionState: ReviewReminderAttentionState?
     var notificationPermissionPromptState: NotificationPermissionPromptState
     var isReviewNotificationPrePromptPresented: Bool
     var guestSignInAfterReviewPromptState: GuestSignInAfterReviewPromptState
@@ -397,6 +398,10 @@ final class FlashcardsStore {
         self.isTestModeEnabled = userDefaults.bool(forKey: testModeEnabledUserDefaultsKey)
         self.reviewNotificationsSettings = makeDefaultReviewNotificationsSettings()
         self.strictRemindersSettings = loadStrictRemindersSettings(
+            userDefaults: userDefaults,
+            decoder: decoder
+        )
+        self.reviewReminderAttentionState = loadReviewReminderAttentionState(
             userDefaults: userDefaults,
             decoder: decoder
         )


### PR DESCRIPTION
## Summary
- persist delivered iOS review reminder attention state
- show a native Review tab badge while review reminder attention is active
- clear the badge after successful local reviews in the matching workspace

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git --no-pager diff --check
- xcrun swiftc -parse ...
- worker-owned review: no P0-P4 findings

Full xcodebuild was not run because local disk space was too low for Sentry artifact extraction. Simulator-backed iOS tests were not authorized.