### PR TITLE
Add iOS review reminder badge smoke

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
+++ b/apps/ios/Flashcards/Flashcards/App/RootTabView.swift
@@ -1,5 +1,8 @@
+import Foundation
 import StoreKit
 import SwiftUI
+
+private let rootTabUITestLaunchScenarioEnvironmentKey: String = "FLASHCARDS_UI_TEST_LAUNCH_SCENARIO"
 
 private struct StoreReviewRequestTaskID: Hashable {
     let isSceneActive: Bool
@@ -68,6 +71,10 @@ struct RootTabView: View {
             state: store.reviewReminderAttentionState,
             workspaceId: store.workspace?.workspaceId
         ) ? 1 : 0
+    }
+
+    private var shouldExposeReviewReminderAttentionBadgeMarker: Bool {
+        ProcessInfo.processInfo.environment[rootTabUITestLaunchScenarioEnvironmentKey] != nil
     }
 
     private var guestSignInAfterReviewPromptPresentation: Binding<Bool> {
@@ -467,6 +474,9 @@ struct RootTabView: View {
     private var reviewTab: some View {
         NavigationStack {
             ReviewView()
+                .overlay(alignment: .topLeading) {
+                    self.reviewReminderAttentionBadgeMarker
+                }
         }
         .tabItem {
             Label(
@@ -481,6 +491,18 @@ struct RootTabView: View {
         }
         .badge(self.reviewReminderAttentionBadgeCount)
         .tag(AppTab.review)
+    }
+
+    @ViewBuilder
+    private var reviewReminderAttentionBadgeMarker: some View {
+        if self.shouldExposeReviewReminderAttentionBadgeMarker && self.reviewReminderAttentionBadgeCount > 0 {
+            Color.clear
+                .frame(width: 1, height: 1)
+                .allowsHitTesting(false)
+                .accessibilityElement(children: .ignore)
+                .accessibilityIdentifier(UITestIdentifier.rootTabReviewReminderBadge)
+                .accessibilityValue(String(self.reviewReminderAttentionBadgeCount))
+        }
     }
 
     private var progressTab: some View {

--- a/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
+++ b/apps/ios/Flashcards/Flashcards/App/UITestIdentifiers.swift
@@ -15,6 +15,7 @@ enum UITestIdentifier {
     static let cloudCredentialRecoveryGateEraseButton: String = "cloudCredentialRecoveryGate.eraseButton"
     static let cloudCredentialRecoveryGateEraseProgress: String = "cloudCredentialRecoveryGate.eraseProgress"
     static let rootTabReviewItem: String = "rootTab.review.item"
+    static let rootTabReviewReminderBadge: String = "rootTab.review.reminderBadge"
     static let rootTabAIItem: String = "rootTab.ai.item"
     static let rootTabProgressItem: String = "rootTab.progress.item"
     static let rootTabCardsItem: String = "rootTab.cards.item"

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
@@ -5,13 +5,14 @@ private let marketingScreenshotLocalizationEnvironmentKey: String = "FLASHCARDS_
 enum FlashcardsUITestLaunchScenario: String {
     case guestEmptyWorkspace = "guest_empty_workspace"
     case guestManualReviewCard = "guest_manual_review_card"
+    case guestManualReviewCardWithReminderAttention = "guest_manual_review_card_with_reminder_attention"
     case guestAIReviewCard = "guest_ai_review_card"
     case marketingScreenshots = "marketing_screenshots"
     case marketingGuestSessionCleanup = "marketing_guest_session_cleanup"
 
     var requiresGuestCloudBootstrap: Bool {
         switch self {
-        case .guestEmptyWorkspace, .guestManualReviewCard, .guestAIReviewCard:
+        case .guestEmptyWorkspace, .guestManualReviewCard, .guestManualReviewCardWithReminderAttention, .guestAIReviewCard:
             return false
         case .marketingScreenshots:
             return true
@@ -24,7 +25,7 @@ enum FlashcardsUITestLaunchScenario: String {
         switch self {
         case .marketingScreenshots, .marketingGuestSessionCleanup:
             return true
-        case .guestEmptyWorkspace, .guestManualReviewCard, .guestAIReviewCard:
+        case .guestEmptyWorkspace, .guestManualReviewCard, .guestManualReviewCardWithReminderAttention, .guestAIReviewCard:
             return false
         }
     }
@@ -646,6 +647,13 @@ extension FlashcardsStore {
             return
         case .guestManualReviewCard:
             try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.manualReviewCard, context: context)
+        case .guestManualReviewCardWithReminderAttention:
+            try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.manualReviewCard, context: context)
+            self.markReviewReminderAttention(
+                workspaceId: context.workspaceId,
+                requestId: "ui-test-review-reminder-attention",
+                deliveredAtMillis: epochMillis(date: Date())
+            )
         case .guestAIReviewCard:
             try self.createUITestCard(card: FlashcardsUITestLaunchScenarioData.aiReviewCard, context: context)
         case .marketingScreenshots:

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeReviewTests.swift
@@ -13,6 +13,25 @@ final class LiveSmokeReviewTests: LiveSmokeTestCase {
     }
 
     @MainActor
+    func testLiveSmokeReviewReminderTabBadgeClearsAfterReview() throws {
+        try self.launchApplication(launchScenario: .guestManualReviewCardWithReminderAttention, selectedTab: .review)
+
+        try self.step("verify review reminder tab badge is visible") {
+            try self.assertReviewReminderTabBadgeVisible(timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        }
+
+        try self.step("review the reminded guest manual card") {
+            try self.reviewCurrentCard(
+                expectedFrontText: LiveSmokeLaunchFixtureData.manualReviewFrontText
+            )
+        }
+
+        try self.step("verify review reminder tab badge is gone") {
+            try self.assertReviewReminderTabBadgeHidden(timeout: LiveSmokeConfiguration.shortUiTimeoutSeconds)
+        }
+    }
+
+    @MainActor
     func testLiveSmokeGuestAiCardReviewFlow() throws {
         try self.launchApplication(launchScenario: .guestAIReviewCard, selectedTab: .review)
 

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Configuration/LiveSmokeIdentifiers.swift
@@ -12,6 +12,7 @@ enum LiveSmokeIdentifier {
     static let cloudSignInPostAuthFailureMessage: String = "cloudSignIn.postAuthFailure.message"
     static let cloudSignInExistingWorkspacePrefix: String = "cloudSignIn.existingWorkspace."
     static let rootTabReviewItem: String = "rootTab.review.item"
+    static let rootTabReviewReminderBadge: String = "rootTab.review.reminderBadge"
     static let rootTabAIItem: String = "rootTab.ai.item"
     static let rootTabProgressItem: String = "rootTab.progress.item"
     static let rootTabCardsItem: String = "rootTab.cards.item"
@@ -114,6 +115,7 @@ enum LiveSmokeIdentifier {
 enum LiveSmokeLaunchScenario: String {
     case guestEmptyWorkspace = "guest_empty_workspace"
     case guestManualReviewCard = "guest_manual_review_card"
+    case guestManualReviewCardWithReminderAttention = "guest_manual_review_card_with_reminder_attention"
     case guestAIReviewCard = "guest_ai_review_card"
     case marketingScreenshots = "marketing_screenshots"
     case marketingGuestSessionCleanup = "marketing_guest_session_cleanup"

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Interactions/LiveSmokeTabBarInteractions.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSupport/Interactions/LiveSmokeTabBarInteractions.swift
@@ -9,6 +9,101 @@ private struct LiveSmokeTabBarItemCandidate {
 
 extension LiveSmokeTestCase {
     @MainActor
+    func assertReviewReminderTabBadgeVisible(timeout: TimeInterval) throws {
+        try self.runWithInlineRawScreenStateOnFailure(action: "assert_review_reminder_tab_badge_visible") {
+            let badge = self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge)
+                .firstMatch
+            if self.waitForOptionalElement(
+                badge,
+                identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                timeout: timeout
+            ) == false {
+                throw LiveSmokeFailure.missingElement(
+                    identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                    timeoutSeconds: timeout,
+                    screen: self.currentScreenSummary(),
+                    step: self.currentStepTitle
+                )
+            }
+
+            if try self.waitForElementValue(
+                badge,
+                identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                expectedValue: "1",
+                timeout: LiveSmokeConfiguration.optionalProbeTimeoutSeconds
+            ) == false {
+                throw LiveSmokeFailure.unexpectedElementValue(
+                    identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                    expectedValue: "1",
+                    actualValue: self.elementValue(element: badge),
+                    timeoutSeconds: LiveSmokeConfiguration.optionalProbeTimeoutSeconds,
+                    screen: self.currentScreenSummary(),
+                    step: self.currentStepTitle
+                )
+            }
+        }
+    }
+
+    @MainActor
+    func assertReviewReminderTabBadgeHidden(timeout: TimeInterval) throws {
+        try self.runWithInlineRawScreenStateOnFailure(action: "assert_review_reminder_tab_badge_hidden") {
+            let badge = self.app.descendants(matching: .any)
+                .matching(identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge)
+                .firstMatch
+            let startedAt = Date()
+            let deadline = startedAt.addingTimeInterval(timeout)
+
+            self.logSmokeBreadcrumb(
+                event: "wait_start",
+                action: "wait_for_element_to_disappear",
+                identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                timeoutSeconds: formatDuration(seconds: timeout),
+                durationSeconds: "-",
+                result: "start",
+                note: "waiting for badge marker to disappear"
+            )
+
+            while Date() < deadline {
+                if badge.exists == false {
+                    let durationSeconds = Date().timeIntervalSince(startedAt)
+                    self.logSmokeBreadcrumb(
+                        event: "wait_end",
+                        action: "wait_for_element_to_disappear",
+                        identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                        timeoutSeconds: formatDuration(seconds: timeout),
+                        durationSeconds: formatDuration(seconds: durationSeconds),
+                        result: "success",
+                        note: "badge marker disappeared"
+                    )
+                    return
+                }
+
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: liveSmokeFocusPollIntervalSeconds))
+            }
+
+            let durationSeconds = Date().timeIntervalSince(startedAt)
+            self.logSmokeBreadcrumb(
+                event: "wait_end",
+                action: "wait_for_element_to_disappear",
+                identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                timeoutSeconds: formatDuration(seconds: timeout),
+                durationSeconds: formatDuration(seconds: durationSeconds),
+                result: "failure",
+                note: "badge marker still exists value=\(self.elementValue(element: badge))"
+            )
+            throw LiveSmokeFailure.unexpectedElementValue(
+                identifier: LiveSmokeIdentifier.rootTabReviewReminderBadge,
+                expectedValue: "missing",
+                actualValue: self.elementValue(element: badge),
+                timeoutSeconds: timeout,
+                screen: self.currentScreenSummary(),
+                step: self.currentStepTitle
+            )
+        }
+    }
+
+    @MainActor
     func tapTabBarItem(selectedTab: LiveSmokeSelectedTab, timeout: TimeInterval) throws {
         try self.runWithInlineRawScreenStateOnFailure(action: "tap_tab.\(selectedTab.rawValue)") {
             let tabBarItemLookup = selectedTab.tabBarItemLookup(localization: self.currentLaunchLocalization)


### PR DESCRIPTION
## Summary
- add an iOS live smoke scenario that seeds a review reminder attention state
- expose a UI-test-only marker driven by the same Review tab badge count
- assert the badge appears before a real review and clears afterward

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- git diff --check
- worker-owned review: no P0-P4 findings

Simulator-backed XCUITest was not run because simulator approval was not granted for this task.