### PR TITLE
Fix Android review log DAO test fake

### DIFF
--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/notifications/StrictRemindersManagerTest.kt
@@ -399,6 +399,10 @@ private class FakeReviewLogDao(
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }
 
+    override suspend fun hasReviewLogsAfter(workspaceId: String, afterMillis: Long): Boolean {
+        throw UnsupportedOperationException("Unused in strict reminders manager tests.")
+    }
+
     override suspend fun hasReviewLogsBefore(endMillis: Long): Boolean {
         throw UnsupportedOperationException("Unused in strict reminders manager tests.")
     }


### PR DESCRIPTION
## Summary
- Add the missing ReviewLogDao.hasReviewLogsAfter override to the strict reminders test fake
- Keep the fake behavior explicit for methods unused by these tests

## Verification
- git --no-pager diff --check
- Did not run Gradle locally per repository policy