### PR TITLE
Fix Android StateFlow lint error

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -257,9 +257,7 @@ fun FlashcardsApp(
         val settingsAttentionSummary: SettingsAttentionSummary = makeSettingsAttentionSummary(
             issues = makeSettingsAttentionIssues(cloudState = cloudSettings.cloudState)
         )
-        val reviewReminderAttentionState by appGraph.reviewReminderAttentionController.attentionState.collectAsStateWithLifecycle(
-            initialValue = appGraph.reviewReminderAttentionController.attentionState.value
-        )
+        val reviewReminderAttentionState by appGraph.reviewReminderAttentionController.attentionState.collectAsStateWithLifecycle()
         val currentCanRunImmediateAutoSync by rememberUpdatedState(newValue = canRunImmediateAutoSync)
         val currentCanRefreshCloudAccountContext by rememberUpdatedState(newValue = canRefreshCloudAccountContext)
         val currentVisibleAppScreenState by rememberUpdatedState(newValue = currentVisibleAppScreen)


### PR DESCRIPTION
## Summary
- Use the StateFlow collectAsStateWithLifecycle overload for review reminder attention state
- Remove direct StateFlow.value access from composition so Android lint can pass

## Verification
- git --no-pager diff --check
- rg "attentionState\.value|StateFlowValueCalledInComposition" apps/android/app/src/main/java/com/flashcardsopensourceapp/app -n
- Did not run Gradle locally per repository policy