### PR TITLE
Add Android review reminder badge smoke

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -17,6 +17,7 @@ import com.flashcardsopensourceapp.app.livesmoke.diagnostics.tapBackIcon
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTagToExist
 import com.flashcardsopensourceapp.app.livesmoke.support.LiveSmokeContext
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
+import com.flashcardsopensourceapp.app.navigation.ReviewDestination
 import com.flashcardsopensourceapp.feature.settings.access.accessSettingsScreenTag
 import com.flashcardsopensourceapp.feature.settings.account.accountStatusScreenTag
 import com.flashcardsopensourceapp.feature.settings.device.deviceDiagnosticsScreenTag
@@ -62,7 +63,7 @@ internal fun LiveSmokeContext.openCardsTab() {
 
 internal fun LiveSmokeContext.openReviewTab() {
     clickNode(
-        matcher = hasText("Review").and(other = hasClickAction()),
+        matcher = hasTestTag(ReviewDestination.testTag).and(other = hasClickAction()),
         label = "Review tab"
     )
 }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioCardHelpers.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/support/LiveSmokeScenarioCardHelpers.kt
@@ -1,9 +1,9 @@
 package com.flashcardsopensourceapp.app.livesmoke.support
 
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
@@ -28,6 +28,7 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.model.scheduling.EffortLevel
 import com.flashcardsopensourceapp.feature.cards.cardsCardFrontTextTag
 import com.flashcardsopensourceapp.feature.review.reviewCurrentCardFrontContentTag
+import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag
 import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTitleTag
 import com.flashcardsopensourceapp.feature.review.reviewRateGoodButtonTag
 import com.flashcardsopensourceapp.feature.review.reviewShowAnswerButtonTag
@@ -72,7 +73,7 @@ internal fun LiveSmokeContext.createManualCard(
 
 internal fun LiveSmokeContext.rateVisibleReviewCardGood() {
     waitUntilAtLeastOneExistsOrFail(
-        matcher = hasText("Show answer"),
+        matcher = hasTestTag(reviewShowAnswerButtonTag),
         timeoutMillis = internalUiTimeoutMillis
     )
     clickTag(tag = reviewShowAnswerButtonTag, label = "Show answer")
@@ -82,7 +83,7 @@ internal fun LiveSmokeContext.rateVisibleReviewCardGood() {
         context = "while waiting for the review queue to advance"
     ) {
         composeRule.onAllNodesWithTag(reviewShowAnswerButtonTag).fetchSemanticsNodes().isNotEmpty() ||
-            composeRule.onAllNodesWithText("Session complete").fetchSemanticsNodes().isNotEmpty()
+            composeRule.onAllNodesWithTag(reviewEmptyStateTag).fetchSemanticsNodes().isNotEmpty()
     }
 }
 

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTest.kt
@@ -16,9 +16,12 @@ import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilAtLeastOne
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilWithMitigation
 import com.flashcardsopensourceapp.app.livesmoke.flows.openCardsTab
 import com.flashcardsopensourceapp.app.livesmoke.support.LiveSmokeContext
+import com.flashcardsopensourceapp.app.livesmoke.support.assertCardReachableInReview
 import com.flashcardsopensourceapp.app.livesmoke.support.appGraph
 import com.flashcardsopensourceapp.app.livesmoke.support.externalUiTimeoutMillis
 import com.flashcardsopensourceapp.app.livesmoke.support.internalUiTimeoutMillis
+import com.flashcardsopensourceapp.app.livesmoke.support.rateVisibleReviewCardGood
+import com.flashcardsopensourceapp.app.livesmoke.support.seedCardViaRepository
 import com.flashcardsopensourceapp.app.livesmoke.support.step
 import com.flashcardsopensourceapp.app.support.AppStateResetRule
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
@@ -121,6 +124,71 @@ class NotificationTapSmokeTest : FirebaseAppInstrumentationTimeoutTest() {
                 }
             }
         } finally {
+            liveSmokeContext.clearAppNotifications(context = appContext)
+        }
+    }
+
+    @Test
+    fun reviewReminderNotificationBadgeClearsAfterReview() {
+        val appContext = ApplicationProvider.getApplicationContext<Context>()
+        val markerSuffix = System.currentTimeMillis().toString()
+        val requestId = "android-notification-badge-smoke-$markerSuffix"
+        val markerText = "Android notif badge $markerSuffix"
+        val markerTag = "android-notification-badge-smoke-$markerSuffix"
+
+        try {
+            liveSmokeContext.step("clear stale review reminder badge baseline") {
+                liveSmokeContext.clearReviewReminderAttentionForNotificationSmoke()
+            }
+
+            liveSmokeContext.step("prepare one reviewable card") {
+                liveSmokeContext.seedCardViaRepository(
+                    frontText = markerText,
+                    backText = "Back for $markerText",
+                    markerTag = markerTag
+                )
+                liveSmokeContext.assertCardReachableInReview(
+                    expectedFrontText = markerText,
+                    timeoutMillis = internalUiTimeoutMillis
+                )
+            }
+
+            liveSmokeContext.step("verify the review reminder badge is absent before posting") {
+                liveSmokeContext.waitForReviewReminderBadgeToDisappear()
+            }
+
+            liveSmokeContext.step("grant notification permission and clear old notifications") {
+                liveSmokeContext.grantNotificationPermissionOrThrow(context = appContext)
+                liveSmokeContext.clearAppNotifications(context = appContext)
+            }
+
+            liveSmokeContext.step("background app and post one real review reminder notification") {
+                liveSmokeContext.pressHomeAndWaitForLauncher()
+                liveSmokeContext.postReviewReminderNotificationWithAttention(
+                    context = appContext,
+                    frontText = markerText,
+                    requestId = requestId
+                )
+            }
+
+            liveSmokeContext.step("open the app from the posted review reminder") {
+                liveSmokeContext.openNotificationShadeAndTap(frontText = markerText)
+                liveSmokeContext.waitForReviewScreenAfterNotificationTap()
+            }
+
+            liveSmokeContext.step("verify the review destination shows one reminder badge") {
+                liveSmokeContext.waitForReviewReminderBadgeValue(expectedText = "1")
+            }
+
+            liveSmokeContext.step("complete one real review") {
+                liveSmokeContext.rateVisibleReviewCardGood()
+            }
+
+            liveSmokeContext.step("verify the review reminder badge clears after review") {
+                liveSmokeContext.waitForReviewReminderBadgeToDisappear()
+            }
+        } finally {
+            liveSmokeContext.clearReviewReminderAttentionForNotificationSmoke()
             liveSmokeContext.clearAppNotifications(context = appContext)
         }
     }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/notifications/NotificationTapSmokeTestSupport.kt
@@ -5,14 +5,18 @@ import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
 import android.os.ParcelFileDescriptor
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.core.app.NotificationManagerCompat
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
+import com.flashcardsopensourceapp.app.navigation.reviewReminderAttentionBadgeTag
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.countNodesWithTagInAnySemanticsTree
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.currentBlockingSystemDialogSummaryOrNull
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.dismissExternalSystemDialogIfPresent
+import com.flashcardsopensourceapp.app.livesmoke.diagnostics.nodeSummaryIncludingDescendants
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForFlowValue
+import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitForTagToDisappear
 import com.flashcardsopensourceapp.app.livesmoke.diagnostics.waitUntilWithMitigation
 import com.flashcardsopensourceapp.app.livesmoke.support.LiveSmokeContext
 import com.flashcardsopensourceapp.app.livesmoke.support.appGraph
@@ -25,6 +29,7 @@ import com.flashcardsopensourceapp.feature.review.reviewCurrentCardTag
 import com.flashcardsopensourceapp.feature.review.reviewEmptyStateTag
 import java.io.BufferedReader
 import java.io.InputStreamReader
+import kotlinx.coroutines.runBlocking
 
 private const val notificationPermissionUserFixedFlag: String = "user-fixed"
 private const val notificationPermissionUserSetFlag: String = "user-set"
@@ -86,6 +91,28 @@ internal fun LiveSmokeContext.postReviewReminderNotification(
     return notificationId
 }
 
+internal fun LiveSmokeContext.postReviewReminderNotificationWithAttention(
+    context: Context,
+    frontText: String,
+    requestId: String
+): Int {
+    val notificationId = postReviewReminderNotification(
+        context = context,
+        frontText = frontText,
+        requestId = requestId
+    )
+    appGraph().reviewReminderAttentionController.markDeliveredReviewReminder(
+        workspaceId = requireCurrentWorkspaceIdForNotificationSmoke(),
+        requestId = requestId,
+        deliveredAtMillis = System.currentTimeMillis()
+    )
+    return notificationId
+}
+
+internal fun LiveSmokeContext.clearReviewReminderAttentionForNotificationSmoke() {
+    appGraph().reviewReminderAttentionController.clearAfterSuccessfulReview()
+}
+
 internal fun LiveSmokeContext.activeAppNotificationIds(context: Context): Set<Int> {
     return activeNotificationIds(context = context)
 }
@@ -142,10 +169,65 @@ internal fun LiveSmokeContext.waitForReviewScreenAfterNotificationTap() {
     }
 }
 
+internal fun LiveSmokeContext.waitForReviewReminderBadgeValue(expectedText: String) {
+    try {
+        waitUntilWithMitigation(
+            timeoutMillis = internalUiTimeoutMillis,
+            context = "while waiting for the review reminder badge to show '$expectedText'"
+        ) {
+            reviewReminderBadgeTexts().contains(expectedText)
+        }
+    } catch (error: Throwable) {
+        throw AssertionError(
+            "Review reminder badge did not show '$expectedText'. " +
+                "BadgeTexts=${reviewReminderBadgeTexts()}",
+            error
+        )
+    }
+}
+
+internal fun LiveSmokeContext.waitForReviewReminderBadgeToDisappear() {
+    try {
+        waitForTagToDisappear(
+            tag = reviewReminderAttentionBadgeTag,
+            timeoutMillis = internalUiTimeoutMillis,
+            context = "while waiting for the review reminder badge to disappear"
+        )
+    } catch (error: Throwable) {
+        throw AssertionError(
+            "Review reminder badge did not disappear. BadgeTexts=${reviewReminderBadgeTexts()}",
+            error
+        )
+    }
+}
+
 private fun activeNotificationIds(context: Context): Set<Int> {
     val notificationManager = context.getSystemService(NotificationManager::class.java)
     return notificationManager.activeNotifications
         .map { statusBarNotification -> statusBarNotification.id }
+        .toSet()
+}
+
+private fun LiveSmokeContext.requireCurrentWorkspaceIdForNotificationSmoke(): String {
+    return runBlocking {
+        requireNotNull(appGraph().database.workspaceDao().loadAnyWorkspace()?.workspaceId) {
+            "Expected a current workspace before posting a review reminder notification."
+        }
+    }
+}
+
+private fun LiveSmokeContext.reviewReminderBadgeTexts(): Set<String> {
+    val mergedNodes = composeRule.onAllNodesWithTag(reviewReminderAttentionBadgeTag)
+        .fetchSemanticsNodes()
+    val unmergedNodes = composeRule.onAllNodesWithTag(
+        testTag = reviewReminderAttentionBadgeTag,
+        useUnmergedTree = true
+    ).fetchSemanticsNodes()
+    return (mergedNodes + unmergedNodes)
+        .map(::nodeSummaryIncludingDescendants)
+        .flatMap { text -> text.split(" | ") }
+        .map(String::trim)
+        .filter(String::isNotBlank)
         .toSet()
 }
 


### PR DESCRIPTION
## Summary
- add Android notification smoke coverage for the Review destination reminder badge
- assert the badge baseline is clean before posting, badge shows 1 after posting, and clears after a real review
- use stable Compose test tags for Review navigation and review controls

## Validation
- git --no-pager diff --check
- focused checks for ReviewDestination.testTag navigation and badge cleanup ordering
- final fresh review gate passed with no P0-P4 findings

Gradle/instrumentation not run locally because device/Gradle execution was not authorized.