### PR TITLE
Fix iOS badge notification copy

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -242,7 +242,7 @@ extension FlashcardsStore {
     ///
     /// The reconciler is idempotent and safe to call from multiple triggers. It clears
     /// pending review reminders before rescheduling, and it clears already delivered
-    /// review reminders only when the app becomes active.
+    /// review reminders when the app becomes active or a review is recorded.
     func reconcileReviewNotifications(trigger: ReviewNotificationsReconcileTrigger, now: Date) {
         self.reviewNotificationsRescheduleGeneration += 1
         let generation = self.reviewNotificationsRescheduleGeneration

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Notifications/ReviewNotificationsSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Notifications/ReviewNotificationsSettingsView.swift
@@ -242,7 +242,7 @@ struct ReviewNotificationsSettingsView: View {
             Text(
                 aiSettingsLocalized(
                     "settings.notifications.appIconBadge.description",
-                    "Show a red 1 on the app icon when a reminder fires and you have not reviewed today. It clears when you review or open the app."
+                    "Show a red 1 on the app icon when a reminder fires and you have not reviewed today. Opening the app clears delivered review reminders; the badge clears after you review or turn this off."
                 )
             )
                 .foregroundStyle(.secondary)

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "تستخدم هذه التذكيرات مساحة العمل الحالية فقط وتبقى على هذا الجهاز.";
 "settings.notifications.enableWorkspaceReminders" = "تفعيل تذكيرات مساحة العمل";
 "settings.notifications.appIconBadge.toggle" = "إظهار شارة أيقونة التطبيق";
-"settings.notifications.appIconBadge.description" = "أظهر رقم 1 أحمر على أيقونة التطبيق عندما يصدر تذكير ولم تراجع اليوم. يختفي عندما تراجع أو تفتح التطبيق.";
+"settings.notifications.appIconBadge.description" = "أظهر رقم 1 أحمر على أيقونة التطبيق عندما يصدر تذكير ولم تراجع اليوم. فتح التطبيق يمسح تذكيرات المراجعة المسلّمة؛ وتمسح الشارة بعد أن تراجع أو توقف هذا الخيار.";
 "settings.notifications.section.appIconBadge" = "شارة أيقونة التطبيق";
 "settings.notifications.section.strictReminders" = "تذكيرات السلسلة";
 "settings.notifications.enableStrictReminders" = "تفعيل تذكيرات السلسلة";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "Diese Erinnerungen verwenden nur den aktuellen Arbeitsbereich und bleiben auf diesem Gerät.";
 "settings.notifications.enableWorkspaceReminders" = "Arbeitsbereichserinnerungen aktivieren";
 "settings.notifications.appIconBadge.toggle" = "App-Symbol-Badge anzeigen";
-"settings.notifications.appIconBadge.description" = "Zeigt eine rote 1 auf dem App-Symbol, wenn eine Erinnerung kommt und du heute noch nicht wiederholt hast. Sie verschwindet, wenn du wiederholst oder die App öffnest.";
+"settings.notifications.appIconBadge.description" = "Zeigt eine rote 1 auf dem App-Symbol, wenn eine Erinnerung kommt und du heute noch nicht wiederholt hast. Wenn du die App öffnest, werden zugestellte Wiederholungserinnerungen gelöscht; das Badge verschwindet nach dem Wiederholen oder wenn du dies ausschaltest.";
 "settings.notifications.section.appIconBadge" = "App-Symbol-Badge";
 "settings.notifications.section.strictReminders" = "Serien-Erinnerungen";
 "settings.notifications.enableStrictReminders" = "Serien-Erinnerungen aktivieren";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual y se quedan en este dispositivo.";
 "settings.notifications.enableWorkspaceReminders" = "Activar recordatorios del espacio de trabajo";
 "settings.notifications.appIconBadge.toggle" = "Mostrar la insignia en el icono de la app";
-"settings.notifications.appIconBadge.description" = "Muestra un 1 rojo en el icono de la app cuando llega un recordatorio y aún no has repasado hoy. Desaparece cuando repasas o abres la app.";
+"settings.notifications.appIconBadge.description" = "Muestra un 1 rojo en el icono de la app cuando llega un recordatorio y aún no has repasado hoy. Al abrir la app se borran los recordatorios de repaso entregados; la insignia desaparece después de repasar o desactivar esto.";
 "settings.notifications.section.appIconBadge" = "Insignia del icono de la app";
 "settings.notifications.section.strictReminders" = "Recordatorios de racha";
 "settings.notifications.enableStrictReminders" = "Activar recordatorios de racha";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual y se quedan en este dispositivo.";
 "settings.notifications.enableWorkspaceReminders" = "Activar recordatorios del espacio de trabajo";
 "settings.notifications.appIconBadge.toggle" = "Mostrar la insignia en el ícono de la app";
-"settings.notifications.appIconBadge.description" = "Muestra un 1 rojo en el ícono de la app cuando llega un recordatorio y aún no has repasado hoy. Desaparece cuando repasas o abres la app.";
+"settings.notifications.appIconBadge.description" = "Muestra un 1 rojo en el ícono de la app cuando llega un recordatorio y aún no has repasado hoy. Al abrir la app se borran los recordatorios de repaso entregados; la insignia desaparece después de repasar o desactivar esto.";
 "settings.notifications.section.appIconBadge" = "Insignia del ícono de la app";
 "settings.notifications.section.strictReminders" = "Recordatorios de racha";
 "settings.notifications.enableStrictReminders" = "Activar recordatorios de racha";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "ये रिमाइंडर केवल मौजूदा वर्कस्पेस का उपयोग करते हैं और इसी डिवाइस पर रहते हैं।";
 "settings.notifications.enableWorkspaceReminders" = "वर्कस्पेस रिमाइंडर चालू करें";
 "settings.notifications.appIconBadge.toggle" = "ऐप आइकन बैज दिखाएं";
-"settings.notifications.appIconBadge.description" = "जब रिमाइंडर आए और आपने आज रिव्यू नहीं किया हो, तो ऐप आइकन पर लाल 1 दिखाएं। रिव्यू करने या ऐप खोलने पर यह हट जाता है।";
+"settings.notifications.appIconBadge.description" = "जब रिमाइंडर आए और आपने आज रिव्यू नहीं किया हो, तो ऐप आइकन पर लाल 1 दिखाएं। ऐप खोलने पर डिलीवर हुए रिव्यू रिमाइंडर साफ हो जाते हैं; बैज रिव्यू करने या इसे बंद करने के बाद हटता है।";
 "settings.notifications.section.appIconBadge" = "ऐप आइकन बैज";
 "settings.notifications.section.strictReminders" = "स्ट्रीक रिमाइंडर";
 "settings.notifications.enableStrictReminders" = "स्ट्रीक रिमाइंडर चालू करें";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "これらのリマインダーは現在のワークスペースだけを使い、このデバイスに保存されます。";
 "settings.notifications.enableWorkspaceReminders" = "ワークスペースのリマインダーを有効にする";
 "settings.notifications.appIconBadge.toggle" = "アプリアイコンにバッジを表示";
-"settings.notifications.appIconBadge.description" = "リマインダーが届き、今日まだ復習していない場合、アプリアイコンに赤い 1 を表示します。復習するかアプリを開くと消えます。";
+"settings.notifications.appIconBadge.description" = "リマインダーが届き、今日まだ復習していない場合、アプリアイコンに赤い 1 を表示します。アプリを開くと配信済みの復習リマインダーは消えます。バッジは復習後、またはこれをオフにすると消えます。";
 "settings.notifications.section.appIconBadge" = "アプリアイコンバッジ";
 "settings.notifications.section.strictReminders" = "ストリークリマインダー";
 "settings.notifications.enableStrictReminders" = "ストリークリマインダーを有効にする";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "Эти напоминания используют только текущее рабочее пространство и остаются на этом устройстве.";
 "settings.notifications.enableWorkspaceReminders" = "Включить напоминания рабочего пространства";
 "settings.notifications.appIconBadge.toggle" = "Показывать бейдж на иконке приложения";
-"settings.notifications.appIconBadge.description" = "Показывать красную 1 на иконке приложения, когда приходит напоминание, а вы ещё не повторяли сегодня. Она исчезнет после повторения или открытия приложения.";
+"settings.notifications.appIconBadge.description" = "Показывать красную 1 на иконке приложения, когда приходит напоминание, а вы ещё не повторяли сегодня. При открытии приложения доставленные напоминания о повторении очищаются; бейдж исчезает после повторения или отключения этого параметра.";
 "settings.notifications.section.appIconBadge" = "Бейдж на иконке приложения";
 "settings.notifications.section.strictReminders" = "Напоминания о серии";
 "settings.notifications.enableStrictReminders" = "Включить напоминания о серии";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -518,7 +518,7 @@
 "settings.notifications.reviewReminders.description" = "这些提醒只使用当前工作区，并且仅保留在此设备上。";
 "settings.notifications.enableWorkspaceReminders" = "启用工作区提醒";
 "settings.notifications.appIconBadge.toggle" = "在应用图标上显示徽章";
-"settings.notifications.appIconBadge.description" = "当提醒到达且你今天还未复习时，在应用图标上显示红色 1。复习或打开应用后会消失。";
+"settings.notifications.appIconBadge.description" = "当提醒到达且你今天还未复习时，在应用图标上显示红色 1。打开应用会清除已送达的复习提醒；徽章会在复习后或关闭此开关后清除。";
 "settings.notifications.section.appIconBadge" = "应用图标徽章";
 "settings.notifications.section.strictReminders" = "连续记录提醒";
 "settings.notifications.enableStrictReminders" = "启用连续记录提醒";


### PR DESCRIPTION
## Summary
- clarify iOS app icon badge settings copy to distinguish delivered reminder cleanup from badge clearing
- update localized AI settings strings for supported iOS locales
- update the stale review notification reconciler doc comment

## Validation
- git fetch origin main
- git merge-base --is-ancestor origin/main HEAD
- rg stale badge-copy searches
- plutil -lint on edited AISettings.strings files
- git --no-pager diff --check
- worker-owned review: no P0-P4 findings

Simulator-backed iOS tests were not run per repository instruction.