### PR TITLE
Update Android reminders settings

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/livesmoke/flows/LiveSmokeNavigationFlows.kt
@@ -128,7 +128,7 @@ internal fun LiveSmokeContext.assertSettingsInformationArchitecture() {
     listOf(
         settingsAccountStatusRowTag to "Account status",
         settingsCurrentWorkspaceRowTag to "Workspace",
-        settingsReviewRemindersRowTag to "Review reminders",
+        settingsReviewRemindersRowTag to "Reminders",
         settingsLeaderboardParticipationRowTag to "Leaderboard participation",
         settingsLanguageRowTag to "Language",
         settingsAccessRowTag to "Access",
@@ -173,7 +173,7 @@ internal fun LiveSmokeContext.openSettingsInformationArchitectureDetails() {
         ),
         SettingsDetailProbe(
             rowTag = settingsReviewRemindersRowTag,
-            rowLabel = "Review reminders",
+            rowLabel = "Reminders",
             destinationTag = reviewNotificationsScreenTag
         ),
         SettingsDetailProbe(

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/review/ReviewNotificationsRoute.kt
@@ -23,6 +23,11 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -30,6 +35,9 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.flashcardsopensourceapp.data.local.notifications.ReviewNotificationMode
 import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsScreenScaffold
@@ -60,15 +68,35 @@ fun ReviewNotificationsRoute(
 ) {
     val context = LocalContext.current
     val activity = context as? ComponentActivity
-    val permissionStatus = when {
-        activity == null -> ReviewNotificationPermissionUiStatus.BLOCKED
-        hasNotificationPermission(context = context) -> ReviewNotificationPermissionUiStatus.ALLOWED
-        uiState.hasRequestedSystemPermission -> ReviewNotificationPermissionUiStatus.BLOCKED
-        else -> ReviewNotificationPermissionUiStatus.NOT_REQUESTED
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var permissionRefreshVersion by remember {
+        mutableStateOf(value = 0)
+    }
+    val permissionStatus = if (activity == null) {
+        ReviewNotificationPermissionUiStatus.BLOCKED
+    } else {
+        permissionRefreshVersion
+        when {
+            hasNotificationPermission(context = context) -> ReviewNotificationPermissionUiStatus.ALLOWED
+            uiState.hasRequestedSystemPermission -> ReviewNotificationPermissionUiStatus.BLOCKED
+            else -> ReviewNotificationPermissionUiStatus.NOT_REQUESTED
+        }
+    }
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                permissionRefreshVersion += 1
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted ->
+        permissionRefreshVersion += 1
         if (isGranted) {
             onPermissionGranted()
         }
@@ -123,167 +151,165 @@ fun ReviewNotificationsRoute(
                 }
             }
 
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    Column {
-                        ListItem(
-                            headlineContent = {
-                                Text(stringResource(R.string.settings_notifications_reminders_title))
-                            },
-                            supportingContent = {
-                                Text(stringResource(R.string.settings_notifications_reminders_body))
-                            },
-                            trailingContent = {
-                                Switch(
-                                    checked = uiState.settings.isEnabled,
-                                    onCheckedChange = onUpdateEnabled
+            if (permissionStatus == ReviewNotificationPermissionUiStatus.ALLOWED) {
+                item {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        Column {
+                            ListItem(
+                                headlineContent = {
+                                    Text(stringResource(R.string.settings_notifications_reminders_title))
+                                },
+                                supportingContent = {
+                                    Text(stringResource(R.string.settings_notifications_reminders_body))
+                                },
+                                trailingContent = {
+                                    Switch(
+                                        checked = uiState.settings.isEnabled,
+                                        onCheckedChange = onUpdateEnabled
+                                    )
+                                }
+                            )
+
+                            if (uiState.settings.selectedMode == ReviewNotificationMode.DAILY) {
+                                ReviewNotificationModeSelector(
+                                    selectedMode = uiState.settings.selectedMode,
+                                    onUpdateMode = onUpdateMode
                                 )
-                            }
-                        )
 
-                        if (uiState.settings.selectedMode == ReviewNotificationMode.DAILY) {
-                            ReviewNotificationModeSelector(
-                                selectedMode = uiState.settings.selectedMode,
-                                onUpdateMode = onUpdateMode
-                            )
+                                ListItem(
+                                    headlineContent = {
+                                        Text(stringResource(R.string.settings_notifications_daily_title))
+                                    },
+                                    supportingContent = {
+                                        Text(stringResource(R.string.settings_notifications_daily_example))
+                                    },
+                                    trailingContent = {
+                                        TimeValueStepper(
+                                            hour = uiState.settings.daily.hour,
+                                            minute = uiState.settings.daily.minute,
+                                            onValueChange = onUpdateDailyTime
+                                        )
+                                    }
+                                )
+                            } else {
+                                ReviewNotificationModeSelector(
+                                    selectedMode = uiState.settings.selectedMode,
+                                    onUpdateMode = onUpdateMode
+                                )
 
-                            ListItem(
-                                headlineContent = {
-                                    Text(stringResource(R.string.settings_notifications_daily_title))
-                                },
-                                supportingContent = {
-                                    Text(stringResource(R.string.settings_notifications_daily_example))
-                                },
-                                trailingContent = {
-                                    TimeValueStepper(
-                                        hour = uiState.settings.daily.hour,
-                                        minute = uiState.settings.daily.minute,
-                                        onValueChange = onUpdateDailyTime
-                                    )
-                                }
-                            )
-                        } else {
-                            ReviewNotificationModeSelector(
-                                selectedMode = uiState.settings.selectedMode,
-                                onUpdateMode = onUpdateMode
-                            )
+                                ListItem(
+                                    headlineContent = {
+                                        Text(stringResource(R.string.settings_notifications_inactivity_title))
+                                    },
+                                    supportingContent = {
+                                        Text(stringResource(R.string.settings_notifications_inactivity_example))
+                                    }
+                                )
 
-                            ListItem(
-                                headlineContent = {
-                                    Text(stringResource(R.string.settings_notifications_inactivity_title))
-                                },
-                                supportingContent = {
-                                    Text(stringResource(R.string.settings_notifications_inactivity_example))
-                                }
-                            )
+                                ListItem(
+                                    headlineContent = {
+                                        Text(stringResource(R.string.settings_notifications_from_title))
+                                    },
+                                    trailingContent = {
+                                        TimeValueStepper(
+                                            hour = uiState.settings.inactivity.windowStartHour,
+                                            minute = uiState.settings.inactivity.windowStartMinute,
+                                            onValueChange = onUpdateInactivityWindowStart
+                                        )
+                                    }
+                                )
 
-                            ListItem(
-                                headlineContent = {
-                                    Text(stringResource(R.string.settings_notifications_from_title))
-                                },
-                                trailingContent = {
-                                    TimeValueStepper(
-                                        hour = uiState.settings.inactivity.windowStartHour,
-                                        minute = uiState.settings.inactivity.windowStartMinute,
-                                        onValueChange = onUpdateInactivityWindowStart
-                                    )
-                                }
-                            )
+                                ListItem(
+                                    headlineContent = {
+                                        Text(stringResource(R.string.settings_notifications_to_title))
+                                    },
+                                    trailingContent = {
+                                        TimeValueStepper(
+                                            hour = uiState.settings.inactivity.windowEndHour,
+                                            minute = uiState.settings.inactivity.windowEndMinute,
+                                            onValueChange = onUpdateInactivityWindowEnd
+                                        )
+                                    }
+                                )
 
-                            ListItem(
-                                headlineContent = {
-                                    Text(stringResource(R.string.settings_notifications_to_title))
-                                },
-                                trailingContent = {
-                                    TimeValueStepper(
-                                        hour = uiState.settings.inactivity.windowEndHour,
-                                        minute = uiState.settings.inactivity.windowEndMinute,
-                                        onValueChange = onUpdateInactivityWindowEnd
-                                    )
-                                }
-                            )
-
-                            ListItem(
-                                headlineContent = {
-                                    Text(stringResource(R.string.settings_notifications_remind_after_title))
-                                },
-                                trailingContent = {
-                                    SingleChoiceSegmentedButtonRow {
-                                        listOf(60, 120, 180).forEachIndexed { index, value ->
-                                            SegmentedButton(
-                                                selected = uiState.settings.inactivity.idleMinutes == value,
-                                                onClick = {
-                                                    onUpdateIdleMinutes(value)
-                                                },
-                                                shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
-                                                    index = index,
-                                                    count = 3
-                                                ),
-                                                label = {
-                                                    Text(idleMinutesLabel(minutes = value))
-                                                }
-                                            )
+                                ListItem(
+                                    headlineContent = {
+                                        Text(stringResource(R.string.settings_notifications_remind_after_title))
+                                    },
+                                    trailingContent = {
+                                        SingleChoiceSegmentedButtonRow {
+                                            listOf(60, 120, 180).forEachIndexed { index, value ->
+                                                SegmentedButton(
+                                                    selected = uiState.settings.inactivity.idleMinutes == value,
+                                                    onClick = {
+                                                        onUpdateIdleMinutes(value)
+                                                    },
+                                                    shape = androidx.compose.material3.SegmentedButtonDefaults.itemShape(
+                                                        index = index,
+                                                        count = 3
+                                                    ),
+                                                    label = {
+                                                        Text(idleMinutesLabel(minutes = value))
+                                                    }
+                                                )
+                                            }
                                         }
                                     }
-                                }
-                            )
+                                )
+                            }
                         }
                     }
                 }
-            }
 
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    ListItem(
-                        headlineContent = {
-                            Text(stringResource(R.string.settings_notifications_show_app_icon_badge_title))
-                        },
-                        supportingContent = {
-                            Text(stringResource(R.string.settings_notifications_show_app_icon_badge_body))
-                        },
-                        trailingContent = {
-                            Switch(
-                                checked = uiState.settings.showAppIconBadge,
-                                onCheckedChange = onUpdateShowAppIconBadge
-                            )
-                        }
-                    )
+                item {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        ListItem(
+                            headlineContent = {
+                                Text(stringResource(R.string.settings_notifications_show_app_icon_badge_title))
+                            },
+                            supportingContent = {
+                                Text(stringResource(R.string.settings_notifications_show_app_icon_badge_body))
+                            },
+                            trailingContent = {
+                                Switch(
+                                    checked = uiState.settings.showAppIconBadge,
+                                    onCheckedChange = onUpdateShowAppIconBadge
+                                )
+                            }
+                        )
+                    }
                 }
-            }
 
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    ListItem(
-                        headlineContent = {
-                            Text(stringResource(R.string.settings_notifications_strict_reminders_title))
-                        },
-                        supportingContent = {
-                            Text(
-                                stringResource(R.string.settings_notifications_strict_reminders_body) +
-                                    "\n\n" +
-                                    stringResource(R.string.settings_notifications_strict_reminders_device_note)
-                            )
-                        },
-                        trailingContent = {
-                            Switch(
-                                checked = uiState.strictRemindersSettings.isEnabled,
-                                onCheckedChange = onUpdateStrictRemindersEnabled
-                            )
-                        }
-                    )
+                item {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        ListItem(
+                            headlineContent = {
+                                Text(stringResource(R.string.settings_notifications_strict_reminders_title))
+                            },
+                            supportingContent = {
+                                Text(stringResource(R.string.settings_notifications_strict_reminders_body))
+                            },
+                            trailingContent = {
+                                Switch(
+                                    checked = uiState.strictRemindersSettings.isEnabled,
+                                    onCheckedChange = onUpdateStrictRemindersEnabled
+                                )
+                            }
+                        )
+                    }
                 }
-            }
 
-            item {
-                Card(modifier = Modifier.fillMaxWidth()) {
-                    ListItem(
-                        headlineContent = {
-                            Text(stringResource(R.string.settings_notifications_this_device_title))
-                        },
-                        supportingContent = {
-                            Text(stringResource(R.string.settings_notifications_this_device_body))
-                        }
-                    )
+                item {
+                    Card(modifier = Modifier.fillMaxWidth()) {
+                        ListItem(
+                            headlineContent = {
+                                Text(stringResource(R.string.settings_notifications_this_device_title))
+                            },
+                            supportingContent = {
+                                Text(stringResource(R.string.settings_notifications_this_device_body))
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -84,8 +84,8 @@
     <string name="settings_root_feedback_summary">Share an idea to improve the app</string>
     <string name="settings_root_test_title">Test</string>
     <string name="settings_root_test_summary">2 items</string>
-    <string name="settings_review_reminders_title">Review reminders</string>
-    <string name="settings_review_reminders_summary">Workspace reminders and streak reminders for this device</string>
+    <string name="settings_review_reminders_title">Reminders</string>
+    <string name="settings_review_reminders_summary">Workspace reminders and streak reminders</string>
     <string name="settings_review_animations_title">Review Animations</string>
     <string name="settings_review_animations_summary">Show animations after rating a card</string>
     <string name="settings_review_animations_toggle_title">Show animations after rating a card</string>
@@ -125,7 +125,7 @@
     <string name="settings_notification_diagnostics_title">Notification diagnostics</string>
     <string name="settings_notification_diagnostics_load_failed">Could not load notification diagnostics.</string>
     <string name="settings_notification_diagnostics_state_section">State</string>
-    <string name="settings_notification_diagnostics_review_section">Review reminders</string>
+    <string name="settings_notification_diagnostics_review_section">Reminders</string>
     <string name="settings_notification_diagnostics_strict_section">Streak reminders</string>
     <string name="settings_notification_diagnostics_state_title">Android notifications</string>
     <string name="settings_notification_diagnostics_review_settings_title">Review settings</string>
@@ -293,19 +293,18 @@
     <string name="settings_access_photos_guidance">Android 14+ uses the system photo picker here, so broad storage access is not required.</string>
     <string name="settings_access_files_guidance">Android uses the system document picker here, so broad storage access is not required.</string>
 
-    <string name="settings_notifications_title">Review reminders</string>
+    <string name="settings_notifications_title">Reminders</string>
     <string name="settings_notifications_this_device_title">This device only</string>
     <string name="settings_notifications_this_device_body">Study reminders stay on this device and contain cards only, never marketing.</string>
     <string name="settings_notifications_permission_title">Permission</string>
     <string name="settings_notifications_allow_button">Allow notifications</string>
-    <string name="settings_notifications_permission_guidance_allowed">Android can deliver enabled study reminders on this device.</string>
-    <string name="settings_notifications_permission_guidance_request">Allow Android notifications to deliver study reminders on this device.</string>
-    <string name="settings_notifications_permission_guidance_blocked">Android is blocking study reminders on this device. Open app settings to allow notifications again.</string>
+    <string name="settings_notifications_permission_guidance_allowed">Android can deliver enabled study reminders.</string>
+    <string name="settings_notifications_permission_guidance_request">Allow Android notifications to deliver study reminders.</string>
+    <string name="settings_notifications_permission_guidance_blocked">Android is blocking study reminders. Open app settings to allow notifications again.</string>
     <string name="settings_notifications_strict_reminders_title">Streak reminders</string>
     <string name="settings_notifications_strict_reminders_body">If you have not reviewed today, Flashcards reminds you 4, 3, and 2 hours before midnight so you can keep your streak.</string>
-    <string name="settings_notifications_strict_reminders_device_note">Works across the app on this device.</string>
-    <string name="settings_notifications_reminders_title">Workspace review reminders</string>
-    <string name="settings_notifications_reminders_body">Send cards from the current workspace on this device.</string>
+    <string name="settings_notifications_reminders_title">Workspace reminders</string>
+    <string name="settings_notifications_reminders_body">Send cards from the current workspace.</string>
     <string name="settings_notifications_show_app_icon_badge_title">Show app icon badge</string>
     <string name="settings_notifications_show_app_icon_badge_body">Supported launchers may show a red 1 or dot while a review reminder notification is active. Opening the app or completing a review clears delivered review reminders.</string>
     <string name="settings_notifications_mode_daily">Daily</string>


### PR DESCRIPTION
## Summary
- Rename Android reminder settings labels to Reminders.
- Show only the Permission card until notification permission is allowed.
- Refresh permission state on resume while keeping persisted reminder settings unchanged when hidden.

## Validation
- git --no-pager diff --check
- rg -n "Review reminders|for this device|on this device|settings_notifications_strict_reminders_device_note" apps/android/feature/settings apps/android/app/src/androidTest
- Worker review: no P0-P4 findings, green light.
- Gradle not run per instruction.