### PR TITLE
[codex] Update iOS reminder settings

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/SettingsView.swift
@@ -79,8 +79,8 @@ struct SettingsView: View {
             Section(aiSettingsLocalized("settings.section.general", "General")) {
                 NavigationLink(value: SettingsNavigationDestination.workspaceNotifications) {
                     SettingsNavigationRow(
-                        title: aiSettingsLocalized("settings.row.reviewReminders", "Review Reminders"),
-                        value: aiSettingsLocalized("settings.row.reviewReminders.value", "This Device"),
+                        title: aiSettingsLocalized("settings.row.reviewReminders", "Reminders"),
+                        value: nil,
                         systemImage: "bell.badge",
                         attentionCount: nil
                     )

--- a/apps/ios/Flashcards/Flashcards/Settings/Workspace/Notifications/ReviewNotificationsSettingsView.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Workspace/Notifications/ReviewNotificationsSettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ReviewNotificationsSettingsView: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var permissionStatus: ReviewNotificationPermissionStatus = .notRequested
     @State private var permissionErrorMessage: String = ""
@@ -24,185 +25,188 @@ struct ReviewNotificationsSettingsView: View {
                 }
             }
 
-            Section(aiSettingsLocalized("settings.notifications.section.reviewReminders", "Workspace Review Reminders")) {
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.reviewReminders.description",
-                        "These reminders use the current workspace only and stay on this device."
-                    )
-                )
-                    .foregroundStyle(.secondary)
-
-                Toggle(
-                    aiSettingsLocalized("settings.notifications.enableWorkspaceReminders", "Enable workspace reminders"),
-                    isOn: Binding(
-                        get: {
-                            store.reviewNotificationsSettings.isEnabled
-                        },
-                        set: { isEnabled in
-                            store.updateReviewNotificationsEnabled(isEnabled: isEnabled)
-                        }
-                    )
-                )
-            }
-
-            if store.reviewNotificationsSettings.selectedMode == .daily {
-                Section(aiSettingsLocalized("settings.notifications.section.dailyReminder", "Daily reminder")) {
-                    self.reviewNotificationModePicker
-
-                    Text(aiSettingsLocalized("settings.notifications.dailyExample", "Send one card every day at the selected time."))
-                        .foregroundStyle(.secondary)
-
-                    DatePicker(
-                        aiSettingsLocalized("settings.notifications.time", "Time"),
-                        selection: Binding(
-                            get: {
-                                makeTimeOnlyDate(
-                                    hour: store.reviewNotificationsSettings.daily.hour,
-                                    minute: store.reviewNotificationsSettings.daily.minute
-                                )
-                            },
-                            set: { nextDate in
-                                let components = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: nextDate)
-                                store.updateDailyReviewNotifications(
-                                    hour: components.hour ?? defaultDailyReminderHour,
-                                    minute: components.minute ?? defaultDailyReminderMinute
-                                )
-                            }
-                        ),
-                        displayedComponents: [.hourAndMinute]
-                    )
-                }
-            } else {
-                Section(aiSettingsLocalized("settings.notifications.section.inactivityReminder", "Cards reminder")) {
-                    self.reviewNotificationModePicker
-
+            if self.permissionStatus == .allowed {
+                Section(aiSettingsLocalized("settings.notifications.section.reviewReminders", "Workspace Reminders")) {
                     Text(
                         aiSettingsLocalized(
-                            "settings.notifications.inactivityExample",
-                            "Send a card after you have been away for a while, during the time window you choose."
+                            "settings.notifications.reviewReminders.description",
+                            "These reminders use the current workspace only."
                         )
                     )
                         .foregroundStyle(.secondary)
 
-                    DatePicker(
-                        aiSettingsLocalized("settings.notifications.from", "From"),
-                        selection: Binding(
+                    Toggle(
+                        aiSettingsLocalized("settings.notifications.enableWorkspaceReminders", "Enable workspace reminders"),
+                        isOn: Binding(
                             get: {
-                                makeTimeOnlyDate(
-                                    hour: store.reviewNotificationsSettings.inactivity.windowStartHour,
-                                    minute: store.reviewNotificationsSettings.inactivity.windowStartMinute
-                                )
+                                store.reviewNotificationsSettings.isEnabled
                             },
-                            set: { nextDate in
-                                let components = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: nextDate)
-                                store.updateInactivityReviewNotifications(
-                                    windowStartHour: components.hour ?? defaultDailyReminderHour,
-                                    windowStartMinute: components.minute ?? defaultDailyReminderMinute,
-                                    windowEndHour: store.reviewNotificationsSettings.inactivity.windowEndHour,
-                                    windowEndMinute: store.reviewNotificationsSettings.inactivity.windowEndMinute,
-                                    idleMinutes: store.reviewNotificationsSettings.inactivity.idleMinutes
-                                )
-                            }
-                        ),
-                        displayedComponents: [.hourAndMinute]
-                    )
-
-                    DatePicker(
-                        aiSettingsLocalized("settings.notifications.to", "To"),
-                        selection: Binding(
-                            get: {
-                                makeTimeOnlyDate(
-                                    hour: store.reviewNotificationsSettings.inactivity.windowEndHour,
-                                    minute: store.reviewNotificationsSettings.inactivity.windowEndMinute
-                                )
-                            },
-                            set: { nextDate in
-                                let components = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: nextDate)
-                                store.updateInactivityReviewNotifications(
-                                    windowStartHour: store.reviewNotificationsSettings.inactivity.windowStartHour,
-                                    windowStartMinute: store.reviewNotificationsSettings.inactivity.windowStartMinute,
-                                    windowEndHour: components.hour ?? defaultInactivityReminderWindowEndHour,
-                                    windowEndMinute: components.minute ?? defaultInactivityReminderWindowEndMinute,
-                                    idleMinutes: store.reviewNotificationsSettings.inactivity.idleMinutes
-                                )
-                            }
-                        ),
-                        displayedComponents: [.hourAndMinute]
-                    )
-
-                    Picker(
-                        aiSettingsLocalized("settings.notifications.remindAfter", "Remind me after"),
-                        selection: Binding(
-                            get: {
-                                store.reviewNotificationsSettings.inactivity.idleMinutes
-                            },
-                            set: { idleMinutes in
-                                store.updateInactivityReviewNotifications(
-                                    windowStartHour: store.reviewNotificationsSettings.inactivity.windowStartHour,
-                                    windowStartMinute: store.reviewNotificationsSettings.inactivity.windowStartMinute,
-                                    windowEndHour: store.reviewNotificationsSettings.inactivity.windowEndHour,
-                                    windowEndMinute: store.reviewNotificationsSettings.inactivity.windowEndMinute,
-                                    idleMinutes: idleMinutes
-                                )
+                            set: { isEnabled in
+                                store.updateReviewNotificationsEnabled(isEnabled: isEnabled)
                             }
                         )
-                    ) {
-                        ForEach([30, 60, 90, 120, 180, 240], id: \.self) { minutes in
-                            Text(formatIdleMinutes(minutes: minutes)).tag(minutes)
+                    )
+                }
+
+                if store.reviewNotificationsSettings.selectedMode == .daily {
+                    Section(aiSettingsLocalized("settings.notifications.section.dailyReminder", "Daily reminder")) {
+                        self.reviewNotificationModePicker
+
+                        Text(aiSettingsLocalized("settings.notifications.dailyExample", "Send one card every day at the selected time."))
+                            .foregroundStyle(.secondary)
+
+                        DatePicker(
+                            aiSettingsLocalized("settings.notifications.time", "Time"),
+                            selection: Binding(
+                                get: {
+                                    makeTimeOnlyDate(
+                                        hour: store.reviewNotificationsSettings.daily.hour,
+                                        minute: store.reviewNotificationsSettings.daily.minute
+                                    )
+                                },
+                                set: { nextDate in
+                                    let components = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: nextDate)
+                                    store.updateDailyReviewNotifications(
+                                        hour: components.hour ?? defaultDailyReminderHour,
+                                        minute: components.minute ?? defaultDailyReminderMinute
+                                    )
+                                }
+                            ),
+                            displayedComponents: [.hourAndMinute]
+                        )
+                    }
+                } else {
+                    Section(aiSettingsLocalized("settings.notifications.section.inactivityReminder", "Cards reminder")) {
+                        self.reviewNotificationModePicker
+
+                        Text(
+                            aiSettingsLocalized(
+                                "settings.notifications.inactivityExample",
+                                "Send a card after you have been away for a while, during the time window you choose."
+                            )
+                        )
+                            .foregroundStyle(.secondary)
+
+                        DatePicker(
+                            aiSettingsLocalized("settings.notifications.from", "From"),
+                            selection: Binding(
+                                get: {
+                                    makeTimeOnlyDate(
+                                        hour: store.reviewNotificationsSettings.inactivity.windowStartHour,
+                                        minute: store.reviewNotificationsSettings.inactivity.windowStartMinute
+                                    )
+                                },
+                                set: { nextDate in
+                                    let components = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: nextDate)
+                                    store.updateInactivityReviewNotifications(
+                                        windowStartHour: components.hour ?? defaultDailyReminderHour,
+                                        windowStartMinute: components.minute ?? defaultDailyReminderMinute,
+                                        windowEndHour: store.reviewNotificationsSettings.inactivity.windowEndHour,
+                                        windowEndMinute: store.reviewNotificationsSettings.inactivity.windowEndMinute,
+                                        idleMinutes: store.reviewNotificationsSettings.inactivity.idleMinutes
+                                    )
+                                }
+                            ),
+                            displayedComponents: [.hourAndMinute]
+                        )
+
+                        DatePicker(
+                            aiSettingsLocalized("settings.notifications.to", "To"),
+                            selection: Binding(
+                                get: {
+                                    makeTimeOnlyDate(
+                                        hour: store.reviewNotificationsSettings.inactivity.windowEndHour,
+                                        minute: store.reviewNotificationsSettings.inactivity.windowEndMinute
+                                    )
+                                },
+                                set: { nextDate in
+                                    let components = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: nextDate)
+                                    store.updateInactivityReviewNotifications(
+                                        windowStartHour: store.reviewNotificationsSettings.inactivity.windowStartHour,
+                                        windowStartMinute: store.reviewNotificationsSettings.inactivity.windowStartMinute,
+                                        windowEndHour: components.hour ?? defaultInactivityReminderWindowEndHour,
+                                        windowEndMinute: components.minute ?? defaultInactivityReminderWindowEndMinute,
+                                        idleMinutes: store.reviewNotificationsSettings.inactivity.idleMinutes
+                                    )
+                                }
+                            ),
+                            displayedComponents: [.hourAndMinute]
+                        )
+
+                        Picker(
+                            aiSettingsLocalized("settings.notifications.remindAfter", "Remind me after"),
+                            selection: Binding(
+                                get: {
+                                    store.reviewNotificationsSettings.inactivity.idleMinutes
+                                },
+                                set: { idleMinutes in
+                                    store.updateInactivityReviewNotifications(
+                                        windowStartHour: store.reviewNotificationsSettings.inactivity.windowStartHour,
+                                        windowStartMinute: store.reviewNotificationsSettings.inactivity.windowStartMinute,
+                                        windowEndHour: store.reviewNotificationsSettings.inactivity.windowEndHour,
+                                        windowEndMinute: store.reviewNotificationsSettings.inactivity.windowEndMinute,
+                                        idleMinutes: idleMinutes
+                                    )
+                                }
+                            )
+                        ) {
+                            ForEach([30, 60, 90, 120, 180, 240], id: \.self) { minutes in
+                                Text(formatIdleMinutes(minutes: minutes)).tag(minutes)
+                            }
                         }
                     }
                 }
-            }
 
-            Section(aiSettingsLocalized("settings.notifications.section.appIconBadge", "App Icon Badge")) {
-                self.appIconBadgeToggle
-            }
+                Section(aiSettingsLocalized("settings.notifications.section.appIconBadge", "App Icon Badge")) {
+                    self.appIconBadgeToggle
+                }
 
-            Section(aiSettingsLocalized("settings.notifications.section.strictReminders", "Streak reminders")) {
-                Toggle(
-                    aiSettingsLocalized("settings.notifications.enableStrictReminders", "Enable streak reminders"),
-                    isOn: Binding(
-                        get: {
-                            store.strictRemindersSettings.isEnabled
-                        },
-                        set: { isEnabled in
-                            store.updateStrictRemindersEnabled(isEnabled: isEnabled)
-                        }
+                Section(aiSettingsLocalized("settings.notifications.section.strictReminders", "Streak reminders")) {
+                    Toggle(
+                        aiSettingsLocalized("settings.notifications.enableStrictReminders", "Enable streak reminders"),
+                        isOn: Binding(
+                            get: {
+                                store.strictRemindersSettings.isEnabled
+                            },
+                            set: { isEnabled in
+                                store.updateStrictRemindersEnabled(isEnabled: isEnabled)
+                            }
+                        )
                     )
-                )
 
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.strictReminders.description",
-                        "If you have not reviewed today, Flashcards reminds you 4, 3, and 2 hours before midnight so you can keep your streak."
+                    Text(
+                        aiSettingsLocalized(
+                            "settings.notifications.strictReminders.description",
+                            "If you have not reviewed today, Flashcards reminds you 4, 3, and 2 hours before midnight so you can keep your streak."
+                        )
                     )
-                )
-                    .foregroundStyle(.secondary)
+                        .foregroundStyle(.secondary)
+                }
 
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.strictReminders.deviceNote",
-                        "Works across the app on this device."
+                Section {
+                    Text(
+                        aiSettingsLocalized(
+                            "settings.notifications.description",
+                            "Study reminders stay on this device and contain cards only, never marketing."
+                        )
                     )
-                )
-                    .foregroundStyle(.secondary)
-            }
-
-            Section {
-                Text(
-                    aiSettingsLocalized(
-                        "settings.notifications.description",
-                        "Study reminders stay on this device and contain cards only, never marketing."
-                    )
-                )
-                    .foregroundStyle(.secondary)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .listStyle(.insetGrouped)
         .navigationTitle(aiSettingsLocalized("settings.notifications.title", "Notifications"))
         .task(id: store.workspace?.workspaceId) {
             await self.refreshPermissionStatus()
+        }
+        .onChange(of: self.scenePhase) { _, nextPhase in
+            guard nextPhase == .active else {
+                return
+            }
+
+            Task { @MainActor in
+                await self.refreshPermissionStatus()
+            }
         }
     }
 
@@ -249,6 +253,7 @@ struct ReviewNotificationsSettingsView: View {
         }
     }
 
+    @MainActor
     private func refreshPermissionStatus() async {
         self.permissionStatus = await resolveReviewNotificationPermissionStatus()
     }

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "متقدم";
 "settings.row.accountStatus" = "حالة الحساب";
 "settings.row.currentWorkspace" = "مساحة العمل";
-"settings.row.reviewReminders" = "تذكيرات المراجعة";
-"settings.row.reviewReminders.value" = "هذا الجهاز";
+"settings.row.reviewReminders" = "التذكيرات";
 "settings.row.reviewAnimations" = "رسوم المراجعة المتحركة";
 "settings.row.leaderboardParticipation" = "المشاركة في لوحة الصدارة";
 "settings.row.language" = "اللغة";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "الإخطارات";
 "settings.notifications.description" = "تبقى تذكيرات الدراسة على هذا الجهاز وتحتوي على بطاقات فقط، ولا تتضمن تسويقًا.";
 "settings.notifications.section.permission" = "إذن";
-"settings.notifications.section.reviewReminders" = "تذكيرات مراجعة مساحة العمل";
-"settings.notifications.reviewReminders.description" = "تستخدم هذه التذكيرات مساحة العمل الحالية فقط وتبقى على هذا الجهاز.";
+"settings.notifications.section.reviewReminders" = "تذكيرات مساحة العمل";
+"settings.notifications.reviewReminders.description" = "تستخدم هذه التذكيرات مساحة العمل الحالية فقط.";
 "settings.notifications.enableWorkspaceReminders" = "تفعيل تذكيرات مساحة العمل";
 "settings.notifications.appIconBadge.toggle" = "إظهار شارة أيقونة التطبيق";
 "settings.notifications.appIconBadge.description" = "أظهر رقم 1 أحمر على أيقونة التطبيق عندما يصدر تذكير ولم تراجع اليوم. فتح التطبيق يمسح تذكيرات المراجعة المسلّمة؛ وتمسح الشارة بعد أن تراجع أو توقف هذا الخيار.";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "تذكيرات السلسلة";
 "settings.notifications.enableStrictReminders" = "تفعيل تذكيرات السلسلة";
 "settings.notifications.strictReminders.description" = "إذا لم تراجع اليوم، يذكرك Flashcards قبل منتصف الليل بـ 4 و3 و2 ساعة كي تحافظ على سلسلتك.";
-"settings.notifications.strictReminders.deviceNote" = "تعمل في كل التطبيق على هذا الجهاز.";
 "settings.notifications.section.dailyReminder" = "تذكير يومي";
 "settings.notifications.section.inactivityReminder" = "تذكير البطاقات";
 "settings.notifications.permission.allowed" = "مسموح";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "Erweitert";
 "settings.row.accountStatus" = "Kontostatus";
 "settings.row.currentWorkspace" = "Arbeitsbereich";
-"settings.row.reviewReminders" = "Wiederholungserinnerungen";
-"settings.row.reviewReminders.value" = "Dieses Gerät";
+"settings.row.reviewReminders" = "Erinnerungen";
 "settings.row.reviewAnimations" = "Wiederholungsanimationen";
 "settings.row.leaderboardParticipation" = "Bestenlisten-Teilnahme";
 "settings.row.language" = "Sprache";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "Benachrichtigungen";
 "settings.notifications.description" = "Lernerinnerungen bleiben auf diesem Gerät und enthalten nur Karten, niemals Marketing.";
 "settings.notifications.section.permission" = "Erlaubnis";
-"settings.notifications.section.reviewReminders" = "Arbeitsbereichsbezogene Wiederholungserinnerungen";
-"settings.notifications.reviewReminders.description" = "Diese Erinnerungen verwenden nur den aktuellen Arbeitsbereich und bleiben auf diesem Gerät.";
+"settings.notifications.section.reviewReminders" = "Arbeitsbereichserinnerungen";
+"settings.notifications.reviewReminders.description" = "Diese Erinnerungen verwenden nur den aktuellen Arbeitsbereich.";
 "settings.notifications.enableWorkspaceReminders" = "Arbeitsbereichserinnerungen aktivieren";
 "settings.notifications.appIconBadge.toggle" = "App-Symbol-Badge anzeigen";
 "settings.notifications.appIconBadge.description" = "Zeigt eine rote 1 auf dem App-Symbol, wenn eine Erinnerung kommt und du heute noch nicht wiederholt hast. Wenn du die App öffnest, werden zugestellte Wiederholungserinnerungen gelöscht; das Badge verschwindet nach dem Wiederholen oder wenn du dies ausschaltest.";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "Serien-Erinnerungen";
 "settings.notifications.enableStrictReminders" = "Serien-Erinnerungen aktivieren";
 "settings.notifications.strictReminders.description" = "Wenn du heute noch nicht wiederholt hast, erinnert dich Flashcards 4, 3 und 2 Stunden vor Mitternacht, damit deine Serie bleibt.";
-"settings.notifications.strictReminders.deviceNote" = "Funktioniert appweit auf diesem Gerät.";
 "settings.notifications.section.dailyReminder" = "Tägliche Erinnerung";
 "settings.notifications.section.inactivityReminder" = "Karten-Erinnerung";
 "settings.notifications.permission.allowed" = "Zulässig";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "Avanzado";
 "settings.row.accountStatus" = "Estado de la cuenta";
 "settings.row.currentWorkspace" = "Espacio de trabajo";
-"settings.row.reviewReminders" = "Recordatorios de repaso";
-"settings.row.reviewReminders.value" = "Este dispositivo";
+"settings.row.reviewReminders" = "Recordatorios";
 "settings.row.reviewAnimations" = "Animaciones de repaso";
 "settings.row.leaderboardParticipation" = "Participación en la clasificación";
 "settings.row.language" = "Idioma";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "Notificaciones";
 "settings.notifications.description" = "Los recordatorios de estudio permanecen en este dispositivo y contienen solo tarjetas, nunca marketing.";
 "settings.notifications.section.permission" = "Permiso";
-"settings.notifications.section.reviewReminders" = "Recordatorios de repaso del espacio de trabajo";
-"settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual y se quedan en este dispositivo.";
+"settings.notifications.section.reviewReminders" = "Recordatorios del espacio de trabajo";
+"settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual.";
 "settings.notifications.enableWorkspaceReminders" = "Activar recordatorios del espacio de trabajo";
 "settings.notifications.appIconBadge.toggle" = "Mostrar la insignia en el icono de la app";
 "settings.notifications.appIconBadge.description" = "Muestra un 1 rojo en el icono de la app cuando llega un recordatorio y aún no has repasado hoy. Al abrir la app se borran los recordatorios de repaso entregados; la insignia desaparece después de repasar o desactivar esto.";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "Recordatorios de racha";
 "settings.notifications.enableStrictReminders" = "Activar recordatorios de racha";
 "settings.notifications.strictReminders.description" = "Si aún no has repasado hoy, Flashcards te recuerda 4, 3 y 2 horas antes de medianoche para que mantengas tu racha.";
-"settings.notifications.strictReminders.deviceNote" = "Funciona en toda la app en este dispositivo.";
 "settings.notifications.section.dailyReminder" = "Recordatorio diario";
 "settings.notifications.section.inactivityReminder" = "Recordatorio de tarjetas";
 "settings.notifications.permission.allowed" = "Permitido";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "Avanzado";
 "settings.row.accountStatus" = "Estado de la cuenta";
 "settings.row.currentWorkspace" = "Espacio de trabajo";
-"settings.row.reviewReminders" = "Recordatorios de repaso";
-"settings.row.reviewReminders.value" = "Este dispositivo";
+"settings.row.reviewReminders" = "Recordatorios";
 "settings.row.reviewAnimations" = "Animaciones de repaso";
 "settings.row.leaderboardParticipation" = "Participación en la tabla";
 "settings.row.language" = "Idioma";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "Notificaciones";
 "settings.notifications.description" = "Los recordatorios de estudio permanecen en este dispositivo y contienen solo tarjetas, nunca marketing.";
 "settings.notifications.section.permission" = "Permiso";
-"settings.notifications.section.reviewReminders" = "Recordatorios de repaso del espacio de trabajo";
-"settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual y se quedan en este dispositivo.";
+"settings.notifications.section.reviewReminders" = "Recordatorios del espacio de trabajo";
+"settings.notifications.reviewReminders.description" = "Estos recordatorios usan solo el espacio de trabajo actual.";
 "settings.notifications.enableWorkspaceReminders" = "Activar recordatorios del espacio de trabajo";
 "settings.notifications.appIconBadge.toggle" = "Mostrar la insignia en el ícono de la app";
 "settings.notifications.appIconBadge.description" = "Muestra un 1 rojo en el ícono de la app cuando llega un recordatorio y aún no has repasado hoy. Al abrir la app se borran los recordatorios de repaso entregados; la insignia desaparece después de repasar o desactivar esto.";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "Recordatorios de racha";
 "settings.notifications.enableStrictReminders" = "Activar recordatorios de racha";
 "settings.notifications.strictReminders.description" = "Si aún no has repasado hoy, Flashcards te recuerda 4, 3 y 2 horas antes de medianoche para que mantengas tu racha.";
-"settings.notifications.strictReminders.deviceNote" = "Funciona en toda la app en este dispositivo.";
 "settings.notifications.section.dailyReminder" = "Recordatorio diario";
 "settings.notifications.section.inactivityReminder" = "Recordatorio de tarjetas";
 "settings.notifications.permission.allowed" = "Permitido";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "उन्नत";
 "settings.row.accountStatus" = "खाता स्थिति";
 "settings.row.currentWorkspace" = "वर्कस्पेस";
-"settings.row.reviewReminders" = "समीक्षा रिमाइंडर";
-"settings.row.reviewReminders.value" = "यह डिवाइस";
+"settings.row.reviewReminders" = "रिमाइंडर";
 "settings.row.reviewAnimations" = "समीक्षा एनिमेशन";
 "settings.row.leaderboardParticipation" = "लीडरबोर्ड भागीदारी";
 "settings.row.language" = "भाषा";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "सूचनाएं";
 "settings.notifications.description" = "स्टडी रिमाइंडर इस डिवाइस पर रहते हैं और उनमें सिर्फ कार्ड होते हैं, मार्केटिंग कभी नहीं।";
 "settings.notifications.section.permission" = "अनुमति";
-"settings.notifications.section.reviewReminders" = "वर्कस्पेस रिव्यू रिमाइंडर";
-"settings.notifications.reviewReminders.description" = "ये रिमाइंडर केवल मौजूदा वर्कस्पेस का उपयोग करते हैं और इसी डिवाइस पर रहते हैं।";
+"settings.notifications.section.reviewReminders" = "वर्कस्पेस रिमाइंडर";
+"settings.notifications.reviewReminders.description" = "ये रिमाइंडर केवल मौजूदा वर्कस्पेस का उपयोग करते हैं।";
 "settings.notifications.enableWorkspaceReminders" = "वर्कस्पेस रिमाइंडर चालू करें";
 "settings.notifications.appIconBadge.toggle" = "ऐप आइकन बैज दिखाएं";
 "settings.notifications.appIconBadge.description" = "जब रिमाइंडर आए और आपने आज रिव्यू नहीं किया हो, तो ऐप आइकन पर लाल 1 दिखाएं। ऐप खोलने पर डिलीवर हुए रिव्यू रिमाइंडर साफ हो जाते हैं; बैज रिव्यू करने या इसे बंद करने के बाद हटता है।";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "स्ट्रीक रिमाइंडर";
 "settings.notifications.enableStrictReminders" = "स्ट्रीक रिमाइंडर चालू करें";
 "settings.notifications.strictReminders.description" = "अगर आपने आज रिव्यू नहीं किया है, तो Flashcards आधी रात से 4, 3 और 2 घंटे पहले याद दिलाता है ताकि आपकी स्ट्रीक बनी रहे।";
-"settings.notifications.strictReminders.deviceNote" = "इस डिवाइस पर पूरे ऐप में काम करता है।";
 "settings.notifications.section.dailyReminder" = "दैनिक अनुस्मारक";
 "settings.notifications.section.inactivityReminder" = "कार्ड रिमाइंडर";
 "settings.notifications.permission.allowed" = "अनुमति है";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "詳細";
 "settings.row.accountStatus" = "アカウント状態";
 "settings.row.currentWorkspace" = "ワークスペース";
-"settings.row.reviewReminders" = "復習リマインダー";
-"settings.row.reviewReminders.value" = "このデバイス";
+"settings.row.reviewReminders" = "リマインダー";
 "settings.row.reviewAnimations" = "復習アニメーション";
 "settings.row.leaderboardParticipation" = "リーダーボード参加";
 "settings.row.language" = "言語";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "通知";
 "settings.notifications.description" = "学習リマインダーはこのデバイス上に残り、カードだけを含み、マーケティングは含みません。";
 "settings.notifications.section.permission" = "許可";
-"settings.notifications.section.reviewReminders" = "ワークスペースの復習リマインダー";
-"settings.notifications.reviewReminders.description" = "これらのリマインダーは現在のワークスペースだけを使い、このデバイスに保存されます。";
+"settings.notifications.section.reviewReminders" = "ワークスペースのリマインダー";
+"settings.notifications.reviewReminders.description" = "これらのリマインダーは現在のワークスペースだけを使います。";
 "settings.notifications.enableWorkspaceReminders" = "ワークスペースのリマインダーを有効にする";
 "settings.notifications.appIconBadge.toggle" = "アプリアイコンにバッジを表示";
 "settings.notifications.appIconBadge.description" = "リマインダーが届き、今日まだ復習していない場合、アプリアイコンに赤い 1 を表示します。アプリを開くと配信済みの復習リマインダーは消えます。バッジは復習後、またはこれをオフにすると消えます。";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "ストリークリマインダー";
 "settings.notifications.enableStrictReminders" = "ストリークリマインダーを有効にする";
 "settings.notifications.strictReminders.description" = "今日まだ復習していない場合、連続記録を保てるように、Flashcards が午前0時の4、3、2時間前に通知します。";
-"settings.notifications.strictReminders.deviceNote" = "このデバイス上でアプリ全体に適用されます。";
 "settings.notifications.section.dailyReminder" = "毎日のリマインダー";
 "settings.notifications.section.inactivityReminder" = "カードリマインダー";
 "settings.notifications.permission.allowed" = "許可";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "Дополнительно";
 "settings.row.accountStatus" = "Статус аккаунта";
 "settings.row.currentWorkspace" = "Рабочая область";
-"settings.row.reviewReminders" = "Напоминания о повторении";
-"settings.row.reviewReminders.value" = "Это устройство";
+"settings.row.reviewReminders" = "Напоминания";
 "settings.row.reviewAnimations" = "Анимации повторения";
 "settings.row.leaderboardParticipation" = "Участие в таблице лидеров";
 "settings.row.language" = "Язык";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "Уведомления";
 "settings.notifications.description" = "Учебные напоминания остаются на этом устройстве и содержат только карточки, без маркетинга.";
 "settings.notifications.section.permission" = "Разрешение";
-"settings.notifications.section.reviewReminders" = "Напоминания о повторении для рабочего пространства";
-"settings.notifications.reviewReminders.description" = "Эти напоминания используют только текущее рабочее пространство и остаются на этом устройстве.";
+"settings.notifications.section.reviewReminders" = "Напоминания рабочего пространства";
+"settings.notifications.reviewReminders.description" = "Эти напоминания используют только текущее рабочее пространство.";
 "settings.notifications.enableWorkspaceReminders" = "Включить напоминания рабочего пространства";
 "settings.notifications.appIconBadge.toggle" = "Показывать бейдж на иконке приложения";
 "settings.notifications.appIconBadge.description" = "Показывать красную 1 на иконке приложения, когда приходит напоминание, а вы ещё не повторяли сегодня. При открытии приложения доставленные напоминания о повторении очищаются; бейдж исчезает после повторения или отключения этого параметра.";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "Напоминания о серии";
 "settings.notifications.enableStrictReminders" = "Включить напоминания о серии";
 "settings.notifications.strictReminders.description" = "Если вы сегодня ещё не повторяли, Flashcards напомнит за 4, 3 и 2 часа до полуночи, чтобы вы сохранили серию.";
-"settings.notifications.strictReminders.deviceNote" = "Работают во всём приложении на этом устройстве.";
 "settings.notifications.section.dailyReminder" = "Ежедневное напоминание";
 "settings.notifications.section.inactivityReminder" = "Напоминание с карточками";
 "settings.notifications.permission.allowed" = "Разрешено";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -133,8 +133,7 @@
 "settings.section.advanced" = "高级";
 "settings.row.accountStatus" = "账户状态";
 "settings.row.currentWorkspace" = "工作空间";
-"settings.row.reviewReminders" = "复习提醒";
-"settings.row.reviewReminders.value" = "本设备";
+"settings.row.reviewReminders" = "提醒";
 "settings.row.reviewAnimations" = "复习动画";
 "settings.row.leaderboardParticipation" = "排行榜参与";
 "settings.row.language" = "语言";
@@ -514,8 +513,8 @@
 "settings.notifications.title" = "通知";
 "settings.notifications.description" = "学习提醒保留在此设备上，只包含卡片，绝不包含营销内容。";
 "settings.notifications.section.permission" = "权限";
-"settings.notifications.section.reviewReminders" = "工作区复习提醒";
-"settings.notifications.reviewReminders.description" = "这些提醒只使用当前工作区，并且仅保留在此设备上。";
+"settings.notifications.section.reviewReminders" = "工作区提醒";
+"settings.notifications.reviewReminders.description" = "这些提醒仅使用当前工作区。";
 "settings.notifications.enableWorkspaceReminders" = "启用工作区提醒";
 "settings.notifications.appIconBadge.toggle" = "在应用图标上显示徽章";
 "settings.notifications.appIconBadge.description" = "当提醒到达且你今天还未复习时，在应用图标上显示红色 1。打开应用会清除已送达的复习提醒；徽章会在复习后或关闭此开关后清除。";
@@ -523,7 +522,6 @@
 "settings.notifications.section.strictReminders" = "连续记录提醒";
 "settings.notifications.enableStrictReminders" = "启用连续记录提醒";
 "settings.notifications.strictReminders.description" = "如果你今天还未复习，Flashcards 会在午夜前 4、3、2 小时提醒你，帮助你保持连续记录。";
-"settings.notifications.strictReminders.deviceNote" = "在此设备上的整个应用中生效。";
 "settings.notifications.section.dailyReminder" = "每日提醒";
 "settings.notifications.section.inactivityReminder" = "卡片提醒";
 "settings.notifications.permission.allowed" = "允许";

--- a/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSettingsTests.swift
+++ b/apps/ios/Flashcards/FlashcardsUITests/LiveSmokeSettingsTests.swift
@@ -43,7 +43,7 @@ final class LiveSmokeSettingsTests: LiveSmokeTestCase {
 
         try self.assertTextExistsScrollingIntoView("General", timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
         try self.openSettingsRootRow(identifier: LiveSmokeIdentifier.settingsReviewRemindersRow)
-        try self.assertTextExistsScrollingIntoView("Workspace Review Reminders", timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
+        try self.assertTextExistsScrollingIntoView("Permission", timeout: LiveSmokeConfiguration.longUiTimeoutSeconds)
         try self.returnToSettingsRoot()
 
         try self.assertReviewAnimationsRowOrder()
@@ -150,7 +150,7 @@ final class LiveSmokeSettingsTests: LiveSmokeTestCase {
         }
 
         throw LiveSmokeFailure.unexpectedAccountState(
-            message: "General settings rows should appear as Review Reminders, Review Animations, Leaderboard participation, then Language.",
+            message: "General settings rows should appear as Reminders, Review Animations, Leaderboard participation, then Language.",
             screen: self.currentScreenSummary(),
             step: self.currentStepTitle
         )


### PR DESCRIPTION
## Summary
- Rename the iOS Settings root reminders row to Reminders and remove its device value.
- Show only the Permission section on the reminder detail screen until notification permission is allowed.
- Keep persisted reminder settings intact while updating localized settings copy and the settings smoke expectation.

## Validation
- git merge-base --is-ancestor origin/main HEAD
- rg -n "Review Reminders|This Device|Workspace Review Reminders|settings.row.reviewReminders.value" apps/ios/Flashcards/Flashcards apps/ios/Flashcards/FlashcardsUITests
- plutil -lint apps/ios/Flashcards/Flashcards/{ar,de,es-ES,es-MX,hi,ja,ru,zh-Hans}.lproj/AISettings.strings
- git --no-pager diff --check
- git --no-pager diff --cached --check

No iOS simulator-backed tests were run, per instruction.