### PR TITLE
Add web technical error dialog foundation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,6 +9,7 @@ import {
   subscribeToAccountDeletionPending,
 } from "./accountDeletion";
 import { AppDataProvider, useAppData } from "./appData";
+import { AppErrorDialogProvider } from "./appError/AppErrorContext";
 import {
   ApiError,
   ApiContractError,
@@ -743,20 +744,22 @@ export default function App(): ReactElement {
   return (
     <AppErrorBoundary fallback={<AppCrashFallback />}>
       <BrowserRouter>
-        <TestModeProvider>
-          <SentryRoutes>
-            <Route
-              path={friendInvitePreviewIndexRoute}
-              element={renderDeferredRoute(<FriendInvitePreviewScreen />, "friendInvite.loading")}
-            />
-            <Route
-              path={friendInvitePreviewRoutePattern}
-              element={renderDeferredRoute(<FriendInvitePreviewScreen />, "friendInvite.loading")}
-            />
-            <Route path={friendInviteRoutePattern} element={<FriendInviteScreen />} />
-            <Route path="/*" element={<AuthenticatedApp />} />
-          </SentryRoutes>
-        </TestModeProvider>
+        <AppErrorDialogProvider>
+          <TestModeProvider>
+            <SentryRoutes>
+              <Route
+                path={friendInvitePreviewIndexRoute}
+                element={renderDeferredRoute(<FriendInvitePreviewScreen />, "friendInvite.loading")}
+              />
+              <Route
+                path={friendInvitePreviewRoutePattern}
+                element={renderDeferredRoute(<FriendInvitePreviewScreen />, "friendInvite.loading")}
+              />
+              <Route path={friendInviteRoutePattern} element={<FriendInviteScreen />} />
+              <Route path="/*" element={<AuthenticatedApp />} />
+            </SentryRoutes>
+          </TestModeProvider>
+        </AppErrorDialogProvider>
       </BrowserRouter>
     </AppErrorBoundary>
   );

--- a/apps/web/src/appError/AppErrorContext.tsx
+++ b/apps/web/src/appError/AppErrorContext.tsx
@@ -1,0 +1,109 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactElement, type ReactNode } from "react";
+import { type TranslationKey, type TranslationValues, useI18n } from "../i18n";
+import { captureAppOperationError } from "../observability/appOperationObservation";
+import type { WebAppOperation, WebObservationFeature } from "../observability/webObservability";
+import { AppErrorDialog } from "./AppErrorDialog";
+import {
+  buildAppErrorPresentation,
+  type AppErrorPresentation,
+  type AppErrorPresentationMessages,
+} from "./appErrorPresentation";
+
+type AppErrorTranslate = (key: TranslationKey, values?: TranslationValues) => string;
+
+export type AppTechnicalErrorContext = Readonly<{
+  feature: WebObservationFeature;
+  operation: WebAppOperation;
+  userId: string | null;
+  workspaceId: string | null;
+  installationId: string | null;
+  entityId: string | null;
+}>;
+
+type AppErrorDialogContextValue = Readonly<{
+  showTechnicalError: (error: unknown, context: AppTechnicalErrorContext) => void;
+  showTechnicalErrorPreview: () => void;
+  dismiss: () => void;
+}>;
+
+type AppErrorDialogProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+const AppErrorDialogContext = createContext<AppErrorDialogContextValue | null>(null);
+
+function buildPresentationMessages(t: AppErrorTranslate): AppErrorPresentationMessages {
+  return {
+    title: t("appError.technicalError.title"),
+    message: t("appError.technicalError.message"),
+    labels: {
+      name: t("appError.technicalError.labels.name"),
+      message: t("appError.technicalError.labels.message"),
+      endpoint: t("appError.technicalError.labels.endpoint"),
+      requestId: t("appError.technicalError.labels.requestId"),
+      statusCode: t("appError.technicalError.labels.statusCode"),
+      code: t("appError.technicalError.labels.code"),
+      bodyKind: t("appError.technicalError.labels.bodyKind"),
+      attemptCount: t("appError.technicalError.labels.attemptCount"),
+      originalErrorName: t("appError.technicalError.labels.originalErrorName"),
+      unavailable: t("common.unavailable"),
+    },
+  };
+}
+
+function buildPreviewError(): Error {
+  const previewError = new Error("Preview technical failure for dialog testing.");
+  previewError.name = "AppErrorPreview";
+
+  return previewError;
+}
+
+export function AppErrorDialogProvider(props: AppErrorDialogProviderProps): ReactElement {
+  const { children } = props;
+  const { t } = useI18n();
+  const [presentation, setPresentation] = useState<AppErrorPresentation | null>(null);
+
+  const dismiss = useCallback((): void => {
+    setPresentation(null);
+  }, []);
+
+  const showTechnicalError = useCallback((error: unknown, context: AppTechnicalErrorContext): void => {
+    captureAppOperationError(error, {
+      feature: context.feature,
+      operation: context.operation,
+      userId: context.userId,
+      workspaceId: context.workspaceId,
+      installationId: context.installationId,
+      entityId: context.entityId,
+    });
+
+    setPresentation(buildAppErrorPresentation(error, buildPresentationMessages(t)));
+  }, [t]);
+
+  const showTechnicalErrorPreview = useCallback((): void => {
+    setPresentation(buildAppErrorPresentation(buildPreviewError(), buildPresentationMessages(t)));
+  }, [t]);
+
+  const contextValue = useMemo((): AppErrorDialogContextValue => ({
+    showTechnicalError,
+    showTechnicalErrorPreview,
+    dismiss,
+  }), [dismiss, showTechnicalError, showTechnicalErrorPreview]);
+
+  return (
+    <AppErrorDialogContext.Provider value={contextValue}>
+      {children}
+      <AppErrorDialog presentation={presentation} onDismiss={dismiss} />
+    </AppErrorDialogContext.Provider>
+  );
+}
+
+export function useAppErrorDialog(): AppErrorDialogContextValue {
+  const contextValue = useContext(AppErrorDialogContext);
+
+  if (contextValue === null) {
+    throw new Error("useAppErrorDialog must be used within AppErrorDialogProvider");
+  }
+
+  return contextValue;
+}

--- a/apps/web/src/appError/AppErrorDialog.tsx
+++ b/apps/web/src/appError/AppErrorDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, type MouseEvent, type ReactElement } from "react";
+import { createPortal } from "react-dom";
+import { useI18n } from "../i18n";
+import type { AppErrorPresentation } from "./appErrorPresentation";
+
+export type AppErrorDialogProps = Readonly<{
+  presentation: AppErrorPresentation | null;
+  onDismiss: () => void;
+}>;
+
+export function AppErrorDialog(props: AppErrorDialogProps): ReactElement | null {
+  const { presentation, onDismiss } = props;
+  const { t } = useI18n();
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (presentation === null) {
+      return undefined;
+    }
+
+    previousFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        onDismiss();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return (): void => {
+      window.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
+  }, [onDismiss, presentation]);
+
+  function dismissFromBackdrop(event: MouseEvent<HTMLDivElement>): void {
+    if (event.target === event.currentTarget) {
+      onDismiss();
+    }
+  }
+
+  if (presentation === null || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div className="app-error-dialog-backdrop" onMouseDown={dismissFromBackdrop}>
+      <section
+        className="panel app-error-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="app-error-dialog-title"
+        aria-describedby="app-error-dialog-message"
+        data-testid="app-error-dialog"
+      >
+        <div className="cell-stack">
+          <h2 id="app-error-dialog-title" className="panel-subtitle">{presentation.title}</h2>
+          <p id="app-error-dialog-message" className="subtitle">{presentation.message}</p>
+        </div>
+
+        <details className="app-error-dialog-details" data-testid="app-error-dialog-details">
+          <summary>{t("appError.technicalError.detailsToggle")}</summary>
+          <pre>{presentation.technicalDetails}</pre>
+        </details>
+
+        <div className="screen-actions">
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="primary-btn"
+            onClick={onDismiss}
+            data-testid="app-error-dialog-close"
+          >
+            {t("appError.technicalError.close")}
+          </button>
+        </div>
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/appError/appErrorPresentation.ts
+++ b/apps/web/src/appError/appErrorPresentation.ts
@@ -1,0 +1,112 @@
+import { normalizeCaughtError } from "../observability/webObservability";
+
+export type AppErrorPresentation = Readonly<{
+  title: string;
+  message: string;
+  technicalDetails: string;
+}>;
+
+export type AppErrorPresentationLabels = Readonly<{
+  name: string;
+  message: string;
+  endpoint: string;
+  requestId: string;
+  statusCode: string;
+  code: string;
+  bodyKind: string;
+  attemptCount: string;
+  originalErrorName: string;
+  unavailable: string;
+}>;
+
+export type AppErrorPresentationMessages = Readonly<{
+  title: string;
+  message: string;
+  labels: AppErrorPresentationLabels;
+}>;
+
+type ErrorMetadataCarrier = Readonly<{
+  endpoint?: unknown;
+  requestId?: unknown;
+  statusCode?: unknown;
+  code?: unknown;
+  responseBodyKind?: unknown;
+  attemptCount?: unknown;
+  originalErrorName?: unknown;
+}>;
+
+type TechnicalDetailEntry = Readonly<{
+  label: string;
+  value: string;
+}>;
+
+function readStringMetadata(error: Error, key: keyof ErrorMetadataCarrier): string | null {
+  const metadataValue = (error as ErrorMetadataCarrier)[key];
+
+  return typeof metadataValue === "string" && metadataValue.trim() !== "" ? metadataValue : null;
+}
+
+function readNumberMetadata(error: Error, key: keyof ErrorMetadataCarrier): number | null {
+  const metadataValue = (error as ErrorMetadataCarrier)[key];
+
+  return typeof metadataValue === "number" && Number.isFinite(metadataValue) ? metadataValue : null;
+}
+
+function buildRequiredDetailEntry(label: string, value: string, unavailable: string): TechnicalDetailEntry {
+  const trimmedValue = value.trim();
+
+  return {
+    label,
+    value: trimmedValue === "" ? unavailable : trimmedValue,
+  };
+}
+
+function buildOptionalStringDetailEntry(
+  label: string,
+  value: string | null,
+): TechnicalDetailEntry | null {
+  return value === null ? null : { label, value };
+}
+
+function buildOptionalNumberDetailEntry(
+  label: string,
+  value: number | null,
+): TechnicalDetailEntry | null {
+  return value === null ? null : { label, value: String(value) };
+}
+
+function formatTechnicalDetailEntry(entry: TechnicalDetailEntry): string {
+  return `${entry.label}: ${entry.value}`;
+}
+
+function buildTechnicalDetails(error: Error, labels: AppErrorPresentationLabels): string {
+  const entries: ReadonlyArray<TechnicalDetailEntry | null> = [
+    buildRequiredDetailEntry(labels.name, error.name, labels.unavailable),
+    buildRequiredDetailEntry(labels.message, error.message, labels.unavailable),
+    buildOptionalStringDetailEntry(labels.endpoint, readStringMetadata(error, "endpoint")),
+    buildOptionalStringDetailEntry(labels.requestId, readStringMetadata(error, "requestId")),
+    buildOptionalNumberDetailEntry(labels.statusCode, readNumberMetadata(error, "statusCode")),
+    buildOptionalStringDetailEntry(labels.code, readStringMetadata(error, "code")),
+    buildOptionalStringDetailEntry(labels.bodyKind, readStringMetadata(error, "responseBodyKind")),
+    buildOptionalNumberDetailEntry(labels.attemptCount, readNumberMetadata(error, "attemptCount")),
+    buildOptionalStringDetailEntry(labels.originalErrorName, readStringMetadata(error, "originalErrorName")),
+  ];
+
+  return entries
+    .filter((entry): entry is TechnicalDetailEntry => entry !== null)
+    .map(formatTechnicalDetailEntry)
+    .join("\n");
+}
+
+export function buildAppErrorPresentation(
+  caughtError: unknown,
+  messages: AppErrorPresentationMessages,
+): AppErrorPresentation {
+  const error = normalizeCaughtError(caughtError);
+
+  return {
+    title: messages.title,
+    message: messages.message,
+    technicalDetails: buildTechnicalDetails(error, messages.labels),
+  };
+}

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -81,6 +81,25 @@ const arCatalog: TranslationCatalog = {
   shell: {
     primaryNavigation: "التنقل الرئيسي",
   },
+  appError: {
+    technicalError: {
+      title: "حدث خطأ ما",
+      message: "حدث خطأ تقني. حاول مرة أخرى أو أعد تشغيل التطبيق.",
+      detailsToggle: "التفاصيل التقنية",
+      close: "إغلاق",
+      labels: {
+        name: "الاسم",
+        message: "الرسالة",
+        endpoint: "نقطة النهاية",
+        requestId: "معرّف الطلب",
+        statusCode: "رمز الحالة",
+        code: "الرمز",
+        bodyKind: "نوع المحتوى",
+        attemptCount: "عدد المحاولات",
+        originalErrorName: "الخطأ الأصلي",
+      },
+    },
+  },
   filters: {
     allCards: "كل البطاقات",
     and: "و",
@@ -388,6 +407,11 @@ const arCatalog: TranslationCatalog = {
       screenSubtitle: "شغّل متغيرات تفاعل المراجعة مباشرة.",
       probability: "احتمال {{percent}}",
       playAccessibility: "تشغيل حركة {{variant}}، {{probability}}",
+    },
+    technicalError: {
+      title: "مربع حوار الخطأ التقني",
+      description: "عاين مربع حوار الأخطاء التقنية المشترك.",
+      value: "معاينة",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -81,6 +81,25 @@ const deCatalog: TranslationCatalog = {
   shell: {
     primaryNavigation: "Primäre Navigation",
   },
+  appError: {
+    technicalError: {
+      title: "Etwas ist schiefgelaufen",
+      message: "Ein technischer Fehler ist aufgetreten. Versuche es erneut oder starte die App neu.",
+      detailsToggle: "Technische Details",
+      close: "Schließen",
+      labels: {
+        name: "Name",
+        message: "Meldung",
+        endpoint: "Endpunkt",
+        requestId: "Anfrage-ID",
+        statusCode: "Statuscode",
+        code: "Code",
+        bodyKind: "Body-Typ",
+        attemptCount: "Anzahl der Versuche",
+        originalErrorName: "Ursprünglicher Fehler",
+      },
+    },
+  },
   filters: {
     allCards: "Alle Karten",
     and: "UND",
@@ -388,6 +407,11 @@ const deCatalog: TranslationCatalog = {
       screenSubtitle: "Spiele Wiederholungsreaktions-Varianten direkt ab.",
       probability: "{{percent}} Wahrscheinlichkeit",
       playAccessibility: "Animation {{variant}} abspielen, {{probability}}",
+    },
+    technicalError: {
+      title: "Dialog für technischen Fehler",
+      description: "Zeige eine Vorschau des gemeinsamen Dialogs für technische Fehler.",
+      value: "Vorschau",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -79,6 +79,25 @@ const enCatalog = {
   shell: {
     primaryNavigation: "Primary navigation",
   },
+  appError: {
+    technicalError: {
+      title: "Something went wrong",
+      message: "A technical error occurred. Try again or restart the app.",
+      detailsToggle: "Technical details",
+      close: "Close",
+      labels: {
+        name: "Name",
+        message: "Message",
+        endpoint: "Endpoint",
+        requestId: "Request ID",
+        statusCode: "Status code",
+        code: "Code",
+        bodyKind: "Body kind",
+        attemptCount: "Attempt count",
+        originalErrorName: "Original error",
+      },
+    },
+  },
   filters: {
     allCards: "All cards",
     and: "AND",
@@ -386,6 +405,11 @@ const enCatalog = {
       screenSubtitle: "Play review reaction variants directly.",
       probability: "{{percent}} probability",
       playAccessibility: "Play {{variant}} animation, {{probability}}",
+    },
+    technicalError: {
+      title: "Technical error dialog",
+      description: "Preview the shared technical-error dialog.",
+      value: "Preview",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -81,6 +81,25 @@ const esEsCatalog: TranslationCatalog = {
   shell: {
     primaryNavigation: "Navegación principal",
   },
+  appError: {
+    technicalError: {
+      title: "Algo salió mal",
+      message: "Se produjo un error técnico. Inténtalo de nuevo o reinicia la aplicación.",
+      detailsToggle: "Detalles técnicos",
+      close: "Cerrar",
+      labels: {
+        name: "Nombre",
+        message: "Mensaje",
+        endpoint: "Endpoint",
+        requestId: "ID de solicitud",
+        statusCode: "Código de estado",
+        code: "Código",
+        bodyKind: "Tipo de cuerpo",
+        attemptCount: "Número de intentos",
+        originalErrorName: "Error original",
+      },
+    },
+  },
   filters: {
     allCards: "Todas las tarjetas",
     and: "Y",
@@ -388,6 +407,11 @@ const esEsCatalog: TranslationCatalog = {
       screenSubtitle: "Reproduce directamente las variantes de reacción de repaso.",
       probability: "{{percent}} de probabilidad",
       playAccessibility: "Reproducir la animación {{variant}}, {{probability}}",
+    },
+    technicalError: {
+      title: "Diálogo de error técnico",
+      description: "Previsualiza el diálogo compartido de error técnico.",
+      value: "Vista previa",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -81,6 +81,25 @@ const esMxCatalog: TranslationCatalog = {
   shell: {
     primaryNavigation: "Navegación principal",
   },
+  appError: {
+    technicalError: {
+      title: "Algo salió mal",
+      message: "Se produjo un error técnico. Intenta de nuevo o reinicia la aplicación.",
+      detailsToggle: "Detalles técnicos",
+      close: "Cerrar",
+      labels: {
+        name: "Nombre",
+        message: "Mensaje",
+        endpoint: "Endpoint",
+        requestId: "ID de solicitud",
+        statusCode: "Código de estado",
+        code: "Código",
+        bodyKind: "Tipo de cuerpo",
+        attemptCount: "Número de intentos",
+        originalErrorName: "Error original",
+      },
+    },
+  },
   filters: {
     allCards: "Todas las tarjetas",
     and: "Y",
@@ -388,6 +407,11 @@ const esMxCatalog: TranslationCatalog = {
       screenSubtitle: "Reproduce directamente las variantes de reacción de repaso.",
       probability: "{{percent}} de probabilidad",
       playAccessibility: "Reproducir la animación {{variant}}, {{probability}}",
+    },
+    technicalError: {
+      title: "Diálogo de error técnico",
+      description: "Previsualiza el diálogo compartido de error técnico.",
+      value: "Vista previa",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -81,6 +81,25 @@ const hiCatalog: TranslationCatalog = {
   shell: {
     primaryNavigation: "मुख्य नेविगेशन",
   },
+  appError: {
+    technicalError: {
+      title: "कुछ गलत हो गया",
+      message: "एक तकनीकी त्रुटि हुई। फिर से कोशिश करें या ऐप फिर से शुरू करें।",
+      detailsToggle: "तकनीकी विवरण",
+      close: "बंद करें",
+      labels: {
+        name: "नाम",
+        message: "संदेश",
+        endpoint: "एंडपॉइंट",
+        requestId: "अनुरोध ID",
+        statusCode: "स्थिति कोड",
+        code: "कोड",
+        bodyKind: "बॉडी प्रकार",
+        attemptCount: "कोशिशों की संख्या",
+        originalErrorName: "मूल त्रुटि",
+      },
+    },
+  },
   filters: {
     allCards: "सभी कार्ड",
     and: "और",
@@ -388,6 +407,11 @@ const hiCatalog: TranslationCatalog = {
       screenSubtitle: "रिव्यू रिएक्शन वैरिएंट सीधे चलाएं।",
       probability: "{{percent}} संभावना",
       playAccessibility: "{{variant}} ऐनिमेशन चलाएं, {{probability}}",
+    },
+    technicalError: {
+      title: "तकनीकी त्रुटि डायलॉग",
+      description: "साझा तकनीकी-त्रुटि डायलॉग का प्रीव्यू देखें।",
+      value: "प्रीव्यू",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -81,6 +81,25 @@ export const jaCatalog = {
   shell: {
     primaryNavigation: "メインナビゲーション",
   },
+  appError: {
+    technicalError: {
+      title: "問題が発生しました",
+      message: "技術的なエラーが発生しました。もう一度試すか、アプリを再起動してください。",
+      detailsToggle: "技術的な詳細",
+      close: "閉じる",
+      labels: {
+        name: "名前",
+        message: "メッセージ",
+        endpoint: "エンドポイント",
+        requestId: "リクエスト ID",
+        statusCode: "ステータスコード",
+        code: "コード",
+        bodyKind: "本文の種類",
+        attemptCount: "試行回数",
+        originalErrorName: "元のエラー",
+      },
+    },
+  },
   filters: {
     allCards: "すべてのカード",
     and: "AND",
@@ -388,6 +407,11 @@ export const jaCatalog = {
       screenSubtitle: "復習リアクションのバリエーションを直接再生します。",
       probability: "確率 {{percent}}",
       playAccessibility: "{{variant}} のアニメーションを再生、{{probability}}",
+    },
+    technicalError: {
+      title: "技術エラーダイアログ",
+      description: "共通の技術エラーダイアログをプレビューします。",
+      value: "プレビュー",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -81,6 +81,25 @@ export const ruCatalog = {
   shell: {
     primaryNavigation: "Основная навигация",
   },
+  appError: {
+    technicalError: {
+      title: "Что-то пошло не так",
+      message: "Произошла техническая ошибка. Попробуйте еще раз или перезапустите приложение.",
+      detailsToggle: "Технические детали",
+      close: "Закрыть",
+      labels: {
+        name: "Имя",
+        message: "Сообщение",
+        endpoint: "Эндпоинт",
+        requestId: "ID запроса",
+        statusCode: "Код статуса",
+        code: "Код",
+        bodyKind: "Тип тела",
+        attemptCount: "Число попыток",
+        originalErrorName: "Исходная ошибка",
+      },
+    },
+  },
   filters: {
     allCards: "Все карточки",
     and: "AND",
@@ -388,6 +407,11 @@ export const ruCatalog = {
       screenSubtitle: "Запускайте варианты реакции на повторение напрямую.",
       probability: "Вероятность {{percent}}",
       playAccessibility: "Воспроизвести анимацию {{variant}}, {{probability}}",
+    },
+    technicalError: {
+      title: "Диалог технической ошибки",
+      description: "Предпросмотр общего диалога технической ошибки.",
+      value: "Предпросмотр",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -81,6 +81,25 @@ export const zhHansCatalog = {
   shell: {
     primaryNavigation: "主导航",
   },
+  appError: {
+    technicalError: {
+      title: "出了点问题",
+      message: "发生技术错误。请重试或重新启动应用。",
+      detailsToggle: "技术详情",
+      close: "关闭",
+      labels: {
+        name: "名称",
+        message: "消息",
+        endpoint: "端点",
+        requestId: "请求 ID",
+        statusCode: "状态码",
+        code: "代码",
+        bodyKind: "正文类型",
+        attemptCount: "尝试次数",
+        originalErrorName: "原始错误",
+      },
+    },
+  },
   filters: {
     allCards: "所有卡片",
     and: "AND",
@@ -388,6 +407,11 @@ export const zhHansCatalog = {
       screenSubtitle: "直接播放复习反应变体。",
       probability: "{{percent}} 概率",
       playAccessibility: "播放 {{variant}} 动画，{{probability}}",
+    },
+    technicalError: {
+      title: "技术错误对话框",
+      description: "预览共享技术错误对话框。",
+      value: "预览",
     },
   },
   settingsWorkspace: {

--- a/apps/web/src/screens/settings/TestSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/TestSettingsScreen.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactElement } from "react";
+import { useAppErrorDialog } from "../../appError/AppErrorContext";
 import { type TranslationKey, type TranslationValues, useI18n } from "../../i18n";
 import { settingsTestAnimationsRoute } from "../../routes";
 import {
@@ -25,7 +26,7 @@ import {
   reviewReactionLottieFallbackVariant,
   startReviewReactionLottiePrewarm,
 } from "../review/reactions/reviewReactionLottie";
-import { SettingsGroup, SettingsNavigationCard, SettingsShell } from "./SettingsShared";
+import { SettingsActionCard, SettingsGroup, SettingsNavigationCard, SettingsShell } from "./SettingsShared";
 
 type Translate = (key: TranslationKey, values?: TranslationValues) => string;
 type FormatNumber = (value: number, options?: Readonly<Intl.NumberFormatOptions>) => string;
@@ -36,6 +37,7 @@ const probabilityFormatOptions: Readonly<Intl.NumberFormatOptions> = {
 
 export function TestSettingsScreen(): ReactElement {
   const { t } = useI18n();
+  const { showTechnicalErrorPreview } = useAppErrorDialog();
 
   return (
     <SettingsShell
@@ -52,6 +54,13 @@ export function TestSettingsScreen(): ReactElement {
               value={t("settingsTest.animations.value")}
               to={settingsTestAnimationsRoute}
               testId="test-settings-animations-row"
+            />
+            <SettingsActionCard
+              title={t("settingsTest.technicalError.title")}
+              description={t("settingsTest.technicalError.description")}
+              value={t("settingsTest.technicalError.value")}
+              onClick={showTechnicalErrorPreview}
+              testId="test-settings-technical-error-row"
             />
           </div>
         </SettingsGroup>

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -43,4 +43,5 @@
   --desktop-shell-gutter: var(--shell-frame-gap);
   --content-width: 1240px;
   --shell-width: 1320px;
+  --z-index-app-modal-top: 300;
 }

--- a/apps/web/src/styles/ui.css
+++ b/apps/web/src/styles/ui.css
@@ -266,6 +266,55 @@
   font-size: 14px;
 }
 
+.app-error-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-index-app-modal-top);
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  overflow-y: auto;
+  background: rgba(9, 10, 15, 0.8);
+  backdrop-filter: blur(10px);
+}
+
+.app-error-dialog {
+  width: min(100%, 520px);
+  max-height: calc(100vh - 40px);
+  display: grid;
+  gap: 18px;
+  overflow-y: auto;
+}
+
+.app-error-dialog-details {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+}
+
+.app-error-dialog-details > summary {
+  padding: 11px 14px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-weight: 650;
+}
+
+.app-error-dialog-details > summary:hover {
+  color: var(--text);
+}
+
+.app-error-dialog-details > pre {
+  margin: 0;
+  padding: 0 14px 14px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .txn-scroll {
   overflow-x: auto;
   width: 100%;


### PR DESCRIPTION
## Summary
- add shared web technical-error dialog provider, presenter, and portal dialog
- wire a hidden Tests preview action through the same dialog UI without reporting
- add localized dialog/test strings and top-modal z-index styling

## Validation
- npm ci passed with existing Node engine warning
- ./node_modules/.bin/tsc -b --pretty false passed
- ./node_modules/.bin/vitest run src/i18n/context.test.tsx src/screens/settings/SettingsScreen.navigation.test.tsx passed
- git --no-pager diff --check passed
- final worker-owned review reported no P0-P4 findings

## Residual risk
- browser visual smoke/capture flow was not run