### PR TITLE
Fix Cards search dismissal state

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift
@@ -86,7 +86,6 @@ struct CardsScreen: View {
 
     @State private var editorPresentation: CardEditorPresentation? = nil
     @State private var isFilterSheetPresented: Bool = false
-    @State private var isSearchPresented: Bool = false
     @State private var searchText: String = ""
     @State private var committedFilter: CardFilter? = nil
     @State private var draftFilter: CardFilter? = nil
@@ -164,7 +163,6 @@ struct CardsScreen: View {
         .navigationTitle(String(localized: "Cards", table: reviewCardsStringsTableName))
         .searchable(
             text: self.$searchText,
-            isPresented: self.$isSearchPresented,
             placement: .automatic,
             prompt: String(localized: "Search cards", table: reviewCardsStringsTableName)
         )
@@ -404,11 +402,7 @@ struct CardsScreen: View {
     }
 
     private func dismissCardsSearch() {
-        guard self.isSearchPresented else {
-            return
-        }
         self.dismissSearch()
-        self.isSearchPresented = false
     }
 
     private func saveCard() {


### PR DESCRIPTION
This PR removes Cards' local `isSearchPresented` mirror and lets SwiftUI own native search presentation. It targets a device-specific issue where Cards search could reopen after dismissal. The fix is intentionally minimal: search UI, toolbar behavior, filtering, sync, and editor flows are otherwise unchanged.

Validation:
- `rg -n "isSearchPresented" apps/ios/Flashcards/Flashcards/Cards/List/CardsScreen.swift`: no matches after edit
- `git --no-pager diff --check`: passed
- Worker-owned read-only review: no P0-P4 findings; green light for commit
- Generic/device iOS `xcodebuild` build attempts did not reach compilation because Xcode reported no valid destination for the scheme before compilation
- No simulator-backed tests, XCUITest, screenshot generation, or smoke flows were run

Residual risk:
- Affected-device search dismissal behavior still needs production/device verification after release.