### PR TITLE
Fix Android cloud technical error dialogs

### DIFF
--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/prompts/guestreview/GuestSignInAfterReviewPromptDialogTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/prompts/guestreview/GuestSignInAfterReviewPromptDialogTest.kt
@@ -98,10 +98,12 @@ class GuestSignInAfterReviewPromptDialogTest : FirebaseAppInstrumentationTimeout
                                 isVerifyingCode = false,
                                 errorMessage = "",
                                 errorTechnicalDetails = null,
+                                errorTechnicalDetailsReportId = null,
                                 challengeEmail = null
                             ),
                             onEmailChange = {},
                             onSendCode = {},
+                            onShowTechnicalDetails = { _, _ -> },
                             onBack = {
                                 navController.popBackStack()
                             }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDangerZoneRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDangerZoneRouteTest.kt
@@ -35,6 +35,8 @@ class AccountDangerZoneRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isDeleting = false,
                         deleteState = DestructiveActionState.IDLE,
                         errorMessage = "",
+                        errorTechnicalDetails = null,
+                        errorTechnicalDetailsReportId = null,
                         successMessage = "",
                         showDeleteConfirmation = false
                     ),
@@ -42,6 +44,7 @@ class AccountDangerZoneRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onDismissDeleteConfirmation = {},
                     onConfirmationTextChange = {},
                     onDeleteAccount = {},
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {}
                 )
             }
@@ -64,6 +67,8 @@ class AccountDangerZoneRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         isDeleting = true,
                         deleteState = DestructiveActionState.IN_PROGRESS,
                         errorMessage = "",
+                        errorTechnicalDetails = null,
+                        errorTechnicalDetailsReportId = null,
                         successMessage = "",
                         showDeleteConfirmation = false
                     ),
@@ -71,6 +76,7 @@ class AccountDangerZoneRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onDismissDeleteConfirmation = {},
                     onConfirmationTextChange = {},
                     onDeleteAccount = {},
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {}
                 )
             }
@@ -90,7 +96,9 @@ class AccountDangerZoneRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         confirmationText = "",
                         isDeleting = false,
                         deleteState = DestructiveActionState.FAILED,
-                        errorMessage = "Delete request did not finish.",
+                        errorMessage = settingsString(SettingsR.string.settings_account_danger_zone_delete_failed),
+                        errorTechnicalDetails = "Delete request did not finish.",
+                        errorTechnicalDetailsReportId = "test-account-delete-failure",
                         successMessage = "",
                         showDeleteConfirmation = true
                     ),
@@ -98,6 +106,7 @@ class AccountDangerZoneRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onDismissDeleteConfirmation = {},
                     onConfirmationTextChange = {},
                     onDeleteAccount = {},
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {}
                 )
             }
@@ -105,7 +114,9 @@ class AccountDangerZoneRouteTest : FirebaseAppInstrumentationTimeoutTest() {
 
         composeRule.onNodeWithText(settingsString(SettingsR.string.settings_account_danger_zone_dialog_title)).assertIsDisplayed()
         composeRule.waitUntil(timeoutMillis = 5_000L) {
-            composeRule.onAllNodesWithText("Delete request did not finish.").fetchSemanticsNodes().size == 2
+            composeRule.onAllNodesWithText(
+                settingsString(SettingsR.string.settings_account_danger_zone_delete_failed)
+            ).fetchSemanticsNodes().size == 2
         }
         composeRule.onNodeWithText(settingsString(SettingsR.string.settings_account_danger_zone_confirmation_phrase)).assertIsDisplayed()
         composeRule.onNodeWithText(settingsString(SettingsR.string.settings_cancel)).assertIsDisplayed()

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDeletionBlockingSurfaceTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/AccountDeletionBlockingSurfaceTest.kt
@@ -3,11 +3,13 @@ package com.flashcardsopensourceapp.app.routes
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.flashcardsopensourceapp.app.AccountDeletionBlockingSurface
 import com.flashcardsopensourceapp.app.FirebaseAppInstrumentationTimeoutTest
+import com.flashcardsopensourceapp.app.accountDeletionBlockingTechnicalDetailsTag
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.data.local.model.cloud.AccountDeletionState
 import org.junit.Assert.assertEquals
@@ -26,6 +28,7 @@ class AccountDeletionBlockingSurfaceTest : FirebaseAppInstrumentationTimeoutTest
             FlashcardsTheme {
                 AccountDeletionBlockingSurface(
                     accountDeletionState = AccountDeletionState.Hidden,
+                    onShowTechnicalDetails = { _, _ -> },
                     onRetryDeletion = {}
                 )
             }
@@ -40,11 +43,20 @@ class AccountDeletionBlockingSurfaceTest : FirebaseAppInstrumentationTimeoutTest
     @Test
     fun failedStateShowsRetryActionAndErrorMessage() {
         var retryCalls = 0
+        var technicalDetails = ""
+        var technicalDetailsReportId = ""
 
         composeRule.setContent {
             FlashcardsTheme {
                 AccountDeletionBlockingSurface(
-                    accountDeletionState = AccountDeletionState.Failed(message = "Delete request did not finish."),
+                    accountDeletionState = AccountDeletionState.Failed(
+                        message = "Delete request did not finish.",
+                        technicalDetailsReportId = "test-account-deletion-state-failed"
+                    ),
+                    onShowTechnicalDetails = { details, reportId ->
+                        technicalDetails = details
+                        technicalDetailsReportId = reportId
+                    },
                     onRetryDeletion = {
                         retryCalls += 1
                     }
@@ -53,11 +65,18 @@ class AccountDeletionBlockingSurfaceTest : FirebaseAppInstrumentationTimeoutTest
         }
 
         composeRule.onNodeWithText("Deleting account").assertIsDisplayed()
-        composeRule.onNodeWithText("Delete request did not finish.").assertIsDisplayed()
+        composeRule.onNodeWithText(
+            "The delete request did not finish yet. Retry to keep the account deletion moving forward."
+        ).assertIsDisplayed()
+        composeRule.onNodeWithTag(accountDeletionBlockingTechnicalDetailsTag).performClick()
         composeRule.onNodeWithText("Retry deletion").performClick()
         composeRule.waitUntil(timeoutMillis = 5_000L) {
-            retryCalls == 1
+            retryCalls == 1 &&
+                technicalDetails == "AccountDeletionState.Failed: Delete request did not finish." &&
+                technicalDetailsReportId == "test-account-deletion-state-failed"
         }
+        assertEquals("AccountDeletionState.Failed: Delete request did not finish.", technicalDetails)
+        assertEquals("test-account-deletion-state-failed", technicalDetailsReportId)
         assertEquals(1, retryCalls)
     }
 }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/CloudPostAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/CloudPostAuthRouteTest.kt
@@ -45,6 +45,8 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         processingTitle = "",
                         processingMessage = "",
                         errorMessage = "",
+                        errorTechnicalDetails = null,
+                        errorTechnicalDetailsReportId = null,
                         canRetry = false,
                         canLogout = false,
                         failureActionLabel = "Log out",
@@ -56,6 +58,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onSelectWorkspace = {},
                     onRetry = {},
                     onFailureAction = {},
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {},
                     canNavigateBack = true
                 )
@@ -102,6 +105,8 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         processingTitle = "",
                         processingMessage = "",
                         errorMessage = "",
+                        errorTechnicalDetails = null,
+                        errorTechnicalDetailsReportId = null,
                         canRetry = false,
                         canLogout = false,
                         failureActionLabel = "Log out",
@@ -113,6 +118,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     },
                     onRetry = {},
                     onFailureAction = {},
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {},
                     canNavigateBack = true
                 )
@@ -150,6 +156,8 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         processingTitle = "",
                         processingMessage = "",
                         errorMessage = "Cloud sync could not finish.",
+                        errorTechnicalDetails = "Cloud sync could not finish.",
+                        errorTechnicalDetailsReportId = "test-cloud-post-auth-failure",
                         canRetry = true,
                         canLogout = true,
                         failureActionLabel = "Log out",
@@ -163,6 +171,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onFailureAction = {
                         logoutCalls += 1
                     },
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {},
                     canNavigateBack = true
                 )
@@ -196,6 +205,8 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         processingTitle = "",
                         processingMessage = "",
                         errorMessage = "",
+                        errorTechnicalDetails = null,
+                        errorTechnicalDetailsReportId = null,
                         canRetry = false,
                         canLogout = false,
                         failureActionLabel = "Log out",
@@ -207,6 +218,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onSelectWorkspace = {},
                     onRetry = {},
                     onFailureAction = {},
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {},
                     canNavigateBack = true
                 )
@@ -242,6 +254,8 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                         processingTitle = "",
                         processingMessage = "",
                         errorMessage = "Local data recovery failed. Try again; local data stays on this device.",
+                        errorTechnicalDetails = "Local data recovery failed. Try again; local data stays on this device.",
+                        errorTechnicalDetailsReportId = "test-cloud-post-auth-recovery-failure",
                         canRetry = true,
                         canLogout = false,
                         failureActionLabel = "Log out",
@@ -255,6 +269,7 @@ class CloudPostAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                     onFailureAction = {
                         failureActionCalls += 1
                     },
+                    onShowTechnicalDetails = { _, _ -> },
                     onBack = {},
                     canNavigateBack = true
                 )

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/RtlLayoutTest.kt
@@ -62,10 +62,12 @@ class RtlLayoutTest : FirebaseAppInstrumentationTimeoutTest() {
                     isVerifyingCode = false,
                     errorMessage = "",
                     errorTechnicalDetails = null,
+                    errorTechnicalDetailsReportId = null,
                     challengeEmail = "rtl@example.com"
                 ),
                 onCodeChange = { _ -> },
                 onVerifyCode = {},
+                onShowTechnicalDetails = { _, _ -> },
                 onBack = {}
             )
         }

--- a/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsAuthRouteTest.kt
+++ b/apps/android/app/src/androidTest/java/com/flashcardsopensourceapp/app/routes/SettingsAuthRouteTest.kt
@@ -43,10 +43,12 @@ class SettingsAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                                 isVerifyingCode = false,
                                 errorMessage = "",
                                 errorTechnicalDetails = null,
+                                errorTechnicalDetailsReportId = null,
                                 challengeEmail = null
                             ),
                             onEmailChange = { email = it },
                             onSendCode = { route = "code" },
+                            onShowTechnicalDetails = { _, _ -> },
                             onBack = {}
                         )
                     }
@@ -61,10 +63,12 @@ class SettingsAuthRouteTest : FirebaseAppInstrumentationTimeoutTest() {
                                 isVerifyingCode = false,
                                 errorMessage = "",
                                 errorTechnicalDetails = null,
+                                errorTechnicalDetailsReportId = null,
                                 challengeEmail = email
                             ),
                             onCodeChange = { code = it },
                             onVerifyCode = {},
+                            onShowTechnicalDetails = { _, _ -> },
                             onBack = { route = "email" }
                         )
                     }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.flashcardsopensourceapp.app.di.AppGraph
+import com.flashcardsopensourceapp.core.ui.nextAppTechnicalErrorReportId
+import com.flashcardsopensourceapp.core.ui.renderTechnicalErrorDetails
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryState
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudCredentialRecoveryGateRoute
 import com.flashcardsopensourceapp.feature.settings.cloud.CloudCredentialRecoveryGateStep
@@ -62,12 +64,20 @@ internal fun CloudCredentialRecoveryGateContainer(
     var eraseErrorMessage: String by rememberSaveable {
         mutableStateOf("")
     }
+    var eraseErrorTechnicalDetails: String? by rememberSaveable {
+        mutableStateOf(null)
+    }
+    var eraseErrorTechnicalDetailsReportId: String? by rememberSaveable {
+        mutableStateOf(null)
+    }
 
     LaunchedEffect(recoveryState) {
         gateStep = CloudCredentialRecoveryGateStep.OVERVIEW
         isEraseConfirmationVisible = false
         isErasing = false
         eraseErrorMessage = ""
+        eraseErrorTechnicalDetails = null
+        eraseErrorTechnicalDetailsReportId = null
         signInViewModel.cancelSignIn()
     }
 
@@ -92,9 +102,13 @@ internal fun CloudCredentialRecoveryGateContainer(
         isEraseConfirmationVisible = isEraseConfirmationVisible,
         isErasing = isErasing,
         eraseErrorMessage = eraseErrorMessage,
+        eraseErrorTechnicalDetails = eraseErrorTechnicalDetails,
+        eraseErrorTechnicalDetailsReportId = eraseErrorTechnicalDetailsReportId,
         onSignIn = {
             signInViewModel.cancelSignIn()
             eraseErrorMessage = ""
+            eraseErrorTechnicalDetails = null
+            eraseErrorTechnicalDetailsReportId = null
             isEraseConfirmationVisible = false
             gateStep = CloudCredentialRecoveryGateStep.EMAIL
         },
@@ -135,8 +149,18 @@ internal fun CloudCredentialRecoveryGateContainer(
         onBackToEmail = {
             gateStep = CloudCredentialRecoveryGateStep.EMAIL
         },
+        onShowTechnicalDetails = { technicalDetails, reportId ->
+            appGraph.showTechnicalErrorDialog(
+                reportId = reportId,
+                title = context.getString(R.string.technical_error_dialog_default_title),
+                message = context.getString(R.string.technical_error_dialog_default_message),
+                technicalDetails = technicalDetails
+            )
+        },
         onRequestEraseConfirmation = {
             eraseErrorMessage = ""
+            eraseErrorTechnicalDetails = null
+            eraseErrorTechnicalDetailsReportId = null
             isEraseConfirmationVisible = true
         },
         onDismissEraseConfirmation = {
@@ -148,6 +172,8 @@ internal fun CloudCredentialRecoveryGateContainer(
             coroutineScope.launch {
                 isErasing = true
                 eraseErrorMessage = ""
+                eraseErrorTechnicalDetails = null
+                eraseErrorTechnicalDetailsReportId = null
                 try {
                     appGraph.cloudAccountRepository.eraseLocalDataForCredentialRecovery()
                     signInViewModel.cancelSignIn()
@@ -156,7 +182,11 @@ internal fun CloudCredentialRecoveryGateContainer(
                 } catch (error: CancellationException) {
                     throw error
                 } catch (error: Exception) {
-                    eraseErrorMessage = error.message ?: eraseFailedMessage
+                    eraseErrorMessage = eraseFailedMessage
+                    eraseErrorTechnicalDetails = renderTechnicalErrorDetails(error = error)
+                    eraseErrorTechnicalDetailsReportId = nextAppTechnicalErrorReportId(
+                        source = "cloud-credential-recovery-erase"
+                    )
                 } finally {
                     isErasing = false
                 }

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -87,6 +88,7 @@ import com.flashcardsopensourceapp.data.local.repository.sync.AutoSyncSource
 import com.flashcardsopensourceapp.core.ui.AppTechnicalError
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.core.ui.components.AppTechnicalErrorDialog
+import com.flashcardsopensourceapp.core.ui.renderTechnicalErrorDetails
 import com.flashcardsopensourceapp.core.ui.theme.FlashcardsTheme
 import com.flashcardsopensourceapp.feature.review.reaction.rememberReviewReactionLottieConfigurationStore
 import com.flashcardsopensourceapp.feature.settings.SettingsAttentionBadge
@@ -98,6 +100,8 @@ import kotlinx.coroutines.launch
 
 private const val startupLoadingTag: String = "app.startupLoading"
 private const val startupErrorTag: String = "app.startupError"
+internal const val accountDeletionBlockingTechnicalDetailsTag: String =
+    "accountDeletionBlocking.technicalDetails"
 
 @Composable
 fun FlashcardsApp(
@@ -110,30 +114,6 @@ fun FlashcardsApp(
         val startupState by appGraph.startupState.collectAsStateWithLifecycle(
             initialValue = AppStartupState.Loading
         )
-        when (val currentStartupState = startupState) {
-            AppStartupState.Loading -> {
-                StartupLoadingScreen()
-                return@FlashcardsTheme
-            }
-
-            is AppStartupState.Failed -> {
-                StartupErrorScreen(
-                    message = currentStartupState.message,
-                    onRetry = appGraph::retryStartup
-                )
-                return@FlashcardsTheme
-            }
-
-            AppStartupState.Ready -> Unit
-        }
-
-        val snackbarHostState = remember { SnackbarHostState() }
-        val reviewReactionLottieConfigurationStore = rememberReviewReactionLottieConfigurationStore()
-        LaunchedEffect(appGraph.appMessageBus, snackbarHostState) {
-            appGraph.appMessageBus.messages.collect { message ->
-                snackbarHostState.showSnackbar(message = message)
-            }
-        }
         val activeTechnicalError by appGraph.appMessageBus.activeTechnicalError.collectAsStateWithLifecycle()
         val activeTechnicalErrorPreview by appGraph.testTechnicalErrorDialogPreviewController
             .activePreviewTechnicalError
@@ -145,6 +125,44 @@ fun FlashcardsApp(
                 appGraph.testTechnicalErrorDialogPreviewController.dismissTestPreview()
             } else {
                 appGraph.testTechnicalErrorDialogPreviewController.dismissTestPreview()
+            }
+        }
+        when (val currentStartupState = startupState) {
+            AppStartupState.Loading -> {
+                StartupLoadingScreen()
+                return@FlashcardsTheme
+            }
+
+            is AppStartupState.Failed -> {
+                val context = LocalContext.current
+                Box(modifier = Modifier.fillMaxSize()) {
+                    StartupErrorScreen(
+                        technicalDetails = currentStartupState.technicalDetails,
+                        onShowTechnicalDetails = { technicalDetails ->
+                            appGraph.showReportedTechnicalErrorDialog(
+                                title = context.getString(R.string.technical_error_dialog_default_title),
+                                message = context.getString(R.string.technical_error_dialog_default_message),
+                                technicalDetails = technicalDetails
+                            )
+                        },
+                        onRetry = appGraph::retryStartup
+                    )
+                    AppTechnicalErrorDialogHost(
+                        error = displayedTechnicalError,
+                        onDismiss = dismissDisplayedTechnicalError
+                    )
+                }
+                return@FlashcardsTheme
+            }
+
+            AppStartupState.Ready -> Unit
+        }
+
+        val snackbarHostState = remember { SnackbarHostState() }
+        val reviewReactionLottieConfigurationStore = rememberReviewReactionLottieConfigurationStore()
+        LaunchedEffect(appGraph.appMessageBus, snackbarHostState) {
+            appGraph.appMessageBus.messages.collect { message ->
+                snackbarHostState.showSnackbar(message = message)
             }
         }
 
@@ -570,6 +588,14 @@ fun FlashcardsApp(
                 )
                 AccountDeletionBlockingSurface(
                     accountDeletionState = accountDeletionState,
+                    onShowTechnicalDetails = { technicalDetails, reportId ->
+                        appGraph.showTechnicalErrorDialog(
+                            reportId = reportId,
+                            title = applicationContext.getString(R.string.technical_error_dialog_default_title),
+                            message = applicationContext.getString(R.string.technical_error_dialog_default_message),
+                            technicalDetails = technicalDetails
+                        )
+                    },
                     onRetryDeletion = {
                         appGraph.cloudAccountRepository.retryPendingAccountDeletion()
                     }
@@ -727,7 +753,8 @@ private fun StartupLoadingScreen() {
 
 @Composable
 private fun StartupErrorScreen(
-    message: String,
+    technicalDetails: String,
+    onShowTechnicalDetails: (String) -> Unit,
     onRetry: () -> Unit
 ) {
     Surface(
@@ -751,9 +778,14 @@ private fun StartupErrorScreen(
                         style = MaterialTheme.typography.titleLarge
                     )
                     Text(
-                        text = message,
+                        text = stringResource(id = R.string.startup_error_message),
                         style = MaterialTheme.typography.bodyMedium
                     )
+                    if (technicalDetails.isNotBlank()) {
+                        OutlinedButton(onClick = { onShowTechnicalDetails(technicalDetails) }) {
+                            Text(text = stringResource(id = R.string.technical_error_dialog_show_details))
+                        }
+                    }
                     Button(onClick = onRetry) {
                         Text(text = stringResource(id = R.string.startup_error_retry))
                     }
@@ -794,6 +826,7 @@ private fun UnsupportedRuntimeScreen() {
 @Composable
 internal fun AccountDeletionBlockingSurface(
     accountDeletionState: AccountDeletionState,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onRetryDeletion: suspend () -> Unit
 ) {
     if (accountDeletionState == AccountDeletionState.Hidden) {
@@ -837,16 +870,26 @@ internal fun AccountDeletionBlockingSurface(
                         )
                     }
                     is AccountDeletionState.Failed -> {
+                        val technicalDetails = renderTechnicalErrorDetails(
+                            errorType = "AccountDeletionState.Failed",
+                            message = accountDeletionState.message
+                        )
                         Text(
                             text = stringResource(id = R.string.account_deletion_failed_message),
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                        Card(modifier = Modifier.fillMaxWidth()) {
-                            Text(
-                                text = accountDeletionState.message,
-                                color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.padding(16.dp)
-                            )
+                        OutlinedButton(
+                            onClick = {
+                                onShowTechnicalDetails(
+                                    technicalDetails,
+                                    accountDeletionState.technicalDetailsReportId
+                                )
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(accountDeletionBlockingTechnicalDetailsTag)
+                        ) {
+                            Text(stringResource(id = R.string.technical_error_dialog_show_details))
                         }
                         Button(
                             onClick = {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -22,6 +22,8 @@ import com.flashcardsopensourceapp.core.observability.AndroidExceptionIssueEvent
 import com.flashcardsopensourceapp.core.observability.AppObservability
 import com.flashcardsopensourceapp.core.observability.CloudObservationIdentity
 import com.flashcardsopensourceapp.core.ui.AppMessageBus
+import com.flashcardsopensourceapp.core.ui.AppTechnicalError
+import com.flashcardsopensourceapp.core.ui.renderTechnicalErrorDetails
 import com.flashcardsopensourceapp.core.ui.TestModeStore
 import com.flashcardsopensourceapp.core.ui.VisibleAppScreenController
 import com.flashcardsopensourceapp.app.navigation.AppHandoffCoordinator
@@ -98,8 +100,12 @@ private const val appGraphLogTag: String = "AppGraph"
 sealed interface AppStartupState {
     data object Loading : AppStartupState
     data object Ready : AppStartupState
-    data class Failed(val message: String) : AppStartupState
+    data class Failed(val technicalDetails: String) : AppStartupState
 }
+
+private class AppTechnicalErrorDetailsException(
+    technicalDetails: String
+) : IllegalStateException(technicalDetails)
 
 data class AppGuestCloudSession(
     val workspaceId: String
@@ -436,7 +442,7 @@ class AppGraph(
                     "event=app_startup_exception ${renderSanitizedThrowableLogFields(error = error)}"
                 )
                 startupStateMutable.value = AppStartupState.Failed(
-                    message = error.message ?: "Android startup failed."
+                    technicalDetails = renderTechnicalErrorDetails(error = error)
                 )
             }
         }
@@ -467,7 +473,7 @@ class AppGraph(
         }) {
             AppStartupState.Ready -> Unit
             is AppStartupState.Failed -> {
-                throw IllegalStateException(currentStartupState.message)
+                throw IllegalStateException(currentStartupState.technicalDetails)
             }
 
             AppStartupState.Loading -> {
@@ -482,6 +488,38 @@ class AppGraph(
 
     fun retryStartup() {
         startStartup()
+    }
+
+    fun showTechnicalErrorDialog(
+        reportId: String,
+        title: String,
+        message: String,
+        technicalDetails: String
+    ) {
+        appMessageBus.showTechnicalError(
+            error = AppTechnicalError(
+                reportId = reportId,
+                title = title,
+                message = message,
+                technicalDetails = technicalDetails
+            ),
+            throwable = AppTechnicalErrorDetailsException(technicalDetails = technicalDetails)
+        )
+    }
+
+    fun showReportedTechnicalErrorDialog(
+        title: String,
+        message: String,
+        technicalDetails: String
+    ) {
+        appMessageBus.showReportedTechnicalError(
+            error = AppTechnicalError(
+                reportId = "already-reported",
+                title = title,
+                message = message,
+                technicalDetails = technicalDetails
+            )
+        )
     }
 
     private fun captureTechnicalErrorDialogException(throwable: Throwable) {

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -11,6 +11,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.flashcardsopensourceapp.app.R
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.app.navigation.SettingsDestination
 import com.flashcardsopensourceapp.app.navigation.navigateToTopLevelDestination
@@ -73,6 +74,14 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                         }
                     }
                 },
+                onShowTechnicalDetails = { technicalDetails, reportId ->
+                    appGraph.showTechnicalErrorDialog(
+                        reportId = reportId,
+                        title = context.getString(R.string.technical_error_dialog_default_title),
+                        message = context.getString(R.string.technical_error_dialog_default_message),
+                        technicalDetails = technicalDetails
+                    )
+                },
                 onBack = {
                     navController.popBackStack()
                 }
@@ -108,6 +117,14 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                             }
                         }
                     }
+                },
+                onShowTechnicalDetails = { technicalDetails, reportId ->
+                    appGraph.showTechnicalErrorDialog(
+                        reportId = reportId,
+                        title = context.getString(R.string.technical_error_dialog_default_title),
+                        message = context.getString(R.string.technical_error_dialog_default_message),
+                        technicalDetails = technicalDetails
+                    )
                 },
                 onBack = {
                     navController.popBackStack()
@@ -165,6 +182,14 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                             navigateToSettingsAccountStatus(navController = navController)
                         }
                     }
+                },
+                onShowTechnicalDetails = { technicalDetails, reportId ->
+                    appGraph.showTechnicalErrorDialog(
+                        reportId = reportId,
+                        title = context.getString(R.string.technical_error_dialog_default_title),
+                        message = context.getString(R.string.technical_error_dialog_default_message),
+                        technicalDetails = technicalDetails
+                    )
                 },
                 onBack = {
                     navController.popBackStack()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import com.flashcardsopensourceapp.app.R
 import com.flashcardsopensourceapp.app.di.AppGraph
 import com.flashcardsopensourceapp.feature.settings.account.AccountDangerZoneRoute
 import com.flashcardsopensourceapp.feature.settings.account.AccountLegalRoute
@@ -168,6 +169,14 @@ internal fun NavGraphBuilder.registerSettingsAccountNavGraph(
                 coroutineScope.launch {
                     accountDangerZoneViewModel.deleteAccount()
                 }
+            },
+            onShowTechnicalDetails = { technicalDetails, reportId ->
+                appGraph.showTechnicalErrorDialog(
+                    reportId = reportId,
+                    title = context.getString(R.string.technical_error_dialog_default_title),
+                    message = context.getString(R.string.technical_error_dialog_default_message),
+                    technicalDetails = technicalDetails
+                )
             },
             onBack = {
                 navController.popBackStack()

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsRootNavGraph.kt
@@ -364,6 +364,7 @@ internal fun NavGraphBuilder.registerSettingsRootDestinations(
             onShowTechnicalErrorDialogPreview = {
                 appGraph.testTechnicalErrorDialogPreviewController.showTestPreview(
                     error = AppTechnicalError(
+                        reportId = "settings-test-technical-error-preview",
                         title = technicalErrorTitle,
                         message = technicalErrorMessage,
                         technicalDetails = technicalErrorDetails

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="top_level_cards">Cards</string>
     <string name="top_level_settings">Settings</string>
     <string name="startup_error_title">Startup failed</string>
+    <string name="startup_error_message">Flashcards could not finish starting. Retry startup, or open technical details if support asks for them.</string>
     <string name="startup_error_retry">Retry startup</string>
     <string name="unsupported_android_runtime_title">Android version unsupported</string>
     <string name="unsupported_android_runtime_message">Flashcards requires Android 14 or newer. Update Android on this device or install the app on a supported device.</string>

--- a/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/AppMessageBus.kt
+++ b/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/AppMessageBus.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 
 fun interface TransientMessageController {
     fun showMessage(message: String)
@@ -33,6 +34,7 @@ class AppMessageBus(
         extraBufferCapacity = 32
     )
     private val activeTechnicalErrorFlow = MutableStateFlow<AppTechnicalError?>(value = null)
+    private val reportedTechnicalErrorIds: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     val messages: Flow<String> = messagesFlow.asSharedFlow()
     val activeTechnicalError: StateFlow<AppTechnicalError?> = activeTechnicalErrorFlow.asStateFlow()
@@ -45,7 +47,13 @@ class AppMessageBus(
         error: AppTechnicalError,
         throwable: Throwable
     ) {
-        reportTechnicalError(throwable)
+        if (reportedTechnicalErrorIds.add(error.reportId)) {
+            reportTechnicalError(throwable)
+        }
+        activeTechnicalErrorFlow.value = error
+    }
+
+    fun showReportedTechnicalError(error: AppTechnicalError) {
         activeTechnicalErrorFlow.value = error
     }
 

--- a/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/AppTechnicalError.kt
+++ b/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/AppTechnicalError.kt
@@ -1,10 +1,20 @@
 package com.flashcardsopensourceapp.core.ui
 
+import java.util.concurrent.atomic.AtomicLong
+
+private val appTechnicalErrorReportIdSequence = AtomicLong(0L)
+
 data class AppTechnicalError(
+    val reportId: String,
     val title: String,
     val message: String,
     val technicalDetails: String
 )
+
+fun nextAppTechnicalErrorReportId(source: String): String {
+    val normalizedSource = source.trim().ifEmpty { "technical-error" }
+    return "$normalizedSource:${appTechnicalErrorReportIdSequence.incrementAndGet()}"
+}
 
 interface AppTechnicalErrorController {
     fun showTechnicalError(

--- a/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/TechnicalErrorDetails.kt
+++ b/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/TechnicalErrorDetails.kt
@@ -1,0 +1,20 @@
+package com.flashcardsopensourceapp.core.ui
+
+fun renderTechnicalErrorDetails(error: Throwable): String {
+    return renderTechnicalErrorDetails(
+        errorType = error::class.java.name,
+        message = error.message
+    )
+}
+
+fun renderTechnicalErrorDetails(
+    errorType: String,
+    message: String?
+): String {
+    val trimmedErrorType = errorType.trim().ifEmpty { "TechnicalError" }
+    val trimmedMessage = message?.trim().orEmpty()
+    if (trimmedMessage.isEmpty()) {
+        return trimmedErrorType
+    }
+    return "$trimmedErrorType: $trimmedMessage"
+}

--- a/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/components/AppTechnicalErrorDialog.kt
+++ b/apps/android/core/ui/src/main/java/com/flashcardsopensourceapp/core/ui/components/AppTechnicalErrorDialog.kt
@@ -33,6 +33,7 @@ fun AppTechnicalErrorDialog(
     onDismiss: () -> Unit
 ) {
     var isShowingDetails by rememberSaveable(
+        error.reportId,
         error.title,
         error.message,
         error.technicalDetails

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/identity/CloudIdentityResetCoordinatorTest.kt
@@ -132,6 +132,7 @@ class CloudIdentityResetCoordinatorTest {
 
         val failedState = environment.cloudPreferencesStore.currentAccountDeletionState()
         assertTrue(failedState is AccountDeletionState.Failed)
+        assertTrue((failedState as AccountDeletionState.Failed).technicalDetailsReportId.isNotBlank())
         assertEquals(1, remoteGateway.deleteAccountCalls)
         assertEquals(CloudAccountState.LINKED, environment.cloudPreferencesStore.currentCloudSettings().cloudState)
         assertEquals(initialLocalWorkspaceId, environment.database.workspaceDao().loadAnyWorkspace()?.workspaceId)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/CloudPreferencesStore.kt
@@ -54,6 +54,7 @@ private const val activeWorkspaceIdKey: String = "active-workspace-id"
 private const val updatedAtMillisKey: String = "updated-at-millis"
 private const val accountDeletionStatusKey: String = "account-deletion-status"
 private const val accountDeletionFailureMessageKey: String = "account-deletion-failure-message"
+private const val accountDeletionFailureReportIdKey: String = "account-deletion-failure-report-id"
 private const val customOriginKey: String = "custom-origin"
 private const val cloudCredentialRecoveryStateKey: String = "cloud-credential-recovery-state"
 private const val reviewReactionAnimationsEnabledKey: String = "review-reaction-animations-enabled"
@@ -388,22 +389,29 @@ class CloudPreferencesStore(
         metadataPreferences.edit(commit = true) {
             putString(accountDeletionStatusKey, accountDeletionStatusInProgress)
             remove(accountDeletionFailureMessageKey)
+            remove(accountDeletionFailureReportIdKey)
         }
         accountDeletionState.value = AccountDeletionState.InProgress
     }
 
     fun markAccountDeletionFailed(message: String) {
+        val reportId = nextAccountDeletionFailureReportId()
         metadataPreferences.edit(commit = true) {
             putString(accountDeletionStatusKey, accountDeletionStatusFailed)
             putString(accountDeletionFailureMessageKey, message)
+            putString(accountDeletionFailureReportIdKey, reportId)
         }
-        accountDeletionState.value = AccountDeletionState.Failed(message = message)
+        accountDeletionState.value = AccountDeletionState.Failed(
+            message = message,
+            technicalDetailsReportId = reportId
+        )
     }
 
     fun clearAccountDeletionState() {
         metadataPreferences.edit(commit = true) {
             putString(accountDeletionStatusKey, accountDeletionStatusHidden)
             remove(accountDeletionFailureMessageKey)
+            remove(accountDeletionFailureReportIdKey)
         }
         accountDeletionState.value = AccountDeletionState.Hidden
     }
@@ -452,12 +460,27 @@ class CloudPreferencesStore(
     private fun loadAccountDeletionState(): AccountDeletionState {
         return when (metadataPreferences.getString(accountDeletionStatusKey, accountDeletionStatusHidden)) {
             accountDeletionStatusInProgress -> AccountDeletionState.InProgress
-            accountDeletionStatusFailed -> AccountDeletionState.Failed(
-                message = metadataPreferences.getString(accountDeletionFailureMessageKey, null)
+            accountDeletionStatusFailed -> {
+                val message = metadataPreferences.getString(accountDeletionFailureMessageKey, null)
                     ?: "Account deletion failed."
-            )
+                AccountDeletionState.Failed(
+                    message = message,
+                    technicalDetailsReportId = metadataPreferences.getString(
+                        accountDeletionFailureReportIdKey,
+                        null
+                    ) ?: legacyAccountDeletionFailureReportId(message = message)
+                )
+            }
             else -> AccountDeletionState.Hidden
         }
+    }
+
+    private fun nextAccountDeletionFailureReportId(): String {
+        return "account-deletion-state-failed:${UUID.randomUUID()}"
+    }
+
+    private fun legacyAccountDeletionFailureReportId(message: String): String {
+        return "account-deletion-state-failed:legacy:${message.hashCode()}"
     }
 
     private fun loadAccountPreferences(): AccountPreferences {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cloud/CloudModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/cloud/CloudModels.kt
@@ -201,6 +201,7 @@ sealed interface AccountDeletionState {
     data object InProgress : AccountDeletionState
 
     data class Failed(
-        val message: String
+        val message: String,
+        val technicalDetailsReportId: String
     ) : AccountDeletionState
 }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneRoute.kt
@@ -40,6 +40,7 @@ fun AccountDangerZoneRoute(
     onDismissDeleteConfirmation: () -> Unit,
     onConfirmationTextChange: (String) -> Unit,
     onDeleteAccount: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onBack: () -> Unit
 ) {
     val strings = createSettingsStringResolver(context = LocalContext.current)
@@ -56,11 +57,31 @@ fun AccountDangerZoneRoute(
             if (uiState.errorMessage.isNotEmpty()) {
                 item {
                     Card(modifier = Modifier.fillMaxWidth()) {
-                        Text(
-                            text = uiState.errorMessage,
-                            color = MaterialTheme.colorScheme.error,
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
                             modifier = Modifier.padding(20.dp)
-                        )
+                        ) {
+                            Text(
+                                text = uiState.errorMessage,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                            if (
+                                uiState.errorTechnicalDetails.isNullOrBlank().not() &&
+                                uiState.errorTechnicalDetailsReportId.isNullOrBlank().not()
+                            ) {
+                                TextButton(
+                                    onClick = {
+                                        onShowTechnicalDetails(
+                                            uiState.errorTechnicalDetails.orEmpty(),
+                                            uiState.errorTechnicalDetailsReportId.orEmpty()
+                                        )
+                                    },
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text(stringResource(R.string.settings_sign_in_error_show_details))
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -172,6 +193,22 @@ fun AccountDangerZoneRoute(
                             text = uiState.errorMessage,
                             color = MaterialTheme.colorScheme.error
                         )
+                    }
+                    if (
+                        uiState.deleteState == DestructiveActionState.FAILED &&
+                        uiState.errorTechnicalDetails.isNullOrBlank().not() &&
+                        uiState.errorTechnicalDetailsReportId.isNullOrBlank().not()
+                    ) {
+                        TextButton(
+                            onClick = {
+                                onShowTechnicalDetails(
+                                    uiState.errorTechnicalDetails.orEmpty(),
+                                    uiState.errorTechnicalDetailsReportId.orEmpty()
+                                )
+                            }
+                        ) {
+                            Text(stringResource(R.string.settings_sign_in_error_show_details))
+                        }
                     }
                     DestructiveConfirmationPhraseText(
                         text = accountDeletionConfirmationText(strings = strings),

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneUiState.kt
@@ -8,6 +8,8 @@ data class AccountDangerZoneUiState(
     val isDeleting: Boolean,
     val deleteState: DestructiveActionState,
     val errorMessage: String,
+    val errorTechnicalDetails: String?,
+    val errorTechnicalDetailsReportId: String?,
     val successMessage: String,
     val showDeleteConfirmation: Boolean
 )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/account/AccountDangerZoneViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
+import com.flashcardsopensourceapp.core.ui.nextAppTechnicalErrorReportId
+import com.flashcardsopensourceapp.core.ui.renderTechnicalErrorDetails
 import com.flashcardsopensourceapp.data.local.model.cloud.AccountDeletionState
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
@@ -14,6 +16,7 @@ import com.flashcardsopensourceapp.feature.settings.R
 import com.flashcardsopensourceapp.feature.settings.SettingsStringResolver
 import com.flashcardsopensourceapp.feature.settings.accountDeletionConfirmationText
 import com.flashcardsopensourceapp.feature.settings.createSettingsStringResolver
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -24,6 +27,8 @@ import kotlinx.coroutines.flow.update
 private data class AccountDangerZoneDraftState(
     val confirmationText: String,
     val errorMessage: String,
+    val errorTechnicalDetails: String?,
+    val errorTechnicalDetailsReportId: String?,
     val showDeleteConfirmation: Boolean
 )
 
@@ -35,6 +40,8 @@ class AccountDangerZoneViewModel(
         value = AccountDangerZoneDraftState(
             confirmationText = "",
             errorMessage = "",
+            errorTechnicalDetails = null,
+            errorTechnicalDetailsReportId = null,
             showDeleteConfirmation = false
         )
     )
@@ -54,9 +61,22 @@ class AccountDangerZoneViewModel(
                 AccountDeletionState.Hidden -> DestructiveActionState.IDLE
             },
             errorMessage = when (deletionState) {
-                is AccountDeletionState.Failed -> deletionState.message
+                is AccountDeletionState.Failed -> strings.get(R.string.settings_account_danger_zone_delete_failed)
                 AccountDeletionState.Hidden,
                 AccountDeletionState.InProgress -> draft.errorMessage
+            },
+            errorTechnicalDetails = when (deletionState) {
+                is AccountDeletionState.Failed -> renderTechnicalErrorDetails(
+                    errorType = "AccountDeletionState.Failed",
+                    message = deletionState.message
+                )
+                AccountDeletionState.Hidden,
+                AccountDeletionState.InProgress -> draft.errorTechnicalDetails
+            },
+            errorTechnicalDetailsReportId = when (deletionState) {
+                is AccountDeletionState.Failed -> deletionState.technicalDetailsReportId
+                AccountDeletionState.Hidden,
+                AccountDeletionState.InProgress -> draft.errorTechnicalDetailsReportId
             },
             successMessage = "",
             showDeleteConfirmation = draft.showDeleteConfirmation
@@ -70,6 +90,8 @@ class AccountDangerZoneViewModel(
             isDeleting = false,
             deleteState = DestructiveActionState.IDLE,
             errorMessage = "",
+            errorTechnicalDetails = null,
+            errorTechnicalDetailsReportId = null,
             successMessage = "",
             showDeleteConfirmation = false
         )
@@ -79,7 +101,9 @@ class AccountDangerZoneViewModel(
         draftState.update { state ->
             state.copy(
                 showDeleteConfirmation = true,
-                errorMessage = ""
+                errorMessage = "",
+                errorTechnicalDetails = null,
+                errorTechnicalDetailsReportId = null
             )
         }
     }
@@ -97,7 +121,9 @@ class AccountDangerZoneViewModel(
         draftState.update { state ->
             state.copy(
                 confirmationText = value,
-                errorMessage = ""
+                errorMessage = "",
+                errorTechnicalDetails = null,
+                errorTechnicalDetailsReportId = null
             )
         }
     }
@@ -106,7 +132,9 @@ class AccountDangerZoneViewModel(
         if (uiState.value.confirmationText != accountDeletionConfirmationText(strings = strings)) {
             draftState.update { state ->
                 state.copy(
-                    errorMessage = strings.get(R.string.settings_account_danger_zone_confirmation_required)
+                    errorMessage = strings.get(R.string.settings_account_danger_zone_confirmation_required),
+                    errorTechnicalDetails = null,
+                    errorTechnicalDetailsReportId = null
                 )
             }
             return false
@@ -118,19 +146,28 @@ class AccountDangerZoneViewModel(
                 state.copy(
                     confirmationText = "",
                     errorMessage = "",
+                    errorTechnicalDetails = null,
+                    errorTechnicalDetailsReportId = null,
                     showDeleteConfirmation = false
                 )
             }
             true
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Exception) {
             draftState.update { state ->
                 state.copy(
-                    errorMessage = error.message ?: strings.get(R.string.settings_account_danger_zone_delete_failed)
+                    errorMessage = strings.get(R.string.settings_account_danger_zone_delete_failed),
+                    errorTechnicalDetails = renderTechnicalErrorDetails(error = error),
+                    errorTechnicalDetailsReportId = nextAppTechnicalErrorReportId(
+                        source = "account-danger-zone-delete"
+                    )
                 )
             }
             false
         }
     }
+
 }
 
 fun createAccountDangerZoneViewModelFactory(

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/CloudPackageApi.kt
@@ -59,12 +59,14 @@ fun CloudSignInEmailRoute(
     uiState: CloudSignInUiState,
     onEmailChange: (String) -> Unit,
     onSendCode: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onBack: () -> Unit
 ) {
     CloudSignInEmailRouteImpl(
         uiState = uiState,
         onEmailChange = onEmailChange,
         onSendCode = onSendCode,
+        onShowTechnicalDetails = onShowTechnicalDetails,
         onBack = onBack
     )
 }
@@ -74,12 +76,14 @@ fun CloudSignInCodeRoute(
     uiState: CloudSignInUiState,
     onCodeChange: (String) -> Unit,
     onVerifyCode: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onBack: () -> Unit
 ) {
     CloudSignInCodeRouteImpl(
         uiState = uiState,
         onCodeChange = onCodeChange,
         onVerifyCode = onVerifyCode,
+        onShowTechnicalDetails = onShowTechnicalDetails,
         onBack = onBack
     )
 }
@@ -88,12 +92,16 @@ fun CloudSignInCodeRoute(
 fun CloudSignInErrorCard(
     message: String,
     technicalDetails: String?,
-    modifier: Modifier
+    technicalDetailsReportId: String?,
+    modifier: Modifier,
+    onShowTechnicalDetails: (String, String) -> Unit
 ) {
     CloudSignInErrorCardImpl(
         message = message,
         technicalDetails = technicalDetails,
-        modifier = modifier
+        technicalDetailsReportId = technicalDetailsReportId,
+        modifier = modifier,
+        onShowTechnicalDetails = onShowTechnicalDetails
     )
 }
 
@@ -104,6 +112,7 @@ fun CloudPostAuthRoute(
     onSelectWorkspace: (CloudWorkspaceLinkSelection) -> Unit,
     onRetry: () -> Unit,
     onFailureAction: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onBack: () -> Unit,
     canNavigateBack: Boolean
 ) {
@@ -113,6 +122,7 @@ fun CloudPostAuthRoute(
         onSelectWorkspace = onSelectWorkspace,
         onRetry = onRetry,
         onFailureAction = onFailureAction,
+        onShowTechnicalDetails = onShowTechnicalDetails,
         onBack = onBack,
         canNavigateBack = canNavigateBack
     )
@@ -128,6 +138,8 @@ fun CloudCredentialRecoveryGateRoute(
     isEraseConfirmationVisible: Boolean,
     isErasing: Boolean,
     eraseErrorMessage: String,
+    eraseErrorTechnicalDetails: String?,
+    eraseErrorTechnicalDetailsReportId: String?,
     onSignIn: () -> Unit,
     onEmailChange: (String) -> Unit,
     onSendCode: () -> Unit,
@@ -138,6 +150,7 @@ fun CloudCredentialRecoveryGateRoute(
     onRetryPostAuth: () -> Unit,
     onBackToOverview: () -> Unit,
     onBackToEmail: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onRequestEraseConfirmation: () -> Unit,
     onDismissEraseConfirmation: () -> Unit,
     onConfirmErase: () -> Unit
@@ -151,6 +164,8 @@ fun CloudCredentialRecoveryGateRoute(
         isEraseConfirmationVisible = isEraseConfirmationVisible,
         isErasing = isErasing,
         eraseErrorMessage = eraseErrorMessage,
+        eraseErrorTechnicalDetails = eraseErrorTechnicalDetails,
+        eraseErrorTechnicalDetailsReportId = eraseErrorTechnicalDetailsReportId,
         onSignIn = onSignIn,
         onEmailChange = onEmailChange,
         onSendCode = onSendCode,
@@ -161,6 +176,7 @@ fun CloudCredentialRecoveryGateRoute(
         onRetryPostAuth = onRetryPostAuth,
         onBackToOverview = onBackToOverview,
         onBackToEmail = onBackToEmail,
+        onShowTechnicalDetails = onShowTechnicalDetails,
         onRequestEraseConfirmation = onRequestEraseConfirmation,
         onDismissEraseConfirmation = onDismissEraseConfirmation,
         onConfirmErase = onConfirmErase

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/credentialRecovery/CloudCredentialRecoveryGateRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/credentialRecovery/CloudCredentialRecoveryGateRoute.kt
@@ -62,6 +62,8 @@ fun CloudCredentialRecoveryGateRoute(
     isEraseConfirmationVisible: Boolean,
     isErasing: Boolean,
     eraseErrorMessage: String,
+    eraseErrorTechnicalDetails: String?,
+    eraseErrorTechnicalDetailsReportId: String?,
     onSignIn: () -> Unit,
     onEmailChange: (String) -> Unit,
     onSendCode: () -> Unit,
@@ -72,6 +74,7 @@ fun CloudCredentialRecoveryGateRoute(
     onRetryPostAuth: () -> Unit,
     onBackToOverview: () -> Unit,
     onBackToEmail: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onRequestEraseConfirmation: () -> Unit,
     onDismissEraseConfirmation: () -> Unit,
     onConfirmErase: () -> Unit
@@ -113,7 +116,10 @@ fun CloudCredentialRecoveryGateRoute(
                 recoveryState = recoveryState,
                 isErasing = isErasing,
                 eraseErrorMessage = eraseErrorMessage,
+                eraseErrorTechnicalDetails = eraseErrorTechnicalDetails,
+                eraseErrorTechnicalDetailsReportId = eraseErrorTechnicalDetailsReportId,
                 onSignIn = onSignIn,
+                onShowTechnicalDetails = onShowTechnicalDetails,
                 onRequestEraseConfirmation = onRequestEraseConfirmation
             )
         }
@@ -123,6 +129,7 @@ fun CloudCredentialRecoveryGateRoute(
                 uiState = signInUiState,
                 onEmailChange = onEmailChange,
                 onSendCode = onSendCode,
+                onShowTechnicalDetails = onShowTechnicalDetails,
                 onBack = onBackToOverview
             )
         }
@@ -132,6 +139,7 @@ fun CloudCredentialRecoveryGateRoute(
                 uiState = signInUiState,
                 onCodeChange = onCodeChange,
                 onVerifyCode = onVerifyCode,
+                onShowTechnicalDetails = onShowTechnicalDetails,
                 onBack = onBackToEmail
             )
         }
@@ -156,6 +164,7 @@ fun CloudCredentialRecoveryGateRoute(
                 onSelectWorkspace = onSelectWorkspace,
                 onRetry = onRetryPostAuth,
                 onFailureAction = {},
+                onShowTechnicalDetails = onShowTechnicalDetails,
                 onBack = onBackToOverview,
                 canNavigateBack = isRecoveryStateActive
             )
@@ -166,6 +175,9 @@ fun CloudCredentialRecoveryGateRoute(
         CloudCredentialRecoveryEraseConfirmationDialog(
             isErasing = isErasing,
             eraseErrorMessage = eraseErrorMessage,
+            eraseErrorTechnicalDetails = eraseErrorTechnicalDetails,
+            eraseErrorTechnicalDetailsReportId = eraseErrorTechnicalDetailsReportId,
+            onShowTechnicalDetails = onShowTechnicalDetails,
             onDismiss = onDismissEraseConfirmation,
             onConfirm = onConfirmErase
         )
@@ -177,7 +189,10 @@ private fun CloudCredentialRecoveryGateOverview(
     recoveryState: CloudCredentialRecoveryState,
     isErasing: Boolean,
     eraseErrorMessage: String,
+    eraseErrorTechnicalDetails: String?,
+    eraseErrorTechnicalDetailsReportId: String?,
     onSignIn: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onRequestEraseConfirmation: () -> Unit
 ) {
     Scaffold(
@@ -223,8 +238,10 @@ private fun CloudCredentialRecoveryGateOverview(
                 item {
                     CloudSignInErrorCard(
                         message = eraseErrorMessage,
-                        technicalDetails = null,
-                        modifier = Modifier.fillMaxWidth()
+                        technicalDetails = eraseErrorTechnicalDetails,
+                        technicalDetailsReportId = eraseErrorTechnicalDetailsReportId,
+                        modifier = Modifier.fillMaxWidth(),
+                        onShowTechnicalDetails = onShowTechnicalDetails
                     )
                 }
             }
@@ -263,6 +280,9 @@ private fun CloudCredentialRecoveryGateOverview(
 private fun CloudCredentialRecoveryEraseConfirmationDialog(
     isErasing: Boolean,
     eraseErrorMessage: String,
+    eraseErrorTechnicalDetails: String?,
+    eraseErrorTechnicalDetailsReportId: String?,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit
 ) {
@@ -312,6 +332,21 @@ private fun CloudCredentialRecoveryEraseConfirmationDialog(
                         text = eraseErrorMessage,
                         color = MaterialTheme.colorScheme.error
                     )
+                }
+                if (
+                    eraseErrorTechnicalDetails.isNullOrBlank().not() &&
+                    eraseErrorTechnicalDetailsReportId.isNullOrBlank().not()
+                ) {
+                    TextButton(
+                        onClick = {
+                            onShowTechnicalDetails(
+                                eraseErrorTechnicalDetails.orEmpty(),
+                                eraseErrorTechnicalDetailsReportId.orEmpty()
+                            )
+                        }
+                    ) {
+                        Text(stringResource(R.string.settings_sign_in_error_show_details))
+                    }
                 }
             }
         },

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthRoute.kt
@@ -45,6 +45,7 @@ fun CloudPostAuthRoute(
     onSelectWorkspace: (CloudWorkspaceLinkSelection) -> Unit,
     onRetry: () -> Unit,
     onFailureAction: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onBack: () -> Unit,
     canNavigateBack: Boolean
 ) {
@@ -136,6 +137,22 @@ fun CloudPostAuthRoute(
                                     text = uiState.errorMessage,
                                     color = MaterialTheme.colorScheme.error
                                 )
+                                if (
+                                    uiState.errorTechnicalDetails.isNullOrBlank().not() &&
+                                    uiState.errorTechnicalDetailsReportId.isNullOrBlank().not()
+                                ) {
+                                    OutlinedButton(
+                                        onClick = {
+                                            onShowTechnicalDetails(
+                                                uiState.errorTechnicalDetails.orEmpty(),
+                                                uiState.errorTechnicalDetailsReportId.orEmpty()
+                                            )
+                                        },
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        Text(stringResource(R.string.settings_sign_in_error_show_details))
+                                    }
+                                }
                             }
 
                             CloudPostAuthMode.IDLE -> {

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthStateReducers.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthStateReducers.kt
@@ -32,6 +32,8 @@ internal fun prepareCloudPostAuthWorkspaceCompletion(
             strings.get(R.string.settings_post_auth_linking_body)
         },
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = if (requiresCloudGuestUpgrade(linkContext = linkContext)) {
@@ -64,6 +66,8 @@ internal fun prepareCloudPostAuthGuestLocalRecovery(
         processingTitle = strings.get(R.string.settings_post_auth_recovering_local_data_title),
         processingMessage = strings.get(R.string.settings_post_auth_recovering_local_data_body),
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = CloudPostAuthRetryAction.CompleteGuestLocalRecovery(
@@ -86,6 +90,8 @@ internal fun prepareCloudPostAuthSyncOnly(
         processingTitle = strings.get(R.string.settings_post_auth_syncing_title),
         processingMessage = strings.get(R.string.settings_post_auth_syncing_body),
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = CloudPostAuthRetryAction.SyncOnly(
@@ -99,6 +105,8 @@ internal fun failCloudPostAuth(
     state: CloudSignInDraftState,
     authAttemptId: Long,
     errorMessage: String,
+    errorTechnicalDetails: String?,
+    errorTechnicalDetailsReportId: String?,
     recoveryErrorBlocked: Boolean,
     postAuthResetAllowed: Boolean
 ): CloudSignInDraftState {
@@ -109,6 +117,8 @@ internal fun failCloudPostAuth(
         processingTitle = "",
         processingMessage = "",
         postAuthErrorMessage = errorMessage,
+        postAuthErrorTechnicalDetails = errorTechnicalDetails,
+        postAuthErrorTechnicalDetailsReportId = errorTechnicalDetailsReportId,
         postAuthRecoveryBlocked = recoveryErrorBlocked,
         postAuthResetAllowed = postAuthResetAllowed,
         retryAction = if (recoveryErrorBlocked) {
@@ -136,6 +146,8 @@ internal fun finishCloudPostAuthSuccess(
         processingTitle = "",
         processingMessage = "",
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = null,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/postAuth/CloudPostAuthUiState.kt
@@ -20,6 +20,8 @@ data class CloudPostAuthUiState(
     val processingTitle: String,
     val processingMessage: String,
     val errorMessage: String,
+    val errorTechnicalDetails: String?,
+    val errorTechnicalDetailsReportId: String?,
     val canRetry: Boolean,
     val canLogout: Boolean,
     val failureActionLabel: String,

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInCodeRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInCodeRoute.kt
@@ -24,6 +24,7 @@ fun CloudSignInCodeRoute(
     uiState: CloudSignInUiState,
     onCodeChange: (String) -> Unit,
     onVerifyCode: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onBack: () -> Unit
 ) {
     SettingsScreenScaffold(
@@ -61,7 +62,9 @@ fun CloudSignInCodeRoute(
                     CloudSignInErrorCard(
                         message = uiState.errorMessage,
                         technicalDetails = uiState.errorTechnicalDetails,
-                        modifier = Modifier.fillMaxWidth()
+                        technicalDetailsReportId = uiState.errorTechnicalDetailsReportId,
+                        modifier = Modifier.fillMaxWidth(),
+                        onShowTechnicalDetails = onShowTechnicalDetails
                     )
                 }
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInEmailRoute.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInEmailRoute.kt
@@ -28,6 +28,7 @@ fun CloudSignInEmailRoute(
     uiState: CloudSignInUiState,
     onEmailChange: (String) -> Unit,
     onSendCode: () -> Unit,
+    onShowTechnicalDetails: (String, String) -> Unit,
     onBack: () -> Unit
 ) {
     SettingsScreenScaffold(
@@ -59,7 +60,9 @@ fun CloudSignInEmailRoute(
                     CloudSignInErrorCard(
                         message = uiState.errorMessage,
                         technicalDetails = uiState.errorTechnicalDetails,
-                        modifier = Modifier.fillMaxWidth()
+                        technicalDetailsReportId = uiState.errorTechnicalDetailsReportId,
+                        modifier = Modifier.fillMaxWidth(),
+                        onShowTechnicalDetails = onShowTechnicalDetails
                     )
                 }
             }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInErrorCard.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInErrorCard.kt
@@ -1,21 +1,15 @@
 package com.flashcardsopensourceapp.feature.settings.cloud.signIn
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -25,12 +19,10 @@ import com.flashcardsopensourceapp.feature.settings.R
 fun CloudSignInErrorCard(
     message: String,
     technicalDetails: String?,
-    modifier: Modifier
+    technicalDetailsReportId: String?,
+    modifier: Modifier,
+    onShowTechnicalDetails: (String, String) -> Unit
 ) {
-    var isShowingDetails by rememberSaveable(message, technicalDetails) {
-        mutableStateOf(false)
-    }
-
     Card(
         modifier = modifier,
         colors = CardDefaults.cardColors(
@@ -46,28 +38,19 @@ fun CloudSignInErrorCard(
                 color = MaterialTheme.colorScheme.onErrorContainer
             )
 
-            if (technicalDetails.isNullOrBlank().not()) {
+            if (technicalDetails.isNullOrBlank().not() && technicalDetailsReportId.isNullOrBlank().not()) {
                 TextButton(
-                    onClick = { isShowingDetails = isShowingDetails.not() },
+                    onClick = {
+                        onShowTechnicalDetails(
+                            technicalDetails.orEmpty(),
+                            technicalDetailsReportId.orEmpty()
+                        )
+                    },
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text(
-                        text = if (isShowingDetails) {
-                            stringResource(R.string.settings_sign_in_error_hide_details)
-                        } else {
-                            stringResource(R.string.settings_sign_in_error_show_details)
-                        }
+                        text = stringResource(R.string.settings_sign_in_error_show_details)
                     )
-                }
-
-                AnimatedVisibility(visible = isShowingDetails) {
-                    SelectionContainer {
-                        Text(
-                            text = technicalDetails.orEmpty(),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onErrorContainer
-                        )
-                    }
                 }
             }
         }

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInStateReducers.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInStateReducers.kt
@@ -16,10 +16,13 @@ internal data class CloudSignInDraftState(
     val isVerifyingCode: Boolean,
     val errorMessage: String,
     val errorTechnicalDetails: String?,
+    val errorTechnicalDetailsReportId: String?,
     val pendingSelection: CloudWorkspaceLinkSelection?,
     val processingTitle: String,
     val processingMessage: String,
     val postAuthErrorMessage: String,
+    val postAuthErrorTechnicalDetails: String?,
+    val postAuthErrorTechnicalDetailsReportId: String?,
     val postAuthRecoveryBlocked: Boolean,
     val postAuthResetAllowed: Boolean,
     val retryAction: CloudPostAuthRetryAction?,
@@ -28,7 +31,14 @@ internal data class CloudSignInDraftState(
 
 internal data class CloudSignInErrorPresentation(
     val message: String,
-    val technicalDetails: String?
+    val technicalDetails: String?,
+    val technicalDetailsReportId: String?
+)
+
+internal data class CloudPostAuthErrorPresentation(
+    val message: String,
+    val technicalDetails: String?,
+    val technicalDetailsReportId: String?
 )
 
 internal fun initialCloudSignInDraftState(): CloudSignInDraftState {
@@ -42,10 +52,13 @@ internal fun initialCloudSignInDraftState(): CloudSignInDraftState {
         isVerifyingCode = false,
         errorMessage = "",
         errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null,
         pendingSelection = null,
         processingTitle = "",
         processingMessage = "",
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = null,
@@ -61,14 +74,24 @@ internal fun updateCloudSignInEmail(
     state: CloudSignInDraftState,
     email: String
 ): CloudSignInDraftState {
-    return state.copy(email = email, errorMessage = "", errorTechnicalDetails = null)
+    return state.copy(
+        email = email,
+        errorMessage = "",
+        errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null
+    )
 }
 
 internal fun updateCloudSignInCode(
     state: CloudSignInDraftState,
     code: String
 ): CloudSignInDraftState {
-    return state.copy(code = code, errorMessage = "", errorTechnicalDetails = null)
+    return state.copy(
+        code = code,
+        errorMessage = "",
+        errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null
+    )
 }
 
 internal fun startCloudSendCodeAttempt(
@@ -84,10 +107,13 @@ internal fun startCloudSendCodeAttempt(
         isVerifyingCode = false,
         errorMessage = "",
         errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null,
         pendingSelection = null,
         processingTitle = "",
         processingMessage = "",
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = null,
@@ -107,6 +133,7 @@ internal fun acceptCloudOtpChallenge(
         isSendingCode = false,
         errorMessage = "",
         errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null,
         challenge = challenge,
         linkContext = null,
         pendingSelection = null,
@@ -127,7 +154,8 @@ internal fun failCloudSendCode(
     return state.copy(
         isSendingCode = false,
         errorMessage = errorPresentation.message,
-        errorTechnicalDetails = errorPresentation.technicalDetails
+        errorTechnicalDetails = errorPresentation.technicalDetails,
+        errorTechnicalDetailsReportId = errorPresentation.technicalDetailsReportId
     )
 }
 
@@ -152,10 +180,13 @@ internal fun startCloudVerifyCodeAttempt(
         isVerifyingCode = true,
         errorMessage = "",
         errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null,
         pendingSelection = null,
         processingTitle = "",
         processingMessage = "",
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = null,
@@ -174,7 +205,8 @@ internal fun failCloudVerifyCode(
     return state.copy(
         isVerifyingCode = false,
         errorMessage = errorPresentation.message,
-        errorTechnicalDetails = errorPresentation.technicalDetails
+        errorTechnicalDetails = errorPresentation.technicalDetails,
+        errorTechnicalDetailsReportId = errorPresentation.technicalDetailsReportId
     )
 }
 
@@ -205,6 +237,7 @@ internal fun publishCloudVerifiedLinkContext(
         isVerifyingCode = isVerifyingCode,
         errorMessage = "",
         errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null,
         challenge = null,
         linkContext = linkContext,
         pendingSelection = if (recoveryErrorMessage.isEmpty()) {
@@ -215,6 +248,8 @@ internal fun publishCloudVerifiedLinkContext(
         processingTitle = "",
         processingMessage = "",
         postAuthErrorMessage = recoveryErrorMessage,
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = recoveryErrorMessage.isNotEmpty(),
         postAuthResetAllowed = isCloudPostAuthResetAllowed(linkContext = linkContext),
         retryAction = null,
@@ -239,12 +274,15 @@ internal fun clearCloudPostAuthDraftState(state: CloudSignInDraftState): CloudSi
         processingTitle = "",
         processingMessage = "",
         postAuthErrorMessage = "",
+        postAuthErrorTechnicalDetails = null,
+        postAuthErrorTechnicalDetailsReportId = null,
         postAuthRecoveryBlocked = false,
         postAuthResetAllowed = false,
         retryAction = null,
         completionToken = null,
         errorMessage = "",
-        errorTechnicalDetails = null
+        errorTechnicalDetails = null,
+        errorTechnicalDetailsReportId = null
     )
 }
 

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInUiState.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInUiState.kt
@@ -8,5 +8,6 @@ data class CloudSignInUiState(
     val isVerifyingCode: Boolean,
     val errorMessage: String,
     val errorTechnicalDetails: String?,
+    val errorTechnicalDetailsReportId: String?,
     val challengeEmail: String?
 )

--- a/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
+++ b/apps/android/feature/settings/src/main/java/com/flashcardsopensourceapp/feature/settings/cloud/signIn/CloudSignInViewModel.kt
@@ -7,6 +7,9 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.flashcardsopensourceapp.core.ui.TransientMessageController
+import com.flashcardsopensourceapp.core.ui.nextAppTechnicalErrorReportId
+import com.flashcardsopensourceapp.core.ui.renderTechnicalErrorDetails
+import com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudCredentialRecoveryRequiredException
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSendCodeResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceLinkContext
@@ -51,6 +54,19 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+private val cloudSendCodeUserCorrectableErrorCodes: Set<String> = setOf(
+    "INVALID_EMAIL",
+    "RATE_LIMITED"
+)
+
+private val cloudVerifyCodeUserCorrectableErrorCodes: Set<String> = setOf(
+    "OTP_CHALLENGE_CONSUMED",
+    "OTP_CODE_INVALID",
+    "OTP_SESSION_EXPIRED",
+    "OTP_TOO_MANY_ATTEMPTS",
+    "OTP_VERIFY_FAILED"
+)
+
 class CloudSignInViewModel(
     private val cloudAccountRepository: CloudAccountRepository,
     private val syncRepository: SyncRepository,
@@ -73,6 +89,7 @@ class CloudSignInViewModel(
                 isVerifyingCode = draft.isVerifyingCode,
                 errorMessage = draft.errorMessage,
                 errorTechnicalDetails = draft.errorTechnicalDetails,
+                errorTechnicalDetailsReportId = draft.errorTechnicalDetailsReportId,
                 challengeEmail = draft.challenge?.email
             )
         },
@@ -84,6 +101,7 @@ class CloudSignInViewModel(
             isVerifyingCode = false,
             errorMessage = "",
             errorTechnicalDetails = null,
+            errorTechnicalDetailsReportId = null,
             challengeEmail = null
         )
     )
@@ -129,6 +147,8 @@ class CloudSignInViewModel(
                 processingTitle = draft.processingTitle,
                 processingMessage = draft.processingMessage,
                 errorMessage = draft.postAuthErrorMessage,
+                errorTechnicalDetails = draft.postAuthErrorTechnicalDetails,
+                errorTechnicalDetailsReportId = draft.postAuthErrorTechnicalDetailsReportId,
                 canRetry = draft.retryAction != null && draft.postAuthRecoveryBlocked.not(),
                 canLogout = canRunCloudPostAuthFailureAction(draft = draft),
                 failureActionLabel = cloudPostAuthFailureActionLabel(
@@ -148,6 +168,8 @@ class CloudSignInViewModel(
             processingTitle = "",
             processingMessage = "",
             errorMessage = "",
+            errorTechnicalDetails = null,
+            errorTechnicalDetailsReportId = null,
             canRetry = false,
             canLogout = false,
             failureActionLabel = strings.get(R.string.settings_logout),
@@ -169,6 +191,27 @@ class CloudSignInViewModel(
 
     private fun nextAuthAttemptId(state: CloudSignInDraftState): Long {
         return nextCloudAuthAttemptId(state = state)
+    }
+
+    private fun technicalDetailsReportIdFor(
+        source: String,
+        technicalDetails: String?
+    ): String? {
+        if (technicalDetails.isNullOrBlank()) {
+            return null
+        }
+        return nextAppTechnicalErrorReportId(source = source)
+    }
+
+    private fun CloudSignInErrorPresentation.withTechnicalDetailsReportId(
+        source: String
+    ): CloudSignInErrorPresentation {
+        return copy(
+            technicalDetailsReportId = technicalDetailsReportIdFor(
+                source = source,
+                technicalDetails = technicalDetails
+            )
+        )
     }
 
     private fun isCurrentAuthAttempt(authAttemptId: Long): Boolean {
@@ -250,7 +293,10 @@ class CloudSignInViewModel(
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return CloudSendCodeNavigationOutcome.NoNavigation
             }
-            val errorPresentation = createSendCodeErrorPresentation(error = error, strings = strings)
+            val errorPresentation = createSendCodeErrorPresentation(
+                error = error,
+                strings = strings
+            ).withTechnicalDetailsReportId(source = "cloud-sign-in-send-code")
             draftState.update { state ->
                 failCloudSendCode(
                     state = state,
@@ -290,7 +336,10 @@ class CloudSignInViewModel(
             if (isCurrentAuthAttempt(authAttemptId = authAttemptId).not()) {
                 return false
             }
-            val errorPresentation = createVerifyCodeErrorPresentation(error = error, strings = strings)
+            val errorPresentation = createVerifyCodeErrorPresentation(
+                error = error,
+                strings = strings
+            ).withTechnicalDetailsReportId(source = "cloud-sign-in-verify-code")
             draftState.update { state ->
                 failCloudVerifyCode(
                     state = state,
@@ -489,20 +538,34 @@ class CloudSignInViewModel(
                 return
             }
             val recoveryError = error as? CloudCredentialRecoveryRequiredException
-            val errorMessage = if (recoveryError != null) {
-                cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings)
+            val errorPresentation = if (recoveryError != null) {
+                CloudPostAuthErrorPresentation(
+                    message = cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings),
+                    technicalDetails = null,
+                    technicalDetailsReportId = null
+                )
             } else {
-                error.message ?: if (requiresCloudGuestUpgrade(linkContext = linkContext)) {
-                    strings.get(R.string.settings_post_auth_guest_upgrade_failed)
-                } else {
-                    strings.get(R.string.settings_post_auth_setup_failed)
-                }
+                val technicalDetails = technicalDetailsFor(error = error)
+                CloudPostAuthErrorPresentation(
+                    message = if (requiresCloudGuestUpgrade(linkContext = linkContext)) {
+                        strings.get(R.string.settings_post_auth_guest_upgrade_failed)
+                    } else {
+                        strings.get(R.string.settings_post_auth_setup_failed)
+                    },
+                    technicalDetails = technicalDetails,
+                    technicalDetailsReportId = technicalDetailsReportIdFor(
+                        source = "cloud-post-auth-complete",
+                        technicalDetails = technicalDetails
+                    )
+                )
             }
             draftState.update { state ->
                 failCloudPostAuth(
                     state = state,
                     authAttemptId = authAttemptId,
-                    errorMessage = errorMessage,
+                    errorMessage = errorPresentation.message,
+                    errorTechnicalDetails = errorPresentation.technicalDetails,
+                    errorTechnicalDetailsReportId = errorPresentation.technicalDetailsReportId,
                     recoveryErrorBlocked = recoveryError != null,
                     postAuthResetAllowed = isInvalidCloudCredentialRecovery(error = recoveryError)
                 )
@@ -556,16 +619,30 @@ class CloudSignInViewModel(
                 return
             }
             val recoveryError = error as? CloudCredentialRecoveryRequiredException
-            val errorMessage = if (recoveryError != null) {
-                cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings)
+            val errorPresentation = if (recoveryError != null) {
+                CloudPostAuthErrorPresentation(
+                    message = cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings),
+                    technicalDetails = null,
+                    technicalDetailsReportId = null
+                )
             } else {
-                error.message ?: strings.get(R.string.settings_post_auth_guest_local_recovery_failed)
+                val technicalDetails = technicalDetailsFor(error = error)
+                CloudPostAuthErrorPresentation(
+                    message = strings.get(R.string.settings_post_auth_guest_local_recovery_failed),
+                    technicalDetails = technicalDetails,
+                    technicalDetailsReportId = technicalDetailsReportIdFor(
+                        source = "cloud-post-auth-guest-local-recovery",
+                        technicalDetails = technicalDetails
+                    )
+                )
             }
             draftState.update { state ->
                 failCloudPostAuth(
                     state = state,
                     authAttemptId = authAttemptId,
-                    errorMessage = errorMessage,
+                    errorMessage = errorPresentation.message,
+                    errorTechnicalDetails = errorPresentation.technicalDetails,
+                    errorTechnicalDetailsReportId = errorPresentation.technicalDetailsReportId,
                     recoveryErrorBlocked = recoveryError != null,
                     postAuthResetAllowed = isInvalidCloudCredentialRecovery(error = recoveryError)
                 )
@@ -621,16 +698,30 @@ class CloudSignInViewModel(
                 return
             }
             val recoveryError = error as? CloudCredentialRecoveryRequiredException
-            val errorMessage = if (recoveryError != null) {
-                cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings)
+            val errorPresentation = if (recoveryError != null) {
+                CloudPostAuthErrorPresentation(
+                    message = cloudPostAuthRecoveryExceptionMessage(error = recoveryError, strings = strings),
+                    technicalDetails = null,
+                    technicalDetailsReportId = null
+                )
             } else {
-                error.message ?: strings.get(R.string.settings_post_auth_sync_failed)
+                val technicalDetails = technicalDetailsFor(error = error)
+                CloudPostAuthErrorPresentation(
+                    message = strings.get(R.string.settings_post_auth_sync_failed),
+                    technicalDetails = technicalDetails,
+                    technicalDetailsReportId = technicalDetailsReportIdFor(
+                        source = "cloud-post-auth-sync",
+                        technicalDetails = technicalDetails
+                    )
+                )
             }
             draftState.update { state ->
                 failCloudPostAuth(
                     state = state,
                     authAttemptId = authAttemptId,
-                    errorMessage = errorMessage,
+                    errorMessage = errorPresentation.message,
+                    errorTechnicalDetails = errorPresentation.technicalDetails,
+                    errorTechnicalDetailsReportId = errorPresentation.technicalDetailsReportId,
                     recoveryErrorBlocked = recoveryError != null,
                     postAuthResetAllowed = isInvalidCloudCredentialRecovery(error = recoveryError)
                 )
@@ -650,6 +741,8 @@ class CloudSignInViewModel(
                     state = state,
                     authAttemptId = authAttemptId,
                     errorMessage = errorMessage,
+                    errorTechnicalDetails = null,
+                    errorTechnicalDetailsReportId = null,
                     recoveryErrorBlocked = false,
                     postAuthResetAllowed = false
                 )
@@ -687,16 +780,34 @@ private fun createSendCodeErrorPresentation(
     error: Exception,
     strings: SettingsStringResolver
 ): CloudSignInErrorPresentation {
-    return if (isCloudTransportFailure(error = error)) {
-        CloudSignInErrorPresentation(
-            message = strings.get(R.string.settings_sign_in_send_code_transport_failed),
-            technicalDetails = error.message?.trim().takeUnless { it.isNullOrEmpty() }
-        )
-    } else {
-        CloudSignInErrorPresentation(
-            message = error.message ?: strings.get(R.string.settings_sign_in_send_code_failed),
-            technicalDetails = null
-        )
+    val expectedUserFailureMessage = expectedCloudSendCodeUserFailureMessage(
+        error = error,
+        strings = strings
+    )
+    return when {
+        expectedUserFailureMessage != null -> {
+            CloudSignInErrorPresentation(
+                message = expectedUserFailureMessage,
+                technicalDetails = null,
+                technicalDetailsReportId = null
+            )
+        }
+
+        isCloudTransportFailure(error = error) -> {
+            CloudSignInErrorPresentation(
+                message = strings.get(R.string.settings_sign_in_send_code_transport_failed),
+                technicalDetails = technicalDetailsFor(error = error),
+                technicalDetailsReportId = null
+            )
+        }
+
+        else -> {
+            CloudSignInErrorPresentation(
+                message = strings.get(R.string.settings_sign_in_send_code_failed),
+                technicalDetails = technicalDetailsFor(error = error),
+                technicalDetailsReportId = null
+            )
+        }
     }
 }
 
@@ -704,21 +815,65 @@ private fun createVerifyCodeErrorPresentation(
     error: Exception,
     strings: SettingsStringResolver
 ): CloudSignInErrorPresentation {
-    return if (isCloudTransportFailure(error = error)) {
-        CloudSignInErrorPresentation(
-            message = strings.get(R.string.settings_sign_in_verify_transport_failed),
-            technicalDetails = error.message?.trim().takeUnless { it.isNullOrEmpty() }
-        )
-    } else {
-        CloudSignInErrorPresentation(
-            message = error.message ?: strings.get(R.string.settings_sign_in_verify_failed),
-            technicalDetails = null
-        )
+    return when {
+        isExpectedCloudVerifyCodeUserFailure(error = error) -> {
+            CloudSignInErrorPresentation(
+                message = strings.get(R.string.settings_sign_in_verify_failed),
+                technicalDetails = null,
+                technicalDetailsReportId = null
+            )
+        }
+
+        isCloudTransportFailure(error = error) -> {
+            CloudSignInErrorPresentation(
+                message = strings.get(R.string.settings_sign_in_verify_transport_failed),
+                technicalDetails = technicalDetailsFor(error = error),
+                technicalDetailsReportId = null
+            )
+        }
+
+        else -> {
+            CloudSignInErrorPresentation(
+                message = strings.get(R.string.settings_sign_in_verify_failed),
+                technicalDetails = technicalDetailsFor(error = error),
+                technicalDetailsReportId = null
+            )
+        }
     }
+}
+
+private fun expectedCloudSendCodeUserFailureMessage(
+    error: Exception,
+    strings: SettingsStringResolver
+): String? {
+    val remoteError = error as? CloudRemoteException ?: return null
+    if (remoteError.statusCode !in 400..499) {
+        return null
+    }
+    val errorCode = remoteError.errorCode ?: return null
+    if (errorCode !in cloudSendCodeUserCorrectableErrorCodes) {
+        return null
+    }
+    return when (errorCode) {
+        "INVALID_EMAIL" -> strings.get(R.string.settings_sign_in_send_code_invalid_email)
+        "RATE_LIMITED" -> strings.get(R.string.settings_sign_in_send_code_rate_limited)
+        else -> strings.get(R.string.settings_sign_in_send_code_failed)
+    }
+}
+
+private fun isExpectedCloudVerifyCodeUserFailure(error: Exception): Boolean {
+    val remoteError = error as? CloudRemoteException ?: return false
+    val errorCode = remoteError.errorCode ?: return false
+    return remoteError.statusCode in 400..499 &&
+        errorCode in cloudVerifyCodeUserCorrectableErrorCodes
 }
 
 private fun isCloudTransportFailure(error: Exception): Boolean {
     return error is IOException
+}
+
+private fun technicalDetailsFor(error: Exception): String {
+    return renderTechnicalErrorDetails(error = error)
 }
 
 fun createCloudSignInViewModelFactory(

--- a/apps/android/feature/settings/src/main/res/values/strings.xml
+++ b/apps/android/feature/settings/src/main/res/values/strings.xml
@@ -489,6 +489,8 @@
     <string name="settings_sign_in_cancelled_message">Signed-in setup was cancelled. This device is disconnected.</string>
     <string name="settings_sign_in_send_code_transport_failed">We could not confirm that the code was sent. Check your connection and try again.</string>
     <string name="settings_sign_in_send_code_failed">Could not send the sign-in code.</string>
+    <string name="settings_sign_in_send_code_invalid_email">Enter a valid email address.</string>
+    <string name="settings_sign_in_send_code_rate_limited">Too many sign-in attempts. Try again later.</string>
     <string name="settings_sign_in_verify_transport_failed">We could not verify the code right now. Check your connection and try again.</string>
     <string name="settings_sign_in_verify_failed">Could not verify the code.</string>
     <string name="settings_cloud_recovery_gate_guest_session_missing_title">Guest session needs recovery</string>

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -266,7 +266,14 @@ class CloudSignInViewModelTest {
         advanceUntilIdle()
 
         assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
-        assertEquals("Temporary recovery failure.", viewModel.postAuthUiState.value.errorMessage)
+        assertEquals(
+            "Local data recovery failed. Try again; local data stays on this device.",
+            viewModel.postAuthUiState.value.errorMessage
+        )
+        assertEquals(
+            "java.lang.IllegalStateException: Temporary recovery failure.",
+            viewModel.postAuthUiState.value.errorTechnicalDetails
+        )
         assertEquals(true, viewModel.postAuthUiState.value.isGuestLocalRecovery)
         assertEquals(true, viewModel.postAuthUiState.value.canRetry)
         assertEquals(false, viewModel.postAuthUiState.value.canLogout)
@@ -468,7 +475,11 @@ class CloudSignInViewModelTest {
         advanceUntilIdle()
 
         assertEquals(CloudPostAuthMode.FAILED, viewModel.postAuthUiState.value.mode)
-        assertEquals("Temporary setup failure.", viewModel.postAuthUiState.value.errorMessage)
+        assertEquals("Cloud workspace setup failed.", viewModel.postAuthUiState.value.errorMessage)
+        assertEquals(
+            "java.lang.IllegalStateException: Temporary setup failure.",
+            viewModel.postAuthUiState.value.errorTechnicalDetails
+        )
         assertEquals(true, viewModel.postAuthUiState.value.canRetry)
         assertEquals(false, viewModel.postAuthUiState.value.canLogout)
 
@@ -775,13 +786,16 @@ class CloudSignInViewModelTest {
             "We could not confirm that the code was sent. Check your connection and try again.",
             viewModel.uiState.value.errorMessage
         )
-        assertEquals("Software caused connection abort", viewModel.uiState.value.errorTechnicalDetails)
+        assertEquals(
+            "java.io.IOException: Software caused connection abort",
+            viewModel.uiState.value.errorTechnicalDetails
+        )
 
         uiStateCollection.cancel()
     }
 
     @Test
-    fun sendCodeServerErrorKeepsFriendlyMessageWithoutTechnicalDisclosure() = runTest(dispatcher) {
+    fun sendCodeInvalidEmailKeepsInlineMessageWithoutTechnicalDisclosure() = runTest(dispatcher) {
         Dispatchers.setMain(dispatcher)
         val repository = FakeCloudAccountRepository()
         repository.enqueueSendCodeError(
@@ -789,7 +803,7 @@ class CloudSignInViewModelTest {
                 message = "Enter a valid email address. Reference: req-123",
                 statusCode = 400,
                 responseBody = "{\"error\":\"bad request\"}",
-                errorCode = "VALIDATION_ERROR",
+                errorCode = "INVALID_EMAIL",
                 requestId = "req-123",
                 syncConflict = null
             )
@@ -808,8 +822,47 @@ class CloudSignInViewModelTest {
         viewModel.sendCode()
         advanceUntilIdle()
 
-        assertEquals("Enter a valid email address. Reference: req-123", viewModel.uiState.value.errorMessage)
+        assertEquals("Enter a valid email address.", viewModel.uiState.value.errorMessage)
         assertNull(viewModel.uiState.value.errorTechnicalDetails)
+        assertNull(viewModel.uiState.value.errorTechnicalDetailsReportId)
+
+        uiStateCollection.cancel()
+    }
+
+    @Test
+    fun sendCodeUnknownClientErrorShowsSafeMessageAndTechnicalDetails() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueSendCodeError(
+            CloudRemoteException(
+                message = "Cloud request failed: statusCode=404 path=sendCode requestId=req-404",
+                statusCode = 404,
+                responseBody = "not found",
+                errorCode = null,
+                requestId = "req-404",
+                syncConflict = null
+            )
+        )
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val uiStateCollection = backgroundScope.async {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.updateEmail("person@example.com")
+        viewModel.sendCode()
+        advanceUntilIdle()
+
+        assertEquals("Could not send the sign-in code.", viewModel.uiState.value.errorMessage)
+        assertEquals(
+            "com.flashcardsopensourceapp.data.local.cloud.remote.CloudRemoteException: " +
+                "Cloud request failed: statusCode=404 path=sendCode requestId=req-404",
+            viewModel.uiState.value.errorTechnicalDetails
+        )
 
         uiStateCollection.cancel()
     }
@@ -849,7 +902,57 @@ class CloudSignInViewModelTest {
             "We could not verify the code right now. Check your connection and try again.",
             viewModel.uiState.value.errorMessage
         )
-        assertEquals("Connection reset by peer", viewModel.uiState.value.errorTechnicalDetails)
+        assertEquals(
+            "java.io.IOException: Connection reset by peer",
+            viewModel.uiState.value.errorTechnicalDetails
+        )
+
+        uiStateCollection.cancel()
+    }
+
+    @Test
+    fun verifyCodeOtpVerifyFailedKeepsInlineMessageWithoutTechnicalDisclosure() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        val repository = FakeCloudAccountRepository()
+        repository.enqueueSendCodeResult(
+            CloudSendCodeResult.OtpRequired(
+                challenge = CloudOtpChallenge(
+                    email = "person@example.com",
+                    csrfToken = "csrf-token",
+                    otpSessionToken = "otp-session-token"
+                )
+            )
+        )
+        repository.enqueueVerifyCodeError(
+            CloudRemoteException(
+                message = "Could not verify the code. Reference: req-verify",
+                statusCode = 400,
+                responseBody = "{\"error\":\"bad request\"}",
+                errorCode = "OTP_VERIFY_FAILED",
+                requestId = "req-verify",
+                syncConflict = null
+            )
+        )
+        val viewModel = CloudSignInViewModel(
+            cloudAccountRepository = repository,
+            syncRepository = FakeSyncRepository(),
+            messageController = TransientMessageController { },
+            strings = strings
+        )
+        val uiStateCollection = backgroundScope.async {
+            viewModel.uiState.collect()
+        }
+
+        viewModel.updateEmail("person@example.com")
+        assertEquals(CloudSendCodeNavigationOutcome.OtpRequired, viewModel.sendCode())
+        viewModel.updateCode("123456")
+        val didVerify = viewModel.verifyCode()
+        advanceUntilIdle()
+
+        assertEquals(false, didVerify)
+        assertEquals("Could not verify the code.", viewModel.uiState.value.errorMessage)
+        assertNull(viewModel.uiState.value.errorTechnicalDetails)
+        assertNull(viewModel.uiState.value.errorTechnicalDetailsReportId)
 
         uiStateCollection.cancel()
     }

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -353,6 +353,8 @@ internal class TestSettingsStringResolver : SettingsStringResolver {
             }
 
             R.string.settings_sign_in_send_code_failed -> "Could not send the sign-in code."
+            R.string.settings_sign_in_send_code_invalid_email -> "Enter a valid email address."
+            R.string.settings_sign_in_send_code_rate_limited -> "Too many sign-in attempts. Try again later."
             R.string.settings_sign_in_verify_transport_failed -> {
                 "We could not verify the code right now. Check your connection and try again."
             }


### PR DESCRIPTION
## Summary
- migrate Android startup/cloud/account technical failures to safe visible copy with shared technical details dialog
- keep expected sign-in validation errors inline with local strings and out of Sentry
- add exact-once technical-error reporting via occurrence/report ids, including persisted account deletion failures

## Validation
- `git --no-pager diff --check` passed before commit
- targeted searches/inspection passed for expected send-code safe strings, verify-code behavior, dialog `reportId` keying, persisted account deletion ids, and duplicate/missing capture paths
- Gradle, emulator, instrumentation, unit tests, and Android smoke tests were not run per instruction

## Accepted residual risk
- Startup technical-error dialogs still use constant `reportId = "already-reported"`, so identical startup failures can inherit expanded/collapsed UI state. This is accepted as a minor follow-up for this PR.
