### PR TITLE
[codex] Route iOS review submission technical errors

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
@@ -63,8 +63,8 @@ extension ReviewView {
             try store.enqueueReviewSubmission(cardId: cardId, rating: rating)
             self.screenErrorMessage = ""
         } catch {
-            if isInlineReviewSubmissionError(error: error) {
-                self.screenErrorMessage = Flashcards.errorMessage(error: error)
+            if let inlineErrorMessage = reviewSubmissionInlineErrorMessage(error: error) {
+                self.screenErrorMessage = inlineErrorMessage
             } else {
                 self.screenErrorMessage = ""
                 store.presentTechnicalError(error)
@@ -140,19 +140,19 @@ extension ReviewView {
     }
 }
 
-private func isInlineReviewSubmissionError(error: Error) -> Bool {
+private func reviewSubmissionInlineErrorMessage(error: Error) -> String? {
     if let localStoreError = error as? LocalStoreError {
         switch localStoreError {
         case .validation:
-            return true
+            return Flashcards.errorMessage(error: error)
         case .database, .notFound, .uninitialized:
-            return false
+            return nil
         }
     }
 
     if error is PendingGuestUpgradeLocalMutationError {
-        return true
+        return Flashcards.errorMessage(error: error)
     }
 
-    return false
+    return nil
 }


### PR DESCRIPTION
## Summary
- keep expected Review submission validation and guest-upgrade guidance inline
- route unexpected immediate Review submission failures through the shared technical error sheet

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse apps/ios/Flashcards/Flashcards/Review/View/ReviewView+Effects.swift
- targeted raw error-message assignment search in scoped Review/Cards/Progress files
- read-only review subagent found no P0-P4 issues

No simulator-backed iOS tests, XCUITest, screenshots, or local smoke flows were run by instruction.