### PR TITLE
Migrate iOS cloud auth error details

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Auth/CloudAuthService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Auth/CloudAuthService.swift
@@ -43,6 +43,12 @@ enum CloudAuthError: LocalizedError {
                     table: "Foundation",
                     comment: "Cloud auth error when the OTP code is invalid"
                 )
+            case "OTP_TOO_MANY_ATTEMPTS":
+                return String(
+                    localized: "cloud_auth.error.otp_too_many_attempts",
+                    table: "Foundation",
+                    comment: "Cloud auth error when too many OTP attempts were made"
+                )
             case "OTP_SEND_FAILED":
                 return appendCloudRequestIdReference(
                     message: String(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/FlashcardsStore+GuestCloudUpgrade.swift
@@ -13,6 +13,18 @@ extension FlashcardsStore {
         linkContext: CloudWorkspaceLinkContext,
         selection: CloudWorkspaceLinkSelection
     ) async throws {
+        try await self.completeGuestCloudLink(
+            linkContext: linkContext,
+            selection: selection,
+            technicalErrorCaptureContext: nil
+        )
+    }
+
+    func completeGuestCloudLink(
+        linkContext: CloudWorkspaceLinkContext,
+        selection: CloudWorkspaceLinkSelection,
+        technicalErrorCaptureContext: TechnicalErrorCaptureContext?
+    ) async throws {
         _ = try await self.cloudRuntime.runWorkspaceCompletion { [weak self] in
             guard let self else {
                 throw LocalStoreError.uninitialized("Flashcards store is unavailable")
@@ -27,7 +39,10 @@ extension FlashcardsStore {
             }
 
             let configuration = try self.currentCloudServiceConfiguration()
-            let trigger = self.manualCloudSyncTrigger(now: Date())
+            let trigger = self.postAuthCloudSyncTrigger(
+                now: Date(),
+                technicalErrorCaptureContext: technicalErrorCaptureContext
+            )
             try self.validatePendingGuestUpgradeAccountIfNeeded(
                 userId: linkContext.userId,
                 apiBaseUrl: linkContext.apiBaseUrl
@@ -424,7 +439,7 @@ extension FlashcardsStore {
                 )
             }
         } catch {
-            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
+            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error, trigger: trigger)
             if trigger.surfacesGlobalErrorMessage {
                 self.globalErrorMessage = Flashcards.errorMessage(error: error)
             }
@@ -715,10 +730,11 @@ extension FlashcardsStore {
                     error: error,
                     linkedSession: linkedSession,
                     fallbackCloudState: self.cloudSettings?.cloudState,
-                    action: "guest_cloud_link_sync"
+                    action: "guest_cloud_link_sync",
+                    captureContext: trigger.technicalErrorCaptureContext
                 )
             }
-            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
+            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error, trigger: trigger)
             if trigger.surfacesGlobalErrorMessage {
                 self.globalErrorMessage = Flashcards.errorMessage(error: error)
             }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudLink.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CloudLink.swift
@@ -4,6 +4,10 @@ enum CloudBootstrapEligibilityError: LocalizedError {
     case remoteWorkspaceIsNotEmpty
 
     var errorDescription: String? {
+        self.visiblePostAuthMessage
+    }
+
+    var visiblePostAuthMessage: String {
         switch self {
         case .remoteWorkspaceIsNotEmpty:
             return "Choose a new or empty workspace on this server before uploading the current local data."
@@ -14,6 +18,13 @@ enum CloudBootstrapEligibilityError: LocalizedError {
 @MainActor
 extension FlashcardsStore {
     func sendCloudSignInCode(email: String) async throws -> CloudSendCodeResult {
+        try await self.sendCloudSignInCode(email: email, captureContext: nil)
+    }
+
+    func sendCloudSignInCode(
+        email: String,
+        captureContext: TechnicalErrorCaptureContext?
+    ) async throws -> CloudSendCodeResult {
         let configuration = try self.currentCloudServiceConfiguration()
         do {
             let result = try await self.cloudRuntime.sendCode(email: email, configuration: configuration)
@@ -26,13 +37,22 @@ extension FlashcardsStore {
             self.captureCloudAuthFailure(
                 error: error,
                 configuration: configuration,
-                action: .sendCode
+                action: .sendCode,
+                captureContext: captureContext
             )
             throw error
         }
     }
 
     func verifyCloudOtp(challenge: CloudOtpChallenge, code: String) async throws -> CloudVerifiedAuthContext {
+        try await self.verifyCloudOtp(challenge: challenge, code: code, captureContext: nil)
+    }
+
+    func verifyCloudOtp(
+        challenge: CloudOtpChallenge,
+        code: String,
+        captureContext: TechnicalErrorCaptureContext?
+    ) async throws -> CloudVerifiedAuthContext {
         let configuration = try self.currentCloudServiceConfiguration()
         do {
             let context = try await self.cloudRuntime.verifyCode(
@@ -49,7 +69,8 @@ extension FlashcardsStore {
             self.captureCloudAuthFailure(
                 error: error,
                 configuration: configuration,
-                action: .verifyCode
+                action: .verifyCode,
+                captureContext: captureContext
             )
             throw error
         }
@@ -224,10 +245,23 @@ extension FlashcardsStore {
         linkContext: CloudWorkspaceLinkContext,
         selection: CloudWorkspaceLinkSelection
     ) async throws {
+        try await self.completeCloudLink(
+            linkContext: linkContext,
+            selection: selection,
+            technicalErrorCaptureContext: nil
+        )
+    }
+
+    func completeCloudLink(
+        linkContext: CloudWorkspaceLinkContext,
+        selection: CloudWorkspaceLinkSelection,
+        technicalErrorCaptureContext: TechnicalErrorCaptureContext?
+    ) async throws {
         if linkContext.postAuthRecoveryRoute == .guestLocalRecovery {
             try await self.completeGuestLocalRecoveryCloudLink(
                 linkContext: linkContext,
-                selection: selection
+                selection: selection,
+                technicalErrorCaptureContext: technicalErrorCaptureContext
             )
             return
         }
@@ -241,7 +275,10 @@ extension FlashcardsStore {
                 throw LocalStoreError.uninitialized("Workspace is unavailable")
             }
 
-            let trigger = self.manualCloudSyncTrigger(now: Date())
+            let trigger = self.postAuthCloudSyncTrigger(
+                now: Date(),
+                technicalErrorCaptureContext: technicalErrorCaptureContext
+            )
             try self.validatePostAuthRecoveryRouteBeforeCloudLinkCompletion(
                 linkContext: linkContext,
                 selection: selection
@@ -340,7 +377,8 @@ extension FlashcardsStore {
 
     private func completeGuestLocalRecoveryCloudLink(
         linkContext: CloudWorkspaceLinkContext,
-        selection: CloudWorkspaceLinkSelection
+        selection: CloudWorkspaceLinkSelection,
+        technicalErrorCaptureContext: TechnicalErrorCaptureContext?
     ) async throws {
         _ = try await self.cloudRuntime.runWorkspaceCompletion { [weak self] in
             guard let self else {
@@ -351,7 +389,10 @@ extension FlashcardsStore {
                 throw LocalStoreError.uninitialized("Workspace is unavailable")
             }
 
-            let trigger = self.manualCloudSyncTrigger(now: Date())
+            let trigger = self.postAuthCloudSyncTrigger(
+                now: Date(),
+                technicalErrorCaptureContext: technicalErrorCaptureContext
+            )
             let recoveryState = try self.validateGuestLocalRecoveryBeforeCloudLinkCompletion(
                 linkContext: linkContext,
                 selection: selection
@@ -779,10 +820,11 @@ extension FlashcardsStore {
                     error: error,
                     linkedSession: linkedSession,
                     fallbackCloudState: self.cloudSettings?.cloudState,
-                    action: "cloud_link_sync"
+                    action: "cloud_link_sync",
+                    captureContext: trigger.technicalErrorCaptureContext
                 )
             }
-            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
+            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error, trigger: trigger)
             if trigger.surfacesGlobalErrorMessage {
                 self.globalErrorMessage = Flashcards.errorMessage(error: error)
             }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudRestore.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/CredentialRecovery/FlashcardsStore+CloudRestore.swift
@@ -42,7 +42,7 @@ extension FlashcardsStore {
                 trigger: trigger,
                 action: "same_workspace_cloud_restore"
             )
-            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error)
+            self.syncStatus = self.transitionSyncStatusForCloudFailure(error: error, trigger: trigger)
             if trigger.surfacesGlobalErrorMessage {
                 self.globalErrorMessage = Flashcards.errorMessage(error: error)
             }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Diagnostics/FlashcardsStore+CloudAuthDiagnostics.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Diagnostics/FlashcardsStore+CloudAuthDiagnostics.swift
@@ -21,6 +21,20 @@ extension FlashcardsStore {
         configuration: CloudServiceConfiguration,
         action: CloudAuthFailureAction
     ) {
+        self.captureCloudAuthFailure(
+            error: error,
+            configuration: configuration,
+            action: action,
+            captureContext: nil
+        )
+    }
+
+    func captureCloudAuthFailure(
+        error: Error,
+        configuration: CloudServiceConfiguration,
+        action: CloudAuthFailureAction,
+        captureContext: TechnicalErrorCaptureContext?
+    ) {
         let diagnostics = cloudAuthFailureDiagnostics(error: error)
         let scope = IOSObservationScope(
             feature: .cloudAuth,
@@ -60,6 +74,7 @@ extension FlashcardsStore {
             return
         }
 
+        self.markTechnicalErrorCaptured(captureContext: captureContext)
         FlashcardsObservability.captureException(
             .cloudAuthFailed(
                 error: error,
@@ -80,7 +95,8 @@ private let userCorrectableCloudAuthBackendCodes: Set<String> = [
     "INVALID_EMAIL",
     "OTP_CHALLENGE_CONSUMED",
     "OTP_CODE_INVALID",
-    "OTP_SESSION_EXPIRED"
+    "OTP_SESSION_EXPIRED",
+    "OTP_TOO_MANY_ATTEMPTS"
 ]
 
 private struct CloudAuthFailureDiagnosticsFields {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Sync/FlashcardsStore+CloudSync.swift
@@ -20,7 +20,29 @@ extension FlashcardsStore {
             now: now,
             extendsFastPolling: false,
             allowsVisibleChangeBanner: false,
-            surfacesGlobalErrorMessage: true
+            surfacesGlobalErrorMessage: true,
+            technicalErrorCaptureContext: nil
+        )
+    }
+
+    func postAuthCloudSyncTrigger(now: Date) -> CloudSyncTrigger {
+        self.postAuthCloudSyncTrigger(
+            now: now,
+            technicalErrorCaptureContext: nil
+        )
+    }
+
+    func postAuthCloudSyncTrigger(
+        now: Date,
+        technicalErrorCaptureContext: TechnicalErrorCaptureContext?
+    ) -> CloudSyncTrigger {
+        CloudSyncTrigger(
+            source: .postAuth,
+            now: now,
+            extendsFastPolling: false,
+            allowsVisibleChangeBanner: false,
+            surfacesGlobalErrorMessage: false,
+            technicalErrorCaptureContext: technicalErrorCaptureContext
         )
     }
 
@@ -94,7 +116,8 @@ extension FlashcardsStore {
             } catch {
                 self.syncStatus = self.syncStatusForCloudFailure(
                     error: error,
-                    fallbackCloudState: failureStateCloudState
+                    fallbackCloudState: failureStateCloudState,
+                    trigger: trigger
                 )
                 self.captureCloudSyncFailureIfNeeded(
                     error: error,
@@ -110,7 +133,8 @@ extension FlashcardsStore {
             }
             self.syncStatus = self.syncStatusForCloudFailure(
                 error: failureError,
-                fallbackCloudState: failureStateCloudState
+                fallbackCloudState: failureStateCloudState,
+                trigger: trigger
             )
             self.captureCloudSyncFailureIfNeeded(
                 error: failureError,
@@ -408,8 +432,13 @@ extension FlashcardsStore {
 
     private func syncStatusForCloudFailure(
         error: Error,
-        fallbackCloudState: CloudAccountState?
+        fallbackCloudState: CloudAccountState?,
+        trigger: CloudSyncTrigger
     ) -> SyncStatus {
+        if trigger.source == .postAuth {
+            return .idle
+        }
+
         if let blockedMessage = self.blockedCloudIdentityConflictMessage(error: error) {
             return .blocked(message: blockedMessage)
         }
@@ -422,6 +451,18 @@ extension FlashcardsStore {
     }
 
     func transitionSyncStatusForCloudFailure(error: Error) -> SyncStatus {
+        if let blockedMessage = self.blockedCloudIdentityConflictMessage(error: error) {
+            return .blocked(message: blockedMessage)
+        }
+
+        return .failed(message: Flashcards.errorMessage(error: error))
+    }
+
+    func transitionSyncStatusForCloudFailure(error: Error, trigger: CloudSyncTrigger) -> SyncStatus {
+        if trigger.source == .postAuth {
+            return .idle
+        }
+
         if let blockedMessage = self.blockedCloudIdentityConflictMessage(error: error) {
             return .blocked(message: blockedMessage)
         }
@@ -446,7 +487,8 @@ extension FlashcardsStore {
         error: Error,
         linkedSession: CloudLinkedSession,
         fallbackCloudState: CloudAccountState?,
-        action: String
+        action: String,
+        captureContext: TechnicalErrorCaptureContext?
     ) {
         let diagnostics = cloudSyncFailureDiagnostics(error: error)
         let scope = IOSObservationScope(
@@ -460,6 +502,7 @@ extension FlashcardsStore {
             cloudState: fallbackCloudState ?? self.cloudSettings?.cloudState,
             configurationMode: linkedSession.configurationMode
         )
+        self.markTechnicalErrorCaptured(captureContext: captureContext)
         FlashcardsObservability.captureException(
             .cloudSyncFailed(
                 error: error,
@@ -490,7 +533,8 @@ extension FlashcardsStore {
             error: error,
             linkedSession: linkedSession,
             fallbackCloudState: fallbackCloudState,
-            action: action
+            action: action,
+            captureContext: trigger.technicalErrorCaptureContext
         )
     }
 

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
@@ -27,12 +27,13 @@ enum CloudSyncTriggerSource: Hashable, Sendable {
     case polling
     case localMutation
     case manualSyncNow
+    case postAuth
 
     var usesImmediateStartDebounce: Bool {
         switch self {
         case .appLaunch, .appForeground, .reviewTabSelected, .cardsTabSelected:
             return true
-        case .polling, .localMutation, .manualSyncNow:
+        case .polling, .localMutation, .manualSyncNow, .postAuth:
             return false
         }
     }
@@ -44,6 +45,40 @@ struct CloudSyncTrigger: Hashable, Sendable {
     let extendsFastPolling: Bool
     let allowsVisibleChangeBanner: Bool
     let surfacesGlobalErrorMessage: Bool
+    let technicalErrorCaptureContext: TechnicalErrorCaptureContext?
+
+    init(
+        source: CloudSyncTriggerSource,
+        now: Date,
+        extendsFastPolling: Bool,
+        allowsVisibleChangeBanner: Bool,
+        surfacesGlobalErrorMessage: Bool
+    ) {
+        self.init(
+            source: source,
+            now: now,
+            extendsFastPolling: extendsFastPolling,
+            allowsVisibleChangeBanner: allowsVisibleChangeBanner,
+            surfacesGlobalErrorMessage: surfacesGlobalErrorMessage,
+            technicalErrorCaptureContext: nil
+        )
+    }
+
+    init(
+        source: CloudSyncTriggerSource,
+        now: Date,
+        extendsFastPolling: Bool,
+        allowsVisibleChangeBanner: Bool,
+        surfacesGlobalErrorMessage: Bool,
+        technicalErrorCaptureContext: TechnicalErrorCaptureContext?
+    ) {
+        self.source = source
+        self.now = now
+        self.extendsFastPolling = extendsFastPolling
+        self.allowsVisibleChangeBanner = allowsVisibleChangeBanner
+        self.surfacesGlobalErrorMessage = surfacesGlobalErrorMessage
+        self.technicalErrorCaptureContext = technicalErrorCaptureContext
+    }
 }
 
 struct CloudSyncResult: Hashable, Sendable {

--- a/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/ErrorMessageSupport.swift
@@ -1,8 +1,33 @@
 import Foundation
 
-struct CloudAuthInlineErrorPresentation: Equatable {
+struct CloudAuthInlineErrorPresentation {
     let message: String
-    let technicalDetails: String?
+    let technicalError: TechnicalErrorAction?
+}
+
+enum TechnicalErrorCapturePolicy: Equatable {
+    case captureOnPresentation
+    case alreadyCaptured
+}
+
+struct TechnicalErrorAction: Identifiable {
+    let id: String
+    let error: Error
+    let capturePolicy: TechnicalErrorCapturePolicy
+
+    init(error: Error, capturePolicy: TechnicalErrorCapturePolicy) {
+        self.id = UUID().uuidString
+        self.error = error
+        self.capturePolicy = capturePolicy
+    }
+}
+
+struct TechnicalErrorCaptureContext: Hashable, Sendable {
+    let id: String
+
+    init() {
+        self.id = UUID().uuidString
+    }
 }
 
 enum CloudAuthInlineErrorContext {
@@ -21,7 +46,37 @@ func errorMessage(error: Error) -> String {
 func makeTechnicalErrorPresentation(error: Error) -> TechnicalErrorPresentation {
     makeTechnicalErrorPresentation(
         id: UUID().uuidString.lowercased(),
-        technicalDetails: errorMessage(error: error)
+        technicalDetails: technicalErrorDetails(error: error)
+    )
+}
+
+func technicalErrorDetails(error: Error) -> String {
+    if let authError = error as? CloudAuthError {
+        return cloudAuthTechnicalErrorDetails(error: authError)
+    }
+
+    if let guestAuthError = error as? GuestCloudAuthError {
+        return guestCloudAuthTechnicalErrorDetails(error: guestAuthError)
+    }
+
+    if let syncError = error as? CloudSyncError {
+        return cloudSyncTechnicalErrorDetails(error: syncError)
+    }
+
+    return genericTechnicalErrorDetails(error: error)
+}
+
+func makeTechnicalErrorAction(error: Error) -> TechnicalErrorAction {
+    TechnicalErrorAction(
+        error: error,
+        capturePolicy: .captureOnPresentation
+    )
+}
+
+func makeTechnicalErrorAction(error: Error, capturePolicy: TechnicalErrorCapturePolicy) -> TechnicalErrorAction {
+    TechnicalErrorAction(
+        error: error,
+        capturePolicy: capturePolicy
     )
 }
 
@@ -97,16 +152,29 @@ func makeCloudAuthInlineErrorPresentation(
     error: Error,
     context: CloudAuthInlineErrorContext
 ) -> CloudAuthInlineErrorPresentation {
+    if isUserActionableCloudAuthFailure(error: error) {
+        return CloudAuthInlineErrorPresentation(
+            message: errorMessage(error: error),
+            technicalError: nil
+        )
+    }
+
     if isCloudAuthTransportFailure(error: error) {
         return CloudAuthInlineErrorPresentation(
             message: makeCloudAuthTransportFailureMessage(context: context),
-            technicalDetails: String(describing: error)
+            technicalError: TechnicalErrorAction(
+                error: error,
+                capturePolicy: .captureOnPresentation
+            )
         )
     }
 
     return CloudAuthInlineErrorPresentation(
-        message: errorMessage(error: error),
-        technicalDetails: nil
+        message: makeCloudAuthTechnicalFailureMessage(context: context),
+        technicalError: TechnicalErrorAction(
+            error: error,
+            capturePolicy: .captureOnPresentation
+        )
     )
 }
 
@@ -129,4 +197,150 @@ private func makeCloudAuthTransportFailureMessage(context: CloudAuthInlineErrorC
 
 private func isCloudAuthTransportFailure(error: Error) -> Bool {
     return flashcardsURLErrorCode(error: error, remainingDepth: 4) != nil
+}
+
+private func makeCloudAuthTechnicalFailureMessage(context: CloudAuthInlineErrorContext) -> String {
+    switch context {
+    case .sendCode:
+        return String(
+            localized: "cloud_auth.error.otp_send_failed",
+            table: "Foundation",
+            comment: "Cloud auth error when sending the OTP code failed"
+        )
+    case .verifyCode:
+        return String(
+            localized: "cloud_auth.error.otp_verify_failed",
+            table: "Foundation",
+            comment: "Cloud auth error when verifying the OTP code failed"
+        )
+    }
+}
+
+private func isUserActionableCloudAuthFailure(error: Error) -> Bool {
+    guard let authError = error as? CloudAuthError else {
+        return false
+    }
+
+    switch authError {
+    case .invalidResponse(let details, _):
+        guard let code = details.code else {
+            return false
+        }
+
+        return userActionableCloudAuthBackendCodes.contains(code)
+    case .invalidBaseUrl, .invalidResponseBody:
+        return false
+    }
+}
+
+private let userActionableCloudAuthBackendCodes: Set<String> = [
+    "INVALID_EMAIL",
+    "OTP_CHALLENGE_CONSUMED",
+    "OTP_CODE_INVALID",
+    "OTP_SESSION_EXPIRED",
+    "OTP_TOO_MANY_ATTEMPTS"
+]
+
+private func cloudAuthTechnicalErrorDetails(error: CloudAuthError) -> String {
+    switch error {
+    case .invalidBaseUrl(let authBaseUrl):
+        return [
+            "Type: CloudAuthError.invalidBaseUrl",
+            "Auth base URL: \(authBaseUrl)"
+        ].joined(separator: "\n")
+    case .invalidResponse(let details, let statusCode):
+        return cloudApiTechnicalErrorDetails(
+            type: "CloudAuthError.invalidResponse",
+            details: details,
+            statusCode: statusCode
+        )
+    case .invalidResponseBody(let body):
+        return [
+            "Type: CloudAuthError.invalidResponseBody",
+            "Response body: \(body)"
+        ].joined(separator: "\n")
+    }
+}
+
+private func guestCloudAuthTechnicalErrorDetails(error: GuestCloudAuthError) -> String {
+    switch error {
+    case .invalidBaseUrl(let apiBaseUrl):
+        return [
+            "Type: GuestCloudAuthError.invalidBaseUrl",
+            "API base URL: \(apiBaseUrl)"
+        ].joined(separator: "\n")
+    case .invalidResponse(let details, let statusCode):
+        return cloudApiTechnicalErrorDetails(
+            type: "GuestCloudAuthError.invalidResponse",
+            details: details,
+            statusCode: statusCode
+        )
+    case .invalidResponseBody(let body):
+        return [
+            "Type: GuestCloudAuthError.invalidResponseBody",
+            "Response body: \(body)"
+        ].joined(separator: "\n")
+    }
+}
+
+private func cloudSyncTechnicalErrorDetails(error: CloudSyncError) -> String {
+    switch error {
+    case .invalidBaseUrl(let apiBaseUrl):
+        return [
+            "Type: CloudSyncError.invalidBaseUrl",
+            "API base URL: \(apiBaseUrl)"
+        ].joined(separator: "\n")
+    case .invalidResponse(let details, let statusCode):
+        return cloudApiTechnicalErrorDetails(
+            type: "CloudSyncError.invalidResponse",
+            details: details,
+            statusCode: statusCode
+        )
+    }
+}
+
+private func cloudApiTechnicalErrorDetails(
+    type: String,
+    details: CloudApiErrorDetails,
+    statusCode: Int
+) -> String {
+    var lines: [String] = [
+        "Type: \(type)",
+        "Status: \(statusCode)",
+        "Message: \(details.message)"
+    ]
+
+    if let code = details.code {
+        lines.append("Code: \(code)")
+    }
+
+    if let requestId = details.requestId {
+        lines.append("Request ID: \(requestId)")
+    }
+
+    if let syncConflict = details.syncConflict {
+        lines.append("Sync conflict phase: \(syncConflict.phase)")
+        lines.append("Sync conflict entity: \(syncConflict.entityType.rawValue)")
+        lines.append("Sync conflict entity ID: \(syncConflict.entityId)")
+        lines.append("Sync conflict recoverable: \(syncConflict.recoverable)")
+    }
+
+    return lines.joined(separator: "\n")
+}
+
+private func genericTechnicalErrorDetails(error: Error) -> String {
+    let nsError = error as NSError
+    var lines: [String] = [
+        "Type: \(String(reflecting: error))",
+        "Domain: \(nsError.domain)",
+        "Code: \(nsError.code)",
+        "Description: \(nsError.localizedDescription)"
+    ]
+
+    if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+        lines.append("Underlying error:")
+        lines.append(genericTechnicalErrorDetails(error: underlyingError))
+    }
+
+    return lines.joined(separator: "\n")
 }

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -2243,6 +2243,65 @@
         }
       }
     },
+    "cloud_auth.error.otp_too_many_attempts" : {
+      "comment" : "Cloud auth error when too many OTP attempts were made",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمت محاولات كثيرة جدًا. اطلب رمزًا جديدًا."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zu viele Versuche. Fordere einen neuen Code an."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Too many attempts. Request a new code."
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demasiados intentos. Solicita un código nuevo."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demasiados intentos. Solicita un código nuevo."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "बहुत अधिक प्रयास हो गए। नया कोड माँगें।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "試行回数が多すぎます。新しいコードをリクエストしてください。"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Слишком много попыток. Запросите новый код."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尝试次数过多。请重新获取验证码。"
+          }
+        }
+      }
+    },
     "cloud_auth.error.otp_verify_failed" : {
       "comment" : "Cloud auth error when verifying the OTP code failed",
       "localizations" : {

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudOtpVerificationSheet.swift
@@ -9,6 +9,7 @@ struct CloudOtpVerificationSheet: View {
 
     @State private var code: String = ""
     @State private var authErrorPresentation: CloudAuthInlineErrorPresentation?
+    @State private var technicalErrorPresentation: TechnicalErrorPresentation?
     @State private var isVerifyingCode: Bool = false
     @State private var isSendingCode: Bool = false
     @State private var challengeState: OtpChallengeState = .active
@@ -18,6 +19,7 @@ struct CloudOtpVerificationSheet: View {
         case active
         case consumed
         case expired
+        case tooManyAttempts
     }
 
     init(
@@ -39,7 +41,12 @@ struct CloudOtpVerificationSheet: View {
                 Form {
                     if let authErrorPresentation = self.authErrorPresentation {
                         Section {
-                            CloudAuthInlineErrorView(presentation: authErrorPresentation)
+                            CloudAuthInlineErrorView(
+                                presentation: authErrorPresentation,
+                                onTechnicalError: { technicalError in
+                                    self.presentTechnicalError(technicalError)
+                                }
+                            )
                         }
                     }
 
@@ -119,6 +126,14 @@ struct CloudOtpVerificationSheet: View {
                     }
                 }
             }
+            .sheet(item: self.$technicalErrorPresentation) { presentation in
+                TechnicalErrorSheet(
+                    presentation: presentation,
+                    onClose: {
+                        self.technicalErrorPresentation = nil
+                    }
+                )
+            }
         }
     }
 
@@ -138,6 +153,8 @@ struct CloudOtpVerificationSheet: View {
             return aiSettingsLocalized("settings.account.cloudSignIn.challengePrompt.consumed", "This code was already used. Request a new code to continue.")
         case .expired:
             return aiSettingsLocalized("settings.account.cloudSignIn.challengePrompt.expired", "This code expired. Request a new code to continue.")
+        case .tooManyAttempts:
+            return aiSettingsLocalized("settings.account.cloudSignIn.challengePrompt.tooManyAttempts", "Too many attempts. Request a new code to continue.")
         }
     }
 
@@ -154,20 +171,21 @@ struct CloudOtpVerificationSheet: View {
         guard nextCode.isEmpty == false else {
             self.authErrorPresentation = CloudAuthInlineErrorPresentation(
                 message: aiSettingsLocalized("settings.account.cloudSignIn.codeRequired", "Code is required"),
-                technicalDetails: nil
+                technicalError: nil
             )
             return
         }
         guard let currentChallenge = self.currentChallenge else {
             self.authErrorPresentation = CloudAuthInlineErrorPresentation(
                 message: aiSettingsLocalized("settings.account.cloudSignIn.codeStillLoading", "Code is still loading"),
-                technicalDetails: nil
+                technicalError: nil
             )
             return
         }
 
         Task { @MainActor in
             self.isVerifyingCode = true
+            let captureContext = self.store.beginTechnicalErrorCaptureContext()
             defer {
                 self.isVerifyingCode = false
             }
@@ -175,7 +193,8 @@ struct CloudOtpVerificationSheet: View {
             do {
                 let verifiedContext = try await self.store.verifyCloudOtp(
                     challenge: currentChallenge,
-                    code: nextCode
+                    code: nextCode,
+                    captureContext: captureContext
                 )
                 self.code = ""
                 self.challengeState = .consumed
@@ -186,9 +205,12 @@ struct CloudOtpVerificationSheet: View {
                     return
                 }
                 self.applyOtpErrorState(error: error)
-                self.authErrorPresentation = makeCloudAuthInlineErrorPresentation(
-                    error: error,
-                    context: .verifyCode
+                self.presentAuthErrorPresentation(
+                    makeCloudAuthInlineErrorPresentation(
+                        error: error,
+                        context: .verifyCode
+                    ),
+                    captureContext: captureContext
                 )
             }
         }
@@ -198,12 +220,16 @@ struct CloudOtpVerificationSheet: View {
         let currentEmail = self.currentEmail
         Task { @MainActor in
             self.isSendingCode = true
+            let captureContext = self.store.beginTechnicalErrorCaptureContext()
             defer {
                 self.isSendingCode = false
             }
 
             do {
-                let sendCodeResult = try await self.store.sendCloudSignInCode(email: currentEmail)
+                let sendCodeResult = try await self.store.sendCloudSignInCode(
+                    email: currentEmail,
+                    captureContext: captureContext
+                )
 
                 switch sendCodeResult {
                 case .otpChallenge(let nextChallenge):
@@ -218,9 +244,12 @@ struct CloudOtpVerificationSheet: View {
                 if isRequestCancellationError(error: error) {
                     return
                 }
-                self.authErrorPresentation = makeCloudAuthInlineErrorPresentation(
-                    error: error,
-                    context: .sendCode
+                self.presentAuthErrorPresentation(
+                    makeCloudAuthInlineErrorPresentation(
+                        error: error,
+                        context: .sendCode
+                    ),
+                    captureContext: captureContext
                 )
             }
         }
@@ -242,8 +271,34 @@ struct CloudOtpVerificationSheet: View {
                 self.code = ""
                 self.challengeState = .consumed
             }
+
+            if details.code == "OTP_TOO_MANY_ATTEMPTS" {
+                self.code = ""
+                self.challengeState = .tooManyAttempts
+            }
         case .invalidBaseUrl, .invalidResponseBody:
             return
         }
+    }
+
+    private func presentTechnicalError(_ action: TechnicalErrorAction) {
+        self.technicalErrorPresentation = self.store.makeTechnicalErrorPresentation(action: action)
+    }
+
+    private func presentAuthErrorPresentation(
+        _ presentation: CloudAuthInlineErrorPresentation,
+        captureContext: TechnicalErrorCaptureContext
+    ) {
+        self.authErrorPresentation = CloudAuthInlineErrorPresentation(
+            message: presentation.message,
+            technicalError: presentation.technicalError.map { action in
+                self.store.captureTechnicalErrorActionIfNeeded(
+                    action: self.store.makeTechnicalErrorAction(
+                        error: action.error,
+                        captureContext: captureContext
+                    )
+                )
+            }
+        )
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudPostAuthSheets.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudPostAuthSheets.swift
@@ -1,8 +1,8 @@
 import SwiftUI
-import UIKit
 
 struct CloudAuthInlineErrorView: View {
     let presentation: CloudAuthInlineErrorPresentation
+    let onTechnicalError: (TechnicalErrorAction) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -12,19 +12,14 @@ struct CloudAuthInlineErrorView: View {
                 .textSelection(.enabled)
                 .accessibilityIdentifier(UITestIdentifier.cloudSignInInlineAuthErrorMessage)
 
-            if let technicalDetails = self.presentation.technicalDetails {
-                DisclosureGroup(aiSettingsLocalized("settings.account.cloudSignIn.technicalDetails", "Technical details")) {
-                    Text(technicalDetails)
-                        .font(.caption.monospaced())
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
-                        .padding(.top, 4)
-                        .contextMenu {
-                            Button(aiSettingsLocalized("settings.account.cloudSignIn.copyTechnicalDetails", "Copy technical details")) {
-                                UIPasteboard.general.string = technicalDetails
-                            }
-                        }
+            if let technicalError = self.presentation.technicalError {
+                Button {
+                    self.onTechnicalError(technicalError)
+                } label: {
+                    Label(
+                        aiSettingsLocalized("settings.account.cloudSignIn.technicalDetails", "Technical details"),
+                        systemImage: "info.circle"
+                    )
                 }
                 .tint(.secondary)
             }
@@ -78,6 +73,7 @@ struct CloudPostAuthRecoveryNeededSheet: View {
 
 struct CloudPostAuthFailureSheet: View {
     @Environment(FlashcardsStore.self) private var store: FlashcardsStore
+    @State private var technicalErrorPresentation: TechnicalErrorPresentation?
 
     let state: CloudPostAuthFailureState
     let isRetryDisabled: Bool
@@ -106,41 +102,24 @@ struct CloudPostAuthFailureSheet: View {
                 horizontalPadding: 0
             ) {
                 Form {
-                    if self.state.kind == .standard {
-                        Section {
-                            CopyableErrorMessageView(message: self.state.message)
-                                .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureMessage)
-                        }
-                    }
-
                     Section(aiSettingsLocalized("settings.account.cloudSignIn.section.cloudAccount", "Cloud account")) {
                         Text(self.state.title)
                             .font(.headline)
-                        if self.state.kind == .guestLocalRecovery {
-                            Text(self.failureDescription)
-                                .foregroundStyle(.secondary)
-                                .textSelection(.enabled)
-                                .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureMessage)
-                        } else {
-                            Text(self.failureDescription)
-                                .foregroundStyle(.secondary)
-                        }
+                        Text(self.failureDescription)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureMessage)
                     }
 
-                    if let technicalDetails = self.state.technicalDetails {
+                    if let technicalError = self.state.technicalError {
                         Section {
-                            DisclosureGroup(aiSettingsLocalized("settings.account.cloudSignIn.technicalDetails", "Technical details")) {
-                                Text(technicalDetails)
-                                    .font(.caption.monospaced())
-                                    .foregroundStyle(.secondary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .textSelection(.enabled)
-                                    .padding(.top, 4)
-                                    .contextMenu {
-                                        Button(aiSettingsLocalized("settings.account.cloudSignIn.copyTechnicalDetails", "Copy technical details")) {
-                                            UIPasteboard.general.string = technicalDetails
-                                        }
-                                    }
+                            Button {
+                                self.presentTechnicalError(technicalError)
+                            } label: {
+                                Label(
+                                    aiSettingsLocalized("settings.account.cloudSignIn.technicalDetails", "Technical details"),
+                                    systemImage: "info.circle"
+                                )
                             }
                             .tint(.secondary)
                         }
@@ -169,19 +148,28 @@ struct CloudPostAuthFailureSheet: View {
             .accessibilityIdentifier(UITestIdentifier.cloudSignInPostAuthFailureScreen)
             .navigationTitle(aiSettingsLocalized("settings.account.cloudSignIn.cloudSyncTitle", "Cloud sync"))
             .navigationBarTitleDisplayMode(.inline)
+            .sheet(item: self.$technicalErrorPresentation) { presentation in
+                TechnicalErrorSheet(
+                    presentation: presentation,
+                    onClose: {
+                        self.technicalErrorPresentation = nil
+                    }
+                )
+            }
         }
     }
 
     private var failureDescription: String {
         switch self.state.kind {
         case .standard:
-            return aiSettingsLocalized(
-                "settings.account.cloudSignIn.failureDescription",
-                "Your sign-in succeeded, but the cloud workspace setup or initial sync did not finish."
-            )
+            return self.state.message
         case .guestLocalRecovery:
             return self.state.message
         }
+    }
+
+    private func presentTechnicalError(_ action: TechnicalErrorAction) {
+        self.technicalErrorPresentation = self.store.makeTechnicalErrorPresentation(action: action)
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSheet.swift
@@ -21,6 +21,7 @@ struct CloudSignInSheet: View {
     @State private var postAuthRecoveryNeededState: CloudPostAuthRecoveryNeededState?
     @State private var postAuthFailureState: CloudPostAuthFailureState?
     @State private var authErrorPresentation: CloudAuthInlineErrorPresentation?
+    @State private var technicalErrorPresentation: TechnicalErrorPresentation?
     @State private var isSendingCode: Bool = false
     @State private var isLogoutConfirmationPresented: Bool = false
     @State private var hasRecordedActivePresentation: Bool = false
@@ -41,7 +42,12 @@ struct CloudSignInSheet: View {
                 Form {
                     if let authErrorPresentation = self.authErrorPresentation {
                         Section {
-                            CloudAuthInlineErrorView(presentation: authErrorPresentation)
+                            CloudAuthInlineErrorView(
+                                presentation: authErrorPresentation,
+                                onTechnicalError: { technicalError in
+                                    self.presentTechnicalError(technicalError)
+                                }
+                            )
                         }
                     }
 
@@ -175,6 +181,14 @@ struct CloudSignInSheet: View {
             } message: {
                 Text(aiSettingsLocalized("settings.account.status.logoutAlertMessage", "All local workspaces and synced data will be removed from this device."))
             }
+            .sheet(item: self.$technicalErrorPresentation) { presentation in
+                TechnicalErrorSheet(
+                    presentation: presentation,
+                    onClose: {
+                        self.technicalErrorPresentation = nil
+                    }
+                )
+            }
             .onAppear {
                 self.recordActivePresentationIfNeeded()
                 self.scheduleEmailFieldFocus()
@@ -293,7 +307,7 @@ struct CloudSignInSheet: View {
         guard isValidCloudEmail(self.email) else {
             self.authErrorPresentation = CloudAuthInlineErrorPresentation(
                 message: aiSettingsLocalized("settings.account.cloudSignIn.enterValidEmail", "Enter a valid email address"),
-                technicalDetails: nil
+                technicalError: nil
             )
             return
         }
@@ -306,12 +320,16 @@ struct CloudSignInSheet: View {
 
         Task { @MainActor in
             self.isSendingCode = true
+            let captureContext = self.store.beginTechnicalErrorCaptureContext()
             defer {
                 self.isSendingCode = false
             }
 
             do {
-                let sendCodeResult = try await self.store.sendCloudSignInCode(email: nextEmail)
+                let sendCodeResult = try await self.store.sendCloudSignInCode(
+                    email: nextEmail,
+                    captureContext: captureContext
+                )
 
                 switch sendCodeResult {
                 case .otpChallenge(let nextChallenge):
@@ -342,9 +360,12 @@ struct CloudSignInSheet: View {
                 if self.otpSheetState?.id == nextOtpSheetState.id {
                     self.otpSheetState = nil
                 }
-                self.authErrorPresentation = makeCloudAuthInlineErrorPresentation(
-                    error: error,
-                    context: .sendCode
+                self.presentAuthErrorPresentation(
+                    makeCloudAuthInlineErrorPresentation(
+                        error: error,
+                        context: .sendCode
+                    ),
+                    captureContext: captureContext
                 )
             }
         }
@@ -414,16 +435,20 @@ struct CloudSignInSheet: View {
                 )
                 self.presentPostAuthFailure(
                     title: failurePresentation.title,
-                    message: failurePresentation.message ?? Flashcards.errorMessage(error: error),
-                    technicalDetails: Flashcards.errorMessage(error: error),
+                    message: failurePresentation.message ?? makeCloudPostAuthVisibleFailureMessage(error: error),
+                    technicalError: isSafeCloudPostAuthDomainFailure(error: error)
+                        ? nil
+                        : makeTechnicalErrorAction(error: error),
                     retryAction: failurePresentation.retryAction,
                     kind: failurePresentation.kind
                 )
             } else {
                 self.presentPostAuthFailure(
                     title: aiSettingsLocalized("settings.account.cloudSignIn.failure.cloudSetupFailed", "Signed in, but cloud setup failed."),
-                    message: Flashcards.errorMessage(error: error),
-                    technicalDetails: nil,
+                    message: makeCloudPostAuthVisibleFailureMessage(error: error),
+                    technicalError: isSafeCloudPostAuthDomainFailure(error: error)
+                        ? nil
+                        : makeTechnicalErrorAction(error: error),
                     retryAction: .prepareLink(verifiedContext: loadingState.verifiedContext),
                     kind: .standard
                 )
@@ -490,26 +515,26 @@ struct CloudSignInSheet: View {
     }
 
     private func runPostAuthSync(_ syncState: CloudPostAuthSyncState) async {
+        let captureContext = self.store.beginTechnicalErrorCaptureContext()
         do {
             switch syncState.operation {
             case .completeLink(let linkContext, let selection):
                 try await self.store.completeCloudLink(
                     linkContext: linkContext,
-                    selection: selection
+                    selection: selection,
+                    technicalErrorCaptureContext: captureContext
                 )
             case .completeGuestLink(let linkContext, let selection):
                 try await self.store.completeGuestCloudLink(
                     linkContext: linkContext,
-                    selection: selection
+                    selection: selection,
+                    technicalErrorCaptureContext: captureContext
                 )
             case .syncOnly:
                 try await self.store.syncCloudNow(
-                    trigger: CloudSyncTrigger(
-                        source: .manualSyncNow,
+                    trigger: self.store.postAuthCloudSyncTrigger(
                         now: Date(),
-                        extendsFastPolling: false,
-                        allowsVisibleChangeBanner: false,
-                        surfacesGlobalErrorMessage: true
+                        technicalErrorCaptureContext: captureContext
                     )
                 )
             }
@@ -534,10 +559,13 @@ struct CloudSignInSheet: View {
             self.postAuthSyncState = nil
             self.presentPostAuthFailure(
                 title: failurePresentation.title,
-                message: failurePresentation.message ?? Flashcards.errorMessage(error: error),
-                technicalDetails: failurePresentation.kind == .guestLocalRecovery
-                    ? Flashcards.errorMessage(error: error)
-                    : nil,
+                message: failurePresentation.message ?? makeCloudPostAuthVisibleFailureMessage(error: error),
+                technicalError: isSafeCloudPostAuthDomainFailure(error: error)
+                    ? nil
+                    : self.store.makeTechnicalErrorAction(
+                        error: error,
+                        captureContext: captureContext
+                    ),
                 retryAction: failurePresentation.retryAction,
                 kind: failurePresentation.kind
             )
@@ -547,7 +575,7 @@ struct CloudSignInSheet: View {
     private func presentPostAuthFailure(
         title: String,
         message: String,
-        technicalDetails: String?,
+        technicalError: TechnicalErrorAction?,
         retryAction: CloudPostAuthRetryAction,
         kind: CloudPostAuthFailureKind
     ) {
@@ -560,10 +588,33 @@ struct CloudSignInSheet: View {
         self.postAuthFailureState = CloudPostAuthFailureState(
             title: title,
             message: message,
-            technicalDetails: technicalDetails,
+            technicalError: technicalError.map { action in
+                self.store.captureTechnicalErrorActionIfNeeded(action: action)
+            },
             retryAction: retryAction,
             kind: kind
         )
+    }
+
+    private func presentAuthErrorPresentation(
+        _ presentation: CloudAuthInlineErrorPresentation,
+        captureContext: TechnicalErrorCaptureContext
+    ) {
+        self.authErrorPresentation = CloudAuthInlineErrorPresentation(
+            message: presentation.message,
+            technicalError: presentation.technicalError.map { action in
+                self.store.captureTechnicalErrorActionIfNeeded(
+                    action: self.store.makeTechnicalErrorAction(
+                        error: action.error,
+                        captureContext: captureContext
+                    )
+                )
+            }
+        )
+    }
+
+    private func presentTechnicalError(_ action: TechnicalErrorAction) {
+        self.technicalErrorPresentation = self.store.makeTechnicalErrorPresentation(action: action)
     }
 
     private func logoutAndDismiss() {
@@ -573,7 +624,7 @@ struct CloudSignInSheet: View {
         } catch {
             self.authErrorPresentation = CloudAuthInlineErrorPresentation(
                 message: Flashcards.errorMessage(error: error),
-                technicalDetails: nil
+                technicalError: nil
             )
         }
 

--- a/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Settings/Account/CloudSignIn/CloudSignInSupport.swift
@@ -155,25 +155,113 @@ func makeGuestLocalRecoveryPostAuthFailurePresentation(
     )
 }
 
-struct CloudPostAuthFailureState: Identifiable, Hashable {
+func makeCloudPostAuthVisibleFailureMessage(error: Error) -> String {
+    if let safeFailure = safeCloudPostAuthDomainFailure(error: error) {
+        return safeFailure.message
+    }
+
+    return aiSettingsLocalized(
+        "settings.account.cloudSignIn.failureDescription",
+        "Your sign-in succeeded, but the cloud workspace setup or initial sync did not finish."
+    )
+}
+
+func isSafeCloudPostAuthDomainFailure(error: Error) -> Bool {
+    safeCloudPostAuthDomainFailure(error: error) != nil
+}
+
+private enum SafeCloudPostAuthDomainFailure {
+    case bootstrapEligibility(String)
+    case credentialRecovery(String)
+
+    var message: String {
+        switch self {
+        case .bootstrapEligibility(let message),
+             .credentialRecovery(let message):
+            return message
+        }
+    }
+}
+
+private func safeCloudPostAuthDomainFailure(error: Error) -> SafeCloudPostAuthDomainFailure? {
+    if let bootstrapError = error as? CloudBootstrapEligibilityError {
+        switch bootstrapError {
+        case .remoteWorkspaceIsNotEmpty:
+            return .bootstrapEligibility(bootstrapError.visiblePostAuthMessage)
+        }
+    }
+
+    if let credentialRecoveryMessage = safeCloudCredentialRecoveryPostAuthMessage(error: error) {
+        return .credentialRecovery(credentialRecoveryMessage)
+    }
+
+    return nil
+}
+
+private func safeCloudCredentialRecoveryPostAuthMessage(error: Error) -> String? {
+    guard let localStoreError = error as? LocalStoreError else {
+        return nil
+    }
+    guard case .validation(let message) = localStoreError else {
+        return nil
+    }
+
+    if safeCloudCredentialRecoveryPostAuthMessages().contains(message) {
+        return message
+    }
+    if isLocalizedCloudCredentialRecoveryUpgradeWorkspaceMessage(message) {
+        return message
+    }
+
+    return nil
+}
+
+private func safeCloudCredentialRecoveryPostAuthMessages() -> Set<String> {
+    [
+        localizedCloudCredentialRecoveryBlockedMessage(reason: .linkedCredentialsMissing),
+        localizedCloudCredentialRecoveryBlockedMessage(reason: .guestSessionMissing),
+        localizedCloudCredentialRecoveryBlockedMessage(reason: .invalidStoredState),
+        localizedCloudCredentialRecoveryWrongLinkedAccountMessage(),
+        localizedCloudCredentialRecoveryWrongLinkedWorkspaceMessage(),
+        localizedCloudCredentialRecoveryInterruptedUpgradeAccountMessage()
+    ]
+}
+
+private func isLocalizedCloudCredentialRecoveryUpgradeWorkspaceMessage(_ message: String) -> Bool {
+    let sentinel = "__FLASHCARDS_WORKSPACE_NAME__"
+    let localizedTemplate = localizedCloudCredentialRecoveryUpgradeWorkspaceMessage(workspaceName: sentinel)
+    let components = localizedTemplate.components(separatedBy: sentinel)
+
+    guard components.count == 2 else {
+        return message == localizedTemplate
+    }
+
+    let prefix = components[0]
+    let suffix = components[1]
+    return message.hasPrefix(prefix)
+        && message.hasSuffix(suffix)
+        && message.count >= prefix.count + suffix.count
+}
+
+struct CloudPostAuthFailureState: Identifiable {
     let id: String
     let title: String
     let message: String
-    let technicalDetails: String?
+    let technicalError: TechnicalErrorAction?
     let retryAction: CloudPostAuthRetryAction
     let kind: CloudPostAuthFailureKind
 
     init(
         title: String,
         message: String,
-        technicalDetails: String?,
+        technicalError: TechnicalErrorAction?,
         retryAction: CloudPostAuthRetryAction,
         kind: CloudPostAuthFailureKind
     ) {
         self.id = UUID().uuidString
         self.title = title
         self.message = message
-        self.technicalDetails = technicalDetails
+        self.technicalError = technicalError
         self.retryAction = retryAction
         self.kind = kind
     }

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -168,6 +168,7 @@ final class FlashcardsStore {
     @ObservationIgnored var progressReviewScheduleLocalCache: ProgressReviewScheduleLocalCacheEntry?
     @ObservationIgnored var activeAutomaticFeedbackPromptTask: Task<Void, Never>?
     @ObservationIgnored var nextAutomaticFeedbackPromptRetryAt: Date?
+    @ObservationIgnored var capturedTechnicalErrorCaptureContextIDs: Set<String>
 
     var aiChatStore: AIChatStore {
         if let cachedAIChatStore {
@@ -493,6 +494,7 @@ final class FlashcardsStore {
         self.progressReviewScheduleLocalCache = nil
         self.activeAutomaticFeedbackPromptTask = nil
         self.nextAutomaticFeedbackPromptRetryAt = nil
+        self.capturedTechnicalErrorCaptureContextIDs = []
 
         if database != nil && initialGlobalErrorMessage.isEmpty {
             do {
@@ -535,8 +537,56 @@ final class FlashcardsStore {
 
     func presentTechnicalError(_ error: Error) {
         let presentation: TechnicalErrorPresentation = makeTechnicalErrorPresentation(error: error)
-        self.capturePresentedTechnicalError(error: error)
+        self.captureTechnicalErrorForVisiblePresentation(error: error)
         self.presentedTechnicalError = presentation
+    }
+
+    func makeTechnicalErrorPresentation(action: TechnicalErrorAction) -> TechnicalErrorPresentation {
+        let presentation: TechnicalErrorPresentation = Flashcards.makeTechnicalErrorPresentation(error: action.error)
+
+        switch action.capturePolicy {
+        case .captureOnPresentation:
+            self.captureTechnicalErrorForVisiblePresentation(error: action.error)
+        case .alreadyCaptured:
+            break
+        }
+
+        return presentation
+    }
+
+    func captureTechnicalErrorActionIfNeeded(action: TechnicalErrorAction) -> TechnicalErrorAction {
+        switch action.capturePolicy {
+        case .captureOnPresentation:
+            self.captureTechnicalErrorForVisiblePresentation(error: action.error)
+            return TechnicalErrorAction(
+                error: action.error,
+                capturePolicy: .alreadyCaptured
+            )
+        case .alreadyCaptured:
+            return action
+        }
+    }
+
+    func beginTechnicalErrorCaptureContext() -> TechnicalErrorCaptureContext {
+        TechnicalErrorCaptureContext()
+    }
+
+    func makeTechnicalErrorAction(
+        error: Error,
+        captureContext: TechnicalErrorCaptureContext
+    ) -> TechnicalErrorAction {
+        let capturePolicy: TechnicalErrorCapturePolicy = self.consumeTechnicalErrorCaptureContext(captureContext)
+            ? .alreadyCaptured
+            : .captureOnPresentation
+        return Flashcards.makeTechnicalErrorAction(error: error, capturePolicy: capturePolicy)
+    }
+
+    func markTechnicalErrorCaptured(captureContext: TechnicalErrorCaptureContext?) {
+        guard let captureContext else {
+            return
+        }
+
+        self.capturedTechnicalErrorCaptureContextIDs.insert(captureContext.id)
     }
 
     func presentTechnicalErrorPreview() {
@@ -547,7 +597,7 @@ final class FlashcardsStore {
         self.presentedTechnicalError = nil
     }
 
-    private func capturePresentedTechnicalError(error: Error) {
+    private func captureTechnicalErrorForVisiblePresentation(error: Error) {
         FlashcardsObservability.captureSilentFailure(
             error: error,
             scope: IOSObservationScope(
@@ -567,5 +617,9 @@ final class FlashcardsStore {
             backendCode: nil,
             requestId: nil
         )
+    }
+
+    private func consumeTechnicalErrorCaptureContext(_ captureContext: TechnicalErrorCaptureContext) -> Bool {
+        self.capturedTechnicalErrorCaptureContextIDs.remove(captureContext.id) != nil
     }
 }

--- a/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ar.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "أدخل الرمز المكوّن من 8 أرقام الذي وصلك عبر البريد الإلكتروني. إذا لم تجده، فتحقق من مجلد الرسائل غير المرغوب فيها.";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "لقد تم استخدام هذا الرمز بالفعل. اطلب واحدة جديدة للمتابعة.";
 "settings.account.cloudSignIn.challengePrompt.expired" = "لقد انتهت صلاحية هذا الرمز. اطلب واحدة جديدة للمتابعة.";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "حدثت محاولات كثيرة جدًا. اطلب رمزًا جديدًا للمتابعة.";
 "settings.account.cloudSignIn.workspaceDescription" = "اختر خيارًا للمتابعة: اربط هذا الجهاز بمساحة عمل سحابية موجودة أو أنشئ مساحة جديدة.";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "تم تسجيل الدخول، ولكن فشلت المزامنة الأولية.";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "لقد قمت بتسجيل الدخول، ولكن فشل تكوين السحابة.";

--- a/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/de.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "Geben Sie den 8-stelligen Code ein, den Sie per E-Mail erhalten haben. Wenn Sie ihn nicht sehen, prüfen Sie den Spam-Ordner.";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "Dieser Code wurde bereits verwendet. Fordern Sie ein neues an, um fortzufahren.";
 "settings.account.cloudSignIn.challengePrompt.expired" = "Dieser Code ist abgelaufen. Fordern Sie ein neues an, um fortzufahren.";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "Zu viele Versuche. Fordern Sie einen neuen Code an, um fortzufahren.";
 "settings.account.cloudSignIn.workspaceDescription" = "Wählen Sie eine Option, um fortzufahren: Verknüpfen Sie dieses Gerät mit einem vorhandenen Cloud-Arbeitsbereich oder erstellen Sie einen neuen.";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "Angemeldet, aber die erste Synchronisierung ist fehlgeschlagen.";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "Ich habe mich angemeldet, aber die Cloud-Konfiguration ist fehlgeschlagen.";

--- a/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-ES.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "Introduce el codigo de 8 digitos que recibiste por correo. Si no lo ves, revisa la carpeta de spam.";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "Este codigo ya se ha usado. Solicita uno nuevo para continuar.";
 "settings.account.cloudSignIn.challengePrompt.expired" = "Este codigo ha caducado. Solicita uno nuevo para continuar.";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "Demasiados intentos. Solicita un codigo nuevo para continuar.";
 "settings.account.cloudSignIn.workspaceDescription" = "Elige una opcion para continuar: vincular este dispositivo a un espacio de trabajo en la nube existente o crear uno nuevo.";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "Se inicio sesion, pero fallo la sincronizacion inicial.";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "Se inicio sesion, pero fallo la configuracion de la nube.";

--- a/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/es-MX.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "Introduce el codigo de 8 digitos que recibiste por correo. Si no lo ves, revisa la carpeta de spam.";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "Este codigo ya se ha usado. Solicita uno nuevo para continuar.";
 "settings.account.cloudSignIn.challengePrompt.expired" = "Este codigo ha caducado. Solicita uno nuevo para continuar.";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "Demasiados intentos. Solicita un codigo nuevo para continuar.";
 "settings.account.cloudSignIn.workspaceDescription" = "Elige una opcion para continuar: vincular este dispositivo a un espacio de trabajo en la nube existente o crear uno nuevo.";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "Se inicio sesion, pero fallo la sincronizacion inicial.";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "Se inicio sesion, pero fallo la configuracion de la nube.";

--- a/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/hi.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "आपको ईमेल द्वारा प्राप्त 8-अंकीय कोड दर्ज करें। अगर यह न दिखे, तो स्पैम फ़ोल्डर देखें।";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "इस कोड का उपयोग पहले ही किया जा चुका है. जारी रखने के लिए एक नए का अनुरोध करें।";
 "settings.account.cloudSignIn.challengePrompt.expired" = "यह कोड समाप्त हो गया है. जारी रखने के लिए एक नए का अनुरोध करें।";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "बहुत अधिक प्रयास हो गए। जारी रखने के लिए नया कोड माँगें।";
 "settings.account.cloudSignIn.workspaceDescription" = "जारी रखने के लिए एक विकल्प चुनें: इस डिवाइस को मौजूदा क्लाउड वर्कस्पेस से लिंक करें या एक नया बनाएं।";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "लॉग इन किया गया, लेकिन प्रारंभिक सिंक विफल रहा।";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "मैंने लॉग इन किया, लेकिन क्लाउड कॉन्फ़िगरेशन विफल रहा।";

--- a/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ja.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "メールで受け取った 8 桁のコードを入力してください。見つからない場合は、迷惑メールフォルダを確認してください。";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "このコードはすでに使用されています。続行するには、新しいリクエストをリクエストしてください。";
 "settings.account.cloudSignIn.challengePrompt.expired" = "このコードの有効期限は切れています。続行するには、新しいリクエストをリクエストしてください。";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "試行回数が多すぎます。続行するには新しいコードをリクエストしてください。";
 "settings.account.cloudSignIn.workspaceDescription" = "オプションを選択して続行します: このデバイスを既存のクラウド ワークスペースにリンクするか、新しいクラウド ワークスペースを作成します。";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "ログインしましたが、初期同期に失敗しました。";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "ログインしましたが、クラウド構成に失敗しました。";

--- a/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/ru.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "Введите 8-значный код, который вы получили по электронной почте. Если его нет, проверьте папку «Спам».";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "Этот код уже использовался. Чтобы продолжить, запросите новый.";
 "settings.account.cloudSignIn.challengePrompt.expired" = "Срок действия этого кода истек. Чтобы продолжить, запросите новый.";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "Слишком много попыток. Чтобы продолжить, запросите новый код.";
 "settings.account.cloudSignIn.workspaceDescription" = "Выберите вариант продолжения: свяжите это устройство с существующим облачным рабочим пространством или создайте новое.";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "Выполнен вход, но первоначальная синхронизация не удалась.";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "Я вошел в систему, но конфигурация облака не удалась.";

--- a/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
+++ b/apps/ios/Flashcards/Flashcards/zh-Hans.lproj/AISettings.strings
@@ -389,6 +389,7 @@
 "settings.account.cloudSignIn.challengePrompt.active" = "输入您通过电子邮件收到的 8 位代码。如果没有看到，请检查垃圾邮件文件夹。";
 "settings.account.cloudSignIn.challengePrompt.consumed" = "该代码已被使用。请求新的继续。";
 "settings.account.cloudSignIn.challengePrompt.expired" = "该代码已过期。请求新的继续。";
+"settings.account.cloudSignIn.challengePrompt.tooManyAttempts" = "尝试次数过多。请求新的验证码继续。";
 "settings.account.cloudSignIn.workspaceDescription" = "选择一个选项继续：将此设备链接到现有云工作区或创建一个新的云工作区。";
 "settings.account.cloudSignIn.failure.initialSyncFailed" = "已登录，但初始同步失败。";
 "settings.account.cloudSignIn.failure.cloudSetupFailed" = "我登录了，但是云端配置失败。";

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudAuthInlineErrorPresentationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/CloudAuthInlineErrorPresentationTests.swift
@@ -15,7 +15,8 @@ final class CloudAuthInlineErrorPresentationTests: XCTestCase {
             presentation.message,
             "The connection was interrupted while sending the code. Check your email, then try again if needed."
         )
-        XCTAssertEqual(presentation.technicalDetails, String(describing: error as Error))
+        XCTAssertEqual(presentation.technicalError?.capturePolicy, .captureOnPresentation)
+        XCTAssertNotNil(presentation.technicalError)
     }
 
     func testWrappedTransportFailureDuringVerifyCodeStillUsesFriendlyMessage() {
@@ -35,10 +36,57 @@ final class CloudAuthInlineErrorPresentationTests: XCTestCase {
             presentation.message,
             "The connection was interrupted while verifying the code. Try again, or request a new code if needed."
         )
-        XCTAssertEqual(presentation.technicalDetails, String(describing: error as Error))
+        XCTAssertEqual(presentation.technicalError?.capturePolicy, .captureOnPresentation)
+        XCTAssertNotNil(presentation.technicalError)
     }
 
-    func testServerAuthErrorsKeepExistingFriendlyMessageWithoutTechnicalDetails() {
+    func testUserActionableServerAuthErrorsKeepExistingFriendlyMessageWithoutTechnicalError() {
+        let error = CloudAuthError.invalidResponse(
+            CloudApiErrorDetails(
+                message: "invalid code",
+                requestId: "req-123",
+                code: "OTP_CODE_INVALID",
+                syncConflict: nil
+            ),
+            400
+        )
+
+        let presentation = makeCloudAuthInlineErrorPresentation(
+            error: error,
+            context: .verifyCode
+        )
+
+        XCTAssertEqual(
+            presentation.message,
+            "Invalid code. Try again."
+        )
+        XCTAssertNil(presentation.technicalError)
+    }
+
+    func testTooManyOtpAttemptsStayInlineWithoutTechnicalError() {
+        let error = CloudAuthError.invalidResponse(
+            CloudApiErrorDetails(
+                message: "too many attempts",
+                requestId: "req-123",
+                code: "OTP_TOO_MANY_ATTEMPTS",
+                syncConflict: nil
+            ),
+            429
+        )
+
+        let presentation = makeCloudAuthInlineErrorPresentation(
+            error: error,
+            context: .verifyCode
+        )
+
+        XCTAssertEqual(
+            presentation.message,
+            "Too many attempts. Request a new code."
+        )
+        XCTAssertNil(presentation.technicalError)
+    }
+
+    func testTechnicalServerAuthErrorsUseSafeMessageAndTechnicalErrorAction() {
         let error = CloudAuthError.invalidResponse(
             CloudApiErrorDetails(
                 message: "upstream failure",
@@ -56,9 +104,191 @@ final class CloudAuthInlineErrorPresentationTests: XCTestCase {
 
         XCTAssertEqual(
             presentation.message,
-            "Could not send a code. Try again. Reference: req-123"
+            "Could not send a code. Try again."
         )
-        XCTAssertNil(presentation.technicalDetails)
+        XCTAssertEqual(presentation.technicalError?.capturePolicy, .captureOnPresentation)
+        XCTAssertNotNil(presentation.technicalError)
+    }
+
+    func testAuthSetupFailuresUseSafeMessageAndCaptureOnPresentation() {
+        let error = LocalStoreError.validation("Cloud service configuration is unavailable")
+
+        let presentation = makeCloudAuthInlineErrorPresentation(
+            error: error,
+            context: .sendCode
+        )
+
+        XCTAssertEqual(
+            presentation.message,
+            "Could not send a code. Try again."
+        )
+        XCTAssertEqual(presentation.technicalError?.capturePolicy, .captureOnPresentation)
+        XCTAssertNotNil(presentation.technicalError)
+    }
+
+    @MainActor
+    func testAlreadyObservedTechnicalActionCarriesActionLocalOwnership() {
+        let store = FlashcardsStore()
+        let error = LocalStoreError.validation("Cloud service configuration is unavailable")
+        let captureContext = store.beginTechnicalErrorCaptureContext()
+
+        store.markTechnicalErrorCaptured(captureContext: captureContext)
+        let action = store.makeTechnicalErrorAction(
+            error: error,
+            captureContext: captureContext
+        )
+
+        XCTAssertEqual(action.capturePolicy, .alreadyCaptured)
+        XCTAssertTrue(action.error is LocalStoreError)
+        XCTAssertTrue(technicalErrorDetails(error: action.error).contains("Cloud service configuration is unavailable"))
+    }
+
+    @MainActor
+    func testIndependentTechnicalErrorWithSameDetailsStillCapturesOnPresentation() {
+        let store = FlashcardsStore()
+        let error = LocalStoreError.validation("Cloud service configuration is unavailable")
+        let captureContext = store.beginTechnicalErrorCaptureContext()
+        let action = store.makeTechnicalErrorAction(
+            error: error,
+            captureContext: captureContext
+        )
+
+        XCTAssertEqual(action.capturePolicy, .captureOnPresentation)
+        XCTAssertTrue(action.error is LocalStoreError)
+    }
+
+    func testTechnicalErrorDetailsIncludeCloudAuthDiagnostics() {
+        let error = CloudAuthError.invalidResponse(
+            CloudApiErrorDetails(
+                message: "upstream failure",
+                requestId: "req-123",
+                code: "OTP_SEND_FAILED",
+                syncConflict: nil
+            ),
+            500
+        )
+
+        let details = technicalErrorDetails(error: error)
+
+        XCTAssertTrue(details.contains("Type: CloudAuthError.invalidResponse"))
+        XCTAssertTrue(details.contains("Status: 500"))
+        XCTAssertTrue(details.contains("Code: OTP_SEND_FAILED"))
+        XCTAssertTrue(details.contains("Request ID: req-123"))
+        XCTAssertTrue(details.contains("Message: upstream failure"))
+    }
+
+    func testPostAuthBootstrapEligibilityFailureKeepsSafeVisibleMessage() {
+        let message = makeCloudPostAuthVisibleFailureMessage(
+            error: CloudBootstrapEligibilityError.remoteWorkspaceIsNotEmpty
+        )
+
+        XCTAssertEqual(
+            message,
+            "Choose a new or empty workspace on this server before uploading the current local data."
+        )
+        XCTAssertTrue(
+            isSafeCloudPostAuthDomainFailure(
+                error: CloudBootstrapEligibilityError.remoteWorkspaceIsNotEmpty
+            )
+        )
+    }
+
+    func testPostAuthCredentialRecoveryGuidanceFailureKeepsSafeVisibleMessage() {
+        let expectedMessage = localizedCloudCredentialRecoveryWrongLinkedAccountMessage()
+        let error = LocalStoreError.validation(expectedMessage)
+
+        let message = makeCloudPostAuthVisibleFailureMessage(error: error)
+
+        XCTAssertEqual(message, expectedMessage)
+        XCTAssertTrue(isSafeCloudPostAuthDomainFailure(error: error))
+    }
+
+    func testPostAuthCredentialRecoveryWorkspaceGuidanceFailureKeepsSafeVisibleMessage() {
+        let expectedMessage = localizedCloudCredentialRecoveryUpgradeWorkspaceMessage(
+            workspaceName: "Recovered Workspace"
+        )
+        let error = LocalStoreError.validation(expectedMessage)
+
+        let message = makeCloudPostAuthVisibleFailureMessage(error: error)
+
+        XCTAssertEqual(message, expectedMessage)
+        XCTAssertTrue(isSafeCloudPostAuthDomainFailure(error: error))
+    }
+
+    func testPostAuthTechnicalFailureUsesGenericVisibleMessage() {
+        let error = CloudSyncError.invalidResponse(
+            CloudApiErrorDetails(
+                message: "backend raw message",
+                requestId: "req-raw",
+                code: "SYNC_FAILED",
+                syncConflict: nil
+            ),
+            500
+        )
+
+        let message = makeCloudPostAuthVisibleFailureMessage(error: error)
+
+        XCTAssertEqual(
+            message,
+            "Your sign-in succeeded, but the cloud workspace setup or initial sync did not finish."
+        )
+        XCTAssertFalse(message.contains("backend raw message"))
+        XCTAssertFalse(message.contains("req-raw"))
+        XCTAssertFalse(isSafeCloudPostAuthDomainFailure(error: error))
+    }
+
+    func testPostAuthGenericValidationFailureStaysTechnical() {
+        let error = LocalStoreError.validation("Cloud service configuration is unavailable")
+
+        let message = makeCloudPostAuthVisibleFailureMessage(error: error)
+
+        XCTAssertEqual(
+            message,
+            "Your sign-in succeeded, but the cloud workspace setup or initial sync did not finish."
+        )
+        XCTAssertFalse(isSafeCloudPostAuthDomainFailure(error: error))
+    }
+
+    @MainActor
+    func testPostAuthCloudSyncFailureStatusDoesNotExposeRawDiagnostics() {
+        let store = FlashcardsStore()
+        let error = CloudSyncError.invalidResponse(
+            CloudApiErrorDetails(
+                message: "backend raw message",
+                requestId: "req-raw",
+                code: "SYNC_FAILED",
+                syncConflict: nil
+            ),
+            500
+        )
+
+        let status = store.transitionSyncStatusForCloudFailure(
+            error: error,
+            trigger: store.postAuthCloudSyncTrigger(now: Date(timeIntervalSince1970: 0))
+        )
+
+        XCTAssertEqual(status, .idle)
+    }
+
+    @MainActor
+    func testPostAuthBlockedCloudSyncFailureStatusDoesNotExposeRawDiagnostics() {
+        let store = FlashcardsStore()
+        let error = CloudSyncError.invalidResponse(
+            CloudApiErrorDetails(
+                message: "backend raw conflict details",
+                requestId: "req-conflict",
+                code: "SYNC_WORKSPACE_FORK_REQUIRED",
+                syncConflict: nil
+            ),
+            409
+        )
+
+        let status = store.transitionSyncStatusForCloudFailure(
+            error: error,
+            trigger: store.postAuthCloudSyncTrigger(now: Date(timeIntervalSince1970: 0))
+        )
+
+        XCTAssertEqual(status, .idle)
     }
 
     func testCloudApiErrorDetailsDecodePublicSyncConflictWithoutPrivateWorkspaceId() throws {


### PR DESCRIPTION
## Summary
- migrate iOS cloud auth/post-auth raw errors to safe visible copy plus shared technical details
- keep expected/user-actionable auth and post-auth domain failures out of technical mode and observability
- preserve exact-once capture behavior for real technical modal presentations

## Validation
- git --no-pager diff --check
- iOS-targeted Swift parse for changed Swift files
- Foundation.xcstrings JSON validation
- touched AISettings.strings lint
- targeted searches around credential recovery classification, technicalError, and capture paths
- worker-owned read-only review: no P0-P4 findings

Full Xcode build and simulator-backed flows were not run per instruction.