### PR TITLE
Add review timezone storage

### DIFF
--- a/apps/backend/src/cards/queries.ts
+++ b/apps/backend/src/cards/queries.ts
@@ -825,7 +825,7 @@ export async function listReviewHistoryPage(
   const result = await queryWithWorkspaceScope<ReviewHistoryPageRow>(
     { userId, workspaceId },
     [
-      "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server",
+      "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, reviewed_time_zone",
       "FROM content.review_events",
       "WHERE workspace_id = $1",
       cursorClause,

--- a/apps/backend/src/cards/reviews.ts
+++ b/apps/backend/src/cards/reviews.ts
@@ -6,6 +6,7 @@ import {
   type CurrentUserPublicProfileResolver,
 } from "../community/reviewActivityFacts";
 import { HttpError } from "../shared/errors";
+import { storeActiveReviewDayForReviewEventInExecutor } from "../progress/activeReviewDays";
 import {
   computeReviewSchedule,
   type ReviewableCardScheduleState,
@@ -35,6 +36,10 @@ import type {
   ReviewableCardRow,
   SubmitReviewInput,
 } from "./types";
+
+type ProgressTimeZoneRow = Readonly<{
+  progress_time_zone: string | null;
+}>;
 
 // Keep in sync with apps/ios/Flashcards/Flashcards/Review/Scheduling/FsrsScheduler.swift::makeReviewableCardScheduleState(card:).
 function toReviewableCardScheduleState(
@@ -79,6 +84,23 @@ async function loadReviewableCardForUpdate(
   return validateOrResetReviewableCardRow(executor, workspaceId, existingCard);
 }
 
+async function loadProgressTimeZoneForUserInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+): Promise<string | null> {
+  const result = await executor.query<ProgressTimeZoneRow>(
+    [
+      "SELECT progress_time_zone",
+      "FROM org.user_settings",
+      "WHERE user_id = $1",
+      "LIMIT 1",
+    ].join(" "),
+    [userId],
+  );
+
+  return result.rows[0]?.progress_time_zone ?? null;
+}
+
 export async function appendReviewEventSnapshotInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
@@ -92,7 +114,7 @@ export async function appendReviewEventSnapshotInExecutor(
       "(review_event_id, workspace_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server, reviewed_by_user_id)",
       "VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, now()), security.current_user_id())",
       "ON CONFLICT DO NOTHING",
-      "RETURNING review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server",
+      "RETURNING review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, reviewed_time_zone",
     ].join(" "),
     [
       reviewEvent.reviewEventId,
@@ -115,6 +137,17 @@ export async function appendReviewEventSnapshotInExecutor(
     // history import, guest merge) records the fact for the right user. The resolver
     // is invoked only here, on a real insert, and memoizes across a batch.
     const reviewedBy = await resolveReviewedBy();
+    const reviewedTimeZone = reviewEvent.reviewedTimeZone ?? null;
+    const fallbackProgressTimeZone = reviewedTimeZone === null
+      ? await loadProgressTimeZoneForUserInExecutor(executor, reviewedBy.userId)
+      : null;
+    const activeDayWrite = await storeActiveReviewDayForReviewEventInExecutor(executor, {
+      reviewEventId: insertedReviewEvent.reviewEventId,
+      reviewedByUserId: reviewedBy.userId,
+      reviewedAtClient: insertedReviewEvent.reviewedAtClient,
+      reviewedTimeZone,
+      fallbackProgressTimeZone,
+    });
     await recordQualifiedReviewActivityFactInExecutor(executor, reviewedBy, {
       reviewEventId: insertedReviewEvent.reviewEventId,
       rating: insertedReviewEvent.rating,
@@ -123,7 +156,10 @@ export async function appendReviewEventSnapshotInExecutor(
     });
 
     return {
-      reviewEvent: insertedReviewEvent,
+      reviewEvent: {
+        ...insertedReviewEvent,
+        reviewedTimeZone: activeDayWrite.reviewedTimeZone ?? undefined,
+      },
       applied: true,
       changeId: null,
     };
@@ -147,7 +183,7 @@ export async function appendReviewEventSnapshotInExecutor(
 
   const existingResult = await executor.query<ReviewHistoryRow>(
     [
-      "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server",
+      "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, reviewed_time_zone",
       "FROM content.review_events",
       "WHERE workspace_id = $1 AND (review_event_id = $2 OR (replica_id = $3 AND client_event_id = $4))",
       "ORDER BY reviewed_at_server DESC",
@@ -207,6 +243,7 @@ export async function submitReview(
         rating: input.rating,
         reviewedAtClient: reviewedAtClient.toISOString(),
         reviewedAtServer: new Date().toISOString(),
+        reviewedTimeZone: input.reviewedTimeZone,
       },
       normalizedMetadata.lastOperationId,
       createCurrentUserPublicProfileResolver(executor),

--- a/apps/backend/src/cards/shared.ts
+++ b/apps/backend/src/cards/shared.ts
@@ -97,6 +97,7 @@ export function mapReviewHistoryItem(row: ReviewHistoryRow): ReviewHistoryItem {
     rating: row.rating,
     reviewedAtClient: toIsoString(row.reviewed_at_client),
     reviewedAtServer: toIsoString(row.reviewed_at_server),
+    reviewedTimeZone: row.reviewed_time_zone ?? undefined,
   };
 }
 

--- a/apps/backend/src/cards/types.ts
+++ b/apps/backend/src/cards/types.ts
@@ -61,6 +61,7 @@ export type ReviewHistoryRow = Readonly<{
   rating: number;
   reviewed_at_client: TimestampValue;
   reviewed_at_server: TimestampValue;
+  reviewed_time_zone: string | null;
 }>;
 
 export type DeckSummaryRow = Readonly<{
@@ -177,6 +178,7 @@ export type SubmitReviewInput = Readonly<{
   cardId: string;
   rating: ReviewRating;
   reviewedAtClient: string;
+  reviewedTimeZone?: string;
   reviewEventId?: string;
   clientEventId?: string;
 }>;
@@ -195,6 +197,7 @@ export type ReviewEvent = Readonly<{
   rating: number;
   reviewedAtClient: string;
   reviewedAtServer: string;
+  reviewedTimeZone?: string;
 }>;
 
 export type ReviewHistoryItem = ReviewEvent;

--- a/apps/backend/src/guestAuth/merge/index.ts
+++ b/apps/backend/src/guestAuth/merge/index.ts
@@ -215,6 +215,7 @@ function createReviewEventSnapshot(
     rating: reviewEvent.rating,
     reviewedAtClient: toIsoString(reviewEvent.reviewedAtClient),
     reviewedAtServer: toIsoString(reviewEvent.reviewedAtServer),
+    reviewedTimeZone: reviewEvent.reviewedTimeZone ?? undefined,
   };
 }
 

--- a/apps/backend/src/guestAuth/store/reviewEvents.ts
+++ b/apps/backend/src/guestAuth/store/reviewEvents.ts
@@ -11,6 +11,7 @@ type ReviewEventRow = Readonly<{
   rating: number;
   reviewed_at_client: Date | string;
   reviewed_at_server: Date | string;
+  reviewed_time_zone: string | null;
 }>;
 
 export type GuestReviewEventRecord = Readonly<{
@@ -21,6 +22,7 @@ export type GuestReviewEventRecord = Readonly<{
   rating: number;
   reviewedAtClient: Date | string;
   reviewedAtServer: Date | string;
+  reviewedTimeZone: string | null;
 }>;
 
 function mapGuestReviewEventRecord(row: ReviewEventRow): GuestReviewEventRecord {
@@ -32,6 +34,7 @@ function mapGuestReviewEventRecord(row: ReviewEventRow): GuestReviewEventRecord 
     rating: row.rating,
     reviewedAtClient: row.reviewed_at_client,
     reviewedAtServer: row.reviewed_at_server,
+    reviewedTimeZone: row.reviewed_time_zone,
   };
 }
 
@@ -47,7 +50,7 @@ export async function loadGuestReviewEventsInExecutor(
 
   const result = await executor.query<ReviewEventRow>(
     [
-      "SELECT review_event_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server",
+      "SELECT review_event_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server, reviewed_time_zone",
       "FROM content.review_events",
       "WHERE workspace_id = $1",
       "ORDER BY review_sequence ASC, review_event_id ASC",

--- a/apps/backend/src/guestAuthTestHarness/executor.ts
+++ b/apps/backend/src/guestAuthTestHarness/executor.ts
@@ -342,6 +342,7 @@ export function isGuestUpgradeMergeOnlyExecutorQuery(text: string): boolean {
     || text === "SELECT workspace_id FROM sync.find_conflicting_workspace_id($1, $2) LIMIT 1"
     || text.includes("FROM sync.hot_changes")
     || text.includes("INSERT INTO sync.hot_changes")
+    || text === "SELECT progress_time_zone FROM org.user_settings WHERE user_id = $1 LIMIT 1"
     || text.startsWith("DELETE FROM content.")
     || text.startsWith("INSERT INTO content.")
     || text.startsWith("UPDATE content.")

--- a/apps/backend/src/guestAuthTestHarness/fixtures.ts
+++ b/apps/backend/src/guestAuthTestHarness/fixtures.ts
@@ -61,6 +61,7 @@ export function createUserSettingsState(userId: string, workspaceId: string | nu
     user_id: userId,
     workspace_id: workspaceId,
     email,
+    progress_time_zone: null,
   };
 }
 

--- a/apps/backend/src/guestAuthTestHarness/handlers/content.ts
+++ b/apps/backend/src/guestAuthTestHarness/handlers/content.ts
@@ -282,11 +282,43 @@ export function handleContentExecutorQuery<Row extends pg.QueryResultRow>(
       rating: Number(params[5]),
       reviewed_at_client: String(params[6]),
       reviewed_at_server: String(params[7]),
+      reviewed_time_zone: null,
+      reviewed_local_date: null,
+      reviewed_time_zone_source: null,
       // VALUES (..., security.current_user_id()) — immutable authorship from the scope.
       reviewed_by_user_id: typeof state.currentUserId === "string" ? state.currentUserId : null,
     };
     state.reviewEvents.push(insertedReviewEvent);
     return createQueryResult<Row>([createReviewEventQueryRow(insertedReviewEvent) as unknown as Row]);
+  }
+
+  if (
+    text.startsWith("UPDATE content.review_events")
+    && text.includes("SET reviewed_time_zone = $2")
+  ) {
+    const reviewEventId = String(params[0]);
+    const reviewedByUserId = String(params[4]);
+    const reviewEventIndex = state.reviewEvents.findIndex((reviewEvent) => (
+      reviewEvent.review_event_id === reviewEventId
+      && reviewEvent.reviewed_by_user_id === reviewedByUserId
+    ));
+    if (reviewEventIndex === -1) {
+      return createQueryResult<Row>([]);
+    }
+
+    const currentReviewEvent = state.reviewEvents[reviewEventIndex];
+    if (currentReviewEvent === undefined) {
+      return createQueryResult<Row>([]);
+    }
+
+    const updatedReviewEvent: ReviewEventState = {
+      ...currentReviewEvent,
+      reviewed_time_zone: String(params[1]),
+      reviewed_local_date: String(params[2]),
+      reviewed_time_zone_source: String(params[3]),
+    };
+    state.reviewEvents[reviewEventIndex] = updatedReviewEvent;
+    return createQueryResult<Row>([createReviewEventQueryRow(updatedReviewEvent) as unknown as Row]);
   }
 
   return null;

--- a/apps/backend/src/guestAuthTestHarness/handlers/userSettings.ts
+++ b/apps/backend/src/guestAuthTestHarness/handlers/userSettings.ts
@@ -46,6 +46,18 @@ export function handleUserSettingsExecutorQuery<Row extends pg.QueryResultRow>(
     return createQueryResult<Row>(rows);
   }
 
+  if (text === "SELECT progress_time_zone FROM org.user_settings WHERE user_id = $1 LIMIT 1") {
+    const userId = params[0];
+    if (typeof userId !== "string") {
+      return createQueryResult<Row>([]);
+    }
+
+    scope.requireCurrentUserScope(userId);
+    const row = state.userSettings.get(userId) ?? null;
+    const rows = row === null ? [] : [{ progress_time_zone: row.progress_time_zone } as unknown as Row];
+    return createQueryResult<Row>(rows);
+  }
+
   if (text === "UPDATE org.user_settings SET email = $1 WHERE user_id = $2") {
     const email = params[0] === null ? null : String(params[0]);
     const userId = String(params[1]);

--- a/apps/backend/src/guestAuthTestHarness/models.ts
+++ b/apps/backend/src/guestAuthTestHarness/models.ts
@@ -10,6 +10,7 @@ export type UserSettingsState = Readonly<{
   user_id: string;
   workspace_id: string | null;
   email: string | null;
+  progress_time_zone: string | null;
 }>;
 
 export type WorkspaceState = Readonly<{
@@ -94,6 +95,9 @@ export type ReviewEventState = Readonly<{
   rating: number;
   reviewed_at_client: string;
   reviewed_at_server: string;
+  reviewed_time_zone?: string | null;
+  reviewed_local_date?: string | null;
+  reviewed_time_zone_source?: string | null;
   // Immutable authorship. Optional because seeded historical fixtures may predate it;
   // new harness inserts populate it from the request scope, like the real backend.
   reviewed_by_user_id?: string | null;

--- a/apps/backend/src/guestAuthTestHarness/rowShapes.ts
+++ b/apps/backend/src/guestAuthTestHarness/rowShapes.ts
@@ -54,5 +54,6 @@ export function createReviewEventQueryRow(reviewEvent: ReviewEventState): Readon
     rating: reviewEvent.rating,
     reviewed_at_client: reviewEvent.reviewed_at_client,
     reviewed_at_server: reviewEvent.reviewed_at_server,
+    reviewed_time_zone: reviewEvent.reviewed_time_zone ?? null,
   };
 }

--- a/apps/backend/src/progress/activeReviewDays.ts
+++ b/apps/backend/src/progress/activeReviewDays.ts
@@ -1,0 +1,159 @@
+import type { DatabaseExecutor } from "../database";
+import {
+  formatDateAsTimeZoneLocalDate,
+  requireIanaTimeZone,
+} from "./timeZone";
+
+export type ReviewTimeZoneSource = "client" | "user_settings";
+
+export type ReviewActiveDayWriteInput = Readonly<{
+  reviewEventId: string;
+  reviewedByUserId: string;
+  reviewedAtClient: string;
+  reviewedTimeZone: string | null;
+  fallbackProgressTimeZone: string | null;
+}>;
+
+export type ReviewActiveDayWriteResult = Readonly<{
+  reviewedLocalDate: string | null;
+  reviewedTimeZone: string | null;
+  reviewedTimeZoneSource: ReviewTimeZoneSource | null;
+}>;
+
+type SelectedReviewTimeZone = Readonly<{
+  timeZone: string;
+  source: ReviewTimeZoneSource;
+}>;
+
+function parseReviewedAtClient(value: string, reviewEventId: string): Date {
+  const reviewedAtClient = new Date(value);
+  if (Number.isNaN(reviewedAtClient.getTime())) {
+    throw new Error(`reviewedAtClient must be a valid ISO timestamp for reviewEventId=${reviewEventId}`);
+  }
+
+  return reviewedAtClient;
+}
+
+function selectReviewTimeZone(input: ReviewActiveDayWriteInput): SelectedReviewTimeZone | null {
+  if (input.reviewedTimeZone !== null) {
+    return {
+      timeZone: requireIanaTimeZone(input.reviewedTimeZone, "reviewedTimeZone"),
+      source: "client",
+    };
+  }
+
+  if (input.fallbackProgressTimeZone !== null) {
+    return {
+      timeZone: requireIanaTimeZone(input.fallbackProgressTimeZone, "progressTimeZone"),
+      source: "user_settings",
+    };
+  }
+
+  return null;
+}
+
+async function updateReviewEventReviewTimeZoneInExecutor(
+  executor: DatabaseExecutor,
+  input: ReviewActiveDayWriteInput,
+  reviewedLocalDate: string,
+  selectedTimeZone: SelectedReviewTimeZone,
+): Promise<void> {
+  const result = await executor.query(
+    [
+      "UPDATE content.review_events",
+      "SET reviewed_time_zone = $2, reviewed_local_date = $3::date, reviewed_time_zone_source = $4",
+      "WHERE review_event_id = $1 AND reviewed_by_user_id = $5",
+      "RETURNING review_event_id",
+    ].join(" "),
+    [
+      input.reviewEventId,
+      selectedTimeZone.timeZone,
+      reviewedLocalDate,
+      selectedTimeZone.source,
+      input.reviewedByUserId,
+    ],
+  );
+
+  if (result.rows[0] === undefined) {
+    throw new Error(
+      `Review event timezone update did not return a row for reviewEventId=${input.reviewEventId}`,
+    );
+  }
+}
+
+async function upsertUserActiveReviewDayInExecutor(
+  executor: DatabaseExecutor,
+  input: ReviewActiveDayWriteInput,
+  reviewedAtClient: Date,
+  reviewedLocalDate: string,
+  selectedTimeZone: SelectedReviewTimeZone,
+): Promise<void> {
+  await executor.query(
+    [
+      "INSERT INTO progress.user_active_review_days",
+      "(",
+      "reviewed_by_user_id, local_date, review_count, first_reviewed_at_client,",
+      "last_reviewed_at_client, time_zone, time_zone_source",
+      ")",
+      "VALUES ($1, $2::date, 1, $3, $3, $4, $5)",
+      "ON CONFLICT (reviewed_by_user_id, local_date) DO UPDATE",
+      "SET",
+      "review_count = progress.user_active_review_days.review_count + EXCLUDED.review_count,",
+      "first_reviewed_at_client = LEAST(progress.user_active_review_days.first_reviewed_at_client, EXCLUDED.first_reviewed_at_client),",
+      "last_reviewed_at_client = GREATEST(progress.user_active_review_days.last_reviewed_at_client, EXCLUDED.last_reviewed_at_client),",
+      "time_zone = CASE",
+      "WHEN EXCLUDED.first_reviewed_at_client < progress.user_active_review_days.first_reviewed_at_client THEN EXCLUDED.time_zone",
+      "ELSE progress.user_active_review_days.time_zone",
+      "END,",
+      "time_zone_source = CASE",
+      "WHEN EXCLUDED.first_reviewed_at_client < progress.user_active_review_days.first_reviewed_at_client THEN EXCLUDED.time_zone_source",
+      "ELSE progress.user_active_review_days.time_zone_source",
+      "END,",
+      "updated_at = now()",
+    ].join(" "),
+    [
+      input.reviewedByUserId,
+      reviewedLocalDate,
+      reviewedAtClient,
+      selectedTimeZone.timeZone,
+      selectedTimeZone.source,
+    ],
+  );
+}
+
+export async function storeActiveReviewDayForReviewEventInExecutor(
+  executor: DatabaseExecutor,
+  input: ReviewActiveDayWriteInput,
+): Promise<ReviewActiveDayWriteResult> {
+  const selectedTimeZone = selectReviewTimeZone(input);
+  if (selectedTimeZone === null) {
+    return {
+      reviewedLocalDate: null,
+      reviewedTimeZone: null,
+      reviewedTimeZoneSource: null,
+    };
+  }
+
+  const reviewedAtClient = parseReviewedAtClient(input.reviewedAtClient, input.reviewEventId);
+  const reviewedLocalDate = formatDateAsTimeZoneLocalDate(reviewedAtClient, selectedTimeZone.timeZone);
+
+  await updateReviewEventReviewTimeZoneInExecutor(
+    executor,
+    input,
+    reviewedLocalDate,
+    selectedTimeZone,
+  );
+  await upsertUserActiveReviewDayInExecutor(
+    executor,
+    input,
+    reviewedAtClient,
+    reviewedLocalDate,
+    selectedTimeZone,
+  );
+
+  return {
+    reviewedLocalDate,
+    reviewedTimeZone: selectedTimeZone.timeZone,
+    reviewedTimeZoneSource: selectedTimeZone.source,
+  };
+}

--- a/apps/backend/src/progress/index.ts
+++ b/apps/backend/src/progress/index.ts
@@ -14,6 +14,10 @@ import {
   type StreakDayState,
   type StreakFreeze,
 } from "./streakFreeze";
+import {
+  formatDateAsTimeZoneLocalDate,
+  validateIanaTimeZone,
+} from "./timeZone";
 
 // The compact Progress-tab community leaderboard lives in the community module
 // (next to the snapshot writer) but is re-exported here so every /me/progress/*
@@ -191,21 +195,19 @@ function throwProgressValidationError(message: string, code: string): never {
 }
 
 function validateTimeZone(value: string): string {
-  const trimmedValue = value.trim();
-  if (trimmedValue === "") {
+  const validation = validateIanaTimeZone(value);
+  if (validation.ok) {
+    return validation.timeZone;
+  }
+
+  if (validation.issue === "required") {
     throwProgressValidationError("timeZone is required", "PROGRESS_TIMEZONE_REQUIRED");
   }
 
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: trimmedValue });
-  } catch {
-    throwProgressValidationError(
-      "timeZone must be a valid IANA timezone",
-      "PROGRESS_TIMEZONE_INVALID",
-    );
-  }
-
-  return trimmedValue;
+  throwProgressValidationError(
+    "timeZone must be a valid IANA timezone",
+    "PROGRESS_TIMEZONE_INVALID",
+  );
 }
 
 function validateProgressSummaryInput(input: ProgressSummaryInput): ProgressSummaryInput {
@@ -264,33 +266,6 @@ function createUtcDateFromLocalDate(value: string): Date {
 
 function formatUtcDateAsLocalDate(value: Date): string {
   return value.toISOString().slice(0, 10);
-}
-
-function getRequiredDatePart(
-  parts: ReadonlyArray<Intl.DateTimeFormatPart>,
-  partType: "year" | "month" | "day",
-): string {
-  const value = parts.find((part) => part.type === partType)?.value;
-  if (value === undefined || value === "") {
-    throw new Error(`Timezone date is missing ${partType}`);
-  }
-
-  return value;
-}
-
-function formatDateAsTimeZoneLocalDate(value: Date, timeZone: string): string {
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  const parts = formatter.formatToParts(value);
-  const year = getRequiredDatePart(parts, "year");
-  const month = getRequiredDatePart(parts, "month");
-  const day = getRequiredDatePart(parts, "day");
-
-  return `${year}-${month}-${day}`;
 }
 
 function shiftLocalDate(value: string, offsetDays: number): string {

--- a/apps/backend/src/progress/timeZone.ts
+++ b/apps/backend/src/progress/timeZone.ts
@@ -1,0 +1,69 @@
+export type TimeZoneValidationIssue = "required" | "invalid";
+
+export type TimeZoneValidationResult =
+  | Readonly<{ ok: true; timeZone: string }>
+  | Readonly<{ ok: false; issue: TimeZoneValidationIssue }>;
+
+function getRequiredDatePart(
+  parts: ReadonlyArray<Intl.DateTimeFormatPart>,
+  partType: "year" | "month" | "day",
+): string {
+  const value = parts.find((part) => part.type === partType)?.value;
+  if (value === undefined || value === "") {
+    throw new Error(`Timezone date is missing ${partType}`);
+  }
+
+  return value;
+}
+
+export function validateIanaTimeZone(value: string): TimeZoneValidationResult {
+  const trimmedValue = value.trim();
+  if (trimmedValue === "") {
+    return {
+      ok: false,
+      issue: "required",
+    };
+  }
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: trimmedValue });
+  } catch {
+    return {
+      ok: false,
+      issue: "invalid",
+    };
+  }
+
+  return {
+    ok: true,
+    timeZone: trimmedValue,
+  };
+}
+
+export function requireIanaTimeZone(value: string, fieldName: string): string {
+  const validation = validateIanaTimeZone(value);
+  if (validation.ok) {
+    return validation.timeZone;
+  }
+
+  if (validation.issue === "required") {
+    throw new Error(`${fieldName} is required`);
+  }
+
+  throw new Error(`${fieldName} must be a valid IANA timezone`);
+}
+
+export function formatDateAsTimeZoneLocalDate(value: Date, timeZone: string): string {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(value);
+  const year = getRequiredDatePart(parts, "year");
+  const month = getRequiredDatePart(parts, "month");
+  const day = getRequiredDatePart(parts, "day");
+
+  return `${year}-${month}-${day}`;
+}

--- a/apps/backend/src/sync/contracts/input.test.ts
+++ b/apps/backend/src/sync/contracts/input.test.ts
@@ -9,6 +9,7 @@ import type { BootstrapProjectionRow } from "./types";
 type ReviewEventTimestampFixture = Readonly<{
   clientUpdatedAt: string;
   reviewedAtClient: string;
+  reviewedTimeZone?: string;
 }>;
 
 type CardDueAtFixture = Readonly<{
@@ -54,6 +55,7 @@ function createSyncPushInput(
       clientEventId: string;
       rating: 2;
       reviewedAtClient: string;
+      reviewedTimeZone?: string;
     }>;
   }>>;
 }> {
@@ -73,6 +75,7 @@ function createSyncPushInput(
           clientEventId: "client-event-1",
           rating: 2,
           reviewedAtClient: fixture.reviewedAtClient,
+          reviewedTimeZone: fixture.reviewedTimeZone,
         },
       },
     ],
@@ -152,6 +155,51 @@ test("parseSyncPushInput accepts backdated review_event timestamps through the n
   }
   assert.equal(parsedInput.operations[0].clientUpdatedAt, "2018-02-03T04:05:06.000Z");
   assert.equal(parsedInput.operations[0].payload.reviewedAtClient, "2018-02-03T04:05:06.000Z");
+});
+
+test("parseSyncPushInput accepts optional reviewedTimeZone on review_event operations", () => {
+  const input = createSyncPushInput({
+    clientUpdatedAt: "2018-02-03T04:05:06.000Z",
+    reviewedAtClient: "2018-02-03T04:05:06.000Z",
+    reviewedTimeZone: "Europe/Madrid",
+  });
+
+  const parsedInput = parseSyncPushInput(input);
+
+  assert.equal(parsedInput.operations[0]?.entityType, "review_event");
+  if (parsedInput.operations[0]?.entityType !== "review_event") {
+    assert.fail("Expected the parsed sync operation to remain a review_event");
+  }
+  assert.equal(parsedInput.operations[0].payload.reviewedTimeZone, "Europe/Madrid");
+});
+
+test("parseSyncPushInput rejects malformed reviewedTimeZone on review_event operations", () => {
+  const input = createSyncPushInput({
+    clientUpdatedAt: "2018-02-03T04:05:06.000Z",
+    reviewedAtClient: "2018-02-03T04:05:06.000Z",
+    reviewedTimeZone: "Not/A_Timezone",
+  });
+
+  assert.throws(
+    () => parseSyncPushInput(input),
+    (error: unknown) => {
+      if (!(error instanceof HttpError)) {
+        assert.fail("Expected parseSyncPushInput to throw HttpError");
+      }
+
+      assert.equal(error.statusCode, 400);
+      assert.equal(error.code, "SYNC_INVALID_INPUT");
+      assert.deepEqual(error.details?.validationIssues, [
+        {
+          path: "operations.0.payload.reviewedTimeZone",
+          code: "custom",
+          message: "reviewedTimeZone must be a valid IANA timezone",
+        },
+      ]);
+
+      return true;
+    },
+  );
 });
 
 test("parseSyncPushInput rejects review_event operations when clientUpdatedAt diverges from reviewedAtClient", () => {

--- a/apps/backend/src/sync/contracts/input.ts
+++ b/apps/backend/src/sync/contracts/input.ts
@@ -5,6 +5,7 @@ import type {
   ValidationIssueSummary,
 } from "../../shared/errors";
 import { normalizeIsoTimestamp } from "../conflicts/lww";
+import { validateIanaTimeZone } from "../../progress/timeZone";
 
 type Platform = "ios" | "android" | "web";
 
@@ -31,6 +32,20 @@ const commonDaysByMonth: ReadonlyArray<number> = [
   30,
   31,
 ];
+
+function validateReviewedTimeZone(value: string, refinementContext: z.core.$RefinementCtx): void {
+  const validation = validateIanaTimeZone(value);
+  if (validation.ok) {
+    return;
+  }
+
+  refinementContext.addIssue({
+    code: "custom",
+    message: validation.issue === "required"
+      ? "reviewedTimeZone is required when provided"
+      : "reviewedTimeZone must be a valid IANA timezone",
+  });
+}
 
 type IsoDateParts = Readonly<{
   year: number;
@@ -188,6 +203,7 @@ const reviewEventPushPayloadSchema = z.object({
   clientEventId: z.string().min(1),
   rating: reviewRatingSchema,
   reviewedAtClient: z.string().datetime(),
+  reviewedTimeZone: z.string().superRefine(validateReviewedTimeZone).optional(),
 });
 
 const reviewEventImportPayloadSchema = reviewEventPushPayloadSchema.extend({

--- a/apps/backend/src/sync/contracts/types.ts
+++ b/apps/backend/src/sync/contracts/types.ts
@@ -58,6 +58,7 @@ export type ReviewHistoryRow = Readonly<{
   rating: number;
   reviewed_at_client: TimestampValue;
   reviewed_at_server: TimestampValue;
+  reviewed_time_zone: string | null;
   review_sequence: string | number;
 }>;
 

--- a/apps/backend/src/sync/replication/push.ts
+++ b/apps/backend/src/sync/replication/push.ts
@@ -234,6 +234,7 @@ export async function processOperationInExecutor(
         rating: operation.payload.rating,
         reviewedAtClient: normalizedReviewedAtClient,
         reviewedAtServer: new Date().toISOString(),
+        reviewedTimeZone: operation.payload.reviewedTimeZone,
       },
       operation.operationId,
       resolveReviewedBy,

--- a/apps/backend/src/sync/replication/reviewHistory.ts
+++ b/apps/backend/src/sync/replication/reviewHistory.ts
@@ -62,6 +62,7 @@ export function mapReviewHistoryRows(rows: ReadonlyArray<ReviewHistoryRow>): Rea
     rating: row.rating,
     reviewedAtClient: toIsoString(row.reviewed_at_client),
     reviewedAtServer: toIsoString(row.reviewed_at_server),
+    reviewedTimeZone: row.reviewed_time_zone ?? undefined,
   }));
 }
 
@@ -90,6 +91,7 @@ export async function processSyncReviewHistoryImportInExecutor(
           rating: reviewEvent.rating,
           reviewedAtClient: reviewEvent.reviewedAtClient,
           reviewedAtServer: reviewEvent.reviewedAtServer,
+          reviewedTimeZone: reviewEvent.reviewedTimeZone,
         },
         reviewEvent.reviewEventId,
         resolveReviewedBy,
@@ -132,7 +134,7 @@ export async function processSyncReviewHistoryPull(
 
     const result = await executor.query<ReviewHistoryRow>(
       [
-        "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, review_sequence",
+        "SELECT review_event_id, workspace_id, replica_id, client_event_id, card_id, rating, reviewed_at_client, reviewed_at_server, reviewed_time_zone, review_sequence",
         "FROM content.review_events",
         "WHERE workspace_id = $1 AND review_sequence > $2",
         "ORDER BY review_sequence ASC",

--- a/db/migrations/0067_streak_review_timezone_storage.sql
+++ b/db/migrations/0067_streak_review_timezone_storage.sql
@@ -1,0 +1,111 @@
+-- Migration status: Current / additive.
+-- Introduces: review-time timezone storage and user active review day materialization.
+-- Current guidance: new review writes may store the review timezone and local
+--   date at creation time. Historical review rows intentionally remain nullable
+--   here and are not mass-backfilled.
+
+ALTER TABLE org.user_settings
+  ADD COLUMN IF NOT EXISTS progress_time_zone TEXT;
+
+COMMENT ON COLUMN org.user_settings.progress_time_zone IS
+  'Most recently known IANA timezone for Progress calculations. Used only as a fallback for old review clients that do not send reviewed_time_zone.';
+
+ALTER TABLE content.review_events
+  ADD COLUMN IF NOT EXISTS reviewed_time_zone TEXT,
+  ADD COLUMN IF NOT EXISTS reviewed_local_date DATE,
+  ADD COLUMN IF NOT EXISTS reviewed_time_zone_source TEXT;
+
+COMMENT ON COLUMN content.review_events.reviewed_time_zone IS
+  'IANA timezone used to compute reviewed_local_date at review write time. Nullable for historical rows and old clients with no known timezone.';
+COMMENT ON COLUMN content.review_events.reviewed_local_date IS
+  'Local calendar date of reviewed_at_client in reviewed_time_zone, computed once at review write time. Nullable until materialized.';
+COMMENT ON COLUMN content.review_events.reviewed_time_zone_source IS
+  'Source of reviewed_time_zone. client means the review payload supplied it; user_settings means org.user_settings.progress_time_zone was used as an old-client fallback.';
+
+CREATE SCHEMA IF NOT EXISTS progress;
+
+GRANT USAGE ON SCHEMA progress TO backend_app;
+
+CREATE TABLE IF NOT EXISTS progress.user_active_review_days (
+  reviewed_by_user_id       TEXT        NOT NULL REFERENCES org.user_settings(user_id) ON DELETE CASCADE,
+  local_date                DATE        NOT NULL,
+  review_count              INTEGER     NOT NULL CHECK (review_count > 0),
+  first_reviewed_at_client  TIMESTAMPTZ NOT NULL,
+  last_reviewed_at_client   TIMESTAMPTZ NOT NULL,
+  time_zone                 TEXT        NOT NULL,
+  time_zone_source          TEXT        NOT NULL CHECK (time_zone_source IN ('client', 'user_settings')),
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (reviewed_by_user_id, local_date)
+);
+
+COMMENT ON TABLE progress.user_active_review_days IS
+  'One materialized active review day per user/local date, computed from review-time timezone data. Counts every rating, including Again.';
+COMMENT ON COLUMN progress.user_active_review_days.reviewed_by_user_id IS
+  'Authenticated review author. Rows are user-scoped, not workspace-scoped, so streak reads can aggregate across accessible workspaces.';
+COMMENT ON COLUMN progress.user_active_review_days.local_date IS
+  'Review-time local calendar date. This value is not rewritten when the user changes timezone later.';
+COMMENT ON COLUMN progress.user_active_review_days.review_count IS
+  'Number of stored review events for this user/local date. Counts every rating.';
+COMMENT ON COLUMN progress.user_active_review_days.time_zone IS
+  'IANA timezone used for the representative first review that created or anchored this active day.';
+COMMENT ON COLUMN progress.user_active_review_days.time_zone_source IS
+  'Source of time_zone: client review payload or user_settings fallback.';
+
+CREATE INDEX IF NOT EXISTS idx_user_active_review_days_user_local_date_desc
+  ON progress.user_active_review_days(reviewed_by_user_id, local_date DESC);
+
+ALTER TABLE progress.user_active_review_days ENABLE ROW LEVEL SECURITY;
+
+GRANT SELECT (
+  reviewed_by_user_id,
+  local_date,
+  review_count,
+  first_reviewed_at_client,
+  last_reviewed_at_client,
+  time_zone,
+  time_zone_source,
+  created_at,
+  updated_at
+) ON TABLE progress.user_active_review_days TO backend_app;
+
+GRANT INSERT (
+  reviewed_by_user_id,
+  local_date,
+  review_count,
+  first_reviewed_at_client,
+  last_reviewed_at_client,
+  time_zone,
+  time_zone_source
+) ON TABLE progress.user_active_review_days TO backend_app;
+
+GRANT UPDATE (
+  review_count,
+  first_reviewed_at_client,
+  last_reviewed_at_client,
+  time_zone,
+  time_zone_source,
+  updated_at
+) ON TABLE progress.user_active_review_days TO backend_app;
+
+DROP POLICY IF EXISTS user_active_review_days_self_select_runtime ON progress.user_active_review_days;
+CREATE POLICY user_active_review_days_self_select_runtime
+  ON progress.user_active_review_days
+  FOR SELECT
+  TO backend_app
+  USING (reviewed_by_user_id = security.current_user_id());
+
+DROP POLICY IF EXISTS user_active_review_days_self_insert_runtime ON progress.user_active_review_days;
+CREATE POLICY user_active_review_days_self_insert_runtime
+  ON progress.user_active_review_days
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (reviewed_by_user_id = security.current_user_id());
+
+DROP POLICY IF EXISTS user_active_review_days_self_update_runtime ON progress.user_active_review_days;
+CREATE POLICY user_active_review_days_self_update_runtime
+  ON progress.user_active_review_days
+  FOR UPDATE
+  TO backend_app
+  USING (reviewed_by_user_id = security.current_user_id())
+  WITH CHECK (reviewed_by_user_id = security.current_user_id());


### PR DESCRIPTION
## Summary
- Add review-time timezone and local-date storage for review events.
- Materialize one active review day per user/local date during review-event writes.
- Wire optional `reviewedTimeZone` through backend review and sync contracts while keeping old clients compatible.

## Validation
- `npm run lint` in `apps/backend`
- `npm test` in `apps/backend` passed 462/462
- `git --no-pager diff --check`
- Read-only review pass reported no P0-P4 findings