### PR TITLE
Use materialized active days for progress streaks

### DIFF
--- a/apps/backend/src/progress/activeReviewDays.ts
+++ b/apps/backend/src/progress/activeReviewDays.ts
@@ -25,6 +25,17 @@ type SelectedReviewTimeZone = Readonly<{
   source: ReviewTimeZoneSource;
 }>;
 
+type UserSettingsTimeZoneRememberRow = Readonly<{
+  user_id: string;
+  updated: boolean;
+}>;
+
+type UserActiveReviewLocalDateRow = Readonly<{
+  review_date: string;
+}>;
+
+const localDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
 function parseReviewedAtClient(value: string, reviewEventId: string): Date {
   const reviewedAtClient = new Date(value);
   if (Number.isNaN(reviewedAtClient.getTime())) {
@@ -32,6 +43,14 @@ function parseReviewedAtClient(value: string, reviewEventId: string): Date {
   }
 
   return reviewedAtClient;
+}
+
+function normalizeLocalDateFromQuery(value: string): string {
+  if (!localDatePattern.test(value)) {
+    throw new Error(`Invalid active review local date returned from database: ${value}`);
+  }
+
+  return value;
 }
 
 function selectReviewTimeZone(input: ReviewActiveDayWriteInput): SelectedReviewTimeZone | null {
@@ -156,4 +175,153 @@ export async function storeActiveReviewDayForReviewEventInExecutor(
     reviewedTimeZone: selectedTimeZone.timeZone,
     reviewedTimeZoneSource: selectedTimeZone.source,
   };
+}
+
+export async function rememberProgressTimeZoneInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  timeZone: string,
+): Promise<void> {
+  const normalizedTimeZone = requireIanaTimeZone(timeZone, "timeZone");
+  const result = await executor.query<UserSettingsTimeZoneRememberRow>(
+    [
+      "WITH target_user AS (",
+      "SELECT user_id, progress_time_zone",
+      "FROM org.user_settings",
+      "WHERE user_id = $1",
+      "), updated_user AS (",
+      "UPDATE org.user_settings AS user_settings",
+      "SET progress_time_zone = $2",
+      "FROM target_user",
+      "WHERE user_settings.user_id = target_user.user_id",
+      "AND target_user.progress_time_zone IS DISTINCT FROM $2",
+      "RETURNING user_settings.user_id",
+      ")",
+      "SELECT target_user.user_id, (updated_user.user_id IS NOT NULL) AS updated",
+      "FROM target_user",
+      "LEFT JOIN updated_user ON updated_user.user_id = target_user.user_id",
+    ].join(" "),
+    [userId, normalizedTimeZone],
+  );
+
+  if (result.rows[0] === undefined) {
+    throw new Error(`Progress timezone user_settings row was not found for userId=${userId}`);
+  }
+}
+
+export async function materializeMissingActiveReviewDaysForUserInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+  workspaceId: string,
+  timeZone: string,
+): Promise<void> {
+  const normalizedTimeZone = requireIanaTimeZone(timeZone, "timeZone");
+  await executor.query(
+    [
+      "WITH target_review_events AS (",
+      "SELECT",
+      "review_events.review_event_id,",
+      "review_events.reviewed_by_user_id,",
+      "review_events.reviewed_at_client,",
+      "review_events.reviewed_local_date,",
+      "timezone($2, review_events.reviewed_at_client)::date AS fallback_local_date,",
+      "COALESCE(review_events.reviewed_time_zone, $2) AS event_time_zone,",
+      "COALESCE(review_events.reviewed_time_zone_source, 'user_settings') AS event_time_zone_source",
+      "FROM content.review_events AS review_events",
+      "LEFT JOIN progress.user_active_review_days AS active_days",
+      "ON active_days.reviewed_by_user_id = review_events.reviewed_by_user_id",
+      "AND active_days.local_date = COALESCE(",
+      "review_events.reviewed_local_date,",
+      "timezone($2, review_events.reviewed_at_client)::date",
+      ")",
+      "WHERE review_events.reviewed_by_user_id = $1",
+      "AND review_events.workspace_id = $3",
+      "AND (",
+      "review_events.reviewed_local_date IS NULL",
+      "OR active_days.local_date IS NULL",
+      ")",
+      "), updated_review_events AS (",
+      "UPDATE content.review_events AS review_events",
+      "SET reviewed_time_zone = $2,",
+      "reviewed_local_date = target_review_events.fallback_local_date,",
+      "reviewed_time_zone_source = 'user_settings'",
+      "FROM target_review_events",
+      "WHERE review_events.review_event_id = target_review_events.review_event_id",
+      "AND target_review_events.reviewed_local_date IS NULL",
+      "RETURNING review_events.review_event_id",
+      "), active_day_rows AS (",
+      "SELECT",
+      "target_review_events.reviewed_by_user_id,",
+      "COALESCE(target_review_events.reviewed_local_date, target_review_events.fallback_local_date) AS local_date,",
+      "COUNT(*)::int AS review_count,",
+      "MIN(target_review_events.reviewed_at_client) AS first_reviewed_at_client,",
+      "MAX(target_review_events.reviewed_at_client) AS last_reviewed_at_client,",
+      "(ARRAY_AGG(",
+      "CASE",
+      "WHEN target_review_events.reviewed_local_date IS NULL THEN $2",
+      "ELSE target_review_events.event_time_zone",
+      "END",
+      "ORDER BY target_review_events.reviewed_at_client ASC, target_review_events.review_event_id ASC",
+      "))[1] AS time_zone,",
+      "(ARRAY_AGG(",
+      "CASE",
+      "WHEN target_review_events.reviewed_local_date IS NULL THEN 'user_settings'",
+      "ELSE target_review_events.event_time_zone_source",
+      "END",
+      "ORDER BY target_review_events.reviewed_at_client ASC, target_review_events.review_event_id ASC",
+      "))[1] AS time_zone_source",
+      "FROM target_review_events",
+      "GROUP BY",
+      "target_review_events.reviewed_by_user_id,",
+      "COALESCE(target_review_events.reviewed_local_date, target_review_events.fallback_local_date)",
+      ")",
+      "INSERT INTO progress.user_active_review_days",
+      "(",
+      "reviewed_by_user_id, local_date, review_count, first_reviewed_at_client,",
+      "last_reviewed_at_client, time_zone, time_zone_source",
+      ")",
+      "SELECT",
+      "active_day_rows.reviewed_by_user_id,",
+      "active_day_rows.local_date,",
+      "active_day_rows.review_count,",
+      "active_day_rows.first_reviewed_at_client,",
+      "active_day_rows.last_reviewed_at_client,",
+      "active_day_rows.time_zone,",
+      "active_day_rows.time_zone_source",
+      "FROM active_day_rows",
+      "ON CONFLICT (reviewed_by_user_id, local_date) DO UPDATE",
+      "SET",
+      "review_count = progress.user_active_review_days.review_count + EXCLUDED.review_count,",
+      "first_reviewed_at_client = LEAST(progress.user_active_review_days.first_reviewed_at_client, EXCLUDED.first_reviewed_at_client),",
+      "last_reviewed_at_client = GREATEST(progress.user_active_review_days.last_reviewed_at_client, EXCLUDED.last_reviewed_at_client),",
+      "time_zone = CASE",
+      "WHEN EXCLUDED.first_reviewed_at_client < progress.user_active_review_days.first_reviewed_at_client THEN EXCLUDED.time_zone",
+      "ELSE progress.user_active_review_days.time_zone",
+      "END,",
+      "time_zone_source = CASE",
+      "WHEN EXCLUDED.first_reviewed_at_client < progress.user_active_review_days.first_reviewed_at_client THEN EXCLUDED.time_zone_source",
+      "ELSE progress.user_active_review_days.time_zone_source",
+      "END,",
+      "updated_at = now()",
+    ].join(" "),
+    [userId, normalizedTimeZone, workspaceId],
+  );
+}
+
+export async function loadUserActiveReviewLocalDatesInExecutor(
+  executor: DatabaseExecutor,
+  userId: string,
+): Promise<ReadonlyArray<string>> {
+  const result = await executor.query<UserActiveReviewLocalDateRow>(
+    [
+      // Active review days are intentionally user-wide for personal Progress.
+      "SELECT to_char(active_days.local_date, 'YYYY-MM-DD') AS review_date",
+      "FROM progress.user_active_review_days AS active_days",
+      "WHERE active_days.reviewed_by_user_id = $1",
+      "ORDER BY active_days.local_date ASC",
+    ].join(" "),
+    [userId],
+  );
+
+  return result.rows.map((row) => normalizeLocalDateFromQuery(row.review_date));
 }

--- a/apps/backend/src/progress/index.ts
+++ b/apps/backend/src/progress/index.ts
@@ -4,9 +4,16 @@ import {
   type DatabaseExecutor,
   type SqlValue,
 } from "../database";
+import { withTransientDatabaseRetry } from "../database/transient";
 import { unsafeRepeatableReadTransaction } from "../database/unsafe";
+import { createBackendRuntimeObservationScope } from "../observability/sentry";
 import { HttpError } from "../shared/errors";
 import { listUserWorkspaceIdsInExecutor } from "../workspaces/queries";
+import {
+  loadUserActiveReviewLocalDatesInExecutor,
+  materializeMissingActiveReviewDaysForUserInExecutor,
+  rememberProgressTimeZoneInExecutor,
+} from "./activeReviewDays";
 import {
   evaluateStreakFreeze,
   streakFreezePolicy,
@@ -131,10 +138,6 @@ type DailyReviewCountRow = Readonly<{
   easy_count: string | number;
 }>;
 
-type ReviewDateRow = Readonly<{
-  review_date: string;
-}>;
-
 type ReviewScheduleCountRow = Readonly<{
   new_count: string | number;
   today_count: string | number;
@@ -171,11 +174,6 @@ const reviewScheduleSqlColumnByBucketKey: Readonly<Record<ReviewScheduleBucketKe
   years1To2: "years_1_to_2_count",
   later: "later_count",
 };
-
-type WorkspaceProgressSummaryRequest = Readonly<{
-  workspaceId: string;
-  timeZone: string;
-}>;
 
 type WorkspaceProgressReviewScheduleRequest = Readonly<{
   workspaceId: string;
@@ -531,15 +529,6 @@ function addDailyReviewCountRows(
   return nextAggregate;
 }
 
-function accumulateReviewDates(
-  aggregate: Set<string>,
-  rows: ReadonlyArray<ReviewDateRow>,
-): void {
-  for (const row of rows) {
-    aggregate.add(row.review_date);
-  }
-}
-
 function createDailyReviews(
   range: ReadonlyArray<string>,
   aggregate: ReadonlyMap<string, DailyReviewCounts>,
@@ -555,10 +544,6 @@ function createDailyReviews(
       easyCount: counts.easyCount,
     };
   });
-}
-
-function createSortedActiveReviewLocalDates(reviewDates: ReadonlySet<string>): ReadonlyArray<string> {
-  return [...reviewDates].sort((left, right) => left.localeCompare(right));
 }
 
 function createStreakDays(
@@ -690,46 +675,6 @@ async function loadReviewScheduleCountRowInExecutor(
   return row;
 }
 
-async function loadAllReviewDateRowsInExecutor(
-  executor: DatabaseExecutor,
-  request: WorkspaceProgressSummaryRequest,
-): Promise<ReadonlyArray<ReviewDateRow>> {
-  const queryParams: ReadonlyArray<SqlValue> = [
-    request.workspaceId,
-    request.timeZone,
-  ];
-  const result = await executor.query<ReviewDateRow>(
-    [
-      "SELECT",
-      "to_char(review_local_dates.review_local_date, 'YYYY-MM-DD') AS review_date",
-      "FROM (",
-      "SELECT DISTINCT timezone($2, review_events.reviewed_at_client)::date AS review_local_date",
-      "FROM content.review_events AS review_events",
-      "WHERE review_events.workspace_id = $1",
-      ") AS review_local_dates",
-      "ORDER BY review_local_dates.review_local_date DESC",
-    ].join(" "),
-    queryParams,
-  );
-
-  return result.rows;
-}
-
-function findLatestReviewedOn(
-  currentLatest: string | null,
-  candidateLatest: string | null,
-): string | null {
-  if (candidateLatest === null) {
-    return currentLatest;
-  }
-
-  if (currentLatest === null) {
-    return candidateLatest;
-  }
-
-  return currentLatest.localeCompare(candidateLatest) >= 0 ? currentLatest : candidateLatest;
-}
-
 function createProgressSummary(
   activeReviewDayCount: number,
   currentStreakDays: number,
@@ -753,12 +698,11 @@ async function buildUserProgressSummaryInExecutor(
   request: ProgressSummaryRequest,
   generatedAtDate: Date,
 ): Promise<ProgressSummaryResponse> {
-  const reviewDates = new Set<string>();
   await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
-  // Human progress stays intentionally user-wide across every workspace the
-  // user can still access; AI workspace routing does not change that contract.
+  // Personal Progress active streak days are user-wide materialized days.
+  // The workspace loop only bounds raw review_event and watermark reads by RLS.
   const workspaceIds = await listUserWorkspaceIdsInExecutor(executor, request.userId);
-  let lastReviewedOn: string | null = null;
+  await rememberProgressTimeZoneInExecutor(executor, request.userId, request.timeZone);
   let reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> = [];
 
   for (const workspaceId of workspaceIds) {
@@ -766,23 +710,26 @@ async function buildUserProgressSummaryInExecutor(
       userId: request.userId,
       workspaceId,
     });
-    const rows = await loadAllReviewDateRowsInExecutor(executor, {
+    await materializeMissingActiveReviewDaysForUserInExecutor(
+      executor,
+      request.userId,
       workspaceId,
-      timeZone: request.timeZone,
-    });
-    accumulateReviewDates(reviewDates, rows);
-    lastReviewedOn = findLatestReviewedOn(lastReviewedOn, rows[0]?.review_date ?? null);
+      request.timeZone,
+    );
     reviewHistoryWatermarks = reviewHistoryWatermarks.concat(
       await loadReviewHistoryWatermarksInExecutor(executor, [workspaceId]),
     );
   }
 
+  const activeReviewLocalDates = await loadUserActiveReviewLocalDatesInExecutor(executor, request.userId);
+  const activeReviewDateSet = new Set(activeReviewLocalDates);
+  const lastReviewedOn = activeReviewLocalDates.at(-1) ?? null;
   const today = formatDateAsTimeZoneLocalDate(generatedAtDate, request.timeZone);
   // Future-dated rows can appear when a client clock is ahead, so today must
   // be checked against the full normalized date set instead of the latest date.
-  const hasReviewedToday = reviewDates.has(today);
+  const hasReviewedToday = activeReviewDateSet.has(today);
   const streakFreezeEvaluation = evaluateStreakFreeze(
-    createSortedActiveReviewLocalDates(reviewDates),
+    activeReviewLocalDates,
     today,
     streakFreezePolicy,
   );
@@ -790,7 +737,7 @@ async function buildUserProgressSummaryInExecutor(
   return {
     timeZone: request.timeZone,
     summary: createProgressSummary(
-      reviewDates.size,
+      activeReviewLocalDates.length,
       streakFreezeEvaluation.currentStreakDays,
       streakFreezeEvaluation.longestStreakDays,
       hasReviewedToday,
@@ -843,9 +790,11 @@ async function buildUserProgressSeriesInExecutor(
   generatedAtDate: Date,
 ): Promise<ProgressSeries> {
   let dailyReviewCounts: ReadonlyMap<string, DailyReviewCounts> = new Map<string, DailyReviewCounts>();
-  const reviewDates = new Set<string>();
   await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
+  // Daily review counts stay on the bounded raw range query, while streak
+  // state comes from the user-wide materialized active-day table below.
   const workspaceIds = await listUserWorkspaceIdsInExecutor(executor, request.userId);
+  await rememberProgressTimeZoneInExecutor(executor, request.userId, request.timeZone);
   let reviewHistoryWatermarks: ReadonlyArray<ProgressReviewHistoryWatermark> = [];
 
   for (const workspaceId of workspaceIds) {
@@ -862,12 +811,11 @@ async function buildUserProgressSeriesInExecutor(
       to: request.to,
     });
     dailyReviewCounts = addDailyReviewCountRows(dailyReviewCounts, rows);
-    accumulateReviewDates(
-      reviewDates,
-      await loadAllReviewDateRowsInExecutor(executor, {
-        workspaceId,
-        timeZone: request.timeZone,
-      }),
+    await materializeMissingActiveReviewDaysForUserInExecutor(
+      executor,
+      request.userId,
+      workspaceId,
+      request.timeZone,
     );
     reviewHistoryWatermarks = reviewHistoryWatermarks.concat(
       await loadReviewHistoryWatermarksInExecutor(executor, [workspaceId]),
@@ -875,9 +823,11 @@ async function buildUserProgressSeriesInExecutor(
   }
 
   const range = createInclusiveLocalDateRange(request.from, request.to);
+  const activeReviewLocalDates = await loadUserActiveReviewLocalDatesInExecutor(executor, request.userId);
+  const activeReviewDateSet = new Set(activeReviewLocalDates);
   const today = formatDateAsTimeZoneLocalDate(generatedAtDate, request.timeZone);
   const streakFreezeEvaluation = evaluateStreakFreeze(
-    createSortedActiveReviewLocalDates(reviewDates),
+    activeReviewLocalDates,
     today,
     streakFreezePolicy,
   );
@@ -892,7 +842,7 @@ async function buildUserProgressSeriesInExecutor(
     ),
     streakDays: createStreakDays(
       range,
-      reviewDates,
+      activeReviewDateSet,
       streakFreezeEvaluation.streakDays,
       today,
     ),
@@ -923,7 +873,12 @@ export async function loadUserProgressSeriesInExecutor(
 }
 
 export async function loadUserProgressSummary(request: ProgressSummaryRequest): Promise<ProgressSummaryResponse> {
-  return unsafeRepeatableReadTransaction(async (executor) => loadUserProgressSummaryInExecutor(executor, request));
+  return withTransientDatabaseRetry(
+    () => unsafeRepeatableReadTransaction(
+      async (executor) => loadUserProgressSummaryInExecutor(executor, request),
+    ),
+    createBackendRuntimeObservationScope,
+  );
 }
 
 export async function loadUserProgressReviewSchedule(
@@ -935,5 +890,10 @@ export async function loadUserProgressReviewSchedule(
 }
 
 export async function loadUserProgressSeries(request: ProgressSeriesRequest): Promise<ProgressSeries> {
-  return unsafeRepeatableReadTransaction(async (executor) => loadUserProgressSeriesInExecutor(executor, request));
+  return withTransientDatabaseRetry(
+    () => unsafeRepeatableReadTransaction(
+      async (executor) => loadUserProgressSeriesInExecutor(executor, request),
+    ),
+    createBackendRuntimeObservationScope,
+  );
 }

--- a/apps/backend/src/progress/progressContract.test.ts
+++ b/apps/backend/src/progress/progressContract.test.ts
@@ -13,6 +13,11 @@ function loadApiGatewaySource(): string {
   return fs.readFileSync(apiGatewayPath, "utf8");
 }
 
+function loadProgressIndexSource(): string {
+  const progressIndexPath = path.resolve(process.cwd(), "src/progress/index.ts");
+  return fs.readFileSync(progressIndexPath, "utf8").replace(/\s+/g, " ");
+}
+
 test("published contract excludes progress endpoints while the API Gateway resource tree still predeclares the paths", () => {
   const openApiDocument = loadOpenApiDocument() as Readonly<{
     info?: Readonly<{ title?: string; description?: string }>;
@@ -46,6 +51,25 @@ test("progress barrel re-exports the community leaderboard loaders", async () =>
 
   assert.equal(guestLeaderboard.status, "linked_account_required");
   assert.deepEqual(guestLeaderboard.windows, []);
+});
+
+test("public progress streak loaders retry transient repeatable-read materialization failures", () => {
+  const source = loadProgressIndexSource();
+
+  assert.match(source, /import \{ withTransientDatabaseRetry \} from "\.\.\/database\/transient";/);
+  assert.match(source, /import \{ createBackendRuntimeObservationScope \} from "\.\.\/observability\/sentry";/);
+  assert.match(
+    source,
+    /export async function loadUserProgressSummary\(request: ProgressSummaryRequest\): Promise<ProgressSummaryResponse> \{ return withTransientDatabaseRetry\( \(\) => unsafeRepeatableReadTransaction\( async \(executor\) => loadUserProgressSummaryInExecutor\(executor, request\), \), createBackendRuntimeObservationScope, \); \}/,
+  );
+  assert.match(
+    source,
+    /export async function loadUserProgressSeries\(request: ProgressSeriesRequest\): Promise<ProgressSeries> \{ return withTransientDatabaseRetry\( \(\) => unsafeRepeatableReadTransaction\( async \(executor\) => loadUserProgressSeriesInExecutor\(executor, request\), \), createBackendRuntimeObservationScope, \); \}/,
+  );
+  assert.doesNotMatch(
+    source,
+    /export async function loadUserProgressReviewSchedule\( request: ProgressReviewScheduleRequest, \): Promise<ProgressReviewSchedule> \{ return withTransientDatabaseRetry/,
+  );
 });
 
 test("published contract documents the progress leaderboard and the API Gateway predeclares it", () => {

--- a/apps/backend/src/progress/progressReviewSchedule.test.ts
+++ b/apps/backend/src/progress/progressReviewSchedule.test.ts
@@ -46,7 +46,7 @@ test("loadUserProgressReviewScheduleInExecutor returns stable zero buckets for a
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {
       "workspace-1|Europe/Madrid": [
         createEmptyReviewScheduleCountRow(),
@@ -80,7 +80,7 @@ test("loadUserProgressReviewScheduleInExecutor merges bucket counts across works
       "user-1": ["workspace-1", "workspace-2"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {
       "workspace-1|Europe/Madrid": [
         createReviewScheduleCountRow({
@@ -154,7 +154,7 @@ test("loadUserProgressReviewScheduleInExecutor uses timezone calendar boundaries
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {
       "workspace-1|America/Los_Angeles": [
         createEmptyReviewScheduleCountRow(),

--- a/apps/backend/src/progress/progressSeries.test.ts
+++ b/apps/backend/src/progress/progressSeries.test.ts
@@ -13,7 +13,7 @@ test("loadUserProgressSeriesInExecutor returns a zero-filled series for an empty
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 0,
@@ -76,8 +76,8 @@ test("loadUserProgressSeriesInExecutor marks today without review as pending", a
         },
       ],
     },
-    allReviewDateRowsByRequest: {
-      [`workspace-1|${timeZone}`]: [
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: yesterday },
       ],
     },
@@ -148,7 +148,7 @@ test("loadUserProgressSeriesInExecutor fills gaps and merges rating breakdowns a
         },
       ],
     },
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 4,
@@ -200,7 +200,7 @@ test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_clie
         },
       ],
     },
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 1,
@@ -233,6 +233,35 @@ test("loadUserProgressSeriesInExecutor buckets review counts by reviewed_at_clie
     "2026-04-11",
     "2026-04-12",
   ]);
+
+  const materializationQuery = recordedQueries.find((query) => query.text.includes("WITH target_review_events AS"));
+  if (materializationQuery === undefined) {
+    assert.fail("Expected an active review day materialization query to be recorded");
+  }
+  assert.match(materializationQuery.text, /INSERT INTO progress\.user_active_review_days/);
+  assert.match(materializationQuery.text, /WHERE review_events\.reviewed_by_user_id = \$1/);
+  assert.match(materializationQuery.text, /AND review_events\.workspace_id = \$3/);
+  assert.doesNotMatch(materializationQuery.text, /review_events\.rating/);
+  assert.deepEqual(materializationQuery.params, [
+    "user-1",
+    "America/Los_Angeles",
+    "workspace-1",
+  ]);
+
+  const activeDayQuery = recordedQueries.find((query) => (
+    query.text.includes("FROM progress.user_active_review_days AS active_days")
+  ));
+  if (activeDayQuery === undefined) {
+    assert.fail("Expected an active review day read query to be recorded");
+  }
+  assert.deepEqual(activeDayQuery.params, ["user-1"]);
+  assert.doesNotMatch(activeDayQuery.text, /workspace_id/);
+  assert.equal(
+    recordedQueries.some((query) => (
+      query.text.includes("SELECT DISTINCT timezone($2, review_events.reviewed_at_client)::date")
+    )),
+    false,
+  );
 });
 
 test("loadUserProgressSeriesInExecutor applies user scope for memberships and workspace scope for each review query", async () => {
@@ -262,7 +291,7 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
         },
       ],
     },
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 3,
@@ -277,9 +306,29 @@ test("loadUserProgressSeriesInExecutor applies user scope for memberships and wo
     to: "2026-04-14",
   });
 
-  const reviewQueries = recordedQueries.filter((query) => query.text.includes("COUNT(*)::int AS review_count"));
+  const reviewQueries = recordedQueries.filter((query) => query.text.includes("easy_count"));
   assert.equal(reviewQueries.length, 2);
   assert.match(reviewQueries[0]?.text ?? "", /WHERE review_events\.workspace_id = \$1/);
+
+  const materializationQueries = recordedQueries.filter((query) => (
+    query.text.includes("WITH target_review_events AS")
+  ));
+  assert.equal(materializationQueries.length, 2);
+  assert.ok(materializationQueries.every((query) => (
+    query.text.includes("WHERE review_events.reviewed_by_user_id = $1")
+    && query.text.includes("AND review_events.workspace_id = $3")
+  )));
+  assert.deepEqual(materializationQueries.map((query) => query.params), [
+    ["user-1", "Europe/Madrid", "workspace-1"],
+    ["user-1", "Europe/Madrid", "workspace-2"],
+  ]);
+
+  const activeDayQueries = recordedQueries.filter((query) => (
+    query.text.includes("FROM progress.user_active_review_days AS active_days")
+  ));
+  assert.equal(activeDayQueries.length, 1);
+  assert.deepEqual(activeDayQueries[0]?.params, ["user-1"]);
+  assert.doesNotMatch(activeDayQueries[0]?.text ?? "", /workspace_id/);
 
   const scopeQueries = recordedQueries.filter((query) => query.text.includes("set_config('app.user_id', $1, true)"));
   assert.deepEqual(scopeQueries.map((query) => query.params), [

--- a/apps/backend/src/progress/progressSummary.test.ts
+++ b/apps/backend/src/progress/progressSummary.test.ts
@@ -19,7 +19,7 @@ test("loadUserProgressSummaryInExecutor returns zero summary metrics for an empt
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": 0,
@@ -53,6 +53,24 @@ test("loadUserProgressSummaryInExecutor returns zero summary metrics for an empt
   );
 });
 
+test("loadUserProgressSummaryInExecutor raises when the progress timezone settings row is missing", async () => {
+  const { executor } = createProgressExecutor({
+    workspaceIdsByUser: {},
+    reviewRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
+    reviewScheduleRowsByRequest: {},
+    reviewSequenceIdsByWorkspaceId: {},
+  });
+
+  await assert.rejects(
+    () => loadUserProgressSummaryInExecutor(executor, {
+      userId: "missing-user",
+      timeZone: "Europe/Madrid",
+    }),
+    /Progress timezone user_settings row was not found for userId=missing-user/,
+  );
+});
+
 test("loadUserProgressSummaryInExecutor freezes one completed missed day and recharges progress", async () => {
   const timeZone = "Europe/Madrid";
   const today = formatDateAsTimeZoneLocalDate(new Date(), timeZone);
@@ -62,8 +80,8 @@ test("loadUserProgressSummaryInExecutor freezes one completed missed day and rec
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {
-      [`workspace-1|${timeZone}`]: [
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: twoDaysAgo },
       ],
     },
@@ -122,10 +140,10 @@ test("loadUserProgressSummaryInExecutor resets a gap larger than available freez
         },
       ],
     },
-    allReviewDateRowsByRequest: {
-      [`workspace-1|${timeZone}`]: [
-        { review_date: today },
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: sixDaysAgo },
+        { review_date: today },
       ],
     },
     reviewScheduleRowsByRequest: {},
@@ -164,21 +182,18 @@ test("loadUserProgressSummaryInExecutor resets a gap larger than available freez
   ]);
 });
 
-test("loadUserProgressSummaryInExecutor merges all-time review dates across workspaces without double-counting overlap", async () => {
+test("loadUserProgressSummaryInExecutor reads user-wide active review dates without double-counting overlap", async () => {
   const { executor } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1", "workspace-2"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {
-      "workspace-1|Europe/Madrid": [
-        { review_date: "2026-04-14" },
-        { review_date: "2026-04-13" },
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: "2026-04-11" },
-      ],
-      "workspace-2|Europe/Madrid": [
-        { review_date: "2026-04-14" },
         { review_date: "2026-04-12" },
+        { review_date: "2026-04-13" },
+        { review_date: "2026-04-14" },
       ],
     },
     reviewScheduleRowsByRequest: {},
@@ -207,14 +222,14 @@ test("loadUserProgressSummaryInExecutor merges all-time review dates across work
   ]);
 });
 
-test("loadUserProgressSummaryInExecutor derives active review dates from reviewed_at_client in the requested timezone", async () => {
+test("loadUserProgressSummaryInExecutor materializes and reads active review days in the requested timezone", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {
-      "workspace-1|America/Los_Angeles": [
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: "2026-04-11" },
       ],
     },
@@ -229,31 +244,62 @@ test("loadUserProgressSummaryInExecutor derives active review dates from reviewe
     timeZone: "America/Los_Angeles",
   });
 
-  const summaryQuery = recordedQueries.find((query) => (
-    query.text.includes("SELECT DISTINCT timezone($2, review_events.reviewed_at_client)::date AS review_local_date")
+  const timezoneRememberQuery = recordedQueries.find((query) => (
+    query.text.includes("WITH target_user AS")
+    && query.text.includes("UPDATE org.user_settings AS user_settings")
   ));
-  if (summaryQuery === undefined) {
-    assert.fail("Expected an all-time review date query to be recorded");
+  if (timezoneRememberQuery === undefined) {
+    assert.fail("Expected a progress timezone remember query to be recorded");
   }
-  assert.match(summaryQuery.text, /ORDER BY review_local_dates\.review_local_date DESC/);
-  assert.doesNotMatch(summaryQuery.text, /reviewed_at_server/);
-  assert.deepEqual(summaryQuery.params, [
-    "workspace-1",
+  assert.match(timezoneRememberQuery.text, /target_user\.progress_time_zone IS DISTINCT FROM \$2/);
+  assert.match(timezoneRememberQuery.text, /LEFT JOIN updated_user/);
+  assert.deepEqual(timezoneRememberQuery.params, [
+    "user-1",
     "America/Los_Angeles",
   ]);
+
+  const materializationQuery = recordedQueries.find((query) => (
+    query.text.includes("WITH target_review_events AS")
+  ));
+  if (materializationQuery === undefined) {
+    assert.fail("Expected an active review day materialization query to be recorded");
+  }
+  assert.match(materializationQuery.text, /timezone\(\$2, review_events\.reviewed_at_client\)::date/);
+  assert.match(materializationQuery.text, /WHERE review_events\.reviewed_by_user_id = \$1/);
+  assert.match(materializationQuery.text, /AND review_events\.workspace_id = \$3/);
+  assert.match(materializationQuery.text, /INSERT INTO progress\.user_active_review_days/);
+  assert.deepEqual(materializationQuery.params, [
+    "user-1",
+    "America/Los_Angeles",
+    "workspace-1",
+  ]);
+
+  const activeDayQuery = recordedQueries.find((query) => (
+    query.text.includes("FROM progress.user_active_review_days AS active_days")
+  ));
+  if (activeDayQuery === undefined) {
+    assert.fail("Expected an active review day read query to be recorded");
+  }
+  assert.match(activeDayQuery.text, /ORDER BY active_days\.local_date ASC/);
+  assert.doesNotMatch(activeDayQuery.text, /workspace_id/);
+  assert.deepEqual(activeDayQuery.params, ["user-1"]);
+  assert.equal(
+    recordedQueries.some((query) => (
+      query.text.includes("SELECT DISTINCT timezone($2, review_events.reviewed_at_client)::date")
+    )),
+    false,
+  );
 });
 
-test("loadUserProgressSummaryInExecutor applies user scope for memberships and workspace scope for each summary query", async () => {
+test("loadUserProgressSummaryInExecutor applies user scope while reading user-wide active days", async () => {
   const { executor, recordedQueries } = createProgressExecutor({
     workspaceIdsByUser: {
       "user-1": ["workspace-1", "workspace-2"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {
-      "workspace-1|Europe/Madrid": [
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: "2026-04-11" },
-      ],
-      "workspace-2|Europe/Madrid": [
         { review_date: "2026-04-14" },
       ],
     },
@@ -269,11 +315,25 @@ test("loadUserProgressSummaryInExecutor applies user scope for memberships and w
     timeZone: "Europe/Madrid",
   });
 
-  const summaryQueries = recordedQueries.filter((query) => (
-    query.text.includes("SELECT DISTINCT timezone($2, review_events.reviewed_at_client)::date AS review_local_date")
+  const materializationQueries = recordedQueries.filter((query) => (
+    query.text.includes("WITH target_review_events AS")
   ));
-  assert.equal(summaryQueries.length, 2);
-  assert.match(summaryQueries[0]?.text ?? "", /WHERE review_events\.workspace_id = \$1/);
+  assert.equal(materializationQueries.length, 2);
+  assert.ok(materializationQueries.every((query) => (
+    query.text.includes("WHERE review_events.reviewed_by_user_id = $1")
+    && query.text.includes("AND review_events.workspace_id = $3")
+  )));
+  assert.deepEqual(materializationQueries.map((query) => query.params), [
+    ["user-1", "Europe/Madrid", "workspace-1"],
+    ["user-1", "Europe/Madrid", "workspace-2"],
+  ]);
+
+  const activeDayQueries = recordedQueries.filter((query) => (
+    query.text.includes("FROM progress.user_active_review_days AS active_days")
+  ));
+  assert.equal(activeDayQueries.length, 1);
+  assert.deepEqual(activeDayQueries[0]?.params, ["user-1"]);
+  assert.doesNotMatch(activeDayQueries[0]?.text ?? "", /workspace_id/);
 
   const scopeQueries = recordedQueries.filter((query) => query.text.includes("set_config('app.user_id', $1, true)"));
   assert.deepEqual(scopeQueries.map((query) => query.params), [
@@ -294,12 +354,12 @@ test("loadUserProgressSummaryInExecutor keeps summary independent from the reque
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {
-      [`workspace-1|${timeZone}`]: [
-        { review_date: today },
-        { review_date: yesterday },
-        { review_date: twoDaysAgo },
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: tenDaysAgo },
+        { review_date: twoDaysAgo },
+        { review_date: yesterday },
+        { review_date: today },
       ],
     },
     reviewScheduleRowsByRequest: {},
@@ -333,11 +393,11 @@ test("loadUserProgressSummaryInExecutor keeps hasReviewedToday true when a futur
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {
-      [`workspace-1|${timeZone}`]: [
-        { review_date: tomorrow },
-        { review_date: today },
+    activeReviewDateRowsByUser: {
+      "user-1": [
         { review_date: yesterday },
+        { review_date: today },
+        { review_date: tomorrow },
       ],
     },
     reviewScheduleRowsByRequest: {},

--- a/apps/backend/src/progress/progressTestSupport.ts
+++ b/apps/backend/src/progress/progressTestSupport.ts
@@ -40,7 +40,7 @@ type WorkspaceMembershipRow = Readonly<{
 export type ProgressExecutorFixture = Readonly<{
   workspaceIdsByUser: Readonly<Record<string, ReadonlyArray<string>>>;
   reviewRowsByRequest: Readonly<Record<string, ReadonlyArray<DailyReviewCountRow>>>;
-  allReviewDateRowsByRequest: Readonly<Record<string, ReadonlyArray<ReviewDateRow>>>;
+  activeReviewDateRowsByUser: Readonly<Record<string, ReadonlyArray<ReviewDateRow>>>;
   reviewScheduleRowsByRequest: Readonly<Record<string, ReadonlyArray<ReviewScheduleCountRow>>>;
   reviewSequenceIdsByWorkspaceId: Readonly<Record<string, string | number>>;
 }>;
@@ -253,6 +253,28 @@ export function createProgressExecutor(
       }
 
       if (
+        text.includes("WITH target_user AS")
+        && text.includes("UPDATE org.user_settings AS user_settings")
+        && text.includes("target_user.progress_time_zone IS DISTINCT FROM $2")
+      ) {
+        const userId = typeof params[0] === "string" ? params[0] : String(params[0]);
+        if (scope.userId !== userId) {
+          throw new Error("Progress timezone remember requires user scope");
+        }
+
+        if (!(userId in fixture.workspaceIdsByUser)) {
+          return createQueryResult<QueryResultRow>([]) as pg.QueryResult<Row>;
+        }
+
+        return createQueryResult<QueryResultRow>([
+          {
+            user_id: userId,
+            updated: false,
+          },
+        ]) as pg.QueryResult<Row>;
+      }
+
+      if (
         text.includes("SELECT memberships.workspace_id")
         && text.includes("FROM org.workspace_memberships memberships")
       ) {
@@ -264,6 +286,33 @@ export function createProgressExecutor(
         return createQueryResult<WorkspaceMembershipRow>(
           (fixture.workspaceIdsByUser[userId] ?? []).map((workspaceId) => ({ workspace_id: workspaceId })),
         ) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.includes("WITH target_review_events AS")
+        && text.includes("INSERT INTO progress.user_active_review_days")
+      ) {
+        const userId = typeof params[0] === "string" ? params[0] : String(params[0]);
+        const workspaceId = typeof params[2] === "string" ? params[2] : String(params[2]);
+        if (scope.userId !== userId || scope.workspaceId !== workspaceId) {
+          throw new Error("Active review day materialization requires user scope and workspace RLS scope");
+        }
+
+        return createQueryResult<QueryResultRow>([]) as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.includes("FROM progress.user_active_review_days AS active_days")
+        && text.includes("ORDER BY active_days.local_date ASC")
+      ) {
+        const userId = typeof params[0] === "string" ? params[0] : String(params[0]);
+        if (scope.userId !== userId) {
+          throw new Error("Active review date query requires matching user scope");
+        }
+
+        const rows = [...(fixture.activeReviewDateRowsByUser[userId] ?? [])]
+          .sort((left, right) => left.review_date.localeCompare(right.review_date));
+        return createQueryResult<ReviewDateRow>(rows) as unknown as pg.QueryResult<Row>;
       }
 
       if (
@@ -313,22 +362,6 @@ export function createProgressExecutor(
         const key = `${workspaceId}|${timeZone}|${from}|${to}`;
         return createQueryResult<DailyReviewCountRow>(
           fixture.reviewRowsByRequest[key] ?? [],
-        ) as unknown as pg.QueryResult<Row>;
-      }
-
-      if (
-        text.includes("SELECT DISTINCT timezone($2, review_events.reviewed_at_client)::date AS review_local_date")
-        && text.includes("ORDER BY review_local_dates.review_local_date DESC")
-      ) {
-        const workspaceId = typeof params[0] === "string" ? params[0] : String(params[0]);
-        const timeZone = typeof params[1] === "string" ? params[1] : String(params[1]);
-        if (scope.userId === null || scope.workspaceId !== workspaceId) {
-          throw new Error("All review date query requires matching workspace scope");
-        }
-
-        const key = `${workspaceId}|${timeZone}`;
-        return createQueryResult<ReviewDateRow>(
-          fixture.allReviewDateRowsByRequest[key] ?? [],
         ) as unknown as pg.QueryResult<Row>;
       }
 

--- a/apps/backend/src/progress/progressWatermarks.test.ts
+++ b/apps/backend/src/progress/progressWatermarks.test.ts
@@ -20,7 +20,7 @@ test("progress responses include sorted review-history watermarks for accessible
       "user-1": ["workspace-2", "workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {
       "workspace-1|Europe/Madrid": [
         createEmptyReviewScheduleCountRow(),
@@ -69,7 +69,7 @@ test("progress responses return empty review-history watermarks when the user ha
       "user-1": [],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {},
   });
@@ -100,7 +100,7 @@ test("loadUserProgressSummaryInExecutor raises workspace context for invalid rev
       "user-1": ["workspace-1"],
     },
     reviewRowsByRequest: {},
-    allReviewDateRowsByRequest: {},
+    activeReviewDateRowsByUser: {},
     reviewScheduleRowsByRequest: {},
     reviewSequenceIdsByWorkspaceId: {
       "workspace-1": "42-invalid",


### PR DESCRIPTION
## Summary
- Progress summary/series streak inputs now use `progress.user_active_review_days` after lazy materialization.
- Lazy materialization is user+workspace bounded on raw review events while the final active-day read remains user-wide.
- Same-timezone timezone remembrance avoids no-op writes.
- Public summary/series loaders retry transient DB failures around the full repeatable-read transaction.

## Validation
- `cd apps/backend && npm run lint`: passed
- `cd apps/backend && npm test`: passed, 464/464 tests
- Final read-only review: no P0-P4 findings; green light.