### PR TITLE
Capture review time zones on web

### DIFF
--- a/apps/web/src/api/endpoints/sync.test.ts
+++ b/apps/web/src/api/endpoints/sync.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import "./endpointsTestSupport";
+import { primeSessionCsrfToken } from "../transport/transport";
+import { pullReviewHistorySync } from "./sync";
+
+describe("sync API endpoints", () => {
+  it("decodes review-history events with optional reviewed timezone", async () => {
+    primeSessionCsrfToken("csrf-token-1");
+    const reviewEventWithTimeZone = {
+      reviewEventId: "review-1",
+      workspaceId: "workspace-1",
+      cardId: "card-1",
+      replicaId: "device-1",
+      clientEventId: "client-event-1",
+      rating: 2,
+      reviewedAtClient: "2026-03-10T10:00:00.000Z",
+      reviewedTimeZone: "Europe/Madrid",
+      reviewedAtServer: "2026-03-10T10:00:01.000Z",
+    } as const;
+    const reviewEventWithoutTimeZone = {
+      reviewEventId: "review-2",
+      workspaceId: "workspace-1",
+      cardId: "card-2",
+      replicaId: "device-1",
+      clientEventId: "client-event-2",
+      rating: 3,
+      reviewedAtClient: "2026-03-10T11:00:00.000Z",
+      reviewedAtServer: "2026-03-10T11:00:01.000Z",
+    } as const;
+    const fetchMock = vi.fn<(...args: Array<unknown>) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        reviewEvents: [
+          reviewEventWithTimeZone,
+          reviewEventWithoutTimeZone,
+        ],
+        nextReviewSequenceId: 43,
+        hasMore: false,
+      }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await pullReviewHistorySync("workspace-1", "device-1", "web", "1.0.0", 41, 100);
+
+    expect(result).toEqual({
+      reviewEvents: [
+        reviewEventWithTimeZone,
+        reviewEventWithoutTimeZone,
+      ],
+      nextReviewSequenceId: 43,
+      hasMore: false,
+    });
+    expect(result.reviewEvents[1]).not.toHaveProperty("reviewedTimeZone");
+  });
+});

--- a/apps/web/src/apiContracts/studyData.ts
+++ b/apps/web/src/apiContracts/studyData.ts
@@ -15,6 +15,7 @@ import {
   parseNumber,
   parseNumberArray,
   parseObject,
+  parseOptionalField,
   parseRequiredField,
   parseString,
   parseStringArray,
@@ -115,7 +116,7 @@ export function parseDeck(value: unknown, endpoint: string, path: string): Deck 
 
 export function parseReviewEvent(value: unknown, endpoint: string, path: string): ReviewEvent {
   const objectValue = parseObject(value, endpoint, path);
-  return {
+  const reviewEvent: ReviewEvent = {
     reviewEventId: parseRequiredField(objectValue, "reviewEventId", endpoint, path, parseString),
     workspaceId: parseRequiredField(objectValue, "workspaceId", endpoint, path, parseString),
     cardId: parseRequiredField(objectValue, "cardId", endpoint, path, parseString),
@@ -124,5 +125,15 @@ export function parseReviewEvent(value: unknown, endpoint: string, path: string)
     rating: parseRequiredField(objectValue, "rating", endpoint, path, parseReviewRating),
     reviewedAtClient: parseRequiredField(objectValue, "reviewedAtClient", endpoint, path, parseString),
     reviewedAtServer: parseRequiredField(objectValue, "reviewedAtServer", endpoint, path, parseString),
+  };
+  const reviewedTimeZone = parseOptionalField(objectValue, "reviewedTimeZone", endpoint, path, parseString);
+
+  if (reviewedTimeZone === undefined) {
+    return reviewEvent;
+  }
+
+  return {
+    ...reviewEvent,
+    reviewedTimeZone,
   };
 }

--- a/apps/web/src/appData/domain/index.test.ts
+++ b/apps/web/src/appData/domain/index.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { Card } from "../../types";
 import {
   buildCardUpsertOperation,
+  buildReviewEvent,
+  buildReviewEventAppendOperation,
   cardsMatchingReviewFilter,
   compareCardsForReviewOrder,
   doesCardMutationAffectReviewSchedule,
@@ -156,6 +158,40 @@ describe("review order domain", () => {
     const card = makeReviewOrderCard("reviewed-card", "2026-02-31T12:00:00.000Z", "2026-03-10T09:00:00.000Z", null);
 
     expect(() => buildCardUpsertOperation(card)).toThrow(/invalid dueAt/);
+  });
+
+  it("serializes review event timezone only when present", () => {
+    const reviewEvent = buildReviewEvent(
+      "workspace-1",
+      "card-1",
+      "device-1",
+      2,
+      "2026-03-10T10:00:00.000Z",
+      "Europe/Madrid",
+      "review-1",
+      "client-event-1",
+    );
+    const legacyReviewEvent = buildReviewEvent(
+      "workspace-1",
+      "card-1",
+      "device-1",
+      2,
+      "2026-03-10T10:00:00.000Z",
+      undefined,
+      "review-2",
+      "client-event-2",
+    );
+
+    expect(buildReviewEventAppendOperation(reviewEvent).payload).toEqual({
+      reviewEventId: "review-1",
+      cardId: "card-1",
+      clientEventId: "client-event-1",
+      rating: 2,
+      reviewedAtClient: "2026-03-10T10:00:00.000Z",
+      reviewedTimeZone: "Europe/Madrid",
+    });
+    expect(legacyReviewEvent).not.toHaveProperty("reviewedTimeZone");
+    expect(buildReviewEventAppendOperation(legacyReviewEvent).payload).not.toHaveProperty("reviewedTimeZone");
   });
 
   it("classifies only schedule-relevant card mutations as review schedule changes", () => {

--- a/apps/web/src/appData/domain/index.ts
+++ b/apps/web/src/appData/domain/index.ts
@@ -754,10 +754,11 @@ export function buildReviewEvent(
   replicaId: string,
   rating: 0 | 1 | 2 | 3,
   reviewedAtClient: string,
+  reviewedTimeZone: string | undefined,
   reviewEventId: string,
   clientEventId: string,
 ): ReviewEvent {
-  return {
+  const reviewEvent: ReviewEvent = {
     reviewEventId,
     workspaceId,
     cardId,
@@ -766,6 +767,15 @@ export function buildReviewEvent(
     rating,
     reviewedAtClient,
     reviewedAtServer: reviewedAtClient,
+  };
+
+  if (reviewedTimeZone === undefined) {
+    return reviewEvent;
+  }
+
+  return {
+    ...reviewEvent,
+    reviewedTimeZone,
   };
 }
 
@@ -815,18 +825,23 @@ export function buildDeckUpsertOperation(deck: Deck): SyncPushOperation {
 }
 
 export function buildReviewEventAppendOperation(reviewEvent: ReviewEvent): SyncPushOperation {
+  const payload = {
+    reviewEventId: reviewEvent.reviewEventId,
+    cardId: reviewEvent.cardId,
+    clientEventId: reviewEvent.clientEventId,
+    rating: reviewEvent.rating,
+    reviewedAtClient: reviewEvent.reviewedAtClient,
+  };
+
   return {
     operationId: reviewEvent.reviewEventId,
     entityType: "review_event",
     entityId: reviewEvent.reviewEventId,
     action: "append",
     clientUpdatedAt: reviewEvent.reviewedAtClient,
-    payload: {
-      reviewEventId: reviewEvent.reviewEventId,
-      cardId: reviewEvent.cardId,
-      clientEventId: reviewEvent.clientEventId,
-      rating: reviewEvent.rating,
-      reviewedAtClient: reviewEvent.reviewedAtClient,
+    payload: reviewEvent.reviewedTimeZone === undefined ? payload : {
+      ...payload,
+      reviewedTimeZone: reviewEvent.reviewedTimeZone,
     },
   };
 }

--- a/apps/web/src/appData/sync/engine/useSyncEngine.ts
+++ b/apps/web/src/appData/sync/engine/useSyncEngine.ts
@@ -42,6 +42,9 @@ import {
   invalidateProgress,
 } from "../../progress/invalidation/progressInvalidation";
 import {
+  getBrowserTimeZone,
+} from "../../../progress/progressDates";
+import {
   requireCloudInstallationId,
 } from "../local/syncCloudSettings";
 import {
@@ -641,11 +644,14 @@ export function useSyncEngine(params: UseSyncEngineParams): SyncEngine {
       throw new Error("Workspace is unavailable");
     }
 
+    const reviewedAtClient = nowIso();
+    const reviewedTimeZone = getBrowserTimeZone();
     const mutationResult = await runLocalWorkspaceMutation(() => submitReviewLocally({
       workspaceId: activeWorkspaceId,
       cardId,
       rating,
-      reviewedAtClient: nowIso(),
+      reviewedAtClient,
+      reviewedTimeZone,
     }));
     bumpLocalReadVersion();
     invalidateLocalProgress();

--- a/apps/web/src/appData/sync/local/syncLocalMutations.ts
+++ b/apps/web/src/appData/sync/local/syncLocalMutations.ts
@@ -92,6 +92,7 @@ export type SubmitReviewLocallyInput = Readonly<{
   cardId: string;
   rating: LocalReviewRating;
   reviewedAtClient: string;
+  reviewedTimeZone: string;
 }>;
 
 export async function requireCard(workspaceId: string, cardId: string): Promise<Card> {
@@ -290,6 +291,7 @@ export async function submitReviewLocally(input: SubmitReviewLocallyInput): Prom
     installationId,
     input.rating,
     input.reviewedAtClient,
+    input.reviewedTimeZone,
     reviewEventId,
     clientEventId,
   );

--- a/apps/web/src/appData/sync/local/syncSeed.ts
+++ b/apps/web/src/appData/sync/local/syncSeed.ts
@@ -15,6 +15,8 @@ import {
   submitReviewLocally,
 } from "./syncLocalMutations";
 
+const deterministicSeedReviewTimeZone = "UTC";
+
 export type WorkspaceSeedReadiness = Readonly<{
   workspaceSettingsLoaded: boolean;
   hotStateHydrated: boolean;
@@ -140,6 +142,7 @@ export async function seedWorkspaceLocally(input: SeedWorkspaceLocallyInput): Pr
         cardId: nextCard.cardId,
         rating: review.rating,
         reviewedAtClient: review.reviewedAtClient,
+        reviewedTimeZone: deterministicSeedReviewTimeZone,
       });
       nextCard = reviewResult.card;
       if (reviewResult.didChangeProgressHistory) {

--- a/apps/web/src/localDb/progress/progress.test.ts
+++ b/apps/web/src/localDb/progress/progress.test.ts
@@ -342,4 +342,106 @@ describe("localDb progress", () => {
       "2025-01-08",
     ]);
   });
+
+  it("uses stored review-event timezone for local active dates when present", async () => {
+    await putReviewEvent({
+      reviewEventId: "active-date-stored-timezone",
+      workspaceId,
+      cardId: "due-other",
+      replicaId: "device-1",
+      clientEventId: "active-date-stored-timezone-client-event",
+      rating: 2,
+      reviewedAtClient: "2025-01-07T23:30:00.000Z",
+      reviewedTimeZone: "UTC",
+      reviewedAtServer: "2025-01-07T23:30:00.000Z",
+    });
+    await putReviewEvent({
+      reviewEventId: "active-date-legacy-timezone",
+      workspaceId,
+      cardId: "due-same-a",
+      replicaId: "device-1",
+      clientEventId: "active-date-legacy-timezone-client-event",
+      rating: 3,
+      reviewedAtClient: "2025-01-07T23:30:00.000Z",
+      reviewedAtServer: "2025-01-07T23:30:00.000Z",
+    });
+
+    const result = await loadLocalProgressActiveDates([workspaceId], "Europe/Madrid");
+
+    expect(result).toEqual([
+      "2025-01-07",
+      "2025-01-08",
+    ]);
+  });
+
+  it("uses pending review-event timezone for local daily overlays when present", async () => {
+    await putOutboxRecord({
+      operationId: "pending-review-stored-timezone",
+      workspaceId,
+      createdAt: "2025-01-07T23:30:00.000Z",
+      attemptCount: 0,
+      lastError: "",
+      operation: {
+        operationId: "pending-review-stored-timezone",
+        entityType: "review_event",
+        entityId: "pending-review-stored-timezone",
+        action: "append",
+        clientUpdatedAt: "2025-01-07T23:30:00.000Z",
+        payload: {
+          reviewEventId: "pending-review-stored-timezone",
+          cardId: "due-other",
+          clientEventId: "pending-review-stored-timezone-client-event",
+          rating: 2,
+          reviewedAtClient: "2025-01-07T23:30:00.000Z",
+          reviewedTimeZone: "UTC",
+        },
+      },
+    });
+    await putOutboxRecord({
+      operationId: "pending-review-legacy-timezone",
+      workspaceId,
+      createdAt: "2025-01-07T23:30:00.000Z",
+      attemptCount: 0,
+      lastError: "",
+      operation: {
+        operationId: "pending-review-legacy-timezone",
+        entityType: "review_event",
+        entityId: "pending-review-legacy-timezone",
+        action: "append",
+        clientUpdatedAt: "2025-01-07T23:30:00.000Z",
+        payload: {
+          reviewEventId: "pending-review-legacy-timezone",
+          cardId: "due-same-a",
+          clientEventId: "pending-review-legacy-timezone-client-event",
+          rating: 3,
+          reviewedAtClient: "2025-01-07T23:30:00.000Z",
+        },
+      },
+    });
+
+    const result = await loadPendingProgressDailyReviews([workspaceId], {
+      timeZone: "Europe/Madrid",
+      from: "2025-01-07",
+      to: "2025-01-08",
+    });
+
+    expect(result).toEqual([
+      {
+        date: "2025-01-07",
+        reviewCount: 1,
+        againCount: 0,
+        hardCount: 0,
+        goodCount: 1,
+        easyCount: 0,
+      },
+      {
+        date: "2025-01-08",
+        reviewCount: 1,
+        againCount: 0,
+        hardCount: 0,
+        goodCount: 0,
+        easyCount: 1,
+      },
+    ]);
+  });
 });

--- a/apps/web/src/localDb/progress/progress.ts
+++ b/apps/web/src/localDb/progress/progress.ts
@@ -205,7 +205,10 @@ function aggregateReviewEventsByWorkspaceAndLocalDate(
   const counts = new Map<string, ProgressDailyCountRecord>();
 
   for (const reviewEvent of reviewEvents) {
-    const localDate = mapReviewedAtClientToLocalDate(reviewEvent.reviewedAtClient, timeZone);
+    const localDate = mapReviewedAtClientToLocalDate(
+      reviewEvent.reviewedAtClient,
+      reviewEvent.reviewedTimeZone ?? timeZone,
+    );
     const countKey = `${reviewEvent.workspaceId}::${localDate}`;
     const currentCount = counts.get(countKey) ?? createEmptyProgressDailyCountRecord(
       reviewEvent.workspaceId,
@@ -380,13 +383,17 @@ export async function loadPendingProgressDailyReviews(
       continue;
     }
 
-    const localDate = mapReviewedAtClientToLocalDate(outboxRecord.operation.payload.reviewedAtClient, input.timeZone);
+    const payload = outboxRecord.operation.payload;
+    const localDate = mapReviewedAtClientToLocalDate(
+      payload.reviewedAtClient,
+      payload.reviewedTimeZone ?? input.timeZone,
+    );
     if (isDateWithinRange(localDate, input) === false) {
       continue;
     }
 
     const currentCount = counts.get(localDate) ?? createEmptyDailyReviewPoint(localDate);
-    counts.set(localDate, addReviewRatingToDailyReviewPoint(currentCount, outboxRecord.operation.payload.rating));
+    counts.set(localDate, addReviewRatingToDailyReviewPoint(currentCount, payload.rating));
   }
 
   return [...counts.entries()]

--- a/apps/web/src/localDb/reviews/reviews.ts
+++ b/apps/web/src/localDb/reviews/reviews.ts
@@ -811,7 +811,10 @@ export async function putReviewEvent(reviewEvent: ReviewEvent): Promise<void> {
       return;
     }
 
-    const localDate = mapReviewedAtClientToLocalDate(reviewEvent.reviewedAtClient, progressCacheState.timeZone);
+    const localDate = mapReviewedAtClientToLocalDate(
+      reviewEvent.reviewedAtClient,
+      reviewEvent.reviewedTimeZone ?? progressCacheState.timeZone,
+    );
     const existingProgressDailyCount = await getFromStore<ProgressDailyCountRecord>(
       database,
       "progressDailyCounts",

--- a/apps/web/src/progress/progressDates.ts
+++ b/apps/web/src/progress/progressDates.ts
@@ -319,7 +319,7 @@ function fallBackFromInvalidProgressTimeZone(
   return fallbackTimeZone;
 }
 
-function getBrowserTimeZone(): string {
+export function getBrowserTimeZone(): string {
   let timeZone: string | null = null;
   try {
     const observedTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -853,6 +853,7 @@ export type ReviewEvent = Readonly<{
   clientEventId: string;
   rating: ReviewRating;
   reviewedAtClient: string;
+  reviewedTimeZone?: string;
   reviewedAtServer: string;
 }>;
 
@@ -926,6 +927,7 @@ export type SyncPushOperation =
       clientEventId: string;
       rating: ReviewRating;
       reviewedAtClient: string;
+      reviewedTimeZone?: string;
     }>;
   }>;
 


### PR DESCRIPTION
## Summary

- Web captures the browser timezone when a review is created.
- Local review events, outbox records, and sync payloads preserve optional `reviewedTimeZone`.
- Local progress overlays use stored/pending review timezone with requested timezone fallback for old records.

## Validation

- `cd apps/web && npm run build`: passed
- `cd apps/web && npx vitest run src/localDb/progress/progress.test.ts src/appData/domain/index.test.ts src/api/endpoints/progress.test.ts`: passed, 3 files / 42 tests
- `cd apps/web && npx vitest run src/api/endpoints/sync.test.ts`: passed, 1 file / 1 test
- Read-only review: no P0-P4 findings; green light.

## Notes

- `npm ci` was run locally in the worker because `apps/web/node_modules` was absent; npm reported the existing Node engine warning (`25.6.1` vs package `24.x`), but validation passed.