### PR TITLE
Capture review time zones on iOS

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
+++ b/apps/ios/Flashcards/Flashcards/Cards/FlashcardsStore+Mutations.swift
@@ -104,12 +104,14 @@ extension FlashcardsStore {
         let context = try self.requireLocalOutboxMutationContext()
         let now = Date()
         let reviewedAtClient = nowIsoTimestamp()
+        let reviewedTimeZone = TimeZone.current.identifier
         _ = try context.database.submitReview(
             workspaceId: context.workspaceId,
             reviewSubmission: ReviewSubmission(
                 cardId: cardId,
                 rating: rating,
-                reviewedAtClient: reviewedAtClient
+                reviewedAtClient: reviewedAtClient,
+                reviewedTimeZone: reviewedTimeZone
             )
         )
         let reviewedAt = parseIsoTimestamp(value: reviewedAtClient) ?? now

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -303,6 +303,7 @@ extension FlashcardsStore {
     func handleProgressLocalMutation(
         now: Date,
         reviewedAtClient: String,
+        reviewedTimeZone: String?,
         rating: ReviewRating
     ) {
         do {
@@ -346,6 +347,7 @@ extension FlashcardsStore {
                 snapshot: progressSnapshot,
                 scopeKey: scopeKey,
                 reviewedAtClient: reviewedAtClient,
+                reviewedTimeZone: reviewedTimeZone,
                 rating: rating,
                 activeReviewLocalDates: activeReviewLocalDates
             )

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
@@ -530,6 +530,7 @@ extension FlashcardsStore {
                     ProgressReviewEventSource(
                         reviewEventId: reviewEvent.reviewEventId,
                         reviewedAtClient: reviewEvent.reviewedAtClient,
+                        reviewedTimeZone: reviewEvent.reviewedTimeZone,
                         rating: reviewEvent.rating
                     )
                 )
@@ -563,6 +564,7 @@ extension FlashcardsStore {
                         ProgressReviewEventSource(
                             reviewEventId: pendingPayload.reviewEventId,
                             reviewedAtClient: pendingPayload.reviewedAtClient,
+                            reviewedTimeZone: pendingPayload.reviewedTimeZone,
                             rating: pendingRating
                         )
                     )

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/UITestSupport/FlashcardsStore+CloudUITest.swift
@@ -748,7 +748,8 @@ extension FlashcardsStore {
                 reviewSubmission: ReviewSubmission(
                     cardId: card.cardId,
                     rating: reviewSeed.rating,
-                    reviewedAtClient: reviewedAtClient
+                    reviewedAtClient: reviewedAtClient,
+                    reviewedTimeZone: TimeZone.current.identifier
                 )
             )
         }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncContracts.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncContracts.swift
@@ -486,6 +486,7 @@ struct RemoteReviewEventChangePayload: Decodable {
     let clientEventId: String
     let rating: ReviewRating
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
     let reviewedAtServer: String
 }
 
@@ -612,5 +613,6 @@ struct RemoteReviewEventEnvelope: Decodable {
     let clientEventId: String
     let rating: ReviewRating
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
     let reviewedAtServer: String
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncMapper.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncMapper.swift
@@ -66,6 +66,7 @@ enum CloudSyncMapper {
             clientEventId: payload.clientEventId,
             rating: payload.rating,
             reviewedAtClient: payload.reviewedAtClient,
+            reviewedTimeZone: payload.reviewedTimeZone,
             reviewedAtServer: payload.reviewedAtServer
         )
     }
@@ -79,6 +80,7 @@ enum CloudSyncMapper {
             clientEventId: payload.clientEventId,
             rating: payload.rating,
             reviewedAtClient: payload.reviewedAtClient,
+            reviewedTimeZone: payload.reviewedTimeZone,
             reviewedAtServer: payload.reviewedAtServer
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTypes.swift
@@ -378,6 +378,7 @@ struct ReviewEventSyncPayload: Codable, Hashable {
     let clientEventId: String
     let rating: Int
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
 
     enum CodingKeys: String, CodingKey {
         case reviewEventId
@@ -386,6 +387,7 @@ struct ReviewEventSyncPayload: Codable, Hashable {
         case clientEventId
         case rating
         case reviewedAtClient
+        case reviewedTimeZone
     }
 
     init(
@@ -394,7 +396,8 @@ struct ReviewEventSyncPayload: Codable, Hashable {
         installationId: String,
         clientEventId: String,
         rating: Int,
-        reviewedAtClient: String
+        reviewedAtClient: String,
+        reviewedTimeZone: String?
     ) {
         self.reviewEventId = reviewEventId
         self.cardId = cardId
@@ -402,6 +405,7 @@ struct ReviewEventSyncPayload: Codable, Hashable {
         self.clientEventId = clientEventId
         self.rating = rating
         self.reviewedAtClient = reviewedAtClient
+        self.reviewedTimeZone = reviewedTimeZone
     }
 
     init(from decoder: Decoder) throws {
@@ -412,6 +416,7 @@ struct ReviewEventSyncPayload: Codable, Hashable {
         self.clientEventId = try container.decode(String.self, forKey: .clientEventId)
         self.rating = try container.decode(Int.self, forKey: .rating)
         self.reviewedAtClient = try container.decode(String.self, forKey: .reviewedAtClient)
+        self.reviewedTimeZone = try container.decodeIfPresent(String.self, forKey: .reviewedTimeZone)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -421,6 +426,7 @@ struct ReviewEventSyncPayload: Codable, Hashable {
         try container.encode(self.clientEventId, forKey: .clientEventId)
         try container.encode(self.rating, forKey: .rating)
         try container.encode(self.reviewedAtClient, forKey: .reviewedAtClient)
+        try container.encodeIfPresent(self.reviewedTimeZone, forKey: .reviewedTimeZone)
     }
 }
 

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Read.swift
@@ -235,7 +235,7 @@ extension CardStore {
     func loadReviewEvents(workspaceId: String) throws -> [ReviewEvent] {
         try self.core.query(
             sql: """
-            SELECT review_event_id, workspace_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server
+            SELECT review_event_id, workspace_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_time_zone, reviewed_at_server
             FROM review_events
             WHERE workspace_id = ?
             ORDER BY reviewed_at_server DESC
@@ -255,7 +255,8 @@ extension CardStore {
                 clientEventId: DatabaseCore.columnText(statement: statement, index: 4),
                 rating: rating,
                 reviewedAtClient: DatabaseCore.columnText(statement: statement, index: 6),
-                reviewedAtServer: DatabaseCore.columnText(statement: statement, index: 7)
+                reviewedTimeZone: DatabaseCore.columnOptionalText(statement: statement, index: 7),
+                reviewedAtServer: DatabaseCore.columnText(statement: statement, index: 8)
             )
         }
     }

--- a/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Write.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/CardStore/CardStore+Write.swift
@@ -154,6 +154,7 @@ extension CardStore {
         cardId: String,
         rating: ReviewRating,
         reviewedAtClient: String,
+        reviewedTimeZone: String?,
         installationId: String,
         reviewEventId: String,
         clientEventId: String,
@@ -169,9 +170,10 @@ extension CardStore {
                 client_event_id,
                 rating,
                 reviewed_at_client,
+                reviewed_time_zone,
                 reviewed_at_server
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             values: [
                 .text(reviewEventId),
@@ -181,6 +183,7 @@ extension CardStore {
                 .text(clientEventId),
                 .integer(Int64(rating.rawValue)),
                 .text(reviewedAtClient),
+                reviewedTimeZone.map(SQLiteValue.text) ?? .null,
                 .text(reviewedAtServer)
             ]
         )
@@ -193,6 +196,7 @@ extension CardStore {
             clientEventId: clientEventId,
             rating: rating,
             reviewedAtClient: reviewedAtClient,
+            reviewedTimeZone: reviewedTimeZone,
             reviewedAtServer: reviewedAtServer
         )
     }

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabase+Review.swift
@@ -27,6 +27,7 @@ extension LocalDatabase {
                 cardId: reviewSubmission.cardId,
                 rating: reviewSubmission.rating,
                 reviewedAtClient: reviewSubmission.reviewedAtClient,
+                reviewedTimeZone: reviewSubmission.reviewedTimeZone,
                 installationId: cloudSettings.installationId,
                 reviewEventId: reviewEventId,
                 clientEventId: clientEventId,

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseMigrator.swift
@@ -70,6 +70,9 @@ struct LocalDatabaseMigrator {
             case 16:
                 try self.migrateSchemaVersion16To17()
                 schemaVersion = 17
+            case 17:
+                try self.migrateSchemaVersion17To18()
+                schemaVersion = 18
             default:
                 throw LocalStoreError.database("Unsupported local schema version: \(schemaVersion)")
             }
@@ -562,6 +565,20 @@ struct LocalDatabaseMigrator {
             sql: """
             ALTER TABLE sync_state
             ADD COLUMN pending_review_history_import INTEGER NOT NULL DEFAULT 0 CHECK (pending_review_history_import IN (0, 1))
+            """,
+            values: []
+        )
+    }
+
+    private func migrateSchemaVersion17To18() throws {
+        guard try self.core.columnExists(tableName: "review_events", columnName: "reviewed_time_zone") == false else {
+            return
+        }
+
+        try self.core.execute(
+            sql: """
+            ALTER TABLE review_events
+            ADD COLUMN reviewed_time_zone TEXT
             """,
             values: []
         )

--- a/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/LocalDatabase/LocalDatabaseSchema.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum LocalDatabaseSchema {
-    static let currentVersion: Int = 17
+    static let currentVersion: Int = 18
 
     static var baseMigrationSQL: String {
         let defaultEnableFuzzValue: Int = defaultSchedulerSettingsConfig.enableFuzz ? 1 : 0
@@ -78,6 +78,7 @@ enum LocalDatabaseSchema {
             client_event_id TEXT NOT NULL, -- client-generated review-event idempotency key reused on push retry
             rating INTEGER NOT NULL CHECK (rating BETWEEN 0 AND 3), -- review rating from Again to Easy
             reviewed_at_client TEXT NOT NULL, -- timestamp captured on the device when the user answered
+            reviewed_time_zone TEXT, -- IANA timezone identifier captured on the device when the review was created
             reviewed_at_server TEXT NOT NULL, -- local mirror of the backend receive timestamp once synced; local writes use current device time until ack
             UNIQUE (workspace_id, replica_id, client_event_id)
         );

--- a/apps/ios/Flashcards/Flashcards/Database/Sync/OutboxStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Sync/OutboxStore.swift
@@ -42,6 +42,7 @@ private struct ReviewEventOutboxPayload: Codable {
     let clientEventId: String
     let rating: Int
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
 }
 
 private struct ReviewEventOutboxCandidate {
@@ -589,7 +590,8 @@ struct OutboxStore {
                 installationId: installationId,
                 clientEventId: reviewEvent.clientEventId,
                 rating: reviewEvent.rating.rawValue,
-                reviewedAtClient: reviewEvent.reviewedAtClient
+                reviewedAtClient: reviewEvent.reviewedAtClient,
+                reviewedTimeZone: reviewEvent.reviewedTimeZone
             )
         )
         try self.enqueueOutboxOperation(

--- a/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Sync/SyncApplier.swift
@@ -310,9 +310,10 @@ struct SyncApplier {
                 client_event_id,
                 rating,
                 reviewed_at_client,
+                reviewed_time_zone,
                 reviewed_at_server
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             values: [
                 .text(reviewEvent.reviewEventId),
@@ -322,6 +323,7 @@ struct SyncApplier {
                 .text(reviewEvent.clientEventId),
                 .integer(Int64(reviewEvent.rating.rawValue)),
                 .text(reviewEvent.reviewedAtClient),
+                reviewEvent.reviewedTimeZone.map(SQLiteValue.text) ?? .null,
                 .text(reviewEvent.reviewedAtServer)
             ]
         )

--- a/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceForker.swift
+++ b/apps/ios/Flashcards/Flashcards/Database/Workspace/WorkspaceForker.swift
@@ -9,6 +9,7 @@ private struct WorkspaceForkReviewEventRow {
     let clientEventId: String
     let rating: Int64
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
     let reviewedAtServer: String
 }
 
@@ -326,9 +327,10 @@ struct WorkspaceForker {
                     client_event_id,
                     rating,
                     reviewed_at_client,
+                    reviewed_time_zone,
                     reviewed_at_server
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 values: [
                     .text(destinationReviewEventId),
@@ -338,6 +340,7 @@ struct WorkspaceForker {
                     .text(sourceReviewEvent.clientEventId),
                     .integer(sourceReviewEvent.rating),
                     .text(sourceReviewEvent.reviewedAtClient),
+                    sourceReviewEvent.reviewedTimeZone.map(SQLiteValue.text) ?? .null,
                     .text(sourceReviewEvent.reviewedAtServer)
                 ]
             )
@@ -381,7 +384,7 @@ struct WorkspaceForker {
         let placeholders: String = sourceReviewEventIds.map { _ in "?" }.joined(separator: ", ")
         let rows: [WorkspaceForkReviewEventRow] = try self.core.query(
             sql: """
-            SELECT review_event_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_at_server
+            SELECT review_event_id, card_id, replica_id, client_event_id, rating, reviewed_at_client, reviewed_time_zone, reviewed_at_server
             FROM review_events
             WHERE workspace_id = ? AND review_event_id IN (\(placeholders))
             ORDER BY review_event_id ASC
@@ -397,7 +400,8 @@ struct WorkspaceForker {
                 clientEventId: DatabaseCore.columnText(statement: statement, index: 3),
                 rating: DatabaseCore.columnInt64(statement: statement, index: 4),
                 reviewedAtClient: DatabaseCore.columnText(statement: statement, index: 5),
-                reviewedAtServer: DatabaseCore.columnText(statement: statement, index: 6)
+                reviewedTimeZone: DatabaseCore.columnOptionalText(statement: statement, index: 6),
+                reviewedAtServer: DatabaseCore.columnText(statement: statement, index: 7)
             )
         }
 

--- a/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Aggregation/ProgressAggregation.swift
@@ -20,6 +20,7 @@ struct ProgressReviewedAtClientSources: Hashable, Sendable {
 struct ProgressReviewEventSource: Hashable, Sendable {
     let reviewEventId: String
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
     let rating: ReviewRating
 }
 
@@ -470,18 +471,13 @@ private func progressReviewRatingCountsByLocalDate(
     reviewEvents: [ProgressReviewEventSource],
     requestRange: ProgressRequestRange
 ) throws -> [String: ProgressReviewRatingCounts] {
-    let timeZone = try progressTimeZone(identifier: requestRange.timeZone)
-    let calendar = makeProgressStoreCalendar(timeZone: timeZone)
     var ratingCountsByLocalDate: [String: ProgressReviewRatingCounts] = [:]
 
     for reviewEvent in reviewEvents {
-        guard let reviewedAtDate = parseIsoTimestamp(value: reviewEvent.reviewedAtClient) else {
-            throw LocalStoreError.validation(
-                "Progress reviewedAtClient timestamp is invalid: \(reviewEvent.reviewedAtClient)"
-            )
-        }
-
-        let localDate = progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
+        let localDate = try progressReviewEventLocalDate(
+            reviewEvent: reviewEvent,
+            fallbackTimeZone: requestRange.timeZone
+        )
         if localDate < requestRange.from || localDate > requestRange.to {
             continue
         }
@@ -500,17 +496,24 @@ func progressActiveDatesFromReviewEvents(
     reviewEvents: [ProgressReviewEventSource],
     timeZone: String
 ) throws -> Set<String> {
-    let resolvedTimeZone = try progressTimeZone(identifier: timeZone)
-    let calendar = makeProgressStoreCalendar(timeZone: resolvedTimeZone)
     return try Set(reviewEvents.map { reviewEvent in
-        guard let reviewedAtDate = parseIsoTimestamp(value: reviewEvent.reviewedAtClient) else {
-            throw LocalStoreError.validation(
-                "Progress reviewedAtClient timestamp is invalid: \(reviewEvent.reviewedAtClient)"
-            )
-        }
-
-        return progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
+        try progressReviewEventLocalDate(reviewEvent: reviewEvent, fallbackTimeZone: timeZone)
     })
+}
+
+private func progressReviewEventLocalDate(
+    reviewEvent: ProgressReviewEventSource,
+    fallbackTimeZone: String
+) throws -> String {
+    guard let reviewedAtDate = parseIsoTimestamp(value: reviewEvent.reviewedAtClient) else {
+        throw LocalStoreError.validation(
+            "Progress reviewedAtClient timestamp is invalid: \(reviewEvent.reviewedAtClient)"
+        )
+    }
+
+    let timeZone = try progressTimeZone(identifier: reviewEvent.reviewedTimeZone ?? fallbackTimeZone)
+    let calendar = makeProgressStoreCalendar(timeZone: timeZone)
+    return progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
 }
 
 func progressActiveDatesFromReviewedAtClientSources(
@@ -693,6 +696,7 @@ func patchProgressSnapshot(
     snapshot: ProgressSnapshot,
     scopeKey: ProgressScopeKey,
     reviewedAtClient: String,
+    reviewedTimeZone: String?,
     rating: ReviewRating,
     activeReviewLocalDates: Set<String>
 ) throws -> ProgressSnapshot {
@@ -707,8 +711,15 @@ func patchProgressSnapshot(
 
     let timeZone = try progressTimeZone(identifier: scopeKey.timeZone)
     let calendar = makeProgressStoreCalendar(timeZone: timeZone)
-    let reviewedAtDate = try reviewedAtDateForProgressMutation(reviewedAtClient: reviewedAtClient)
-    let reviewedLocalDate = progressLocalDateStringForStore(date: reviewedAtDate, calendar: calendar)
+    let reviewedLocalDate = try progressReviewEventLocalDate(
+        reviewEvent: ProgressReviewEventSource(
+            reviewEventId: "local-progress-mutation",
+            reviewedAtClient: reviewedAtClient,
+            reviewedTimeZone: reviewedTimeZone,
+            rating: rating
+        ),
+        fallbackTimeZone: scopeKey.timeZone
+    )
     let patchedActiveReviewLocalDates = activeReviewLocalDates.union([reviewedLocalDate])
     let dailyReviews = try makePatchedSnapshotProgressDailyReviews(
         snapshot: snapshot,
@@ -956,12 +967,4 @@ private func patchedProgressSourceState(sourceState: ProgressSourceState) -> Pro
     case .serverBase, .serverBaseWithPendingLocalOverlay:
         return .serverBaseWithPendingLocalOverlay
     }
-}
-
-private func reviewedAtDateForProgressMutation(reviewedAtClient: String) throws -> Date {
-    guard let reviewedAtDate = parseIsoTimestamp(value: reviewedAtClient) else {
-        throw LocalStoreError.validation("Progress reviewedAtClient timestamp is invalid: \(reviewedAtClient)")
-    }
-
-    return reviewedAtDate
 }

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/StoreBridge/FlashcardsStore+Review.swift
@@ -289,7 +289,8 @@ extension FlashcardsStore {
                 submission: ReviewSubmission(
                     cardId: request.cardId,
                     rating: request.rating,
-                    reviewedAtClient: request.reviewedAtClient
+                    reviewedAtClient: request.reviewedAtClient,
+                    reviewedTimeZone: request.reviewedTimeZone
                 )
             )
             let now = Date()
@@ -328,6 +329,7 @@ extension FlashcardsStore {
             self.handleProgressLocalMutation(
                 now: now,
                 reviewedAtClient: request.reviewedAtClient,
+                reviewedTimeZone: request.reviewedTimeZone,
                 rating: request.rating
             )
             if bootstrapRefreshOutcome.didChange || didReconcileReviewState {

--- a/apps/ios/Flashcards/Flashcards/Review/Queue/Submission/ReviewQueueRuntime+Submission.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Queue/Submission/ReviewQueueRuntime+Submission.swift
@@ -38,7 +38,8 @@ extension ReviewQueueRuntime {
             ),
             cardSnapshot: cardSnapshot,
             rating: rating,
-            reviewedAtClient: nowIsoTimestamp()
+            reviewedAtClient: nowIsoTimestamp(),
+            reviewedTimeZone: TimeZone.current.identifier
         )
         self.state.pendingReviewRequests.append(request)
 

--- a/apps/ios/Flashcards/Flashcards/Review/ReviewTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/ReviewTypes.swift
@@ -106,6 +106,7 @@ struct ReviewEvent: Codable, Identifiable, Hashable, Sendable {
     let clientEventId: String
     let rating: ReviewRating
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
     let reviewedAtServer: String
 
     enum CodingKeys: String, CodingKey {
@@ -116,6 +117,7 @@ struct ReviewEvent: Codable, Identifiable, Hashable, Sendable {
         case clientEventId
         case rating
         case reviewedAtClient
+        case reviewedTimeZone
         case reviewedAtServer
     }
 
@@ -131,6 +133,7 @@ struct ReviewEvent: Codable, Identifiable, Hashable, Sendable {
         clientEventId: String,
         rating: ReviewRating,
         reviewedAtClient: String,
+        reviewedTimeZone: String?,
         reviewedAtServer: String
     ) {
         self.reviewEventId = reviewEventId
@@ -140,6 +143,7 @@ struct ReviewEvent: Codable, Identifiable, Hashable, Sendable {
         self.clientEventId = clientEventId
         self.rating = rating
         self.reviewedAtClient = reviewedAtClient
+        self.reviewedTimeZone = reviewedTimeZone
         self.reviewedAtServer = reviewedAtServer
     }
 
@@ -152,6 +156,7 @@ struct ReviewEvent: Codable, Identifiable, Hashable, Sendable {
         self.clientEventId = try container.decode(String.self, forKey: .clientEventId)
         self.rating = try container.decode(ReviewRating.self, forKey: .rating)
         self.reviewedAtClient = try container.decode(String.self, forKey: .reviewedAtClient)
+        self.reviewedTimeZone = try container.decodeIfPresent(String.self, forKey: .reviewedTimeZone)
         self.reviewedAtServer = try container.decode(String.self, forKey: .reviewedAtServer)
     }
 
@@ -163,6 +168,7 @@ struct ReviewEvent: Codable, Identifiable, Hashable, Sendable {
         try container.encode(self.clientEventId, forKey: .clientEventId)
         try container.encode(self.rating, forKey: .rating)
         try container.encode(self.reviewedAtClient, forKey: .reviewedAtClient)
+        try container.encodeIfPresent(self.reviewedTimeZone, forKey: .reviewedTimeZone)
         try container.encode(self.reviewedAtServer, forKey: .reviewedAtServer)
     }
 }
@@ -177,4 +183,5 @@ struct ReviewSubmission: Hashable, Sendable {
     let cardId: String
     let rating: ReviewRating
     let reviewedAtClient: String
+    let reviewedTimeZone: String?
 }

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
@@ -238,6 +238,7 @@ struct ReviewSubmissionRequest: Hashable, Sendable {
     let cardSnapshot: Card
     let rating: ReviewRating
     let reviewedAtClient: String
+    let reviewedTimeZone: String
 }
 
 struct ReviewSubmissionFailure: Identifiable, Hashable, Sendable {

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Guest/GuestCloudUpgradeMutationBlockingTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Guest/GuestCloudUpgradeMutationBlockingTests.swift
@@ -382,7 +382,8 @@ final class GuestCloudUpgradeMutationBlockingTests: XCTestCase {
                 submission: ReviewSubmission(
                     cardId: card.cardId,
                     rating: .good,
-                    reviewedAtClient: "2026-04-25T12:00:00.000Z"
+                    reviewedAtClient: "2026-04-25T12:00:00.000Z",
+                    reviewedTimeZone: "UTC"
                 )
             )
             XCTFail("Review submission executor should block guest outbox writes after guest upgrade drain starts.")

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
@@ -771,6 +771,7 @@ enum LinkedSyncRunnerTestTransportSupport {
             let body = try Self.jsonObjectBody(request: request)
             let afterReviewSequenceId = try XCTUnwrap(body["afterReviewSequenceId"] as? NSNumber).int64Value
             CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds.append(afterReviewSequenceId)
+            let reviewedTimeZoneJson = remoteReviewEvent.reviewedTimeZone.map { "\"\($0)\"" } ?? "null"
             return try Self.jsonResponse(
                 request: request,
                 statusCode: 200,
@@ -785,6 +786,7 @@ enum LinkedSyncRunnerTestTransportSupport {
                       "clientEventId": "\(remoteReviewEvent.clientEventId)",
                       "rating": \(remoteReviewEvent.rating.rawValue),
                       "reviewedAtClient": "\(remoteReviewEvent.reviewedAtClient)",
+                      "reviewedTimeZone": \(reviewedTimeZoneJson),
                       "reviewedAtServer": "\(remoteReviewEvent.reviewedAtServer)"
                     }
                   ],

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LocalWorkspaceSyncTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LocalWorkspaceSyncTestSupport.swift
@@ -285,6 +285,7 @@ struct WorkspaceSyncDeckOutboxPayload: Decodable {
 struct WorkspaceSyncReviewEventOutboxPayload: Decodable {
     let reviewEventId: String
     let cardId: String
+    let reviewedTimeZone: String?
 }
 
 struct WorkspaceSyncPushRetryRequestBody: Decodable {

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
@@ -430,7 +430,8 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: savedCard.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-01T00:00:00.000Z"
+                reviewedAtClient: "2026-04-01T00:00:00.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         let reviewEvent = try XCTUnwrap(try database.loadReviewEvents(workspaceId: workspace.workspaceId).first)
@@ -486,7 +487,8 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: savedCard.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-01T00:00:00.000Z"
+                reviewedAtClient: "2026-04-01T00:00:00.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         let reviewEvent = try XCTUnwrap(try database.loadReviewEvents(workspaceId: workspace.workspaceId).first)
@@ -542,7 +544,8 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: savedCard.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-01T00:00:00.000Z"
+                reviewedAtClient: "2026-04-01T00:00:00.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         try database.deleteAllOutboxEntries(workspaceId: workspace.workspaceId)
@@ -560,6 +563,7 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
             clientEventId: "remote-client-event",
             rating: .easy,
             reviewedAtClient: "2026-04-02T00:00:00.000Z",
+            reviewedTimeZone: "UTC",
             reviewedAtServer: "2026-04-02T00:00:01.000Z"
         )
         let configuration = URLSessionConfiguration.ephemeral
@@ -582,8 +586,11 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
 
         let syncState = try XCTUnwrap(try self.loadSyncState(database: database, workspaceId: workspace.workspaceId))
         let reviewEvents = try database.loadReviewEvents(workspaceId: workspace.workspaceId)
+        let importedReviewEvent = try XCTUnwrap(reviewEvents.first { event in
+            event.reviewEventId == remoteReviewEvent.reviewEventId
+        })
         XCTAssertTrue(syncResult.changedEntityTypes.contains(.reviewEvent))
-        XCTAssertTrue(reviewEvents.contains { event in event.reviewEventId == remoteReviewEvent.reviewEventId })
+        XCTAssertEqual("UTC", importedReviewEvent.reviewedTimeZone)
         XCTAssertTrue(CloudSyncRunnerTestURLProtocol.reviewHistoryImportEventCounts.isEmpty)
         XCTAssertEqual([0], CloudSyncRunnerTestURLProtocol.reviewHistoryPullAfterSequenceIds)
         XCTAssertEqual(2, syncState.lastAppliedReviewSequenceId)

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/PublicSync/PublicSyncConflictLocalIdRepairTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/PublicSync/PublicSyncConflictLocalIdRepairTests.swift
@@ -21,7 +21,8 @@ final class PublicSyncConflictLocalIdRepairTests: LocalWorkspaceSyncTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: savedCard.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+                reviewedAtClient: "2026-04-02T15:50:57.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
 
@@ -90,7 +91,8 @@ final class PublicSyncConflictLocalIdRepairTests: LocalWorkspaceSyncTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: savedCard.cardId,
                 rating: .easy,
-                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+                reviewedAtClient: "2026-04-02T15:50:57.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         let sourceReviewEvent = try XCTUnwrap(try database.loadReviewEvents(workspaceId: workspace.workspaceId).first)

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/WorkspaceIdentityFork/LocalWorkspaceLinkMigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/WorkspaceIdentityFork/LocalWorkspaceLinkMigrationTests.swift
@@ -21,7 +21,8 @@ final class LocalWorkspaceLinkMigrationTests: LocalWorkspaceSyncTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: savedCard.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+                reviewedAtClient: "2026-04-02T15:50:57.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         try self.updateSyncState(
@@ -80,7 +81,8 @@ final class LocalWorkspaceLinkMigrationTests: LocalWorkspaceSyncTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: savedCard.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+                reviewedAtClient: "2026-04-02T15:50:57.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         try database.updateWorkspaceSchedulerSettings(
@@ -148,6 +150,7 @@ final class LocalWorkspaceLinkMigrationTests: LocalWorkspaceSyncTestCase {
         XCTAssertEqual(expectedForkedReviewEventId, migratedReviewEvent.reviewEventId)
         XCTAssertEqual("workspace-linked", migratedReviewEvent.workspaceId)
         XCTAssertEqual(expectedForkedCardId, migratedReviewEvent.cardId)
+        XCTAssertEqual("UTC", migratedReviewEvent.reviewedTimeZone)
         XCTAssertTrue(outboxRows.allSatisfy { row in row.workspaceId == "workspace-linked" })
         XCTAssertFalse(outboxRows.contains { row in row.entityId == savedCard.cardId })
         XCTAssertFalse(outboxRows.contains { row in row.entityId == savedDeck.deckId })
@@ -173,6 +176,7 @@ final class LocalWorkspaceLinkMigrationTests: LocalWorkspaceSyncTestCase {
                 return row.entityId == expectedForkedReviewEventId
                     && payload.reviewEventId == expectedForkedReviewEventId
                     && payload.cardId == expectedForkedCardId
+                    && payload.reviewedTimeZone == "UTC"
             }
         )
         XCTAssertEqual(["workspace-linked"], schedulerOutboxRows.map(\.entityId))

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseLifecycleTests.swift
@@ -16,6 +16,7 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
         )
         XCTAssertTrue(try self.hasColumn(database: database, tableName: "cards", columnName: "due_at_millis"))
         XCTAssertTrue(try self.hasColumn(database: database, tableName: "cards", columnName: "fsrs_last_reviewed_at_millis"))
+        XCTAssertTrue(try self.hasColumn(database: database, tableName: "review_events", columnName: "reviewed_time_zone"))
         XCTAssertTrue(try self.hasColumn(database: database, tableName: "outbox", columnName: "review_schedule_impact"))
         XCTAssertTrue(
             try self.hasIndex(
@@ -82,7 +83,8 @@ final class LocalDatabaseLifecycleTests: LocalDatabaseTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: formatIsoTimestamp(date: reviewTime)
+                reviewedAtClient: formatIsoTimestamp(date: reviewTime),
+                reviewedTimeZone: "UTC"
             )
         )
 

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion11To13MigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion11To13MigrationTests.swift
@@ -139,7 +139,8 @@ final class LocalDatabaseSchemaVersion11To13MigrationTests: LocalDatabaseTestCas
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-18T12:00:00.000Z"
+                reviewedAtClient: "2026-04-18T12:00:00.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         try database.close()

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion14To15MigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion14To15MigrationTests.swift
@@ -37,7 +37,8 @@ final class LocalDatabaseSchemaVersion14To15MigrationTests: LocalDatabaseTestCas
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-18T12:00:00.000Z"
+                reviewedAtClient: "2026-04-18T12:00:00.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
         try database.close()

--- a/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion17To18MigrationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/LocalDatabaseSchemaVersion17To18MigrationTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import SQLite3
+import XCTest
+@testable import Flashcards
+
+final class LocalDatabaseSchemaVersion17To18MigrationTests: LocalDatabaseTestCase {
+    func testSchemaVersion17MigrationAddsNullableReviewEventTimezone() throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let card = try database.saveCard(
+            workspaceId: workspace.workspaceId,
+            input: CardEditorInput(
+                frontText: "Question",
+                backText: "Answer",
+                tags: [],
+                effortLevel: .medium
+            ),
+            cardId: nil
+        )
+        _ = try database.submitReview(
+            workspaceId: workspace.workspaceId,
+            reviewSubmission: ReviewSubmission(
+                cardId: card.cardId,
+                rating: .good,
+                reviewedAtClient: "2026-04-18T12:00:00.000Z",
+                reviewedTimeZone: "Europe/Madrid"
+            )
+        )
+        try database.close()
+        self.database = nil
+
+        try self.prepareSchemaVersion17Database(databaseURL: try XCTUnwrap(self.databaseURL))
+
+        let migratedDatabase = try LocalDatabase(databaseURL: try XCTUnwrap(self.databaseURL))
+        self.database = migratedDatabase
+        let reviewEvents = try migratedDatabase.loadReviewEvents(workspaceId: workspace.workspaceId)
+
+        XCTAssertEqual(LocalDatabaseSchema.currentVersion, try self.loadSchemaVersion(database: migratedDatabase))
+        XCTAssertTrue(
+            try self.hasColumn(
+                database: migratedDatabase,
+                tableName: "review_events",
+                columnName: "reviewed_time_zone"
+            )
+        )
+        XCTAssertEqual(1, reviewEvents.count)
+        XCTAssertNil(reviewEvents.first?.reviewedTimeZone)
+    }
+
+    private func prepareSchemaVersion17Database(databaseURL: URL) throws {
+        var connection: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            databaseURL.path,
+            &connection,
+            SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        )
+        guard openResult == SQLITE_OK, let connection else {
+            throw LocalStoreError.database("Failed to open schema v17 test database")
+        }
+        defer {
+            sqlite3_close_v2(connection)
+        }
+
+        let downgradeSQL = """
+        PRAGMA legacy_alter_table = ON;
+        DROP INDEX IF EXISTS idx_review_events_workspace_card_time;
+        DROP INDEX IF EXISTS idx_review_events_reviewed_at_client;
+        ALTER TABLE review_events RENAME TO review_events_v18;
+        CREATE TABLE review_events (
+            review_event_id TEXT PRIMARY KEY,
+            workspace_id TEXT NOT NULL REFERENCES workspaces(workspace_id) ON DELETE CASCADE,
+            card_id TEXT NOT NULL REFERENCES cards(card_id) ON DELETE CASCADE,
+            replica_id TEXT NOT NULL,
+            client_event_id TEXT NOT NULL,
+            rating INTEGER NOT NULL CHECK (rating BETWEEN 0 AND 3),
+            reviewed_at_client TEXT NOT NULL,
+            reviewed_at_server TEXT NOT NULL,
+            UNIQUE (workspace_id, replica_id, client_event_id)
+        );
+        INSERT INTO review_events (
+            review_event_id,
+            workspace_id,
+            card_id,
+            replica_id,
+            client_event_id,
+            rating,
+            reviewed_at_client,
+            reviewed_at_server
+        )
+        SELECT
+            review_event_id,
+            workspace_id,
+            card_id,
+            replica_id,
+            client_event_id,
+            rating,
+            reviewed_at_client,
+            reviewed_at_server
+        FROM review_events_v18;
+        DROP TABLE review_events_v18;
+        CREATE INDEX IF NOT EXISTS idx_review_events_workspace_card_time
+            ON review_events(workspace_id, card_id, reviewed_at_server DESC);
+        CREATE INDEX IF NOT EXISTS idx_review_events_reviewed_at_client
+            ON review_events(reviewed_at_client);
+        DELETE FROM outbox;
+        PRAGMA legacy_alter_table = OFF;
+        PRAGMA user_version = 17;
+        """
+
+        let execResult = sqlite3_exec(connection, downgradeSQL, nil, nil, nil)
+        guard execResult == SQLITE_OK else {
+            let message = String(cString: sqlite3_errmsg(connection))
+            throw LocalStoreError.database("Failed to prepare schema v17 fixture: \(message)")
+        }
+    }
+}

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalMutationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalMutationTests.swift
@@ -47,6 +47,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
         context.store.handleProgressLocalMutation(
             now: now,
             reviewedAtClient: "2026-04-18T12:30:00.000Z",
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 
@@ -128,6 +129,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
         context.store.handleProgressLocalMutation(
             now: now,
             reviewedAtClient: reviewedAtClient,
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 
@@ -213,6 +215,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
         context.store.handleProgressLocalMutation(
             now: now,
             reviewedAtClient: reviewedAtClient,
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 
@@ -265,6 +268,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
         context.store.handleProgressLocalMutation(
             now: now,
             reviewedAtClient: "2026-04-18T12:30:00.000Z",
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 
@@ -340,6 +344,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
         context.store.handleProgressLocalMutation(
             now: now,
             reviewedAtClient: formatIsoTimestamp(date: yesterdayReviewDate),
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 
@@ -397,6 +402,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
                 hour: 12,
                 timeZoneIdentifier: requestRange.timeZone
             ),
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 
@@ -470,6 +476,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
                 hour: 12,
                 timeZoneIdentifier: requestRange.timeZone
             ),
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 
@@ -538,6 +545,7 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
         context.store.handleProgressLocalMutation(
             now: rolloverNow,
             reviewedAtClient: reviewedAtClient,
+            reviewedTimeZone: "UTC",
             rating: .good
         )
 

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalStoreTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalStoreTests.swift
@@ -160,7 +160,8 @@ final class ProgressLocalStoreTests: ProgressStoreTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+                reviewedAtClient: "2026-04-02T15:50:57.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
 
@@ -171,6 +172,7 @@ final class ProgressLocalStoreTests: ProgressStoreTestCase {
 
         XCTAssertEqual(1, pendingBeforeDelete.count)
         XCTAssertEqual("2026-04-02T15:50:57.000Z", pendingBeforeDelete.first?.reviewedAtClient)
+        XCTAssertEqual("UTC", pendingBeforeDelete.first?.reviewedTimeZone)
 
         let outboxEntries = try database.loadOutboxEntries(workspaceId: workspace.workspaceId, limit: Int.max)
         try database.deleteOutboxEntries(operationIds: outboxEntries.map(\.operationId))
@@ -233,7 +235,8 @@ final class ProgressLocalStoreTests: ProgressStoreTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: createdCard.cardId,
                 rating: .good,
-                reviewedAtClient: "2026-04-02T15:50:57.000Z"
+                reviewedAtClient: "2026-04-02T15:50:57.000Z",
+                reviewedTimeZone: "UTC"
             )
         )
 

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSeriesMergeTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSeriesMergeTests.swift
@@ -3,6 +3,36 @@ import XCTest
 @testable import Flashcards
 
 final class ProgressSeriesMergeTests: ProgressStoreTestCase {
+    func testProgressSeriesUsesReviewEventTimezoneForLocalReviewDay() throws {
+        let requestRange = ProgressRequestRange(
+            timeZone: "UTC",
+            from: "2026-04-01",
+            to: "2026-04-02"
+        )
+        let series = try makeProgressSeriesFromReviewEvents(
+            reviewEvents: [
+                ProgressReviewEventSource(
+                    reviewEventId: "review-event-1",
+                    reviewedAtClient: "2026-04-02T01:30:00.000Z",
+                    reviewedTimeZone: "America/Los_Angeles",
+                    rating: .good
+                )
+            ],
+            requestRange: requestRange
+        )
+        let reviewCountsByDate = Dictionary(uniqueKeysWithValues: series.dailyReviews.map { day in
+            (day.date, day.reviewCount)
+        })
+        let streakStatesByDate = Dictionary(uniqueKeysWithValues: series.streakDays.map { day in
+            (day.date, day.state)
+        })
+
+        XCTAssertEqual(1, reviewCountsByDate["2026-04-01"])
+        XCTAssertEqual(0, reviewCountsByDate["2026-04-02"])
+        XCTAssertEqual(.reviewed, streakStatesByDate["2026-04-01"])
+        XCTAssertEqual(.pending, streakStatesByDate["2026-04-02"])
+    }
+
     func testMergeProgressSeriesAppliesOnlyTodayLocalOverlay() throws {
         let requestRange = ProgressSeriesLoadRequest(
             apiBaseUrl: "",

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewSchedulePendingOverlayTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ReviewSchedule/ProgressReviewSchedulePendingOverlayTests.swift
@@ -671,7 +671,8 @@ final class ProgressReviewSchedulePendingOverlayTests: ProgressStoreTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: formatIsoTimestamp(date: now)
+                reviewedAtClient: formatIsoTimestamp(date: now),
+                reviewedTimeZone: "UTC"
             )
         )
         try self.moveReviewScheduleCardDueAt(
@@ -789,7 +790,8 @@ final class ProgressReviewSchedulePendingOverlayTests: ProgressStoreTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: fixture.card.cardId,
                 rating: .good,
-                reviewedAtClient: formatIsoTimestamp(date: fixture.now)
+                reviewedAtClient: formatIsoTimestamp(date: fixture.now),
+                reviewedTimeZone: "UTC"
             )
         )
         try self.moveReviewScheduleCardDueAt(

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressStoreTestCase.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressStoreTestCase.swift
@@ -49,7 +49,8 @@ class ProgressStoreTestCase: XCTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: reviewedAtClient
+                reviewedAtClient: reviewedAtClient,
+                reviewedTimeZone: "UTC"
             )
         )
     }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -71,6 +71,7 @@ func makeProgressSeriesFromReviewedAtClients(
         ProgressReviewEventSource(
             reviewEventId: "test-review-event-\(index + 1)",
             reviewedAtClient: reviewedAtClient,
+            reviewedTimeZone: nil,
             rating: .good
         )
     }

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundReconcileTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Background/ReviewBackgroundReconcileTests.swift
@@ -355,7 +355,8 @@ final class ReviewBackgroundReconcileTests: ProgressStoreTestCase {
             ),
             cardSnapshot: staleSubmittedCard,
             rating: .good,
-            reviewedAtClient: "2026-04-18T09:10:00.000Z"
+            reviewedAtClient: "2026-04-18T09:10:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         store.handleReviewSubmissionFailure(
@@ -451,7 +452,8 @@ final class ReviewBackgroundReconcileTests: ProgressStoreTestCase {
             ),
             cardSnapshot: submittedCard,
             rating: .good,
-            reviewedAtClient: "2026-04-18T09:10:00.000Z"
+            reviewedAtClient: "2026-04-18T09:10:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         store.handleReviewSubmissionFailure(
@@ -572,7 +574,8 @@ final class ReviewBackgroundReconcileTests: ProgressStoreTestCase {
             ),
             cardSnapshot: staleSubmittedCard,
             rating: .good,
-            reviewedAtClient: "2026-04-18T09:10:00.000Z"
+            reviewedAtClient: "2026-04-18T09:10:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         await store.processReviewSubmissionRequest(request: request)

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/ReviewNotificationsSupportTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Notifications/ReviewNotificationsSupportTests.swift
@@ -274,7 +274,8 @@ final class ReviewNotificationsSupportTests: XCTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: formatIsoTimestamp(date: reviewedAt)
+                reviewedAtClient: formatIsoTimestamp(date: reviewedAt),
+                reviewedTimeZone: "UTC"
             )
         )
 
@@ -337,7 +338,8 @@ final class ReviewNotificationsSupportTests: XCTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: formatIsoTimestamp(date: reviewedAt)
+                reviewedAtClient: formatIsoTimestamp(date: reviewedAt),
+                reviewedTimeZone: "UTC"
             )
         )
 
@@ -400,7 +402,8 @@ final class ReviewNotificationsSupportTests: XCTestCase {
             reviewSubmission: ReviewSubmission(
                 cardId: card.cardId,
                 rating: .good,
-                reviewedAtClient: formatIsoTimestamp(date: reviewedAt)
+                reviewedAtClient: formatIsoTimestamp(date: reviewedAt),
+                reviewedTimeZone: "UTC"
             )
         )
         _ = try database.core.execute(

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Queue/ReviewQueueStaleSubmissionContextTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Queue/ReviewQueueStaleSubmissionContextTests.swift
@@ -60,7 +60,8 @@ final class ReviewQueueStaleSubmissionContextTests: XCTestCase {
             ),
             cardSnapshot: submittedCard,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.completeReviewSubmission(
@@ -126,7 +127,8 @@ final class ReviewQueueStaleSubmissionContextTests: XCTestCase {
             ),
             cardSnapshot: submittedCard,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(
@@ -197,7 +199,8 @@ final class ReviewQueueStaleSubmissionContextTests: XCTestCase {
             ),
             cardSnapshot: submittedCard,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(
@@ -277,7 +280,8 @@ final class ReviewQueueStaleSubmissionContextTests: XCTestCase {
             ),
             cardSnapshot: submittedCard,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(
@@ -367,7 +371,8 @@ final class ReviewQueueStaleSubmissionContextTests: XCTestCase {
             ),
             cardSnapshot: submittedCard,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(

--- a/apps/ios/Flashcards/FlashcardsTests/Review/Queue/ReviewQueueSubmissionRollbackTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Review/Queue/ReviewQueueSubmissionRollbackTests.swift
@@ -108,7 +108,8 @@ final class ReviewQueueSubmissionRollbackTests: XCTestCase {
             ),
             cardSnapshot: submittedCardSnapshot,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(
@@ -194,7 +195,8 @@ final class ReviewQueueSubmissionRollbackTests: XCTestCase {
             ),
             cardSnapshot: submittedCardSnapshot,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(
@@ -260,7 +262,8 @@ final class ReviewQueueSubmissionRollbackTests: XCTestCase {
             ),
             cardSnapshot: currentCard,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(
@@ -320,7 +323,8 @@ final class ReviewQueueSubmissionRollbackTests: XCTestCase {
             ),
             cardSnapshot: currentCard,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(
@@ -389,7 +393,8 @@ final class ReviewQueueSubmissionRollbackTests: XCTestCase {
             ),
             cardSnapshot: submittedCardSnapshot,
             rating: .good,
-            reviewedAtClient: "2026-03-09T09:00:00.000Z"
+            reviewedAtClient: "2026-03-09T09:00:00.000Z",
+            reviewedTimeZone: "UTC"
         )
 
         let nextState = runtime.failReviewSubmission(


### PR DESCRIPTION
## Summary

- Add nullable `reviewed_time_zone` to the iOS local `review_events` schema with a v17-to-v18 migration.
- Capture `TimeZone.current.identifier` when iOS review submissions are created.
- Preserve optional `reviewedTimeZone` through local review history, outbox payloads, sync/review-history mapping, workspace fork/copy paths, and related tests.
- Use `event.reviewedTimeZone ?? progressTimeZone` when deriving local Progress active review dates.

## Validation

- `git --no-pager diff --check`: passed
- Generic iOS build attempted, but blocked before compilation by local Xcode destination/platform issue: no eligible `generic/platform=iOS` destination; Xcode reports `iOS 26.5 is not installed`.
- No simulator-backed tests were run, per instruction.
- Final read-only review: no P0-P4 findings; green light.
