### PR TITLE
Capture review time zones on Android

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/di/AppGraph.kt
@@ -311,7 +311,8 @@ class AppGraph(
         database = database,
         preferencesStore = cloudPreferencesStore,
         syncLocalStore = syncLocalStore,
-        localProgressCacheStore = localProgressCacheStore
+        localProgressCacheStore = localProgressCacheStore,
+        timeProvider = SystemTimeProvider
     )
     val feedbackRepository: FeedbackRepository = LocalFeedbackRepository(
         database = database,

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreForkReidentificationContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreForkReidentificationContractTest.kt
@@ -80,7 +80,8 @@ class SyncLocalStoreForkReidentificationContractTest {
             clientEventId = "client-event-1",
             rating = ReviewRating.GOOD,
             reviewedAtMillis = 6L,
-            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+            reviewedAtServerIso = "2026-03-27T19:05:00Z",
+            reviewedTimeZone = null
         )
         database.cardDao().insertCard(originalCard)
         database.tagDao().insertTags(
@@ -165,7 +166,8 @@ class SyncLocalStoreForkReidentificationContractTest {
             clientEventId = "client-event-1",
             rating = ReviewRating.GOOD,
             reviewedAtMillis = 6L,
-            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+            reviewedAtServerIso = "2026-03-27T19:05:00Z",
+            reviewedTimeZone = null
         )
         database.reviewLogDao().insertReviewLog(originalReviewLog)
         syncLocalStore.enqueueReviewEventAppend(reviewLog = originalReviewLog)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreReviewHistoryEventContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreReviewHistoryEventContractTest.kt
@@ -60,7 +60,8 @@ class SyncLocalStoreReviewHistoryEventContractTest {
                 clientEventId = "client-event-1",
                 rating = ReviewRating.GOOD,
                 reviewedAtMillis = 1_000L,
-                reviewedAtServerIso = "2026-03-27T19:05:00Z"
+                reviewedAtServerIso = "2026-03-27T19:05:00Z",
+                reviewedTimeZone = null
             )
         )
 
@@ -191,6 +192,7 @@ private fun makeRemoteReviewHistoryEvent(
         clientEventId = "client-event-$reviewEventId",
         rating = ReviewRating.GOOD.ordinal,
         reviewedAtClient = reviewedAtClient,
-        reviewedAtServer = reviewedAtClient
+        reviewedAtServer = reviewedAtClient,
+        reviewedTimeZone = null
     )
 }

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncLocalStoreWorkspaceIdentityForkContractTest.kt
@@ -90,7 +90,8 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             clientEventId = "client-event-1",
             rating = ReviewRating.GOOD,
             reviewedAtMillis = 6L,
-            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+            reviewedAtServerIso = "2026-03-27T19:05:00Z",
+            reviewedTimeZone = null
         )
         database.cardDao().insertCard(originalCard)
         database.deckDao().insertDeck(originalDeck)
@@ -257,7 +258,8 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             clientEventId = "client-event-1",
             rating = ReviewRating.GOOD,
             reviewedAtMillis = 3L,
-            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+            reviewedAtServerIso = "2026-03-27T19:05:00Z",
+            reviewedTimeZone = null
         )
         database.cardDao().insertCard(originalCard)
         database.reviewLogDao().insertReviewLog(originalReviewLog)
@@ -370,7 +372,8 @@ class SyncLocalStoreWorkspaceIdentityForkContractTest {
             clientEventId = "client-event-1",
             rating = ReviewRating.GOOD,
             reviewedAtMillis = 3L,
-            reviewedAtServerIso = "2026-03-27T19:05:00Z"
+            reviewedAtServerIso = "2026-03-27T19:05:00Z",
+            reviewedTimeZone = null
         )
         database.cardDao().insertCard(originalCard)
         database.reviewLogDao().insertReviewLog(originalReviewLog)

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/guestUpgrade/LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest.kt
@@ -116,7 +116,8 @@ class LocalCloudAccountRepositoryGuestUpgradeMergeRequiredTest {
                 clientEventId = "client-event-explicit-drop",
                 rating = ReviewRating.GOOD,
                 reviewedAtMillis = 210L,
-                reviewedAtServerIso = "2026-04-02T15:51:57.000Z"
+                reviewedAtServerIso = "2026-04-02T15:51:57.000Z",
+                reviewedTimeZone = null
             )
         )
         environment.database.outboxDao().insertOutboxEntry(

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/CloudIdentityTestEnvironment.kt
@@ -323,7 +323,8 @@ internal class CloudIdentityTestEnvironment private constructor(
                 clientEventId = "event-$workspaceId",
                 rating = ReviewRating.GOOD,
                 reviewedAtMillis = 200L,
-                reviewedAtServerIso = "2026-04-02T15:50:57.000Z"
+                reviewedAtServerIso = "2026-04-02T15:50:57.000Z",
+                reviewedTimeZone = null
             )
         )
         return cardId

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/support/LocalDatabaseTestFixtures.kt
@@ -124,7 +124,8 @@ internal fun createTestReviewRepository(runtime: LocalDatabaseTestRuntime): Revi
         localProgressCacheStore = LocalProgressCacheStore(
             database = runtime.database,
             timeProvider = SystemTimeProvider
-        )
+        ),
+        timeProvider = SystemTimeProvider
     )
 }
 

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/sync/LocalSyncOutboxContractTest.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/sync/LocalSyncOutboxContractTest.kt
@@ -182,9 +182,14 @@ class LocalSyncOutboxContractTest {
         assertEquals(1, reviewLogs.size)
         assertFalse(reviewLogs.first().replicaId.isBlank())
         assertFalse(reviewLogs.first().clientEventId.isBlank())
-        assertTrue(entries.any { entry ->
+        assertFalse(reviewLogs.first().reviewedTimeZone.isNullOrBlank())
+        val reviewEventEntry = entries.first { entry ->
             entry.entityType == "review_event" && entry.entityId == reviewLogs.first().reviewLogId
-        })
+        }
+        assertEquals(
+            reviewLogs.first().reviewedTimeZone,
+            JSONObject(reviewEventEntry.payloadJson).getString("reviewedTimeZone")
+        )
         assertTrue(entries.any { entry ->
             entry.entityType == "card" && entry.entityId == cardId
         })

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/sync/CloudSyncRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/sync/CloudSyncRemoteApi.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.transport.CloudJsonHt
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudLongOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull
+import com.flashcardsopensourceapp.data.local.cloud.wire.parseOptionalReviewTimeZone
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudBoolean
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudInt
@@ -65,7 +66,8 @@ data class RemoteReviewHistoryEvent(
     val clientEventId: String,
     val rating: Int,
     val reviewedAtClient: String,
-    val reviewedAtServer: String
+    val reviewedAtServer: String,
+    val reviewedTimeZone: String?
 )
 
 data class RemoteReviewHistoryPullResponse(
@@ -308,6 +310,13 @@ private fun parseReviewHistoryEvents(events: JSONArray): List<RemoteReviewHistor
                     reviewedAtServer = event.requireCloudString(
                         "reviewedAtServer",
                         "reviewHistoryPull.reviewEvents[$index].reviewedAtServer"
+                    ),
+                    reviewedTimeZone = parseOptionalReviewTimeZone(
+                        rawValue = event.optCloudStringOrNull(
+                            "reviewedTimeZone",
+                            "reviewHistoryPull.reviewEvents[$index].reviewedTimeZone"
+                        ),
+                        fieldPath = "reviewHistoryPull.reviewEvents[$index].reviewedTimeZone"
                     )
                 )
             )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncReviewHistoryLocalStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/sync/SyncReviewHistoryLocalStore.kt
@@ -118,7 +118,8 @@ internal class SyncReviewHistoryLocalStore(
                 clientEventId = event.clientEventId,
                 rating = ReviewRating.entries[event.rating],
                 reviewedAtMillis = parseIsoTimestamp(event.reviewedAtClient),
-                reviewedAtServerIso = event.reviewedAtServer
+                reviewedAtServerIso = event.reviewedAtServer,
+                reviewedTimeZone = event.reviewedTimeZone
             )
         }
         var newReviewLogs: List<ReviewLogEntity> = emptyList()

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/wire/SyncWirePayloads.kt
@@ -23,6 +23,8 @@ import com.flashcardsopensourceapp.data.local.model.cards.buildDeckFilterDefinit
 import com.flashcardsopensourceapp.data.local.model.scheduling.decodeSchedulerStepListJson
 import com.flashcardsopensourceapp.data.local.model.cloud.formatIsoTimestamp
 import com.flashcardsopensourceapp.data.local.model.cards.normalizeTags
+import java.time.DateTimeException
+import java.time.ZoneId
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -74,6 +76,7 @@ internal fun buildReviewEventOutboxPayloadJson(reviewLog: ReviewLogEntity): JSON
         .put("clientEventId", reviewLog.clientEventId)
         .put("rating", reviewLog.rating.ordinal)
         .put("reviewedAtClient", formatIsoTimestamp(reviewLog.reviewedAtMillis))
+        .putNullableString("reviewedTimeZone", reviewLog.reviewedTimeZone)
 }
 
 internal fun buildCardBootstrapEntryJson(
@@ -164,6 +167,7 @@ internal fun buildReviewHistoryImportEventJson(reviewLog: ReviewLogEntity): JSON
         .put("clientEventId", reviewLog.clientEventId)
         .put("rating", reviewLog.rating.ordinal)
         .put("reviewedAtClient", formatIsoTimestamp(reviewLog.reviewedAtMillis))
+        .putNullableString("reviewedTimeZone", reviewLog.reviewedTimeZone)
         .put("reviewedAtServer", reviewLog.reviewedAtServerIso)
 }
 
@@ -240,11 +244,33 @@ internal fun decodeOutboxOperation(entry: OutboxEntryEntity): SyncOperation {
                     cardId = payloadJson.requireCloudString("cardId", "outbox.reviewEvent.cardId"),
                     clientEventId = payloadJson.requireCloudString("clientEventId", "outbox.reviewEvent.clientEventId"),
                     rating = payloadJson.requireCloudInt("rating", "outbox.reviewEvent.rating"),
-                    reviewedAtClient = payloadJson.requireCloudString("reviewedAtClient", "outbox.reviewEvent.reviewedAtClient")
+                    reviewedAtClient = payloadJson.requireCloudString("reviewedAtClient", "outbox.reviewEvent.reviewedAtClient"),
+                    reviewedTimeZone = parseOptionalReviewTimeZone(
+                        rawValue = payloadJson.optCloudStringOrNull(
+                            "reviewedTimeZone",
+                            "outbox.reviewEvent.reviewedTimeZone"
+                        ),
+                        fieldPath = "outbox.reviewEvent.reviewedTimeZone"
+                    )
                 )
             )
         }
     )
+}
+
+internal fun parseOptionalReviewTimeZone(rawValue: String?, fieldPath: String): String? {
+    if (rawValue == null) {
+        return null
+    }
+    try {
+        ZoneId.of(rawValue)
+    } catch (error: DateTimeException) {
+        throw CloudContractMismatchException(
+            "Cloud contract mismatch for $fieldPath: expected a valid time zone id, got invalid string \"$rawValue\"",
+            error
+        )
+    }
+    return rawValue
 }
 
 internal fun parseSyncEntityType(rawValue: String): SyncEntityType {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -60,7 +60,7 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 22,
+    version = 23,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ReviewEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ReviewEntities.kt
@@ -32,5 +32,6 @@ data class ReviewLogEntity(
     val clientEventId: String,
     val rating: ReviewRating,
     val reviewedAtMillis: Long,
-    val reviewedAtServerIso: String
+    val reviewedAtServerIso: String,
+    val reviewedTimeZone: String?
 )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -28,7 +28,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration18To19,
         migration19To20,
         migration20To21,
-        migration21To22
+        migration21To22,
+        migration22To23
     )
 }
 
@@ -812,5 +813,11 @@ val migration21To22: Migration = object : Migration(21, 22) {
             ADD COLUMN streakFreezeEarnedUnitsPerStreakDay INTEGER NOT NULL DEFAULT 1
             """.trimIndent()
         )
+    }
+}
+
+val migration22To23: Migration = object : Migration(22, 23) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE review_logs ADD COLUMN reviewedTimeZone TEXT")
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/sync/SyncModels.kt
@@ -92,7 +92,8 @@ data class ReviewEventSyncPayload(
     val cardId: String,
     val clientEventId: String,
     val rating: Int,
-    val reviewedAtClient: String
+    val reviewedAtClient: String,
+    val reviewedTimeZone: String?
 )
 
 sealed interface SyncOperationPayload {

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/sync/CloudSyncRunner.kt
@@ -713,6 +713,7 @@ private fun buildOperationPayload(payload: SyncOperationPayload): JSONObject {
             .put("clientEventId", payload.payload.clientEventId)
             .put("rating", payload.payload.rating)
             .put("reviewedAtClient", payload.payload.reviewedAtClient)
+            .putNullableString("reviewedTimeZone", payload.payload.reviewedTimeZone)
     }
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/LocalProgressCacheStore.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/LocalProgressCacheStore.kt
@@ -19,8 +19,7 @@ class LocalProgressCacheStore(
         reviewLog: ReviewLogEntity,
         updatedAtMillis: Long
     ) {
-        val zoneId = timeProvider.currentZoneId()
-        val timeZone = zoneId.id
+        val timeZone = timeProvider.currentZoneId().id
         val previousHistoryState = database.progressLocalCacheDao().loadProgressReviewHistoryState(reviewLog.workspaceId)
         val previousHistoryVersion = previousHistoryState?.historyVersion ?: 0L
         val nextHistoryVersion = previousHistoryVersion + 1L
@@ -29,8 +28,8 @@ class LocalProgressCacheStore(
             timeZone = timeZone,
             workspaceId = reviewLog.workspaceId,
             localDate = toLocalDate(
-                reviewedAtMillis = reviewLog.reviewedAtMillis,
-                zoneId = zoneId
+                reviewLog = reviewLog,
+                fallbackTimeZone = timeZone
             ),
             countDelta = createProgressRatingCountDelta(rating = reviewLog.rating)
         )
@@ -79,7 +78,8 @@ class LocalProgressCacheStore(
             if (
                 existingReviewLog.workspaceId != reviewLog.workspaceId ||
                 existingReviewLog.reviewedAtMillis != reviewLog.reviewedAtMillis ||
-                existingReviewLog.rating != reviewLog.rating
+                existingReviewLog.rating != reviewLog.rating ||
+                existingReviewLog.reviewedTimeZone != reviewLog.reviewedTimeZone
             ) {
                 replacementWorkspaceIds.add(existingReviewLog.workspaceId)
                 replacementWorkspaceIds.add(reviewLog.workspaceId)
@@ -103,7 +103,6 @@ class LocalProgressCacheStore(
         }
 
         val timeZone = timeProvider.currentZoneId().id
-        val zoneId = timeProvider.currentZoneId()
         newReviewLogs.groupBy(ReviewLogEntity::workspaceId).forEach { (workspaceId, workspaceReviewLogs) ->
             val previousHistoryState = database.progressLocalCacheDao().loadProgressReviewHistoryState(workspaceId)
             val previousHistoryVersion = previousHistoryState?.historyVersion ?: 0L
@@ -111,8 +110,8 @@ class LocalProgressCacheStore(
 
             workspaceReviewLogs.groupBy { reviewLog ->
                 toLocalDate(
-                    reviewedAtMillis = reviewLog.reviewedAtMillis,
-                    zoneId = zoneId
+                    reviewLog = reviewLog,
+                    fallbackTimeZone = timeZone
                 )
             }.forEach { (localDate, dateReviewLogs) ->
                 incrementLocalDayCount(
@@ -199,7 +198,6 @@ class LocalProgressCacheStore(
         timeZone: String,
         updatedAtMillis: Long
     ) {
-        val zoneId = ZoneId.of(timeZone)
         val reviewLogs = database.reviewLogDao().loadReviewLogs()
         val reviewLogsByWorkspace = reviewLogs.groupBy(ReviewLogEntity::workspaceId)
         val historyStates = database.progressLocalCacheDao().loadProgressReviewHistoryStates()
@@ -216,7 +214,6 @@ class LocalProgressCacheStore(
             rebuildWorkspaceStateFromLogsInTransaction(
                 workspaceId = workspaceId,
                 reviewLogs = workspaceReviewLogs,
-                zoneId = zoneId,
                 timeZone = timeZone,
                 updatedAtMillis = updatedAtMillis,
                 nextHistoryVersion = database.progressLocalCacheDao().loadProgressReviewHistoryState(
@@ -244,7 +241,6 @@ class LocalProgressCacheStore(
         rebuildWorkspaceStateFromLogsInTransaction(
             workspaceId = workspaceId,
             reviewLogs = reviewLogs,
-            zoneId = ZoneId.of(timeZone),
             timeZone = timeZone,
             updatedAtMillis = updatedAtMillis,
             nextHistoryVersion = nextHistoryVersion,
@@ -255,7 +251,6 @@ class LocalProgressCacheStore(
     private suspend fun rebuildWorkspaceStateFromLogsInTransaction(
         workspaceId: String,
         reviewLogs: List<ReviewLogEntity>,
-        zoneId: ZoneId,
         timeZone: String,
         updatedAtMillis: Long,
         nextHistoryVersion: Long,
@@ -279,8 +274,8 @@ class LocalProgressCacheStore(
 
         val dayCounts = reviewLogs.groupBy { reviewLog ->
             toLocalDate(
-                reviewedAtMillis = reviewLog.reviewedAtMillis,
-                zoneId = zoneId
+                reviewLog = reviewLog,
+                fallbackTimeZone = timeZone
             )
         }.map { (localDate, dateReviewLogs) ->
             val countDelta = createProgressRatingCountDelta(reviewLogs = dateReviewLogs)
@@ -388,6 +383,16 @@ private fun createProgressRatingCountDelta(
         hardCount = if (rating == ReviewRating.HARD) 1 else 0,
         goodCount = if (rating == ReviewRating.GOOD) 1 else 0,
         easyCount = if (rating == ReviewRating.EASY) 1 else 0
+    )
+}
+
+private fun toLocalDate(
+    reviewLog: ReviewLogEntity,
+    fallbackTimeZone: String
+): String {
+    return toLocalDate(
+        reviewedAtMillis = reviewLog.reviewedAtMillis,
+        zoneId = ZoneId.of(reviewLog.reviewedTimeZone ?: fallbackTimeZone)
     )
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressPendingReviewInputs.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressPendingReviewInputs.kt
@@ -3,6 +3,7 @@ package com.flashcardsopensourceapp.data.local.repository.progress.inputs
 import com.flashcardsopensourceapp.data.local.database.entities.OutboxEntryEntity
 import com.flashcardsopensourceapp.data.local.model.review.ReviewRating
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRepositoryWarning
+import java.time.DateTimeException
 import java.time.Instant
 import java.time.ZoneId
 import org.json.JSONObject
@@ -39,7 +40,6 @@ internal fun createProgressPendingReviewLocalDates(
     timeZone: String
 ): List<ProgressPendingReviewLocalDate> {
     val workspaceIdSet = workspaceIds.toSet()
-    val zoneId = ZoneId.of(timeZone)
     return buildList {
         pendingReviewOutboxEntries.forEach { entry ->
             if (workspaceIdSet.contains(entry.workspaceId).not()) {
@@ -47,7 +47,7 @@ internal fun createProgressPendingReviewLocalDates(
             }
 
             val pendingReviewInput = try {
-                entry.toPendingReviewInput(zoneId = zoneId)
+                entry.toPendingReviewInput(fallbackTimeZone = timeZone)
             } catch (error: IllegalArgumentException) {
                 logProgressRepositoryWarning(
                     event = "progress_pending_overlay_entry_skipped",
@@ -90,7 +90,7 @@ private data class ProgressPendingReviewInput(
 )
 
 private fun OutboxEntryEntity.toPendingReviewInput(
-    zoneId: ZoneId
+    fallbackTimeZone: String
 ): ProgressPendingReviewInput {
     val payloadJsonObject = try {
         JSONObject(payloadJson)
@@ -120,6 +120,11 @@ private fun OutboxEntryEntity.toPendingReviewInput(
         ?: throw IllegalArgumentException(
             "Invalid rating '$ratingOrdinal' in pending review-event payload for outbox entry '$outboxEntryId'."
         )
+    val reviewedTimeZone = payloadJsonObject.getOptionalReviewEventPayloadString(
+        key = "reviewedTimeZone",
+        outboxEntryId = outboxEntryId,
+        payloadJson = payloadJson
+    )
     val reviewedAtInstant = try {
         Instant.parse(reviewedAtClient)
     } catch (error: Exception) {
@@ -129,7 +134,44 @@ private fun OutboxEntryEntity.toPendingReviewInput(
         )
     }
     return ProgressPendingReviewInput(
-        localDate = reviewedAtInstant.atZone(zoneId).toLocalDate().toString(),
+        localDate = reviewedAtInstant.atZone(
+            resolvePendingReviewZoneId(
+                reviewedTimeZone = reviewedTimeZone,
+                fallbackTimeZone = fallbackTimeZone,
+                outboxEntryId = outboxEntryId
+            )
+        ).toLocalDate().toString(),
         rating = rating
     )
+}
+
+private fun JSONObject.getOptionalReviewEventPayloadString(
+    key: String,
+    outboxEntryId: String,
+    payloadJson: String
+): String? {
+    if (has(key).not() || isNull(key)) {
+        return null
+    }
+    val value = get(key)
+    return value as? String ?: throw IllegalArgumentException(
+        "Invalid $key in pending review-event payload for outbox entry '$outboxEntryId': expected string or null. Payload: $payloadJson"
+    )
+}
+
+private fun resolvePendingReviewZoneId(
+    reviewedTimeZone: String?,
+    fallbackTimeZone: String,
+    outboxEntryId: String
+): ZoneId {
+    val timeZone = reviewedTimeZone ?: fallbackTimeZone
+    try {
+        return ZoneId.of(timeZone)
+    } catch (error: DateTimeException) {
+        val fieldName = if (reviewedTimeZone == null) "fallback timeZone" else "reviewedTimeZone"
+        throw IllegalArgumentException(
+            "Invalid $fieldName '$timeZone' in pending review-event payload for outbox entry '$outboxEntryId'.",
+            error
+        )
+    }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/review/LocalReviewRepository.kt
@@ -39,6 +39,7 @@ import com.flashcardsopensourceapp.data.local.repository.cloudsync.workspace.obs
 import com.flashcardsopensourceapp.data.local.repository.cloudsync.sync.runLocalOutboxMutationTransaction
 import com.flashcardsopensourceapp.data.local.repository.decks.toDeckSummary
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.LocalProgressCacheStore
+import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
 import com.flashcardsopensourceapp.data.local.repository.workspace.makeWorkspaceTagsSummary
 import com.flashcardsopensourceapp.data.local.repository.workspace.makeWorkspaceTagsSummaryFromStoredTagNames
 import com.flashcardsopensourceapp.data.local.repository.workspace.toWorkspaceSchedulerSettings
@@ -55,7 +56,8 @@ class LocalReviewRepository(
     private val database: AppDatabase,
     private val preferencesStore: CloudPreferencesStore,
     private val syncLocalStore: SyncLocalStore,
-    private val localProgressCacheStore: LocalProgressCacheStore
+    private val localProgressCacheStore: LocalProgressCacheStore,
+    private val timeProvider: TimeProvider
 ) : ReviewRepository {
     override fun observeReviewSession(
         selectedFilter: ReviewFilter,
@@ -422,7 +424,8 @@ class LocalReviewRepository(
                 clientEventId = UUID.randomUUID().toString(),
                 rating = rating,
                 reviewedAtMillis = reviewedAtMillis,
-                reviewedAtServerIso = formatIsoTimestamp(reviewedAtMillis)
+                reviewedAtServerIso = formatIsoTimestamp(reviewedAtMillis),
+                reviewedTimeZone = timeProvider.currentZoneId().id
             )
             database.reviewLogDao().insertReviewLog(reviewLog = reviewLog)
             localProgressCacheStore.recordReviewInTransaction(


### PR DESCRIPTION
## Summary
- Add nullable `reviewedTimeZone` storage to Android Room review logs with a 22 -> 23 migration.
- Capture `ZoneId` at Android review creation time and persist it through local review logs.
- Preserve optional `reviewedTimeZone` through local DB, outbox JSON, sync push/pull, review-history import, and Progress active-date derivation.
- Continue tolerating old local rows, outbox entries, and remote payloads without timezone.

## Validation
- `git --no-pager diff --check`: passed
- `git --no-pager diff --check -- apps/android`: passed
- Read-only review: no P0-P4 findings; green light.
- Gradle was not run because it was not approved for this task.