### PR TITLE
Add progress active-day backfill job

### DIFF
--- a/apps/backend/src/entrypoints/lambda-progress-active-days-backfill.ts
+++ b/apps/backend/src/entrypoints/lambda-progress-active-days-backfill.ts
@@ -1,0 +1,185 @@
+import type { Handler } from "aws-lambda";
+import {
+  addBackendBreadcrumb,
+  captureBackendException,
+  createBackendObservationScope,
+  initializeBackendSentry,
+  normalizeCaughtError,
+  wrapBackendHandler,
+} from "../observability/sentry";
+
+initializeBackendSentry("progress-active-days-backfill");
+
+type ProgressActiveDaysBackfillEvent = Readonly<{
+  batchSize?: unknown;
+  maxPages?: unknown;
+}>;
+
+type ProgressActiveDaysBackfillResponse = Readonly<{
+  ok: true;
+  batchSize: number;
+  maxPages: number;
+  pagesScanned: number;
+  usersScanned: number;
+  usersMaterialized: number;
+  reviewEventsMaterialized: number;
+  activeReviewDaysUpserted: number;
+  skippedUsers: number;
+  errors: number;
+  finished: boolean;
+}>;
+
+type ProgressActiveDaysBackfillRuntime = Readonly<{
+  backfillActiveReviewDays: typeof import("../progress/activeReviewDaysBackfill").backfillActiveReviewDays;
+}>;
+
+const scheduledBatchSize = 25;
+const scheduledMaxPages = 20;
+const maximumBatchSize = 100;
+const maximumMaxPages = 100;
+
+let progressActiveDaysBackfillRuntimePromise: Promise<ProgressActiveDaysBackfillRuntime> | null = null;
+
+async function createProgressActiveDaysBackfillRuntime(): Promise<ProgressActiveDaysBackfillRuntime> {
+  const { backfillActiveReviewDays } = await import("../progress/activeReviewDaysBackfill");
+  return {
+    backfillActiveReviewDays,
+  };
+}
+
+function getProgressActiveDaysBackfillRuntime(): Promise<ProgressActiveDaysBackfillRuntime> {
+  if (progressActiveDaysBackfillRuntimePromise === null) {
+    progressActiveDaysBackfillRuntimePromise = createProgressActiveDaysBackfillRuntime();
+  }
+
+  return progressActiveDaysBackfillRuntimePromise;
+}
+
+function readOptionalIntegerField(
+  event: ProgressActiveDaysBackfillEvent,
+  fieldName: "batchSize" | "maxPages",
+): number | null {
+  const value = event[fieldName];
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`${fieldName} must be an integer when provided`);
+  }
+
+  return value;
+}
+
+function resolveBoundedInteger(
+  value: number | null,
+  fallbackValue: number,
+  fieldName: "batchSize" | "maxPages",
+  maximumValue: number,
+): number {
+  const resolvedValue = value ?? fallbackValue;
+  if (resolvedValue < 1 || resolvedValue > maximumValue) {
+    throw new Error(`${fieldName} must be between 1 and ${maximumValue}`);
+  }
+
+  return resolvedValue;
+}
+
+function createBackfillRequest(event: ProgressActiveDaysBackfillEvent): Readonly<{
+  batchSize: number;
+  maxPages: number;
+}> {
+  return {
+    batchSize: resolveBoundedInteger(
+      readOptionalIntegerField(event, "batchSize"),
+      scheduledBatchSize,
+      "batchSize",
+      maximumBatchSize,
+    ),
+    maxPages: resolveBoundedInteger(
+      readOptionalIntegerField(event, "maxPages"),
+      scheduledMaxPages,
+      "maxPages",
+      maximumMaxPages,
+    ),
+  };
+}
+
+function createFailureDetails(
+  request: Readonly<{ batchSize: number; maxPages: number }> | null,
+  error: Error,
+): Readonly<{
+  batchSize: number | null;
+  maxPages: number | null;
+  message: string;
+}> {
+  return {
+    batchSize: request?.batchSize ?? null,
+    maxPages: request?.maxPages ?? null,
+    message: error.message,
+  };
+}
+
+const progressActiveDaysBackfillHandler: Handler<
+  ProgressActiveDaysBackfillEvent,
+  ProgressActiveDaysBackfillResponse
+> = async (event, context) => {
+  const observationScope = createBackendObservationScope(
+    "progress-active-days-backfill",
+    context.awsRequestId ?? null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+  let request: Readonly<{ batchSize: number; maxPages: number }> | null = null;
+  try {
+    request = createBackfillRequest(event);
+    const runtime = await getProgressActiveDaysBackfillRuntime();
+    const result = await runtime.backfillActiveReviewDays(request, observationScope);
+
+    addBackendBreadcrumb({
+      action: "progress_active_days_backfill_completed",
+      scope: observationScope,
+      details: {
+        batchSize: request.batchSize,
+        maxPages: request.maxPages,
+        pagesScanned: result.pagesScanned,
+        usersScanned: result.usersScanned,
+        usersMaterialized: result.usersMaterialized,
+        reviewEventsMaterialized: result.reviewEventsMaterialized,
+        activeReviewDaysUpserted: result.activeReviewDaysUpserted,
+        skippedUsers: result.skippedUsers,
+        errors: result.errors,
+        finished: result.finished,
+      },
+    });
+
+    return {
+      ok: true,
+      batchSize: request.batchSize,
+      maxPages: request.maxPages,
+      pagesScanned: result.pagesScanned,
+      usersScanned: result.usersScanned,
+      usersMaterialized: result.usersMaterialized,
+      reviewEventsMaterialized: result.reviewEventsMaterialized,
+      activeReviewDaysUpserted: result.activeReviewDaysUpserted,
+      skippedUsers: result.skippedUsers,
+      errors: result.errors,
+      finished: result.finished,
+    };
+  } catch (error) {
+    const normalizedError = normalizeCaughtError(error);
+    captureBackendException({
+      action: "progress_active_days_backfill_failed",
+      error: normalizedError,
+      scope: observationScope,
+      details: createFailureDetails(request, normalizedError),
+    });
+    throw error;
+  }
+};
+
+export const handler = wrapBackendHandler(progressActiveDaysBackfillHandler);

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -4,6 +4,7 @@ export type BackendService =
   | "chat-live"
   | "global-metrics-snapshot"
   | "community-leaderboard-snapshot"
+  | "progress-active-days-backfill"
   | "migration";
 
 export type BackendObservationScope = Readonly<{
@@ -534,6 +535,35 @@ export type CommunityLeaderboardSnapshotFailureDetails = Readonly<{
   message: string;
 }>;
 
+export type ProgressActiveDaysBackfillCompletedDetails = Readonly<{
+  batchSize: number;
+  maxPages: number;
+  pagesScanned: number;
+  usersScanned: number;
+  usersMaterialized: number;
+  reviewEventsMaterialized: number;
+  activeReviewDaysUpserted: number;
+  skippedUsers: number;
+  errors: number;
+  finished: boolean;
+}>;
+
+export type ProgressActiveDaysBackfillCandidateFailureDetails = Readonly<{
+  userId: string;
+  workspaceId: string;
+  progressTimeZone: string;
+  missingReviewLocalDateCount: number;
+  missingActiveReviewDayCount: number;
+  errorClass: string;
+  errorMessage: string;
+}>;
+
+export type ProgressActiveDaysBackfillFailureDetails = Readonly<{
+  batchSize: number | null;
+  maxPages: number | null;
+  message: string;
+}>;
+
 export type DatabaseTransientRetryDetails = Readonly<{
   attempt: number;
   maxAttempts: number;
@@ -611,6 +641,7 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"request_error", RequestErrorDetails>
   | EventByAction<"global_metrics_snapshot_generated", GlobalMetricsSnapshotGeneratedDetails>
   | EventByAction<"community_leaderboard_snapshot_generated", CommunityLeaderboardSnapshotGeneratedDetails>
+  | EventByAction<"progress_active_days_backfill_completed", ProgressActiveDaysBackfillCompletedDetails>
   | EventByAction<"database_transient_retry", DatabaseTransientRetryDetails>
   | EventByAction<"global_metrics_s3_retry", GlobalMetricsS3RetryDetails>
   | EventByAction<"sync_push", SyncPushDetails>
@@ -696,6 +727,10 @@ export type BackendWarningEvent =
   | (EventByAction<"chat_worker_terminal_state_persisted", ChatWorkerLifecycleDetails> & Readonly<{ message: string }>)
   | (EventByAction<"chat_worker_composer_suggestions_failed", ChatWorkerLifecycleDetails> & Readonly<{ message: string }>)
   | (EventByAction<"chat_transcription_failed", ChatTranscriptionFailureDetails> & Readonly<{ message: string }>)
+  | (EventByAction<
+    "progress_active_days_backfill_candidate_failed",
+    ProgressActiveDaysBackfillCandidateFailureDetails
+  > & Readonly<{ message: string }>)
   | EventByAction<"langfuse_telemetry_flush_failed", LangfuseTelemetryFlushFailureDetails>
   | EventByAction<"langfuse_chat_turn_export_failed", LangfuseChatTurnExportFailureDetails>
   | EventByAction<"langfuse_chat_turn_start_failed", LangfuseChatTurnStartFailureDetails>
@@ -768,6 +803,9 @@ export type BackendExceptionEvent =
   | (EventByAction<"chat_worker_failed", ChatWorkerFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"global_metrics_snapshot_failed", GlobalMetricsSnapshotFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"community_leaderboard_snapshot_failed", CommunityLeaderboardSnapshotFailureDetails> & Readonly<{ error: Error }>)
+  | (EventByAction<"progress_active_days_backfill_failed", ProgressActiveDaysBackfillFailureDetails> & Readonly<{
+    error: Error;
+  }>)
   | (EventByAction<"migration_failed", MigrationFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"chat_live_bootstrap_failed", ChatLiveBootstrapFailureDetails> & Readonly<{ error: Error }>)
   | (EventByAction<"chat_live_request_error", ChatLiveRequestDetails> & Readonly<{ error: Error }>)

--- a/apps/backend/src/progress/activeReviewDays.ts
+++ b/apps/backend/src/progress/activeReviewDays.ts
@@ -20,6 +20,11 @@ export type ReviewActiveDayWriteResult = Readonly<{
   reviewedTimeZoneSource: ReviewTimeZoneSource | null;
 }>;
 
+export type ActiveReviewDayMaterializationResult = Readonly<{
+  reviewEventsMaterialized: number;
+  activeReviewDaysUpserted: number;
+}>;
+
 type SelectedReviewTimeZone = Readonly<{
   timeZone: string;
   source: ReviewTimeZoneSource;
@@ -34,7 +39,21 @@ type UserActiveReviewLocalDateRow = Readonly<{
   review_date: string;
 }>;
 
+type ActiveReviewDayMaterializationRow = Readonly<{
+  review_events_materialized: string | number;
+  active_review_days_upserted: string | number;
+}>;
+
 const localDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseNonNegativeDatabaseInteger(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsedValue) || parsedValue < 0) {
+    throw new Error(`Database ${fieldName} must be a non-negative integer: ${value}`);
+  }
+
+  return parsedValue;
+}
 
 function parseReviewedAtClient(value: string, reviewEventId: string): Date {
   const reviewedAtClient = new Date(value);
@@ -214,9 +233,9 @@ export async function materializeMissingActiveReviewDaysForUserInExecutor(
   userId: string,
   workspaceId: string,
   timeZone: string,
-): Promise<void> {
+): Promise<ActiveReviewDayMaterializationResult> {
   const normalizedTimeZone = requireIanaTimeZone(timeZone, "timeZone");
-  await executor.query(
+  const result = await executor.query<ActiveReviewDayMaterializationRow>(
     [
       "WITH target_review_events AS (",
       "SELECT",
@@ -224,15 +243,17 @@ export async function materializeMissingActiveReviewDaysForUserInExecutor(
       "review_events.reviewed_by_user_id,",
       "review_events.reviewed_at_client,",
       "review_events.reviewed_local_date,",
-      "timezone($2, review_events.reviewed_at_client)::date AS fallback_local_date,",
-      "COALESCE(review_events.reviewed_time_zone, $2) AS event_time_zone,",
-      "COALESCE(review_events.reviewed_time_zone_source, 'user_settings') AS event_time_zone_source",
+      "COALESCE(review_events.reviewed_time_zone, $2) AS materialized_time_zone,",
+      "COALESCE(review_events.reviewed_time_zone_source, 'user_settings') AS materialized_time_zone_source,",
+      "timezone(COALESCE(review_events.reviewed_time_zone, $2), review_events.reviewed_at_client)::date",
+      "AS materialized_local_date,",
+      "active_days.local_date AS active_day_local_date",
       "FROM content.review_events AS review_events",
       "LEFT JOIN progress.user_active_review_days AS active_days",
       "ON active_days.reviewed_by_user_id = review_events.reviewed_by_user_id",
       "AND active_days.local_date = COALESCE(",
       "review_events.reviewed_local_date,",
-      "timezone($2, review_events.reviewed_at_client)::date",
+      "timezone(COALESCE(review_events.reviewed_time_zone, $2), review_events.reviewed_at_client)::date",
       ")",
       "WHERE review_events.reviewed_by_user_id = $1",
       "AND review_events.workspace_id = $3",
@@ -242,9 +263,9 @@ export async function materializeMissingActiveReviewDaysForUserInExecutor(
       ")",
       "), updated_review_events AS (",
       "UPDATE content.review_events AS review_events",
-      "SET reviewed_time_zone = $2,",
-      "reviewed_local_date = target_review_events.fallback_local_date,",
-      "reviewed_time_zone_source = 'user_settings'",
+      "SET reviewed_time_zone = target_review_events.materialized_time_zone,",
+      "reviewed_local_date = target_review_events.materialized_local_date,",
+      "reviewed_time_zone_source = target_review_events.materialized_time_zone_source",
       "FROM target_review_events",
       "WHERE review_events.review_event_id = target_review_events.review_event_id",
       "AND target_review_events.reviewed_local_date IS NULL",
@@ -252,29 +273,23 @@ export async function materializeMissingActiveReviewDaysForUserInExecutor(
       "), active_day_rows AS (",
       "SELECT",
       "target_review_events.reviewed_by_user_id,",
-      "COALESCE(target_review_events.reviewed_local_date, target_review_events.fallback_local_date) AS local_date,",
+      "COALESCE(target_review_events.reviewed_local_date, target_review_events.materialized_local_date) AS local_date,",
       "COUNT(*)::int AS review_count,",
       "MIN(target_review_events.reviewed_at_client) AS first_reviewed_at_client,",
       "MAX(target_review_events.reviewed_at_client) AS last_reviewed_at_client,",
       "(ARRAY_AGG(",
-      "CASE",
-      "WHEN target_review_events.reviewed_local_date IS NULL THEN $2",
-      "ELSE target_review_events.event_time_zone",
-      "END",
+      "target_review_events.materialized_time_zone",
       "ORDER BY target_review_events.reviewed_at_client ASC, target_review_events.review_event_id ASC",
       "))[1] AS time_zone,",
       "(ARRAY_AGG(",
-      "CASE",
-      "WHEN target_review_events.reviewed_local_date IS NULL THEN 'user_settings'",
-      "ELSE target_review_events.event_time_zone_source",
-      "END",
+      "target_review_events.materialized_time_zone_source",
       "ORDER BY target_review_events.reviewed_at_client ASC, target_review_events.review_event_id ASC",
       "))[1] AS time_zone_source",
       "FROM target_review_events",
       "GROUP BY",
       "target_review_events.reviewed_by_user_id,",
-      "COALESCE(target_review_events.reviewed_local_date, target_review_events.fallback_local_date)",
-      ")",
+      "COALESCE(target_review_events.reviewed_local_date, target_review_events.materialized_local_date)",
+      "), upserted_active_days AS (",
       "INSERT INTO progress.user_active_review_days",
       "(",
       "reviewed_by_user_id, local_date, review_count, first_reviewed_at_client,",
@@ -303,9 +318,30 @@ export async function materializeMissingActiveReviewDaysForUserInExecutor(
       "ELSE progress.user_active_review_days.time_zone_source",
       "END,",
       "updated_at = now()",
+      "RETURNING reviewed_by_user_id, local_date",
+      ")",
+      "SELECT",
+      "(SELECT COUNT(*)::int FROM updated_review_events) AS review_events_materialized,",
+      "(SELECT COUNT(*)::int FROM upserted_active_days) AS active_review_days_upserted",
     ].join(" "),
     [userId, normalizedTimeZone, workspaceId],
   );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    throw new Error(`Active review day materialization did not return counters for userId=${userId}, workspaceId=${workspaceId}`);
+  }
+
+  return {
+    reviewEventsMaterialized: parseNonNegativeDatabaseInteger(
+      row.review_events_materialized,
+      "review_events_materialized",
+    ),
+    activeReviewDaysUpserted: parseNonNegativeDatabaseInteger(
+      row.active_review_days_upserted,
+      "active_review_days_upserted",
+    ),
+  };
 }
 
 export async function loadUserActiveReviewLocalDatesInExecutor(

--- a/apps/backend/src/progress/activeReviewDaysBackfill.test.ts
+++ b/apps/backend/src/progress/activeReviewDaysBackfill.test.ts
@@ -1,0 +1,425 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../database";
+import { createBackendObservationScope } from "../observability/sentry";
+import {
+  backfillActiveReviewDaysWithDependencies,
+  loadActiveReviewDaysBackfillCandidatePageInExecutor,
+  loadActiveReviewDaysBackfillCursorInExecutor,
+  saveActiveReviewDaysBackfillCursorInExecutor,
+  type ActiveReviewDaysBackfillCandidatePage,
+  type ActiveReviewDaysBackfillCursor,
+} from "./activeReviewDaysBackfill";
+
+type RecordedQuery = Readonly<{
+  text: string;
+  params: ReadonlyArray<SqlValue>;
+}>;
+
+type CandidatePageRow = pg.QueryResultRow & Readonly<{
+  user_id: string;
+  workspace_id: string;
+  progress_time_zone: string;
+  missing_review_local_date_count: string | number;
+  missing_active_review_day_count: string | number;
+}>;
+
+type CandidateKeyRow = pg.QueryResultRow & Readonly<{
+  user_id: string;
+  workspace_id: string;
+  progress_time_zone: string;
+}>;
+
+type CursorRow = pg.QueryResultRow & Readonly<{
+  cursor_user_id: string | null;
+  cursor_workspace_id: string | null;
+}>;
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    rows: [...rows],
+    fields: [],
+  };
+}
+
+function createRowsExecutor(
+  rows: ReadonlyArray<pg.QueryResultRow>,
+): Readonly<{
+  executor: DatabaseExecutor;
+  recordedQueries: ReadonlyArray<RecordedQuery>;
+}> {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+      return createQueryResult(rows) as unknown as pg.QueryResult<Row>;
+    },
+  };
+
+  return {
+    executor,
+    recordedQueries,
+  };
+}
+
+function createCandidatePageExecutor(
+  candidateKeyRows: ReadonlyArray<CandidateKeyRow>,
+  candidateRows: ReadonlyArray<CandidatePageRow>,
+): Readonly<{
+  executor: DatabaseExecutor;
+  recordedQueries: ReadonlyArray<RecordedQuery>;
+}> {
+  const recordedQueries: Array<RecordedQuery> = [];
+  const executor: DatabaseExecutor = {
+    async query<Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+      if (text.includes("WITH candidate_keys")) {
+        return createQueryResult(candidateRows) as unknown as pg.QueryResult<Row>;
+      }
+
+      return createQueryResult(candidateKeyRows) as unknown as pg.QueryResult<Row>;
+    },
+  };
+
+  return {
+    executor,
+    recordedQueries,
+  };
+}
+
+function createCandidatePage(
+  candidateKeyCount: number,
+  nextCursor: ActiveReviewDaysBackfillCursor,
+  scannedUserIds: ReadonlyArray<string>,
+): ActiveReviewDaysBackfillCandidatePage {
+  return {
+    candidates: [],
+    nextCursor,
+    candidateKeyCount,
+    scannedUserIds,
+  };
+}
+
+function createTestObservationScope() {
+  return createBackendObservationScope(
+    "progress-active-days-backfill",
+    "request-1",
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+}
+
+test("loadActiveReviewDaysBackfillCursorInExecutor returns the stored cursor", async () => {
+  const { executor, recordedQueries } = createRowsExecutor([
+    {
+      cursor_user_id: "user-2",
+      cursor_workspace_id: "00000000-0000-4000-8000-000000000003",
+    } satisfies CursorRow,
+  ]);
+
+  const cursor = await loadActiveReviewDaysBackfillCursorInExecutor(executor);
+
+  assert.deepEqual(cursor, {
+    userId: "user-2",
+    workspaceId: "00000000-0000-4000-8000-000000000003",
+  });
+  assert.equal(recordedQueries.length, 1);
+  assert.match(recordedQueries[0]?.text ?? "", /FROM progress\.active_review_days_backfill_state/);
+  assert.deepEqual(recordedQueries[0]?.params, ["progress_active_days_backfill"]);
+});
+
+test("loadActiveReviewDaysBackfillCursorInExecutor returns null for missing or reset state", async () => {
+  const missingState = createRowsExecutor([]);
+  const missingCursor = await loadActiveReviewDaysBackfillCursorInExecutor(missingState.executor);
+  assert.equal(missingCursor, null);
+
+  const resetState = createRowsExecutor([
+    {
+      cursor_user_id: null,
+      cursor_workspace_id: null,
+    } satisfies CursorRow,
+  ]);
+  const resetCursor = await loadActiveReviewDaysBackfillCursorInExecutor(resetState.executor);
+  assert.equal(resetCursor, null);
+});
+
+test("saveActiveReviewDaysBackfillCursorInExecutor upserts and resets durable cursor state", async () => {
+  const { executor, recordedQueries } = createRowsExecutor([]);
+
+  await saveActiveReviewDaysBackfillCursorInExecutor(executor, {
+    userId: "user-4",
+    workspaceId: "00000000-0000-4000-8000-000000000004",
+  });
+  await saveActiveReviewDaysBackfillCursorInExecutor(executor, null);
+
+  assert.equal(recordedQueries.length, 2);
+  assert.match(recordedQueries[0]?.text ?? "", /INSERT INTO progress\.active_review_days_backfill_state AS state/);
+  assert.match(recordedQueries[0]?.text ?? "", /ON CONFLICT \(job_name\)/);
+  assert.deepEqual(recordedQueries[0]?.params, [
+    "progress_active_days_backfill",
+    "user-4",
+    "00000000-0000-4000-8000-000000000004",
+  ]);
+  assert.deepEqual(recordedQueries[1]?.params, [
+    "progress_active_days_backfill",
+    null,
+    null,
+  ]);
+});
+
+test("loadActiveReviewDaysBackfillCandidatePageInExecutor selects known-timezone users with active-day gaps", async () => {
+  const { executor, recordedQueries } = createCandidatePageExecutor(
+    [
+      {
+        user_id: "user-1",
+        workspace_id: "00000000-0000-4000-8000-000000000001",
+        progress_time_zone: "Europe/Madrid",
+      },
+      {
+        user_id: "user-2",
+        workspace_id: "00000000-0000-4000-8000-000000000003",
+        progress_time_zone: "America/Los_Angeles",
+      },
+    ],
+    [
+      {
+        user_id: "user-1",
+        workspace_id: "00000000-0000-4000-8000-000000000001",
+        progress_time_zone: "Europe/Madrid",
+        missing_review_local_date_count: "2",
+        missing_active_review_day_count: 1,
+      },
+      {
+        user_id: "user-2",
+        workspace_id: "00000000-0000-4000-8000-000000000003",
+        progress_time_zone: "America/Los_Angeles",
+        missing_review_local_date_count: 0,
+        missing_active_review_day_count: "3",
+      },
+    ],
+  );
+
+  const page = await loadActiveReviewDaysBackfillCandidatePageInExecutor(executor, {
+    cursor: null,
+    batchSize: 25,
+  });
+
+  assert.deepEqual(page, {
+    candidates: [
+      {
+        userId: "user-1",
+        workspaceId: "00000000-0000-4000-8000-000000000001",
+        progressTimeZone: "Europe/Madrid",
+        missingReviewLocalDateCount: 2,
+        missingActiveReviewDayCount: 1,
+      },
+      {
+        userId: "user-2",
+        workspaceId: "00000000-0000-4000-8000-000000000003",
+        progressTimeZone: "America/Los_Angeles",
+        missingReviewLocalDateCount: 0,
+        missingActiveReviewDayCount: 3,
+      },
+    ],
+    nextCursor: {
+      userId: "user-2",
+      workspaceId: "00000000-0000-4000-8000-000000000003",
+    },
+    candidateKeyCount: 2,
+    scannedUserIds: ["user-1", "user-2"],
+  });
+
+  assert.equal(recordedQueries.length, 2);
+  const keyPageQuery = recordedQueries[0];
+  const gapQuery = recordedQueries[1];
+  if (keyPageQuery === undefined || gapQuery === undefined) {
+    assert.fail("Expected candidate key and gap queries to be recorded");
+  }
+  assert.match(keyPageQuery.text, /user_settings\.progress_time_zone IS NOT NULL/);
+  assert.doesNotMatch(keyPageQuery.text, /LEFT JOIN progress\.user_active_review_days AS active_days/);
+  assert.match(keyPageQuery.text, /\$1::text IS NULL/);
+  assert.match(
+    keyPageQuery.text,
+    /\(review_events\.reviewed_by_user_id, review_events\.workspace_id\) > \(\$1::text, \$2::uuid\)/,
+  );
+  assert.match(
+    keyPageQuery.text,
+    /GROUP BY review_events\.reviewed_by_user_id, review_events\.workspace_id, user_settings\.progress_time_zone/,
+  );
+  assert.match(keyPageQuery.text, /ORDER BY review_events\.reviewed_by_user_id ASC, review_events\.workspace_id ASC/);
+  assert.match(keyPageQuery.text, /LIMIT \$3/);
+  assert.deepEqual(keyPageQuery.params, [null, null, 25]);
+
+  assert.match(gapQuery.text, /WITH candidate_keys\(user_id, workspace_id, progress_time_zone\) AS \(VALUES/);
+  assert.match(gapQuery.text, /INNER JOIN content\.review_events AS review_events/);
+  assert.match(gapQuery.text, /review_events\.reviewed_by_user_id = candidate_keys\.user_id/);
+  assert.match(gapQuery.text, /review_events\.workspace_id = candidate_keys\.workspace_id/);
+  assert.match(gapQuery.text, /LEFT JOIN progress\.user_active_review_days AS active_days/);
+  assert.match(gapQuery.text, /reviewed_local_date IS NULL OR active_day_local_date IS NULL/);
+  assert.doesNotMatch(gapQuery.text, /LIMIT \$3/);
+  assert.deepEqual(gapQuery.params, [
+    "user-1",
+    "00000000-0000-4000-8000-000000000001",
+    "Europe/Madrid",
+    "user-2",
+    "00000000-0000-4000-8000-000000000003",
+    "America/Los_Angeles",
+  ]);
+});
+
+test("loadActiveReviewDaysBackfillCandidatePageInExecutor applies the keyset cursor", async () => {
+  const { executor, recordedQueries } = createCandidatePageExecutor([], []);
+
+  const page = await loadActiveReviewDaysBackfillCandidatePageInExecutor(executor, {
+    cursor: {
+      userId: "user-2",
+      workspaceId: "00000000-0000-4000-8000-000000000003",
+    },
+    batchSize: 10,
+  });
+
+  assert.deepEqual(page, {
+    candidates: [],
+    nextCursor: null,
+    candidateKeyCount: 0,
+    scannedUserIds: [],
+  });
+  assert.equal(recordedQueries.length, 1);
+  assert.deepEqual(recordedQueries[0]?.params, ["user-2", "00000000-0000-4000-8000-000000000003", 10]);
+});
+
+test("loadActiveReviewDaysBackfillCandidatePageInExecutor advances past key pages with no gaps", async () => {
+  const { executor, recordedQueries } = createCandidatePageExecutor(
+    [
+      {
+        user_id: "user-3",
+        workspace_id: "00000000-0000-4000-8000-000000000004",
+        progress_time_zone: "Europe/London",
+      },
+    ],
+    [],
+  );
+
+  const page = await loadActiveReviewDaysBackfillCandidatePageInExecutor(executor, {
+    cursor: null,
+    batchSize: 25,
+  });
+
+  assert.deepEqual(page, {
+    candidates: [],
+    nextCursor: {
+      userId: "user-3",
+      workspaceId: "00000000-0000-4000-8000-000000000004",
+    },
+    candidateKeyCount: 1,
+    scannedUserIds: ["user-3"],
+  });
+  assert.equal(recordedQueries.length, 2);
+});
+
+test("backfillActiveReviewDaysWithDependencies resumes from stored cursor and advances after a full page", async () => {
+  const observationScope = createTestObservationScope();
+  const savedCursors: Array<ActiveReviewDaysBackfillCursor> = [];
+  const loadedPageCursors: Array<ActiveReviewDaysBackfillCursor> = [];
+  const page = createCandidatePage(
+    1,
+    {
+      userId: "user-3",
+      workspaceId: "00000000-0000-4000-8000-000000000003",
+    },
+    ["user-3"],
+  );
+
+  const result = await backfillActiveReviewDaysWithDependencies(
+    {
+      batchSize: 1,
+      maxPages: 1,
+    },
+    observationScope,
+    {
+      async loadCursor(): Promise<ActiveReviewDaysBackfillCursor> {
+        return {
+          userId: "user-2",
+          workspaceId: "00000000-0000-4000-8000-000000000002",
+        };
+      },
+      async saveCursor(cursor: ActiveReviewDaysBackfillCursor): Promise<void> {
+        savedCursors.push(cursor);
+      },
+      async loadCandidatePage(cursor: ActiveReviewDaysBackfillCursor): Promise<ActiveReviewDaysBackfillCandidatePage> {
+        loadedPageCursors.push(cursor);
+        return page;
+      },
+      async materializeCandidate(): Promise<Readonly<{ reviewEventsMaterialized: number; activeReviewDaysUpserted: number }>> {
+        return {
+          reviewEventsMaterialized: 0,
+          activeReviewDaysUpserted: 0,
+        };
+      },
+    },
+  );
+
+  assert.equal(result.finished, false);
+  assert.equal(result.pagesScanned, 1);
+  assert.deepEqual(loadedPageCursors, [
+    {
+      userId: "user-2",
+      workspaceId: "00000000-0000-4000-8000-000000000002",
+    },
+  ]);
+  assert.deepEqual(savedCursors, [
+    {
+      userId: "user-3",
+      workspaceId: "00000000-0000-4000-8000-000000000003",
+    },
+  ]);
+});
+
+test("backfillActiveReviewDaysWithDependencies resets stored cursor when a pass reaches the end", async () => {
+  const observationScope = createTestObservationScope();
+  const savedCursors: Array<ActiveReviewDaysBackfillCursor> = [];
+
+  const result = await backfillActiveReviewDaysWithDependencies(
+    {
+      batchSize: 25,
+      maxPages: 5,
+    },
+    observationScope,
+    {
+      async loadCursor(): Promise<ActiveReviewDaysBackfillCursor> {
+        return {
+          userId: "user-9",
+          workspaceId: "00000000-0000-4000-8000-000000000009",
+        };
+      },
+      async saveCursor(cursor: ActiveReviewDaysBackfillCursor): Promise<void> {
+        savedCursors.push(cursor);
+      },
+      async loadCandidatePage(): Promise<ActiveReviewDaysBackfillCandidatePage> {
+        return createCandidatePage(0, null, []);
+      },
+      async materializeCandidate(): Promise<Readonly<{ reviewEventsMaterialized: number; activeReviewDaysUpserted: number }>> {
+        assert.fail("No candidates should be materialized after an empty key page");
+      },
+    },
+  );
+
+  assert.equal(result.finished, true);
+  assert.equal(result.pagesScanned, 1);
+  assert.deepEqual(savedCursors, [null]);
+});

--- a/apps/backend/src/progress/activeReviewDaysBackfill.ts
+++ b/apps/backend/src/progress/activeReviewDaysBackfill.ts
@@ -1,0 +1,588 @@
+import type pg from "pg";
+import {
+  applyWorkspaceDatabaseScopeInExecutor,
+  type DatabaseExecutor,
+  type SqlValue,
+} from "../database";
+import { withTransientDatabaseRetry } from "../database/transient";
+import { unsafeRepeatableReadTransaction, unsafeTransaction } from "../database/unsafe";
+import { withReportingReadOnlyTransaction } from "../admin/reportingDb";
+import {
+  captureBackendWarning,
+  normalizeCaughtError,
+  type BackendObservationScope,
+} from "../observability/sentry";
+import {
+  materializeMissingActiveReviewDaysForUserInExecutor,
+  type ActiveReviewDayMaterializationResult,
+} from "./activeReviewDays";
+
+export type ActiveReviewDaysBackfillCursor = Readonly<{
+  userId: string;
+  workspaceId: string;
+}> | null;
+
+export type ActiveReviewDaysBackfillCandidate = Readonly<{
+  userId: string;
+  workspaceId: string;
+  progressTimeZone: string;
+  missingReviewLocalDateCount: number;
+  missingActiveReviewDayCount: number;
+}>;
+
+export type ActiveReviewDaysBackfillCandidatePageInput = Readonly<{
+  cursor: ActiveReviewDaysBackfillCursor;
+  batchSize: number;
+}>;
+
+export type ActiveReviewDaysBackfillCandidatePage = Readonly<{
+  candidates: ReadonlyArray<ActiveReviewDaysBackfillCandidate>;
+  nextCursor: ActiveReviewDaysBackfillCursor;
+  candidateKeyCount: number;
+  scannedUserIds: ReadonlyArray<string>;
+}>;
+
+export type ActiveReviewDaysBackfillRequest = Readonly<{
+  batchSize: number;
+  maxPages: number;
+}>;
+
+export type ActiveReviewDaysBackfillResult = Readonly<{
+  pagesScanned: number;
+  usersScanned: number;
+  usersMaterialized: number;
+  reviewEventsMaterialized: number;
+  activeReviewDaysUpserted: number;
+  skippedUsers: number;
+  errors: number;
+  finished: boolean;
+}>;
+
+export type ActiveReviewDaysBackfillDependencies = Readonly<{
+  loadCursor: (observationScope: BackendObservationScope) => Promise<ActiveReviewDaysBackfillCursor>;
+  saveCursor: (
+    cursor: ActiveReviewDaysBackfillCursor,
+    observationScope: BackendObservationScope,
+  ) => Promise<void>;
+  loadCandidatePage: (
+    cursor: ActiveReviewDaysBackfillCursor,
+    batchSize: number,
+    observationScope: BackendObservationScope,
+  ) => Promise<ActiveReviewDaysBackfillCandidatePage>;
+  materializeCandidate: (
+    candidate: ActiveReviewDaysBackfillCandidate,
+    observationScope: BackendObservationScope,
+  ) => Promise<ActiveReviewDayMaterializationResult>;
+}>;
+
+type ActiveReviewDaysBackfillCandidateRow = Readonly<{
+  user_id: string;
+  workspace_id: string;
+  progress_time_zone: string;
+  missing_review_local_date_count: string | number;
+  missing_active_review_day_count: string | number;
+}>;
+
+type ActiveReviewDaysBackfillCandidateKey = Readonly<{
+  userId: string;
+  workspaceId: string;
+  progressTimeZone: string;
+}>;
+
+type ActiveReviewDaysBackfillCandidateKeyRow = Readonly<{
+  user_id: string;
+  workspace_id: string;
+  progress_time_zone: string;
+}>;
+
+type ActiveReviewDaysBackfillCursorRow = Readonly<{
+  cursor_user_id: string | null;
+  cursor_workspace_id: string | null;
+}>;
+
+type ReportingQueryExecutor = Readonly<{
+  query<Row extends pg.QueryResultRow>(
+    text: string,
+    params: ReadonlyArray<SqlValue>,
+  ): Promise<pg.QueryResult<Row>>;
+}>;
+
+const minimumBatchSize = 1;
+const maximumBatchSize = 100;
+const minimumMaxPages = 1;
+const maximumMaxPages = 100;
+const activeReviewDaysBackfillStateJobName = "progress_active_days_backfill";
+
+function parseNonNegativeDatabaseInteger(value: string | number, fieldName: string): number {
+  const parsedValue = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsedValue) || parsedValue < 0) {
+    throw new Error(`Database ${fieldName} must be a non-negative integer: ${value}`);
+  }
+
+  return parsedValue;
+}
+
+function requireIntegerInRange(
+  value: number,
+  fieldName: string,
+  minimumValue: number,
+  maximumValue: number,
+): number {
+  if (!Number.isInteger(value) || value < minimumValue || value > maximumValue) {
+    throw new Error(`${fieldName} must be an integer between ${minimumValue} and ${maximumValue}`);
+  }
+
+  return value;
+}
+
+function validateBackfillRequest(request: ActiveReviewDaysBackfillRequest): ActiveReviewDaysBackfillRequest {
+  return {
+    batchSize: requireIntegerInRange(request.batchSize, "batchSize", minimumBatchSize, maximumBatchSize),
+    maxPages: requireIntegerInRange(request.maxPages, "maxPages", minimumMaxPages, maximumMaxPages),
+  };
+}
+
+function mapCandidateRow(row: ActiveReviewDaysBackfillCandidateRow): ActiveReviewDaysBackfillCandidate {
+  return {
+    userId: row.user_id,
+    workspaceId: row.workspace_id,
+    progressTimeZone: row.progress_time_zone,
+    missingReviewLocalDateCount: parseNonNegativeDatabaseInteger(
+      row.missing_review_local_date_count,
+      "missing_review_local_date_count",
+    ),
+    missingActiveReviewDayCount: parseNonNegativeDatabaseInteger(
+      row.missing_active_review_day_count,
+      "missing_active_review_day_count",
+    ),
+  };
+}
+
+function mapCandidateKeyRow(row: ActiveReviewDaysBackfillCandidateKeyRow): ActiveReviewDaysBackfillCandidateKey {
+  return {
+    userId: row.user_id,
+    workspaceId: row.workspace_id,
+    progressTimeZone: row.progress_time_zone,
+  };
+}
+
+function createNextCursorFromCandidateKeys(
+  candidateKeys: ReadonlyArray<ActiveReviewDaysBackfillCandidateKey>,
+): ActiveReviewDaysBackfillCursor {
+  const lastCandidateKey = candidateKeys.at(-1);
+  if (lastCandidateKey === undefined) {
+    return null;
+  }
+
+  return {
+    userId: lastCandidateKey.userId,
+    workspaceId: lastCandidateKey.workspaceId,
+  };
+}
+
+function mapCursorRow(row: ActiveReviewDaysBackfillCursorRow): ActiveReviewDaysBackfillCursor {
+  if (row.cursor_user_id === null && row.cursor_workspace_id === null) {
+    return null;
+  }
+
+  if (row.cursor_user_id === null || row.cursor_workspace_id === null) {
+    throw new Error("Progress active-day backfill cursor state must store both cursor_user_id and cursor_workspace_id");
+  }
+
+  return {
+    userId: row.cursor_user_id,
+    workspaceId: row.cursor_workspace_id,
+  };
+}
+
+function requireNextCursorForFullPage(
+  nextCursor: ActiveReviewDaysBackfillCursor,
+): Exclude<ActiveReviewDaysBackfillCursor, null> {
+  if (nextCursor === null) {
+    throw new Error("Progress active-day backfill full candidate key page must return a next cursor");
+  }
+
+  return nextCursor;
+}
+
+function createCandidateKeyValuesSql(candidateKeys: ReadonlyArray<ActiveReviewDaysBackfillCandidateKey>): string {
+  return candidateKeys
+    .map((_candidateKey, index) => {
+      const userIdParameterIndex = index * 3 + 1;
+      const workspaceIdParameterIndex = userIdParameterIndex + 1;
+      const progressTimeZoneParameterIndex = userIdParameterIndex + 2;
+      return `($${userIdParameterIndex}::text, $${workspaceIdParameterIndex}::uuid, $${progressTimeZoneParameterIndex}::text)`;
+    })
+    .join(", ");
+}
+
+function createCandidateKeyValuesParams(
+  candidateKeys: ReadonlyArray<ActiveReviewDaysBackfillCandidateKey>,
+): ReadonlyArray<SqlValue> {
+  return candidateKeys.flatMap((candidateKey) => [
+    candidateKey.userId,
+    candidateKey.workspaceId,
+    candidateKey.progressTimeZone,
+  ]);
+}
+
+function hasMaterializedRows(result: ActiveReviewDayMaterializationResult): boolean {
+  return result.reviewEventsMaterialized > 0 || result.activeReviewDaysUpserted > 0;
+}
+
+function addMaterializationResult(
+  left: ActiveReviewDaysBackfillResult,
+  right: ActiveReviewDayMaterializationResult,
+): ActiveReviewDaysBackfillResult {
+  return {
+    ...left,
+    reviewEventsMaterialized: left.reviewEventsMaterialized + right.reviewEventsMaterialized,
+    activeReviewDaysUpserted: left.activeReviewDaysUpserted + right.activeReviewDaysUpserted,
+  };
+}
+
+export async function loadActiveReviewDaysBackfillCursorInExecutor(
+  executor: DatabaseExecutor,
+): Promise<ActiveReviewDaysBackfillCursor> {
+  const result = await executor.query<ActiveReviewDaysBackfillCursorRow>(
+    [
+      "SELECT",
+      "cursor_user_id,",
+      "cursor_workspace_id::text AS cursor_workspace_id",
+      "FROM progress.active_review_days_backfill_state",
+      "WHERE job_name = $1",
+    ].join(" "),
+    [activeReviewDaysBackfillStateJobName],
+  );
+  const row = result.rows[0];
+  if (row === undefined) {
+    return null;
+  }
+
+  return mapCursorRow(row);
+}
+
+export async function saveActiveReviewDaysBackfillCursorInExecutor(
+  executor: DatabaseExecutor,
+  cursor: ActiveReviewDaysBackfillCursor,
+): Promise<void> {
+  await executor.query(
+    [
+      "INSERT INTO progress.active_review_days_backfill_state AS state",
+      "(job_name, cursor_user_id, cursor_workspace_id)",
+      "VALUES ($1, $2, $3::uuid)",
+      "ON CONFLICT (job_name)",
+      "DO UPDATE SET",
+      "cursor_user_id = EXCLUDED.cursor_user_id,",
+      "cursor_workspace_id = EXCLUDED.cursor_workspace_id,",
+      "updated_at = now()",
+    ].join(" "),
+    [
+      activeReviewDaysBackfillStateJobName,
+      cursor?.userId ?? null,
+      cursor?.workspaceId ?? null,
+    ],
+  );
+}
+
+function createEmptyBackfillResult(): ActiveReviewDaysBackfillResult {
+  return {
+    pagesScanned: 0,
+    usersScanned: 0,
+    usersMaterialized: 0,
+    reviewEventsMaterialized: 0,
+    activeReviewDaysUpserted: 0,
+    skippedUsers: 0,
+    errors: 0,
+    finished: false,
+  };
+}
+
+function countSkippedUsers(
+  skippedUserIds: ReadonlySet<string>,
+  materializedUserIds: ReadonlySet<string>,
+): number {
+  return [...skippedUserIds].filter((userId) => !materializedUserIds.has(userId)).length;
+}
+
+function createCandidateFailureWarningDetails(
+  candidate: ActiveReviewDaysBackfillCandidate,
+  error: Error,
+): Readonly<{
+  userId: string;
+  workspaceId: string;
+  progressTimeZone: string;
+  missingReviewLocalDateCount: number;
+  missingActiveReviewDayCount: number;
+  errorClass: string;
+  errorMessage: string;
+}> {
+  return {
+    userId: candidate.userId,
+    workspaceId: candidate.workspaceId,
+    progressTimeZone: candidate.progressTimeZone,
+    missingReviewLocalDateCount: candidate.missingReviewLocalDateCount,
+    missingActiveReviewDayCount: candidate.missingActiveReviewDayCount,
+    errorClass: error.name,
+    errorMessage: error.message,
+  };
+}
+
+function recordCandidateFailure(
+  candidate: ActiveReviewDaysBackfillCandidate,
+  observationScope: BackendObservationScope,
+  error: unknown,
+): void {
+  const normalizedError = normalizeCaughtError(error);
+  captureBackendWarning({
+    action: "progress_active_days_backfill_candidate_failed",
+    message: "Progress active-day backfill failed for one candidate user/workspace.",
+    scope: observationScope,
+    details: createCandidateFailureWarningDetails(candidate, normalizedError),
+  });
+}
+
+async function materializeCandidate(
+  candidate: ActiveReviewDaysBackfillCandidate,
+  observationScope: BackendObservationScope,
+): Promise<ActiveReviewDayMaterializationResult> {
+  return withTransientDatabaseRetry(
+    () => unsafeRepeatableReadTransaction(async (executor) => {
+      await applyWorkspaceDatabaseScopeInExecutor(executor, {
+        userId: candidate.userId,
+        workspaceId: candidate.workspaceId,
+      });
+      return materializeMissingActiveReviewDaysForUserInExecutor(
+        executor,
+        candidate.userId,
+        candidate.workspaceId,
+        candidate.progressTimeZone,
+      );
+    }),
+    () => observationScope,
+  );
+}
+
+async function loadStoredCursor(
+  observationScope: BackendObservationScope,
+): Promise<ActiveReviewDaysBackfillCursor> {
+  return withTransientDatabaseRetry(
+    () => unsafeTransaction((executor) => loadActiveReviewDaysBackfillCursorInExecutor(executor)),
+    () => observationScope,
+  );
+}
+
+async function saveStoredCursor(
+  cursor: ActiveReviewDaysBackfillCursor,
+  observationScope: BackendObservationScope,
+): Promise<void> {
+  await withTransientDatabaseRetry(
+    () => unsafeTransaction((executor) => saveActiveReviewDaysBackfillCursorInExecutor(executor, cursor)),
+    () => observationScope,
+  );
+}
+
+export async function loadActiveReviewDaysBackfillCandidatePageInExecutor(
+  executor: DatabaseExecutor,
+  input: ActiveReviewDaysBackfillCandidatePageInput,
+): Promise<ActiveReviewDaysBackfillCandidatePage> {
+  const batchSize = requireIntegerInRange(input.batchSize, "batchSize", minimumBatchSize, maximumBatchSize);
+  // Users without a known Progress timezone are intentionally skipped until a
+  // Progress request records one; this job must not mass-materialize with UTC.
+  const candidateKeyResult = await executor.query<ActiveReviewDaysBackfillCandidateKeyRow>(
+    [
+      "SELECT",
+      "review_events.reviewed_by_user_id AS user_id,",
+      "review_events.workspace_id::text AS workspace_id,",
+      "user_settings.progress_time_zone",
+      "FROM content.review_events AS review_events",
+      "INNER JOIN org.user_settings AS user_settings",
+      "ON user_settings.user_id = review_events.reviewed_by_user_id",
+      "WHERE user_settings.progress_time_zone IS NOT NULL",
+      "AND review_events.reviewed_by_user_id IS NOT NULL",
+      "AND (",
+      "$1::text IS NULL",
+      "OR (review_events.reviewed_by_user_id, review_events.workspace_id) > ($1::text, $2::uuid)",
+      ")",
+      "GROUP BY review_events.reviewed_by_user_id, review_events.workspace_id, user_settings.progress_time_zone",
+      "ORDER BY review_events.reviewed_by_user_id ASC, review_events.workspace_id ASC",
+      "LIMIT $3",
+    ].join(" "),
+    [input.cursor?.userId ?? null, input.cursor?.workspaceId ?? null, batchSize],
+  );
+  const candidateKeys = candidateKeyResult.rows.map(mapCandidateKeyRow);
+  if (candidateKeys.length === 0) {
+    return {
+      candidates: [],
+      nextCursor: null,
+      candidateKeyCount: 0,
+      scannedUserIds: [],
+    };
+  }
+
+  const result = await executor.query<ActiveReviewDaysBackfillCandidateRow>(
+    [
+      `WITH candidate_keys(user_id, workspace_id, progress_time_zone) AS (VALUES ${createCandidateKeyValuesSql(candidateKeys)}),`,
+      "review_events_with_gap_state AS (",
+      "SELECT",
+      "candidate_keys.user_id,",
+      "candidate_keys.workspace_id::text AS workspace_id,",
+      "candidate_keys.progress_time_zone,",
+      "review_events.reviewed_local_date,",
+      "COALESCE(",
+      "review_events.reviewed_local_date,",
+      "timezone(COALESCE(review_events.reviewed_time_zone, candidate_keys.progress_time_zone),",
+      "review_events.reviewed_at_client)::date",
+      ") AS materialized_local_date,",
+      "active_days.local_date AS active_day_local_date",
+      "FROM candidate_keys",
+      "INNER JOIN content.review_events AS review_events",
+      "ON review_events.reviewed_by_user_id = candidate_keys.user_id",
+      "AND review_events.workspace_id = candidate_keys.workspace_id",
+      "LEFT JOIN progress.user_active_review_days AS active_days",
+      "ON active_days.reviewed_by_user_id = review_events.reviewed_by_user_id",
+      "AND active_days.local_date = COALESCE(",
+      "review_events.reviewed_local_date,",
+      "timezone(COALESCE(review_events.reviewed_time_zone, candidate_keys.progress_time_zone),",
+      "review_events.reviewed_at_client)::date",
+      ")",
+      ")",
+      "SELECT",
+      "user_id,",
+      "workspace_id,",
+      "progress_time_zone,",
+      "COUNT(*) FILTER (WHERE reviewed_local_date IS NULL)::int AS missing_review_local_date_count,",
+      "COUNT(DISTINCT materialized_local_date) FILTER (WHERE active_day_local_date IS NULL)::int",
+      "AS missing_active_review_day_count",
+      "FROM review_events_with_gap_state",
+      "WHERE reviewed_local_date IS NULL OR active_day_local_date IS NULL",
+      "GROUP BY user_id, workspace_id, progress_time_zone",
+      "ORDER BY user_id ASC, workspace_id ASC",
+    ].join(" "),
+    createCandidateKeyValuesParams(candidateKeys),
+  );
+  const candidates = result.rows.map(mapCandidateRow);
+
+  return {
+    candidates,
+    nextCursor: createNextCursorFromCandidateKeys(candidateKeys),
+    candidateKeyCount: candidateKeys.length,
+    scannedUserIds: [...new Set(candidateKeys.map((candidateKey) => candidateKey.userId))],
+  };
+}
+
+async function loadCandidatePage(
+  cursor: ActiveReviewDaysBackfillCursor,
+  batchSize: number,
+  observationScope: BackendObservationScope,
+): Promise<ActiveReviewDaysBackfillCandidatePage> {
+  return withTransientDatabaseRetry(
+    () => withReportingReadOnlyTransaction(async (client) => {
+      const executor: ReportingQueryExecutor = {
+        query<Row extends pg.QueryResultRow>(
+          text: string,
+          params: ReadonlyArray<SqlValue>,
+        ): Promise<pg.QueryResult<Row>> {
+          return client.query<Row>(text, params as Array<unknown>);
+        },
+      };
+      return loadActiveReviewDaysBackfillCandidatePageInExecutor(executor, { cursor, batchSize });
+    }),
+    () => observationScope,
+  );
+}
+
+export async function backfillActiveReviewDaysWithDependencies(
+  request: ActiveReviewDaysBackfillRequest,
+  observationScope: BackendObservationScope,
+  dependencies: ActiveReviewDaysBackfillDependencies,
+): Promise<ActiveReviewDaysBackfillResult> {
+  const validRequest = validateBackfillRequest(request);
+  let result = createEmptyBackfillResult();
+  let cursor = await dependencies.loadCursor(observationScope);
+  const scannedUserIds = new Set<string>();
+  const materializedUserIds = new Set<string>();
+  const skippedUserIds = new Set<string>();
+
+  for (let pageIndex = 0; pageIndex < validRequest.maxPages; pageIndex += 1) {
+    const page = await dependencies.loadCandidatePage(cursor, validRequest.batchSize, observationScope);
+    result = {
+      ...result,
+      pagesScanned: result.pagesScanned + 1,
+    };
+    for (const scannedUserId of page.scannedUserIds) {
+      scannedUserIds.add(scannedUserId);
+    }
+
+    if (page.candidateKeyCount === 0) {
+      await dependencies.saveCursor(null, observationScope);
+      return {
+        ...result,
+        usersScanned: scannedUserIds.size,
+        usersMaterialized: materializedUserIds.size,
+        skippedUsers: countSkippedUsers(skippedUserIds, materializedUserIds),
+        finished: true,
+      };
+    }
+
+    const candidateUserIds = new Set(page.candidates.map((candidate) => candidate.userId));
+    for (const scannedUserId of page.scannedUserIds) {
+      if (!candidateUserIds.has(scannedUserId)) {
+        skippedUserIds.add(scannedUserId);
+      }
+    }
+
+    for (const candidate of page.candidates) {
+      scannedUserIds.add(candidate.userId);
+      try {
+        const materializationResult = await dependencies.materializeCandidate(candidate, observationScope);
+        result = addMaterializationResult(result, materializationResult);
+        if (hasMaterializedRows(materializationResult)) {
+          materializedUserIds.add(candidate.userId);
+        } else {
+          skippedUserIds.add(candidate.userId);
+        }
+      } catch (error) {
+        recordCandidateFailure(candidate, observationScope, error);
+        result = {
+          ...result,
+          errors: result.errors + 1,
+        };
+      }
+    }
+
+    cursor = page.candidateKeyCount < validRequest.batchSize
+      ? null
+      : requireNextCursorForFullPage(page.nextCursor);
+    await dependencies.saveCursor(cursor, observationScope);
+    if (page.candidateKeyCount < validRequest.batchSize) {
+      return {
+        ...result,
+        usersScanned: scannedUserIds.size,
+        usersMaterialized: materializedUserIds.size,
+        skippedUsers: countSkippedUsers(skippedUserIds, materializedUserIds),
+        finished: true,
+      };
+    }
+  }
+
+  return {
+    ...result,
+    usersScanned: scannedUserIds.size,
+    usersMaterialized: materializedUserIds.size,
+    skippedUsers: countSkippedUsers(skippedUserIds, materializedUserIds),
+    finished: false,
+  };
+}
+
+export async function backfillActiveReviewDays(
+  request: ActiveReviewDaysBackfillRequest,
+  observationScope: BackendObservationScope,
+): Promise<ActiveReviewDaysBackfillResult> {
+  return backfillActiveReviewDaysWithDependencies(request, observationScope, {
+    loadCursor: loadStoredCursor,
+    saveCursor: saveStoredCursor,
+    loadCandidatePage,
+    materializeCandidate,
+  });
+}

--- a/apps/backend/src/progress/progressSummary.test.ts
+++ b/apps/backend/src/progress/progressSummary.test.ts
@@ -264,7 +264,10 @@ test("loadUserProgressSummaryInExecutor materializes and reads active review day
   if (materializationQuery === undefined) {
     assert.fail("Expected an active review day materialization query to be recorded");
   }
-  assert.match(materializationQuery.text, /timezone\(\$2, review_events\.reviewed_at_client\)::date/);
+  assert.match(
+    materializationQuery.text,
+    /timezone\(COALESCE\(review_events\.reviewed_time_zone, \$2\), review_events\.reviewed_at_client\)::date/,
+  );
   assert.match(materializationQuery.text, /WHERE review_events\.reviewed_by_user_id = \$1/);
   assert.match(materializationQuery.text, /AND review_events\.workspace_id = \$3/);
   assert.match(materializationQuery.text, /INSERT INTO progress\.user_active_review_days/);

--- a/apps/backend/src/progress/progressTestSupport.ts
+++ b/apps/backend/src/progress/progressTestSupport.ts
@@ -37,6 +37,11 @@ type WorkspaceMembershipRow = Readonly<{
   workspace_id: string;
 }>;
 
+type ActiveReviewDayMaterializationRow = Readonly<{
+  review_events_materialized: number;
+  active_review_days_upserted: number;
+}>;
+
 export type ProgressExecutorFixture = Readonly<{
   workspaceIdsByUser: Readonly<Record<string, ReadonlyArray<string>>>;
   reviewRowsByRequest: Readonly<Record<string, ReadonlyArray<DailyReviewCountRow>>>;
@@ -298,7 +303,12 @@ export function createProgressExecutor(
           throw new Error("Active review day materialization requires user scope and workspace RLS scope");
         }
 
-        return createQueryResult<QueryResultRow>([]) as pg.QueryResult<Row>;
+        return createQueryResult<ActiveReviewDayMaterializationRow>([
+          {
+            review_events_materialized: 0,
+            active_review_days_upserted: 0,
+          },
+        ]) as unknown as pg.QueryResult<Row>;
       }
 
       if (

--- a/db/migrations/0068_progress_active_review_days_reporting_readonly.sql
+++ b/db/migrations/0068_progress_active_review_days_reporting_readonly.sql
@@ -1,0 +1,18 @@
+-- Migration status: Current / additive.
+-- Introduces: reporting-read access to materialized Progress active review days.
+-- Current guidance: used by backend system jobs to find active-day materialization
+--   gaps without giving the write-capable backend runtime a global RLS bypass.
+
+GRANT USAGE ON SCHEMA progress TO reporting_readonly;
+
+GRANT SELECT (
+  reviewed_by_user_id,
+  local_date
+) ON TABLE progress.user_active_review_days TO reporting_readonly;
+
+DROP POLICY IF EXISTS user_active_review_days_reporting_readonly_select ON progress.user_active_review_days;
+CREATE POLICY user_active_review_days_reporting_readonly_select
+  ON progress.user_active_review_days
+  FOR SELECT
+  TO reporting_readonly
+  USING (true);

--- a/db/migrations/0069_progress_active_review_days_backfill_candidate_index.sql
+++ b/db/migrations/0069_progress_active_review_days_backfill_candidate_index.sql
@@ -1,0 +1,11 @@
+-- Migration status: Current / additive.
+-- Introduces: reviewer/workspace keyset support for Progress active-day backfill.
+-- Current guidance: keeps the backend active-day catch-up job paging over
+--   bounded reviewer/workspace keys instead of repeatedly grouping all review events.
+
+CREATE INDEX IF NOT EXISTS idx_review_events_reviewer_workspace
+  ON content.review_events(reviewed_by_user_id, workspace_id)
+  WHERE reviewed_by_user_id IS NOT NULL;
+
+COMMENT ON INDEX content.idx_review_events_reviewer_workspace IS
+  'Supports Progress active-day backfill candidate keyset scans by reviewer and workspace.';

--- a/db/migrations/0070_progress_active_review_days_backfill_state.sql
+++ b/db/migrations/0070_progress_active_review_days_backfill_state.sql
@@ -1,0 +1,68 @@
+-- Migration status: Current / additive.
+-- Introduces: durable cursor state for the Progress active-day backfill job.
+-- Current guidance: the hourly backend job resumes from this cursor so each
+--   invocation advances through bounded reviewer/workspace key pages.
+
+CREATE TABLE IF NOT EXISTS progress.active_review_days_backfill_state (
+  job_name            TEXT        PRIMARY KEY CHECK (job_name = 'progress_active_days_backfill'),
+  cursor_user_id      TEXT,
+  cursor_workspace_id UUID,
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (
+    (cursor_user_id IS NULL AND cursor_workspace_id IS NULL)
+    OR (cursor_user_id IS NOT NULL AND cursor_workspace_id IS NOT NULL)
+  )
+);
+
+COMMENT ON TABLE progress.active_review_days_backfill_state IS
+  'Single-row durable cursor for the backend Progress active-day backfill job.';
+COMMENT ON COLUMN progress.active_review_days_backfill_state.cursor_user_id IS
+  'Last reviewed_by_user_id scanned by the Progress active-day backfill, or NULL after a full pass completes.';
+COMMENT ON COLUMN progress.active_review_days_backfill_state.cursor_workspace_id IS
+  'Last workspace_id scanned with cursor_user_id by the Progress active-day backfill, or NULL after a full pass completes.';
+COMMENT ON COLUMN progress.active_review_days_backfill_state.updated_at IS
+  'Server timestamp when the backfill cursor was last advanced or reset.';
+
+ALTER TABLE progress.active_review_days_backfill_state ENABLE ROW LEVEL SECURITY;
+
+GRANT USAGE ON SCHEMA progress TO backend_app;
+
+GRANT SELECT (
+  job_name,
+  cursor_user_id,
+  cursor_workspace_id
+) ON TABLE progress.active_review_days_backfill_state TO backend_app;
+
+GRANT INSERT (
+  job_name,
+  cursor_user_id,
+  cursor_workspace_id
+) ON TABLE progress.active_review_days_backfill_state TO backend_app;
+
+GRANT UPDATE (
+  cursor_user_id,
+  cursor_workspace_id,
+  updated_at
+) ON TABLE progress.active_review_days_backfill_state TO backend_app;
+
+DROP POLICY IF EXISTS active_review_days_backfill_state_backend_select ON progress.active_review_days_backfill_state;
+CREATE POLICY active_review_days_backfill_state_backend_select
+  ON progress.active_review_days_backfill_state
+  FOR SELECT
+  TO backend_app
+  USING (true);
+
+DROP POLICY IF EXISTS active_review_days_backfill_state_backend_insert ON progress.active_review_days_backfill_state;
+CREATE POLICY active_review_days_backfill_state_backend_insert
+  ON progress.active_review_days_backfill_state
+  FOR INSERT
+  TO backend_app
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS active_review_days_backfill_state_backend_update ON progress.active_review_days_backfill_state;
+CREATE POLICY active_review_days_backfill_state_backend_update
+  ON progress.active_review_days_backfill_state
+  FOR UPDATE
+  TO backend_app
+  USING (true)
+  WITH CHECK (true);

--- a/infra/aws/lib/ci-cd.ts
+++ b/infra/aws/lib/ci-cd.ts
@@ -14,6 +14,7 @@ export interface CiCdProps {
   globalMetricsSnapshotFn: lambda.IFunction;
   globalMetricsSnapshotFreshnessCheckerFn: lambda.IFunction;
   communityLeaderboardSnapshotFn: lambda.IFunction;
+  progressActiveDaysBackfillFn: lambda.IFunction;
   migrationFn: lambda.IFunction;
   userPoolArn: string;
   webBucket: s3.IBucket;
@@ -133,6 +134,12 @@ export function ciCd(scope: Construct, props: CiCdProps): void {
     sid: "InvokeCommunityLeaderboardSnapshotLambda",
     actions: ["lambda:InvokeFunction"],
     resources: [props.communityLeaderboardSnapshotFn.functionArn],
+  }));
+
+  cdkDeployStatements.push(new iam.PolicyStatement({
+    sid: "InvokeProgressActiveDaysBackfillLambda",
+    actions: ["lambda:InvokeFunction"],
+    resources: [props.progressActiveDaysBackfillFn.functionArn],
   }));
 
   const deployRole = new iam.Role(scope, "GithubActionsRole", {

--- a/infra/aws/lib/monitoring.ts
+++ b/infra/aws/lib/monitoring.ts
@@ -16,8 +16,10 @@ import {
   globalMetricsSnapshotFreshnessMetricStackDimensionName,
 } from "./global-metrics";
 import { communityLeaderboardSnapshotScheduleHours } from "./community-leaderboard";
+import { progressActiveDaysBackfillScheduleHours } from "./progress-active-days-backfill";
 
 const communityLeaderboardSnapshotStaleEvaluationPeriods = 2;
+const progressActiveDaysBackfillStaleEvaluationPeriods = 2;
 
 export interface MonitoringProps {
   alertEmail: string;
@@ -32,6 +34,7 @@ export interface MonitoringProps {
   chatLiveFn: lambda.IFunction;
   globalMetricsSnapshotFn: lambda.IFunction;
   communityLeaderboardSnapshotFn: lambda.IFunction;
+  progressActiveDaysBackfillFn: lambda.IFunction;
 }
 
 export interface MonitoringResult {
@@ -239,6 +242,32 @@ export function monitoring(scope: Construct, props: MonitoringProps): Monitoring
     alarmDescription:
       "Community leaderboard snapshot Lambda has not run for two consecutive hours, " +
       "so the stored leaderboard snapshot is going stale",
+    treatMissingData: cloudwatch.TreatMissingData.BREACHING,
+  }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "ProgressActiveDaysBackfillLambdaErrorAlarm", {
+    metric: props.progressActiveDaysBackfillFn.metricErrors({
+      period: cdk.Duration.minutes(15),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    alarmDescription: "Progress active review days backfill Lambda had errors",
+    treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+  }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
+
+  new cloudwatch.Alarm(scope, "ProgressActiveDaysBackfillStaleAlarm", {
+    metric: props.progressActiveDaysBackfillFn.metricInvocations({
+      period: cdk.Duration.hours(progressActiveDaysBackfillScheduleHours),
+      statistic: "Sum",
+    }),
+    threshold: 1,
+    comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+    evaluationPeriods: progressActiveDaysBackfillStaleEvaluationPeriods,
+    datapointsToAlarm: progressActiveDaysBackfillStaleEvaluationPeriods,
+    alarmDescription:
+      "Progress active review days backfill Lambda has not run for two consecutive hours, " +
+      "so known-timezone users may keep missing active-day materialization",
     treatMissingData: cloudwatch.TreatMissingData.BREACHING,
   }).addAlarmAction(new cloudwatchActions.SnsAction(alertTopic));
 

--- a/infra/aws/lib/outputs.ts
+++ b/infra/aws/lib/outputs.ts
@@ -26,6 +26,7 @@ export interface OutputsProps {
   globalMetricsSnapshotFunction: lambda.IFunction;
   globalMetricsSnapshotFreshnessCheckerFunction: lambda.IFunction;
   communityLeaderboardSnapshotFunction: lambda.IFunction;
+  progressActiveDaysBackfillFunction: lambda.IFunction;
   globalMetricsVisible: boolean;
   userPoolId: string;
   userPoolClientId: string;
@@ -130,6 +131,11 @@ export function outputs(scope: Construct, props: OutputsProps): void {
   new cdk.CfnOutput(scope, "CommunityLeaderboardSnapshotFunctionName", {
     value: props.communityLeaderboardSnapshotFunction.functionName,
     description: "Lambda function name for community leaderboard snapshot generation",
+  });
+
+  new cdk.CfnOutput(scope, "ProgressActiveDaysBackfillFunctionName", {
+    value: props.progressActiveDaysBackfillFunction.functionName,
+    description: "Lambda function name for Progress active review days backfill",
   });
 
   new cdk.CfnOutput(scope, "GlobalMetricsVisible", {

--- a/infra/aws/lib/progress-active-days-backfill.test.ts
+++ b/infra/aws/lib/progress-active-days-backfill.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+import {
+  progressActiveDaysBackfillScheduleExpression,
+  progressActiveDaysBackfillScheduleHours,
+} from "./progress-active-days-backfill";
+
+function readLibSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("progress active days backfill is scheduled hourly", () => {
+  assert.equal(progressActiveDaysBackfillScheduleHours, 1);
+  assert.equal(progressActiveDaysBackfillScheduleExpression, "cron(15 * * * ? *)");
+});
+
+test("progress active days backfill construct creates the hourly schedule and Lambda", () => {
+  const source = readLibSource("lib/progress-active-days-backfill.ts");
+
+  assert.match(source, /new lambdaNodejs\.NodejsFunction\(scope, "ProgressActiveDaysBackfillHandler"/);
+  assert.match(
+    source,
+    /entry: resolveFromRepoRoot\("apps", "backend", "src", "entrypoints", "lambda-progress-active-days-backfill\.ts"\)/,
+  );
+  assert.match(source, /DB_SECRET_ARN: props\.backendDbSecret\.secretArn/);
+  assert.match(source, /REPORTING_DB_SECRET_ARN: props\.reportingDbSecret\.secretArn/);
+  assert.match(source, /props\.backendDbSecret\.grantRead\(backfillFunction\)/);
+  assert.match(source, /props\.reportingDbSecret\.grantRead\(backfillFunction\)/);
+  assert.match(source, /new scheduler\.CfnSchedule\(scope, "ProgressActiveDaysBackfillHourlySchedule"/);
+  assert.match(source, /scheduleExpression: progressActiveDaysBackfillScheduleExpression/);
+  assert.match(source, /new iam\.Role\(scope, "ProgressActiveDaysBackfillSchedulerRole"/);
+  assert.match(source, /actions: \["lambda:InvokeFunction"\]/);
+});
+
+test("stack wires the progress active days backfill function into monitoring, ci-cd, and outputs", () => {
+  const source = readLibSource("lib/stack.ts");
+
+  assert.match(source, /const progressActiveDaysBackfillResult = progressActiveDaysBackfill\(this, \{/);
+  assert.match(source, /backendDbSecret: dbResult\.backendDbSecret,/);
+  assert.match(source, /reportingDbSecret: dbResult\.reportingDbSecret,/);
+  assert.match(source, /progressActiveDaysBackfillFn: progressActiveDaysBackfillResult\.backfillFunction,/);
+  assert.match(source, /progressActiveDaysBackfillFunction: progressActiveDaysBackfillResult\.backfillFunction,/);
+});
+
+test("monitoring alarms cover progress active days backfill errors and staleness", () => {
+  const source = readLibSource("lib/monitoring.ts");
+
+  assert.match(source, /new cloudwatch\.Alarm\(scope, "ProgressActiveDaysBackfillLambdaErrorAlarm"/);
+  assert.match(source, /props\.progressActiveDaysBackfillFn\.metricErrors\(/);
+  assert.match(source, /new cloudwatch\.Alarm\(scope, "ProgressActiveDaysBackfillStaleAlarm"/);
+  assert.match(source, /props\.progressActiveDaysBackfillFn\.metricInvocations\(/);
+  assert.match(source, /comparisonOperator: cloudwatch\.ComparisonOperator\.LESS_THAN_THRESHOLD/);
+  assert.match(source, /treatMissingData: cloudwatch\.TreatMissingData\.BREACHING/);
+});
+
+test("ci-cd grants the release workflow permission to invoke the progress active days backfill Lambda", () => {
+  const source = readLibSource("lib/ci-cd.ts");
+
+  assert.match(source, /sid: "InvokeProgressActiveDaysBackfillLambda"/);
+  assert.match(source, /resources: \[props\.progressActiveDaysBackfillFn\.functionArn\]/);
+});

--- a/infra/aws/lib/progress-active-days-backfill.ts
+++ b/infra/aws/lib/progress-active-days-backfill.ts
@@ -1,0 +1,133 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as scheduler from "aws-cdk-lib/aws-scheduler";
+import { Construct } from "constructs";
+import { backendNodejsProjectPaths, resolveFromRepoRoot } from "./nodejs-project-paths";
+import { createSentrySourceMapUploadCommand } from "./sentry-source-maps";
+
+export interface ProgressActiveDaysBackfillProps {
+  vpc: ec2.Vpc;
+  lambdaSg: ec2.SecurityGroup;
+  db: rds.DatabaseInstance;
+  backendDbSecret: cdk.aws_secretsmanager.Secret;
+  reportingDbSecret: cdk.aws_secretsmanager.ISecret;
+  sentryDsnSecretArn: string | undefined;
+  sentryEnvironment: string | undefined;
+  sentryRelease: string | undefined;
+  sentryTracesSampleRate: string | undefined;
+}
+
+export interface ProgressActiveDaysBackfillResult {
+  backfillFunction: lambdaNodejs.NodejsFunction;
+}
+
+export const progressActiveDaysBackfillScheduleHours = 1;
+export const progressActiveDaysBackfillScheduleExpression = "cron(15 * * * ? *)";
+
+const lambdaBundling: lambdaNodejs.BundlingOptions = {
+  minify: true,
+  sourceMap: true,
+  commandHooks: {
+    beforeBundling: () => [],
+    beforeInstall: () => [],
+    afterBundling: (_inputDir: string, outputDir: string) => [
+      `curl -sfo ${outputDir}/rds-global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`,
+      createSentrySourceMapUploadCommand(outputDir),
+    ],
+  },
+};
+
+function hasConfiguredValue(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+function addOptionalSentryEnvironment(
+  scope: Construct,
+  fn: lambdaNodejs.NodejsFunction,
+  props: ProgressActiveDaysBackfillProps,
+): void {
+  if (!hasConfiguredValue(props.sentryDsnSecretArn)) {
+    return;
+  }
+  if (
+    !hasConfiguredValue(props.sentryEnvironment) ||
+    !hasConfiguredValue(props.sentryRelease) ||
+    !hasConfiguredValue(props.sentryTracesSampleRate)
+  ) {
+    throw new Error("sentryEnvironment, sentryRelease, and sentryTracesSampleRate are required when sentryDsnSecretArn is configured");
+  }
+
+  const tracesSampleRate = Number(props.sentryTracesSampleRate);
+  if (!Number.isFinite(tracesSampleRate) || tracesSampleRate < 0 || tracesSampleRate > 1) {
+    throw new Error("sentryTracesSampleRate must be a number between 0 and 1");
+  }
+
+  const secret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+    scope,
+    "ProgressActiveDaysBackfillSentryDsnSecret",
+    props.sentryDsnSecretArn,
+  );
+  secret.grantRead(fn);
+  fn.addEnvironment("SENTRY_DSN", secret.secretValue.unsafeUnwrap());
+  fn.addEnvironment("SENTRY_ENVIRONMENT", props.sentryEnvironment);
+  fn.addEnvironment("SENTRY_RELEASE", props.sentryRelease);
+  fn.addEnvironment("SENTRY_TRACES_SAMPLE_RATE", props.sentryTracesSampleRate);
+}
+
+export function progressActiveDaysBackfill(
+  scope: Construct,
+  props: ProgressActiveDaysBackfillProps,
+): ProgressActiveDaysBackfillResult {
+  const backfillFunction = new lambdaNodejs.NodejsFunction(scope, "ProgressActiveDaysBackfillHandler", {
+    entry: resolveFromRepoRoot("apps", "backend", "src", "entrypoints", "lambda-progress-active-days-backfill.ts"),
+    handler: "handler",
+    runtime: lambda.Runtime.NODEJS_24_X,
+    timeout: cdk.Duration.minutes(5),
+    memorySize: 512,
+    vpc: props.vpc,
+    vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+    securityGroups: [props.lambdaSg],
+    ...backendNodejsProjectPaths,
+    bundling: lambdaBundling,
+    environment: {
+      NODE_EXTRA_CA_CERTS: "/var/task/rds-global-bundle.pem",
+      DB_SECRET_ARN: props.backendDbSecret.secretArn,
+      REPORTING_DB_SECRET_ARN: props.reportingDbSecret.secretArn,
+      DB_HOST: props.db.dbInstanceEndpointAddress,
+      DB_NAME: "flashcards",
+    },
+  });
+
+  props.backendDbSecret.grantRead(backfillFunction);
+  props.reportingDbSecret.grantRead(backfillFunction);
+  addOptionalSentryEnvironment(scope, backfillFunction, props);
+
+  const schedulerInvokeRole = new iam.Role(scope, "ProgressActiveDaysBackfillSchedulerRole", {
+    assumedBy: new iam.ServicePrincipal("scheduler.amazonaws.com"),
+  });
+  schedulerInvokeRole.addToPolicy(new iam.PolicyStatement({
+    actions: ["lambda:InvokeFunction"],
+    resources: [backfillFunction.functionArn],
+  }));
+
+  new scheduler.CfnSchedule(scope, "ProgressActiveDaysBackfillHourlySchedule", {
+    description: "Materialize missing Progress active review days every hour",
+    flexibleTimeWindow: { mode: "OFF" },
+    scheduleExpression: progressActiveDaysBackfillScheduleExpression,
+    scheduleExpressionTimezone: "UTC",
+    state: "ENABLED",
+    target: {
+      arn: backfillFunction.functionArn,
+      input: "{}",
+      roleArn: schedulerInvokeRole.roleArn,
+    },
+  });
+
+  return {
+    backfillFunction,
+  };
+}

--- a/infra/aws/lib/stack.ts
+++ b/infra/aws/lib/stack.ts
@@ -16,6 +16,7 @@ import { authGateway } from "./gateways/auth-gateway";
 import { analyticsAccess, type AnalyticsAccessResult } from "./analytics-access";
 import { globalMetrics } from "./global-metrics";
 import { communityLeaderboard } from "./community-leaderboard";
+import { progressActiveDaysBackfill } from "./progress-active-days-backfill";
 
 function getOptionalContextValue(stack: cdk.Stack, key: string): string | undefined {
   const value = stack.node.tryGetContext(key);
@@ -167,6 +168,14 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       backendDbSecret: dbResult.backendDbSecret,
       ...sentryContext,
     });
+    const progressActiveDaysBackfillResult = progressActiveDaysBackfill(this, {
+      vpc: net.vpc,
+      lambdaSg: net.lambdaSg,
+      db: dbResult.db,
+      backendDbSecret: dbResult.backendDbSecret,
+      reportingDbSecret: dbResult.reportingDbSecret,
+      ...sentryContext,
+    });
     let analyticsAccessResult: AnalyticsAccessResult | undefined;
     if (analyticsAccessRequested) {
       if (analyticsSshPublicKeysValue === undefined) {
@@ -273,6 +282,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       chatLiveFn: api.chatLiveFn,
       globalMetricsSnapshotFn: globalMetricsResult.snapshotFunction,
       communityLeaderboardSnapshotFn: communityLeaderboardResult.snapshotFunction,
+      progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
     });
 
     ciCd(this, {
@@ -284,6 +294,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       globalMetricsSnapshotFn: globalMetricsResult.snapshotFunction,
       globalMetricsSnapshotFreshnessCheckerFn: globalMetricsResult.snapshotFreshnessCheckerFunction,
       communityLeaderboardSnapshotFn: communityLeaderboardResult.snapshotFunction,
+      progressActiveDaysBackfillFn: progressActiveDaysBackfillResult.backfillFunction,
       migrationFn,
       userPoolArn: authResult.userPool.userPoolArn,
       webBucket: web.bucket,
@@ -311,6 +322,7 @@ export class FlashcardsOpenSourceAppStack extends cdk.Stack {
       globalMetricsSnapshotFunction: globalMetricsResult.snapshotFunction,
       globalMetricsSnapshotFreshnessCheckerFunction: globalMetricsResult.snapshotFreshnessCheckerFunction,
       communityLeaderboardSnapshotFunction: communityLeaderboardResult.snapshotFunction,
+      progressActiveDaysBackfillFunction: progressActiveDaysBackfillResult.backfillFunction,
       globalMetricsVisible,
       userPoolId: authResult.userPool.userPoolId,
       userPoolClientId: authResult.userPoolClient.userPoolClientId,


### PR DESCRIPTION
## Summary
- add backend active-day backfill Lambda using existing progress materialization helper
- page known-timezone user/workspace keys with scoped gap checks and durable cursor state
- wire scheduled Lambda, monitoring, CI invoke permission, outputs, and least-privilege migrations

## Validation
- cd apps/backend && npm run lint
- cd apps/backend && npm test (472/472)
- cd infra/aws && npm test (17/17)
- git --no-pager diff --check

## Review
- final read-only review after durable cursor fix: no P0-P4 findings; green light for commit