### PR TITLE
Add backend streak leaderboard read API

### DIFF
--- a/api/src/openapi.yaml
+++ b/api/src/openapi.yaml
@@ -540,6 +540,85 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /me/progress/leaderboards/streak:
+    get:
+      tags:
+        - bootstrap
+      summary: Load the compact community streak leaderboard
+      description: >-
+        Returns the latest daily current-streak leaderboard snapshot with
+        viewer-perspective ranks, viewer-favoring tie placement, and
+        server-computed compact rows. The metric is current streak days from
+        the public daily snapshot, so public values can trail the user's live
+        personal streak. Guests receive status linked_account_required and
+        opted-out users receive participation_disabled, both without rows.
+        ApiKey authentication is rejected. Only opaque public profile ids and
+        locale-derived anonymous display names are returned by default. Rows can
+        also include a viewer-private friendDisplayName when the participant is
+        a current opted-in friend of the viewer. Internal user ids, invitation
+        ids, emails, raw active-day dates, and base sort positions are never
+        exposed.
+      security:
+        - BearerAuth: []
+        - GuestAuthorizationHeader: []
+        - SessionCookie: []
+      responses:
+        '200':
+          description: Compact current-streak leaderboard
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StreakLeaderboardResponse'
+              example:
+                status: ready
+                metric:
+                  metricVersion: streak_days_v1
+                  title: Current streak days
+                  description: Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak.
+                snapshotId: 3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4
+                snapshotGeneratedAt: '2026-06-10T12:00:05.000Z'
+                asOfUtcDate: '2026-06-10'
+                nextRefreshAfter: '2026-06-11T12:00:00.000Z'
+                participantCount: 2
+                viewer:
+                  publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
+                  displayName: You
+                  rank: 2
+                  streakDays: 3
+                rows:
+                  - kind: top
+                    publicProfileId: a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d
+                    anonymousDisplayName: Silver Bright Harbor
+                    streakDays: 5
+                    rank: 1
+                  - kind: viewer
+                    publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
+                    anonymousDisplayName: Jade Swift River
+                    streakDays: 3
+                    rank: 2
+                rankingRows:
+                  - kind: participant
+                    publicProfileId: a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d
+                    anonymousDisplayName: Silver Bright Harbor
+                    streakDays: 5
+                    rank: 1
+                  - kind: viewer
+                    publicProfileId: 5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f
+                    anonymousDisplayName: Jade Swift River
+                    streakDays: 3
+                    rank: 2
+        '403':
+          description: Forbidden authentication transport
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /agent/me:
     $ref: paths/agent_me.yaml
   /agent/workspaces:
@@ -911,6 +990,188 @@ components:
           description: Empty unless status is ready; otherwise one item per leaderboard window.
           items:
             $ref: '#/components/schemas/ProgressLeaderboardWindow'
+    StreakLeaderboardMetric:
+      type: object
+      additionalProperties: false
+      required:
+        - metricVersion
+        - title
+        - description
+      properties:
+        metricVersion:
+          type: string
+          enum:
+            - streak_days_v1
+        title:
+          type: string
+        description:
+          type: string
+          description: >-
+            Communicates that the metric is current streak days from the public
+            daily snapshot and can trail the user's live personal streak.
+    StreakLeaderboardViewer:
+      type: object
+      additionalProperties: false
+      required:
+        - publicProfileId
+        - displayName
+        - rank
+        - streakDays
+      properties:
+        publicProfileId:
+          $ref: ./components/schemas/UuidString.yaml
+        displayName:
+          type: string
+          enum:
+            - You
+          description: Always "You"; clients render the viewer row using the row kind.
+        rank:
+          type: integer
+          minimum: 1
+        streakDays:
+          type: integer
+          minimum: 0
+    StreakLeaderboardParticipantRow:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - publicProfileId
+        - anonymousDisplayName
+        - streakDays
+        - rank
+      properties:
+        kind:
+          type: string
+          enum:
+            - top
+            - neighbor
+            - viewer
+        publicProfileId:
+          $ref: ./components/schemas/UuidString.yaml
+        anonymousDisplayName:
+          type: string
+          description: Locale-aware anonymous display label derived from the public profile id.
+        friendDisplayName:
+          type: string
+          description: Viewer-private friend label shown only for current opted-in friends.
+        streakDays:
+          type: integer
+          minimum: 0
+        rank:
+          type: integer
+          minimum: 1
+    StreakLeaderboardGapRow:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          enum:
+            - gap
+    StreakLeaderboardRow:
+      oneOf:
+        - $ref: '#/components/schemas/StreakLeaderboardParticipantRow'
+        - $ref: '#/components/schemas/StreakLeaderboardGapRow'
+    StreakLeaderboardRankingRow:
+      type: object
+      additionalProperties: false
+      required:
+        - kind
+        - publicProfileId
+        - anonymousDisplayName
+        - streakDays
+        - rank
+      properties:
+        kind:
+          type: string
+          enum:
+            - participant
+            - viewer
+        publicProfileId:
+          $ref: ./components/schemas/UuidString.yaml
+        anonymousDisplayName:
+          type: string
+          description: Locale-aware anonymous display label derived from the public profile id.
+        friendDisplayName:
+          type: string
+          description: Viewer-private friend label shown only for current opted-in friends.
+        streakDays:
+          type: integer
+          minimum: 0
+        rank:
+          type: integer
+          minimum: 1
+    StreakLeaderboardReadyResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - metric
+        - snapshotId
+        - snapshotGeneratedAt
+        - asOfUtcDate
+        - nextRefreshAfter
+        - participantCount
+        - viewer
+        - rows
+        - rankingRows
+      properties:
+        status:
+          type: string
+          enum:
+            - ready
+        metric:
+          $ref: '#/components/schemas/StreakLeaderboardMetric'
+        snapshotId:
+          $ref: ./components/schemas/UuidString.yaml
+        snapshotGeneratedAt:
+          type: string
+          format: date-time
+        asOfUtcDate:
+          type: string
+          format: date
+        nextRefreshAfter:
+          type: string
+          format: date-time
+        participantCount:
+          type: integer
+          minimum: 0
+          description: >-
+            Size of the viewer-perspective ranking. Always includes the viewer
+            so the viewer rank is never greater than this value.
+        viewer:
+          $ref: '#/components/schemas/StreakLeaderboardViewer'
+        rows:
+          type: array
+          items:
+            $ref: '#/components/schemas/StreakLeaderboardRow'
+        rankingRows:
+          type: array
+          description: Full frozen viewer-perspective ranking list with contiguous ranks and no gap rows.
+          items:
+            $ref: '#/components/schemas/StreakLeaderboardRankingRow'
+    StreakLeaderboardNonReadyResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - status
+        - metric
+      properties:
+        status:
+          type: string
+          enum:
+            - linked_account_required
+            - participation_disabled
+            - snapshot_unavailable
+        metric:
+          $ref: '#/components/schemas/StreakLeaderboardMetric'
+    StreakLeaderboardResponse:
+      oneOf:
+        - $ref: '#/components/schemas/StreakLeaderboardReadyResponse'
+        - $ref: '#/components/schemas/StreakLeaderboardNonReadyResponse'
     ErrorResponse:
       type: object
       additionalProperties: true

--- a/apps/backend/src/community/leaderboard/streakLeaderboard.test.ts
+++ b/apps/backend/src/community/leaderboard/streakLeaderboard.test.ts
@@ -1,0 +1,408 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type pg from "pg";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import {
+  loadStreakLeaderboard,
+  loadStreakLeaderboardInExecutor,
+  type StreakLeaderboard,
+  type StreakLeaderboardParticipantRow,
+  type StreakLeaderboardRankingRow,
+  type StreakLeaderboardRow,
+} from "./streakLeaderboard";
+
+type QueryResultRow = pg.QueryResultRow;
+
+type SnapshotHeaderRow = Readonly<{
+  snapshot_id: string;
+  generated_at: Date;
+  as_of_utc_date: string;
+}>;
+
+type SnapshotEntryRow = Readonly<{
+  public_profile_id: string;
+  streak_days: number;
+  base_sort_position: number;
+}>;
+
+type FriendshipFixture = Readonly<{
+  friendPublicProfileId: string;
+  friendDisplayName: string;
+  leaderboardParticipationEnabled: boolean;
+}>;
+
+type ViewerProfileFixture = Readonly<{
+  publicProfileId: string;
+  leaderboardParticipationEnabled: boolean;
+}>;
+
+type StreakLeaderboardExecutorFixture = Readonly<{
+  viewerUserId: string;
+  viewerProfile: ViewerProfileFixture;
+  friendships: ReadonlyArray<FriendshipFixture>;
+  header: SnapshotHeaderRow | null;
+  entries: ReadonlyArray<SnapshotEntryRow>;
+}>;
+
+type RecordedQuery = Readonly<{ text: string; params: ReadonlyArray<SqlValue> }>;
+
+type RankingSummary = Readonly<{
+  kind: StreakLeaderboardRankingRow["kind"];
+  publicProfileId: string;
+  streakDays: number;
+  rank: number;
+}>;
+
+const VIEWER_USER_ID = "user-viewer";
+const VIEWER_PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
+const FRIEND_PROFILE_ID = "00000000-0000-4000-8000-000000000fa1";
+const SNAPSHOT_ID = "3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4";
+const SNAPSHOT_GENERATED_AT = new Date("2026-06-10T12:00:05.000Z");
+const EXPECTED_GENERATED_AT_ISO = "2026-06-10T12:00:05.000Z";
+const EXPECTED_AS_OF_DATE = "2026-06-10";
+const EXPECTED_NEXT_REFRESH_ISO = "2026-06-11T12:00:00.000Z";
+
+function createQueryResult<Row extends QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createReadyHeader(): SnapshotHeaderRow {
+  return {
+    snapshot_id: SNAPSHOT_ID,
+    generated_at: SNAPSHOT_GENERATED_AT,
+    as_of_utc_date: EXPECTED_AS_OF_DATE,
+  };
+}
+
+function includesQuery(recordedQueries: ReadonlyArray<RecordedQuery>, substring: string): boolean {
+  return recordedQueries.some((query) => query.text.includes(substring));
+}
+
+function participantRows(
+  rows: ReadonlyArray<StreakLeaderboardRow>,
+): ReadonlyArray<StreakLeaderboardParticipantRow> {
+  return rows.filter((row): row is StreakLeaderboardParticipantRow => row.kind !== "gap");
+}
+
+function summarizeRankingRows(rows: ReadonlyArray<StreakLeaderboardRankingRow>): ReadonlyArray<RankingSummary> {
+  return rows.map((row) => ({
+    kind: row.kind,
+    publicProfileId: row.publicProfileId,
+    streakDays: row.streakDays,
+    rank: row.rank,
+  }));
+}
+
+function assertReadyLeaderboard(leaderboard: StreakLeaderboard): asserts leaderboard is Extract<StreakLeaderboard, { status: "ready" }> {
+  assert.equal(leaderboard.status, "ready");
+}
+
+function assertNoFriendDisplayName(
+  row: StreakLeaderboardParticipantRow | StreakLeaderboardRankingRow,
+): void {
+  assert.equal("friendDisplayName" in row, false);
+}
+
+function createStreakLeaderboardExecutor(
+  fixture: StreakLeaderboardExecutorFixture,
+): Readonly<{ executor: DatabaseExecutor; recordedQueries: ReadonlyArray<RecordedQuery> }> {
+  const recordedQueries: Array<RecordedQuery> = [];
+  let scopedUserId: string | null = null;
+
+  const executor: DatabaseExecutor = {
+    async query<Row extends QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> {
+      recordedQueries.push({ text, params });
+
+      if (text.includes("set_config('app.user_id', $1, true)")) {
+        scopedUserId = typeof params[0] === "string" ? params[0] : null;
+        return createQueryResult<QueryResultRow>([]) as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("security.current_user_id() AS user_id")) {
+        if (scopedUserId !== fixture.viewerUserId) {
+          throw new Error("current_user_id read requires the viewer user scope");
+        }
+
+        return createQueryResult([{ user_id: fixture.viewerUserId }]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (
+        text.includes("FROM community.public_profiles")
+        && text.includes("leaderboard_participation_enabled")
+        && text.includes("WHERE user_id = $1")
+        && !text.includes("INSERT")
+      ) {
+        if (scopedUserId !== fixture.viewerUserId) {
+          throw new Error("public profile read requires the viewer user scope");
+        }
+
+        return createQueryResult([
+          {
+            public_profile_id: fixture.viewerProfile.publicProfileId,
+            leaderboard_participation_enabled: fixture.viewerProfile.leaderboardParticipationEnabled,
+          },
+        ]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("INSERT INTO community.public_profiles")) {
+        throw new Error("viewer profile was pre-seeded; no insert expected");
+      }
+
+      if (text.includes("FROM community.read_current_user_leaderboard_friend_labels() AS friend_labels")) {
+        if (scopedUserId !== fixture.viewerUserId) {
+          throw new Error("friendship read requires the viewer user scope");
+        }
+        if (params.length !== 0) {
+          throw new Error("friendship read helper does not accept request parameters");
+        }
+        if (text.includes("friend_user_id")) {
+          throw new Error("streak leaderboard friend label read must not select internal friend user ids");
+        }
+
+        return createQueryResult(
+          fixture.friendships
+            .filter((friendship) => friendship.leaderboardParticipationEnabled)
+            .map((friendship) => ({
+              friend_public_profile_id: friendship.friendPublicProfileId,
+              friend_display_name: friendship.friendDisplayName,
+            })),
+        ) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("FROM community.streak_leaderboard_snapshots")) {
+        assert.equal(params[0], "streak_days_v1");
+        assert.equal(text.includes("user_id"), false);
+        assert.equal(text.includes("email"), false);
+        return createQueryResult(fixture.header === null ? [] : [fixture.header]) as unknown as pg.QueryResult<Row>;
+      }
+
+      if (text.includes("FROM community.streak_leaderboard_snapshot_entries")) {
+        assert.equal(params[0], fixture.header?.snapshot_id);
+        for (const internalField of ["user_id", "email", "base_sort_position AS base_sort_position"]) {
+          assert.equal(text.includes(internalField), internalField === "base_sort_position AS base_sort_position");
+        }
+
+        return createQueryResult(
+          fixture.entries.map((entry) => ({
+            public_profile_id: entry.public_profile_id,
+            streak_days: entry.streak_days,
+            base_sort_position: entry.base_sort_position,
+          })),
+        ) as unknown as pg.QueryResult<Row>;
+      }
+
+      throw new Error(`Unexpected streak leaderboard read query: ${text}`);
+    },
+  };
+
+  return { executor, recordedQueries };
+}
+
+test("guest viewers receive linked_account_required with localized metric copy and no database access", async () => {
+  const leaderboard = await loadStreakLeaderboard({
+    userId: VIEWER_USER_ID,
+    transport: "guest",
+    localeHint: "ru",
+  });
+
+  assert.equal(leaderboard.status, "linked_account_required");
+  assert.equal(leaderboard.metric.metricVersion, "streak_days_v1");
+  assert.notEqual(leaderboard.metric.title, "Current streak days");
+  assert.equal("rows" in leaderboard, false);
+});
+
+test("opted-out viewers receive participation_disabled without reading snapshot data", async () => {
+  const { executor, recordedQueries } = createStreakLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: false },
+    friendships: [],
+    header: createReadyHeader(),
+    entries: [],
+  });
+
+  const leaderboard = await loadStreakLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+  );
+
+  assert.equal(leaderboard.status, "participation_disabled");
+  assert.equal("rows" in leaderboard, false);
+  assert.equal(includesQuery(recordedQueries, "community.streak_leaderboard_snapshots"), false);
+  assert.equal(includesQuery(recordedQueries, "community.streak_leaderboard_snapshot_entries"), false);
+});
+
+test("missing snapshots yield snapshot_unavailable without reading entries or friends", async () => {
+  const { executor, recordedQueries } = createStreakLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    friendships: [],
+    header: null,
+    entries: [],
+  });
+
+  const leaderboard = await loadStreakLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "bearer", localeHint: "en" },
+  );
+
+  assert.equal(leaderboard.status, "snapshot_unavailable");
+  assert.equal("rows" in leaderboard, false);
+  assert.equal(includesQuery(recordedQueries, "community.read_current_user_leaderboard_friend_labels"), false);
+  assert.equal(includesQuery(recordedQueries, "community.streak_leaderboard_snapshot_entries"), false);
+});
+
+test("equal streaks rank the viewer above non-viewers with the same value", async () => {
+  const { executor } = createStreakLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    friendships: [],
+    header: createReadyHeader(),
+    entries: [
+      { public_profile_id: "00000000-0000-4000-8000-0000000000c1", streak_days: 8, base_sort_position: 1 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000c2", streak_days: 5, base_sort_position: 2 },
+      { public_profile_id: VIEWER_PROFILE_ID, streak_days: 5, base_sort_position: 3 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000c4", streak_days: 5, base_sort_position: 4 },
+      { public_profile_id: "00000000-0000-4000-8000-0000000000c5", streak_days: 2, base_sort_position: 5 },
+    ],
+  });
+
+  const leaderboard = await loadStreakLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+  );
+
+  assertReadyLeaderboard(leaderboard);
+  assert.equal(leaderboard.viewer.rank, 2);
+  assert.equal(leaderboard.viewer.streakDays, 5);
+  assert.deepEqual(summarizeRankingRows(leaderboard.rankingRows), [
+    {
+      kind: "participant",
+      publicProfileId: "00000000-0000-4000-8000-0000000000c1",
+      streakDays: 8,
+      rank: 1,
+    },
+    {
+      kind: "viewer",
+      publicProfileId: VIEWER_PROFILE_ID,
+      streakDays: 5,
+      rank: 2,
+    },
+    {
+      kind: "participant",
+      publicProfileId: "00000000-0000-4000-8000-0000000000c2",
+      streakDays: 5,
+      rank: 3,
+    },
+    {
+      kind: "participant",
+      publicProfileId: "00000000-0000-4000-8000-0000000000c4",
+      streakDays: 5,
+      rank: 4,
+    },
+    {
+      kind: "participant",
+      publicProfileId: "00000000-0000-4000-8000-0000000000c5",
+      streakDays: 2,
+      rank: 5,
+    },
+  ]);
+});
+
+test("ready response includes compact friend rows and excludes internal identifiers", async () => {
+  const { executor } = createStreakLeaderboardExecutor({
+    viewerUserId: VIEWER_USER_ID,
+    viewerProfile: { publicProfileId: VIEWER_PROFILE_ID, leaderboardParticipationEnabled: true },
+    friendships: [
+      {
+        friendPublicProfileId: FRIEND_PROFILE_ID,
+        friendDisplayName: "Mina",
+        leaderboardParticipationEnabled: true,
+      },
+    ],
+    header: createReadyHeader(),
+    entries: [
+      { public_profile_id: "00000000-0000-4000-8000-000000000101", streak_days: 30, base_sort_position: 1 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000102", streak_days: 25, base_sort_position: 2 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000103", streak_days: 20, base_sort_position: 3 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000104", streak_days: 18, base_sort_position: 4 },
+      { public_profile_id: FRIEND_PROFILE_ID, streak_days: 16, base_sort_position: 5 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000106", streak_days: 14, base_sort_position: 6 },
+      { public_profile_id: VIEWER_PROFILE_ID, streak_days: 12, base_sort_position: 7 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000108", streak_days: 8, base_sort_position: 8 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000109", streak_days: 4, base_sort_position: 9 },
+      { public_profile_id: "00000000-0000-4000-8000-000000000110", streak_days: 0, base_sort_position: 10 },
+    ],
+  });
+
+  const leaderboard = await loadStreakLeaderboardInExecutor(
+    executor,
+    { userId: VIEWER_USER_ID, transport: "session", localeHint: "en" },
+  );
+
+  assertReadyLeaderboard(leaderboard);
+  assert.equal(leaderboard.snapshotId, SNAPSHOT_ID);
+  assert.equal(leaderboard.snapshotGeneratedAt, EXPECTED_GENERATED_AT_ISO);
+  assert.equal(leaderboard.asOfUtcDate, EXPECTED_AS_OF_DATE);
+  assert.equal(leaderboard.nextRefreshAfter, EXPECTED_NEXT_REFRESH_ISO);
+  assert.equal(leaderboard.participantCount, 10);
+  assert.equal(leaderboard.rankingRows.length, leaderboard.participantCount);
+  assert.deepEqual(
+    leaderboard.rows.map((row) => (row.kind === "gap" ? "gap" : `${row.kind}:${row.rank}`)),
+    [
+      "top:1",
+      "top:2",
+      "top:3",
+      "gap",
+      "neighbor:5",
+      "neighbor:6",
+      "viewer:7",
+      "neighbor:8",
+      "gap",
+      "neighbor:10",
+    ],
+  );
+
+  const friendCompactRow = participantRows(leaderboard.rows)
+    .find((row) => row.publicProfileId === FRIEND_PROFILE_ID);
+  const friendRankingRow = leaderboard.rankingRows
+    .find((row) => row.publicProfileId === FRIEND_PROFILE_ID);
+  const nonFriendRankingRow = leaderboard.rankingRows
+    .find((row) => row.publicProfileId === "00000000-0000-4000-8000-000000000104");
+
+  assert.equal(friendCompactRow?.friendDisplayName, "Mina");
+  assert.equal(friendRankingRow?.friendDisplayName, "Mina");
+  if (nonFriendRankingRow === undefined) {
+    throw new Error("Expected a non-friend ranking row.");
+  }
+  assertNoFriendDisplayName(nonFriendRankingRow);
+
+  const serialized = JSON.stringify(leaderboard);
+  assert.equal(serialized.includes("publicProfileId"), true);
+  assert.equal(serialized.includes("anonymousDisplayName"), true);
+  assert.equal(serialized.includes("friendDisplayName"), true);
+  assert.equal(serialized.includes("streakDays"), true);
+  assert.equal(serialized.includes("qualifiedReviewCount"), false);
+  for (const internalField of [
+    VIEWER_USER_ID,
+    "user_id",
+    "userId",
+    "friend_user_id",
+    "friendUserId",
+    "friend_public_profile_id",
+    "friendPublicProfileId",
+    "base_sort",
+    "baseSort",
+    "email",
+  ]) {
+    assert.equal(serialized.includes(internalField), false, `serialized payload must not include ${internalField}`);
+  }
+});

--- a/apps/backend/src/community/leaderboard/streakLeaderboard.ts
+++ b/apps/backend/src/community/leaderboard/streakLeaderboard.ts
@@ -1,0 +1,613 @@
+import {
+  applyUserDatabaseScopeInExecutor,
+  type DatabaseExecutor,
+} from "../../database";
+import { unsafeTransaction } from "../../database/unsafe";
+import type { AuthTransport } from "../../auth";
+import {
+  createAnonymousDisplayName,
+  ensurePublicProfileForCurrentUserInExecutor,
+} from "../publicProfiles";
+import {
+  getAnonymousDisplayNameWordPools,
+  resolveAnonymousDisplayNameLocale,
+  type AnonymousDisplayNameLocale,
+} from "../anonymousDisplayNames";
+import { STREAK_LEADERBOARD_SNAPSHOT_METRIC_VERSION } from "./streakLeaderboardSnapshots";
+
+/**
+ * Client-facing streak leaderboard read.
+ *
+ * The daily job writes tie-neutral base orderings into
+ * community.streak_leaderboard_snapshots / _entries. This module derives the
+ * viewer-perspective ranking, compact row list, and locale-derived anonymous
+ * names at read time. Privacy contract: only opaque public_profile_ids and
+ * display names leave this module. Internal user ids, emails, raw dates beyond
+ * the public snapshot date, and base_sort_position are never serialized.
+ */
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+const DAILY_REFRESH_UTC_HOUR = 12;
+
+const STREAK_LEADERBOARD_VIEWER_DISPLAY_NAME = "You" as const;
+
+export const STREAK_LEADERBOARD_STATUSES = [
+  "ready",
+  "linked_account_required",
+  "participation_disabled",
+  "snapshot_unavailable",
+] as const;
+
+export type StreakLeaderboardStatus = (typeof STREAK_LEADERBOARD_STATUSES)[number];
+export type StreakLeaderboardNonReadyStatus = Exclude<StreakLeaderboardStatus, "ready">;
+
+export const STREAK_LEADERBOARD_ROW_KINDS = [
+  "top",
+  "neighbor",
+  "viewer",
+  "gap",
+] as const;
+
+export type StreakLeaderboardRowKind = (typeof STREAK_LEADERBOARD_ROW_KINDS)[number];
+
+export type StreakLeaderboardMetric = Readonly<{
+  metricVersion: typeof STREAK_LEADERBOARD_SNAPSHOT_METRIC_VERSION;
+  title: string;
+  description: string;
+}>;
+
+export type StreakLeaderboardViewer = Readonly<{
+  publicProfileId: string;
+  displayName: typeof STREAK_LEADERBOARD_VIEWER_DISPLAY_NAME;
+  rank: number;
+  streakDays: number;
+}>;
+
+export type StreakLeaderboardParticipantRow = Readonly<{
+  kind: "top" | "neighbor" | "viewer";
+  publicProfileId: string;
+  anonymousDisplayName: string;
+  friendDisplayName?: string;
+  streakDays: number;
+  rank: number;
+}>;
+
+export type StreakLeaderboardGapRow = Readonly<{
+  kind: "gap";
+}>;
+
+export type StreakLeaderboardRow = StreakLeaderboardParticipantRow | StreakLeaderboardGapRow;
+
+export type StreakLeaderboardRankingRow = Readonly<{
+  kind: "participant" | "viewer";
+  publicProfileId: string;
+  anonymousDisplayName: string;
+  friendDisplayName?: string;
+  streakDays: number;
+  rank: number;
+}>;
+
+export type StreakLeaderboardReady = Readonly<{
+  status: "ready";
+  metric: StreakLeaderboardMetric;
+  snapshotId: string;
+  snapshotGeneratedAt: string;
+  asOfUtcDate: string;
+  nextRefreshAfter: string;
+  participantCount: number;
+  viewer: StreakLeaderboardViewer;
+  rows: ReadonlyArray<StreakLeaderboardRow>;
+  rankingRows: ReadonlyArray<StreakLeaderboardRankingRow>;
+}>;
+
+export type StreakLeaderboardNonReady = Readonly<{
+  status: StreakLeaderboardNonReadyStatus;
+  metric: StreakLeaderboardMetric;
+}>;
+
+export type StreakLeaderboard = StreakLeaderboardReady | StreakLeaderboardNonReady;
+
+export type StreakLeaderboardRequest = Readonly<{
+  userId: string;
+  transport: AuthTransport;
+  localeHint: string;
+}>;
+
+type StreakLeaderboardMetricCopy = Readonly<{
+  title: string;
+  description: string;
+}>;
+
+const STREAK_LEADERBOARD_METRIC_COPY_BY_LOCALE: Readonly<
+  Record<AnonymousDisplayNameLocale, StreakLeaderboardMetricCopy>
+> = {
+  en: {
+    title: "Current streak days",
+    description: "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak.",
+  },
+  ar: {
+    title: "أيام السلسلة الحالية",
+    description: "يستخدم الترتيب أيام السلسلة الحالية من اللقطة العامة اليومية. قد تتأخر القيم العامة عن سلسلتك الشخصية المباشرة.",
+  },
+  "zh-Hans": {
+    title: "当前连续天数",
+    description: "排名使用公共每日快照中的当前连续天数。公共数值可能落后于你的实时个人连续记录。",
+  },
+  de: {
+    title: "Aktuelle Serien-Tage",
+    description: "Ränge verwenden aktuelle Serien-Tage aus dem öffentlichen täglichen Snapshot. Öffentliche Werte können deiner live persönlichen Serie hinterherhinken.",
+  },
+  hi: {
+    title: "मौजूदा स्ट्रीक दिन",
+    description: "रैंक सार्वजनिक दैनिक स्नैपशॉट के मौजूदा स्ट्रीक दिनों का उपयोग करती है। सार्वजनिक मान आपकी लाइव निजी स्ट्रीक से पीछे रह सकते हैं।",
+  },
+  ja: {
+    title: "現在の連続日数",
+    description: "順位は公開の日次スナップショットの現在の連続日数を使います。公開値は個人の最新連続記録より遅れることがあります。",
+  },
+  ru: {
+    title: "Текущая серия в днях",
+    description: "Рейтинг использует текущую серию в днях из публичного ежедневного снимка. Публичные значения могут отставать от вашей личной серии в реальном времени.",
+  },
+  "es-MX": {
+    title: "Días de racha actual",
+    description: "La clasificación usa los días de racha actual de la captura pública diaria. Los valores públicos pueden ir detrás de tu racha personal en vivo.",
+  },
+  "es-ES": {
+    title: "Días de racha actual",
+    description: "La clasificación usa los días de racha actual de la captura pública diaria. Los valores públicos pueden ir por detrás de tu racha personal en vivo.",
+  },
+};
+
+type StreakLeaderboardSnapshotEntry = Readonly<{
+  publicProfileId: string;
+  streakDays: number;
+  baseSortPosition: number;
+}>;
+
+type StreakLeaderboardSnapshotHeader = Readonly<{
+  snapshotId: string;
+  generatedAt: string;
+  asOfUtcDate: string;
+}>;
+
+type RankedParticipant = Readonly<{
+  publicProfileId: string;
+  streakDays: number;
+  rank: number;
+  isViewer: boolean;
+}>;
+
+type ViewerPerspectiveRanking = Readonly<{
+  ranked: ReadonlyArray<RankedParticipant>;
+  viewerRank: number;
+  viewerStreakDays: number;
+}>;
+
+type StreakLeaderboardSnapshotHeaderRow = Readonly<{
+  snapshot_id: string;
+  generated_at: Date | string;
+  as_of_utc_date: Date | string;
+}>;
+
+type StreakLeaderboardSnapshotEntryRow = Readonly<{
+  public_profile_id: string;
+  streak_days: number | string;
+  base_sort_position: number | string;
+}>;
+
+type StreakLeaderboardFriendDisplayNameRow = Readonly<{
+  friend_public_profile_id: string;
+  friend_display_name: string;
+}>;
+
+function resolveStreakLeaderboardMetric(localeHint: string): StreakLeaderboardMetric {
+  const copy = STREAK_LEADERBOARD_METRIC_COPY_BY_LOCALE[resolveAnonymousDisplayNameLocale(localeHint)];
+  return {
+    metricVersion: STREAK_LEADERBOARD_SNAPSHOT_METRIC_VERSION,
+    title: copy.title,
+    description: copy.description,
+  };
+}
+
+function buildNonReadyStreakLeaderboard(
+  status: StreakLeaderboardNonReadyStatus,
+  localeHint: string,
+): StreakLeaderboardNonReady {
+  return {
+    status,
+    metric: resolveStreakLeaderboardMetric(localeHint),
+  };
+}
+
+function assertStreakLeaderboardReadTransport(transport: AuthTransport): void {
+  if (transport !== "session" && transport !== "bearer" && transport !== "none") {
+    throw new Error(
+      `Streak leaderboard read requires a signed-in human transport, received ${transport}.`,
+    );
+  }
+}
+
+function normalizeTimestamp(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid streak leaderboard snapshot timestamp: ${String(value)}`);
+  }
+
+  return date.toISOString();
+}
+
+function normalizeUtcDate(value: Date | string): string {
+  const utcDate = value instanceof Date ? value.toISOString().slice(0, 10) : value;
+  if (!/^\d{4}-\d{2}-\d{2}$/u.test(utcDate)) {
+    throw new Error(`Invalid streak leaderboard UTC date: ${String(value)}`);
+  }
+
+  const parsed = new Date(`${utcDate}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== utcDate) {
+    throw new Error(`Invalid streak leaderboard UTC date: ${String(value)}`);
+  }
+
+  return utcDate;
+}
+
+function normalizeNonNegativeInteger(value: number | string, field: string): number {
+  const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid non-negative integer for ${field}: ${String(value)}`);
+  }
+
+  return parsed;
+}
+
+function normalizePositiveInteger(value: number | string, field: string): number {
+  const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`Invalid positive integer for ${field}: ${String(value)}`);
+  }
+
+  return parsed;
+}
+
+function normalizeFriendDisplayName(value: string, publicProfileId: string): string {
+  const displayNameLength = Array.from(value.trim()).length;
+  if (displayNameLength < 1 || displayNameLength > 30 || /[\u0000-\u001F\u007F]/u.test(value)) {
+    throw new Error(`Invalid friend display name for public profile ${publicProfileId}.`);
+  }
+
+  return value;
+}
+
+function computeNextRefreshAfter(generatedAt: string): string {
+  const generatedAtDate = new Date(generatedAt);
+  if (Number.isNaN(generatedAtDate.getTime())) {
+    throw new Error(`Invalid streak leaderboard snapshot generatedAt: ${generatedAt}`);
+  }
+
+  const sameDayRefresh = Date.UTC(
+    generatedAtDate.getUTCFullYear(),
+    generatedAtDate.getUTCMonth(),
+    generatedAtDate.getUTCDate(),
+    DAILY_REFRESH_UTC_HOUR,
+    0,
+    0,
+    0,
+  );
+  const nextRefresh = sameDayRefresh > generatedAtDate.getTime()
+    ? sameDayRefresh
+    : sameDayRefresh + MILLISECONDS_PER_DAY;
+
+  return new Date(nextRefresh).toISOString();
+}
+
+/**
+ * The streak leaderboard favors the viewer inside ties: equal-streak non-viewers
+ * keep their stored base order, but the viewer is inserted before every other
+ * participant with the same streakDays value.
+ */
+function findViewerInsertionIndex(
+  others: ReadonlyArray<StreakLeaderboardSnapshotEntry>,
+  viewerStreakDays: number,
+): number {
+  const index = others.findIndex((entry) => entry.streakDays <= viewerStreakDays);
+  return index === -1 ? others.length : index;
+}
+
+function buildViewerPerspectiveRanking(
+  entries: ReadonlyArray<StreakLeaderboardSnapshotEntry>,
+  viewerPublicProfileId: string,
+): ViewerPerspectiveRanking {
+  const viewerEntry = entries.find((entry) => entry.publicProfileId === viewerPublicProfileId) ?? null;
+  const viewerStreakDays = viewerEntry === null ? 0 : viewerEntry.streakDays;
+  const others = entries
+    .filter((entry) => entry.publicProfileId !== viewerPublicProfileId)
+    .sort((left, right) => left.baseSortPosition - right.baseSortPosition);
+
+  const viewerInsertionIndex = findViewerInsertionIndex(others, viewerStreakDays);
+  const ordered: Array<Readonly<{ publicProfileId: string; streakDays: number; isViewer: boolean }>> = [];
+  others.forEach((entry, index) => {
+    if (index === viewerInsertionIndex) {
+      ordered.push({ publicProfileId: viewerPublicProfileId, streakDays: viewerStreakDays, isViewer: true });
+    }
+
+    ordered.push({
+      publicProfileId: entry.publicProfileId,
+      streakDays: entry.streakDays,
+      isViewer: false,
+    });
+  });
+  if (viewerInsertionIndex === others.length) {
+    ordered.push({ publicProfileId: viewerPublicProfileId, streakDays: viewerStreakDays, isViewer: true });
+  }
+
+  const ranked: ReadonlyArray<RankedParticipant> = ordered.map((participant, index) => ({
+    ...participant,
+    rank: index + 1,
+  }));
+  const viewerRank = ranked.find((participant) => participant.isViewer)?.rank ?? ranked.length;
+
+  return { ranked, viewerRank, viewerStreakDays };
+}
+
+function buildParticipantRow(
+  participant: RankedParticipant,
+  topRowCount: number,
+  resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
+): StreakLeaderboardParticipantRow {
+  const kind: "top" | "neighbor" | "viewer" = participant.isViewer
+    ? "viewer"
+    : participant.rank <= topRowCount
+      ? "top"
+      : "neighbor";
+  const friendDisplayName = friendDisplayNamesByPublicProfileId.get(participant.publicProfileId);
+
+  return {
+    kind,
+    publicProfileId: participant.publicProfileId,
+    anonymousDisplayName: resolveName(participant.publicProfileId),
+    ...(friendDisplayName === undefined ? {} : { friendDisplayName }),
+    streakDays: participant.streakDays,
+    rank: participant.rank,
+  };
+}
+
+function buildRankingRow(
+  participant: RankedParticipant,
+  resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
+): StreakLeaderboardRankingRow {
+  const friendDisplayName = friendDisplayNamesByPublicProfileId.get(participant.publicProfileId);
+
+  return {
+    kind: participant.isViewer ? "viewer" : "participant",
+    publicProfileId: participant.publicProfileId,
+    anonymousDisplayName: resolveName(participant.publicProfileId),
+    ...(friendDisplayName === undefined ? {} : { friendDisplayName }),
+    streakDays: participant.streakDays,
+    rank: participant.rank,
+  };
+}
+
+function buildRankingRows(
+  ranked: ReadonlyArray<RankedParticipant>,
+  resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
+): ReadonlyArray<StreakLeaderboardRankingRow> {
+  return ranked.map((participant) => (
+    buildRankingRow(participant, resolveName, friendDisplayNamesByPublicProfileId)
+  ));
+}
+
+function buildCompactRows(
+  ranked: ReadonlyArray<RankedParticipant>,
+  viewerRank: number,
+  resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
+): ReadonlyArray<StreakLeaderboardRow> {
+  const total = ranked.length;
+  const topRowCount = Math.min(3, total);
+
+  const shownRanks = new Set<number>();
+  for (let rank = 1; rank <= topRowCount; rank += 1) {
+    shownRanks.add(rank);
+  }
+  if (viewerRank > topRowCount) {
+    for (const candidate of [viewerRank - 1, viewerRank, viewerRank + 1]) {
+      if (candidate >= 1 && candidate <= total) {
+        shownRanks.add(candidate);
+      }
+    }
+  } else if (viewerRank === topRowCount && viewerRank < total) {
+    shownRanks.add(viewerRank + 1);
+  }
+  if (total > topRowCount) {
+    shownRanks.add(total);
+  }
+  for (const participant of ranked) {
+    if (friendDisplayNamesByPublicProfileId.has(participant.publicProfileId)) {
+      shownRanks.add(participant.rank);
+    }
+  }
+
+  const orderedRanks = [...shownRanks].sort((left, right) => left - right);
+  const rows: Array<StreakLeaderboardRow> = [];
+  let previousRank = 0;
+  for (const rank of orderedRanks) {
+    if (previousRank !== 0 && rank > previousRank + 1) {
+      rows.push({ kind: "gap" });
+    }
+
+    const participant = ranked[rank - 1];
+    if (participant === undefined) {
+      throw new Error(`Missing ranked streak participant for rank ${rank}.`);
+    }
+
+    rows.push(buildParticipantRow(participant, topRowCount, resolveName, friendDisplayNamesByPublicProfileId));
+    previousRank = rank;
+  }
+
+  if (previousRank < total) {
+    rows.push({ kind: "gap" });
+  }
+
+  return rows;
+}
+
+function buildReadyStreakLeaderboard(
+  header: StreakLeaderboardSnapshotHeader,
+  entries: ReadonlyArray<StreakLeaderboardSnapshotEntry>,
+  viewerPublicProfileId: string,
+  metric: StreakLeaderboardMetric,
+  resolveName: (publicProfileId: string) => string,
+  friendDisplayNamesByPublicProfileId: ReadonlyMap<string, string>,
+): StreakLeaderboardReady {
+  const ranking = buildViewerPerspectiveRanking(entries, viewerPublicProfileId);
+
+  return {
+    status: "ready",
+    metric,
+    snapshotId: header.snapshotId,
+    snapshotGeneratedAt: header.generatedAt,
+    asOfUtcDate: header.asOfUtcDate,
+    nextRefreshAfter: computeNextRefreshAfter(header.generatedAt),
+    participantCount: ranking.ranked.length,
+    viewer: {
+      publicProfileId: viewerPublicProfileId,
+      displayName: STREAK_LEADERBOARD_VIEWER_DISPLAY_NAME,
+      rank: ranking.viewerRank,
+      streakDays: ranking.viewerStreakDays,
+    },
+    rows: buildCompactRows(
+      ranking.ranked,
+      ranking.viewerRank,
+      resolveName,
+      friendDisplayNamesByPublicProfileId,
+    ),
+    rankingRows: buildRankingRows(ranking.ranked, resolveName, friendDisplayNamesByPublicProfileId),
+  };
+}
+
+async function readLatestStreakLeaderboardSnapshotHeaderInExecutor(
+  executor: DatabaseExecutor,
+): Promise<StreakLeaderboardSnapshotHeader | null> {
+  const result = await executor.query<StreakLeaderboardSnapshotHeaderRow>(
+    [
+      "SELECT",
+      "snapshots.snapshot_id::text AS snapshot_id,",
+      "snapshots.generated_at AS generated_at,",
+      "snapshots.as_of_utc_date AS as_of_utc_date",
+      "FROM community.streak_leaderboard_snapshots AS snapshots",
+      "WHERE snapshots.metric_version = $1",
+      "ORDER BY snapshots.as_of_utc_date DESC",
+      "LIMIT 1",
+    ].join(" "),
+    [STREAK_LEADERBOARD_SNAPSHOT_METRIC_VERSION],
+  );
+
+  const row = result.rows[0];
+  if (row === undefined) {
+    return null;
+  }
+
+  return {
+    snapshotId: row.snapshot_id,
+    generatedAt: normalizeTimestamp(row.generated_at),
+    asOfUtcDate: normalizeUtcDate(row.as_of_utc_date),
+  };
+}
+
+async function readStreakLeaderboardSnapshotEntriesInExecutor(
+  executor: DatabaseExecutor,
+  snapshotId: string,
+): Promise<ReadonlyArray<StreakLeaderboardSnapshotEntry>> {
+  const result = await executor.query<StreakLeaderboardSnapshotEntryRow>(
+    [
+      "SELECT",
+      "entries.public_profile_id::text AS public_profile_id,",
+      "entries.streak_days AS streak_days,",
+      "entries.base_sort_position AS base_sort_position",
+      "FROM community.streak_leaderboard_snapshot_entries AS entries",
+      "WHERE entries.snapshot_id = $1::uuid",
+      "ORDER BY entries.base_sort_position ASC",
+    ].join(" "),
+    [snapshotId],
+  );
+
+  return result.rows.map((row) => ({
+    publicProfileId: row.public_profile_id,
+    streakDays: normalizeNonNegativeInteger(row.streak_days, "streak_days"),
+    baseSortPosition: normalizePositiveInteger(row.base_sort_position, "base_sort_position"),
+  }));
+}
+
+async function readViewerFriendDisplayNamesInExecutor(
+  executor: DatabaseExecutor,
+): Promise<ReadonlyMap<string, string>> {
+  const result = await executor.query<StreakLeaderboardFriendDisplayNameRow>(
+    [
+      "SELECT",
+      "friend_labels.friend_public_profile_id::text AS friend_public_profile_id,",
+      "friend_labels.friend_display_name AS friend_display_name",
+      "FROM community.read_current_user_leaderboard_friend_labels() AS friend_labels",
+      "ORDER BY friend_labels.friend_public_profile_id",
+    ].join(" "),
+    [],
+  );
+
+  const friendDisplayNamesByPublicProfileId = new Map<string, string>();
+  for (const row of result.rows) {
+    friendDisplayNamesByPublicProfileId.set(
+      row.friend_public_profile_id,
+      normalizeFriendDisplayName(row.friend_display_name, row.friend_public_profile_id),
+    );
+  }
+
+  return friendDisplayNamesByPublicProfileId;
+}
+
+export async function loadStreakLeaderboardInExecutor(
+  executor: DatabaseExecutor,
+  request: StreakLeaderboardRequest,
+): Promise<StreakLeaderboard> {
+  assertStreakLeaderboardReadTransport(request.transport);
+
+  const metric = resolveStreakLeaderboardMetric(request.localeHint);
+  await applyUserDatabaseScopeInExecutor(executor, { userId: request.userId });
+
+  const viewerProfile = await ensurePublicProfileForCurrentUserInExecutor(executor);
+  if (!viewerProfile.leaderboardParticipationEnabled) {
+    return buildNonReadyStreakLeaderboard("participation_disabled", request.localeHint);
+  }
+
+  const snapshotHeader = await readLatestStreakLeaderboardSnapshotHeaderInExecutor(executor);
+  if (snapshotHeader === null) {
+    return buildNonReadyStreakLeaderboard("snapshot_unavailable", request.localeHint);
+  }
+
+  const friendDisplayNamesByPublicProfileId = await readViewerFriendDisplayNamesInExecutor(executor);
+  const entries = await readStreakLeaderboardSnapshotEntriesInExecutor(executor, snapshotHeader.snapshotId);
+  const wordPools = getAnonymousDisplayNameWordPools(request.localeHint);
+  const resolveName = (publicProfileId: string): string => createAnonymousDisplayName(publicProfileId, wordPools);
+
+  return buildReadyStreakLeaderboard(
+    snapshotHeader,
+    entries,
+    viewerProfile.publicProfileId,
+    metric,
+    resolveName,
+    friendDisplayNamesByPublicProfileId,
+  );
+}
+
+export async function loadStreakLeaderboard(
+  request: StreakLeaderboardRequest,
+): Promise<StreakLeaderboard> {
+  if (request.transport === "guest") {
+    return buildNonReadyStreakLeaderboard("linked_account_required", request.localeHint);
+  }
+
+  return unsafeTransaction(
+    async (executor) => loadStreakLeaderboardInExecutor(executor, request),
+  );
+}

--- a/apps/backend/src/observability/sentry/events.ts
+++ b/apps/backend/src/observability/sentry/events.ts
@@ -186,6 +186,14 @@ export type ProgressLeaderboardDetails = Readonly<{
   windowCount: number | null;
 }>;
 
+export type StreakLeaderboardDetails = Readonly<{
+  statusCode: number;
+  authTransport: string;
+  status: string | null;
+  metricVersion: string | null;
+  participantCount: number | null;
+}>;
+
 export type AccountDeleteDetails = Readonly<{
   statusCode: number;
   transport: string;
@@ -679,6 +687,8 @@ export type BackendBreadcrumbEvent =
   | EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>>
   | EventByAction<"me_progress_leaderboard", ProgressLeaderboardDetails>
   | EventByAction<"me_progress_leaderboard_error", FailureDetailsFor<ProgressLeaderboardDetails>>
+  | EventByAction<"me_progress_streak_leaderboard", StreakLeaderboardDetails>
+  | EventByAction<"me_progress_streak_leaderboard_error", FailureDetailsFor<StreakLeaderboardDetails>>
   | EventByAction<"account_delete", AccountDeleteDetails>
   | EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>>
   | EventByAction<"feedback_state", FeedbackStateDetails>
@@ -796,6 +806,10 @@ export type BackendExceptionEvent =
   | (EventByAction<"me_progress_review_schedule_error", FailureDetailsFor<ProgressReviewScheduleDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"me_progress_series_error", FailureDetailsFor<ProgressSeriesDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"me_progress_leaderboard_error", FailureDetailsFor<ProgressLeaderboardDetails>> & Readonly<{ error: Error }>)
+  | (
+    EventByAction<"me_progress_streak_leaderboard_error", FailureDetailsFor<StreakLeaderboardDetails>>
+    & Readonly<{ error: Error }>
+  )
   | (EventByAction<"account_delete_error", FailureDetailsFor<AccountDeleteDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"feedback_state_error", FailureDetailsFor<FeedbackStateDetails>> & Readonly<{ error: Error }>)
   | (EventByAction<"feedback_prompt_event_error", FailureDetailsFor<FeedbackPromptEventDetails>> & Readonly<{ error: Error }>)

--- a/apps/backend/src/progress/index.ts
+++ b/apps/backend/src/progress/index.ts
@@ -35,6 +35,12 @@ export {
   type ProgressLeaderboard,
   type ProgressLeaderboardRequest,
 } from "../community/leaderboard/progressLeaderboard";
+export {
+  loadStreakLeaderboard,
+  loadStreakLeaderboardInExecutor,
+  type StreakLeaderboard,
+  type StreakLeaderboardRequest,
+} from "../community/leaderboard/streakLeaderboard";
 
 export type ProgressSummaryInput = Readonly<{
   timeZone: string;

--- a/apps/backend/src/routes/system/contracts.test.ts
+++ b/apps/backend/src/routes/system/contracts.test.ts
@@ -111,6 +111,20 @@ test("API Gateway predeclares /me/progress/leaderboard", () => {
   );
 });
 
+test("API Gateway predeclares /me/progress/leaderboards/streak", () => {
+  const apiGatewayPath = resolve(process.cwd(), "../../infra/aws/lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(
+    apiGatewaySource,
+    /const meProgressLeaderboards = meProgress\.addResource\("leaderboards"\);/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /meProgressLeaderboards\.addResource\("streak"\)\.addMethod\("GET", integration\);/,
+  );
+});
+
 test("published OpenAPI documents the progress leaderboard without internal ids", () => {
   const openApiDocument = loadOpenApiDocument() as Readonly<{
     paths?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
@@ -141,6 +155,61 @@ test("published OpenAPI documents the progress leaderboard without internal ids"
     assert.equal(serializedSchemas.includes(expectedField), true, `OpenAPI must document ${expectedField}`);
   }
   for (const internalField of [
+    "userId",
+    "friend_user_id",
+    "friendUserId",
+    "friend_public_profile_id",
+    "friendPublicProfileId",
+    "created_from_invitation_id",
+    "friendInvitationId",
+    "inviter_user_id",
+    "inviterUserId",
+    "createdFromInvitationId",
+    "baseSort",
+    "reviewed_by",
+    "reviewedBy",
+    "email",
+  ]) {
+    assert.equal(serializedSchemas.includes(internalField), false, `OpenAPI must not expose ${internalField}`);
+  }
+});
+
+test("published OpenAPI documents the streak leaderboard without internal ids or rating fields", () => {
+  const openApiDocument = loadOpenApiDocument() as Readonly<{
+    paths?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
+    components?: Readonly<{ schemas?: Readonly<Record<string, unknown>> }>;
+  }>;
+  const leaderboardPath = openApiDocument.paths?.["/me/progress/leaderboards/streak"];
+  const schemas = openApiDocument.components?.schemas ?? {};
+  const leaderboardSchemas = Object.fromEntries(
+    Object.entries(schemas).filter(([name]) => name.startsWith("StreakLeaderboard")),
+  );
+  const serializedSchemas = JSON.stringify(leaderboardSchemas);
+
+  assert.notEqual(leaderboardPath?.get, undefined);
+  assert.notEqual(schemas.StreakLeaderboardResponse, undefined);
+  for (const expectedField of [
+    "status",
+    "metricVersion",
+    "streakDays",
+    "anonymousDisplayName",
+    "friendDisplayName",
+    "publicProfileId",
+    "rank",
+    "snapshotId",
+    "snapshotGeneratedAt",
+    "asOfUtcDate",
+    "nextRefreshAfter",
+    "participantCount",
+    "rankingRows",
+  ]) {
+    assert.equal(serializedSchemas.includes(expectedField), true, `OpenAPI must document ${expectedField}`);
+  }
+  for (const internalField of [
+    "defaultWindowKey",
+    "windowKey",
+    "windows",
+    "qualifiedReviewCount",
     "userId",
     "friend_user_id",
     "friendUserId",

--- a/apps/backend/src/routes/system/index.ts
+++ b/apps/backend/src/routes/system/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./friendInvitations";
 import {
   loadProgressLeaderboard,
+  loadStreakLeaderboard,
   loadUserProgressReviewSchedule,
   loadUserProgressSeries,
   loadUserProgressSummary,
@@ -41,6 +42,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
   const loadUserProgressSeriesFn = options.loadUserProgressSeriesFn ?? loadUserProgressSeries;
   const loadUserProgressSummaryFn = options.loadUserProgressSummaryFn ?? loadUserProgressSummary;
   const loadProgressLeaderboardFn = options.loadProgressLeaderboardFn ?? loadProgressLeaderboard;
+  const loadStreakLeaderboardFn = options.loadStreakLeaderboardFn ?? loadStreakLeaderboard;
   const updateAccountPreferencesFn = options.updateAccountPreferencesFn ?? updateAccountPreferences;
   const ensurePublicProfileForUserFn = options.ensurePublicProfileForUserFn ?? ensurePublicProfileForUser;
   const updateLeaderboardParticipationFn = options.updateLeaderboardParticipationFn ?? updateLeaderboardParticipation;
@@ -112,6 +114,7 @@ export function createSystemRoutes(options: SystemRoutesOptions): Hono<AppEnv> {
     loadUserProgressSeriesFn,
     loadUserProgressSummaryFn,
     loadProgressLeaderboardFn,
+    loadStreakLeaderboardFn,
   });
   registerAccountDeletionRoute(app, {
     allowedOrigins: options.allowedOrigins,

--- a/apps/backend/src/routes/system/progress.test.ts
+++ b/apps/backend/src/routes/system/progress.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import type {
   ProgressLeaderboard,
   ProgressSummaryResponse,
+  StreakLeaderboard,
 } from "../../progress";
 import type { RequestContext } from "../../server/requestContext";
 import {
@@ -10,6 +11,7 @@ import {
   createProgressReviewSchedule,
   createProgressSeries,
   createProgressSummaryResponse,
+  createStreakLeaderboard,
   createSystemTestApp,
 } from "./systemTestSupport";
 
@@ -171,6 +173,58 @@ test("GET /me/progress/leaderboard rejects ApiKey authentication", async () => {
     },
   });
   const response = await app.request("http://localhost/me/progress/leaderboard");
+
+  assert.equal(called, false);
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    error: "This endpoint requires Guest, Bearer, or Session authentication",
+    requestId: "request-1",
+    code: "PROGRESS_HUMAN_AUTH_REQUIRED",
+  });
+});
+
+test("GET /me/progress/leaderboards/streak returns the streak leaderboard for Session and Bearer", async () => {
+  const transports: ReadonlyArray<RequestContext["transport"]> = ["session", "bearer"];
+
+  for (const transport of transports) {
+    const app = createSystemTestApp({
+      transport,
+      locale: "es-MX",
+      loadStreakLeaderboardFn: async ({ userId, transport: requestTransport, localeHint }) => {
+        assert.equal(userId, "user-1");
+        assert.equal(requestTransport, transport);
+        assert.equal(localeHint, "es-MX");
+        return createStreakLeaderboard();
+      },
+    });
+    const response = await app.request("http://localhost/me/progress/leaderboards/streak");
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), createStreakLeaderboard());
+  }
+});
+
+test("GET /me/progress/leaderboards/streak returns linked_account_required for Guest", async () => {
+  const app = createSystemTestApp({ transport: "guest" });
+  const response = await app.request("http://localhost/me/progress/leaderboards/streak");
+  const payload = await response.json() as StreakLeaderboard;
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.status, "linked_account_required");
+  assert.equal("rows" in payload, false);
+  assert.equal(payload.metric.metricVersion, "streak_days_v1");
+});
+
+test("GET /me/progress/leaderboards/streak rejects ApiKey authentication", async () => {
+  let called = false;
+  const app = createSystemTestApp({
+    transport: "api_key",
+    loadStreakLeaderboardFn: async () => {
+      called = true;
+      return createStreakLeaderboard();
+    },
+  });
+  const response = await app.request("http://localhost/me/progress/leaderboards/streak");
 
   assert.equal(called, false);
   assert.equal(response.status, 403);

--- a/apps/backend/src/routes/system/progress.ts
+++ b/apps/backend/src/routes/system/progress.ts
@@ -1,6 +1,7 @@
 import type { Hono } from "hono";
 import {
   loadProgressLeaderboard,
+  loadStreakLeaderboard,
   loadUserProgressReviewSchedule,
   loadUserProgressSeries,
   loadUserProgressSummary,
@@ -11,6 +12,7 @@ import {
   type ProgressReviewSchedule,
   type ProgressSeries,
   type ProgressSummaryResponse,
+  type StreakLeaderboard,
 } from "../../progress";
 import {
   addBackendBreadcrumb,
@@ -31,6 +33,7 @@ export {
   loadUserProgressReviewSchedule,
   loadUserProgressSeries,
   loadUserProgressSummary,
+  loadStreakLeaderboard,
 };
 
 type ProgressRoutesOptions = Readonly<{
@@ -40,6 +43,7 @@ type ProgressRoutesOptions = Readonly<{
   loadUserProgressSeriesFn: typeof loadUserProgressSeries;
   loadUserProgressSummaryFn: typeof loadUserProgressSummary;
   loadProgressLeaderboardFn: typeof loadProgressLeaderboard;
+  loadStreakLeaderboardFn: typeof loadStreakLeaderboard;
 }>;
 
 export function registerProgressRoutes(
@@ -226,6 +230,8 @@ export function registerProgressRoutes(
     }
   });
 
+  // Legacy rating leaderboard path. A future /me/progress/leaderboards/rating
+  // alias is intentionally outside the streak leaderboard change.
   app.get("/me/progress/leaderboard", async (context) => {
     const { requestContext } = await options.loadRequestContextFromRequestFn(
       context.req.raw,
@@ -270,6 +276,53 @@ export function registerProgressRoutes(
         error,
         { action: "me_progress_leaderboard_error", error: normalizeCaughtError(error), scope, details },
         { action: "me_progress_leaderboard_error", scope, details },
+      );
+      throw error;
+    }
+  });
+
+  app.get("/me/progress/leaderboards/streak", async (context) => {
+    const { requestContext } = await options.loadRequestContextFromRequestFn(
+      context.req.raw,
+      options.allowedOrigins,
+    );
+    const requestId = context.get("requestId");
+
+    try {
+      assertProgressHumanTransport(requestContext.transport);
+
+      const leaderboard = await options.loadStreakLeaderboardFn({
+        userId: requestContext.userId,
+        transport: requestContext.transport,
+        localeHint: requestContext.locale,
+      });
+
+      addBackendBreadcrumb({
+        action: "me_progress_streak_leaderboard",
+        scope: createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId),
+        details: {
+          statusCode: 200,
+          authTransport: requestContext.transport,
+          status: leaderboard.status,
+          metricVersion: leaderboard.metric.metricVersion,
+          participantCount: leaderboard.status === "ready" ? leaderboard.participantCount : null,
+        },
+      });
+
+      return context.json(leaderboard satisfies StreakLeaderboard);
+    } catch (error) {
+      const scope = createSystemScope(requestId, context.req.path, context.req.method, requestContext.userId);
+      const details = {
+        authTransport: requestContext.transport,
+        status: null,
+        metricVersion: null,
+        participantCount: null,
+        ...createBackendFailureDetails(error),
+      };
+      reportBackendExceptionOrBreadcrumb(
+        error,
+        { action: "me_progress_streak_leaderboard_error", error: normalizeCaughtError(error), scope, details },
+        { action: "me_progress_streak_leaderboard_error", scope, details },
       );
       throw error;
     }

--- a/apps/backend/src/routes/system/systemTestSupport.ts
+++ b/apps/backend/src/routes/system/systemTestSupport.ts
@@ -18,6 +18,8 @@ import type {
   ProgressSeriesRequest,
   ProgressSummaryRequest,
   ProgressSummaryResponse,
+  StreakLeaderboard,
+  StreakLeaderboardRequest,
 } from "../../progress";
 import type { AppEnv } from "../../server/app";
 import type { RequestContext } from "../../server/requestContext";
@@ -43,6 +45,7 @@ type SystemTestAppOptions = Readonly<{
   loadUserProgressSeriesFn?: (args: ProgressSeriesRequest) => Promise<ProgressSeries>;
   loadUserProgressSummaryFn?: (args: ProgressSummaryRequest) => Promise<ProgressSummaryResponse>;
   loadProgressLeaderboardFn?: (args: ProgressLeaderboardRequest) => Promise<ProgressLeaderboard>;
+  loadStreakLeaderboardFn?: (args: StreakLeaderboardRequest) => Promise<StreakLeaderboard>;
 }>;
 
 export function createDefaultAccountPreferences(): AccountPreferences {
@@ -216,6 +219,60 @@ export function createProgressLeaderboard(): ProgressLeaderboard {
   };
 }
 
+export function createStreakLeaderboard(): StreakLeaderboard {
+  return {
+    status: "ready",
+    metric: {
+      metricVersion: "streak_days_v1",
+      title: "Current streak days",
+      description: "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak.",
+    },
+    snapshotId: "3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4",
+    snapshotGeneratedAt: "2026-06-10T12:00:05.000Z",
+    asOfUtcDate: "2026-06-10",
+    nextRefreshAfter: "2026-06-11T12:00:00.000Z",
+    participantCount: 2,
+    viewer: {
+      publicProfileId: "5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f",
+      displayName: "You",
+      rank: 2,
+      streakDays: 3,
+    },
+    rows: [
+      {
+        kind: "top",
+        publicProfileId: "a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d",
+        anonymousDisplayName: "Silver Bright Harbor",
+        streakDays: 5,
+        rank: 1,
+      },
+      {
+        kind: "viewer",
+        publicProfileId: "5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f",
+        anonymousDisplayName: "Jade Swift River",
+        streakDays: 3,
+        rank: 2,
+      },
+    ],
+    rankingRows: [
+      {
+        kind: "participant",
+        publicProfileId: "a1d2c3b4-5e6f-4a8b-9c0d-1e2f3a4b5c6d",
+        anonymousDisplayName: "Silver Bright Harbor",
+        streakDays: 5,
+        rank: 1,
+      },
+      {
+        kind: "viewer",
+        publicProfileId: "5b9d3f2a-1c4e-4a7b-9f0d-2e6c8a1b4d7f",
+        anonymousDisplayName: "Jade Swift River",
+        streakDays: 3,
+        rank: 2,
+      },
+    ],
+  };
+}
+
 export function createSystemTestApp(options: SystemTestAppOptions): Hono<AppEnv> {
   const app = new Hono<AppEnv>();
   app.use("*", async (context, next) => {
@@ -269,6 +326,7 @@ export function createSystemTestApp(options: SystemTestAppOptions): Hono<AppEnv>
     loadUserProgressSeriesFn: options.loadUserProgressSeriesFn,
     loadUserProgressSummaryFn: options.loadUserProgressSummaryFn,
     loadProgressLeaderboardFn: options.loadProgressLeaderboardFn,
+    loadStreakLeaderboardFn: options.loadStreakLeaderboardFn,
   }));
 
   return app;

--- a/apps/backend/src/routes/system/types.ts
+++ b/apps/backend/src/routes/system/types.ts
@@ -9,6 +9,7 @@ import type {
 import type { PublicProfile } from "../../community/publicProfiles";
 import type {
   loadProgressLeaderboard,
+  loadStreakLeaderboard,
   loadUserProgressReviewSchedule,
   loadUserProgressSeries,
   loadUserProgressSummary,
@@ -22,6 +23,7 @@ export type SystemRoutesOptions = Readonly<{
   loadUserProgressSeriesFn?: typeof loadUserProgressSeries;
   loadUserProgressSummaryFn?: typeof loadUserProgressSummary;
   loadProgressLeaderboardFn?: typeof loadProgressLeaderboard;
+  loadStreakLeaderboardFn?: typeof loadStreakLeaderboard;
   updateAccountPreferencesFn?: UpdateAccountPreferencesFn;
   ensurePublicProfileForUserFn?: EnsurePublicProfileForUserFn;
   updateLeaderboardParticipationFn?: UpdateLeaderboardParticipationFn;

--- a/infra/aws/lib/gateways/api-gateway.test.ts
+++ b/infra/aws/lib/gateways/api-gateway.test.ts
@@ -57,6 +57,20 @@ test("API Gateway predeclares /me/progress/leaderboard", () => {
   );
 });
 
+test("API Gateway predeclares /me/progress/leaderboards/streak", () => {
+  const apiGatewayPath = resolve(process.cwd(), "lib/gateways/api-gateway.ts");
+  const apiGatewaySource = readFileSync(apiGatewayPath, "utf8");
+
+  assert.match(
+    apiGatewaySource,
+    /const meProgressLeaderboards = meProgress\.addResource\("leaderboards"\);/,
+  );
+  assert.match(
+    apiGatewaySource,
+    /meProgressLeaderboards\.addResource\("streak"\)\.addMethod\("GET", integration\);/,
+  );
+});
+
 test("global snapshot API Gateway mock preflight allows content type and Sentry trace headers", () => {
   const stack = new cdk.Stack();
   const restApi = new apigw.RestApi(stack, "Api");

--- a/infra/aws/lib/gateways/api-gateway.ts
+++ b/infra/aws/lib/gateways/api-gateway.ts
@@ -630,6 +630,8 @@ export function apiGateway(scope: Construct, props: ApiGatewayProps): ApiGateway
   meProgress.addResource("review-schedule").addMethod("GET", integration);
   meProgress.addResource("series").addMethod("GET", integration);
   meProgress.addResource("leaderboard").addMethod("GET", integration);
+  const meProgressLeaderboards = meProgress.addResource("leaderboards");
+  meProgressLeaderboards.addResource("streak").addMethod("GET", integration);
   me.addResource("delete").addMethod("POST", integration);
 
   const community = restApi.root.addResource("community");


### PR DESCRIPTION
## Summary
- Add GET /me/progress/leaderboards/streak backed by streak snapshot tables
- Preserve legacy rating leaderboard path and document streak contract in OpenAPI
- Predeclare the new API Gateway route and add backend/contract coverage

## Validation
- npm run lint --prefix apps/backend
- npm run test --prefix apps/backend (487/487)
- npm test --prefix infra/aws (23/23)
- Review round: no P0-P4 findings