### PR TITLE
Add web AI chat suggestions setting

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -46,6 +46,7 @@ import {
   reviewRoute,
   settingsAccessRoute,
   settingsAccessDetailRoutePattern,
+  settingsAIChatSuggestionsRoute,
   settingsCurrentWorkspaceRoute,
   settingsDeckNewRoute,
   settingsDecksRoute,
@@ -67,6 +68,7 @@ import {
 } from "./routes";
 import { isWorkspaceManagementLocked } from "./workspaceManagement";
 import { TestModeProvider, useTestMode } from "./testMode";
+import { AIChatPreferencesProvider } from "./chat/preferences/AIChatPreferencesContext";
 import { CardFormScreen } from "./screens/cards/form/CardFormScreen";
 import { CardsScreen } from "./screens/cards/list/CardsScreen";
 import { FriendInviteScreen } from "./screens/invite/FriendInviteScreen";
@@ -130,6 +132,9 @@ const LanguageSettingsScreen = lazy(async () => import("./screens/settings/Langu
 })));
 const LeaderboardParticipationSettingsScreen = lazy(async () => import("./screens/settings/LeaderboardParticipationSettingsScreen").then((module) => ({
   default: module.LeaderboardParticipationSettingsScreen,
+})));
+const AIChatSuggestionsSettingsScreen = lazy(async () => import("./screens/settings/AIChatSuggestionsSettingsScreen").then((module) => ({
+  default: module.AIChatSuggestionsSettingsScreen,
 })));
 const SettingsScreen = lazy(async () => import("./screens/settings/SettingsScreen").then((module) => ({
   default: module.SettingsScreen,
@@ -733,6 +738,7 @@ export function RoutedShell(): ReactElement {
           <Route path={settingsAccessDetailRoutePattern} element={renderDeferredRoute(<AccessPermissionDetailScreen />, "loading.accessDetails")} />
           <Route path={settingsNotificationsRoute} element={renderDeferredRoute(<NotificationsSettingsScreen />, "loading.notificationSettings")} />
           <Route path={settingsReviewAnimationsRoute} element={renderDeferredRoute(<ReviewAnimationsSettingsScreen />, "loading.settings")} />
+          <Route path={settingsAIChatSuggestionsRoute} element={renderDeferredRoute(<AIChatSuggestionsSettingsScreen />, "loading.settings")} />
           <Route path={settingsSchedulerRoute} element={renderDeferredRoute(<WorkspaceSchedulerScreen />, "loading.schedulerSettings")} />
           <Route path={settingsExportRoute} element={renderDeferredRoute(<WorkspaceExportScreen />, "loading.exportSettings")} />
           <Route path={settingsResetStudyProgressRoute} element={renderDeferredRoute(<ResetStudyProgressScreen />, "loading.settings")} />
@@ -790,13 +796,15 @@ export function RoutedShell(): ReactElement {
 function AuthenticatedApp(): ReactElement {
   return (
     <AppDataProvider>
-      <ChatLayoutProvider>
-        <ChatSessionControllerProvider>
-          <ChatDraftProvider>
-            <AppShell />
-          </ChatDraftProvider>
-        </ChatSessionControllerProvider>
-      </ChatLayoutProvider>
+      <AIChatPreferencesProvider>
+        <ChatLayoutProvider>
+          <ChatSessionControllerProvider>
+            <ChatDraftProvider>
+              <AppShell />
+            </ChatDraftProvider>
+          </ChatSessionControllerProvider>
+        </ChatLayoutProvider>
+      </AIChatPreferencesProvider>
     </AppDataProvider>
   );
 }

--- a/apps/web/src/accountDeletion.test.ts
+++ b/apps/web/src/accountDeletion.test.ts
@@ -7,6 +7,7 @@ import {
   isBrowserReauthRequired,
   markBrowserReauthRequired,
 } from "./accountDeletion";
+import { AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY } from "./chat/preferences/AIChatPreferencesContext";
 import { INSTALLATION_ID_STORAGE_KEY } from "./clientIdentity";
 import { LOCALE_PREFERENCE_STORAGE_KEY } from "./i18n/runtime";
 import { loadCloudSettings, putCloudSettings } from "./localDb/sync/cloudSettings";
@@ -60,6 +61,7 @@ function createStorageMock(): Storage {
 function seedLocalBrowserState(): void {
   window.localStorage.setItem(INSTALLATION_ID_STORAGE_KEY, "installation-1");
   window.localStorage.setItem(LOCALE_PREFERENCE_STORAGE_KEY, "ar");
+  window.localStorage.setItem(AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY, "false");
   window.localStorage.setItem("flashcards-warm-start-snapshot", JSON.stringify({
     version: 1,
   }));
@@ -82,6 +84,7 @@ function expectLocalBrowserStateCleared(): void {
   expect(isBrowserReauthRequired()).toBe(false);
   expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
   expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
+  expect(window.localStorage.getItem(AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY)).toBe("false");
 }
 
 function createMockOpenDbRequest(fire: (request: IDBOpenDBRequest) => void): IDBOpenDBRequest {
@@ -186,6 +189,7 @@ describe("account deletion local cleanup helpers", () => {
     expect(isBrowserReauthRequired()).toBe(true);
     expect(window.localStorage.getItem(INSTALLATION_ID_STORAGE_KEY)).toBe("installation-1");
     expect(window.localStorage.getItem(LOCALE_PREFERENCE_STORAGE_KEY)).toBe("ar");
+    expect(window.localStorage.getItem(AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY)).toBe("false");
     expect(observabilityMocks.addWebBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
       action: "local_browser_data_cleanup",
       details: expect.objectContaining({

--- a/apps/web/src/accountDeletion.ts
+++ b/apps/web/src/accountDeletion.ts
@@ -6,6 +6,7 @@ import {
   type LocalBrowserDataCleanupReason,
   type WebObservationScope,
 } from "./observability/webObservability";
+import { AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY } from "./chat/preferences/AIChatPreferencesContext";
 import { TEST_MODE_STORAGE_KEY } from "./testMode";
 
 export type { LocalBrowserDataCleanupReason } from "./observability/webObservability";
@@ -24,6 +25,7 @@ const APP_LOCAL_STORAGE_KEYS: ReadonlyArray<string> = [
 const PRESERVED_BROWSER_LOCAL_STORAGE_KEYS: ReadonlyArray<string> = [
   INSTALLATION_ID_STORAGE_KEY,
   LOCALE_PREFERENCE_STORAGE_KEY,
+  AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY,
   TEST_MODE_STORAGE_KEY,
 ];
 
@@ -241,11 +243,11 @@ export function clearAuthResetRequired(): void {
  * Clears browser-local user state aggressively after logout, account deletion,
  * or a confirmed account switch.
  *
- * The stable installation id, explicit locale preference, and hidden test-mode
- * flag are intentionally retained because they are browser-scoped preferences
- * rather than user-scoped session state. Keeping them preserves device identity,
- * UI language, and local tester tooling across re-login while still clearing
- * application data.
+ * The stable installation id, explicit locale preference, AI chat suggestions
+ * setting, and hidden test-mode flag are intentionally retained because they are
+ * browser-scoped preferences rather than user-scoped session state. Keeping them
+ * preserves device identity, UI language, local chat UI preferences, and local
+ * tester tooling across re-login while still clearing application data.
  */
 export async function clearAllLocalBrowserData(reason: LocalBrowserDataCleanupReason): Promise<void> {
   const browserStorage = getBrowserStorage();

--- a/apps/web/src/chat/ChatPanel/ChatPanel.tsx
+++ b/apps/web/src/chat/ChatPanel/ChatPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from "../composer/chatComposerState";
 import { renderStoredMessageContent } from "../history/chatMessageContent";
 import { useChatAutoScroll } from "../history/useChatAutoScroll";
+import { useAIChatPreferences } from "../preferences/AIChatPreferencesContext";
 import { useChatSession } from "../sessionController";
 import { useChatAttachments } from "../attachments/useChatAttachments";
 import { useChatComposerKeyboard } from "../composer/useChatComposerKeyboard";
@@ -38,6 +39,7 @@ export function ChatPanel(props: Props): ReactElement {
   const appData = useAppData();
   const { showCapturedTechnicalError, showTechnicalError } = useAppErrorDialog();
   const { t, formatNumber } = useI18n();
+  const { aiChatComposerSuggestionsEnabled } = useAIChatPreferences();
   const {
     draft,
     focusComposerRequestVersion,
@@ -227,6 +229,7 @@ export function ChatPanel(props: Props): ReactElement {
   });
   const isSendButtonBusy = sendPhase === "preparingSend" || sendPhase === "startingRun";
   const canShowComposerSuggestions = getCanShowComposerSuggestions({
+    areComposerSuggestionsEnabled: aiChatComposerSuggestionsEnabled,
     composerAction,
     composerSuggestionsCount: composerSuggestions.length,
     dictationState,
@@ -238,6 +241,7 @@ export function ChatPanel(props: Props): ReactElement {
     pendingAttachmentCount: pendingAttachments.length,
     sendPhase,
   });
+  const visibleComposerSuggestions = canShowComposerSuggestions ? composerSuggestions : [];
   const microphoneAriaLabel = dictationState === "recording" ? t("chatPanel.dictation.stop") : t("chatPanel.dictation.start");
   const dictationStatusLabel = dictationState === "requesting_permission"
     ? t("chatPanel.dictation.waitingForPermission")
@@ -382,14 +386,14 @@ export function ChatPanel(props: Props): ReactElement {
           </div>
         ) : null}
 
-        {canShowComposerSuggestions ? (
+        {visibleComposerSuggestions.length > 0 ? (
           <div
             className="chat-composer-suggestions"
             aria-label={t("chatPanel.suggestedReplies")}
             data-testid="chat-composer-suggestions"
-            data-suggestion-count={composerSuggestions.length}
+            data-suggestion-count={visibleComposerSuggestions.length}
           >
-            {composerSuggestions.map((suggestion, index) => (
+            {visibleComposerSuggestions.map((suggestion, index) => (
               <button
                 key={suggestion.id}
                 type="button"

--- a/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
+++ b/apps/web/src/chat/ChatPanel/tests/support/ChatPanelTestSupport.ts
@@ -7,6 +7,7 @@ import type { Locale, LocalePreference } from "../../../../i18n/types";
 import type { ChatSessionSnapshot, StartChatRunRequestBody } from "../../../../types";
 import { defaultChatConfig } from "../../../sessionController/support/config";
 import { ChatDraftProvider } from "../../../composer/ChatDraftContext";
+import { AIChatPreferencesProvider } from "../../../preferences/AIChatPreferencesContext";
 import { ChatSessionControllerProvider } from "../../../sessionController";
 import {
   loadChatDraftWorkspaceState,
@@ -811,14 +812,18 @@ export function setupChatPanelTest(): ChatPanelTestHarness {
           AppErrorDialogProvider,
           null,
           createElement(
-            ChatSessionControllerProvider,
+            AIChatPreferencesProvider,
             null,
             createElement(
-              ChatDraftProvider,
+              ChatSessionControllerProvider,
               null,
-              createElement(MessagesScrollerMetricsConfigurator),
-              createElement(LocalePreferenceProbe),
-              panel,
+              createElement(
+                ChatDraftProvider,
+                null,
+                createElement(MessagesScrollerMetricsConfigurator),
+                createElement(LocalePreferenceProbe),
+                panel,
+              ),
             ),
           ),
         ),

--- a/apps/web/src/chat/composer/chatComposerState.test.ts
+++ b/apps/web/src/chat/composer/chatComposerState.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getCanShowComposerSuggestions } from "./chatComposerState";
+
+const visibleSuggestionParams = {
+  areComposerSuggestionsEnabled: true,
+  composerAction: "send",
+  composerSuggestionsCount: 1,
+  dictationState: "idle",
+  inputText: "",
+  isAssistantRunActive: false,
+  isChatActionLocked: false,
+  isHistoryLoaded: true,
+  isStopping: false,
+  pendingAttachmentCount: 0,
+  sendPhase: "idle",
+} as const;
+
+describe("getCanShowComposerSuggestions", () => {
+  it("hides composer suggestions when the local preference is disabled", () => {
+    expect(getCanShowComposerSuggestions({
+      ...visibleSuggestionParams,
+      areComposerSuggestionsEnabled: false,
+    })).toBe(false);
+  });
+
+  it("shows composer suggestions when the local preference and composer state allow them", () => {
+    expect(getCanShowComposerSuggestions(visibleSuggestionParams)).toBe(true);
+  });
+});

--- a/apps/web/src/chat/composer/chatComposerState.ts
+++ b/apps/web/src/chat/composer/chatComposerState.ts
@@ -116,6 +116,7 @@ export function getCanSendPendingMessage(params: Readonly<{
 }
 
 export function getCanShowComposerSuggestions(params: Readonly<{
+  areComposerSuggestionsEnabled: boolean;
   composerAction: ChatComposerAction;
   composerSuggestionsCount: number;
   dictationState: ChatDictationState;
@@ -128,6 +129,7 @@ export function getCanShowComposerSuggestions(params: Readonly<{
   sendPhase: ChatComposerSendPhase;
 }>): boolean {
   const {
+    areComposerSuggestionsEnabled,
     composerAction,
     composerSuggestionsCount,
     dictationState,
@@ -140,7 +142,8 @@ export function getCanShowComposerSuggestions(params: Readonly<{
     sendPhase,
   } = params;
 
-  return isHistoryLoaded
+  return areComposerSuggestionsEnabled
+    && isHistoryLoaded
     && composerAction === "send"
     && sendPhase === "idle"
     && !isAssistantRunActive

--- a/apps/web/src/chat/preferences/AIChatPreferencesContext.tsx
+++ b/apps/web/src/chat/preferences/AIChatPreferencesContext.tsx
@@ -1,0 +1,111 @@
+import { createContext, useContext, useEffect, useState, type ReactElement, type ReactNode } from "react";
+
+export const AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY = "flashcards-ai-chat-composer-suggestions-enabled";
+
+const aiChatPreferencesChangeEventName = "flashcards-ai-chat-preferences-change";
+
+type AIChatPreferencesContextValue = Readonly<{
+  aiChatComposerSuggestionsEnabled: boolean;
+  setAIChatComposerSuggestionsEnabled: (nextValue: boolean) => void;
+}>;
+
+type AIChatPreferencesProviderProps = Readonly<{
+  children: ReactNode;
+}>;
+
+type AIChatPreferencesListener = () => void;
+
+const AIChatPreferencesContext = createContext<AIChatPreferencesContextValue | null>(null);
+
+function getBrowserStorage(): Storage {
+  const storageValue = window.localStorage;
+  if (
+    typeof storageValue?.getItem !== "function"
+    || typeof storageValue.setItem !== "function"
+    || typeof storageValue.removeItem !== "function"
+  ) {
+    throw new Error("Browser localStorage is required for Web AI chat preferences.");
+  }
+
+  return storageValue;
+}
+
+export function readStoredAIChatComposerSuggestionsEnabled(): boolean {
+  const storage = getBrowserStorage();
+  const storedValue = storage.getItem(AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY);
+  if (storedValue === null) {
+    return true;
+  }
+
+  if (storedValue === "true") {
+    return true;
+  }
+
+  if (storedValue === "false") {
+    return false;
+  }
+
+  storage.removeItem(AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY);
+  return true;
+}
+
+function persistAIChatComposerSuggestionsEnabled(nextValue: boolean): void {
+  getBrowserStorage().setItem(AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY, String(nextValue));
+}
+
+function dispatchAIChatPreferencesChange(): void {
+  window.dispatchEvent(new Event(aiChatPreferencesChangeEventName));
+}
+
+function subscribeToAIChatPreferences(listener: AIChatPreferencesListener): () => void {
+  const handleStorage = (event: StorageEvent): void => {
+    if (event.key === AI_CHAT_COMPOSER_SUGGESTIONS_STORAGE_KEY || event.key === null) {
+      listener();
+    }
+  };
+
+  window.addEventListener("storage", handleStorage);
+  window.addEventListener(aiChatPreferencesChangeEventName, listener);
+
+  return (): void => {
+    window.removeEventListener("storage", handleStorage);
+    window.removeEventListener(aiChatPreferencesChangeEventName, listener);
+  };
+}
+
+export function AIChatPreferencesProvider(props: AIChatPreferencesProviderProps): ReactElement {
+  const { children } = props;
+  const [aiChatComposerSuggestionsEnabled, setAIChatComposerSuggestionsEnabledState] = useState<boolean>(() => (
+    readStoredAIChatComposerSuggestionsEnabled()
+  ));
+
+  useEffect(() => subscribeToAIChatPreferences(() => {
+    setAIChatComposerSuggestionsEnabledState(readStoredAIChatComposerSuggestionsEnabled());
+  }), []);
+
+  function setAIChatComposerSuggestionsEnabled(nextValue: boolean): void {
+    persistAIChatComposerSuggestionsEnabled(nextValue);
+    setAIChatComposerSuggestionsEnabledState(nextValue);
+    dispatchAIChatPreferencesChange();
+  }
+
+  return (
+    <AIChatPreferencesContext.Provider
+      value={{
+        aiChatComposerSuggestionsEnabled,
+        setAIChatComposerSuggestionsEnabled,
+      }}
+    >
+      {children}
+    </AIChatPreferencesContext.Provider>
+  );
+}
+
+export function useAIChatPreferences(): AIChatPreferencesContextValue {
+  const contextValue = useContext(AIChatPreferencesContext);
+  if (contextValue === null) {
+    throw new Error("useAIChatPreferences must be used within AIChatPreferencesProvider");
+  }
+
+  return contextValue;
+}

--- a/apps/web/src/i18n/catalogs/ar.ts
+++ b/apps/web/src/i18n/catalogs/ar.ts
@@ -517,6 +517,12 @@ const arCatalog: TranslationCatalog = {
     toggleTitle: "إظهار الرسوم المتحركة بعد تقييم بطاقة",
     toggleDescription: "ينطبق هذا فقط على رسوم التفاعل المتحركة في المراجعة.",
   },
+  aiChatSuggestionsSettings: {
+    title: "اقتراحات دردشة الذكاء الاصطناعي",
+    subtitle: "تحكم في اقتراحات المطالبات في حقل كتابة دردشة الذكاء الاصطناعي.",
+    toggleTitle: "عرض الاقتراحات في حقل كتابة دردشة الذكاء الاصطناعي",
+    toggleDescription: "تظهر المطالبات المقترحة أعلى حقل الكتابة عندما تكون الدردشة خاملة وجاهزة.",
+  },
   leaderboardParticipationSettings: {
     title: "المشاركة في لوحة الصدارة",
     subtitle: "تحكم في ظهورك في تصنيفات المجتمع وإمكانية رؤيتها.",

--- a/apps/web/src/i18n/catalogs/de.ts
+++ b/apps/web/src/i18n/catalogs/de.ts
@@ -517,6 +517,12 @@ const deCatalog: TranslationCatalog = {
     toggleTitle: "Animationen nach der Bewertung einer Karte anzeigen",
     toggleDescription: "Betrifft nur die Reaktionsanimationen beim Wiederholen.",
   },
+  aiChatSuggestionsSettings: {
+    title: "KI-Chat-Vorschläge",
+    subtitle: "Steuere vorgeschlagene Prompts im KI-Chat-Eingabefeld.",
+    toggleTitle: "Vorschläge im KI-Chat-Eingabefeld anzeigen",
+    toggleDescription: "Vorgeschlagene Prompts erscheinen über dem Eingabefeld, wenn der Chat bereit und inaktiv ist.",
+  },
   leaderboardParticipationSettings: {
     title: "Bestenlisten-Teilnahme",
     subtitle: "Lege fest, ob du in Community-Ranglisten erscheinst und sie sehen kannst.",

--- a/apps/web/src/i18n/catalogs/en.ts
+++ b/apps/web/src/i18n/catalogs/en.ts
@@ -515,6 +515,12 @@ const enCatalog = {
     toggleTitle: "Show animations after rating a card",
     toggleDescription: "Only the review reaction animations are affected.",
   },
+  aiChatSuggestionsSettings: {
+    title: "AI Chat Suggestions",
+    subtitle: "Control suggested prompt chips in the AI chat composer.",
+    toggleTitle: "Show suggestions in the AI chat composer",
+    toggleDescription: "Suggested prompts appear above the composer when chat is idle and ready.",
+  },
   leaderboardParticipationSettings: {
     title: "Leaderboard participation",
     subtitle: "Control whether you appear in and can view community rankings.",

--- a/apps/web/src/i18n/catalogs/es-ES.ts
+++ b/apps/web/src/i18n/catalogs/es-ES.ts
@@ -517,6 +517,12 @@ const esEsCatalog: TranslationCatalog = {
     toggleTitle: "Mostrar animaciones después de calificar una tarjeta",
     toggleDescription: "Solo afecta a las animaciones de reacción del repaso.",
   },
+  aiChatSuggestionsSettings: {
+    title: "Sugerencias del chat de IA",
+    subtitle: "Controla las sugerencias que aparecen en el compositor del chat de IA.",
+    toggleTitle: "Mostrar sugerencias en el compositor del chat de IA",
+    toggleDescription: "Las sugerencias aparecen encima del compositor cuando el chat está inactivo y listo.",
+  },
   leaderboardParticipationSettings: {
     title: "Participación en la clasificación",
     subtitle: "Controla si apareces en las clasificaciones de la comunidad y si puedes verlas.",

--- a/apps/web/src/i18n/catalogs/es-MX.ts
+++ b/apps/web/src/i18n/catalogs/es-MX.ts
@@ -517,6 +517,12 @@ const esMxCatalog: TranslationCatalog = {
     toggleTitle: "Mostrar animaciones después de calificar una tarjeta",
     toggleDescription: "Solo afecta a las animaciones de reacción del repaso.",
   },
+  aiChatSuggestionsSettings: {
+    title: "Sugerencias del chat de IA",
+    subtitle: "Controla las sugerencias que aparecen en el compositor del chat de IA.",
+    toggleTitle: "Mostrar sugerencias en el compositor del chat de IA",
+    toggleDescription: "Las sugerencias aparecen encima del compositor cuando el chat está inactivo y listo.",
+  },
   leaderboardParticipationSettings: {
     title: "Participación en la tabla",
     subtitle: "Controla si apareces en las posiciones de la comunidad y si puedes verlas.",

--- a/apps/web/src/i18n/catalogs/hi.ts
+++ b/apps/web/src/i18n/catalogs/hi.ts
@@ -517,6 +517,12 @@ const hiCatalog: TranslationCatalog = {
     toggleTitle: "कार्ड रेट करने के बाद एनिमेशन दिखाएँ",
     toggleDescription: "यह केवल रिव्यू रिएक्शन एनिमेशन को प्रभावित करता है।",
   },
+  aiChatSuggestionsSettings: {
+    title: "AI चैट सुझाव",
+    subtitle: "AI चैट कम्पोज़र में दिखने वाले सुझाए गए प्रॉम्प्ट नियंत्रित करें।",
+    toggleTitle: "AI चैट कम्पोज़र में सुझाव दिखाएँ",
+    toggleDescription: "जब चैट खाली और तैयार होती है, तो सुझाए गए प्रॉम्प्ट कम्पोज़र के ऊपर दिखते हैं।",
+  },
   leaderboardParticipationSettings: {
     title: "लीडरबोर्ड भागीदारी",
     subtitle: "नियंत्रित करें कि आप समुदाय रैंकिंग में दिखें और उन्हें देख सकें या नहीं.",

--- a/apps/web/src/i18n/catalogs/ja.ts
+++ b/apps/web/src/i18n/catalogs/ja.ts
@@ -517,6 +517,12 @@ export const jaCatalog = {
     toggleTitle: "カード評価後にアニメーションを表示",
     toggleDescription: "復習時のリアクションアニメーションだけに適用されます。",
   },
+  aiChatSuggestionsSettings: {
+    title: "AIチャットの提案",
+    subtitle: "AIチャット入力欄に表示する提案プロンプトを管理します。",
+    toggleTitle: "AIチャット入力欄に提案を表示",
+    toggleDescription: "チャットが待機中で準備できているとき、入力欄の上に提案プロンプトが表示されます。",
+  },
   leaderboardParticipationSettings: {
     title: "リーダーボード参加",
     subtitle: "コミュニティランキングに表示されるか、ランキングを見られるかを管理します。",

--- a/apps/web/src/i18n/catalogs/ru.ts
+++ b/apps/web/src/i18n/catalogs/ru.ts
@@ -517,6 +517,12 @@ export const ruCatalog = {
     toggleTitle: "Показывать анимации после оценки карточки",
     toggleDescription: "Влияет только на анимации реакции при повторении.",
   },
+  aiChatSuggestionsSettings: {
+    title: "Подсказки AI-чата",
+    subtitle: "Управляйте подсказками над полем ввода AI-чата.",
+    toggleTitle: "Показывать подсказки в поле ввода AI-чата",
+    toggleDescription: "Подсказки появляются над полем ввода, когда чат свободен и готов.",
+  },
   leaderboardParticipationSettings: {
     title: "Участие в таблице лидеров",
     subtitle: "Управляйте тем, показывают ли вас в рейтинге сообщества и видите ли вы его.",

--- a/apps/web/src/i18n/catalogs/zh-Hans.ts
+++ b/apps/web/src/i18n/catalogs/zh-Hans.ts
@@ -517,6 +517,12 @@ export const zhHansCatalog = {
     toggleTitle: "评分后显示动画",
     toggleDescription: "只影响复习评分后的反应动画。",
   },
+  aiChatSuggestionsSettings: {
+    title: "AI 聊天建议",
+    subtitle: "控制 AI 聊天输入框中的建议提示。",
+    toggleTitle: "在 AI 聊天输入框中显示建议",
+    toggleDescription: "当聊天处于空闲且就绪状态时，建议提示会显示在输入框上方。",
+  },
   leaderboardParticipationSettings: {
     title: "排行榜参与",
     subtitle: "控制你是否出现在社区排名中，以及是否可以查看排名。",

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -26,6 +26,7 @@ export const settingsFeedbackRoute: string = "/settings/feedback";
 export const settingsLanguageRoute: string = "/settings/language";
 export const settingsLeaderboardParticipationRoute: string = "/settings/leaderboard-participation";
 export const settingsReviewAnimationsRoute: string = "/settings/review-animations";
+export const settingsAIChatSuggestionsRoute: string = "/settings/ai-chat-suggestions";
 export const settingsServerRoute: string = "/settings/server";
 export const settingsResetStudyProgressRoute: string = "/settings/reset-study-progress";
 export const settingsDeleteCurrentWorkspaceRoute: string = "/settings/delete-current-workspace";

--- a/apps/web/src/screens/settings/AIChatSuggestionsSettingsScreen.tsx
+++ b/apps/web/src/screens/settings/AIChatSuggestionsSettingsScreen.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from "react";
+import { useAIChatPreferences } from "../../chat/preferences/AIChatPreferencesContext";
+import { useI18n } from "../../i18n";
+import { SettingsGroup, SettingsShell } from "./SettingsShared";
+
+export function AIChatSuggestionsSettingsScreen(): ReactElement {
+  const { aiChatComposerSuggestionsEnabled, setAIChatComposerSuggestionsEnabled } = useAIChatPreferences();
+  const { t } = useI18n();
+
+  return (
+    <SettingsShell
+      title={t("aiChatSuggestionsSettings.title")}
+      subtitle={t("aiChatSuggestionsSettings.subtitle")}
+      activeTab="general"
+    >
+      <SettingsGroup>
+        <article className="content-card settings-toggle-card" data-testid="ai-chat-suggestions-settings-card">
+          <div className="settings-nav-card-copy">
+            <strong className="panel-subtitle">{t("aiChatSuggestionsSettings.toggleTitle")}</strong>
+            <p className="subtitle">{t("aiChatSuggestionsSettings.toggleDescription")}</p>
+          </div>
+          <button
+            className="settings-toggle-control"
+            type="button"
+            role="switch"
+            aria-label={t("aiChatSuggestionsSettings.toggleTitle")}
+            aria-checked={aiChatComposerSuggestionsEnabled}
+            data-state={aiChatComposerSuggestionsEnabled ? "on" : "off"}
+            data-testid="ai-chat-suggestions-toggle"
+            onClick={() => setAIChatComposerSuggestionsEnabled(aiChatComposerSuggestionsEnabled === false)}
+          >
+            <span className="settings-toggle-track" aria-hidden="true">
+              <span className="settings-toggle-thumb" />
+            </span>
+            <span className="settings-toggle-value">
+              {aiChatComposerSuggestionsEnabled ? t("common.on") : t("common.off")}
+            </span>
+          </button>
+        </article>
+      </SettingsGroup>
+    </SettingsShell>
+  );
+}

--- a/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.navigation.test.tsx
@@ -5,10 +5,12 @@ import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppDataContextValue } from "../../appData";
 import { AppErrorDialogProvider } from "../../appError/AppErrorContext";
+import { AIChatPreferencesProvider } from "../../chat/preferences/AIChatPreferencesContext";
 import { I18nProvider } from "../../i18n";
 import {
   accountDangerZoneRoute,
   accountStatusRoute,
+  settingsAIChatSuggestionsRoute,
   settingsCurrentWorkspaceRoute,
   settingsFeedbackRoute,
   settingsLanguageRoute,
@@ -60,6 +62,31 @@ type SettingsScreenTestHarness = Readonly<{
 
 function throwNotUsed(functionName: string): never {
   throw new Error(`${functionName} was not expected in this test`);
+}
+
+function createStorageMock(): Storage {
+  const state = new Map<string, string>();
+
+  return {
+    get length(): number {
+      return state.size;
+    },
+    clear(): void {
+      state.clear();
+    },
+    getItem(key: string): string | null {
+      return state.get(key) ?? null;
+    },
+    key(index: number): string | null {
+      return [...state.keys()][index] ?? null;
+    },
+    removeItem(key: string): void {
+      state.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      state.set(key, value);
+    },
+  };
 }
 
 function createAppData(): Mutable<AppDataContextValue> {
@@ -165,6 +192,10 @@ function setupSettingsScreenTest(): SettingsScreenTestHarness {
     isTestModeEnabledRef.current = false;
     useAppDataMock.mockReset();
     useAppDataMock.mockReturnValue(createAppData());
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
     container = document.createElement("div");
     document.body.appendChild(container);
     root = ReactDOM.createRoot(container);
@@ -199,10 +230,12 @@ function setupSettingsScreenTest(): SettingsScreenTestHarness {
       currentRoot.render(
         <I18nProvider>
           <AppErrorDialogProvider>
-            <MemoryRouter initialEntries={["/settings"]}>
-              <SettingsScreen />
-              <LocationProbe />
-            </MemoryRouter>
+            <AIChatPreferencesProvider>
+              <MemoryRouter initialEntries={["/settings"]}>
+                <SettingsScreen />
+                <LocationProbe />
+              </MemoryRouter>
+            </AIChatPreferencesProvider>
           </AppErrorDialogProvider>
         </I18nProvider>,
       );
@@ -295,6 +328,7 @@ describe("SettingsScreen navigation", () => {
       "settings-row-current-workspace",
       "settings-row-review-reminders",
       "settings-row-review-animations",
+      "settings-row-ai-chat-suggestions",
       "settings-row-leaderboard-participation",
       "settings-row-language",
       "settings-row-access",
@@ -317,7 +351,8 @@ describe("SettingsScreen navigation", () => {
     expect(getContainer().querySelector("[data-testid='settings-invite-open']")?.textContent).toBe("Invite friend");
     expect(rowIndex("settings-invite-open")).toBeLessThan(rowIndex("settings-row-account-status"));
     expect(rowIndex("settings-row-review-reminders")).toBeLessThan(rowIndex("settings-row-review-animations"));
-    expect(rowIndex("settings-row-review-animations")).toBeLessThan(rowIndex("settings-row-leaderboard-participation"));
+    expect(rowIndex("settings-row-review-animations")).toBeLessThan(rowIndex("settings-row-ai-chat-suggestions"));
+    expect(rowIndex("settings-row-ai-chat-suggestions")).toBeLessThan(rowIndex("settings-row-leaderboard-participation"));
     expect(rowIndex("settings-row-leaderboard-participation")).toBeLessThan(rowIndex("settings-row-language"));
     expect(rowIndex("settings-row-support")).toBeLessThan(rowIndex("settings-row-legal"));
     expect(getContainer().querySelector("[data-testid='settings-row-test']")).toBeNull();
@@ -366,6 +401,9 @@ describe("SettingsScreen navigation", () => {
 
     await clickRow("settings-row-review-animations");
     expect(currentPathname()).toBe(settingsReviewAnimationsRoute);
+
+    await clickRow("settings-row-ai-chat-suggestions");
+    expect(currentPathname()).toBe(settingsAIChatSuggestionsRoute);
 
     await clickRow("settings-row-leaderboard-participation");
     expect(currentPathname()).toBe(settingsLeaderboardParticipationRoute);

--- a/apps/web/src/screens/settings/SettingsScreen.tsx
+++ b/apps/web/src/screens/settings/SettingsScreen.tsx
@@ -17,6 +17,7 @@ import {
   accountStatusRoute,
   accountSupportRoute,
   settingsAccessRoute,
+  settingsAIChatSuggestionsRoute,
   settingsCurrentWorkspaceRoute,
   settingsDecksRoute,
   settingsDeleteCurrentWorkspaceRoute,
@@ -33,6 +34,7 @@ import {
   settingsTagsRoute,
   settingsTestRoute,
 } from "../../routes";
+import { useAIChatPreferences } from "../../chat/preferences/AIChatPreferencesContext";
 import { useTestMode } from "../../testMode";
 import { FriendInviteCreateDialog } from "../friends/FriendInviteCreateDialog";
 import {
@@ -78,6 +80,7 @@ export function SettingsScreen(): ReactElement {
     workspaceSettings,
   } = useAppData();
   const { localePreference, t } = useI18n();
+  const { aiChatComposerSuggestionsEnabled } = useAIChatPreferences();
   const { isTestModeEnabled } = useTestMode();
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState<boolean>(false);
   const currentWorkspaceName = activeWorkspace?.name ?? t("common.unavailable");
@@ -152,6 +155,13 @@ export function SettingsScreen(): ReactElement {
             value={session?.preferences.reviewReactionAnimationsEnabled === false ? t("common.off") : t("common.on")}
             to={settingsReviewAnimationsRoute}
             testId="settings-row-review-animations"
+          />
+          <SettingsNavigationCard
+            title={t("aiChatSuggestionsSettings.title")}
+            description={t("aiChatSuggestionsSettings.subtitle")}
+            value={aiChatComposerSuggestionsEnabled ? t("common.on") : t("common.off")}
+            to={settingsAIChatSuggestionsRoute}
+            testId="settings-row-ai-chat-suggestions"
           />
           <SettingsNavigationCard
             title={t("leaderboardParticipationSettings.title")}


### PR DESCRIPTION
## Summary
- add a web-local AI chat composer suggestions preference and settings screen
- gate AI chat composer suggestion chips from the local preference
- preserve the browser-local preference across local account cleanup

## Validation
- npm ci passed; local Node v25.6.1 warned against package engine 24.x and npm audit reported one existing high severity issue
- npx vitest run src/screens/settings/SettingsScreen.navigation.test.tsx src/chat/composer/chatComposerState.test.ts passed: 2 files, 8 tests
- npm run build passed with existing Vite large chunk warnings
- npx vitest run src/accountDeletion.test.ts src/chat/ChatPanel/tests/lifecycle/ChatPanel.new-chat.test.tsx passed: 2 files, 20 tests
- git --no-pager diff --check passed
- worker-owned fresh review found no P0-P4 issues and gave green light