### PR TITLE
Add Android streak leaderboard data support

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/ProgressContextRefreshController.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/ProgressContextRefreshController.kt
@@ -68,6 +68,17 @@ class ProgressContextRefreshController(
                         error = error
                     )
                 }
+
+                try {
+                    progressRepository.refreshStreakLeaderboardIfInvalidated()
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Exception) {
+                    captureProgressRefreshFailure(
+                        refreshAction = "refresh_streak_leaderboard_if_invalidated",
+                        error = error
+                    )
+                }
             }
         }
     }

--- a/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/ProgressContextRefreshControllerTest.kt
+++ b/apps/android/app/src/test/java/com/flashcardsopensourceapp/app/ProgressContextRefreshControllerTest.kt
@@ -9,6 +9,7 @@ import com.flashcardsopensourceapp.core.ui.VisibleAppScreen
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
 import kotlinx.coroutines.CompletableDeferred
@@ -48,6 +49,7 @@ class ProgressContextRefreshControllerTest {
         assertEquals(0, repository.seriesRefreshCallCount)
         assertEquals(0, repository.reviewScheduleRefreshCallCount)
         assertEquals(0, repository.leaderboardRefreshCallCount)
+        assertEquals(0, repository.streakLeaderboardRefreshCallCount)
     }
 
     @Test
@@ -69,7 +71,8 @@ class ProgressContextRefreshControllerTest {
                 repository.summaryRefreshCallCount == 1 &&
                     repository.seriesRefreshCallCount == 1 &&
                     repository.reviewScheduleRefreshCallCount == 1 &&
-                    repository.leaderboardRefreshCallCount == 1
+                    repository.leaderboardRefreshCallCount == 1 &&
+                    repository.streakLeaderboardRefreshCallCount == 1
             }
         } finally {
             appScope.cancel()
@@ -79,6 +82,7 @@ class ProgressContextRefreshControllerTest {
         assertEquals(1, repository.seriesRefreshCallCount)
         assertEquals(1, repository.reviewScheduleRefreshCallCount)
         assertEquals(1, repository.leaderboardRefreshCallCount)
+        assertEquals(1, repository.streakLeaderboardRefreshCallCount)
     }
 
     @Test
@@ -104,13 +108,15 @@ class ProgressContextRefreshControllerTest {
             assertEquals(1, repository.summaryRefreshCallCount)
             assertEquals(0, repository.seriesRefreshCallCount)
             assertEquals(0, repository.reviewScheduleRefreshCallCount)
+            assertEquals(0, repository.streakLeaderboardRefreshCallCount)
 
             repository.releaseFirstSummaryRefresh()
 
             awaitUntil {
                 repository.summaryRefreshCallCount == 2 &&
                     repository.seriesRefreshCallCount == 0 &&
-                    repository.reviewScheduleRefreshCallCount == 0
+                    repository.reviewScheduleRefreshCallCount == 0 &&
+                    repository.streakLeaderboardRefreshCallCount == 0
             }
         } finally {
             appScope.cancel()
@@ -119,6 +125,7 @@ class ProgressContextRefreshControllerTest {
         assertEquals(2, repository.summaryRefreshCallCount)
         assertEquals(0, repository.seriesRefreshCallCount)
         assertEquals(0, repository.reviewScheduleRefreshCallCount)
+        assertEquals(0, repository.streakLeaderboardRefreshCallCount)
     }
 
     @Test
@@ -138,14 +145,16 @@ class ProgressContextRefreshControllerTest {
             awaitUntil {
                 repository.summaryRefreshCallCount == 1 &&
                     repository.seriesRefreshCallCount == 1 &&
-                    repository.reviewScheduleRefreshCallCount == 1
+                    repository.reviewScheduleRefreshCallCount == 1 &&
+                    repository.streakLeaderboardRefreshCallCount == 1
             }
 
             controller.refreshIfInvalidated(visibleScreen = VisibleAppScreen.PROGRESS)
             awaitUntil {
                 repository.summaryRefreshCallCount == 2 &&
                     repository.seriesRefreshCallCount == 2 &&
-                    repository.reviewScheduleRefreshCallCount == 2
+                    repository.reviewScheduleRefreshCallCount == 2 &&
+                    repository.streakLeaderboardRefreshCallCount == 2
             }
         } finally {
             appScope.cancel()
@@ -154,6 +163,7 @@ class ProgressContextRefreshControllerTest {
         assertEquals(2, repository.summaryRefreshCallCount)
         assertEquals(2, repository.seriesRefreshCallCount)
         assertEquals(2, repository.reviewScheduleRefreshCallCount)
+        assertEquals(2, repository.streakLeaderboardRefreshCallCount)
     }
 }
 
@@ -195,6 +205,9 @@ private class FakeProgressRepository(
     @Volatile
     var leaderboardRefreshCallCount: Int = 0
 
+    @Volatile
+    var streakLeaderboardRefreshCallCount: Int = 0
+
     override fun observeSummarySnapshot(): Flow<ProgressSummarySnapshot?> {
         return emptyFlow()
     }
@@ -208,6 +221,10 @@ private class FakeProgressRepository(
     }
 
     override fun observeLeaderboardSnapshot(): Flow<ProgressLeaderboardSnapshot?> {
+        return emptyFlow()
+    }
+
+    override fun observeStreakLeaderboardSnapshot(): Flow<ProgressStreakLeaderboardSnapshot?> {
         return emptyFlow()
     }
 
@@ -233,6 +250,10 @@ private class FakeProgressRepository(
         leaderboardRefreshCallCount += 1
     }
 
+    override suspend fun refreshStreakLeaderboardIfInvalidated() {
+        streakLeaderboardRefreshCallCount += 1
+    }
+
     override suspend fun refreshLeaderboardForReviewShortcut() {
         throw UnsupportedOperationException("Not used in ProgressContextRefreshControllerTest.")
     }
@@ -250,6 +271,10 @@ private class FakeProgressRepository(
     }
 
     override suspend fun refreshLeaderboardManually() {
+        throw UnsupportedOperationException("Not used in ProgressContextRefreshControllerTest.")
+    }
+
+    override suspend fun refreshStreakLeaderboardManually() {
         throw UnsupportedOperationException("Not used in ProgressContextRefreshControllerTest.")
     }
 

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration23To24Test.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/migrations/AppDatabaseMigration23To24Test.kt
@@ -1,0 +1,58 @@
+package com.flashcardsopensourceapp.data.local.migrations
+
+import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.flashcardsopensourceapp.data.local.database.migrations.migration23To24
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val migration23To24DatabaseName: String = "migration-23-to-24-test.db"
+
+@RunWith(AndroidJUnit4::class)
+class AppDatabaseMigration23To24Test {
+    @After
+    fun tearDown(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        deleteMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration23To24DatabaseName
+        )
+    }
+
+    @Test
+    fun migration23To24AddsProgressStreakLeaderboardCacheTable(): Unit {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        createMigrationDatabaseFixture(
+            context = context,
+            databaseName = migration23To24DatabaseName,
+            version = 23,
+            configureDatabase = {}
+        )
+
+        val openHelper: SupportSQLiteOpenHelper = openMigrationDatabaseAtVersion(
+            context = context,
+            databaseName = migration23To24DatabaseName,
+            version = 23
+        )
+        val database: SupportSQLiteDatabase = openHelper.writableDatabase
+
+        try {
+            migration23To24.migrate(database)
+
+            assertTrue(
+                migrationTableExists(
+                    database = database,
+                    tableName = "progress_streak_leaderboard_cache"
+                )
+            )
+        } finally {
+            database.close()
+            openHelper.close()
+        }
+    }
+}

--- a/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
+++ b/apps/android/data/local/src/androidTest/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/support/FakeCloudRemoteGateway.kt
@@ -26,6 +26,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSendCodeResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
@@ -71,6 +72,8 @@ internal class FakeCloudRemoteGateway private constructor(
     private var bootstrapPullResponseIndex: Int = 0
     private var bootstrapPushErrorIndex: Int = 0
     private var importReviewHistoryErrorIndex: Int = 0
+    private var progressLeaderboardResponse: CloudProgressLeaderboard? = null
+    private var progressStreakLeaderboardResponse: CloudProgressStreakLeaderboard? = null
 
     companion object {
         fun standard(): FakeCloudRemoteGateway {
@@ -377,6 +380,14 @@ internal class FakeCloudRemoteGateway private constructor(
     val importReviewHistoryBodies = mutableListOf<JSONObject>()
     val createdWorkspaceId: String = createdWorkspace.workspaceId
 
+    fun setProgressLeaderboardResponse(response: CloudProgressLeaderboard): Unit {
+        progressLeaderboardResponse = response
+    }
+
+    fun setProgressStreakLeaderboardResponse(response: CloudProgressStreakLeaderboard): Unit {
+        progressStreakLeaderboardResponse = response
+    }
+
     override suspend fun validateConfiguration(configuration: CloudServiceConfiguration) {
     }
 
@@ -565,7 +576,18 @@ internal class FakeCloudRemoteGateway private constructor(
         apiBaseUrl: String,
         authorizationHeader: String
     ): CloudProgressLeaderboard {
-        throw UnsupportedOperationException()
+        return requireNotNull(progressLeaderboardResponse) {
+            "Fake progress leaderboard response was not configured."
+        }
+    }
+
+    override suspend fun loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ): CloudProgressStreakLeaderboard {
+        return requireNotNull(progressStreakLeaderboardResponse) {
+            "Fake progress streak leaderboard response was not configured."
+        }
     }
 
     override suspend fun loadCommunityProfile(

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteGateway.kt
@@ -23,6 +23,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSendCodeResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
@@ -125,6 +126,10 @@ interface CloudRemoteGateway {
         apiBaseUrl: String,
         authorizationHeader: String
     ): CloudProgressLeaderboard
+    suspend fun loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ): CloudProgressStreakLeaderboard
     suspend fun loadCommunityProfile(
         apiBaseUrl: String,
         authorizationHeader: String

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteService.kt
@@ -35,6 +35,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSendCodeResult
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
@@ -311,6 +312,16 @@ class CloudRemoteService private constructor(
         authorizationHeader: String
     ): CloudProgressLeaderboard {
         return progressApi.loadProgressLeaderboard(
+            apiBaseUrl = apiBaseUrl,
+            authorizationHeader = authorizationHeader
+        )
+    }
+
+    override suspend fun loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ): CloudProgressStreakLeaderboard {
+        return progressApi.loadProgressStreakLeaderboard(
             apiBaseUrl = apiBaseUrl,
             authorizationHeader = authorizationHeader
         )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/progress/CloudProgressRemoteApi.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgre
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgressReviewScheduleCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgressSeriesCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgressSummaryCloudPath
+import com.flashcardsopensourceapp.data.local.cloud.remote.transport.buildProgressStreakLeaderboardCloudPath
 import com.flashcardsopensourceapp.data.local.cloud.wire.CloudContractMismatchException
 import com.flashcardsopensourceapp.data.local.cloud.wire.optCloudStringOrNull
 import com.flashcardsopensourceapp.data.local.cloud.wire.requireCloudArray
@@ -28,6 +29,11 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardMetric
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardViewer
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus
@@ -107,6 +113,21 @@ internal class CloudProgressRemoteApi(
         return parseCloudProgressLeaderboard(
             payload = response,
             fieldPath = "progress.leaderboard"
+        )
+    }
+
+    suspend fun loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ): CloudProgressStreakLeaderboard {
+        val response = httpClient.getJson(
+            baseUrl = apiBaseUrl,
+            path = buildProgressStreakLeaderboardCloudPath(),
+            authorizationHeader = authorizationHeader
+        )
+        return parseCloudProgressStreakLeaderboard(
+            payload = response,
+            fieldPath = "progress.streakLeaderboard"
         )
     }
 }
@@ -640,6 +661,208 @@ private fun requirePositiveLeaderboardRank(
 ): Int {
     if (value < 1) {
         throw CloudContractMismatchException("$fieldPath must be at least 1.")
+    }
+
+    return value
+}
+
+internal fun parseCloudProgressStreakLeaderboard(
+    payload: JSONObject,
+    fieldPath: String
+): CloudProgressStreakLeaderboard {
+    val status = ProgressLeaderboardStatus.fromWireKey(
+        wireKey = payload.requireCloudString("status", "$fieldPath.status")
+    )
+    val metric = payload.requireCloudObject("metric", "$fieldPath.metric")
+        .toCloudProgressStreakLeaderboardMetric(fieldPath = "$fieldPath.metric")
+    if (status != ProgressLeaderboardStatus.READY) {
+        return CloudProgressStreakLeaderboard.NonReady(
+            status = status,
+            metric = metric
+        )
+    }
+
+    val viewer = payload.requireCloudObject("viewer", "$fieldPath.viewer")
+        .toCloudProgressStreakLeaderboardViewer(fieldPath = "$fieldPath.viewer")
+    val rowsArray = payload.requireCloudArray("rows", "$fieldPath.rows")
+    val rows = buildList {
+        for (index in 0 until rowsArray.length()) {
+            add(
+                rowsArray.requireCloudObject(index, "$fieldPath.rows[$index]")
+                    .toCloudProgressStreakLeaderboardRow(fieldPath = "$fieldPath.rows[$index]")
+            )
+        }
+    }
+    val rankingRowsArray = payload.requireCloudArray("rankingRows", "$fieldPath.rankingRows")
+    val rankingRows = buildList {
+        for (index in 0 until rankingRowsArray.length()) {
+            add(
+                rankingRowsArray.requireCloudObject(index, "$fieldPath.rankingRows[$index]")
+                    .toCloudProgressStreakLeaderboardRankingRow(fieldPath = "$fieldPath.rankingRows[$index]")
+            )
+        }
+    }
+    val asOfUtcDate = payload.requireCloudString("asOfUtcDate", "$fieldPath.asOfUtcDate")
+    parseCloudProgressLocalDate(
+        value = asOfUtcDate,
+        fieldPath = "$fieldPath.asOfUtcDate"
+    )
+    validateCloudProgressStreakLeaderboardReadyPayload(
+        fieldPath = fieldPath,
+        participantCount = requireNonNegativeLeaderboardInt(
+            value = payload.requireCloudInt("participantCount", "$fieldPath.participantCount"),
+            fieldPath = "$fieldPath.participantCount"
+        ),
+        viewer = viewer,
+        rankingRows = rankingRows
+    )
+
+    return CloudProgressStreakLeaderboard.Ready(
+        status = status,
+        metric = metric,
+        snapshotId = payload.requireCloudString("snapshotId", "$fieldPath.snapshotId"),
+        snapshotGeneratedAt = payload.requireCloudString("snapshotGeneratedAt", "$fieldPath.snapshotGeneratedAt"),
+        asOfUtcDate = asOfUtcDate,
+        nextRefreshAfter = payload.requireCloudString("nextRefreshAfter", "$fieldPath.nextRefreshAfter"),
+        participantCount = rankingRows.size,
+        viewer = viewer,
+        rows = rows,
+        rankingRows = rankingRows
+    )
+}
+
+private fun JSONObject.toCloudProgressStreakLeaderboardMetric(
+    fieldPath: String
+): CloudProgressStreakLeaderboardMetric {
+    val metricVersion = requireCloudString("metricVersion", "$fieldPath.metricVersion")
+    if (metricVersion != "streak_days_v1") {
+        throw CloudContractMismatchException(
+            "$fieldPath.metricVersion expected 'streak_days_v1' but got '$metricVersion'."
+        )
+    }
+
+    return CloudProgressStreakLeaderboardMetric(
+        metricVersion = metricVersion,
+        title = requireCloudString("title", "$fieldPath.title"),
+        description = requireCloudString("description", "$fieldPath.description")
+    )
+}
+
+private fun JSONObject.toCloudProgressStreakLeaderboardViewer(
+    fieldPath: String
+): CloudProgressStreakLeaderboardViewer {
+    val displayName = requireCloudString("displayName", "$fieldPath.displayName")
+    if (displayName != "You") {
+        throw CloudContractMismatchException("$fieldPath.displayName expected 'You' but got '$displayName'.")
+    }
+
+    return CloudProgressStreakLeaderboardViewer(
+        publicProfileId = requireCloudString("publicProfileId", "$fieldPath.publicProfileId"),
+        displayName = displayName,
+        rank = requirePositiveLeaderboardRank(
+            value = requireCloudInt("rank", "$fieldPath.rank"),
+            fieldPath = "$fieldPath.rank"
+        ),
+        streakDays = requireNonNegativeLeaderboardInt(
+            value = requireCloudInt("streakDays", "$fieldPath.streakDays"),
+            fieldPath = "$fieldPath.streakDays"
+        )
+    )
+}
+
+private fun JSONObject.toCloudProgressStreakLeaderboardRow(
+    fieldPath: String
+): CloudProgressStreakLeaderboardRow {
+    val kind = requireCloudString("kind", "$fieldPath.kind")
+    if (kind == "gap") {
+        return CloudProgressStreakLeaderboardRow.Gap
+    }
+
+    return CloudProgressStreakLeaderboardRow.Participant(
+        kind = ProgressLeaderboardParticipantRowKind.fromWireKey(wireKey = kind),
+        publicProfileId = requireCloudString("publicProfileId", "$fieldPath.publicProfileId"),
+        anonymousDisplayName = requireCloudString("anonymousDisplayName", "$fieldPath.anonymousDisplayName"),
+        friendDisplayName = optCloudStringOrNull("friendDisplayName", "$fieldPath.friendDisplayName"),
+        streakDays = requireNonNegativeLeaderboardInt(
+            value = requireCloudInt("streakDays", "$fieldPath.streakDays"),
+            fieldPath = "$fieldPath.streakDays"
+        ),
+        rank = requirePositiveLeaderboardRank(
+            value = requireCloudInt("rank", "$fieldPath.rank"),
+            fieldPath = "$fieldPath.rank"
+        )
+    )
+}
+
+private fun JSONObject.toCloudProgressStreakLeaderboardRankingRow(
+    fieldPath: String
+): CloudProgressStreakLeaderboardRankingRow {
+    return CloudProgressStreakLeaderboardRankingRow(
+        kind = CloudProgressLeaderboardRankingRowKind.fromWireKey(
+            wireKey = requireCloudString("kind", "$fieldPath.kind")
+        ),
+        publicProfileId = requireCloudString("publicProfileId", "$fieldPath.publicProfileId"),
+        anonymousDisplayName = requireCloudString("anonymousDisplayName", "$fieldPath.anonymousDisplayName"),
+        friendDisplayName = optCloudStringOrNull("friendDisplayName", "$fieldPath.friendDisplayName"),
+        streakDays = requireNonNegativeLeaderboardInt(
+            value = requireCloudInt("streakDays", "$fieldPath.streakDays"),
+            fieldPath = "$fieldPath.streakDays"
+        ),
+        rank = requirePositiveLeaderboardRank(
+            value = requireCloudInt("rank", "$fieldPath.rank"),
+            fieldPath = "$fieldPath.rank"
+        )
+    )
+}
+
+private fun validateCloudProgressStreakLeaderboardReadyPayload(
+    fieldPath: String,
+    participantCount: Int,
+    viewer: CloudProgressStreakLeaderboardViewer,
+    rankingRows: List<CloudProgressStreakLeaderboardRankingRow>
+) {
+    if (participantCount != rankingRows.size) {
+        throw CloudContractMismatchException(
+            "$fieldPath.participantCount expected rankingRows size ${rankingRows.size} but got $participantCount."
+        )
+    }
+    val viewerRows = rankingRows.filter { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }
+    if (viewerRows.size != 1) {
+        throw CloudContractMismatchException("$fieldPath.rankingRows must include exactly one viewer row.")
+    }
+    val viewerRow = viewerRows.single()
+    if (
+        viewerRow.publicProfileId != viewer.publicProfileId ||
+        viewerRow.rank != viewer.rank ||
+        viewerRow.streakDays != viewer.streakDays
+    ) {
+        throw CloudContractMismatchException("$fieldPath.viewer must match the rankingRows viewer row.")
+    }
+
+    var previousStreakDays: Int? = null
+    rankingRows.forEachIndexed { index, row ->
+        val expectedRank = index + 1
+        if (row.rank != expectedRank) {
+            throw CloudContractMismatchException(
+                "$fieldPath.rankingRows[$index].rank expected $expectedRank but got ${row.rank}."
+            )
+        }
+        val resolvedPreviousStreakDays = previousStreakDays
+        if (resolvedPreviousStreakDays != null && row.streakDays > resolvedPreviousStreakDays) {
+            throw CloudContractMismatchException(
+                "$fieldPath.rankingRows[$index].streakDays must not be greater than the previous ranked row."
+            )
+        }
+        previousStreakDays = row.streakDays
+    }
+}
+
+private fun requireNonNegativeLeaderboardInt(
+    value: Int,
+    fieldPath: String
+): Int {
+    if (value < 0) {
+        throw CloudContractMismatchException("$fieldPath must not be negative.")
     }
 
     return value

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/cloud/remote/transport/CloudRemotePaths.kt
@@ -45,6 +45,10 @@ internal fun buildProgressLeaderboardCloudPath(): String {
     return "/me/progress/leaderboard"
 }
 
+internal fun buildProgressStreakLeaderboardCloudPath(): String {
+    return "/me/progress/leaderboards/streak"
+}
+
 internal fun buildCommunityProfileCloudPath(): String {
     return "/me/community/profile"
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/core/AppDatabase.kt
@@ -21,6 +21,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.ProgressLocalDay
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewHistoryStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewScheduleCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSeriesCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.ProgressStreakLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSummaryCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ReviewLogEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
@@ -56,11 +57,12 @@ private const val appDatabaseName: String = "flashcards-android.db"
         ProgressSeriesCacheEntity::class,
         ProgressReviewScheduleCacheEntity::class,
         ProgressLeaderboardCacheEntity::class,
+        ProgressStreakLeaderboardCacheEntity::class,
         ProgressLocalDayCountEntity::class,
         ProgressReviewHistoryStateEntity::class,
         ProgressLocalCacheStateEntity::class
     ],
-    version = 23,
+    version = 24,
     exportSchema = false
 )
 @TypeConverters(DatabaseTypeConverters::class)

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/entities/ProgressEntities.kt
@@ -65,6 +65,16 @@ data class ProgressLeaderboardCacheEntity(
     val updatedAtMillis: Long
 )
 
+// Keeps the streak leaderboard cache distinct from the rating leaderboard cache
+// because both payloads are compact rankings but use different metric fields.
+@Entity(tableName = "progress_streak_leaderboard_cache")
+data class ProgressStreakLeaderboardCacheEntity(
+    @PrimaryKey val scopeKey: String,
+    val scopeId: String,
+    val payloadJson: String,
+    val updatedAtMillis: Long
+)
+
 @Entity(
     tableName = "progress_local_day_counts",
     primaryKeys = ["timeZone", "workspaceId", "localDate"],

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/migrations/AppDatabaseMigrations.kt
@@ -29,7 +29,8 @@ fun createAppDatabaseMigrations(): Array<Migration> {
         migration19To20,
         migration20To21,
         migration21To22,
-        migration22To23
+        migration22To23,
+        migration23To24
     )
 }
 
@@ -819,5 +820,20 @@ val migration21To22: Migration = object : Migration(21, 22) {
 val migration22To23: Migration = object : Migration(22, 23) {
     override fun migrate(db: SupportSQLiteDatabase) {
         db.execSQL("ALTER TABLE review_logs ADD COLUMN reviewedTimeZone TEXT")
+    }
+}
+
+val migration23To24: Migration = object : Migration(23, 24) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS progress_streak_leaderboard_cache (
+                scopeKey TEXT NOT NULL PRIMARY KEY,
+                scopeId TEXT NOT NULL,
+                payloadJson TEXT NOT NULL,
+                updatedAtMillis INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
     }
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/progress/ProgressRemoteCacheDao.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/database/progress/ProgressRemoteCacheDao.kt
@@ -7,6 +7,7 @@ import androidx.room.Query
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewScheduleCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSeriesCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.ProgressStreakLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSummaryCacheEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -24,6 +25,9 @@ interface ProgressRemoteCacheDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertProgressLeaderboardCache(entry: ProgressLeaderboardCacheEntity)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertProgressStreakLeaderboardCache(entry: ProgressStreakLeaderboardCacheEntity)
+
     @Query("SELECT * FROM progress_summary_cache ORDER BY updatedAtMillis DESC, scopeKey DESC")
     fun observeProgressSummaryCaches(): Flow<List<ProgressSummaryCacheEntity>>
 
@@ -36,6 +40,12 @@ interface ProgressRemoteCacheDao {
     @Query("SELECT * FROM progress_leaderboard_cache ORDER BY updatedAtMillis DESC, scopeKey DESC")
     fun observeProgressLeaderboardCaches(): Flow<List<ProgressLeaderboardCacheEntity>>
 
+    @Query("SELECT * FROM progress_streak_leaderboard_cache ORDER BY updatedAtMillis DESC, scopeKey DESC")
+    fun observeProgressStreakLeaderboardCaches(): Flow<List<ProgressStreakLeaderboardCacheEntity>>
+
     @Query("DELETE FROM progress_leaderboard_cache")
     suspend fun deleteAllProgressLeaderboardCaches()
+
+    @Query("DELETE FROM progress_streak_leaderboard_cache")
+    suspend fun deleteAllProgressStreakLeaderboardCaches()
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressLeaderboardModels.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/model/progress/ProgressLeaderboardModels.kt
@@ -1,6 +1,8 @@
 package com.flashcardsopensourceapp.data.local.model.progress
 
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import java.time.Instant
+import java.time.ZoneOffset
 
 enum class ProgressLeaderboardWindowKey(
     val wireKey: String,
@@ -314,6 +316,290 @@ private fun CloudProgressLeaderboardRankingRow.toCompactProgressLeaderboardRow(
         anonymousDisplayName = anonymousDisplayName,
         friendDisplayName = friendDisplayName,
         qualifiedReviewCount = qualifiedReviewCount,
+        rank = rank
+    )
+}
+
+data class ProgressStreakLeaderboardScopeKey(
+    val scopeId: String
+)
+
+data class CloudProgressStreakLeaderboardMetric(
+    val metricVersion: String,
+    val title: String,
+    val description: String
+)
+
+data class CloudProgressStreakLeaderboardViewer(
+    val publicProfileId: String,
+    val displayName: String,
+    val rank: Int,
+    val streakDays: Int
+)
+
+sealed interface CloudProgressStreakLeaderboardRow {
+    data class Participant(
+        val kind: ProgressLeaderboardParticipantRowKind,
+        val publicProfileId: String,
+        val anonymousDisplayName: String,
+        val friendDisplayName: String?,
+        val streakDays: Int,
+        val rank: Int
+    ) : CloudProgressStreakLeaderboardRow
+
+    data object Gap : CloudProgressStreakLeaderboardRow
+}
+
+data class CloudProgressStreakLeaderboardRankingRow(
+    val kind: CloudProgressLeaderboardRankingRowKind,
+    val publicProfileId: String,
+    val anonymousDisplayName: String,
+    val friendDisplayName: String?,
+    val streakDays: Int,
+    val rank: Int
+)
+
+sealed interface CloudProgressStreakLeaderboard {
+    val status: ProgressLeaderboardStatus
+    val metric: CloudProgressStreakLeaderboardMetric
+
+    data class Ready(
+        override val status: ProgressLeaderboardStatus,
+        override val metric: CloudProgressStreakLeaderboardMetric,
+        val snapshotId: String,
+        val snapshotGeneratedAt: String,
+        val asOfUtcDate: String,
+        val nextRefreshAfter: String,
+        val participantCount: Int,
+        val viewer: CloudProgressStreakLeaderboardViewer,
+        val rows: List<CloudProgressStreakLeaderboardRow>,
+        val rankingRows: List<CloudProgressStreakLeaderboardRankingRow>
+    ) : CloudProgressStreakLeaderboard {
+        init {
+            require(status == ProgressLeaderboardStatus.READY) {
+                "Ready streak leaderboard payload must use ready status."
+            }
+        }
+    }
+
+    data class NonReady(
+        override val status: ProgressLeaderboardStatus,
+        override val metric: CloudProgressStreakLeaderboardMetric
+    ) : CloudProgressStreakLeaderboard {
+        init {
+            require(status != ProgressLeaderboardStatus.READY) {
+                "Non-ready streak leaderboard payload must not use ready status."
+            }
+        }
+    }
+}
+
+data class ProgressStreakLeaderboardSnapshot(
+    val scopeKey: ProgressStreakLeaderboardScopeKey,
+    val cloudState: CloudAccountState,
+    val leaderboard: CloudProgressStreakLeaderboard?,
+    val renderedLeaderboard: CloudProgressStreakLeaderboard?,
+    val payloadUpdatedAtMillis: Long?,
+    val viewerCurrentStreakDays: Int?,
+    val isRefreshDue: Boolean,
+    val didLastRemoteLoadFail: Boolean
+)
+
+fun createRenderedProgressStreakLeaderboard(
+    leaderboard: CloudProgressStreakLeaderboard?,
+    viewerCurrentStreakDays: Int?,
+    currentTimeMillis: Long
+): CloudProgressStreakLeaderboard? {
+    if (viewerCurrentStreakDays != null) {
+        require(viewerCurrentStreakDays >= 0) {
+            "Viewer current streak days must not be negative."
+        }
+    }
+
+    return when (leaderboard) {
+        null -> viewerCurrentStreakDays?.let { streakDays ->
+            createViewerOnlyProgressStreakLeaderboard(
+                viewerCurrentStreakDays = streakDays,
+                currentTimeMillis = currentTimeMillis
+            )
+        }
+        is CloudProgressStreakLeaderboard.NonReady -> {
+            if (
+                leaderboard.status == ProgressLeaderboardStatus.SNAPSHOT_UNAVAILABLE &&
+                viewerCurrentStreakDays != null
+            ) {
+                createViewerOnlyProgressStreakLeaderboard(
+                    viewerCurrentStreakDays = viewerCurrentStreakDays,
+                    currentTimeMillis = currentTimeMillis
+                )
+            } else {
+                leaderboard
+            }
+        }
+        is CloudProgressStreakLeaderboard.Ready -> leaderboard.toRenderedProgressStreakLeaderboard(
+            viewerCurrentStreakDays = viewerCurrentStreakDays
+        )
+    }
+}
+
+private fun createViewerOnlyProgressStreakLeaderboard(
+    viewerCurrentStreakDays: Int,
+    currentTimeMillis: Long
+): CloudProgressStreakLeaderboard.Ready {
+    val generatedAt = Instant.ofEpochMilli(currentTimeMillis)
+    val asOfUtcDate = generatedAt.atZone(ZoneOffset.UTC).toLocalDate().toString()
+    val viewer = CloudProgressStreakLeaderboardViewer(
+        publicProfileId = "local-viewer",
+        displayName = "You",
+        rank = 1,
+        streakDays = viewerCurrentStreakDays
+    )
+    val viewerRankingRow = CloudProgressStreakLeaderboardRankingRow(
+        kind = CloudProgressLeaderboardRankingRowKind.VIEWER,
+        publicProfileId = viewer.publicProfileId,
+        anonymousDisplayName = viewer.displayName,
+        friendDisplayName = null,
+        streakDays = viewer.streakDays,
+        rank = viewer.rank
+    )
+
+    return CloudProgressStreakLeaderboard.Ready(
+        status = ProgressLeaderboardStatus.READY,
+        metric = createDefaultProgressStreakLeaderboardMetric(),
+        snapshotId = "local-viewer",
+        snapshotGeneratedAt = generatedAt.toString(),
+        asOfUtcDate = asOfUtcDate,
+        nextRefreshAfter = generatedAt.toString(),
+        participantCount = 1,
+        viewer = viewer,
+        rows = listOf(viewerRankingRow.toCompactProgressStreakLeaderboardRow(topRowCount = 1)),
+        rankingRows = listOf(viewerRankingRow)
+    )
+}
+
+private fun createDefaultProgressStreakLeaderboardMetric(): CloudProgressStreakLeaderboardMetric {
+    return CloudProgressStreakLeaderboardMetric(
+        metricVersion = "streak_days_v1",
+        title = "Current streak days",
+        description = "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+    )
+}
+
+private fun CloudProgressStreakLeaderboard.Ready.toRenderedProgressStreakLeaderboard(
+    viewerCurrentStreakDays: Int?
+): CloudProgressStreakLeaderboard.Ready {
+    val viewerRankingRow = requireNotNull(
+        rankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }
+    ) {
+        "Streak leaderboard rankingRows must include viewer '${viewer.publicProfileId}'."
+    }
+    val viewerStreakDays = maxOf(
+        viewer.streakDays,
+        viewerCurrentStreakDays ?: 0
+    )
+    val participantRows = rankingRows.filter { row ->
+        row.kind != CloudProgressLeaderboardRankingRowKind.VIEWER
+    }
+    val viewerInsertionIndex = participantRows.indexOfFirst { row ->
+        row.streakDays <= viewerStreakDays
+    }.let { index ->
+        if (index == -1) {
+            participantRows.size
+        } else {
+            index
+        }
+    }
+    val unrankedRows = participantRows.toMutableList().apply {
+        add(
+            viewerInsertionIndex,
+            viewerRankingRow.copy(streakDays = viewerStreakDays)
+        )
+    }
+    val projectedRankingRows = unrankedRows.mapIndexed { index, row ->
+        row.copy(rank = index + 1)
+    }
+    val projectedViewer = requireNotNull(
+        projectedRankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }
+    ) {
+        "Projected streak leaderboard rankingRows must include viewer '${viewer.publicProfileId}'."
+    }
+
+    return copy(
+        participantCount = projectedRankingRows.size,
+        viewer = viewer.copy(
+            rank = projectedViewer.rank,
+            streakDays = projectedViewer.streakDays
+        ),
+        rows = buildProgressStreakLeaderboardCompactRows(rankingRows = projectedRankingRows),
+        rankingRows = projectedRankingRows
+    )
+}
+
+private fun buildProgressStreakLeaderboardCompactRows(
+    rankingRows: List<CloudProgressStreakLeaderboardRankingRow>
+): List<CloudProgressStreakLeaderboardRow> {
+    val totalRowCount = rankingRows.size
+    val topRowCount = minOf(3, totalRowCount)
+    val viewerRank = requireNotNull(
+        rankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }?.rank
+    ) {
+        "Projected streak leaderboard rankingRows must include a viewer row."
+    }
+    val shownRanks = mutableSetOf<Int>()
+    (1..topRowCount).forEach { rank ->
+        shownRanks.add(rank)
+    }
+    if (viewerRank > topRowCount) {
+        listOf(viewerRank - 1, viewerRank, viewerRank + 1).forEach { rank ->
+            if (rank >= 1 && rank <= totalRowCount) {
+                shownRanks.add(rank)
+            }
+        }
+    } else if (viewerRank == topRowCount && viewerRank < totalRowCount) {
+        shownRanks.add(viewerRank + 1)
+    }
+    if (totalRowCount > topRowCount) {
+        shownRanks.add(totalRowCount)
+    }
+    rankingRows.forEach { row ->
+        if (row.friendDisplayName != null) {
+            shownRanks.add(row.rank)
+        }
+    }
+
+    val rowsByRank = rankingRows.associateBy { row -> row.rank }
+    return buildList {
+        var previousRank = 0
+        shownRanks.sorted().forEach { rank ->
+            if (previousRank != 0 && rank > previousRank + 1) {
+                add(CloudProgressStreakLeaderboardRow.Gap)
+            }
+
+            val rankingRow = requireNotNull(rowsByRank[rank]) {
+                "Projected streak leaderboard rankingRows must include rank $rank."
+            }
+            add(rankingRow.toCompactProgressStreakLeaderboardRow(topRowCount = topRowCount))
+            previousRank = rank
+        }
+        if (previousRank < totalRowCount) {
+            add(CloudProgressStreakLeaderboardRow.Gap)
+        }
+    }
+}
+
+private fun CloudProgressStreakLeaderboardRankingRow.toCompactProgressStreakLeaderboardRow(
+    topRowCount: Int
+): CloudProgressStreakLeaderboardRow.Participant {
+    return CloudProgressStreakLeaderboardRow.Participant(
+        kind = when {
+            kind == CloudProgressLeaderboardRankingRowKind.VIEWER -> ProgressLeaderboardParticipantRowKind.VIEWER
+            rank <= topRowCount -> ProgressLeaderboardParticipantRowKind.TOP
+            else -> ProgressLeaderboardParticipantRowKind.NEIGHBOR
+        },
+        publicProfileId = publicProfileId,
+        anonymousDisplayName = anonymousDisplayName,
+        friendDisplayName = friendDisplayName,
+        streakDays = streakDays,
         rank = rank
     )
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/Repositories.kt
@@ -27,6 +27,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudOtpChallenge
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceDeletePreview
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceDeleteResult
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
@@ -48,6 +49,7 @@ import com.flashcardsopensourceapp.data.local.model.review.PendingReviewedCard
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.model.review.ReviewCard
 import com.flashcardsopensourceapp.data.local.model.review.ReviewFilter
@@ -141,15 +143,18 @@ interface ProgressRepository {
     fun observeSeriesSnapshot(): Flow<ProgressSeriesSnapshot?>
     fun observeReviewScheduleSnapshot(): Flow<ProgressReviewScheduleSnapshot?>
     fun observeLeaderboardSnapshot(): Flow<ProgressLeaderboardSnapshot?>
+    fun observeStreakLeaderboardSnapshot(): Flow<ProgressStreakLeaderboardSnapshot?>
     suspend fun refreshSummaryIfInvalidated()
     suspend fun refreshSeriesIfInvalidated()
     suspend fun refreshReviewScheduleIfInvalidated()
     suspend fun refreshLeaderboardIfInvalidated()
+    suspend fun refreshStreakLeaderboardIfInvalidated()
     suspend fun refreshLeaderboardForReviewShortcut()
     suspend fun refreshSummaryManually()
     suspend fun refreshSeriesManually()
     suspend fun refreshReviewScheduleManually()
     suspend fun refreshLeaderboardManually()
+    suspend fun refreshStreakLeaderboardManually()
 }
 
 interface FeedbackRepository {
@@ -193,6 +198,7 @@ interface CloudAccountRepository {
     suspend fun loadProgressSeries(timeZone: String, from: String, to: String): CloudProgressSeries
     suspend fun loadProgressReviewSchedule(timeZone: String): CloudProgressReviewSchedule
     suspend fun loadProgressLeaderboard(): CloudProgressLeaderboard
+    suspend fun loadProgressStreakLeaderboard(): CloudProgressStreakLeaderboard
     suspend fun loadCommunityProfile(): CloudCommunityProfile
     suspend fun updateCommunityLeaderboardParticipation(
         leaderboardParticipationEnabled: Boolean

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/account/LocalCloudAccountRepository.kt
@@ -29,6 +29,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.shouldRefreshCloudIdTo
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.sync.AccountPreferences
 import com.flashcardsopensourceapp.data.local.model.sync.CloudAccountSnapshot
@@ -299,6 +300,10 @@ class LocalCloudAccountRepository(
         return progressRemoteReader.loadProgressLeaderboard()
     }
 
+    override suspend fun loadProgressStreakLeaderboard(): CloudProgressStreakLeaderboard {
+        return progressRemoteReader.loadProgressStreakLeaderboard()
+    }
+
     override suspend fun loadCommunityProfile(): CloudCommunityProfile {
         return progressRemoteReader.loadCommunityProfile()
     }
@@ -313,6 +318,7 @@ class LocalCloudAccountRepository(
         // while the cached payload would stay rendered until its hourly nextRefreshAfter.
         // Dropping the cache makes the next Progress visit refetch the correct status.
         database.progressRemoteCacheDao().deleteAllProgressLeaderboardCaches()
+        database.progressRemoteCacheDao().deleteAllProgressStreakLeaderboardCaches()
         return updatedProfile
     }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/progress/CloudProgressRemoteReader.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/cloudsync/progress/CloudProgressRemoteReader.kt
@@ -8,6 +8,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudCommunityProfile
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
@@ -67,6 +68,16 @@ internal class CloudProgressRemoteReader(
         return operationCoordinator.runExclusive {
             val progressSession: ProgressCloudSession = progressSession()
             remoteService.loadProgressLeaderboard(
+                apiBaseUrl = progressSession.apiBaseUrl,
+                authorizationHeader = progressSession.authorizationHeader
+            )
+        }
+    }
+
+    suspend fun loadProgressStreakLeaderboard(): CloudProgressStreakLeaderboard {
+        return operationCoordinator.runExclusive {
+            val progressSession: ProgressCloudSession = progressSession()
+            remoteService.loadProgressStreakLeaderboard(
                 apiBaseUrl = progressSession.apiBaseUrl,
                 authorizationHeader = progressSession.authorizationHeader
             )

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/LocalProgressRepository.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/LocalProgressRepository.kt
@@ -6,6 +6,7 @@ import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
@@ -19,6 +20,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.inputs.observe
 import com.flashcardsopensourceapp.data.local.repository.progress.orchestration.ProgressLeaderboardOrchestration
 import com.flashcardsopensourceapp.data.local.repository.progress.orchestration.ProgressReviewScheduleOrchestration
 import com.flashcardsopensourceapp.data.local.repository.progress.orchestration.ProgressSeriesOrchestration
+import com.flashcardsopensourceapp.data.local.repository.progress.orchestration.ProgressStreakLeaderboardOrchestration
 import com.flashcardsopensourceapp.data.local.repository.progress.orchestration.ProgressSummaryOrchestration
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressBackgroundLauncher
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressObservationVersions
@@ -88,6 +90,13 @@ class LocalProgressRepository(
         observability = observability,
         observationVersions = observationVersions
     )
+    private val streakLeaderboardOrchestration = ProgressStreakLeaderboardOrchestration(
+        database = database,
+        cloudAccountRepository = cloudAccountRepository,
+        timeProvider = timeProvider,
+        observability = observability,
+        observationVersions = observationVersions
+    )
 
     // Captured handle for the input-observation flow so the lifecycle of this
     // long-running collector is explicit rather than hidden inside an init block.
@@ -123,6 +132,10 @@ class LocalProgressRepository(
         return leaderboardOrchestration.observeSnapshot()
     }
 
+    override fun observeStreakLeaderboardSnapshot(): Flow<ProgressStreakLeaderboardSnapshot?> {
+        return streakLeaderboardOrchestration.observeSnapshot()
+    }
+
     override suspend fun refreshSummaryIfInvalidated() {
         summaryOrchestration.refreshIfInvalidated()
     }
@@ -137,6 +150,10 @@ class LocalProgressRepository(
 
     override suspend fun refreshLeaderboardIfInvalidated() {
         leaderboardOrchestration.refreshIfInvalidated()
+    }
+
+    override suspend fun refreshStreakLeaderboardIfInvalidated() {
+        streakLeaderboardOrchestration.refreshIfInvalidated()
     }
 
     override suspend fun refreshLeaderboardForReviewShortcut() {
@@ -157,6 +174,10 @@ class LocalProgressRepository(
 
     override suspend fun refreshLeaderboardManually() {
         leaderboardOrchestration.refreshManually()
+    }
+
+    override suspend fun refreshStreakLeaderboardManually() {
+        streakLeaderboardOrchestration.refreshManually()
     }
 
     private fun handleProgressInputs(
@@ -180,6 +201,13 @@ class LocalProgressRepository(
         leaderboardOrchestration.handleInputs(
             inputs = inputs,
             clockSnapshot = clockSnapshot
+        )
+        streakLeaderboardOrchestration.handleInputs(
+            inputs = inputs,
+            clockSnapshot = clockSnapshot,
+            viewerCurrentStreakDays = summaryHandledInputs.currentStoreState.snapshot
+                ?.renderedSummary
+                ?.currentStreakDays
         )
 
         if (

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/cache/ProgressCacheSerialization.kt
@@ -1,9 +1,11 @@
 package com.flashcardsopensourceapp.data.local.repository.progress.cache
 
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressLeaderboard
+import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewScheduleCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSeriesCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.ProgressStreakLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSummaryCacheEntity
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
@@ -15,12 +17,16 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRepositoryWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.createInclusiveLocalDateRange
@@ -133,8 +139,26 @@ internal fun CloudProgressLeaderboard.toCacheEntity(
     )
 }
 
+internal fun CloudProgressStreakLeaderboard.toCacheEntity(
+    scopeKey: ProgressStreakLeaderboardScopeKey,
+    updatedAtMillis: Long
+): ProgressStreakLeaderboardCacheEntity {
+    return ProgressStreakLeaderboardCacheEntity(
+        scopeKey = serializeProgressStreakLeaderboardScopeKey(scopeKey = scopeKey),
+        scopeId = scopeKey.scopeId,
+        payloadJson = serializeCloudProgressStreakLeaderboard(leaderboard = this).toString(),
+        updatedAtMillis = updatedAtMillis
+    )
+}
+
 internal fun serializeProgressLeaderboardScopeKey(
     scopeKey: ProgressLeaderboardScopeKey
+): String {
+    return scopeKey.scopeId
+}
+
+internal fun serializeProgressStreakLeaderboardScopeKey(
+    scopeKey: ProgressStreakLeaderboardScopeKey
 ): String {
     return scopeKey.scopeId
 }
@@ -161,6 +185,28 @@ internal data class ProgressLeaderboardCachedPayload(
     val updatedAtMillis: Long
 )
 
+internal fun findProgressStreakLeaderboardServerBase(
+    leaderboardCaches: List<ProgressStreakLeaderboardCacheEntity>,
+    scopeKey: ProgressStreakLeaderboardScopeKey
+): ProgressStreakLeaderboardCachedPayload? {
+    return leaderboardCaches.asSequence()
+        .filter { entry -> entry.scopeId == scopeKey.scopeId }
+        .mapNotNull { entry ->
+            entry.toCloudProgressStreakLeaderboardOrNull()?.let { leaderboard ->
+                ProgressStreakLeaderboardCachedPayload(
+                    leaderboard = leaderboard,
+                    updatedAtMillis = entry.updatedAtMillis
+                )
+            }
+        }
+        .firstOrNull()
+}
+
+internal data class ProgressStreakLeaderboardCachedPayload(
+    val leaderboard: CloudProgressStreakLeaderboard,
+    val updatedAtMillis: Long
+)
+
 internal fun ProgressLeaderboardCacheEntity.toCloudProgressLeaderboardOrNull(): CloudProgressLeaderboard? {
     return runCatching {
         parseCloudProgressLeaderboard(
@@ -170,6 +216,25 @@ internal fun ProgressLeaderboardCacheEntity.toCloudProgressLeaderboardOrNull(): 
     }.getOrElse { error ->
         logProgressRepositoryWarning(
             event = "progress_leaderboard_cache_skipped",
+            fields = listOf(
+                "scopeKey" to scopeKey,
+                "scopeId" to scopeId
+            ),
+            error = error
+        )
+        null
+    }
+}
+
+internal fun ProgressStreakLeaderboardCacheEntity.toCloudProgressStreakLeaderboardOrNull(): CloudProgressStreakLeaderboard? {
+    return runCatching {
+        parseCloudProgressStreakLeaderboard(
+            payload = JSONObject(payloadJson),
+            fieldPath = "progressStreakLeaderboardCache"
+        )
+    }.getOrElse { error ->
+        logProgressRepositoryWarning(
+            event = "progress_streak_leaderboard_cache_skipped",
             fields = listOf(
                 "scopeKey" to scopeKey,
                 "scopeId" to scopeId
@@ -237,6 +302,54 @@ internal fun serializeCloudProgressLeaderboard(
         )
 }
 
+internal fun serializeCloudProgressStreakLeaderboard(
+    leaderboard: CloudProgressStreakLeaderboard
+): JSONObject {
+    val baseJson = JSONObject()
+        .put("status", leaderboard.status.wireKey)
+        .put(
+            "metric",
+            JSONObject()
+                .put("metricVersion", leaderboard.metric.metricVersion)
+                .put("title", leaderboard.metric.title)
+                .put("description", leaderboard.metric.description)
+        )
+
+    return when (leaderboard) {
+        is CloudProgressStreakLeaderboard.NonReady -> baseJson
+        is CloudProgressStreakLeaderboard.Ready -> baseJson
+            .put("snapshotId", leaderboard.snapshotId)
+            .put("snapshotGeneratedAt", leaderboard.snapshotGeneratedAt)
+            .put("asOfUtcDate", leaderboard.asOfUtcDate)
+            .put("nextRefreshAfter", leaderboard.nextRefreshAfter)
+            .put("participantCount", leaderboard.participantCount)
+            .put(
+                "viewer",
+                JSONObject()
+                    .put("publicProfileId", leaderboard.viewer.publicProfileId)
+                    .put("displayName", leaderboard.viewer.displayName)
+                    .put("rank", leaderboard.viewer.rank)
+                    .put("streakDays", leaderboard.viewer.streakDays)
+            )
+            .put(
+                "rows",
+                JSONArray().apply {
+                    leaderboard.rows.forEach { row ->
+                        put(row.toCacheJson())
+                    }
+                }
+            )
+            .put(
+                "rankingRows",
+                JSONArray().apply {
+                    leaderboard.rankingRows.forEach { row ->
+                        put(row.toCacheJson())
+                    }
+                }
+            )
+    }
+}
+
 private fun CloudProgressLeaderboardRow.toCacheJson(): JSONObject {
     return when (this) {
         is CloudProgressLeaderboardRow.Gap -> JSONObject().put("kind", "gap")
@@ -257,6 +370,29 @@ private fun CloudProgressLeaderboardRankingRow.toCacheJson(): JSONObject {
         .put("anonymousDisplayName", anonymousDisplayName)
         .putOptionalCloudString(name = "friendDisplayName", value = friendDisplayName)
         .put("qualifiedReviewCount", qualifiedReviewCount)
+        .put("rank", rank)
+}
+
+private fun CloudProgressStreakLeaderboardRow.toCacheJson(): JSONObject {
+    return when (this) {
+        is CloudProgressStreakLeaderboardRow.Gap -> JSONObject().put("kind", "gap")
+        is CloudProgressStreakLeaderboardRow.Participant -> JSONObject()
+            .put("kind", kind.wireKey)
+            .put("publicProfileId", publicProfileId)
+            .put("anonymousDisplayName", anonymousDisplayName)
+            .putOptionalCloudString(name = "friendDisplayName", value = friendDisplayName)
+            .put("streakDays", streakDays)
+            .put("rank", rank)
+    }
+}
+
+private fun CloudProgressStreakLeaderboardRankingRow.toCacheJson(): JSONObject {
+    return JSONObject()
+        .put("kind", kind.wireKey)
+        .put("publicProfileId", publicProfileId)
+        .put("anonymousDisplayName", anonymousDisplayName)
+        .putOptionalCloudString(name = "friendDisplayName", value = friendDisplayName)
+        .put("streakDays", streakDays)
         .put("rank", rank)
 }
 

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressObservedInputs.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/inputs/ProgressObservedInputs.kt
@@ -12,6 +12,7 @@ import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewHi
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewScheduleCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressReviewScheduleCardDueEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSeriesCacheEntity
+import com.flashcardsopensourceapp.data.local.database.entities.ProgressStreakLeaderboardCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.ProgressSummaryCacheEntity
 import com.flashcardsopensourceapp.data.local.database.entities.SyncStateEntity
 import com.flashcardsopensourceapp.data.local.database.entities.WorkspaceEntity
@@ -51,6 +52,7 @@ internal data class ProgressObservedInputs(
     val seriesCaches: List<ProgressSeriesCacheEntity>,
     val reviewScheduleCaches: List<ProgressReviewScheduleCacheEntity>,
     val leaderboardCaches: List<ProgressLeaderboardCacheEntity>,
+    val streakLeaderboardCaches: List<ProgressStreakLeaderboardCacheEntity>,
     val qualifiedReviewActivity: ProgressQualifiedReviewActivity
 )
 
@@ -193,8 +195,9 @@ internal fun observeProgressInputs(
         seriesInputsFlow,
         remoteCacheDao.observeProgressReviewScheduleCaches(),
         remoteCacheDao.observeProgressLeaderboardCaches(),
+        remoteCacheDao.observeProgressStreakLeaderboardCaches(),
         qualifiedReviewActivityFlow
-    ) { seriesInputs, reviewScheduleCaches, leaderboardCaches, qualifiedReviewActivity ->
+    ) { seriesInputs, reviewScheduleCaches, leaderboardCaches, streakLeaderboardCaches, qualifiedReviewActivity ->
         ProgressObservedInputs(
             cloudSettings = seriesInputs.summaryInputs.baseInputs.cloudSettings,
             workspaces = seriesInputs.summaryInputs.baseInputs.workspaces,
@@ -210,6 +213,7 @@ internal fun observeProgressInputs(
             seriesCaches = seriesInputs.seriesCaches,
             reviewScheduleCaches = reviewScheduleCaches,
             leaderboardCaches = leaderboardCaches,
+            streakLeaderboardCaches = streakLeaderboardCaches,
             qualifiedReviewActivity = qualifiedReviewActivity
         )
     }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressStreakLeaderboardOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressStreakLeaderboardOrchestration.kt
@@ -1,0 +1,224 @@
+package com.flashcardsopensourceapp.data.local.repository.progress.orchestration
+
+import com.flashcardsopensourceapp.core.observability.AppObservability
+import com.flashcardsopensourceapp.data.local.database.core.AppDatabase
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
+import com.flashcardsopensourceapp.data.local.repository.CloudAccountRepository
+import com.flashcardsopensourceapp.data.local.repository.shared.TimeProvider
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.findProgressStreakLeaderboardServerBase
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.serializeProgressStreakLeaderboardScopeKey
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCacheEntity
+import com.flashcardsopensourceapp.data.local.repository.progress.inputs.ProgressClockSnapshot
+import com.flashcardsopensourceapp.data.local.repository.progress.inputs.ProgressObservedInputs
+import com.flashcardsopensourceapp.data.local.repository.progress.inputs.createProgressClockSnapshot
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressObservationVersions
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRefreshCoordinator
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRemoteRefreshSyncMode
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressStreakLeaderboardStoreInputs
+import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.ProgressStreakLeaderboardStoreState
+import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.createProgressStreakLeaderboardScopeKey
+import com.flashcardsopensourceapp.data.local.repository.progress.snapshots.createProgressStreakLeaderboardStoreState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+private data class ProgressStreakLeaderboardLatestInputs(
+    val inputs: ProgressObservedInputs,
+    val viewerCurrentStreakDays: Int?
+)
+
+internal class ProgressStreakLeaderboardOrchestration(
+    private val database: AppDatabase,
+    private val cloudAccountRepository: CloudAccountRepository,
+    private val timeProvider: TimeProvider,
+    private val observability: AppObservability,
+    private val observationVersions: ProgressObservationVersions
+) {
+    private val snapshotMutable = MutableStateFlow<ProgressStreakLeaderboardSnapshot?>(null)
+    private val latestInputsMutable = MutableStateFlow<ProgressStreakLeaderboardLatestInputs?>(null)
+    private val failedRemoteLoadScopeKeyMutable = MutableStateFlow<String?>(null)
+    private val refreshCoordinator = ProgressRefreshCoordinator()
+
+    fun observeSnapshot(): Flow<ProgressStreakLeaderboardSnapshot?> {
+        return snapshotMutable.asStateFlow()
+    }
+
+    fun handleInputs(
+        inputs: ProgressObservedInputs,
+        clockSnapshot: ProgressClockSnapshot,
+        viewerCurrentStreakDays: Int?
+    ): ProgressStreakLeaderboardStoreState {
+        latestInputsMutable.value = ProgressStreakLeaderboardLatestInputs(
+            inputs = inputs,
+            viewerCurrentStreakDays = viewerCurrentStreakDays
+        )
+        val currentStoreState = createStoreState(
+            inputs = inputs,
+            clockSnapshot = clockSnapshot,
+            viewerCurrentStreakDays = viewerCurrentStreakDays
+        )
+        publishSnapshotIfChanged(snapshot = currentStoreState.snapshot)
+        return currentStoreState
+    }
+
+    suspend fun refreshIfInvalidated() {
+        refreshFromCurrentStoreState()
+    }
+
+    suspend fun refreshManually() {
+        refreshFromCurrentStoreState()
+    }
+
+    private suspend fun refreshFromCurrentStoreState() {
+        val storeState = currentStoreState() ?: return
+        publishSnapshotIfChanged(snapshot = storeState.snapshot)
+        if (storeState.cloudState != CloudAccountState.LINKED) {
+            return
+        }
+        if (storeState.snapshot.leaderboard != null && storeState.snapshot.isRefreshDue.not()) {
+            return
+        }
+
+        val serializedScopeKey = serializeProgressStreakLeaderboardScopeKey(scopeKey = storeState.scopeKey)
+        if (
+            refreshCoordinator.beginRefresh(
+                scopeKey = serializedScopeKey,
+                syncMode = ProgressRemoteRefreshSyncMode.SKIP_SYNC
+            ).not()
+        ) {
+            return
+        }
+
+        var refreshStoreState = storeState
+        while (true) {
+            try {
+                performRefresh(refreshStoreState = refreshStoreState)
+            } catch (error: Throwable) {
+                refreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
+                throw error
+            }
+
+            refreshCoordinator.completeRefreshIteration(scopeKey = serializedScopeKey) ?: return
+            val latestStoreState = currentStoreState()
+            if (latestStoreState == null) {
+                refreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
+                return
+            }
+            if (serializeProgressStreakLeaderboardScopeKey(scopeKey = latestStoreState.scopeKey) != serializedScopeKey) {
+                refreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
+                return
+            }
+            if (latestStoreState.cloudState != CloudAccountState.LINKED) {
+                refreshCoordinator.endRefresh(scopeKey = serializedScopeKey)
+                return
+            }
+            refreshStoreState = latestStoreState
+        }
+    }
+
+    private suspend fun performRefresh(
+        refreshStoreState: ProgressStreakLeaderboardStoreState
+    ) {
+        val serializedScopeKey = serializeProgressStreakLeaderboardScopeKey(scopeKey = refreshStoreState.scopeKey)
+        val remoteLeaderboard = try {
+            cloudAccountRepository.loadProgressStreakLeaderboard()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            failedRemoteLoadScopeKeyMutable.value = serializedScopeKey
+            publishLatestSnapshot()
+            if (shouldSuppressRemoteLoadWarning(refreshStoreState = refreshStoreState)) {
+                return
+            }
+            logProgressRefreshWarning(
+                observability = observability,
+                observationVersions = observationVersions,
+                event = "progress_streak_leaderboard_remote_load_failed",
+                scopeId = refreshStoreState.scopeKey.scopeId,
+                source = "streak_leaderboard_remote_load",
+                fields = listOf("scopeKey" to serializedScopeKey),
+                error = error
+            )
+            return
+        }
+
+        val latestStoreState = currentStoreState() ?: return
+        if (latestStoreState.scopeKey != refreshStoreState.scopeKey) {
+            return
+        }
+
+        database.progressRemoteCacheDao().insertProgressStreakLeaderboardCache(
+            entry = remoteLeaderboard.toCacheEntity(
+                scopeKey = latestStoreState.scopeKey,
+                updatedAtMillis = timeProvider.currentTimeMillis()
+            )
+        )
+        if (failedRemoteLoadScopeKeyMutable.value == serializedScopeKey) {
+            failedRemoteLoadScopeKeyMutable.value = null
+        }
+    }
+
+    private fun shouldSuppressRemoteLoadWarning(
+        refreshStoreState: ProgressStreakLeaderboardStoreState
+    ): Boolean {
+        val latestStoreState = currentStoreState() ?: return true
+        if (latestStoreState.scopeKey != refreshStoreState.scopeKey) {
+            return true
+        }
+
+        return latestStoreState.cloudState != CloudAccountState.LINKED
+    }
+
+    private fun publishLatestSnapshot() {
+        val storeState = currentStoreState() ?: return
+        publishSnapshotIfChanged(snapshot = storeState.snapshot)
+    }
+
+    private fun publishSnapshotIfChanged(
+        snapshot: ProgressStreakLeaderboardSnapshot?
+    ) {
+        if (snapshotMutable.value == snapshot) {
+            return
+        }
+
+        snapshotMutable.value = snapshot
+    }
+
+    private fun currentStoreState(): ProgressStreakLeaderboardStoreState? {
+        val latestInputs = latestInputsMutable.value ?: return null
+        return createStoreState(
+            inputs = latestInputs.inputs,
+            clockSnapshot = createProgressClockSnapshot(timeProvider = timeProvider),
+            viewerCurrentStreakDays = latestInputs.viewerCurrentStreakDays
+        )
+    }
+
+    private fun createStoreState(
+        inputs: ProgressObservedInputs,
+        clockSnapshot: ProgressClockSnapshot,
+        viewerCurrentStreakDays: Int?
+    ): ProgressStreakLeaderboardStoreState {
+        val scopeKey = createProgressStreakLeaderboardScopeKey(cloudSettings = inputs.cloudSettings)
+        return createProgressStreakLeaderboardStoreState(
+            inputs = ProgressStreakLeaderboardStoreInputs(
+                scopeKey = scopeKey,
+                cloudState = inputs.cloudSettings.cloudState,
+                serverBase = findProgressStreakLeaderboardServerBase(
+                    leaderboardCaches = inputs.streakLeaderboardCaches,
+                    scopeKey = scopeKey
+                ),
+                viewerCurrentStreakDays = if (inputs.cloudSettings.cloudState == CloudAccountState.LINKED) {
+                    viewerCurrentStreakDays
+                } else {
+                    null
+                },
+                didLastRemoteLoadFail = failedRemoteLoadScopeKeyMutable.value ==
+                    serializeProgressStreakLeaderboardScopeKey(scopeKey = scopeKey),
+                currentTimeMillis = clockSnapshot.currentTimeMillis
+            )
+        )
+    }
+}

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressScopeKeys.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressScopeKeys.kt
@@ -5,6 +5,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudSettings
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.repository.progress.progressHistoryDayCount
 import java.time.LocalDate
@@ -56,6 +57,14 @@ internal fun createProgressLeaderboardScopeKey(
     cloudSettings: CloudSettings
 ): ProgressLeaderboardScopeKey {
     return ProgressLeaderboardScopeKey(
+        scopeId = createProgressScopeId(cloudSettings = cloudSettings)
+    )
+}
+
+internal fun createProgressStreakLeaderboardScopeKey(
+    cloudSettings: CloudSettings
+): ProgressStreakLeaderboardScopeKey {
+    return ProgressStreakLeaderboardScopeKey(
         scopeId = createProgressScopeId(cloudSettings = cloudSettings)
     )
 }

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStoreState.kt
@@ -7,6 +7,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
@@ -15,11 +16,15 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewSched
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardScopeKey
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.ProgressLeaderboardCachedPayload
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.ProgressStreakLeaderboardCachedPayload
 import com.flashcardsopensourceapp.data.local.repository.progress.inputs.ProgressPendingReviewLocalDate
 import com.flashcardsopensourceapp.data.local.repository.progress.inputs.ProgressQualifiedReviewActivity
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRepositoryWarning
@@ -79,10 +84,25 @@ internal data class ProgressLeaderboardStoreInputs(
     val currentTimeMillis: Long
 )
 
+internal data class ProgressStreakLeaderboardStoreInputs(
+    val scopeKey: ProgressStreakLeaderboardScopeKey,
+    val cloudState: CloudAccountState,
+    val serverBase: ProgressStreakLeaderboardCachedPayload?,
+    val viewerCurrentStreakDays: Int?,
+    val didLastRemoteLoadFail: Boolean,
+    val currentTimeMillis: Long
+)
+
 internal data class ProgressLeaderboardStoreState(
     val scopeKey: ProgressLeaderboardScopeKey,
     val cloudState: CloudAccountState,
     val snapshot: ProgressLeaderboardSnapshot
+)
+
+internal data class ProgressStreakLeaderboardStoreState(
+    val scopeKey: ProgressStreakLeaderboardScopeKey,
+    val cloudState: CloudAccountState,
+    val snapshot: ProgressStreakLeaderboardSnapshot
 )
 
 internal data class ProgressSummaryStoreState(
@@ -246,6 +266,32 @@ internal fun createProgressLeaderboardStoreState(
     )
 }
 
+internal fun createProgressStreakLeaderboardStoreState(
+    inputs: ProgressStreakLeaderboardStoreInputs
+): ProgressStreakLeaderboardStoreState {
+    return ProgressStreakLeaderboardStoreState(
+        scopeKey = inputs.scopeKey,
+        cloudState = inputs.cloudState,
+        snapshot = ProgressStreakLeaderboardSnapshot(
+            scopeKey = inputs.scopeKey,
+            cloudState = inputs.cloudState,
+            leaderboard = inputs.serverBase?.leaderboard,
+            renderedLeaderboard = createRenderedProgressStreakLeaderboard(
+                leaderboard = inputs.serverBase?.leaderboard,
+                viewerCurrentStreakDays = inputs.viewerCurrentStreakDays,
+                currentTimeMillis = inputs.currentTimeMillis
+            ),
+            payloadUpdatedAtMillis = inputs.serverBase?.updatedAtMillis,
+            viewerCurrentStreakDays = inputs.viewerCurrentStreakDays,
+            isRefreshDue = isProgressStreakLeaderboardRefreshDue(
+                leaderboard = inputs.serverBase?.leaderboard,
+                currentTimeMillis = inputs.currentTimeMillis
+            ),
+            didLastRemoteLoadFail = inputs.didLastRemoteLoadFail
+        )
+    )
+}
+
 // Rolling windows are measured in whole hours backward from the device clock; the
 // unbounded all-time window uses the full qualified count. Only the viewer row count
 // is ever overlaid with these values, server snapshot ranks stay authoritative.
@@ -300,6 +346,35 @@ private fun parseProgressLeaderboardInstantMillisOrNull(rawInstant: String): Lon
     }.getOrElse { error ->
         logProgressRepositoryWarning(
             event = "progress_leaderboard_next_refresh_after_invalid",
+            fields = listOf("nextRefreshAfter" to rawInstant),
+            error = error
+        )
+        null
+    }
+}
+
+internal fun isProgressStreakLeaderboardRefreshDue(
+    leaderboard: CloudProgressStreakLeaderboard?,
+    currentTimeMillis: Long
+): Boolean {
+    return when (leaderboard) {
+        null -> true
+        is CloudProgressStreakLeaderboard.NonReady -> true
+        is CloudProgressStreakLeaderboard.Ready -> {
+            val nextRefreshAfterMillis = parseProgressStreakLeaderboardInstantMillisOrNull(
+                rawInstant = leaderboard.nextRefreshAfter
+            ) ?: return true
+            currentTimeMillis >= nextRefreshAfterMillis
+        }
+    }
+}
+
+private fun parseProgressStreakLeaderboardInstantMillisOrNull(rawInstant: String): Long? {
+    return runCatching {
+        Instant.parse(rawInstant).toEpochMilli()
+    }.getOrElse { error ->
+        logProgressRepositoryWarning(
+            event = "progress_streak_leaderboard_next_refresh_after_invalid",
             fields = listOf("nextRefreshAfter" to rawInstant),
             error = error
         )

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/cloud/remote/CloudRemoteServiceTest.kt
@@ -7,6 +7,7 @@ import com.flashcardsopensourceapp.data.local.cloud.remote.guest.buildGuestUpgra
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressReviewScheduleResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSeriesResponse
+import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.cloud.remote.progress.parseCloudProgressSummaryResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.sync.parseRemotePushResponse
 import com.flashcardsopensourceapp.data.local.cloud.remote.transport.parseCloudErrorPayload
@@ -15,6 +16,8 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudFriendInvitationC
 import com.flashcardsopensourceapp.data.local.model.cloud.CloudGuestUpgradeSelection
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleBucketKey
 import com.flashcardsopensourceapp.data.local.model.sync.SyncEntityType
@@ -452,6 +455,134 @@ class CloudRemoteServiceTest {
         assertEquals("Kai", window.rankingRows[0].friendDisplayName)
         val participantRow = window.rows[0] as CloudProgressLeaderboardRow.Participant
         assertEquals("Kai", participantRow.friendDisplayName)
+    }
+
+    @Test
+    fun parseCloudProgressStreakLeaderboardReadsRankingRows() {
+        val response = JSONObject(
+            """
+            {
+              "status": "ready",
+              "metric": {
+                "metricVersion": "streak_days_v1",
+                "title": "Current streak days",
+                "description": "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+              },
+              "snapshotId": "3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4",
+              "snapshotGeneratedAt": "2026-06-10T12:00:05.000Z",
+              "asOfUtcDate": "2026-06-10",
+              "nextRefreshAfter": "2026-06-11T12:00:00.000Z",
+              "participantCount": 2,
+              "viewer": {
+                "publicProfileId": "viewer-profile",
+                "displayName": "You",
+                "rank": 2,
+                "streakDays": 3
+              },
+              "rows": [
+                {
+                  "kind": "top",
+                  "publicProfileId": "participant-1",
+                  "anonymousDisplayName": "Silver Bright Harbor",
+                  "friendDisplayName": "Kai",
+                  "streakDays": 5,
+                  "rank": 1
+                },
+                {
+                  "kind": "viewer",
+                  "publicProfileId": "viewer-profile",
+                  "anonymousDisplayName": "Jade Swift River",
+                  "streakDays": 3,
+                  "rank": 2
+                }
+              ],
+              "rankingRows": [
+                {
+                  "kind": "participant",
+                  "publicProfileId": "participant-1",
+                  "anonymousDisplayName": "Silver Bright Harbor",
+                  "friendDisplayName": "Kai",
+                  "streakDays": 5,
+                  "rank": 1
+                },
+                {
+                  "kind": "viewer",
+                  "publicProfileId": "viewer-profile",
+                  "anonymousDisplayName": "Jade Swift River",
+                  "streakDays": 3,
+                  "rank": 2
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        val leaderboard = parseCloudProgressStreakLeaderboard(
+            payload = response,
+            fieldPath = "progress.streakLeaderboard"
+        )
+
+        assertTrue(leaderboard is CloudProgressStreakLeaderboard.Ready)
+        val readyLeaderboard = leaderboard as CloudProgressStreakLeaderboard.Ready
+        assertEquals("2026-06-10", readyLeaderboard.asOfUtcDate)
+        assertEquals(2, readyLeaderboard.rankingRows.size)
+        assertEquals(CloudProgressLeaderboardRankingRowKind.VIEWER, readyLeaderboard.rankingRows[1].kind)
+        assertEquals("viewer-profile", readyLeaderboard.rankingRows[1].publicProfileId)
+        assertEquals("Kai", readyLeaderboard.rankingRows[0].friendDisplayName)
+        val participantRow = readyLeaderboard.rows[0] as CloudProgressStreakLeaderboardRow.Participant
+        assertEquals("Kai", participantRow.friendDisplayName)
+        assertEquals(5, participantRow.streakDays)
+    }
+
+    @Test
+    fun parseCloudProgressStreakLeaderboardRejectsIncreasingRankingStreakDays() {
+        val response = JSONObject(
+            """
+            {
+              "status": "ready",
+              "metric": {
+                "metricVersion": "streak_days_v1",
+                "title": "Current streak days",
+                "description": "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+              },
+              "snapshotId": "3e6c0b88-5f5a-4db3-8c8c-9d6a3840a1e4",
+              "snapshotGeneratedAt": "2026-06-10T12:00:05.000Z",
+              "asOfUtcDate": "2026-06-10",
+              "nextRefreshAfter": "2026-06-11T12:00:00.000Z",
+              "participantCount": 2,
+              "viewer": {
+                "publicProfileId": "viewer-profile",
+                "displayName": "You",
+                "rank": 2,
+                "streakDays": 5
+              },
+              "rows": [],
+              "rankingRows": [
+                {
+                  "kind": "participant",
+                  "publicProfileId": "participant-1",
+                  "anonymousDisplayName": "Silver Bright Harbor",
+                  "streakDays": 3,
+                  "rank": 1
+                },
+                {
+                  "kind": "viewer",
+                  "publicProfileId": "viewer-profile",
+                  "anonymousDisplayName": "Jade Swift River",
+                  "streakDays": 5,
+                  "rank": 2
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertThrows(CloudContractMismatchException::class.java) {
+            parseCloudProgressStreakLeaderboard(
+                payload = response,
+                fieldPath = "progress.streakLeaderboard"
+            )
+        }
     }
 
     @Test

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRepositoryTestFixtures.kt
@@ -17,6 +17,11 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardWindow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewScheduleBucket
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardMetric
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardViewer
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
@@ -228,6 +233,75 @@ private fun createProgressLeaderboardParticipantRowForTest(
         anonymousDisplayName = rankingRow.anonymousDisplayName,
         friendDisplayName = rankingRow.friendDisplayName,
         qualifiedReviewCount = rankingRow.qualifiedReviewCount,
+        rank = rankingRow.rank
+    )
+}
+
+internal fun createProgressStreakLeaderboardForTest(
+    rankingRows: List<CloudProgressStreakLeaderboardRankingRow>
+): CloudProgressStreakLeaderboard.Ready {
+    val viewerRow = requireNotNull(
+        rankingRows.firstOrNull { row -> row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER }
+    )
+    return CloudProgressStreakLeaderboard.Ready(
+        status = ProgressLeaderboardStatus.READY,
+        metric = CloudProgressStreakLeaderboardMetric(
+            metricVersion = "streak_days_v1",
+            title = "Current streak days",
+            description = "Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak."
+        ),
+        snapshotId = "snapshot-1",
+        snapshotGeneratedAt = "2026-06-10T12:00:05.000Z",
+        asOfUtcDate = "2026-06-10",
+        nextRefreshAfter = "2026-06-11T12:00:00.000Z",
+        participantCount = rankingRows.size,
+        viewer = CloudProgressStreakLeaderboardViewer(
+            publicProfileId = viewerRow.publicProfileId,
+            displayName = "You",
+            rank = viewerRow.rank,
+            streakDays = viewerRow.streakDays
+        ),
+        rows = rankingRows.map { row ->
+            createProgressStreakLeaderboardParticipantRowForTest(
+                kind = when {
+                    row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER -> ProgressLeaderboardParticipantRowKind.VIEWER
+                    row.rank <= 3 -> ProgressLeaderboardParticipantRowKind.TOP
+                    else -> ProgressLeaderboardParticipantRowKind.NEIGHBOR
+                },
+                rankingRow = row
+            )
+        },
+        rankingRows = rankingRows
+    )
+}
+
+internal fun createProgressStreakLeaderboardRankingRowForTest(
+    kind: CloudProgressLeaderboardRankingRowKind,
+    publicProfileId: String,
+    anonymousDisplayName: String,
+    streakDays: Int,
+    rank: Int
+): CloudProgressStreakLeaderboardRankingRow {
+    return CloudProgressStreakLeaderboardRankingRow(
+        kind = kind,
+        publicProfileId = publicProfileId,
+        anonymousDisplayName = anonymousDisplayName,
+        friendDisplayName = null,
+        streakDays = streakDays,
+        rank = rank
+    )
+}
+
+private fun createProgressStreakLeaderboardParticipantRowForTest(
+    kind: ProgressLeaderboardParticipantRowKind,
+    rankingRow: CloudProgressStreakLeaderboardRankingRow
+): CloudProgressStreakLeaderboardRow.Participant {
+    return CloudProgressStreakLeaderboardRow.Participant(
+        kind = kind,
+        publicProfileId = rankingRow.publicProfileId,
+        anonymousDisplayName = rankingRow.anonymousDisplayName,
+        friendDisplayName = rankingRow.friendDisplayName,
+        streakDays = rankingRow.streakDays,
         rank = rankingRow.rank
     )
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressCacheValidationTest.kt
@@ -7,20 +7,25 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudDailyReviewPoint
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewHistoryWatermark
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.findProgressReviewScheduleServerBase
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCacheEntity
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressLeaderboardOrNull
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressStreakLeaderboardOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressReviewScheduleOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressSeriesOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.cache.toCloudProgressSummaryOrNull
 import com.flashcardsopensourceapp.data.local.repository.progress.createCloudSettings
 import com.flashcardsopensourceapp.data.local.repository.progress.createProgressLeaderboardForTest
 import com.flashcardsopensourceapp.data.local.repository.progress.createProgressLeaderboardRankingRowForTest
+import com.flashcardsopensourceapp.data.local.repository.progress.createProgressStreakLeaderboardForTest
+import com.flashcardsopensourceapp.data.local.repository.progress.createProgressStreakLeaderboardRankingRowForTest
 import com.flashcardsopensourceapp.data.local.repository.progress.createReviewSchedule
 import java.time.LocalDate
 import java.time.ZoneId
@@ -318,6 +323,48 @@ class ProgressCacheValidationTest {
             restoredRows.map { row -> row.kind }
         )
         assertEquals(listOf(1, 2), restoredRows.map { row -> row.rank })
+        assertEquals(listOf("Kai", null), restoredRows.map { row -> row.friendDisplayName })
+    }
+
+    @Test
+    fun progressStreakLeaderboardCachePreservesRankingRows(): Unit {
+        val leaderboard = createProgressStreakLeaderboardForTest(
+            rankingRows = listOf(
+                createProgressStreakLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+                    publicProfileId = "participant-1",
+                    anonymousDisplayName = "Silver Bright Harbor",
+                    streakDays = 9,
+                    rank = 1
+                ).copy(friendDisplayName = "Kai"),
+                createProgressStreakLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.VIEWER,
+                    publicProfileId = "viewer-profile",
+                    anonymousDisplayName = "Misty Quiet Grove",
+                    streakDays = 7,
+                    rank = 2
+                )
+            )
+        )
+
+        val restoredLeaderboard = leaderboard.toCacheEntity(
+            scopeKey = ProgressStreakLeaderboardScopeKey(scopeId = "linked:user-1"),
+            updatedAtMillis = 1L
+        ).toCloudProgressStreakLeaderboardOrNull()
+
+        val restoredReadyLeaderboard = checkNotNull(restoredLeaderboard)
+        assertTrue(restoredReadyLeaderboard is CloudProgressStreakLeaderboard.Ready)
+        val readyLeaderboard = restoredReadyLeaderboard as CloudProgressStreakLeaderboard.Ready
+        val restoredRows = readyLeaderboard.rankingRows
+        assertEquals(
+            listOf(
+                CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+                CloudProgressLeaderboardRankingRowKind.VIEWER
+            ),
+            restoredRows.map { row -> row.kind }
+        )
+        assertEquals(listOf(1, 2), restoredRows.map { row -> row.rank })
+        assertEquals(listOf(9, 7), restoredRows.map { row -> row.streakDays })
         assertEquals(listOf("Kai", null), restoredRows.map { row -> row.friendDisplayName })
     }
 }

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStreakLeaderboardSnapshotTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/snapshots/ProgressStreakLeaderboardSnapshotTest.kt
@@ -1,0 +1,118 @@
+package com.flashcardsopensourceapp.data.local.repository.progress.snapshots
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboardRankingRowKind
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardScopeKey
+import com.flashcardsopensourceapp.data.local.repository.progress.cache.ProgressStreakLeaderboardCachedPayload
+import com.flashcardsopensourceapp.data.local.repository.progress.createProgressStreakLeaderboardForTest
+import com.flashcardsopensourceapp.data.local.repository.progress.createProgressStreakLeaderboardRankingRowForTest
+import java.time.Instant
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProgressStreakLeaderboardSnapshotTest {
+    @Test
+    fun localCurrentStreakProjectsViewerAboveEqualStreakRows(): Unit {
+        val leaderboard = createProgressStreakLeaderboardForTest(
+            rankingRows = listOf(
+                createProgressStreakLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+                    publicProfileId = "participant-1",
+                    anonymousDisplayName = "Silver Bright Harbor",
+                    streakDays = 7,
+                    rank = 1
+                ),
+                createProgressStreakLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+                    publicProfileId = "participant-2",
+                    anonymousDisplayName = "Amber Calm Meadow",
+                    streakDays = 5,
+                    rank = 2
+                ),
+                createProgressStreakLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.VIEWER,
+                    publicProfileId = "viewer-profile",
+                    anonymousDisplayName = "Misty Quiet Grove",
+                    streakDays = 4,
+                    rank = 3
+                )
+            )
+        )
+
+        val snapshot = createProgressStreakLeaderboardStoreState(
+            inputs = ProgressStreakLeaderboardStoreInputs(
+                scopeKey = ProgressStreakLeaderboardScopeKey(scopeId = "linked:user-1"),
+                cloudState = CloudAccountState.LINKED,
+                serverBase = ProgressStreakLeaderboardCachedPayload(
+                    leaderboard = leaderboard,
+                    updatedAtMillis = 1L
+                ),
+                viewerCurrentStreakDays = 5,
+                didLastRemoteLoadFail = false,
+                currentTimeMillis = Instant.parse("2026-06-10T12:30:00.000Z").toEpochMilli()
+            )
+        ).snapshot
+
+        val renderedLeaderboard = snapshot.renderedLeaderboard as CloudProgressStreakLeaderboard.Ready
+        assertFalse(snapshot.isRefreshDue)
+        assertEquals(2, renderedLeaderboard.viewer.rank)
+        assertEquals(5, renderedLeaderboard.viewer.streakDays)
+        assertEquals(
+            listOf("participant-1", "viewer-profile", "participant-2"),
+            renderedLeaderboard.rankingRows.map { row -> row.publicProfileId }
+        )
+    }
+
+    @Test
+    fun missingServerRowsRenderViewerOnlyFromCurrentSummary(): Unit {
+        val snapshot = createProgressStreakLeaderboardStoreState(
+            inputs = ProgressStreakLeaderboardStoreInputs(
+                scopeKey = ProgressStreakLeaderboardScopeKey(scopeId = "linked:user-1"),
+                cloudState = CloudAccountState.LINKED,
+                serverBase = null,
+                viewerCurrentStreakDays = 6,
+                didLastRemoteLoadFail = false,
+                currentTimeMillis = Instant.parse("2026-06-10T12:30:00.000Z").toEpochMilli()
+            )
+        ).snapshot
+
+        val renderedLeaderboard = snapshot.renderedLeaderboard as CloudProgressStreakLeaderboard.Ready
+        assertTrue(snapshot.isRefreshDue)
+        assertEquals(null, snapshot.leaderboard)
+        assertEquals(1, renderedLeaderboard.viewer.rank)
+        assertEquals(6, renderedLeaderboard.viewer.streakDays)
+        assertEquals(1, renderedLeaderboard.rankingRows.size)
+        assertEquals(CloudProgressLeaderboardRankingRowKind.VIEWER, renderedLeaderboard.rankingRows.single().kind)
+    }
+
+    @Test
+    fun refreshDueUsesStreakPayloadNextRefreshAfter(): Unit {
+        val leaderboard = createProgressStreakLeaderboardForTest(
+            rankingRows = listOf(
+                createProgressStreakLeaderboardRankingRowForTest(
+                    kind = CloudProgressLeaderboardRankingRowKind.VIEWER,
+                    publicProfileId = "viewer-profile",
+                    anonymousDisplayName = "Misty Quiet Grove",
+                    streakDays = 4,
+                    rank = 1
+                )
+            )
+        )
+
+        assertFalse(
+            isProgressStreakLeaderboardRefreshDue(
+                leaderboard = leaderboard,
+                currentTimeMillis = Instant.parse("2026-06-11T11:59:59.999Z").toEpochMilli()
+            )
+        )
+        assertTrue(
+            isProgressStreakLeaderboardRefreshDue(
+                leaderboard = leaderboard,
+                currentTimeMillis = Instant.parse("2026-06-11T12:00:00.000Z").toEpochMilli()
+            )
+        )
+    }
+}

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -95,6 +95,9 @@ class ProgressViewModel(
         launchAndLogFailure(event = "progress_leaderboard_refresh_if_invalidated_failed") {
             progressRepository.refreshLeaderboardIfInvalidated()
         }
+        launchAndLogFailure(event = "progress_streak_leaderboard_refresh_if_invalidated_failed") {
+            progressRepository.refreshStreakLeaderboardIfInvalidated()
+        }
     }
 
     fun refreshManually() {
@@ -109,6 +112,9 @@ class ProgressViewModel(
         }
         launchAndLogFailure(event = "progress_leaderboard_refresh_manually_failed") {
             progressRepository.refreshLeaderboardManually()
+        }
+        launchAndLogFailure(event = "progress_streak_leaderboard_refresh_manually_failed") {
+            progressRepository.refreshStreakLeaderboardManually()
         }
     }
 

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelLifecycleTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelLifecycleTest.kt
@@ -58,10 +58,12 @@ class ProgressViewModelLifecycleTest {
             assertEquals(1, repository.refreshSeriesIfInvalidatedCallCount)
             assertEquals(1, repository.refreshReviewScheduleIfInvalidatedCallCount)
             assertEquals(1, repository.refreshLeaderboardIfInvalidatedCallCount)
+            assertEquals(1, repository.refreshStreakLeaderboardIfInvalidatedCallCount)
             assertEquals(0, repository.refreshSummaryManuallyCallCount)
             assertEquals(0, repository.refreshSeriesManuallyCallCount)
             assertEquals(0, repository.refreshReviewScheduleManuallyCallCount)
             assertEquals(0, repository.refreshLeaderboardManuallyCallCount)
+            assertEquals(0, repository.refreshStreakLeaderboardManuallyCallCount)
         } finally {
             Dispatchers.resetMain()
         }
@@ -82,10 +84,12 @@ class ProgressViewModelLifecycleTest {
             assertEquals(0, repository.refreshSeriesIfInvalidatedCallCount)
             assertEquals(0, repository.refreshReviewScheduleIfInvalidatedCallCount)
             assertEquals(0, repository.refreshLeaderboardIfInvalidatedCallCount)
+            assertEquals(0, repository.refreshStreakLeaderboardIfInvalidatedCallCount)
             assertEquals(1, repository.refreshSummaryManuallyCallCount)
             assertEquals(1, repository.refreshSeriesManuallyCallCount)
             assertEquals(1, repository.refreshReviewScheduleManuallyCallCount)
             assertEquals(1, repository.refreshLeaderboardManuallyCallCount)
+            assertEquals(1, repository.refreshStreakLeaderboardManuallyCallCount)
         } finally {
             Dispatchers.resetMain()
         }

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
@@ -27,6 +27,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewSched
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressLeaderboard
@@ -48,6 +49,7 @@ internal class FakeProgressRepository : ProgressRepository {
     private val seriesSnapshots = MutableStateFlow<ProgressSeriesSnapshot?>(null)
     private val reviewScheduleSnapshots = MutableStateFlow<ProgressReviewScheduleSnapshot?>(null)
     private val leaderboardSnapshots = MutableStateFlow<ProgressLeaderboardSnapshot?>(null)
+    private val streakLeaderboardSnapshots = MutableStateFlow<ProgressStreakLeaderboardSnapshot?>(null)
     var refreshSummaryIfInvalidatedCallCount: Int = 0
         private set
     var refreshSeriesIfInvalidatedCallCount: Int = 0
@@ -55,6 +57,8 @@ internal class FakeProgressRepository : ProgressRepository {
     var refreshReviewScheduleIfInvalidatedCallCount: Int = 0
         private set
     var refreshLeaderboardIfInvalidatedCallCount: Int = 0
+        private set
+    var refreshStreakLeaderboardIfInvalidatedCallCount: Int = 0
         private set
     var refreshLeaderboardForReviewShortcutCallCount: Int = 0
         private set
@@ -65,6 +69,8 @@ internal class FakeProgressRepository : ProgressRepository {
     var refreshReviewScheduleManuallyCallCount: Int = 0
         private set
     var refreshLeaderboardManuallyCallCount: Int = 0
+        private set
+    var refreshStreakLeaderboardManuallyCallCount: Int = 0
         private set
 
     fun emitSummarySnapshot(
@@ -107,6 +113,10 @@ internal class FakeProgressRepository : ProgressRepository {
         return leaderboardSnapshots
     }
 
+    override fun observeStreakLeaderboardSnapshot(): Flow<ProgressStreakLeaderboardSnapshot?> {
+        return streakLeaderboardSnapshots
+    }
+
     override suspend fun refreshSummaryIfInvalidated() {
         refreshSummaryIfInvalidatedCallCount += 1
     }
@@ -121,6 +131,10 @@ internal class FakeProgressRepository : ProgressRepository {
 
     override suspend fun refreshLeaderboardIfInvalidated() {
         refreshLeaderboardIfInvalidatedCallCount += 1
+    }
+
+    override suspend fun refreshStreakLeaderboardIfInvalidated() {
+        refreshStreakLeaderboardIfInvalidatedCallCount += 1
     }
 
     override suspend fun refreshLeaderboardForReviewShortcut() {
@@ -141,6 +155,10 @@ internal class FakeProgressRepository : ProgressRepository {
 
     override suspend fun refreshLeaderboardManually() {
         refreshLeaderboardManuallyCallCount += 1
+    }
+
+    override suspend fun refreshStreakLeaderboardManually() {
+        refreshStreakLeaderboardManuallyCallCount += 1
     }
 }
 

--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTestSupport.kt
@@ -23,6 +23,7 @@ import com.flashcardsopensourceapp.data.local.model.cloud.CloudWorkspaceSummary
 import com.flashcardsopensourceapp.data.local.model.cloud.StoredCloudCredentials
 import com.flashcardsopensourceapp.data.local.model.cloud.makeOfficialCloudServiceConfiguration
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
@@ -284,6 +285,10 @@ internal class FakeCloudAccountRepository : CloudAccountRepository {
     }
 
     override suspend fun loadProgressLeaderboard(): CloudProgressLeaderboard {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun loadProgressStreakLeaderboard(): CloudProgressStreakLeaderboard {
         throw UnsupportedOperationException()
     }
 


### PR DESCRIPTION
## Summary
- add Android data/local streak leaderboard remote parsing, cache storage, repository orchestration, and viewer projection
- wire streak leaderboard refresh through Android progress refresh paths
- add focused parser, cache/projection, fake, and migration coverage

## Validation
- git --no-pager diff --check
- worker-owned read-only review: no P0-P4 findings
- Gradle not run because ./gradlew requires explicit approval for this task