### PR TITLE
Add iOS streak leaderboard data

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+Progress.swift
@@ -169,11 +169,16 @@ extension FlashcardsStore {
                 scopeKey: leaderboardScopeKey,
                 now: now
             )
+            let shouldRefreshStreakLeaderboard = self.shouldRefreshProgressStreakLeaderboard(
+                scopeKey: leaderboardScopeKey,
+                now: now
+            )
 
             guard shouldRefreshSummary
                 || shouldRefreshSeries
                 || shouldRefreshReviewSchedule
-                || shouldRefreshLeaderboard else {
+                || shouldRefreshLeaderboard
+                || shouldRefreshStreakLeaderboard else {
                 return
             }
 
@@ -205,31 +210,30 @@ extension FlashcardsStore {
                 }
             }
 
-            if shouldRefreshReviewSchedule && shouldRefreshLeaderboard {
-                async let refreshReviewSchedule: Void = self.refreshProgressReviewScheduleServerBase(
-                    scopeKey: scheduleScopeKey,
-                    linkedSession: activeSession
-                )
-                async let refreshLeaderboard: Void = self.refreshProgressLeaderboardServerBase(
-                    scopeKey: leaderboardScopeKey,
-                    linkedSession: activeSession
-                )
-                _ = await (refreshReviewSchedule, refreshLeaderboard)
-            } else if shouldRefreshReviewSchedule {
-                await self.refreshProgressReviewScheduleServerBase(
-                    scopeKey: scheduleScopeKey,
-                    linkedSession: activeSession
-                )
-            } else if shouldRefreshLeaderboard {
-                await self.refreshProgressLeaderboardServerBase(
-                    scopeKey: leaderboardScopeKey,
-                    linkedSession: activeSession
-                )
-            }
+            async let refreshReviewSchedule: Void = self.refreshProgressReviewScheduleServerBaseIfNeeded(
+                scopeKey: scheduleScopeKey,
+                linkedSession: activeSession
+            )
+            async let refreshLeaderboard: Void = self.refreshProgressLeaderboardServerBaseIfNeeded(
+                scopeKey: leaderboardScopeKey,
+                linkedSession: activeSession,
+                now: now
+            )
+            async let refreshStreakLeaderboard: Void = self.refreshProgressStreakLeaderboardServerBaseIfNeeded(
+                scopeKey: leaderboardScopeKey,
+                linkedSession: activeSession,
+                now: now
+            )
+            _ = await (refreshReviewSchedule, refreshLeaderboard, refreshStreakLeaderboard)
 
             if self.progressObservedScopeKey == scopeKey {
                 try self.publishProgressSnapshot(scopeKey: scopeKey)
                 self.publishReviewScheduleSnapshotIsolatingErrors(scopeKey: scheduleScopeKey)
+                self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                    scopeKey: leaderboardScopeKey,
+                    seriesScopeKey: scopeKey,
+                    now: now
+                )
             }
         } catch {
             if isRequestCancellationError(error: error) {
@@ -269,7 +273,20 @@ extension FlashcardsStore {
                 scopeKey: leaderboardScopeKey,
                 linkedSession: activeSession
             )
-            _ = await (refreshSummary, refreshSeries, refreshReviewSchedule, refreshLeaderboard)
+            async let refreshStreakLeaderboard: Void = self.refreshProgressStreakLeaderboardServerBaseIfLinked(
+                scopeKey: leaderboardScopeKey,
+                linkedSession: activeSession
+            )
+            _ = await (refreshSummary, refreshSeries, refreshReviewSchedule, refreshLeaderboard, refreshStreakLeaderboard)
+
+            if self.progressObservedScopeKey == scopeKey {
+                try self.publishProgressSnapshot(scopeKey: scopeKey)
+                self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                    scopeKey: leaderboardScopeKey,
+                    seriesScopeKey: scopeKey,
+                    now: now
+                )
+            }
         } catch {
             if isRequestCancellationError(error: error) {
                 return
@@ -296,6 +313,64 @@ extension FlashcardsStore {
         )
     }
 
+    private func refreshProgressStreakLeaderboardServerBaseIfLinked(
+        scopeKey: ProgressLeaderboardScopeKey,
+        linkedSession: CloudLinkedSession
+    ) async {
+        guard scopeKey.cloudState == .linked else {
+            return
+        }
+
+        await self.refreshProgressStreakLeaderboardServerBase(
+            scopeKey: scopeKey,
+            linkedSession: linkedSession
+        )
+    }
+
+    private func refreshProgressReviewScheduleServerBaseIfNeeded(
+        scopeKey: ReviewScheduleScopeKey,
+        linkedSession: CloudLinkedSession
+    ) async {
+        guard self.shouldRefreshProgressReviewSchedule(scopeKey: scopeKey) else {
+            return
+        }
+
+        await self.refreshProgressReviewScheduleServerBase(
+            scopeKey: scopeKey,
+            linkedSession: linkedSession
+        )
+    }
+
+    private func refreshProgressLeaderboardServerBaseIfNeeded(
+        scopeKey: ProgressLeaderboardScopeKey,
+        linkedSession: CloudLinkedSession,
+        now: Date
+    ) async {
+        guard self.shouldRefreshProgressLeaderboard(scopeKey: scopeKey, now: now) else {
+            return
+        }
+
+        await self.refreshProgressLeaderboardServerBase(
+            scopeKey: scopeKey,
+            linkedSession: linkedSession
+        )
+    }
+
+    private func refreshProgressStreakLeaderboardServerBaseIfNeeded(
+        scopeKey: ProgressLeaderboardScopeKey,
+        linkedSession: CloudLinkedSession,
+        now: Date
+    ) async {
+        guard self.shouldRefreshProgressStreakLeaderboard(scopeKey: scopeKey, now: now) else {
+            return
+        }
+
+        await self.refreshProgressStreakLeaderboardServerBase(
+            scopeKey: scopeKey,
+            linkedSession: linkedSession
+        )
+    }
+
     func handleProgressContextDidChange(now: Date) {
         self.prepareProgressForCurrentVisibleTabAndRefreshIfNeeded(now: now)
     }
@@ -317,23 +392,34 @@ extension FlashcardsStore {
             )
             try self.markProgressReviewSchedulePendingLocalOverlay(scopeKey: scheduleScopeKey)
             try self.publishReviewProgressBadgeState(scopeKey: scopeKey)
+            let leaderboardScopeKey = self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
             self.publishReviewScheduleSnapshotIsolatingErrors(
                 scopeKey: scheduleScopeKey
             )
             // Re-render the cached leaderboard so the viewer's live qualified
             // count reflects the just-submitted review immediately.
             self.publishProgressLeaderboardSnapshotIsolatingErrors(
-                scopeKey: self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey),
+                scopeKey: leaderboardScopeKey,
                 now: now
             )
 
             guard let progressSnapshot = self.progressSnapshot else {
+                self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                    scopeKey: leaderboardScopeKey,
+                    seriesScopeKey: scopeKey,
+                    now: now
+                )
                 self.clearProgressErrorMessage()
                 return
             }
 
             guard progressSnapshot.scopeKey == scopeKey else {
                 try self.publishProgressSnapshot(scopeKey: scopeKey)
+                self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                    scopeKey: leaderboardScopeKey,
+                    seriesScopeKey: scopeKey,
+                    now: now
+                )
                 self.clearProgressErrorMessage()
                 return
             }
@@ -352,6 +438,11 @@ extension FlashcardsStore {
                 activeReviewLocalDates: activeReviewLocalDates
             )
             self.applyProgressSnapshot(snapshot: patchedSnapshot)
+            self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                scopeKey: leaderboardScopeKey,
+                seriesScopeKey: scopeKey,
+                now: now
+            )
             self.clearProgressErrorMessage()
         } catch {
             self.presentTechnicalError(error)
@@ -429,6 +520,11 @@ extension FlashcardsStore {
             if reviewProgressDataChanged && isReviewVisible == false {
                 self.publishProgressLeaderboardSnapshotIsolatingErrors(
                     scopeKey: self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey),
+                    now: now
+                )
+                self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                    scopeKey: self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey),
+                    seriesScopeKey: scopeKey,
                     now: now
                 )
             }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressErrorState.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressErrorState.swift
@@ -54,6 +54,15 @@ func localizedProgressLeaderboardRefreshErrorMessage() -> String {
     )
 }
 
+func localizedProgressStreakLeaderboardRefreshErrorMessage() -> String {
+    String(
+        localized: "progress.error.streak_leaderboard_refresh_failed",
+        defaultValue: "Streak leaderboard couldn't refresh. Pull to try again.",
+        table: progressStringsTableName,
+        comment: "Generic progress card message when streak leaderboard refresh fails"
+    )
+}
+
 @MainActor
 extension FlashcardsStore {
     func clearProgressErrorMessage() {
@@ -93,6 +102,14 @@ extension FlashcardsStore {
     func beginProgressLeaderboardRefreshErrorScope() {
         self.applyProgressErrorState(
             state: progressErrorStateClearingGeneralAndLeaderboardRefreshMessages(
+                state: self.progressErrorState
+            )
+        )
+    }
+
+    func beginProgressStreakLeaderboardRefreshErrorScope() {
+        self.applyProgressErrorState(
+            state: progressErrorStateClearingGeneralAndStreakLeaderboardRefreshMessages(
                 state: self.progressErrorState
             )
         )
@@ -174,9 +191,26 @@ extension FlashcardsStore {
         )
     }
 
+    func clearProgressStreakLeaderboardRefreshErrorMessage() {
+        self.applyProgressErrorState(
+            state: progressErrorStateClearingStreakLeaderboardRefreshMessage(
+                state: self.progressErrorState
+            )
+        )
+    }
+
     func replaceProgressLeaderboardRefreshErrorMessage(message: String) {
         self.applyProgressErrorState(
             state: progressErrorStateWithLeaderboardRefreshMessage(
+                state: self.progressErrorState,
+                message: message
+            )
+        )
+    }
+
+    func replaceProgressStreakLeaderboardRefreshErrorMessage(message: String) {
+        self.applyProgressErrorState(
+            state: progressErrorStateWithStreakLeaderboardRefreshMessage(
                 state: self.progressErrorState,
                 message: message
             )

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressRefresh.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressRefresh.swift
@@ -273,6 +273,77 @@ extension FlashcardsStore {
         }
     }
 
+    func refreshProgressStreakLeaderboardServerBase(
+        scopeKey: ProgressLeaderboardScopeKey,
+        linkedSession: CloudLinkedSession
+    ) async {
+        let refreshToken = self.progressStreakLeaderboardRefreshToken
+        if self.progressActiveStreakLeaderboardRefreshScopeKey == scopeKey,
+           self.progressActiveStreakLeaderboardRefreshToken == refreshToken {
+            return
+        }
+
+        self.progressActiveStreakLeaderboardRefreshScopeKey = scopeKey
+        self.progressActiveStreakLeaderboardRefreshToken = refreshToken
+        self.isProgressStreakLeaderboardRefreshing = true
+        self.updateProgressRefreshingState()
+        self.beginProgressStreakLeaderboardRefreshErrorScope()
+
+        defer {
+            if self.progressActiveStreakLeaderboardRefreshScopeKey == scopeKey,
+               self.progressActiveStreakLeaderboardRefreshToken == refreshToken {
+                self.progressActiveStreakLeaderboardRefreshScopeKey = nil
+                self.progressActiveStreakLeaderboardRefreshToken = nil
+                self.isProgressStreakLeaderboardRefreshing = false
+                self.updateProgressRefreshingState()
+            }
+        }
+
+        do {
+            let serverBase = try await self.loadProgressStreakLeaderboardServerBaseWithSessionRecovery(
+                linkedSession: linkedSession
+            )
+
+            guard self.isCurrentProgressStreakLeaderboardRefresh(scopeKey: scopeKey, refreshToken: refreshToken) else {
+                return
+            }
+
+            let persistedServerBase = PersistedProgressStreakLeaderboardServerBase(
+                scopeKey: scopeKey,
+                serverBase: serverBase,
+                storedAt: nowIsoTimestamp()
+            )
+            try self.persistProgressStreakLeaderboardServerBase(serverBase: persistedServerBase)
+            self.progressStreakLeaderboardServerBaseCache = persistedServerBase
+            self.progressStreakLeaderboardInvalidatedScopeKeys.remove(scopeKey)
+            self.clearProgressStreakLeaderboardRefreshErrorMessage()
+
+            guard let observedScopeKey = self.progressObservedScopeKey,
+                  self.currentProgressLeaderboardScopeKey(seriesScopeKey: observedScopeKey) == scopeKey else {
+                return
+            }
+
+            self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                scopeKey: scopeKey,
+                seriesScopeKey: observedScopeKey,
+                now: Date()
+            )
+        } catch {
+            if isRequestCancellationError(error: error) {
+                return
+            }
+
+            guard self.isCurrentProgressStreakLeaderboardRefresh(scopeKey: scopeKey, refreshToken: refreshToken) else {
+                return
+            }
+
+            self.presentTechnicalError(error)
+            self.replaceProgressStreakLeaderboardRefreshErrorMessage(
+                message: localizedProgressStreakLeaderboardRefreshErrorMessage()
+            )
+        }
+    }
+
     func shouldRefreshProgressSummary(scopeKey: ProgressSummaryScopeKey) -> Bool {
         guard self.progressSummaryServerBaseCache?.scopeKey == scopeKey else {
             return true
@@ -334,6 +405,27 @@ extension FlashcardsStore {
         )
     }
 
+    func shouldRefreshProgressStreakLeaderboard(
+        scopeKey: ProgressLeaderboardScopeKey,
+        now: Date
+    ) -> Bool {
+        guard scopeKey.cloudState == .linked else {
+            return false
+        }
+        guard let cachedServerBase = self.progressStreakLeaderboardServerBaseCache,
+              cachedServerBase.scopeKey == scopeKey else {
+            return true
+        }
+        if self.progressStreakLeaderboardInvalidatedScopeKeys.contains(scopeKey) {
+            return true
+        }
+
+        return progressStreakLeaderboardRequiresScheduledRefresh(
+            leaderboard: cachedServerBase.serverBase,
+            now: now
+        )
+    }
+
     func activeProgressCloudSession(scopeKey: ProgressScopeKey) -> CloudLinkedSession? {
         guard let cloudSettings = self.cloudSettings else {
             return nil
@@ -375,6 +467,9 @@ extension FlashcardsStore {
         self.invalidateProgressSummaryAndSeries(scopeKey: scopeKey, summaryScopeKey: summaryScopeKey)
         self.invalidateProgressReviewSchedule(scopeKey: scheduleScopeKey)
         self.invalidateProgressLeaderboard(
+            scopeKey: self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+        )
+        self.invalidateProgressStreakLeaderboard(
             scopeKey: self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
         )
     }
@@ -420,6 +515,17 @@ extension FlashcardsStore {
         self.updateProgressRefreshingState()
     }
 
+    func invalidateProgressStreakLeaderboard(scopeKey: ProgressLeaderboardScopeKey) {
+        // Keep the persisted payload so an offline manual refresh still renders the
+        // cached leaderboard; the invalidation only forces the next online refetch.
+        self.progressStreakLeaderboardInvalidatedScopeKeys.insert(scopeKey)
+        self.progressStreakLeaderboardRefreshToken += 1
+        self.progressActiveStreakLeaderboardRefreshScopeKey = nil
+        self.progressActiveStreakLeaderboardRefreshToken = nil
+        self.isProgressStreakLeaderboardRefreshing = false
+        self.updateProgressRefreshingState()
+    }
+
     func markProgressReviewSchedulePendingLocalOverlay(scopeKey: ReviewScheduleScopeKey) throws {
         self.progressReviewScheduleInvalidatedScopeKeys.insert(scopeKey)
         if let cachedServerBase = self.progressReviewScheduleServerBaseCache,
@@ -445,6 +551,7 @@ extension FlashcardsStore {
             || self.isProgressSeriesRefreshing
             || self.isProgressReviewScheduleRefreshing
             || self.isProgressLeaderboardRefreshing
+            || self.isProgressStreakLeaderboardRefreshing
         if self.isProgressRefreshing != isRefreshing {
             self.isProgressRefreshing = isRefreshing
         }
@@ -558,6 +665,26 @@ extension FlashcardsStore {
         }
     }
 
+    private func loadProgressStreakLeaderboardServerBase(
+        linkedSession: CloudLinkedSession
+    ) async throws -> UserProgressStreakLeaderboard {
+        let cloudSyncService = try requireCloudSyncService(cloudSyncService: self.dependencies.cloudSyncService)
+        let leaderboard = try await cloudSyncService.loadProgressStreakLeaderboard(
+            apiBaseUrl: linkedSession.apiBaseUrl,
+            authorizationHeader: linkedSession.authorizationHeaderValue
+        )
+        try validateProgressStreakLeaderboard(leaderboard: leaderboard)
+        return leaderboard
+    }
+
+    private func loadProgressStreakLeaderboardServerBaseWithSessionRecovery(
+        linkedSession: CloudLinkedSession
+    ) async throws -> UserProgressStreakLeaderboard {
+        try await self.withCloudSessionPreservingStableContext(linkedSession: linkedSession) { refreshedSession in
+            try await self.loadProgressStreakLeaderboardServerBase(linkedSession: refreshedSession)
+        }
+    }
+
     private func isCurrentProgressSummaryRefresh(
         scopeKey: ProgressSummaryScopeKey,
         refreshToken: Int
@@ -592,5 +719,14 @@ extension FlashcardsStore {
         self.progressActiveLeaderboardRefreshScopeKey == scopeKey
             && self.progressActiveLeaderboardRefreshToken == refreshToken
             && self.progressLeaderboardRefreshToken == refreshToken
+    }
+
+    private func isCurrentProgressStreakLeaderboardRefresh(
+        scopeKey: ProgressLeaderboardScopeKey,
+        refreshToken: Int
+    ) -> Bool {
+        self.progressActiveStreakLeaderboardRefreshScopeKey == scopeKey
+            && self.progressActiveStreakLeaderboardRefreshToken == refreshToken
+            && self.progressStreakLeaderboardRefreshToken == refreshToken
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/FlashcardsStore+ProgressSnapshot.swift
@@ -20,6 +20,9 @@ extension FlashcardsStore {
             self.progressLeaderboardServerBaseCache = self.loadPersistedProgressLeaderboardServerBase(
                 scopeKey: self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
             )
+            self.progressStreakLeaderboardServerBaseCache = self.loadPersistedProgressStreakLeaderboardServerBase(
+                scopeKey: self.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+            )
             self.clearProgressErrorMessage()
             if previousScopeKey != nil {
                 self.invalidateProgress(
@@ -57,6 +60,14 @@ extension FlashcardsStore {
         if self.progressLeaderboardSnapshot?.scopeKey != leaderboardScopeKey
             || self.progressLeaderboardPublishedClientRevision != self.progressReviewedAtClientRevision {
             self.publishProgressLeaderboardSnapshotIsolatingErrors(scopeKey: leaderboardScopeKey, now: now)
+        }
+        if self.progressStreakLeaderboardSnapshot?.scopeKey != leaderboardScopeKey
+            || self.progressStreakLeaderboardPublishedClientRevision != self.progressReviewedAtClientRevision {
+            self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                scopeKey: leaderboardScopeKey,
+                seriesScopeKey: scopeKey,
+                now: now
+            )
         }
 
         return scopeKey
@@ -372,6 +383,92 @@ extension FlashcardsStore {
         }
     }
 
+    func publishProgressStreakLeaderboardSnapshot(
+        scopeKey: ProgressLeaderboardScopeKey,
+        seriesScopeKey: ProgressScopeKey,
+        now: Date
+    ) throws {
+        let snapshot = try self.makeCurrentProgressStreakLeaderboardSnapshot(
+            scopeKey: scopeKey,
+            seriesScopeKey: seriesScopeKey,
+            now: now
+        )
+        self.applyProgressStreakLeaderboardSnapshot(snapshot: snapshot)
+        self.progressStreakLeaderboardPublishedClientRevision = self.progressReviewedAtClientRevision
+    }
+
+    private func makeCurrentProgressStreakLeaderboardSnapshot(
+        scopeKey: ProgressLeaderboardScopeKey,
+        seriesScopeKey: ProgressScopeKey,
+        now: Date
+    ) throws -> ProgressStreakLeaderboardSnapshot {
+        _ = now
+        let personalStreakDays = try self.currentProgressStreakDays(seriesScopeKey: seriesScopeKey)
+        switch scopeKey.cloudState {
+        case .none, .some(.disconnected), .some(.linkingReady), .some(.guest):
+            return try makeProgressStreakLeaderboardSnapshot(
+                leaderboard: nil,
+                scopeKey: scopeKey,
+                personalStreakDays: personalStreakDays
+            )
+        case .some(.linked):
+            break
+        }
+
+        guard let cachedServerBase = self.progressStreakLeaderboardServerBaseCache,
+              cachedServerBase.scopeKey == scopeKey else {
+            return try makeProgressStreakLeaderboardSnapshot(
+                leaderboard: nil,
+                scopeKey: scopeKey,
+                personalStreakDays: personalStreakDays
+            )
+        }
+
+        return try makeProgressStreakLeaderboardSnapshot(
+            leaderboard: cachedServerBase.serverBase,
+            scopeKey: scopeKey,
+            personalStreakDays: personalStreakDays
+        )
+    }
+
+    private func currentProgressStreakDays(seriesScopeKey: ProgressScopeKey) throws -> Int? {
+        if let progressSnapshot = self.progressSnapshot,
+           progressSnapshot.scopeKey == seriesScopeKey {
+            return progressSnapshot.summary.currentStreakDays
+        }
+
+        let reviewedAtClientSources = try self.loadProgressReviewedAtClientSources()
+        let renderedProgress = try self.makeProgressRenderedSummaryAndSeries(
+            scopeKey: seriesScopeKey,
+            reviewedAtClientSources: reviewedAtClientSources
+        )
+        return renderedProgress.renderedSummary.summary.currentStreakDays
+    }
+
+    func publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+        scopeKey: ProgressLeaderboardScopeKey,
+        seriesScopeKey: ProgressScopeKey,
+        now: Date
+    ) {
+        do {
+            try self.publishProgressStreakLeaderboardSnapshot(
+                scopeKey: scopeKey,
+                seriesScopeKey: seriesScopeKey,
+                now: now
+            )
+        } catch {
+            if isRequestCancellationError(error: error) {
+                return
+            }
+
+            self.applyProgressStreakLeaderboardSnapshot(snapshot: nil)
+            self.presentTechnicalError(error)
+            self.replaceProgressStreakLeaderboardRefreshErrorMessage(
+                message: localizedProgressStreakLeaderboardRefreshErrorMessage()
+            )
+        }
+    }
+
     func applyProgressLeaderboardSnapshot(snapshot: ProgressLeaderboardSnapshot?) {
         if self.progressLeaderboardSnapshot != snapshot {
             self.progressLeaderboardSnapshot = snapshot
@@ -379,6 +476,12 @@ extension FlashcardsStore {
         self.applyReviewLeaderboardBadgeState(
             badgeState: makeReviewLeaderboardBadgeState(progressLeaderboardSnapshot: snapshot)
         )
+    }
+
+    func applyProgressStreakLeaderboardSnapshot(snapshot: ProgressStreakLeaderboardSnapshot?) {
+        if self.progressStreakLeaderboardSnapshot != snapshot {
+            self.progressStreakLeaderboardSnapshot = snapshot
+        }
     }
 
     func publishReviewProgressBadgeState(scopeKey: ProgressScopeKey) throws {
@@ -400,6 +503,7 @@ extension FlashcardsStore {
         if snapshot == nil {
             self.applyReviewScheduleSnapshot(snapshot: nil)
             self.applyProgressLeaderboardSnapshot(snapshot: nil)
+            self.applyProgressStreakLeaderboardSnapshot(snapshot: nil)
         }
 
         self.applyReviewProgressBadgeState(

--- a/apps/ios/Flashcards/Flashcards/Cloud/Progress/ProgressServerBaseCache.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Progress/ProgressServerBaseCache.swift
@@ -56,11 +56,19 @@ struct PersistedProgressLeaderboardServerBase: Codable, Hashable, Sendable {
     let storedAt: String
 }
 
+/// Cached daily streak leaderboard payload exactly as the API returned it.
+struct PersistedProgressStreakLeaderboardServerBase: Codable, Hashable, Sendable {
+    let scopeKey: ProgressLeaderboardScopeKey
+    let serverBase: UserProgressStreakLeaderboard
+    let storedAt: String
+}
+
 private let progressSummaryServerBaseCacheUserDefaultsKeyPrefix: String = "progress-summary-server-base"
 private let progressSeriesServerBaseCacheUserDefaultsKeyPrefix: String = "progress-series-server-base"
 private let reviewScheduleServerBaseCacheUserDefaultsKeyPrefix: String = "progress-review-schedule-server-base"
 private let legacyProgressLeaderboardServerBaseCacheUserDefaultsKeyPrefix: String = "progress-leaderboard-server-base"
 private let progressLeaderboardServerBaseCacheUserDefaultsKeyPrefix: String = "progress-leaderboard-server-base-v2"
+private let progressStreakLeaderboardServerBaseCacheUserDefaultsKeyPrefix: String = "progress-streak-leaderboard-server-base-v1"
 
 @MainActor
 extension FlashcardsStore {
@@ -97,6 +105,16 @@ extension FlashcardsStore {
         self.removeLegacyProgressLeaderboardServerBase(scopeKey: serverBase.scopeKey)
     }
 
+    func persistProgressStreakLeaderboardServerBase(
+        serverBase: PersistedProgressStreakLeaderboardServerBase
+    ) throws {
+        let data = try self.encoder.encode(serverBase)
+        self.userDefaults.set(
+            data,
+            forKey: progressStreakLeaderboardServerBaseUserDefaultsKey(scopeKey: serverBase.scopeKey)
+        )
+    }
+
     func removePersistedReviewScheduleServerBase(scopeKey: ReviewScheduleScopeKey) {
         self.userDefaults.removeObject(
             forKey: reviewScheduleServerBaseUserDefaultsKey(scopeKey: scopeKey)
@@ -108,6 +126,12 @@ extension FlashcardsStore {
             forKey: progressLeaderboardServerBaseUserDefaultsKey(scopeKey: scopeKey)
         )
         self.removeLegacyProgressLeaderboardServerBase(scopeKey: scopeKey)
+    }
+
+    func removePersistedProgressStreakLeaderboardServerBase(scopeKey: ProgressLeaderboardScopeKey) {
+        self.userDefaults.removeObject(
+            forKey: progressStreakLeaderboardServerBaseUserDefaultsKey(scopeKey: scopeKey)
+        )
     }
 
     func loadPersistedProgressSummaryServerBase(
@@ -321,6 +345,56 @@ extension FlashcardsStore {
         }
     }
 
+    func loadPersistedProgressStreakLeaderboardServerBase(
+        scopeKey: ProgressLeaderboardScopeKey
+    ) -> PersistedProgressStreakLeaderboardServerBase? {
+        let key = progressStreakLeaderboardServerBaseUserDefaultsKey(scopeKey: scopeKey)
+        guard let data = self.userDefaults.data(forKey: key) else {
+            return nil
+        }
+
+        do {
+            let serverBase = try self.decoder.decode(PersistedProgressStreakLeaderboardServerBase.self, from: data)
+            guard serverBase.scopeKey == scopeKey else {
+                self.removeProgressServerBaseCache(
+                    key: key,
+                    cacheKind: "streak_leaderboard",
+                    reason: "scope_mismatch",
+                    expectedScopeKey: scopeKey.storageKey,
+                    actualScopeKey: serverBase.scopeKey.storageKey,
+                    errorMessage: nil
+                )
+                return nil
+            }
+
+            do {
+                try validateProgressStreakLeaderboard(leaderboard: serverBase.serverBase)
+            } catch {
+                self.removeProgressServerBaseCache(
+                    key: key,
+                    cacheKind: "streak_leaderboard",
+                    reason: "validation_failed",
+                    expectedScopeKey: scopeKey.storageKey,
+                    actualScopeKey: serverBase.scopeKey.storageKey,
+                    errorMessage: Flashcards.errorMessage(error: error)
+                )
+                return nil
+            }
+
+            return serverBase
+        } catch {
+            self.removeProgressServerBaseCache(
+                key: key,
+                cacheKind: "streak_leaderboard",
+                reason: "decode_failed",
+                expectedScopeKey: scopeKey.storageKey,
+                actualScopeKey: nil,
+                errorMessage: Flashcards.errorMessage(error: error)
+            )
+            return nil
+        }
+    }
+
     private func removeLegacyProgressLeaderboardServerBase(scopeKey: ProgressLeaderboardScopeKey) {
         // The unversioned cache predates rankingRows, which the current renderer requires.
         self.userDefaults.removeObject(
@@ -377,6 +451,10 @@ private func reviewScheduleServerBaseUserDefaultsKey(scopeKey: ReviewScheduleSco
 
 private func progressLeaderboardServerBaseUserDefaultsKey(scopeKey: ProgressLeaderboardScopeKey) -> String {
     "\(progressLeaderboardServerBaseCacheUserDefaultsKeyPrefix)|\(scopeKey.storageKey)"
+}
+
+private func progressStreakLeaderboardServerBaseUserDefaultsKey(scopeKey: ProgressLeaderboardScopeKey) -> String {
+    "\(progressStreakLeaderboardServerBaseCacheUserDefaultsKeyPrefix)|\(scopeKey.storageKey)"
 }
 
 private func legacyProgressLeaderboardServerBaseUserDefaultsKey(scopeKey: ProgressLeaderboardScopeKey) -> String {

--- a/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CommunityProfile.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Store/Account/FlashcardsStore+CommunityProfile.swift
@@ -39,7 +39,14 @@ extension FlashcardsStore {
             return
         }
 
+        let previousProfile = self.communityPublicProfile
         self.communityPublicProfile = profile
+        if self.shouldResetProgressLeaderboardsAfterCommunityProfileRefresh(
+            previousProfile: previousProfile,
+            profile: profile
+        ) {
+            self.handleProgressLeaderboardParticipationDidChange()
+        }
     }
 
     func updateLeaderboardParticipationEnabled(isEnabled: Bool) async throws {
@@ -104,13 +111,48 @@ extension FlashcardsStore {
             linkedUserId: cloudSettings.linkedUserId,
             localeIdentifier: progressLeaderboardPreferredLocaleIdentifier()
         )
+        let now = Date()
         self.removePersistedProgressLeaderboardServerBase(scopeKey: scopeKey)
+        self.removePersistedProgressStreakLeaderboardServerBase(scopeKey: scopeKey)
         if self.progressLeaderboardServerBaseCache?.scopeKey == scopeKey {
             self.progressLeaderboardServerBaseCache = nil
         }
+        if self.progressStreakLeaderboardServerBaseCache?.scopeKey == scopeKey {
+            self.progressStreakLeaderboardServerBaseCache = nil
+        }
         self.invalidateProgressLeaderboard(scopeKey: scopeKey)
+        self.invalidateProgressStreakLeaderboard(scopeKey: scopeKey)
         // Republish immediately so rows fetched under the previous participation
         // status are never rendered again while the forced refetch is pending.
-        self.publishProgressLeaderboardSnapshotIsolatingErrors(scopeKey: scopeKey, now: Date())
+        self.publishProgressLeaderboardSnapshotIsolatingErrors(scopeKey: scopeKey, now: now)
+        if let observedScopeKey = self.progressObservedScopeKey,
+           self.currentProgressLeaderboardScopeKey(seriesScopeKey: observedScopeKey) == scopeKey {
+            self.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+                scopeKey: scopeKey,
+                seriesScopeKey: observedScopeKey,
+                now: now
+            )
+        } else if self.progressStreakLeaderboardSnapshot?.scopeKey == scopeKey {
+            self.applyProgressStreakLeaderboardSnapshot(snapshot: nil)
+        }
+    }
+
+    private func shouldResetProgressLeaderboardsAfterCommunityProfileRefresh(
+        previousProfile: CommunityPublicProfile?,
+        profile: CommunityPublicProfile
+    ) -> Bool {
+        guard let previousProfile else {
+            return profile.leaderboardParticipationEnabled == false
+                || profile.linkedAccountRequiredForLeaderboard
+                || self.progressLeaderboardServerBaseCache != nil
+                || self.progressStreakLeaderboardServerBaseCache != nil
+                || self.progressLeaderboardSnapshot != nil
+                || self.progressStreakLeaderboardSnapshot != nil
+        }
+
+        return previousProfile.publicProfileId != profile.publicProfileId
+            || previousProfile.anonymousDisplayName != profile.anonymousDisplayName
+            || previousProfile.leaderboardParticipationEnabled != profile.leaderboardParticipationEnabled
+            || previousProfile.linkedAccountRequiredForLeaderboard != profile.linkedAccountRequiredForLeaderboard
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncService.swift
@@ -217,6 +217,19 @@ final class CloudSyncService: @unchecked Sendable {
         )
     }
 
+    func loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ) async throws -> UserProgressStreakLeaderboard {
+        try await self.transport.request(
+            apiBaseUrl: apiBaseUrl,
+            authorizationHeader: authorizationHeader,
+            path: "/me/progress/leaderboards/streak",
+            method: "GET",
+            body: Optional<String>.none
+        )
+    }
+
     func loadCommunityPublicProfile(
         apiBaseUrl: String,
         authorizationHeader: String

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressLeaderboardTypes.swift
@@ -148,6 +148,169 @@ struct UserProgressLeaderboard: Codable, Hashable, Sendable {
     let windows: [ProgressLeaderboardWindow]
 }
 
+struct ProgressStreakLeaderboardViewer: Codable, Hashable, Sendable {
+    let publicProfileId: String
+    let displayName: String
+    let rank: Int
+    let streakDays: Int
+}
+
+struct ProgressStreakLeaderboardParticipantRow: Codable, Hashable, Sendable {
+    let kind: ProgressLeaderboardParticipantKind
+    let publicProfileId: String
+    /// Server-generated from the public profile id and the request locale.
+    /// Clients must never generate or persist their own anonymous names.
+    let anonymousDisplayName: String
+    /// Viewer-private friend label shown only for current opted-in friends.
+    let friendDisplayName: String?
+    let streakDays: Int
+    let rank: Int
+}
+
+struct ProgressStreakLeaderboardRankingRow: Codable, Hashable, Sendable {
+    let kind: ProgressLeaderboardRankingRowKind
+    let publicProfileId: String
+    /// Server-generated from the public profile id and the request locale.
+    /// Clients must never generate or persist their own anonymous names.
+    let anonymousDisplayName: String
+    /// Viewer-private friend label shown only for current opted-in friends.
+    let friendDisplayName: String?
+    let streakDays: Int
+    let rank: Int
+}
+
+enum ProgressStreakLeaderboardRow: Codable, Hashable, Sendable {
+    case participant(ProgressStreakLeaderboardParticipantRow)
+    case gap
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+    }
+
+    private static let gapKindRawValue: String = "gap"
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(String.self, forKey: .kind)
+        if kind == Self.gapKindRawValue {
+            self = .gap
+            return
+        }
+
+        self = .participant(try ProgressStreakLeaderboardParticipantRow(from: decoder))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case .gap:
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(Self.gapKindRawValue, forKey: .kind)
+        case .participant(let participantRow):
+            try participantRow.encode(to: encoder)
+        }
+    }
+}
+
+struct ProgressStreakLeaderboardReadyPayload: Codable, Hashable, Sendable {
+    let snapshotId: String
+    let snapshotGeneratedAt: String
+    let asOfUtcDate: String
+    let nextRefreshAfter: String
+    let participantCount: Int
+    let viewer: ProgressStreakLeaderboardViewer
+    let rows: [ProgressStreakLeaderboardRow]
+    let rankingRows: [ProgressStreakLeaderboardRankingRow]
+}
+
+struct UserProgressStreakLeaderboard: Codable, Hashable, Sendable {
+    let status: ProgressLeaderboardStatus
+    let metric: ProgressLeaderboardMetric
+    /// Present only when status is ready. Non-ready streak responses carry no rows.
+    let readyPayload: ProgressStreakLeaderboardReadyPayload?
+
+    private enum CodingKeys: String, CodingKey {
+        case status
+        case metric
+        case snapshotId
+        case snapshotGeneratedAt
+        case asOfUtcDate
+        case nextRefreshAfter
+        case participantCount
+        case viewer
+        case rows
+        case rankingRows
+    }
+
+    private static let readyPayloadCodingKeys: [CodingKeys] = [
+        .snapshotId,
+        .snapshotGeneratedAt,
+        .asOfUtcDate,
+        .nextRefreshAfter,
+        .participantCount,
+        .viewer,
+        .rows,
+        .rankingRows,
+    ]
+
+    init(
+        status: ProgressLeaderboardStatus,
+        metric: ProgressLeaderboardMetric,
+        readyPayload: ProgressStreakLeaderboardReadyPayload?
+    ) {
+        self.status = status
+        self.metric = metric
+        self.readyPayload = readyPayload
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let status = try container.decode(ProgressLeaderboardStatus.self, forKey: .status)
+        let metric = try container.decode(ProgressLeaderboardMetric.self, forKey: .metric)
+        let readyPayload: ProgressStreakLeaderboardReadyPayload?
+        if status == .ready {
+            readyPayload = ProgressStreakLeaderboardReadyPayload(
+                snapshotId: try container.decode(String.self, forKey: .snapshotId),
+                snapshotGeneratedAt: try container.decode(String.self, forKey: .snapshotGeneratedAt),
+                asOfUtcDate: try container.decode(String.self, forKey: .asOfUtcDate),
+                nextRefreshAfter: try container.decode(String.self, forKey: .nextRefreshAfter),
+                participantCount: try container.decode(Int.self, forKey: .participantCount),
+                viewer: try container.decode(ProgressStreakLeaderboardViewer.self, forKey: .viewer),
+                rows: try container.decode([ProgressStreakLeaderboardRow].self, forKey: .rows),
+                rankingRows: try container.decode([ProgressStreakLeaderboardRankingRow].self, forKey: .rankingRows)
+            )
+        } else {
+            if let unexpectedKey = Self.readyPayloadCodingKeys.first(where: { key in container.contains(key) }) {
+                throw DecodingError.dataCorruptedError(
+                    forKey: unexpectedKey,
+                    in: container,
+                    debugDescription: "Non-ready streak leaderboard payload must not include \(unexpectedKey.stringValue)."
+                )
+            }
+            readyPayload = nil
+        }
+
+        self.init(status: status, metric: metric, readyPayload: readyPayload)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.status, forKey: .status)
+        try container.encode(self.metric, forKey: .metric)
+        guard let readyPayload else {
+            return
+        }
+
+        try container.encode(readyPayload.snapshotId, forKey: .snapshotId)
+        try container.encode(readyPayload.snapshotGeneratedAt, forKey: .snapshotGeneratedAt)
+        try container.encode(readyPayload.asOfUtcDate, forKey: .asOfUtcDate)
+        try container.encode(readyPayload.nextRefreshAfter, forKey: .nextRefreshAfter)
+        try container.encode(readyPayload.participantCount, forKey: .participantCount)
+        try container.encode(readyPayload.viewer, forKey: .viewer)
+        try container.encode(readyPayload.rows, forKey: .rows)
+        try container.encode(readyPayload.rankingRows, forKey: .rankingRows)
+    }
+}
+
 enum ProgressLeaderboardValidationError: LocalizedError {
     case unexpectedWindows(status: String, windowCount: Int)
     case invalidWindowKeys([String])
@@ -195,6 +358,53 @@ enum ProgressLeaderboardValidationError: LocalizedError {
     }
 }
 
+enum ProgressStreakLeaderboardValidationError: LocalizedError {
+    case missingReadyPayload
+    case unexpectedReadyPayload(status: String)
+    case invalidTimestamp(field: String, value: String)
+    case invalidAsOfUtcDate(String)
+    case negativeParticipantCount(Int)
+    case invalidViewerRank(rank: Int, participantCount: Int)
+    case negativeStreakDays(streakDays: Int)
+    case invalidRowRank(rank: Int)
+    case rankingRowCountMismatch(participantCount: Int, rankingRowCount: Int)
+    case invalidRankingRowRank(expectedRank: Int, actualRank: Int)
+    case unorderedRankingRows(previousRank: Int, previousStreakDays: Int, rank: Int, streakDays: Int)
+    case viewerRowMismatch
+    case viewerRankingRowMismatch
+
+    var errorDescription: String? {
+        switch self {
+        case .missingReadyPayload:
+            return "Streak leaderboard with ready status must contain a ready payload."
+        case .unexpectedReadyPayload(let status):
+            return "Streak leaderboard with status \(status) must not contain a ready payload."
+        case .invalidTimestamp(let field, let value):
+            return "Streak leaderboard contained an invalid \(field) timestamp: \(value)."
+        case .invalidAsOfUtcDate(let value):
+            return "Streak leaderboard contained an invalid asOfUtcDate value: \(value)."
+        case .negativeParticipantCount(let participantCount):
+            return "Streak leaderboard contained a negative participant count: \(participantCount)."
+        case .invalidViewerRank(let rank, let participantCount):
+            return "Streak leaderboard viewer rank \(rank) is outside 1...\(participantCount)."
+        case .negativeStreakDays(let streakDays):
+            return "Streak leaderboard contained a negative streakDays value: \(streakDays)."
+        case .invalidRowRank(let rank):
+            return "Streak leaderboard contained an invalid row rank: \(rank)."
+        case .rankingRowCountMismatch(let participantCount, let rankingRowCount):
+            return "Streak leaderboard participant count \(participantCount) did not match ranking row count \(rankingRowCount)."
+        case .invalidRankingRowRank(let expectedRank, let actualRank):
+            return "Streak leaderboard expected ranking row rank \(expectedRank), received \(actualRank)."
+        case .unorderedRankingRows(let previousRank, let previousStreakDays, let rank, let streakDays):
+            return "Streak leaderboard ranking row \(rank) streak \(streakDays) exceeded previous rank \(previousRank) streak \(previousStreakDays)."
+        case .viewerRowMismatch:
+            return "Streak leaderboard rows did not contain exactly one viewer row matching the viewer."
+        case .viewerRankingRowMismatch:
+            return "Streak leaderboard ranking rows did not contain exactly one viewer row matching the viewer."
+        }
+    }
+}
+
 /// Refresh policy for a cached payload: ready payloads wait for the earliest
 /// server-provided nextRefreshAfter, an unavailable snapshot retries on the next
 /// pass, and the remaining placeholder statuses stay cached until invalidated.
@@ -213,6 +423,25 @@ func progressLeaderboardRequiresScheduledRefresh(
         }
 
         return now >= earliestNextRefreshAfter
+    case .snapshotUnavailable:
+        return true
+    case .participationDisabled, .linkedAccountRequired:
+        return false
+    }
+}
+
+func progressStreakLeaderboardRequiresScheduledRefresh(
+    leaderboard: UserProgressStreakLeaderboard,
+    now: Date
+) -> Bool {
+    switch leaderboard.status {
+    case .ready:
+        guard let readyPayload = leaderboard.readyPayload,
+              let nextRefreshAfter = parseIsoTimestamp(value: readyPayload.nextRefreshAfter) else {
+            return true
+        }
+
+        return now >= nextRefreshAfter
     case .snapshotUnavailable:
         return true
     case .participationDisabled, .linkedAccountRequired:
@@ -388,5 +617,151 @@ private func validateProgressLeaderboardRankingRows(window: ProgressLeaderboardW
         viewerRow.qualifiedReviewCount == window.viewer.qualifiedReviewCount
     else {
         throw ProgressLeaderboardValidationError.viewerRankingRowMismatch(windowKey: windowKey)
+    }
+}
+
+func validateProgressStreakLeaderboard(leaderboard: UserProgressStreakLeaderboard) throws {
+    guard leaderboard.status == .ready else {
+        guard leaderboard.readyPayload == nil else {
+            throw ProgressStreakLeaderboardValidationError.unexpectedReadyPayload(
+                status: leaderboard.status.rawValue
+            )
+        }
+
+        return
+    }
+
+    guard let readyPayload = leaderboard.readyPayload else {
+        throw ProgressStreakLeaderboardValidationError.missingReadyPayload
+    }
+
+    try validateProgressStreakLeaderboardReadyPayload(readyPayload: readyPayload)
+}
+
+private func validateProgressStreakLeaderboardReadyPayload(
+    readyPayload: ProgressStreakLeaderboardReadyPayload
+) throws {
+    let timestampFields: [(field: String, value: String)] = [
+        ("snapshotGeneratedAt", readyPayload.snapshotGeneratedAt),
+        ("nextRefreshAfter", readyPayload.nextRefreshAfter),
+    ]
+    for timestampField in timestampFields {
+        guard parseIsoTimestamp(value: timestampField.value) != nil else {
+            throw ProgressStreakLeaderboardValidationError.invalidTimestamp(
+                field: timestampField.field,
+                value: timestampField.value
+            )
+        }
+    }
+
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    guard progressStrictDate(localDate: readyPayload.asOfUtcDate, calendar: calendar) != nil else {
+        throw ProgressStreakLeaderboardValidationError.invalidAsOfUtcDate(readyPayload.asOfUtcDate)
+    }
+
+    guard readyPayload.participantCount >= 0 else {
+        throw ProgressStreakLeaderboardValidationError.negativeParticipantCount(readyPayload.participantCount)
+    }
+
+    guard readyPayload.viewer.rank >= 1, readyPayload.viewer.rank <= readyPayload.participantCount else {
+        throw ProgressStreakLeaderboardValidationError.invalidViewerRank(
+            rank: readyPayload.viewer.rank,
+            participantCount: readyPayload.participantCount
+        )
+    }
+
+    guard readyPayload.viewer.streakDays >= 0 else {
+        throw ProgressStreakLeaderboardValidationError.negativeStreakDays(
+            streakDays: readyPayload.viewer.streakDays
+        )
+    }
+
+    try validateProgressStreakLeaderboardRankingRows(readyPayload: readyPayload)
+
+    var viewerRows: [ProgressStreakLeaderboardParticipantRow] = []
+    for row in readyPayload.rows {
+        guard case .participant(let participantRow) = row else {
+            continue
+        }
+
+        guard participantRow.streakDays >= 0 else {
+            throw ProgressStreakLeaderboardValidationError.negativeStreakDays(
+                streakDays: participantRow.streakDays
+            )
+        }
+
+        guard participantRow.rank >= 1 else {
+            throw ProgressStreakLeaderboardValidationError.invalidRowRank(rank: participantRow.rank)
+        }
+
+        if participantRow.kind == .viewer {
+            viewerRows.append(participantRow)
+        }
+    }
+
+    guard
+        viewerRows.count == 1,
+        let viewerRow = viewerRows.first,
+        viewerRow.publicProfileId == readyPayload.viewer.publicProfileId,
+        viewerRow.rank == readyPayload.viewer.rank,
+        viewerRow.streakDays == readyPayload.viewer.streakDays
+    else {
+        throw ProgressStreakLeaderboardValidationError.viewerRowMismatch
+    }
+}
+
+private func validateProgressStreakLeaderboardRankingRows(
+    readyPayload: ProgressStreakLeaderboardReadyPayload
+) throws {
+    guard readyPayload.rankingRows.count == readyPayload.participantCount else {
+        throw ProgressStreakLeaderboardValidationError.rankingRowCountMismatch(
+            participantCount: readyPayload.participantCount,
+            rankingRowCount: readyPayload.rankingRows.count
+        )
+    }
+
+    var viewerRows: [ProgressStreakLeaderboardRankingRow] = []
+    var previousRankingRow: ProgressStreakLeaderboardRankingRow?
+    for (index, rankingRow) in readyPayload.rankingRows.enumerated() {
+        guard rankingRow.streakDays >= 0 else {
+            throw ProgressStreakLeaderboardValidationError.negativeStreakDays(
+                streakDays: rankingRow.streakDays
+            )
+        }
+
+        let expectedRank = index + 1
+        guard rankingRow.rank == expectedRank else {
+            throw ProgressStreakLeaderboardValidationError.invalidRankingRowRank(
+                expectedRank: expectedRank,
+                actualRank: rankingRow.rank
+            )
+        }
+
+        if let previousRankingRow,
+           rankingRow.streakDays > previousRankingRow.streakDays {
+            throw ProgressStreakLeaderboardValidationError.unorderedRankingRows(
+                previousRank: previousRankingRow.rank,
+                previousStreakDays: previousRankingRow.streakDays,
+                rank: rankingRow.rank,
+                streakDays: rankingRow.streakDays
+            )
+        }
+
+        if rankingRow.kind == .viewer {
+            viewerRows.append(rankingRow)
+        }
+
+        previousRankingRow = rankingRow
+    }
+
+    guard
+        viewerRows.count == 1,
+        let viewerRow = viewerRows.first,
+        viewerRow.publicProfileId == readyPayload.viewer.publicProfileId,
+        viewerRow.rank == readyPayload.viewer.rank,
+        viewerRow.streakDays == readyPayload.viewer.streakDays
+    else {
+        throw ProgressStreakLeaderboardValidationError.viewerRankingRowMismatch
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Model/ProgressSnapshotTypes.swift
@@ -165,3 +165,48 @@ struct ProgressLeaderboardParticipantRowState: Hashable, Sendable {
     let qualifiedReviewCount: Int
     let rank: Int
 }
+
+struct ProgressStreakLeaderboardSnapshot: Hashable, Sendable {
+    let scopeKey: ProgressLeaderboardScopeKey
+    let state: ProgressStreakLeaderboardSnapshotState
+}
+
+enum ProgressStreakLeaderboardSnapshotState: Hashable, Sendable {
+    /// Linked account without a cached server payload and no personal Progress snapshot yet.
+    case awaitingServerData
+    case ready(ProgressStreakLeaderboardReadyState)
+}
+
+struct ProgressStreakLeaderboardReadyState: Hashable, Sendable {
+    let snapshotGeneratedAt: String?
+    let asOfUtcDate: String?
+    let participantCount: Int
+    /// Viewer rank after applying the live personal streak to the frozen daily ranking.
+    let viewerRank: Int
+    /// Server snapshot streak overlaid with the current personal Progress streak.
+    let viewerStreakDays: Int
+    let rows: [ProgressStreakLeaderboardRowState]
+}
+
+enum ProgressStreakLeaderboardRowState: Hashable, Identifiable, Sendable {
+    case participant(ProgressStreakLeaderboardParticipantRowState)
+    case gap(ProgressLeaderboardGapRowState)
+
+    var id: String {
+        switch self {
+        case .participant(let row):
+            return "participant-\(row.rank)-\(row.publicProfileId ?? "local-viewer")"
+        case .gap(let row):
+            return row.id
+        }
+    }
+}
+
+struct ProgressStreakLeaderboardParticipantRowState: Hashable, Sendable {
+    let kind: ProgressLeaderboardParticipantKind
+    let publicProfileId: String?
+    let anonymousDisplayName: String
+    let friendDisplayName: String?
+    let streakDays: Int
+    let rank: Int
+}

--- a/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Presentation/ProgressSnapshotFactory.swift
@@ -116,6 +116,110 @@ func makeProgressLeaderboardSnapshot(
     )
 }
 
+func makeProgressStreakLeaderboardPlaceholderSnapshot(
+    scopeKey: ProgressLeaderboardScopeKey
+) -> ProgressStreakLeaderboardSnapshot {
+    ProgressStreakLeaderboardSnapshot(
+        scopeKey: scopeKey,
+        state: .awaitingServerData
+    )
+}
+
+func makeProgressStreakLeaderboardSnapshot(
+    leaderboard: UserProgressStreakLeaderboard?,
+    scopeKey: ProgressLeaderboardScopeKey,
+    personalStreakDays: Int?
+) throws -> ProgressStreakLeaderboardSnapshot {
+    if let leaderboard {
+        try validateProgressStreakLeaderboard(leaderboard: leaderboard)
+    }
+
+    if let readyPayload = leaderboard?.readyPayload {
+        return try makeProgressStreakLeaderboardSnapshot(
+            readyPayload: readyPayload,
+            scopeKey: scopeKey,
+            personalStreakDays: personalStreakDays
+        )
+    }
+
+    guard let personalStreakDays else {
+        return makeProgressStreakLeaderboardPlaceholderSnapshot(scopeKey: scopeKey)
+    }
+
+    return try makeLocalProgressStreakLeaderboardSnapshot(
+        scopeKey: scopeKey,
+        personalStreakDays: personalStreakDays
+    )
+}
+
+private func makeProgressStreakLeaderboardSnapshot(
+    readyPayload: ProgressStreakLeaderboardReadyPayload,
+    scopeKey: ProgressLeaderboardScopeKey,
+    personalStreakDays: Int?
+) throws -> ProgressStreakLeaderboardSnapshot {
+    let overlaidViewerStreakDays = max(
+        readyPayload.viewer.streakDays,
+        personalStreakDays ?? readyPayload.viewer.streakDays
+    )
+    let projectedRankingRows = try makeProjectedProgressStreakLeaderboardRankingRows(
+        readyPayload: readyPayload,
+        viewerStreakDays: overlaidViewerStreakDays
+    )
+    let projectedViewerRank = try progressStreakLeaderboardViewerRank(rankingRows: projectedRankingRows)
+    let rows = try makeCompactProgressStreakLeaderboardRowStates(
+        rankingRows: projectedRankingRows,
+        viewerRank: projectedViewerRank
+    )
+
+    return ProgressStreakLeaderboardSnapshot(
+        scopeKey: scopeKey,
+        state: .ready(
+            ProgressStreakLeaderboardReadyState(
+                snapshotGeneratedAt: readyPayload.snapshotGeneratedAt,
+                asOfUtcDate: readyPayload.asOfUtcDate,
+                participantCount: readyPayload.participantCount,
+                viewerRank: projectedViewerRank,
+                viewerStreakDays: overlaidViewerStreakDays,
+                rows: rows
+            )
+        )
+    )
+}
+
+private func makeLocalProgressStreakLeaderboardSnapshot(
+    scopeKey: ProgressLeaderboardScopeKey,
+    personalStreakDays: Int
+) throws -> ProgressStreakLeaderboardSnapshot {
+    guard personalStreakDays >= 0 else {
+        throw LocalStoreError.validation("Personal streak days must not be negative: \(personalStreakDays)")
+    }
+
+    return ProgressStreakLeaderboardSnapshot(
+        scopeKey: scopeKey,
+        state: .ready(
+            ProgressStreakLeaderboardReadyState(
+                snapshotGeneratedAt: nil,
+                asOfUtcDate: nil,
+                participantCount: 1,
+                viewerRank: 1,
+                viewerStreakDays: personalStreakDays,
+                rows: [
+                    .participant(
+                        ProgressStreakLeaderboardParticipantRowState(
+                            kind: .viewer,
+                            publicProfileId: nil,
+                            anonymousDisplayName: progressLeaderboardViewerRowTitle(),
+                            friendDisplayName: nil,
+                            streakDays: personalStreakDays,
+                            rank: 1
+                        )
+                    ),
+                ]
+            )
+        )
+    )
+}
+
 /// The live overlay only reranks the current viewer against the frozen server
 /// ranking; other participants stay in the server-provided order.
 private func makeProgressLeaderboardWindowState(
@@ -336,6 +440,166 @@ private func resolveProgressLeaderboardDefaultWindowKey(
     }
 
     return bestWindowKey
+}
+
+private func makeProjectedProgressStreakLeaderboardRankingRows(
+    readyPayload: ProgressStreakLeaderboardReadyPayload,
+    viewerStreakDays: Int
+) throws -> [ProgressStreakLeaderboardRankingRow] {
+    guard let serverViewerRow = readyPayload.rankingRows.first(where: { rankingRow in
+        rankingRow.kind == .viewer
+    }) else {
+        throw LocalStoreError.validation("Streak leaderboard ranking rows are missing the viewer")
+    }
+
+    let participantRows = readyPayload.rankingRows.filter { rankingRow in
+        rankingRow.kind == .participant
+    }
+    let projectedViewerRow = ProgressStreakLeaderboardRankingRow(
+        kind: .viewer,
+        publicProfileId: serverViewerRow.publicProfileId,
+        anonymousDisplayName: serverViewerRow.anonymousDisplayName,
+        friendDisplayName: serverViewerRow.friendDisplayName,
+        streakDays: viewerStreakDays,
+        rank: serverViewerRow.rank
+    )
+    let insertionIndex = participantRows.firstIndex { rankingRow in
+        rankingRow.streakDays <= viewerStreakDays
+    } ?? participantRows.count
+    let projectedRows = Array(participantRows.prefix(insertionIndex))
+        + [projectedViewerRow]
+        + Array(participantRows.suffix(participantRows.count - insertionIndex))
+
+    return projectedRows.enumerated().map { index, rankingRow in
+        ProgressStreakLeaderboardRankingRow(
+            kind: rankingRow.kind,
+            publicProfileId: rankingRow.publicProfileId,
+            anonymousDisplayName: rankingRow.anonymousDisplayName,
+            friendDisplayName: rankingRow.friendDisplayName,
+            streakDays: rankingRow.streakDays,
+            rank: index + 1
+        )
+    }
+}
+
+private func progressStreakLeaderboardViewerRank(
+    rankingRows: [ProgressStreakLeaderboardRankingRow]
+) throws -> Int {
+    guard let viewerRow = rankingRows.first(where: { rankingRow in
+        rankingRow.kind == .viewer
+    }) else {
+        throw LocalStoreError.validation("Projected streak leaderboard ranking rows are missing the viewer")
+    }
+
+    return viewerRow.rank
+}
+
+private func makeCompactProgressStreakLeaderboardRowStates(
+    rankingRows: [ProgressStreakLeaderboardRankingRow],
+    viewerRank: Int
+) throws -> [ProgressStreakLeaderboardRowState] {
+    let participantCount = rankingRows.count
+    let topRowCount = min(progressLeaderboardTopRowCount, participantCount)
+    var shownRanks: Set<Int> = []
+
+    if topRowCount > 0 {
+        for rank in 1...topRowCount {
+            shownRanks.insert(rank)
+        }
+    }
+
+    if viewerRank > topRowCount {
+        for rank in [viewerRank - 1, viewerRank, viewerRank + 1] {
+            guard rank >= 1, rank <= participantCount else {
+                continue
+            }
+
+            shownRanks.insert(rank)
+        }
+    } else if viewerRank == topRowCount && viewerRank < participantCount {
+        shownRanks.insert(viewerRank + 1)
+    }
+
+    if participantCount > topRowCount {
+        shownRanks.insert(participantCount)
+    }
+    for rankingRow in rankingRows where isProgressStreakLeaderboardFriendRow(rankingRow: rankingRow) {
+        shownRanks.insert(rankingRow.rank)
+    }
+
+    var rows: [ProgressStreakLeaderboardRowState] = []
+    var previousRank: Int = 0
+    for rank in shownRanks.sorted() {
+        if previousRank != 0, rank > previousRank + 1 {
+            rows.append(.gap(ProgressLeaderboardGapRowState(id: "gap-\(rows.count)")))
+        }
+
+        let rankingRowIndex = rank - 1
+        guard rankingRows.indices.contains(rankingRowIndex) else {
+            throw LocalStoreError.validation("Projected streak leaderboard ranking rows are missing rank \(rank)")
+        }
+
+        rows.append(
+            .participant(
+                makeProgressStreakLeaderboardParticipantRowState(
+                    rankingRow: rankingRows[rankingRowIndex],
+                    topRowCount: topRowCount
+                )
+            )
+        )
+        previousRank = rank
+    }
+
+    if previousRank < participantCount {
+        rows.append(.gap(ProgressLeaderboardGapRowState(id: "gap-\(rows.count)")))
+    }
+
+    return rows
+}
+
+private func makeProgressStreakLeaderboardParticipantRowState(
+    rankingRow: ProgressStreakLeaderboardRankingRow,
+    topRowCount: Int
+) -> ProgressStreakLeaderboardParticipantRowState {
+    ProgressStreakLeaderboardParticipantRowState(
+        kind: progressLeaderboardParticipantKind(
+            rankingRowKind: rankingRow.kind,
+            rank: rankingRow.rank,
+            topRowCount: topRowCount
+        ),
+        publicProfileId: rankingRow.publicProfileId,
+        anonymousDisplayName: rankingRow.anonymousDisplayName,
+        friendDisplayName: rankingRow.friendDisplayName,
+        streakDays: rankingRow.streakDays,
+        rank: rankingRow.rank
+    )
+}
+
+private func isProgressStreakLeaderboardFriendRow(
+    rankingRow: ProgressStreakLeaderboardRankingRow
+) -> Bool {
+    guard rankingRow.kind == .participant,
+          let friendDisplayName = rankingRow.friendDisplayName else {
+        return false
+    }
+
+    return friendDisplayName.isEmpty == false
+}
+
+private func progressLeaderboardParticipantKind(
+    rankingRowKind: ProgressLeaderboardRankingRowKind,
+    rank: Int,
+    topRowCount: Int
+) -> ProgressLeaderboardParticipantKind {
+    if rankingRowKind == .viewer {
+        return .viewer
+    }
+
+    if rank <= topRowCount {
+        return .top
+    }
+
+    return .neighbor
 }
 
 private struct ProgressTimelineDay: Hashable, Sendable {

--- a/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressErrorState.swift
+++ b/apps/ios/Flashcards/Flashcards/Progress/Sections/ProgressErrorState.swift
@@ -7,6 +7,7 @@ struct ProgressErrorState: Equatable, Sendable {
     let reviewScheduleRefreshMessage: String
     let reviewScheduleRenderMessage: String
     let leaderboardRefreshMessage: String
+    let streakLeaderboardRefreshMessage: String
 }
 
 func makeEmptyProgressErrorState() -> ProgressErrorState {
@@ -16,7 +17,8 @@ func makeEmptyProgressErrorState() -> ProgressErrorState {
         seriesRefreshMessage: "",
         reviewScheduleRefreshMessage: "",
         reviewScheduleRenderMessage: "",
-        leaderboardRefreshMessage: ""
+        leaderboardRefreshMessage: "",
+        streakLeaderboardRefreshMessage: ""
     )
 }
 
@@ -27,7 +29,8 @@ func progressErrorStateWithOnlyGeneralMessage(message: String) -> ProgressErrorS
         seriesRefreshMessage: "",
         reviewScheduleRefreshMessage: "",
         reviewScheduleRenderMessage: "",
-        leaderboardRefreshMessage: ""
+        leaderboardRefreshMessage: "",
+        streakLeaderboardRefreshMessage: ""
     )
 }
 
@@ -38,7 +41,8 @@ func progressErrorStateClearingGeneralAndSummaryRefreshMessages(state: ProgressE
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -49,7 +53,8 @@ func progressErrorStateClearingGeneralAndSeriesRefreshMessages(state: ProgressEr
         seriesRefreshMessage: "",
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -60,7 +65,20 @@ func progressErrorStateClearingGeneralAndLeaderboardRefreshMessages(state: Progr
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: ""
+        leaderboardRefreshMessage: "",
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
+    )
+}
+
+func progressErrorStateClearingGeneralAndStreakLeaderboardRefreshMessages(state: ProgressErrorState) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: "",
+        summaryRefreshMessage: state.summaryRefreshMessage,
+        seriesRefreshMessage: state.seriesRefreshMessage,
+        reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
+        reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: ""
     )
 }
 
@@ -71,7 +89,8 @@ func progressErrorStateClearingGeneralMessage(state: ProgressErrorState) -> Prog
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -82,7 +101,8 @@ func progressErrorStateClearingSummaryRefreshMessage(state: ProgressErrorState) 
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -93,7 +113,8 @@ func progressErrorStateClearingSeriesRefreshMessage(state: ProgressErrorState) -
         seriesRefreshMessage: "",
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -104,7 +125,8 @@ func progressErrorStateClearingReviewScheduleRefreshMessage(state: ProgressError
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: "",
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -115,7 +137,8 @@ func progressErrorStateClearingReviewScheduleRenderMessage(state: ProgressErrorS
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: "",
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -126,7 +149,20 @@ func progressErrorStateClearingLeaderboardRefreshMessage(state: ProgressErrorSta
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: ""
+        leaderboardRefreshMessage: "",
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
+    )
+}
+
+func progressErrorStateClearingStreakLeaderboardRefreshMessage(state: ProgressErrorState) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: state.generalMessage,
+        summaryRefreshMessage: state.summaryRefreshMessage,
+        seriesRefreshMessage: state.seriesRefreshMessage,
+        reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
+        reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: ""
     )
 }
 
@@ -140,7 +176,8 @@ func progressErrorStateWithSummaryRefreshMessage(
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -154,7 +191,8 @@ func progressErrorStateWithSeriesRefreshMessage(
         seriesRefreshMessage: message,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -168,7 +206,8 @@ func progressErrorStateWithReviewScheduleRefreshMessage(
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: message,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -182,7 +221,8 @@ func progressErrorStateWithReviewScheduleRenderMessage(
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: message,
-        leaderboardRefreshMessage: state.leaderboardRefreshMessage
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
     )
 }
 
@@ -196,7 +236,23 @@ func progressErrorStateWithLeaderboardRefreshMessage(
         seriesRefreshMessage: state.seriesRefreshMessage,
         reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
         reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
-        leaderboardRefreshMessage: message
+        leaderboardRefreshMessage: message,
+        streakLeaderboardRefreshMessage: state.streakLeaderboardRefreshMessage
+    )
+}
+
+func progressErrorStateWithStreakLeaderboardRefreshMessage(
+    state: ProgressErrorState,
+    message: String
+) -> ProgressErrorState {
+    ProgressErrorState(
+        generalMessage: "",
+        summaryRefreshMessage: state.summaryRefreshMessage,
+        seriesRefreshMessage: state.seriesRefreshMessage,
+        reviewScheduleRefreshMessage: state.reviewScheduleRefreshMessage,
+        reviewScheduleRenderMessage: state.reviewScheduleRenderMessage,
+        leaderboardRefreshMessage: state.leaderboardRefreshMessage,
+        streakLeaderboardRefreshMessage: message
     )
 }
 
@@ -208,6 +264,7 @@ func progressErrorDisplayMessage(state: ProgressErrorState) -> String {
         state.reviewScheduleRefreshMessage,
         state.reviewScheduleRenderMessage,
         state.leaderboardRefreshMessage,
+        state.streakLeaderboardRefreshMessage,
     ]
         .filter { message in
             message.isEmpty == false

--- a/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
+++ b/apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings
@@ -6727,6 +6727,65 @@
         }
       }
     },
+    "progress.error.streak_leaderboard_refresh_failed" : {
+      "comment" : "Generic progress card message when streak leaderboard refresh fails",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر تحديث لوحة صدارة السلسلة. اسحب للمحاولة مرة أخرى."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streak-Bestenliste konnte nicht aktualisiert werden. Zum erneuten Versuch ziehen."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streak leaderboard couldn't refresh. Pull to try again."
+          }
+        },
+        "es-ES" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo actualizar la clasificación de rachas. Desliza para intentarlo de nuevo."
+          }
+        },
+        "es-MX" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo actualizar la tabla de rachas. Desliza para intentarlo de nuevo."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "स्ट्रीक लीडरबोर्ड रीफ़्रेश नहीं हो सका। फिर से कोशिश करने के लिए खींचें।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連続記録のリーダーボードを更新できませんでした。もう一度試すには下に引いてください。"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось обновить таблицу серий. Потяните, чтобы повторить попытку."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法刷新连续天数排行榜。下拉重试。"
+          }
+        }
+      }
+    },
     "progress.error.review_schedule_refresh_failed" : {
       "comment" : "Generic progress card message when review schedule refresh fails",
       "localizations" : {

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -75,6 +75,7 @@ final class FlashcardsStore {
     var progressSnapshot: ProgressSnapshot?
     var reviewScheduleSnapshot: ReviewScheduleSnapshot?
     var progressLeaderboardSnapshot: ProgressLeaderboardSnapshot?
+    var progressStreakLeaderboardSnapshot: ProgressStreakLeaderboardSnapshot?
     var reviewLeaderboardBadgeState: ReviewLeaderboardBadgeState
     var reviewProgressBadgeState: ReviewProgressBadgeState
     var progressErrorMessage: String
@@ -138,31 +139,38 @@ final class FlashcardsStore {
     @ObservationIgnored var progressSeriesServerBaseCache: PersistedProgressSeriesServerBase?
     @ObservationIgnored var progressReviewScheduleServerBaseCache: PersistedReviewScheduleServerBase?
     @ObservationIgnored var progressLeaderboardServerBaseCache: PersistedProgressLeaderboardServerBase?
+    @ObservationIgnored var progressStreakLeaderboardServerBaseCache: PersistedProgressStreakLeaderboardServerBase?
     @ObservationIgnored var progressObservedScopeKey: ProgressScopeKey?
     @ObservationIgnored var progressErrorState: ProgressErrorState
     @ObservationIgnored var progressSummaryInvalidatedScopeKeys: Set<ProgressSummaryScopeKey>
     @ObservationIgnored var progressSeriesInvalidatedScopeKeys: Set<ProgressScopeKey>
     @ObservationIgnored var progressReviewScheduleInvalidatedScopeKeys: Set<ReviewScheduleScopeKey>
     @ObservationIgnored var progressLeaderboardInvalidatedScopeKeys: Set<ProgressLeaderboardScopeKey>
+    @ObservationIgnored var progressStreakLeaderboardInvalidatedScopeKeys: Set<ProgressLeaderboardScopeKey>
     @ObservationIgnored var progressSummaryRefreshToken: Int
     @ObservationIgnored var progressSeriesRefreshToken: Int
     @ObservationIgnored var progressReviewScheduleRefreshToken: Int
     @ObservationIgnored var progressLeaderboardRefreshToken: Int
+    @ObservationIgnored var progressStreakLeaderboardRefreshToken: Int
     @ObservationIgnored var progressActiveSummaryRefreshScopeKey: ProgressSummaryScopeKey?
     @ObservationIgnored var progressActiveSeriesRefreshScopeKey: ProgressScopeKey?
     @ObservationIgnored var progressActiveReviewScheduleRefreshScopeKey: ReviewScheduleScopeKey?
     @ObservationIgnored var progressActiveLeaderboardRefreshScopeKey: ProgressLeaderboardScopeKey?
+    @ObservationIgnored var progressActiveStreakLeaderboardRefreshScopeKey: ProgressLeaderboardScopeKey?
     @ObservationIgnored var progressActiveSummaryRefreshToken: Int?
     @ObservationIgnored var progressActiveSeriesRefreshToken: Int?
     @ObservationIgnored var progressActiveReviewScheduleRefreshToken: Int?
     @ObservationIgnored var progressActiveLeaderboardRefreshToken: Int?
+    @ObservationIgnored var progressActiveStreakLeaderboardRefreshToken: Int?
     @ObservationIgnored var isProgressSummaryRefreshing: Bool
     @ObservationIgnored var isProgressSeriesRefreshing: Bool
     @ObservationIgnored var isProgressReviewScheduleRefreshing: Bool
     @ObservationIgnored var isProgressLeaderboardRefreshing: Bool
+    @ObservationIgnored var isProgressStreakLeaderboardRefreshing: Bool
     @ObservationIgnored var isCommunityProfileUpdateInFlight: Bool
     @ObservationIgnored var progressReviewedAtClientRevision: Int
     @ObservationIgnored var progressLeaderboardPublishedClientRevision: Int?
+    @ObservationIgnored var progressStreakLeaderboardPublishedClientRevision: Int?
     @ObservationIgnored var progressReviewScheduleLocalRevision: Int
     @ObservationIgnored var progressReviewedAtClientCache: ProgressReviewedAtClientCacheEntry?
     @ObservationIgnored var progressReviewScheduleLocalCache: ProgressReviewScheduleLocalCacheEntry?
@@ -373,6 +381,7 @@ final class FlashcardsStore {
         self.progressSnapshot = nil
         self.reviewScheduleSnapshot = nil
         self.progressLeaderboardSnapshot = nil
+        self.progressStreakLeaderboardSnapshot = nil
         self.reviewLeaderboardBadgeState = makeEmptyReviewLeaderboardBadgeState()
         self.reviewProgressBadgeState = makeEmptyReviewProgressBadgeState()
         self.progressErrorMessage = ""
@@ -464,31 +473,38 @@ final class FlashcardsStore {
         self.progressSeriesServerBaseCache = nil
         self.progressReviewScheduleServerBaseCache = nil
         self.progressLeaderboardServerBaseCache = nil
+        self.progressStreakLeaderboardServerBaseCache = nil
         self.progressObservedScopeKey = nil
         self.progressErrorState = makeEmptyProgressErrorState()
         self.progressSummaryInvalidatedScopeKeys = []
         self.progressSeriesInvalidatedScopeKeys = []
         self.progressReviewScheduleInvalidatedScopeKeys = []
         self.progressLeaderboardInvalidatedScopeKeys = []
+        self.progressStreakLeaderboardInvalidatedScopeKeys = []
         self.progressSummaryRefreshToken = 0
         self.progressSeriesRefreshToken = 0
         self.progressReviewScheduleRefreshToken = 0
         self.progressLeaderboardRefreshToken = 0
+        self.progressStreakLeaderboardRefreshToken = 0
         self.progressActiveSummaryRefreshScopeKey = nil
         self.progressActiveSeriesRefreshScopeKey = nil
         self.progressActiveReviewScheduleRefreshScopeKey = nil
         self.progressActiveLeaderboardRefreshScopeKey = nil
+        self.progressActiveStreakLeaderboardRefreshScopeKey = nil
         self.progressActiveSummaryRefreshToken = nil
         self.progressActiveSeriesRefreshToken = nil
         self.progressActiveReviewScheduleRefreshToken = nil
         self.progressActiveLeaderboardRefreshToken = nil
+        self.progressActiveStreakLeaderboardRefreshToken = nil
         self.isProgressSummaryRefreshing = false
         self.isProgressSeriesRefreshing = false
         self.isProgressReviewScheduleRefreshing = false
         self.isProgressLeaderboardRefreshing = false
+        self.isProgressStreakLeaderboardRefreshing = false
         self.isCommunityProfileUpdateInFlight = false
         self.progressReviewedAtClientRevision = 0
         self.progressLeaderboardPublishedClientRevision = nil
+        self.progressStreakLeaderboardPublishedClientRevision = nil
         self.progressReviewScheduleLocalRevision = 0
         self.progressReviewedAtClientCache = nil
         self.progressReviewScheduleLocalCache = nil

--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStoreSupport.swift
@@ -43,6 +43,10 @@ protocol CloudSyncServing {
         apiBaseUrl: String,
         authorizationHeader: String
     ) async throws -> UserProgressLeaderboard
+    func loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ) async throws -> UserProgressStreakLeaderboard
     func loadCommunityPublicProfile(
         apiBaseUrl: String,
         authorizationHeader: String

--- a/apps/ios/Flashcards/FlashcardsTests/AI/Store/Support/AIChatStoreTestCloudSyncService.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/AI/Store/Support/AIChatStoreTestCloudSyncService.swift
@@ -154,6 +154,15 @@ extension AIChatStoreTestSupport {
             return makeNonReadyProgressLeaderboardForTests(status: .snapshotUnavailable)
         }
 
+        func loadProgressStreakLeaderboard(
+            apiBaseUrl: String,
+            authorizationHeader: String
+        ) async throws -> UserProgressStreakLeaderboard {
+            _ = apiBaseUrl
+            _ = authorizationHeader
+            return makeNonReadyProgressStreakLeaderboardForTests(status: .snapshotUnavailable)
+        }
+
         func loadCommunityPublicProfile(
             apiBaseUrl: String,
             authorizationHeader: String

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/GuestCloudUpgradeTestSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/GuestCloudUpgradeTestSupport.swift
@@ -170,6 +170,15 @@ final class GuestUpgradeDrainCloudSyncService: CloudSyncServing {
         return makeNonReadyProgressLeaderboardForTests(status: .snapshotUnavailable)
     }
 
+    func loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ) async throws -> UserProgressStreakLeaderboard {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        return makeNonReadyProgressStreakLeaderboardForTests(status: .snapshotUnavailable)
+    }
+
     func loadCommunityPublicProfile(
         apiBaseUrl: String,
         authorizationHeader: String

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalMutationTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressLocalMutationTests.swift
@@ -487,6 +487,116 @@ final class ProgressLocalMutationTests: ProgressStoreTestCase {
     }
 
     @MainActor
+    func testHandleProgressLocalMutationPublishesStreakLeaderboardFromPatchedSnapshot() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:00:00.000Z"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T11:59:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T11:59:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let scopeKey = try context.store.prepareProgressSnapshot(now: now)
+        let leaderboardScopeKey = context.store.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+        context.store.progressStreakLeaderboardServerBaseCache = PersistedProgressStreakLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            serverBase: makeReadyProgressStreakLeaderboardForTests(
+                participantCount: 2,
+                viewer: ProgressStreakLeaderboardViewer(
+                    publicProfileId: "profile-viewer",
+                    displayName: "You",
+                    rank: 2,
+                    streakDays: 0
+                ),
+                rows: [
+                    makeProgressStreakLeaderboardParticipantRowForTests(
+                        kind: .top,
+                        publicProfileId: "profile-peer",
+                        anonymousDisplayName: "Amber Calm Meadow",
+                        streakDays: 1,
+                        rank: 1
+                    ),
+                    makeProgressStreakLeaderboardParticipantRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        streakDays: 0,
+                        rank: 2
+                    ),
+                ],
+                rankingRows: [
+                    makeProgressStreakLeaderboardRankingRowForTests(
+                        kind: .participant,
+                        publicProfileId: "profile-peer",
+                        anonymousDisplayName: "Amber Calm Meadow",
+                        streakDays: 1,
+                        rank: 1
+                    ),
+                    makeProgressStreakLeaderboardRankingRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        streakDays: 0,
+                        rank: 2
+                    ),
+                ],
+                snapshotGeneratedAt: "2026-06-10T00:00:05.000Z",
+                nextRefreshAfter: "2026-06-11T00:00:00.000Z"
+            ),
+            storedAt: "2026-06-10T00:00:05.000Z"
+        )
+        context.store.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+            scopeKey: leaderboardScopeKey,
+            seriesScopeKey: scopeKey,
+            now: now
+        )
+        let initialReadyState = try progressStreakLeaderboardReadyState(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(2, initialReadyState.viewerRank)
+        XCTAssertEqual(0, initialReadyState.viewerStreakDays)
+
+        context.store.handleProgressLocalMutation(
+            now: now,
+            reviewedAtClient: "2026-06-10T12:15:00.000Z",
+            reviewedTimeZone: "UTC",
+            rating: .good
+        )
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(1, progressSnapshot.summary.currentStreakDays)
+        let readyState = try progressStreakLeaderboardReadyState(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(1, readyState.viewerRank)
+        XCTAssertEqual(1, readyState.viewerStreakDays)
+    }
+
+    @MainActor
     func testHandleProgressLocalMutationRebuildsSnapshotAfterLocalDayRollover() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
@@ -567,4 +677,14 @@ private func progressStreakState(
     snapshot.chartData.chartDays.first { chartDay in
         chartDay.localDate == localDate
     }?.streakState
+}
+
+private func progressStreakLeaderboardReadyState(
+    snapshot: ProgressStreakLeaderboardSnapshot
+) throws -> ProgressStreakLeaderboardReadyState {
+    guard case .ready(let readyState) = snapshot.state else {
+        throw LocalStoreError.validation("Expected a ready streak leaderboard snapshot")
+    }
+
+    return readyState
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/ProgressSnapshotFactoryTests.swift
@@ -176,6 +176,224 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
         )
     }
 
+    func testStreakLeaderboardProjectionUsesPersonalStreakAndViewerWinsTies() throws {
+        let leaderboard = makeReadyProgressStreakLeaderboardForTests(
+            participantCount: 4,
+            viewer: ProgressStreakLeaderboardViewer(
+                publicProfileId: "profile-viewer",
+                displayName: "You",
+                rank: 3,
+                streakDays: 3
+            ),
+            rows: [
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .top,
+                    publicProfileId: "profile-top",
+                    anonymousDisplayName: "Silver Bright Harbor",
+                    streakDays: 8,
+                    rank: 1
+                ),
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .top,
+                    publicProfileId: "profile-peer",
+                    anonymousDisplayName: "Amber Calm Meadow",
+                    streakDays: 5,
+                    rank: 2
+                ),
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    streakDays: 3,
+                    rank: 3
+                ),
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .neighbor,
+                    publicProfileId: "profile-tail",
+                    anonymousDisplayName: "Blue Final Harbor",
+                    streakDays: 1,
+                    rank: 4
+                ),
+            ],
+            rankingRows: [
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-top",
+                    anonymousDisplayName: "Silver Bright Harbor",
+                    streakDays: 8,
+                    rank: 1
+                ),
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-peer",
+                    anonymousDisplayName: "Amber Calm Meadow",
+                    streakDays: 5,
+                    rank: 2
+                ),
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    streakDays: 3,
+                    rank: 3
+                ),
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-tail",
+                    anonymousDisplayName: "Blue Final Harbor",
+                    streakDays: 1,
+                    rank: 4
+                ),
+            ],
+            snapshotGeneratedAt: "2026-06-10T12:00:05.000Z",
+            nextRefreshAfter: "2026-06-11T12:00:00.000Z"
+        )
+
+        let snapshot = try makeProgressStreakLeaderboardSnapshot(
+            leaderboard: leaderboard,
+            scopeKey: self.scopeKey,
+            personalStreakDays: 5
+        )
+
+        guard case .ready(let readyState) = snapshot.state else {
+            XCTFail("Expected ready streak leaderboard state, received \(snapshot.state)")
+            return
+        }
+
+        XCTAssertEqual(4, readyState.participantCount)
+        XCTAssertEqual(2, readyState.viewerRank)
+        XCTAssertEqual(5, readyState.viewerStreakDays)
+
+        let participantRows = readyState.rows.compactMap { row -> ProgressStreakLeaderboardParticipantRowState? in
+            guard case .participant(let participantRow) = row else {
+                return nil
+            }
+
+            return participantRow
+        }
+        let viewerRow = try XCTUnwrap(participantRows.first { row in
+            row.kind == .viewer
+        })
+        let tiedPeerRow = try XCTUnwrap(participantRows.first { row in
+            row.publicProfileId == "profile-peer"
+        })
+
+        XCTAssertEqual(2, viewerRow.rank)
+        XCTAssertEqual(5, viewerRow.streakDays)
+        XCTAssertEqual(3, tiedPeerRow.rank)
+        XCTAssertEqual(5, tiedPeerRow.streakDays)
+    }
+
+    func testStreakLeaderboardAcceptsMultipleGapRowsForSeparatedParticipantRows() throws {
+        let viewerRank = 16
+        let rankingRows = (1...24).map { rank in
+            makeProgressStreakLeaderboardRankingRowForTests(
+                kind: rank == viewerRank ? .viewer : .participant,
+                publicProfileId: rank == viewerRank ? "profile-viewer" : "profile-\(rank)",
+                anonymousDisplayName: rank == viewerRank ? "Indigo Quiet Field" : "Rank \(rank)",
+                streakDays: 25 - rank,
+                rank: rank
+            )
+        }
+        let leaderboard = makeReadyProgressStreakLeaderboardForTests(
+            participantCount: 24,
+            viewer: ProgressStreakLeaderboardViewer(
+                publicProfileId: "profile-viewer",
+                displayName: "You",
+                rank: viewerRank,
+                streakDays: 9
+            ),
+            rows: [
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .top,
+                    publicProfileId: "profile-1",
+                    anonymousDisplayName: "Rank 1",
+                    streakDays: 24,
+                    rank: 1
+                ),
+                .gap,
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .neighbor,
+                    publicProfileId: "profile-8",
+                    anonymousDisplayName: "Rank 8",
+                    streakDays: 17,
+                    rank: 8
+                ),
+                .gap,
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    streakDays: 9,
+                    rank: viewerRank
+                ),
+                .gap,
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .neighbor,
+                    publicProfileId: "profile-24",
+                    anonymousDisplayName: "Rank 24",
+                    streakDays: 1,
+                    rank: 24
+                ),
+            ],
+            rankingRows: rankingRows,
+            snapshotGeneratedAt: "2026-06-10T12:00:05.000Z",
+            nextRefreshAfter: "2026-06-11T12:00:00.000Z"
+        )
+
+        try validateProgressStreakLeaderboard(leaderboard: leaderboard)
+        let snapshot = try makeProgressStreakLeaderboardSnapshot(
+            leaderboard: leaderboard,
+            scopeKey: self.scopeKey,
+            personalStreakDays: nil
+        )
+
+        guard case .ready(let readyState) = snapshot.state else {
+            XCTFail("Expected ready streak leaderboard state, received \(snapshot.state)")
+            return
+        }
+
+        XCTAssertEqual(viewerRank, readyState.viewerRank)
+        XCTAssertEqual(9, readyState.viewerStreakDays)
+    }
+
+    func testStreakLeaderboardUsesPersonalViewerRowWithoutReadyServerPayload() throws {
+        let missingServerSnapshot = try makeProgressStreakLeaderboardSnapshot(
+            leaderboard: nil,
+            scopeKey: self.scopeKey,
+            personalStreakDays: 12
+        )
+        let unavailableServerSnapshot = try makeProgressStreakLeaderboardSnapshot(
+            leaderboard: makeNonReadyProgressStreakLeaderboardForTests(status: .snapshotUnavailable),
+            scopeKey: self.scopeKey,
+            personalStreakDays: 12
+        )
+
+        for snapshot in [missingServerSnapshot, unavailableServerSnapshot] {
+            guard case .ready(let readyState) = snapshot.state else {
+                XCTFail("Expected ready local streak leaderboard state, received \(snapshot.state)")
+                return
+            }
+
+            XCTAssertNil(readyState.snapshotGeneratedAt)
+            XCTAssertNil(readyState.asOfUtcDate)
+            XCTAssertEqual(1, readyState.participantCount)
+            XCTAssertEqual(1, readyState.viewerRank)
+            XCTAssertEqual(12, readyState.viewerStreakDays)
+            XCTAssertEqual(1, readyState.rows.count)
+
+            guard case .participant(let viewerRow) = readyState.rows[0] else {
+                XCTFail("Expected local viewer row, received \(readyState.rows[0])")
+                return
+            }
+
+            XCTAssertEqual(.viewer, viewerRow.kind)
+            XCTAssertNil(viewerRow.publicProfileId)
+            XCTAssertEqual(12, viewerRow.streakDays)
+            XCTAssertEqual(1, viewerRow.rank)
+        }
+    }
+
     func testBestLeaderboardPlacementChoosesLowestViewerRank() throws {
         let readyState = self.makeReadyLeaderboardState(
             viewerRanksByWindow: [
@@ -748,6 +966,36 @@ final class ProgressSnapshotFactoryTests: XCTestCase {
             XCTAssertEqual(LeaderboardWindowKey.last24Hours.rawValue, windowKey)
             XCTAssertEqual(3, expectedRank)
             XCTAssertEqual(4, actualRank)
+        }
+    }
+
+    func testDecoderRejectsNonReadyStreakLeaderboardWithReadyPayloadFields() throws {
+        let json = """
+        {
+          "status": "snapshot_unavailable",
+          "metric": {
+            "metricVersion": "streak_days_v1",
+            "title": "Current streak days",
+            "description": "Ranks use current streak days from the public daily snapshot."
+          },
+          "snapshotId": "49c6a3f5-7dc7-48ef-9f81-8ec98c13f86c"
+        }
+        """
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(
+                UserProgressStreakLeaderboard.self,
+                from: Data(json.utf8)
+            )
+        ) { error in
+            guard case DecodingError.dataCorrupted(let context) = error else {
+                XCTFail("Expected dataCorrupted decoding error, received \(error)")
+                return
+            }
+
+            XCTAssertTrue(
+                context.debugDescription.contains("Non-ready streak leaderboard payload must not include snapshotId.")
+            )
         }
     }
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressBadgeRefreshTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Refresh/ProgressBadgeRefreshTests.swift
@@ -138,6 +138,561 @@ final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
     }
 
     @MainActor
+    func testProgressStreakLeaderboardRefreshCachesSeparatelyAndUsesNextRefreshAfter() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:30:00.000Z"))
+        let beforeNextRefresh = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T13:30:00.000Z"))
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        context.store.cloudRuntime.setActiveCloudSession(
+            linkedSession: CloudLinkedSession(
+                userId: linkedUserId,
+                workspaceId: workspace.workspaceId,
+                email: nil,
+                configurationMode: .official,
+                apiBaseUrl: context.apiBaseUrl,
+                authorization: .bearer("id-token-1")
+            )
+        )
+        context.cloudSyncService.serverProgressStreakLeaderboard = makeReadyProgressStreakLeaderboardForTests(
+            participantCount: 2,
+            viewer: ProgressStreakLeaderboardViewer(
+                publicProfileId: "profile-viewer",
+                displayName: "You",
+                rank: 2,
+                streakDays: 0
+            ),
+            rows: [
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .top,
+                    publicProfileId: "profile-top",
+                    anonymousDisplayName: "Silver Bright Harbor",
+                    streakDays: 3,
+                    rank: 1
+                ),
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    streakDays: 0,
+                    rank: 2
+                ),
+            ],
+            rankingRows: [
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-top",
+                    anonymousDisplayName: "Silver Bright Harbor",
+                    streakDays: 3,
+                    rank: 1
+                ),
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    streakDays: 0,
+                    rank: 2
+                ),
+            ],
+            snapshotGeneratedAt: "2026-06-10T12:00:05.000Z",
+            nextRefreshAfter: "2026-06-11T12:00:00.000Z"
+        )
+
+        await context.store.refreshProgressIfNeeded(now: now)
+
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressStreakLeaderboardCallCount)
+        XCTAssertEqual(.snapshotUnavailable, context.store.progressLeaderboardServerBaseCache?.serverBase.status)
+        XCTAssertEqual(.ready, context.store.progressStreakLeaderboardServerBaseCache?.serverBase.status)
+
+        await context.store.refreshProgressIfNeeded(now: beforeNextRefresh)
+
+        XCTAssertEqual(1, context.cloudSyncService.loadProgressStreakLeaderboardCallCount)
+    }
+
+    @MainActor
+    func testManualProgressRefreshReprojectsStreakLeaderboardAfterFreshProgress() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:30:00.000Z"))
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let initialServerSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let initialServerSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: initialServerSummary,
+            serverSeries: initialServerSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        context.store.cloudRuntime.setActiveCloudSession(
+            linkedSession: makeProgressLinkedSessionForBadgeTests(
+                userId: linkedUserId,
+                workspaceId: workspace.workspaceId,
+                apiBaseUrl: context.apiBaseUrl
+            )
+        )
+        context.cloudSyncService.serverProgressStreakLeaderboard = makeReadyProgressStreakLeaderboardForTests(
+            participantCount: 2,
+            viewer: ProgressStreakLeaderboardViewer(
+                publicProfileId: "profile-viewer",
+                displayName: "You",
+                rank: 2,
+                streakDays: 0
+            ),
+            rows: [
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .top,
+                    publicProfileId: "profile-peer",
+                    anonymousDisplayName: "Amber Calm Meadow",
+                    streakDays: 1,
+                    rank: 1
+                ),
+                makeProgressStreakLeaderboardParticipantRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    streakDays: 0,
+                    rank: 2
+                ),
+            ],
+            rankingRows: [
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .participant,
+                    publicProfileId: "profile-peer",
+                    anonymousDisplayName: "Amber Calm Meadow",
+                    streakDays: 1,
+                    rank: 1
+                ),
+                makeProgressStreakLeaderboardRankingRowForTests(
+                    kind: .viewer,
+                    publicProfileId: "profile-viewer",
+                    anonymousDisplayName: "Indigo Quiet Field",
+                    streakDays: 0,
+                    rank: 2
+                ),
+            ],
+            snapshotGeneratedAt: "2026-06-10T00:00:05.000Z",
+            nextRefreshAfter: "2026-06-11T00:00:00.000Z"
+        )
+
+        await context.store.refreshProgressIfNeeded(now: now)
+        let initialReadyState = try progressStreakLeaderboardReadyStateForBadgeTests(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(2, initialReadyState.viewerRank)
+        XCTAssertEqual(0, initialReadyState.viewerStreakDays)
+
+        context.cloudSyncService.serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [
+                requestRange.to: 1
+            ],
+            generatedAt: "2026-06-10T12:20:00.000Z"
+        )
+        context.cloudSyncService.serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [requestRange.to],
+            generatedAt: "2026-06-10T12:20:00.000Z"
+        )
+
+        await context.store.refreshProgressManually(now: now)
+
+        let progressSnapshot = try XCTUnwrap(context.store.progressSnapshot)
+        XCTAssertEqual(1, progressSnapshot.summary.currentStreakDays)
+        let readyState = try progressStreakLeaderboardReadyStateForBadgeTests(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(1, readyState.viewerRank)
+        XCTAssertEqual(1, readyState.viewerStreakDays)
+    }
+
+    @MainActor
+    func testProgressLeaderboardRefreshErrorsAreSeparatedByMetric() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:30:00.000Z"))
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        let linkedSession = makeProgressLinkedSessionForBadgeTests(
+            userId: linkedUserId,
+            workspaceId: workspace.workspaceId,
+            apiBaseUrl: context.apiBaseUrl
+        )
+        let scopeKey = try context.store.prepareProgressScope(now: now)
+        let leaderboardScopeKey = context.store.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+
+        context.cloudSyncService.loadProgressLeaderboardError = LocalStoreError.validation(
+            "Rating leaderboard refresh failed"
+        )
+        await context.store.refreshProgressLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        XCTAssertFalse(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
+        XCTAssertTrue(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
+
+        await context.store.refreshProgressStreakLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        XCTAssertFalse(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
+        XCTAssertTrue(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
+
+        context.store.clearProgressLeaderboardRefreshErrorMessage()
+        context.cloudSyncService.loadProgressLeaderboardError = nil
+        context.cloudSyncService.loadProgressStreakLeaderboardError = LocalStoreError.validation(
+            "Streak leaderboard refresh failed"
+        )
+        await context.store.refreshProgressStreakLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        XCTAssertTrue(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
+        XCTAssertFalse(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
+
+        await context.store.refreshProgressLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            linkedSession: linkedSession
+        )
+        XCTAssertTrue(context.store.progressErrorState.leaderboardRefreshMessage.isEmpty)
+        XCTAssertFalse(context.store.progressErrorState.streakLeaderboardRefreshMessage.isEmpty)
+    }
+
+    @MainActor
+    func testLeaderboardParticipationChangeClearsRatingAndStreakCaches() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:30:00.000Z"))
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        context.store.cloudRuntime.setActiveCloudSession(
+            linkedSession: makeProgressLinkedSessionForBadgeTests(
+                userId: linkedUserId,
+                workspaceId: workspace.workspaceId,
+                apiBaseUrl: context.apiBaseUrl
+            )
+        )
+        let scopeKey = try context.store.prepareProgressSnapshot(now: now)
+        let leaderboardScopeKey = context.store.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+        let ratingServerBase = PersistedProgressLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            serverBase: makeNonReadyProgressLeaderboardForTests(status: .snapshotUnavailable),
+            storedAt: "2026-06-10T12:00:05.000Z"
+        )
+        let streakServerBase = PersistedProgressStreakLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            serverBase: makeReadyProgressStreakLeaderboardForTests(
+                participantCount: 1,
+                viewer: ProgressStreakLeaderboardViewer(
+                    publicProfileId: "profile-viewer",
+                    displayName: "You",
+                    rank: 1,
+                    streakDays: 4
+                ),
+                rows: [
+                    makeProgressStreakLeaderboardParticipantRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        streakDays: 4,
+                        rank: 1
+                    ),
+                ],
+                rankingRows: [
+                    makeProgressStreakLeaderboardRankingRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        streakDays: 4,
+                        rank: 1
+                    ),
+                ],
+                snapshotGeneratedAt: "2026-06-10T00:00:05.000Z",
+                nextRefreshAfter: "2026-06-11T00:00:00.000Z"
+            ),
+            storedAt: "2026-06-10T00:00:05.000Z"
+        )
+        try context.store.persistProgressLeaderboardServerBase(serverBase: ratingServerBase)
+        try context.store.persistProgressStreakLeaderboardServerBase(serverBase: streakServerBase)
+        context.store.progressLeaderboardServerBaseCache = ratingServerBase
+        context.store.progressStreakLeaderboardServerBaseCache = streakServerBase
+        context.store.communityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: true
+        )
+        context.cloudSyncService.updatedCommunityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: false
+        )
+        context.store.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+            scopeKey: leaderboardScopeKey,
+            seriesScopeKey: scopeKey,
+            now: now
+        )
+        let initialReadyState = try progressStreakLeaderboardReadyStateForBadgeTests(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(4, initialReadyState.viewerStreakDays)
+
+        try await context.store.updateLeaderboardParticipationEnabled(isEnabled: false)
+
+        XCTAssertEqual(1, context.cloudSyncService.updateCommunityLeaderboardParticipationCallCount)
+        XCTAssertEqual(
+            false,
+            try XCTUnwrap(context.cloudSyncService.lastUpdateCommunityLeaderboardParticipationEnabled)
+        )
+        XCTAssertNil(context.store.loadPersistedProgressLeaderboardServerBase(scopeKey: leaderboardScopeKey))
+        XCTAssertNil(context.store.loadPersistedProgressStreakLeaderboardServerBase(scopeKey: leaderboardScopeKey))
+        XCTAssertNil(context.store.progressLeaderboardServerBaseCache)
+        XCTAssertNil(context.store.progressStreakLeaderboardServerBaseCache)
+        let readyState = try progressStreakLeaderboardReadyStateForBadgeTests(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(0, readyState.viewerStreakDays)
+        let participantRows = readyState.rows.compactMap { row -> ProgressStreakLeaderboardParticipantRowState? in
+            guard case .participant(let participantRow) = row else {
+                return nil
+            }
+
+            return participantRow
+        }
+        XCTAssertEqual(1, participantRows.count)
+        XCTAssertNil(participantRows.first?.publicProfileId)
+    }
+
+    @MainActor
+    func testRemoteCommunityProfileRefreshClearsRatingAndStreakCachesWhenParticipationChanges() async throws {
+        let database = try self.makeDatabase()
+        let workspace = try database.workspaceSettingsStore.loadWorkspace()
+        let cloudSettings = try database.workspaceSettingsStore.loadCloudSettings()
+
+        let now = try XCTUnwrap(parseIsoTimestamp(value: "2026-06-10T12:30:00.000Z"))
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        let requestRange = try makeTestProgressRequestRange(
+            now: now,
+            timeZone: timeZone,
+            dayCount: 140
+        )
+        let serverSeries = try makeTestProgressSeries(
+            requestRange: requestRange,
+            reviewCountsByDate: [:],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let serverSummary = try makeTestProgressSummary(
+            timeZone: requestRange.timeZone,
+            reviewDates: [],
+            generatedAt: "2026-06-10T12:00:00.000Z"
+        )
+        let context = try self.makeProgressStoreContext(
+            database: database,
+            workspaceId: workspace.workspaceId,
+            installationId: cloudSettings.installationId,
+            serverSummary: serverSummary,
+            serverSeries: serverSeries,
+            loadProgressSummaryError: nil,
+            loadProgressSeriesError: nil,
+            cloudState: .linked
+        )
+        defer { context.tearDown() }
+
+        let linkedUserId = try XCTUnwrap(context.store.cloudSettings?.linkedUserId)
+        context.store.cloudRuntime.setActiveCloudSession(
+            linkedSession: makeProgressLinkedSessionForBadgeTests(
+                userId: linkedUserId,
+                workspaceId: workspace.workspaceId,
+                apiBaseUrl: context.apiBaseUrl
+            )
+        )
+        let scopeKey = try context.store.prepareProgressSnapshot(now: now)
+        let leaderboardScopeKey = context.store.currentProgressLeaderboardScopeKey(seriesScopeKey: scopeKey)
+        let ratingServerBase = PersistedProgressLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            serverBase: makeNonReadyProgressLeaderboardForTests(status: .snapshotUnavailable),
+            storedAt: "2026-06-10T12:00:05.000Z"
+        )
+        let streakServerBase = PersistedProgressStreakLeaderboardServerBase(
+            scopeKey: leaderboardScopeKey,
+            serverBase: makeReadyProgressStreakLeaderboardForTests(
+                participantCount: 1,
+                viewer: ProgressStreakLeaderboardViewer(
+                    publicProfileId: "profile-viewer",
+                    displayName: "You",
+                    rank: 1,
+                    streakDays: 4
+                ),
+                rows: [
+                    makeProgressStreakLeaderboardParticipantRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        streakDays: 4,
+                        rank: 1
+                    ),
+                ],
+                rankingRows: [
+                    makeProgressStreakLeaderboardRankingRowForTests(
+                        kind: .viewer,
+                        publicProfileId: "profile-viewer",
+                        anonymousDisplayName: "Indigo Quiet Field",
+                        streakDays: 4,
+                        rank: 1
+                    ),
+                ],
+                snapshotGeneratedAt: "2026-06-10T00:00:05.000Z",
+                nextRefreshAfter: "2026-06-11T00:00:00.000Z"
+            ),
+            storedAt: "2026-06-10T00:00:05.000Z"
+        )
+        try context.store.persistProgressLeaderboardServerBase(serverBase: ratingServerBase)
+        try context.store.persistProgressStreakLeaderboardServerBase(serverBase: streakServerBase)
+        context.store.progressLeaderboardServerBaseCache = ratingServerBase
+        context.store.progressStreakLeaderboardServerBaseCache = streakServerBase
+        context.store.communityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: true
+        )
+        context.cloudSyncService.serverCommunityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: false
+        )
+        context.store.publishProgressStreakLeaderboardSnapshotIsolatingErrors(
+            scopeKey: leaderboardScopeKey,
+            seriesScopeKey: scopeKey,
+            now: now
+        )
+        let initialReadyState = try progressStreakLeaderboardReadyStateForBadgeTests(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(4, initialReadyState.viewerStreakDays)
+
+        try await context.store.refreshCommunityPublicProfileIfAvailable()
+
+        XCTAssertEqual(1, context.cloudSyncService.loadCommunityPublicProfileCallCount)
+        XCTAssertNil(context.store.loadPersistedProgressLeaderboardServerBase(scopeKey: leaderboardScopeKey))
+        XCTAssertNil(context.store.loadPersistedProgressStreakLeaderboardServerBase(scopeKey: leaderboardScopeKey))
+        XCTAssertNil(context.store.progressLeaderboardServerBaseCache)
+        XCTAssertNil(context.store.progressStreakLeaderboardServerBaseCache)
+        let readyState = try progressStreakLeaderboardReadyStateForBadgeTests(
+            snapshot: try XCTUnwrap(context.store.progressStreakLeaderboardSnapshot)
+        )
+        XCTAssertEqual(0, readyState.viewerStreakDays)
+        let participantRows = readyState.rows.compactMap { row -> ProgressStreakLeaderboardParticipantRowState? in
+            guard case .participant(let participantRow) = row else {
+                return nil
+            }
+
+            return participantRow
+        }
+        XCTAssertEqual(1, participantRows.count)
+        XCTAssertNil(participantRows.first?.publicProfileId)
+    }
+
+    @MainActor
     func testRefreshReviewProgressBadgeKeepsLocalTodayReviewWhenServerSummaryIsStale() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()
@@ -472,4 +1027,29 @@ final class ProgressBadgeRefreshTests: ProgressStoreTestCase {
         XCTAssertEqual(1, context.cloudSyncService.loadProgressSummaryCallCount)
         XCTAssertEqual(0, context.cloudSyncService.loadProgressSeriesCallCount)
     }
+}
+
+private func makeProgressLinkedSessionForBadgeTests(
+    userId: String,
+    workspaceId: String,
+    apiBaseUrl: String
+) -> CloudLinkedSession {
+    CloudLinkedSession(
+        userId: userId,
+        workspaceId: workspaceId,
+        email: nil,
+        configurationMode: .official,
+        apiBaseUrl: apiBaseUrl,
+        authorization: .bearer("id-token-1")
+    )
+}
+
+private func progressStreakLeaderboardReadyStateForBadgeTests(
+    snapshot: ProgressStreakLeaderboardSnapshot
+) throws -> ProgressStreakLeaderboardReadyState {
+    guard case .ready(let readyState) = snapshot.state else {
+        throw LocalStoreError.validation("Expected a ready streak leaderboard snapshot")
+    }
+
+    return readyState
 }

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressCloudSyncService.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressCloudSyncService.swift
@@ -75,10 +75,16 @@ final class ProgressCloudSyncService: CloudSyncServing {
     var serverSeries: UserProgressSeries
     var serverReviewSchedule: UserReviewSchedule
     var serverProgressLeaderboard: UserProgressLeaderboard
+    var serverProgressStreakLeaderboard: UserProgressStreakLeaderboard
+    var serverCommunityPublicProfile: CommunityPublicProfile
+    var updatedCommunityPublicProfile: CommunityPublicProfile
     var loadProgressSummaryError: Error?
     var loadProgressSeriesError: Error?
     var loadProgressReviewScheduleError: Error?
     var loadProgressLeaderboardError: Error?
+    var loadProgressStreakLeaderboardError: Error?
+    var loadCommunityPublicProfileError: Error?
+    var updateCommunityLeaderboardParticipationError: Error?
     private(set) var lastLoadProgressSummaryRequest: ProgressSummaryLoadRequest?
     private(set) var lastLoadProgressSeriesRequest: ProgressSeriesLoadRequest?
     private(set) var lastLoadProgressReviewScheduleRequest: ProgressReviewScheduleLoadRequest?
@@ -87,6 +93,10 @@ final class ProgressCloudSyncService: CloudSyncServing {
     private(set) var loadProgressSeriesCallCount: Int
     private(set) var loadProgressReviewScheduleCallCount: Int
     private(set) var loadProgressLeaderboardCallCount: Int
+    private(set) var loadProgressStreakLeaderboardCallCount: Int
+    private(set) var loadCommunityPublicProfileCallCount: Int
+    private(set) var updateCommunityLeaderboardParticipationCallCount: Int
+    private(set) var lastUpdateCommunityLeaderboardParticipationEnabled: Bool?
 
     init(
         serverSummary: UserProgressSummary,
@@ -98,10 +108,20 @@ final class ProgressCloudSyncService: CloudSyncServing {
         self.serverSeries = serverSeries
         self.serverReviewSchedule = makeEmptyReviewScheduleForTests(timeZone: serverSeries.timeZone)
         self.serverProgressLeaderboard = makeNonReadyProgressLeaderboardForTests(status: .snapshotUnavailable)
+        self.serverProgressStreakLeaderboard = makeNonReadyProgressStreakLeaderboardForTests(status: .snapshotUnavailable)
+        self.serverCommunityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: true
+        )
+        self.updatedCommunityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: true
+        )
         self.loadProgressSummaryError = loadProgressSummaryError
         self.loadProgressSeriesError = loadProgressSeriesError
         self.loadProgressReviewScheduleError = nil
         self.loadProgressLeaderboardError = nil
+        self.loadProgressStreakLeaderboardError = nil
+        self.loadCommunityPublicProfileError = nil
+        self.updateCommunityLeaderboardParticipationError = nil
         self.lastLoadProgressSummaryRequest = nil
         self.lastLoadProgressSeriesRequest = nil
         self.lastLoadProgressReviewScheduleRequest = nil
@@ -110,6 +130,10 @@ final class ProgressCloudSyncService: CloudSyncServing {
         self.loadProgressSeriesCallCount = 0
         self.loadProgressReviewScheduleCallCount = 0
         self.loadProgressLeaderboardCallCount = 0
+        self.loadProgressStreakLeaderboardCallCount = 0
+        self.loadCommunityPublicProfileCallCount = 0
+        self.updateCommunityLeaderboardParticipationCallCount = 0
+        self.lastUpdateCommunityLeaderboardParticipationEnabled = nil
     }
 
     init(
@@ -124,10 +148,20 @@ final class ProgressCloudSyncService: CloudSyncServing {
         self.serverSeries = serverSeries
         self.serverReviewSchedule = serverReviewSchedule
         self.serverProgressLeaderboard = makeNonReadyProgressLeaderboardForTests(status: .snapshotUnavailable)
+        self.serverProgressStreakLeaderboard = makeNonReadyProgressStreakLeaderboardForTests(status: .snapshotUnavailable)
+        self.serverCommunityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: true
+        )
+        self.updatedCommunityPublicProfile = makeCommunityPublicProfileForProgressTests(
+            leaderboardParticipationEnabled: true
+        )
         self.loadProgressSummaryError = loadProgressSummaryError
         self.loadProgressSeriesError = loadProgressSeriesError
         self.loadProgressReviewScheduleError = loadProgressReviewScheduleError
         self.loadProgressLeaderboardError = nil
+        self.loadProgressStreakLeaderboardError = nil
+        self.loadCommunityPublicProfileError = nil
+        self.updateCommunityLeaderboardParticipationError = nil
         self.lastLoadProgressSummaryRequest = nil
         self.lastLoadProgressSeriesRequest = nil
         self.lastLoadProgressReviewScheduleRequest = nil
@@ -136,6 +170,10 @@ final class ProgressCloudSyncService: CloudSyncServing {
         self.loadProgressSeriesCallCount = 0
         self.loadProgressReviewScheduleCallCount = 0
         self.loadProgressLeaderboardCallCount = 0
+        self.loadProgressStreakLeaderboardCallCount = 0
+        self.loadCommunityPublicProfileCallCount = 0
+        self.updateCommunityLeaderboardParticipationCallCount = 0
+        self.lastUpdateCommunityLeaderboardParticipationEnabled = nil
     }
 
     func fetchCloudAccount(apiBaseUrl: String, bearerToken: String) async throws -> CloudAccountSnapshot {
@@ -222,13 +260,32 @@ final class ProgressCloudSyncService: CloudSyncServing {
         return self.serverProgressLeaderboard
     }
 
+    func loadProgressStreakLeaderboard(
+        apiBaseUrl: String,
+        authorizationHeader: String
+    ) async throws -> UserProgressStreakLeaderboard {
+        _ = apiBaseUrl
+        _ = authorizationHeader
+        self.loadProgressStreakLeaderboardCallCount += 1
+        if let loadProgressStreakLeaderboardError {
+            throw loadProgressStreakLeaderboardError
+        }
+
+        return self.serverProgressStreakLeaderboard
+    }
+
     func loadCommunityPublicProfile(
         apiBaseUrl: String,
         authorizationHeader: String
     ) async throws -> CommunityPublicProfile {
         _ = apiBaseUrl
         _ = authorizationHeader
-        fatalError("Not used in progress tests.")
+        self.loadCommunityPublicProfileCallCount += 1
+        if let loadCommunityPublicProfileError {
+            throw loadCommunityPublicProfileError
+        }
+
+        return self.serverCommunityPublicProfile
     }
 
     func updateCommunityLeaderboardParticipation(
@@ -238,8 +295,18 @@ final class ProgressCloudSyncService: CloudSyncServing {
     ) async throws -> CommunityPublicProfile {
         _ = apiBaseUrl
         _ = authorizationHeader
-        _ = isEnabled
-        fatalError("Not used in progress tests.")
+        self.updateCommunityLeaderboardParticipationCallCount += 1
+        self.lastUpdateCommunityLeaderboardParticipationEnabled = isEnabled
+        if let updateCommunityLeaderboardParticipationError {
+            throw updateCommunityLeaderboardParticipationError
+        }
+
+        return CommunityPublicProfile(
+            publicProfileId: self.updatedCommunityPublicProfile.publicProfileId,
+            anonymousDisplayName: self.updatedCommunityPublicProfile.anonymousDisplayName,
+            leaderboardParticipationEnabled: isEnabled,
+            linkedAccountRequiredForLeaderboard: self.updatedCommunityPublicProfile.linkedAccountRequiredForLeaderboard
+        )
     }
 
     func loadFeedbackState(

--- a/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Progress/Support/ProgressTestFixtures.swift
@@ -249,6 +249,25 @@ func makeTestProgressLeaderboardMetric() -> ProgressLeaderboardMetric {
     )
 }
 
+func makeTestProgressStreakLeaderboardMetric() -> ProgressLeaderboardMetric {
+    ProgressLeaderboardMetric(
+        metricVersion: "streak_days_v1",
+        title: "Current streak days",
+        description: "Ranks use current streak days from the public daily snapshot."
+    )
+}
+
+func makeCommunityPublicProfileForProgressTests(
+    leaderboardParticipationEnabled: Bool
+) -> CommunityPublicProfile {
+    CommunityPublicProfile(
+        publicProfileId: "profile-viewer",
+        anonymousDisplayName: "Indigo Quiet Field",
+        leaderboardParticipationEnabled: leaderboardParticipationEnabled,
+        linkedAccountRequiredForLeaderboard: false
+    )
+}
+
 func makeNonReadyProgressLeaderboardForTests(
     status: ProgressLeaderboardStatus
 ) -> UserProgressLeaderboard {
@@ -257,6 +276,16 @@ func makeNonReadyProgressLeaderboardForTests(
         metric: makeTestProgressLeaderboardMetric(),
         defaultWindowKey: .last24Hours,
         windows: []
+    )
+}
+
+func makeNonReadyProgressStreakLeaderboardForTests(
+    status: ProgressLeaderboardStatus
+) -> UserProgressStreakLeaderboard {
+    UserProgressStreakLeaderboard(
+        status: status,
+        metric: makeTestProgressStreakLeaderboardMetric(),
+        readyPayload: nil
     )
 }
 
@@ -290,11 +319,71 @@ func makeReadyProgressLeaderboardForTests(
     )
 }
 
+func makeReadyProgressStreakLeaderboardForTests(
+    participantCount: Int,
+    viewer: ProgressStreakLeaderboardViewer,
+    rows: [ProgressStreakLeaderboardRow],
+    rankingRows: [ProgressStreakLeaderboardRankingRow],
+    snapshotGeneratedAt: String,
+    nextRefreshAfter: String
+) -> UserProgressStreakLeaderboard {
+    UserProgressStreakLeaderboard(
+        status: .ready,
+        metric: makeTestProgressStreakLeaderboardMetric(),
+        readyPayload: ProgressStreakLeaderboardReadyPayload(
+            snapshotId: "49c6a3f5-7dc7-48ef-9f81-8ec98c13f86c",
+            snapshotGeneratedAt: snapshotGeneratedAt,
+            asOfUtcDate: "2026-06-10",
+            nextRefreshAfter: nextRefreshAfter,
+            participantCount: participantCount,
+            viewer: viewer,
+            rows: rows,
+            rankingRows: rankingRows
+        )
+    )
+}
+
 func makeProgressLeaderboardScopeKeyForTests() -> ProgressLeaderboardScopeKey {
     ProgressLeaderboardScopeKey(
         cloudState: .linked,
         linkedUserId: "linked-user-1",
         localeIdentifier: "en"
+    )
+}
+
+func makeProgressStreakLeaderboardParticipantRowForTests(
+    kind: ProgressLeaderboardParticipantKind,
+    publicProfileId: String,
+    anonymousDisplayName: String,
+    streakDays: Int,
+    rank: Int
+) -> ProgressStreakLeaderboardRow {
+    .participant(
+        ProgressStreakLeaderboardParticipantRow(
+            kind: kind,
+            publicProfileId: publicProfileId,
+            anonymousDisplayName: anonymousDisplayName,
+            friendDisplayName: nil,
+            streakDays: streakDays,
+            rank: rank
+        )
+    )
+}
+
+func makeProgressStreakLeaderboardRankingRowForTests(
+    kind: ProgressLeaderboardRankingRowKind,
+    publicProfileId: String,
+    anonymousDisplayName: String,
+    streakDays: Int,
+    rank: Int
+) -> ProgressStreakLeaderboardRankingRow {
+    ProgressStreakLeaderboardRankingRow(
+        kind: kind,
+        publicProfileId: publicProfileId,
+        anonymousDisplayName: anonymousDisplayName,
+        friendDisplayName: nil,
+        streakDays: streakDays,
+        rank: rank
     )
 }
 


### PR DESCRIPTION
## Summary
- add iOS streak leaderboard wire models, validation, cloud loading, and persisted cache state
- add store refresh orchestration and viewer projection using the current progress streak
- add focused progress tests and test fakes for independent rating/streak responses

## Validation
- git --no-pager diff --check
- python3 -m json.tool apps/ios/Flashcards/Flashcards/Resources/Localization/Foundation.xcstrings >/dev/null
- xcodebuild -project "apps/ios/Flashcards/Flashcards Open Source App.xcodeproj" -scheme "Flashcards Open Source App" -derivedDataPath "tmp/ios-derived-data" -destination 'generic/platform=iOS Simulator' build (failed before compilation: iOS 26.5 platform/runtime is not installed)

Simulator-backed tests/smokes were not run per task instruction.