### PR TITLE
Add Android streak leaderboard UI

### DIFF
--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressRoute.kt
@@ -28,6 +28,7 @@ import com.flashcardsopensourceapp.feature.progress.sections.LeaderboardSectionC
 import com.flashcardsopensourceapp.feature.progress.sections.LoadingCard
 import com.flashcardsopensourceapp.feature.progress.sections.ReviewScheduleSectionCard
 import com.flashcardsopensourceapp.feature.progress.sections.ReviewsSectionCard
+import com.flashcardsopensourceapp.feature.progress.sections.StreakLeaderboardSectionCard
 import com.flashcardsopensourceapp.feature.progress.sections.StreakSectionCard
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -164,6 +165,13 @@ fun ProgressRoute(
                             onSelectWindow = onSelectLeaderboardWindow,
                             onCreateFriendInvitation = onCreateFriendInvitation,
                             onClearFriendInvitationFailure = onClearFriendInvitationFailure,
+                            onOpenSignIn = onOpenSignIn,
+                            onOpenLeaderboardSettings = onOpenLeaderboardSettings
+                        )
+                    }
+                    item {
+                        StreakLeaderboardSectionCard(
+                            uiState = uiState.streakLeaderboardSection,
                             onOpenSignIn = onOpenSignIn,
                             onOpenLeaderboardSettings = onOpenLeaderboardSettings
                         )

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressUiState.kt
@@ -109,6 +109,38 @@ sealed interface ProgressLeaderboardSectionUiState {
     }
 }
 
+sealed interface ProgressStreakLeaderboardRowUiState {
+    data class Participant(
+        val rank: Int,
+        val displayName: String,
+        val streakDays: Int,
+        val isViewer: Boolean
+    ) : ProgressStreakLeaderboardRowUiState
+
+    data object Gap : ProgressStreakLeaderboardRowUiState
+}
+
+sealed interface ProgressStreakLeaderboardSectionUiState {
+    data object Loading : ProgressStreakLeaderboardSectionUiState
+
+    data object SignInRequired : ProgressStreakLeaderboardSectionUiState
+
+    data object ParticipationDisabled : ProgressStreakLeaderboardSectionUiState
+
+    data object Offline : ProgressStreakLeaderboardSectionUiState
+
+    data object SnapshotUnavailable : ProgressStreakLeaderboardSectionUiState
+
+    data class Ready(
+        // Server-localized explanation that public streak rankings may trail live local streaks;
+        // null falls back to the client string resource.
+        val metricDescription: String?,
+        val participantCount: Int,
+        val rows: List<ProgressStreakLeaderboardRowUiState>,
+        val snapshotGeneratedAtMillis: Long?
+    ) : ProgressStreakLeaderboardSectionUiState
+}
+
 sealed interface ProgressSummaryUiState {
     data object Loading : ProgressSummaryUiState
 
@@ -134,6 +166,7 @@ sealed interface ProgressUiState {
         val streakSection: ProgressStreakSectionUiState,
         val reviewsSection: ProgressReviewsSectionUiState,
         val reviewScheduleSection: ProgressReviewScheduleSectionUiState?,
-        val leaderboardSection: ProgressLeaderboardSectionUiState
+        val leaderboardSection: ProgressLeaderboardSectionUiState,
+        val streakLeaderboardSection: ProgressStreakLeaderboardSectionUiState
     ) : ProgressUiState
 }

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModel.kt
@@ -13,6 +13,8 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressLeader
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressReviewSchedule
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRow
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardSnapshot
@@ -20,6 +22,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboard
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardWindowKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewScheduleSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.resolveBestLeaderboardPlacement
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
@@ -55,17 +58,29 @@ class ProgressViewModel(
     init {
         viewModelScope.launch {
             combine(
-                progressRepository.observeSummarySnapshot(),
-                progressRepository.observeSeriesSnapshot(),
-                progressRepository.observeReviewScheduleSnapshot(),
-                progressRepository.observeLeaderboardSnapshot(),
+                combine(
+                    progressRepository.observeSummarySnapshot(),
+                    progressRepository.observeSeriesSnapshot(),
+                    progressRepository.observeReviewScheduleSnapshot(),
+                    progressRepository.observeLeaderboardSnapshot(),
+                    progressRepository.observeStreakLeaderboardSnapshot()
+                ) { summarySnapshot, seriesSnapshot, reviewScheduleSnapshot, leaderboardSnapshot, streakLeaderboardSnapshot ->
+                    ProgressSnapshotInputs(
+                        summarySnapshot = summarySnapshot,
+                        seriesSnapshot = seriesSnapshot,
+                        reviewScheduleSnapshot = reviewScheduleSnapshot,
+                        leaderboardSnapshot = leaderboardSnapshot,
+                        streakLeaderboardSnapshot = streakLeaderboardSnapshot
+                    )
+                },
                 selectedLeaderboardWindowMutable
-            ) { summarySnapshot, seriesSnapshot, reviewScheduleSnapshot, leaderboardSnapshot, selectedLeaderboardWindow ->
+            ) { snapshots, selectedLeaderboardWindow ->
                 createProgressUiState(
-                    summarySnapshot = summarySnapshot,
-                    seriesSnapshot = seriesSnapshot,
-                    reviewScheduleSnapshot = reviewScheduleSnapshot,
-                    leaderboardSnapshot = leaderboardSnapshot,
+                    summarySnapshot = snapshots.summarySnapshot,
+                    seriesSnapshot = snapshots.seriesSnapshot,
+                    reviewScheduleSnapshot = snapshots.reviewScheduleSnapshot,
+                    leaderboardSnapshot = snapshots.leaderboardSnapshot,
+                    streakLeaderboardSnapshot = snapshots.streakLeaderboardSnapshot,
                     selectedLeaderboardWindowKey = selectedLeaderboardWindow
                 )
             }.collect { uiState ->
@@ -136,6 +151,14 @@ class ProgressViewModel(
     }
 }
 
+private data class ProgressSnapshotInputs(
+    val summarySnapshot: ProgressSummarySnapshot?,
+    val seriesSnapshot: ProgressSeriesSnapshot?,
+    val reviewScheduleSnapshot: ProgressReviewScheduleSnapshot?,
+    val leaderboardSnapshot: ProgressLeaderboardSnapshot?,
+    val streakLeaderboardSnapshot: ProgressStreakLeaderboardSnapshot?
+)
+
 private data class ParsedProgressPoint(
     val date: LocalDate,
     val reviewCount: Int,
@@ -155,6 +178,7 @@ private fun createProgressUiState(
     seriesSnapshot: ProgressSeriesSnapshot?,
     reviewScheduleSnapshot: ProgressReviewScheduleSnapshot?,
     leaderboardSnapshot: ProgressLeaderboardSnapshot?,
+    streakLeaderboardSnapshot: ProgressStreakLeaderboardSnapshot?,
     selectedLeaderboardWindowKey: ProgressLeaderboardWindowKey?
 ): ProgressUiState {
     if (seriesSnapshot == null) {
@@ -167,6 +191,7 @@ private fun createProgressUiState(
             seriesSnapshot = seriesSnapshot,
             reviewScheduleSnapshot = reviewScheduleSnapshot,
             leaderboardSnapshot = leaderboardSnapshot,
+            streakLeaderboardSnapshot = streakLeaderboardSnapshot,
             selectedLeaderboardWindowKey = selectedLeaderboardWindowKey
         )
     }.getOrElse { error ->
@@ -174,6 +199,8 @@ private fun createProgressUiState(
             summarySnapshot = summarySnapshot,
             seriesSnapshot = seriesSnapshot,
             reviewScheduleSnapshot = reviewScheduleSnapshot,
+            leaderboardSnapshot = leaderboardSnapshot,
+            streakLeaderboardSnapshot = streakLeaderboardSnapshot,
             error = error
         )
         ProgressUiState.Error(message = null)
@@ -185,6 +212,7 @@ private fun createLoadedProgressUiState(
     seriesSnapshot: ProgressSeriesSnapshot,
     reviewScheduleSnapshot: ProgressReviewScheduleSnapshot?,
     leaderboardSnapshot: ProgressLeaderboardSnapshot?,
+    streakLeaderboardSnapshot: ProgressStreakLeaderboardSnapshot?,
     selectedLeaderboardWindowKey: ProgressLeaderboardWindowKey?
 ): ProgressUiState {
     val today = LocalDate.parse(seriesSnapshot.renderedSeries.to)
@@ -196,6 +224,9 @@ private fun createLoadedProgressUiState(
         leaderboardSection = createProgressLeaderboardSectionUiState(
             snapshot = leaderboardSnapshot,
             selectedWindowKey = selectedLeaderboardWindowKey
+        ),
+        streakLeaderboardSection = createProgressStreakLeaderboardSectionUiState(
+            snapshot = streakLeaderboardSnapshot
         )
     )
 }
@@ -243,6 +274,58 @@ internal fun createProgressLeaderboardSectionUiState(
     }
 }
 
+internal fun createProgressStreakLeaderboardSectionUiState(
+    snapshot: ProgressStreakLeaderboardSnapshot?
+): ProgressStreakLeaderboardSectionUiState {
+    if (snapshot == null) {
+        return ProgressStreakLeaderboardSectionUiState.Loading
+    }
+    if (snapshot.cloudState != CloudAccountState.LINKED) {
+        return ProgressStreakLeaderboardSectionUiState.SignInRequired
+    }
+
+    val leaderboard = snapshot.renderedLeaderboard
+    if (leaderboard == null) {
+        return if (snapshot.didLastRemoteLoadFail) {
+            ProgressStreakLeaderboardSectionUiState.Offline
+        } else {
+            ProgressStreakLeaderboardSectionUiState.Loading
+        }
+    }
+
+    return when (leaderboard) {
+        is CloudProgressStreakLeaderboard.NonReady -> {
+            when (leaderboard.status) {
+                ProgressLeaderboardStatus.LINKED_ACCOUNT_REQUIRED -> {
+                    ProgressStreakLeaderboardSectionUiState.SignInRequired
+                }
+                ProgressLeaderboardStatus.PARTICIPATION_DISABLED -> {
+                    ProgressStreakLeaderboardSectionUiState.ParticipationDisabled
+                }
+                ProgressLeaderboardStatus.SNAPSHOT_UNAVAILABLE -> {
+                    ProgressStreakLeaderboardSectionUiState.SnapshotUnavailable
+                }
+                ProgressLeaderboardStatus.READY -> {
+                    throw IllegalStateException("Non-ready streak leaderboard must not use ready status.")
+                }
+            }
+        }
+        is CloudProgressStreakLeaderboard.Ready -> {
+            ProgressStreakLeaderboardSectionUiState.Ready(
+                metricDescription = leaderboard.metric.description.takeIf { description ->
+                    description.isNotBlank()
+                },
+                participantCount = leaderboard.participantCount,
+                rows = leaderboard.rows.map { row -> row.toUiState() },
+                snapshotGeneratedAtMillis = parseLeaderboardSnapshotGeneratedAtMillis(
+                    rawInstant = leaderboard.snapshotGeneratedAt,
+                    invalidEvent = "progress_streak_leaderboard_snapshot_generated_at_invalid"
+                )
+            )
+        }
+    }
+}
+
 private fun CloudProgressLeaderboardWindow.toUiState(): ProgressLeaderboardWindowUiState {
     return ProgressLeaderboardWindowUiState(
         windowKey = windowKey,
@@ -258,18 +341,40 @@ private fun CloudProgressLeaderboardWindow.toUiState(): ProgressLeaderboardWindo
                 )
             }
         },
-        snapshotGeneratedAtMillis = runCatching {
-            Instant.parse(snapshotGeneratedAt).toEpochMilli()
-        }.getOrElse { error ->
-            // A malformed timestamp only suppresses the freshness label, but the
-            // contract drift must stay visible in logs instead of failing silently.
-            logProgressViewModelWarning(
-                event = "progress_leaderboard_snapshot_generated_at_invalid",
-                error = error
-            )
-            null
-        }
+        snapshotGeneratedAtMillis = parseLeaderboardSnapshotGeneratedAtMillis(
+            rawInstant = snapshotGeneratedAt,
+            invalidEvent = "progress_leaderboard_snapshot_generated_at_invalid"
+        )
     )
+}
+
+private fun CloudProgressStreakLeaderboardRow.toUiState(): ProgressStreakLeaderboardRowUiState {
+    return when (this) {
+        CloudProgressStreakLeaderboardRow.Gap -> ProgressStreakLeaderboardRowUiState.Gap
+        is CloudProgressStreakLeaderboardRow.Participant -> ProgressStreakLeaderboardRowUiState.Participant(
+            rank = rank,
+            displayName = friendDisplayName ?: anonymousDisplayName,
+            streakDays = streakDays,
+            isViewer = kind == ProgressLeaderboardParticipantRowKind.VIEWER
+        )
+    }
+}
+
+private fun parseLeaderboardSnapshotGeneratedAtMillis(
+    rawInstant: String,
+    invalidEvent: String
+): Long? {
+    return runCatching {
+        Instant.parse(rawInstant).toEpochMilli()
+    }.getOrElse { error ->
+        // A malformed timestamp only suppresses the freshness label, but the
+        // contract drift must stay visible in logs instead of failing silently.
+        logProgressViewModelWarning(
+            event = invalidEvent,
+            error = error
+        )
+        null
+    }
 }
 
 private fun CloudProgressSeries.toUiState(
@@ -277,7 +382,8 @@ private fun CloudProgressSeries.toUiState(
     today: LocalDate,
     summary: ProgressSummaryUiState,
     reviewSchedule: ProgressReviewScheduleSectionUiState?,
-    leaderboardSection: ProgressLeaderboardSectionUiState
+    leaderboardSection: ProgressLeaderboardSectionUiState,
+    streakLeaderboardSection: ProgressStreakLeaderboardSectionUiState
 ): ProgressUiState {
     val parsedPoints = dailyReviews
         .map { point ->
@@ -312,7 +418,8 @@ private fun CloudProgressSeries.toUiState(
         streakSection = streakSection,
         reviewsSection = reviewsSection,
         reviewScheduleSection = reviewSchedule,
-        leaderboardSection = leaderboardSection
+        leaderboardSection = leaderboardSection,
+        streakLeaderboardSection = streakLeaderboardSection
     )
 }
 
@@ -611,6 +718,8 @@ private fun logProgressUiStateMappingFailure(
     summarySnapshot: ProgressSummarySnapshot?,
     seriesSnapshot: ProgressSeriesSnapshot,
     reviewScheduleSnapshot: ProgressReviewScheduleSnapshot?,
+    leaderboardSnapshot: ProgressLeaderboardSnapshot?,
+    streakLeaderboardSnapshot: ProgressStreakLeaderboardSnapshot?,
     error: Throwable
 ) {
     val message = buildProgressViewModelLogMessage(
@@ -624,6 +733,8 @@ private fun logProgressUiStateMappingFailure(
             "reviewScheduleScopeId" to reviewScheduleSnapshot?.scopeKey?.scopeId,
             "reviewScheduleSource" to reviewScheduleSnapshot?.source?.name,
             "reviewScheduleTotalCards" to reviewScheduleSnapshot?.renderedSchedule?.totalCards?.toString(),
+            "leaderboardScopeId" to leaderboardSnapshot?.scopeKey?.scopeId,
+            "streakLeaderboardScopeId" to streakLeaderboardSnapshot?.scopeKey?.scopeId,
             "source" to seriesSnapshot.source.name,
             "dailyReviewCount" to seriesSnapshot.renderedSeries.dailyReviews.size.toString()
         )

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressLeaderboardSection.kt
@@ -141,8 +141,10 @@ internal fun LeaderboardSectionCard(
                 }
 
                 ProgressLeaderboardSectionUiState.SignInRequired -> {
-                    LeaderboardResolvedContent {
-                        LeaderboardPlaceholder(
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
                             message = stringResource(id = R.string.progress_leaderboard_sign_in_message),
                             buttonLabel = stringResource(id = R.string.progress_leaderboard_sign_in_button),
                             onButtonClick = onOpenSignIn
@@ -151,8 +153,10 @@ internal fun LeaderboardSectionCard(
                 }
 
                 ProgressLeaderboardSectionUiState.ParticipationDisabled -> {
-                    LeaderboardResolvedContent {
-                        LeaderboardPlaceholder(
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
                             message = stringResource(id = R.string.progress_leaderboard_participation_disabled_message),
                             buttonLabel = stringResource(id = R.string.progress_leaderboard_participation_disabled_button),
                             onButtonClick = onOpenLeaderboardSettings
@@ -161,8 +165,10 @@ internal fun LeaderboardSectionCard(
                 }
 
                 ProgressLeaderboardSectionUiState.Offline -> {
-                    LeaderboardResolvedContent {
-                        LeaderboardPlaceholder(
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
                             message = stringResource(id = R.string.progress_leaderboard_offline_message),
                             buttonLabel = null,
                             onButtonClick = null
@@ -171,8 +177,10 @@ internal fun LeaderboardSectionCard(
                 }
 
                 ProgressLeaderboardSectionUiState.SnapshotUnavailable -> {
-                    LeaderboardResolvedContent {
-                        LeaderboardPlaceholder(
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
                             message = stringResource(id = R.string.progress_leaderboard_unavailable_message),
                             buttonLabel = null,
                             onButtonClick = null
@@ -181,7 +189,9 @@ internal fun LeaderboardSectionCard(
                 }
 
                 is ProgressLeaderboardSectionUiState.Ready -> {
-                    LeaderboardResolvedContent {
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressLeaderboardResolvedContentTag
+                    ) {
                         LeaderboardReadyContent(
                             uiState = uiState,
                             onSelectWindow = onSelectWindow
@@ -198,12 +208,12 @@ internal fun LeaderboardSectionCard(
         val infoBody = readyState?.metricDescription ?: fallbackInfoBody
         val selectedSnapshotGeneratedAtMillis = readyState?.selectedWindow?.snapshotGeneratedAtMillis
         val updatedText = selectedSnapshotGeneratedAtMillis?.let { snapshotGeneratedAtMillis ->
-            stringResource(
-                id = R.string.progress_leaderboard_updated_label,
-                leaderboardElapsedMinutes(
-                    snapshotGeneratedAtMillis = snapshotGeneratedAtMillis,
-                    nowMillis = System.currentTimeMillis()
-                )
+                    stringResource(
+                        id = R.string.progress_leaderboard_updated_label,
+                        progressLeaderboardElapsedMinutes(
+                            snapshotGeneratedAtMillis = snapshotGeneratedAtMillis,
+                            nowMillis = System.currentTimeMillis()
+                        )
             )
         }
         AlertDialog(
@@ -239,14 +249,15 @@ internal fun LeaderboardSectionCard(
 }
 
 @Composable
-private fun LeaderboardResolvedContent(
+internal fun ProgressLeaderboardResolvedContent(
+    testTag: String,
     content: @Composable () -> Unit
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier
             .fillMaxWidth()
-            .testTag(progressLeaderboardResolvedContentTag)
+            .testTag(testTag)
     ) {
         content()
     }
@@ -315,11 +326,22 @@ private fun LeaderboardReadyContent(
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             selectedWindow.rows.forEach { row ->
                 when (row) {
-                    ProgressLeaderboardRowUiState.Gap -> LeaderboardGapRow()
-                    is ProgressLeaderboardRowUiState.Participant -> LeaderboardParticipantRow(
-                        row = row,
+                    ProgressLeaderboardRowUiState.Gap -> ProgressLeaderboardGapRow(
+                        contentDescription = stringResource(
+                            id = R.string.progress_leaderboard_gap_content_description
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    is ProgressLeaderboardRowUiState.Participant -> ProgressLeaderboardParticipantRow(
                         rankLabel = countFormatter.format(row.rank.toLong()),
-                        countLabel = countFormatter.format(row.qualifiedReviewCount.toLong())
+                        displayName = if (row.isViewer) {
+                            stringResource(id = R.string.progress_leaderboard_you)
+                        } else {
+                            row.displayName
+                        },
+                        metricLabel = countFormatter.format(row.qualifiedReviewCount.toLong()),
+                        isViewer = row.isViewer,
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
             }
@@ -338,7 +360,7 @@ private fun LeaderboardReadyContent(
     }
 }
 
-private fun leaderboardElapsedMinutes(snapshotGeneratedAtMillis: Long, nowMillis: Long): Long {
+internal fun progressLeaderboardElapsedMinutes(snapshotGeneratedAtMillis: Long, nowMillis: Long): Long {
     return maxOf(0L, nowMillis - snapshotGeneratedAtMillis) / millisecondsPerMinute
 }
 
@@ -365,32 +387,30 @@ private fun leaderboardReservedRows(
 }
 
 @Composable
-private fun LeaderboardParticipantRow(
-    row: ProgressLeaderboardRowUiState.Participant,
+internal fun ProgressLeaderboardParticipantRow(
     rankLabel: String,
-    countLabel: String
+    displayName: String,
+    metricLabel: String,
+    isViewer: Boolean,
+    modifier: Modifier
 ) {
     val emphasisColor = MaterialTheme.colorScheme.primary
-    val rowColor = if (row.isViewer) emphasisColor else MaterialTheme.colorScheme.onSurface
-    val rowWeight = if (row.isViewer) FontWeight.SemiBold else null
+    val rowColor = if (isViewer) emphasisColor else MaterialTheme.colorScheme.onSurface
+    val rowWeight = if (isViewer) FontWeight.SemiBold else null
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.fillMaxWidth()
+        modifier = modifier
     ) {
         Text(
             text = stringResource(id = R.string.progress_leaderboard_rank_label, rankLabel),
-            color = if (row.isViewer) emphasisColor else MaterialTheme.colorScheme.onSurfaceVariant,
+            color = if (isViewer) emphasisColor else MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = rowWeight
         )
         Text(
-            text = if (row.isViewer) {
-                stringResource(id = R.string.progress_leaderboard_you)
-            } else {
-                row.displayName
-            },
+            text = displayName,
             color = rowColor,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = rowWeight,
@@ -399,7 +419,7 @@ private fun LeaderboardParticipantRow(
             modifier = Modifier.weight(1f)
         )
         Text(
-            text = countLabel,
+            text = metricLabel,
             color = rowColor,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = rowWeight,
@@ -452,23 +472,24 @@ private fun LeaderboardReservedGapRow() {
 }
 
 @Composable
-private fun LeaderboardGapRow() {
-    val gapContentDescription = stringResource(id = R.string.progress_leaderboard_gap_content_description)
+internal fun ProgressLeaderboardGapRow(
+    contentDescription: String,
+    modifier: Modifier
+) {
     Text(
         text = "⋯",
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         style = MaterialTheme.typography.bodyMedium,
         textAlign = TextAlign.Center,
-        modifier = Modifier
-            .fillMaxWidth()
+        modifier = modifier
             .clearAndSetSemantics {
-                contentDescription = gapContentDescription
+                this.contentDescription = contentDescription
             }
     )
 }
 
 @Composable
-private fun LeaderboardPlaceholder(
+internal fun ProgressLeaderboardPlaceholder(
     message: String,
     buttonLabel: String?,
     onButtonClick: (() -> Unit)?

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressSectionDefaults.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressSectionDefaults.kt
@@ -16,3 +16,15 @@ const val progressLeaderboardPeriodSelectorTag: String = "progress_leaderboard_p
 const val progressLeaderboardInfoButtonTag: String = "progress_leaderboard_info_button"
 const val progressLeaderboardInviteButtonTag: String = "progress_leaderboard_invite_button"
 const val progressLeaderboardInviteDisplayNameFieldTag: String = "progress_leaderboard_invite_display_name_field"
+const val progressStreakLeaderboardSectionTag: String = "progress_streak_leaderboard_section"
+const val progressStreakLeaderboardResolvedContentTag: String =
+    "progress_streak_leaderboard_resolved_content"
+const val progressStreakLeaderboardInfoButtonTag: String = "progress_streak_leaderboard_info_button"
+
+fun progressStreakLeaderboardParticipantRowTag(rank: Int): String {
+    return "progress_streak_leaderboard_row_$rank"
+}
+
+fun progressStreakLeaderboardGapRowTag(index: Int): String {
+    return "progress_streak_leaderboard_gap_row_$index"
+}

--- a/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakLeaderboardSection.kt
+++ b/apps/android/feature/progress/src/main/java/com/flashcardsopensourceapp/feature/progress/sections/ProgressStreakLeaderboardSection.kt
@@ -1,0 +1,260 @@
+package com.flashcardsopensourceapp.feature.progress.sections
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.flashcardsopensourceapp.feature.progress.ProgressStreakLeaderboardRowUiState
+import com.flashcardsopensourceapp.feature.progress.ProgressStreakLeaderboardSectionUiState
+import com.flashcardsopensourceapp.feature.progress.R
+import java.text.NumberFormat
+import java.util.Locale
+
+@Composable
+internal fun StreakLeaderboardSectionCard(
+    uiState: ProgressStreakLeaderboardSectionUiState,
+    onOpenSignIn: () -> Unit,
+    onOpenLeaderboardSettings: () -> Unit
+) {
+    var isInfoDialogVisible by rememberSaveable { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(progressStreakLeaderboardSectionTag),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer
+        ),
+        shape = progressSectionShape
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(
+                    text = stringResource(id = R.string.progress_streak_leaderboard_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(
+                    onClick = { isInfoDialogVisible = true },
+                    modifier = Modifier.testTag(progressStreakLeaderboardInfoButtonTag)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Info,
+                        contentDescription = stringResource(
+                            id = R.string.progress_streak_leaderboard_info_button_content_description
+                        )
+                    )
+                }
+            }
+
+            when (uiState) {
+                ProgressStreakLeaderboardSectionUiState.Loading -> {
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 16.dp)
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                ProgressStreakLeaderboardSectionUiState.SignInRequired -> {
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressStreakLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
+                            message = stringResource(id = R.string.progress_streak_leaderboard_sign_in_message),
+                            buttonLabel = stringResource(id = R.string.progress_leaderboard_sign_in_button),
+                            onButtonClick = onOpenSignIn
+                        )
+                    }
+                }
+
+                ProgressStreakLeaderboardSectionUiState.ParticipationDisabled -> {
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressStreakLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
+                            message = stringResource(
+                                id = R.string.progress_streak_leaderboard_participation_disabled_message
+                            ),
+                            buttonLabel = stringResource(
+                                id = R.string.progress_leaderboard_participation_disabled_button
+                            ),
+                            onButtonClick = onOpenLeaderboardSettings
+                        )
+                    }
+                }
+
+                ProgressStreakLeaderboardSectionUiState.Offline -> {
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressStreakLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
+                            message = stringResource(id = R.string.progress_streak_leaderboard_offline_message),
+                            buttonLabel = null,
+                            onButtonClick = null
+                        )
+                    }
+                }
+
+                ProgressStreakLeaderboardSectionUiState.SnapshotUnavailable -> {
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressStreakLeaderboardResolvedContentTag
+                    ) {
+                        ProgressLeaderboardPlaceholder(
+                            message = stringResource(id = R.string.progress_streak_leaderboard_unavailable_message),
+                            buttonLabel = null,
+                            onButtonClick = null
+                        )
+                    }
+                }
+
+                is ProgressStreakLeaderboardSectionUiState.Ready -> {
+                    ProgressLeaderboardResolvedContent(
+                        testTag = progressStreakLeaderboardResolvedContentTag
+                    ) {
+                        ProgressStreakLeaderboardReadyContent(uiState = uiState)
+                    }
+                }
+            }
+        }
+    }
+
+    if (isInfoDialogVisible) {
+        val readyState = uiState as? ProgressStreakLeaderboardSectionUiState.Ready
+        val fallbackInfoBody = stringResource(id = R.string.progress_streak_leaderboard_info_fallback_body)
+        val infoBody = readyState?.metricDescription ?: fallbackInfoBody
+        val updatedText = readyState?.snapshotGeneratedAtMillis?.let { snapshotGeneratedAtMillis ->
+            stringResource(
+                id = R.string.progress_leaderboard_updated_label,
+                progressLeaderboardElapsedMinutes(
+                    snapshotGeneratedAtMillis = snapshotGeneratedAtMillis,
+                    nowMillis = System.currentTimeMillis()
+                )
+            )
+        }
+        AlertDialog(
+            onDismissRequest = { isInfoDialogVisible = false },
+            confirmButton = {
+                TextButton(onClick = { isInfoDialogVisible = false }) {
+                    Text(stringResource(id = R.string.progress_leaderboard_info_dismiss))
+                }
+            },
+            title = {
+                Text(stringResource(id = R.string.progress_streak_leaderboard_info_title))
+            },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(infoBody)
+                    if (updatedText != null) {
+                        Text(updatedText)
+                    }
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun ProgressStreakLeaderboardReadyContent(
+    uiState: ProgressStreakLeaderboardSectionUiState.Ready
+) {
+    val configuration = LocalConfiguration.current
+    val locale = if (configuration.locales.isEmpty) {
+        Locale.getDefault()
+    } else {
+        configuration.locales[0]
+    }
+    val countFormatter = remember(locale) {
+        NumberFormat.getIntegerInstance(locale)
+    }
+
+    if (uiState.rows.isEmpty()) {
+        Text(
+            text = stringResource(id = R.string.progress_streak_leaderboard_empty),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    } else {
+        Text(
+            text = pluralStringResource(
+                id = R.plurals.progress_leaderboard_participant_count,
+                count = uiState.participantCount,
+                countFormatter.format(uiState.participantCount.toLong())
+            ),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall
+        )
+
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            uiState.rows.forEachIndexed { index, row ->
+                when (row) {
+                    ProgressStreakLeaderboardRowUiState.Gap -> ProgressLeaderboardGapRow(
+                        contentDescription = stringResource(
+                            id = R.string.progress_leaderboard_gap_content_description
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(progressStreakLeaderboardGapRowTag(index = index))
+                    )
+                    is ProgressStreakLeaderboardRowUiState.Participant -> {
+                        val streakDaysLabel = pluralStringResource(
+                            id = R.plurals.progress_streak_leaderboard_day_count,
+                            count = row.streakDays,
+                            countFormatter.format(row.streakDays.toLong())
+                        )
+                        ProgressLeaderboardParticipantRow(
+                            rankLabel = countFormatter.format(row.rank.toLong()),
+                            displayName = if (row.isViewer) {
+                                stringResource(id = R.string.progress_leaderboard_you)
+                            } else {
+                                row.displayName
+                            },
+                            metricLabel = streakDaysLabel,
+                            isViewer = row.isViewer,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testTag(progressStreakLeaderboardParticipantRowTag(rank = row.rank))
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/apps/android/feature/progress/src/main/res/values/strings.xml
+++ b/apps/android/feature/progress/src/main/res/values/strings.xml
@@ -43,9 +43,9 @@
     <string name="progress_review_schedule_bucket_years_1_to_2">1-2 years</string>
     <string name="progress_review_schedule_bucket_later">Later</string>
     <string name="progress_review_schedule_bucket_value">%1$s (%2$s)</string>
-    <string name="progress_leaderboard_title">Leaderboard</string>
-    <string name="progress_leaderboard_info_button_content_description">About the leaderboard</string>
-    <string name="progress_leaderboard_info_title">How ranking works</string>
+    <string name="progress_leaderboard_title">Rating leaderboard</string>
+    <string name="progress_leaderboard_info_button_content_description">About the rating leaderboard</string>
+    <string name="progress_leaderboard_info_title">How rating ranking works</string>
     <string name="progress_leaderboard_info_fallback_body">Hard, Good, and Easy reviews count toward your rank. Again does not count.</string>
     <string name="progress_leaderboard_info_dismiss">OK</string>
     <string name="progress_leaderboard_window_last_24_hours">24h</string>
@@ -58,12 +58,21 @@
     <string name="progress_leaderboard_gap_content_description">Hidden ranks</string>
     <string name="progress_leaderboard_empty_window">No qualified reviews in this period yet.</string>
     <string name="progress_leaderboard_updated_label">Updated %1$d min ago</string>
-    <string name="progress_leaderboard_sign_in_message">Sign up or sign in to see how your reviews rank in the community.</string>
+    <string name="progress_leaderboard_sign_in_message">Sign up or sign in to see how your reviews rank on the rating leaderboard.</string>
     <string name="progress_leaderboard_sign_in_button">Sign in</string>
-    <string name="progress_leaderboard_participation_disabled_message">Rankings are visible only while you participate in the leaderboard. Turn participation on in leaderboard settings.</string>
+    <string name="progress_leaderboard_participation_disabled_message">Rating rankings are visible only while you participate in the rating leaderboard. Turn participation on in leaderboard settings.</string>
     <string name="progress_leaderboard_participation_disabled_button">Open leaderboard settings</string>
-    <string name="progress_leaderboard_offline_message">The leaderboard needs a connection. It will load when you are back online.</string>
-    <string name="progress_leaderboard_unavailable_message">The leaderboard is not ready yet. Check back soon.</string>
+    <string name="progress_leaderboard_offline_message">The rating leaderboard needs a connection. It will load when you are back online.</string>
+    <string name="progress_leaderboard_unavailable_message">The rating leaderboard is not ready yet. Check back soon.</string>
+    <string name="progress_streak_leaderboard_title">Streak leaderboard</string>
+    <string name="progress_streak_leaderboard_info_button_content_description">About the streak leaderboard</string>
+    <string name="progress_streak_leaderboard_info_title">How streak ranking works</string>
+    <string name="progress_streak_leaderboard_info_fallback_body">Ranks use current streak days from the public daily snapshot. Public values can trail your live personal streak.</string>
+    <string name="progress_streak_leaderboard_empty">No streak leaderboard rows yet.</string>
+    <string name="progress_streak_leaderboard_sign_in_message">Sign up or sign in to compare streaks with the community.</string>
+    <string name="progress_streak_leaderboard_participation_disabled_message">Streak rankings are visible only while you participate in the streak leaderboard. Turn participation on in leaderboard settings.</string>
+    <string name="progress_streak_leaderboard_offline_message">The streak leaderboard needs a connection. It will load when you are back online.</string>
+    <string name="progress_streak_leaderboard_unavailable_message">The streak leaderboard is not ready yet. Check back soon.</string>
     <string name="progress_today">Today</string>
     <plurals name="progress_streak_summary_content_description">
         <item quantity="one">Review streak %d day.</item>
@@ -80,5 +89,9 @@
     <plurals name="progress_leaderboard_participant_count">
         <item quantity="one">%1$s participant</item>
         <item quantity="other">%1$s participants</item>
+    </plurals>
+    <plurals name="progress_streak_leaderboard_day_count">
+        <item quantity="one">%1$s day</item>
+        <item quantity="other">%1$s days</item>
     </plurals>
 </resources>

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelStreakLeaderboardTest.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelStreakLeaderboardTest.kt
@@ -1,0 +1,101 @@
+package com.flashcardsopensourceapp.feature.progress
+
+import com.flashcardsopensourceapp.data.local.model.cloud.CloudAccountState
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProgressViewModelStreakLeaderboardTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Test
+    fun streakLeaderboardSnapshotMapsToReadyRows() = runTest(dispatcher) {
+        Dispatchers.setMain(dispatcher)
+        try {
+            val repository = FakeProgressRepository()
+            val viewModel = createProgressViewModelForTest(progressRepository = repository)
+
+            repository.emitSummarySnapshot(snapshot = createProgressSummarySnapshot())
+            repository.emitSeriesSnapshot(snapshot = createProgressSeriesSnapshot())
+            repository.emitStreakLeaderboardSnapshot(snapshot = createProgressStreakLeaderboardSnapshot())
+            advanceUntilIdle()
+
+            val uiState = viewModel.uiState.value as ProgressUiState.Loaded
+            val streakLeaderboardSection =
+                uiState.streakLeaderboardSection as ProgressStreakLeaderboardSectionUiState.Ready
+            assertEquals(3, streakLeaderboardSection.participantCount)
+            assertEquals(3, streakLeaderboardSection.rows.size)
+            assertTrue(checkNotNull(streakLeaderboardSection.metricDescription).contains("current streak days"))
+            assertEquals(1_776_520_805_000L, streakLeaderboardSection.snapshotGeneratedAtMillis)
+
+            val firstRow = streakLeaderboardSection.rows[0] as ProgressStreakLeaderboardRowUiState.Participant
+            assertEquals(1, firstRow.rank)
+            assertEquals("Streak Participant 1", firstRow.displayName)
+            assertEquals(30, firstRow.streakDays)
+            assertEquals(false, firstRow.isViewer)
+            val viewerRow = streakLeaderboardSection.rows[1] as ProgressStreakLeaderboardRowUiState.Participant
+            assertEquals(2, viewerRow.rank)
+            assertEquals(12, viewerRow.streakDays)
+            assertTrue(viewerRow.isViewer)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun streakLeaderboardUsesViewerOnlyRenderedRowsWhenServerRowsAreUnavailable() {
+        val sectionUiState = createProgressStreakLeaderboardSectionUiState(
+            snapshot = createProgressStreakLeaderboardSnapshot(
+                cloudState = CloudAccountState.LINKED,
+                leaderboard = null,
+                viewerCurrentStreakDays = 12,
+                didLastRemoteLoadFail = false
+            )
+        ) as ProgressStreakLeaderboardSectionUiState.Ready
+
+        assertEquals(1, sectionUiState.participantCount)
+        val viewerRow = sectionUiState.rows.single() as ProgressStreakLeaderboardRowUiState.Participant
+        assertEquals(1, viewerRow.rank)
+        assertEquals(12, viewerRow.streakDays)
+        assertTrue(viewerRow.isViewer)
+    }
+
+    @Test
+    fun guestStreakLeaderboardSnapshotMapsToSignInPlaceholder() {
+        val sectionUiState = createProgressStreakLeaderboardSectionUiState(
+            snapshot = createProgressStreakLeaderboardSnapshot(
+                cloudState = CloudAccountState.GUEST,
+                leaderboard = null,
+                viewerCurrentStreakDays = null,
+                didLastRemoteLoadFail = false
+            )
+        )
+
+        assertEquals(ProgressStreakLeaderboardSectionUiState.SignInRequired, sectionUiState)
+    }
+
+    @Test
+    fun participationDisabledStreakLeaderboardMapsToParticipationPlaceholder() {
+        val sectionUiState = createProgressStreakLeaderboardSectionUiState(
+            snapshot = createProgressStreakLeaderboardSnapshot(
+                cloudState = CloudAccountState.LINKED,
+                leaderboard = createCloudProgressStreakLeaderboardNonReady(
+                    status = ProgressLeaderboardStatus.PARTICIPATION_DISABLED
+                ),
+                viewerCurrentStreakDays = null,
+                didLastRemoteLoadFail = false
+            )
+        )
+
+        assertEquals(ProgressStreakLeaderboardSectionUiState.ParticipationDisabled, sectionUiState)
+    }
+}

--- a/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
+++ b/apps/android/feature/progress/src/test/java/com/flashcardsopensourceapp/feature/progress/ProgressViewModelTestSupport.kt
@@ -15,6 +15,11 @@ import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSeries
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDay
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakDayState
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakFreeze
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardMetric
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRankingRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardRow
+import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressStreakLeaderboardViewer
 import com.flashcardsopensourceapp.data.local.model.progress.CloudProgressSummary
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardParticipantRowKind
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressLeaderboardScopeKey
@@ -27,10 +32,12 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressReviewSched
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSeriesSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSource
+import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressStreakLeaderboardSnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummarySnapshot
 import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressLeaderboard
+import com.flashcardsopensourceapp.data.local.model.progress.createRenderedProgressStreakLeaderboard
 import com.flashcardsopensourceapp.data.local.repository.ProgressRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -95,6 +102,12 @@ internal class FakeProgressRepository : ProgressRepository {
         snapshot: ProgressLeaderboardSnapshot
     ) {
         leaderboardSnapshots.value = snapshot
+    }
+
+    fun emitStreakLeaderboardSnapshot(
+        snapshot: ProgressStreakLeaderboardSnapshot
+    ) {
+        streakLeaderboardSnapshots.value = snapshot
     }
 
     override fun observeSummarySnapshot(): Flow<ProgressSummarySnapshot?> {
@@ -447,6 +460,143 @@ internal fun createCloudProgressLeaderboardWindow(
         ),
         rows = createLeaderboardCompactRows(rankingRows = rankingRows),
         rankingRows = rankingRows
+    )
+}
+
+internal fun createProgressStreakLeaderboardSnapshot(): ProgressStreakLeaderboardSnapshot {
+    return createProgressStreakLeaderboardSnapshot(
+        cloudState = CloudAccountState.LINKED,
+        leaderboard = createCloudProgressStreakLeaderboard(),
+        viewerCurrentStreakDays = null,
+        didLastRemoteLoadFail = false
+    )
+}
+
+internal fun createProgressStreakLeaderboardSnapshot(
+    cloudState: CloudAccountState,
+    leaderboard: CloudProgressStreakLeaderboard?,
+    viewerCurrentStreakDays: Int?,
+    didLastRemoteLoadFail: Boolean
+): ProgressStreakLeaderboardSnapshot {
+    return ProgressStreakLeaderboardSnapshot(
+        scopeKey = ProgressStreakLeaderboardScopeKey(scopeId = "linked:user-1"),
+        cloudState = cloudState,
+        leaderboard = leaderboard,
+        renderedLeaderboard = createRenderedProgressStreakLeaderboard(
+            leaderboard = leaderboard,
+            viewerCurrentStreakDays = viewerCurrentStreakDays,
+            currentTimeMillis = 1_750_000_000_000L
+        ),
+        payloadUpdatedAtMillis = if (leaderboard == null) null else 1_750_000_000_000L,
+        viewerCurrentStreakDays = viewerCurrentStreakDays,
+        isRefreshDue = false,
+        didLastRemoteLoadFail = didLastRemoteLoadFail
+    )
+}
+
+internal fun createCloudProgressStreakLeaderboard(): CloudProgressStreakLeaderboard.Ready {
+    val rankingRows = listOf(
+        createCloudProgressStreakLeaderboardRankingRow(
+            kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+            rank = 1,
+            streakDays = 30
+        ),
+        createCloudProgressStreakLeaderboardRankingRow(
+            kind = CloudProgressLeaderboardRankingRowKind.VIEWER,
+            rank = 2,
+            streakDays = 12
+        ),
+        createCloudProgressStreakLeaderboardRankingRow(
+            kind = CloudProgressLeaderboardRankingRowKind.PARTICIPANT,
+            rank = 3,
+            streakDays = 8
+        )
+    )
+    val viewerRow = rankingRows.single { row ->
+        row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER
+    }
+
+    return CloudProgressStreakLeaderboard.Ready(
+        status = ProgressLeaderboardStatus.READY,
+        metric = CloudProgressStreakLeaderboardMetric(
+            metricVersion = "streak_days_v1",
+            title = "Current streak days",
+            description = "Ranks use current streak days from the public daily snapshot."
+        ),
+        snapshotId = "streak-snapshot-1",
+        snapshotGeneratedAt = "2026-04-18T14:00:05.000Z",
+        asOfUtcDate = "2026-04-18",
+        nextRefreshAfter = "2026-04-19T00:00:00.000Z",
+        participantCount = rankingRows.size,
+        viewer = CloudProgressStreakLeaderboardViewer(
+            publicProfileId = viewerRow.publicProfileId,
+            displayName = "You",
+            rank = viewerRow.rank,
+            streakDays = viewerRow.streakDays
+        ),
+        rows = rankingRows.map { row ->
+            createCloudProgressStreakLeaderboardParticipantRow(
+                kind = when {
+                    row.kind == CloudProgressLeaderboardRankingRowKind.VIEWER -> {
+                        ProgressLeaderboardParticipantRowKind.VIEWER
+                    }
+                    row.rank <= 3 -> ProgressLeaderboardParticipantRowKind.TOP
+                    else -> ProgressLeaderboardParticipantRowKind.NEIGHBOR
+                },
+                rankingRow = row
+            )
+        },
+        rankingRows = rankingRows
+    )
+}
+
+internal fun createCloudProgressStreakLeaderboardNonReady(
+    status: ProgressLeaderboardStatus
+): CloudProgressStreakLeaderboard.NonReady {
+    return CloudProgressStreakLeaderboard.NonReady(
+        status = status,
+        metric = CloudProgressStreakLeaderboardMetric(
+            metricVersion = "streak_days_v1",
+            title = "Current streak days",
+            description = "Ranks use current streak days from the public daily snapshot."
+        )
+    )
+}
+
+private fun createCloudProgressStreakLeaderboardRankingRow(
+    kind: CloudProgressLeaderboardRankingRowKind,
+    rank: Int,
+    streakDays: Int
+): CloudProgressStreakLeaderboardRankingRow {
+    return CloudProgressStreakLeaderboardRankingRow(
+        kind = kind,
+        publicProfileId = if (kind == CloudProgressLeaderboardRankingRowKind.VIEWER) {
+            "viewer-profile"
+        } else {
+            "streak-participant-$rank"
+        },
+        anonymousDisplayName = if (kind == CloudProgressLeaderboardRankingRowKind.VIEWER) {
+            "Misty Quiet Grove"
+        } else {
+            "Streak Participant $rank"
+        },
+        friendDisplayName = null,
+        streakDays = streakDays,
+        rank = rank
+    )
+}
+
+private fun createCloudProgressStreakLeaderboardParticipantRow(
+    kind: ProgressLeaderboardParticipantRowKind,
+    rankingRow: CloudProgressStreakLeaderboardRankingRow
+): CloudProgressStreakLeaderboardRow.Participant {
+    return CloudProgressStreakLeaderboardRow.Participant(
+        kind = kind,
+        publicProfileId = rankingRow.publicProfileId,
+        anonymousDisplayName = rankingRow.anonymousDisplayName,
+        friendDisplayName = rankingRow.friendDisplayName,
+        streakDays = rankingRow.streakDays,
+        rank = rankingRow.rank
     )
 }
 


### PR DESCRIPTION
## Summary
- Add Android Progress streak leaderboard UI state and ViewModel mapping.
- Render a Material 3 streak leaderboard card below the rating leaderboard.
- Add streak leaderboard strings, tags, and focused ViewModel tests.

## Validation
- git --no-pager diff --check
- trailing-whitespace rg check on new files
- Gradle tests not run because ./gradlew requires explicit approval for this task.