### PR TITLE
Fix Android AI HTTP observability event wiring

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteService.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/ai/remote/AiChatRemoteService.kt
@@ -925,7 +925,6 @@ private fun captureAiChatHttpFailureObservation(
                 requestId = requestId,
                 statusCode = statusCode,
                 code = code,
-                stage = stage,
                 appVersion = observationVersions.appVersion,
                 clientVersion = observationVersions.clientVersion,
                 versionCode = observationVersions.versionCode
@@ -943,6 +942,7 @@ private fun captureAiChatHttpFailureObservation(
                 requestId = requestId,
                 statusCode = statusCode,
                 code = code,
+                stage = stage,
                 appVersion = observationVersions.appVersion,
                 clientVersion = observationVersions.clientVersion,
                 versionCode = observationVersions.versionCode


### PR DESCRIPTION
Fixes the Android Release Kotlin compile failure by matching AI HTTP failure observation calls to the current observability event constructors.