### PR TITLE
Fix Android cloud sign-in test exceptions

### DIFF
--- a/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
+++ b/apps/android/feature/settings/src/test/java/com/flashcardsopensourceapp/feature/settings/CloudSignInViewModelTest.kt
@@ -841,7 +841,8 @@ class CloudSignInViewModelTest {
                 responseBody = "not found",
                 errorCode = null,
                 requestId = "req-404",
-                syncConflict = null
+                syncConflict = null,
+                androidObservationAlreadyCaptured = false
             )
         )
         val viewModel = CloudSignInViewModel(
@@ -931,7 +932,8 @@ class CloudSignInViewModelTest {
                 responseBody = "{\"error\":\"bad request\"}",
                 errorCode = "OTP_VERIFY_FAILED",
                 requestId = "req-verify",
-                syncConflict = null
+                syncConflict = null,
+                androidObservationAlreadyCaptured = false
             )
         )
         val viewModel = CloudSignInViewModel(


### PR DESCRIPTION
Adds the explicit androidObservationAlreadyCaptured argument to CloudRemoteException test fixtures so Android unit test compilation matches the current constructor.