### PR TITLE
Fix Android dictation technical alert test

### DIFF
--- a/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/dictation/AiChatRuntimeDictationSessionTest.kt
+++ b/apps/android/feature/ai/src/test/java/com/flashcardsopensourceapp/feature/ai/runtime/dictation/AiChatRuntimeDictationSessionTest.kt
@@ -303,6 +303,7 @@ class AiChatRuntimeDictationSessionTest {
         assertEquals(AiChatDictationState.IDLE, runtime.state.value.dictationState)
         assertEquals("", runtime.state.value.draftMessage)
         val alert = runtime.state.value.activeAlert as AiAlertState.GeneralError
-        assertTrue(alert.message.contains("mismatched sessionId"))
+        assertEquals("AI request failed.", alert.message)
+        assertTrue(checkNotNull(alert.technicalError).message.orEmpty().contains("mismatched sessionId"))
     }
 }


### PR DESCRIPTION
Updates the dictation session mismatch test for the current technical-error alert contract: user-visible message stays safe and the raw mismatch remains attached as the technical error.