### PR TITLE
[codex] Fix iOS technical error presentation call

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
+++ b/apps/ios/Flashcards/Flashcards/Store/FlashcardsStore.swift
@@ -559,7 +559,7 @@ final class FlashcardsStore {
         }
 
         let presentationError = technicalErrorPresentationSource(error: error)
-        let presentation: TechnicalErrorPresentation = makeTechnicalErrorPresentation(error: presentationError)
+        let presentation: TechnicalErrorPresentation = Flashcards.makeTechnicalErrorPresentation(error: presentationError)
         if isTechnicalErrorObserved(error: error) == false {
             self.captureTechnicalErrorForVisiblePresentation(error: presentationError)
         }


### PR DESCRIPTION
## Summary
- Qualify the technical error presentation helper call with the Flashcards module.
- Fix the Swift name-resolution conflict reported by Xcode Cloud archive.

## Validation
- Inspected the staged diff.
- Attempted local xcodebuild Release validation, but local Xcode could not configure the iOS scheme because it reported the required iOS 26.5 device platform was unavailable before Swift compilation.