### PR TITLE
Fix Android technical error string lint

### DIFF
--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/CloudCredentialRecoveryGateContainer.kt
@@ -40,6 +40,12 @@ internal fun CloudCredentialRecoveryGateContainer(
     val eraseFailedMessage: String = stringResource(
         SettingsR.string.settings_cloud_recovery_gate_erase_failed
     )
+    val technicalErrorDialogTitle: String = stringResource(
+        R.string.technical_error_dialog_default_title
+    )
+    val technicalErrorDialogMessage: String = stringResource(
+        R.string.technical_error_dialog_default_message
+    )
     val signInViewModel: CloudSignInViewModel = viewModel(
         viewModelStoreOwner = appGraph.cloudCredentialRecoveryGateViewModelStoreOwner,
         key = "cloud_credential_recovery_sign_in",
@@ -152,8 +158,8 @@ internal fun CloudCredentialRecoveryGateContainer(
         onShowTechnicalDetails = { technicalDetails, reportId ->
             appGraph.showTechnicalErrorDialog(
                 reportId = reportId,
-                title = context.getString(R.string.technical_error_dialog_default_title),
-                message = context.getString(R.string.technical_error_dialog_default_message),
+                title = technicalErrorDialogTitle,
+                message = technicalErrorDialogMessage,
                 technicalDetails = technicalDetails
             )
         },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/FlashcardsApp.kt
@@ -119,6 +119,8 @@ fun FlashcardsApp(
             .activePreviewTechnicalError
             .collectAsStateWithLifecycle()
         val displayedTechnicalError: AppTechnicalError? = activeTechnicalError ?: activeTechnicalErrorPreview
+        val technicalErrorDialogTitle = stringResource(id = R.string.technical_error_dialog_default_title)
+        val technicalErrorDialogMessage = stringResource(id = R.string.technical_error_dialog_default_message)
         val dismissDisplayedTechnicalError: () -> Unit = {
             if (activeTechnicalError != null) {
                 appGraph.appMessageBus.dismissTechnicalError()
@@ -134,14 +136,13 @@ fun FlashcardsApp(
             }
 
             is AppStartupState.Failed -> {
-                val context = LocalContext.current
                 Box(modifier = Modifier.fillMaxSize()) {
                     StartupErrorScreen(
                         technicalDetails = currentStartupState.technicalDetails,
                         onShowTechnicalDetails = { technicalDetails ->
                             appGraph.showReportedTechnicalErrorDialog(
-                                title = context.getString(R.string.technical_error_dialog_default_title),
-                                message = context.getString(R.string.technical_error_dialog_default_message),
+                                title = technicalErrorDialogTitle,
+                                message = technicalErrorDialogMessage,
                                 technicalDetails = technicalDetails
                             )
                         },
@@ -591,8 +592,8 @@ fun FlashcardsApp(
                     onShowTechnicalDetails = { technicalDetails, reportId ->
                         appGraph.showTechnicalErrorDialog(
                             reportId = reportId,
-                            title = applicationContext.getString(R.string.technical_error_dialog_default_title),
-                            message = applicationContext.getString(R.string.technical_error_dialog_default_message),
+                            title = technicalErrorDialogTitle,
+                            message = technicalErrorDialogMessage,
                             technicalDetails = technicalDetails
                         )
                     },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountAuthNavGraph.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
@@ -37,6 +38,8 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
     ) {
         composable(route = SettingsAccountSignInEmailDestination.route) { backStackEntry ->
             val context = LocalContext.current
+            val technicalErrorDialogTitle = stringResource(id = R.string.technical_error_dialog_default_title)
+            val technicalErrorDialogMessage = stringResource(id = R.string.technical_error_dialog_default_message)
             val authGraphBackStackEntry = settingsAccountAuthBackStackEntry(
                 navController = navController,
                 currentBackStackEntry = backStackEntry
@@ -77,8 +80,8 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                 onShowTechnicalDetails = { technicalDetails, reportId ->
                     appGraph.showTechnicalErrorDialog(
                         reportId = reportId,
-                        title = context.getString(R.string.technical_error_dialog_default_title),
-                        message = context.getString(R.string.technical_error_dialog_default_message),
+                        title = technicalErrorDialogTitle,
+                        message = technicalErrorDialogMessage,
                         technicalDetails = technicalDetails
                     )
                 },
@@ -90,6 +93,8 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
 
         composable(route = SettingsAccountSignInCodeDestination.route) { backStackEntry ->
             val context = LocalContext.current
+            val technicalErrorDialogTitle = stringResource(id = R.string.technical_error_dialog_default_title)
+            val technicalErrorDialogMessage = stringResource(id = R.string.technical_error_dialog_default_message)
             val authGraphBackStackEntry = settingsAccountAuthBackStackEntry(
                 navController = navController,
                 currentBackStackEntry = backStackEntry
@@ -121,8 +126,8 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                 onShowTechnicalDetails = { technicalDetails, reportId ->
                     appGraph.showTechnicalErrorDialog(
                         reportId = reportId,
-                        title = context.getString(R.string.technical_error_dialog_default_title),
-                        message = context.getString(R.string.technical_error_dialog_default_message),
+                        title = technicalErrorDialogTitle,
+                        message = technicalErrorDialogMessage,
                         technicalDetails = technicalDetails
                     )
                 },
@@ -134,6 +139,8 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
 
         composable(route = SettingsAccountPostAuthDestination.route) { backStackEntry ->
             val context = LocalContext.current
+            val technicalErrorDialogTitle = stringResource(id = R.string.technical_error_dialog_default_title)
+            val technicalErrorDialogMessage = stringResource(id = R.string.technical_error_dialog_default_message)
             val authGraphBackStackEntry = settingsAccountAuthBackStackEntry(
                 navController = navController,
                 currentBackStackEntry = backStackEntry
@@ -186,8 +193,8 @@ internal fun NavGraphBuilder.registerSettingsAccountAuthNavGraph(
                 onShowTechnicalDetails = { technicalDetails, reportId ->
                     appGraph.showTechnicalErrorDialog(
                         reportId = reportId,
-                        title = context.getString(R.string.technical_error_dialog_default_title),
-                        message = context.getString(R.string.technical_error_dialog_default_message),
+                        title = technicalErrorDialogTitle,
+                        message = technicalErrorDialogMessage,
                         technicalDetails = technicalDetails
                     )
                 },

--- a/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
+++ b/apps/android/app/src/main/java/com/flashcardsopensourceapp/app/navigation/settings/SettingsAccountNavGraph.kt
@@ -2,6 +2,7 @@ package com.flashcardsopensourceapp.app.navigation.settings
 
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraphBuilder
@@ -155,6 +156,8 @@ internal fun NavGraphBuilder.registerSettingsAccountNavGraph(
 
     composable(route = SettingsAccountDangerZoneDestination.route) {
         val context = LocalContext.current
+        val technicalErrorDialogTitle = stringResource(id = R.string.technical_error_dialog_default_title)
+        val technicalErrorDialogMessage = stringResource(id = R.string.technical_error_dialog_default_message)
         val accountDangerZoneViewModel = viewModel<com.flashcardsopensourceapp.feature.settings.account.AccountDangerZoneViewModel>(
             factory = createAccountDangerZoneViewModelFactory(
                 cloudAccountRepository = appGraph.cloudAccountRepository,
@@ -176,8 +179,8 @@ internal fun NavGraphBuilder.registerSettingsAccountNavGraph(
             onShowTechnicalDetails = { technicalDetails, reportId ->
                 appGraph.showTechnicalErrorDialog(
                     reportId = reportId,
-                    title = context.getString(R.string.technical_error_dialog_default_title),
-                    message = context.getString(R.string.technical_error_dialog_default_message),
+                    title = technicalErrorDialogTitle,
+                    message = technicalErrorDialogMessage,
                     technicalDetails = technicalDetails
                 )
             },


### PR DESCRIPTION
## Summary
- read technical error dialog title/message with Compose stringResource
- stop querying localized resource strings through Context in composable callbacks

## Validation
- git --no-pager diff --check
- GitHub Android Release will validate after merge