### PR TITLE
[codex] Fix iOS notification sendability

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -426,9 +426,9 @@ extension FlashcardsStore {
         let center = UNUserNotificationCenter.current()
         let pendingRequestIdentifiers = await pendingReviewNotificationRequestIdentifiers(center: center)
         if trigger.shouldClearDeliveredReviewNotifications {
-            let deliveredReviewNotifications = await deliveredReviewReminderNotifications(center: center)
-            self.markReviewReminderAttentionFromDeliveredNotifications(
-                notifications: deliveredReviewNotifications,
+            let deliveredReviewReminderStates = await deliveredReviewReminderAttentionStates(center: center)
+            self.markReviewReminderAttentionFromDeliveredStates(
+                states: deliveredReviewReminderStates,
                 workspaceId: workspaceId
             )
             self.reconcileReviewReminderAttentionAfterReviewLogs(now: now)
@@ -680,15 +680,10 @@ extension FlashcardsStore {
         self.persistScheduledReviewNotifications(payloads: acceptedPayloads)
     }
 
-    private func markReviewReminderAttentionFromDeliveredNotifications(
-        notifications: [UNNotification],
+    private func markReviewReminderAttentionFromDeliveredStates(
+        states: [ReviewReminderAttentionState],
         workspaceId: String
     ) {
-        let states = notifications.compactMap { notification in
-            makeReviewReminderAttentionState(
-                notification: notification
-            )
-        }
         let currentWorkspaceStates = states.filter { state in
             state.workspaceId == workspaceId
         }

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationDiagnosticsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationDiagnosticsSupport.swift
@@ -138,15 +138,14 @@ func deliveredReviewNotificationRequestIdentifiers(
     }
 }
 
-func deliveredReviewReminderNotifications(
+func deliveredReviewReminderAttentionStates(
     center: UNUserNotificationCenter
-) async -> [UNNotification] {
+) async -> [ReviewReminderAttentionState] {
     await withCheckedContinuation { continuation in
         center.getDeliveredNotifications { notifications in
             continuation.resume(
-                returning: notifications.filter { notification in
-                    isReviewNotificationRequestIdentifier(identifier: notification.request.identifier)
-                        && parseAppNotificationTapRequest(userInfo: notification.request.content.userInfo) == .openReviewReminder
+                returning: notifications.compactMap { notification in
+                    makeReviewReminderAttentionState(notification: notification)
                 }
             )
         }


### PR DESCRIPTION
## Summary
- Convert delivered review reminder notifications to sendable attention states inside the Notification Center callback.
- Update the store reschedule path to consume `ReviewReminderAttentionState` values instead of `[UNNotification]`.

## Root cause
Xcode Cloud strict concurrency rejected returning `[UNNotification]` from an async continuation because `UNNotification` is not `Sendable`.

## Validation
- `git --no-pager diff --check`
- Attempted local `xcodebuild` Release validation, but local Xcode could not configure the iOS scheme because it reported the required iOS 26.5 device platform was unavailable before Swift compilation.