### PR TITLE
[codex] Reorder iOS review filters

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/View/ReviewView.swift
@@ -347,28 +347,7 @@ struct ReviewView: View {
 
             Divider()
 
-            Picker(
-                "",
-                selection: Binding(
-                    get: {
-                        store.selectedReviewFilter
-                    },
-                    set: { nextReviewFilter in
-                        store.selectReviewFilter(reviewFilter: nextReviewFilter)
-                    }
-                )
-            ) {
-                ForEach(EffortLevel.allCases) { level in
-                    let reviewFilter = ReviewFilter.effort(level: level)
-
-                    Text(reviewFilterMenuItemLabel(reviewFilter: reviewFilter))
-                        .tag(reviewFilter)
-                }
-            }
-
             if reviewTagSummaries.isEmpty == false {
-                Divider()
-
                 Picker(
                     "",
                     selection: Binding(
@@ -386,6 +365,27 @@ struct ReviewView: View {
                         Text(reviewFilterMenuItemLabel(reviewFilter: reviewFilter))
                             .tag(reviewFilter)
                     }
+                }
+
+                Divider()
+            }
+
+            Picker(
+                "",
+                selection: Binding(
+                    get: {
+                        store.selectedReviewFilter
+                    },
+                    set: { nextReviewFilter in
+                        store.selectReviewFilter(reviewFilter: nextReviewFilter)
+                    }
+                )
+            ) {
+                ForEach(EffortLevel.allCases) { level in
+                    let reviewFilter = ReviewFilter.effort(level: level)
+
+                    Text(reviewFilterMenuItemLabel(reviewFilter: reviewFilter))
+                        .tag(reviewFilter)
                 }
             }
         } label: {


### PR DESCRIPTION
## Summary
- Move the iOS review effort filter picker below the optional tag picker in the Review scope menu.
- Preserve the native SwiftUI Menu and grouped Picker structure.
- Keep the all-cards/deck picker and Edit decks action at the top.

## Validation
- git --no-pager diff --check
- Worker-owned review subagent found no P0-P4 issues.

## Notes
- iOS simulator-backed validation was not run because it was not explicitly allowed.