### PR TITLE
[codex] Move Android effort filters below tags

### DIFF
--- a/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
+++ b/apps/android/feature/review/src/main/java/com/flashcardsopensourceapp/feature/review/components/ReviewFilterSheet.kt
@@ -95,33 +95,6 @@ internal fun ReviewFilterSheet(
                 }
             }
 
-            item {
-                Text(
-                    text = stringResource(id = R.string.review_effort_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
-                )
-            }
-
-            items(availableEffortFilters.size) { index ->
-                val effortFilter = availableEffortFilters[index]
-                ReviewFilterOptionRow(
-                    title = stringResource(
-                        id = R.string.review_filter_title_with_count,
-                        bidiWrap(
-                            text = reviewEffortLabel(effortLevel = effortFilter.effortLevel),
-                            locale = locale
-                        ),
-                        effortFilter.totalCount
-                    ),
-                    subtitle = stringResource(id = R.string.review_virtual_effort_filter_subtitle),
-                    selected = selectedFilter == ReviewFilter.Effort(effortLevel = effortFilter.effortLevel),
-                    onClick = {
-                        onSelectFilter(ReviewFilter.Effort(effortLevel = effortFilter.effortLevel))
-                    }
-                )
-            }
-
             if (availableTagFilters.isNotEmpty()) {
                 item {
                     Text(
@@ -149,6 +122,33 @@ internal fun ReviewFilterSheet(
                         }
                     )
                 }
+            }
+
+            item {
+                Text(
+                    text = stringResource(id = R.string.review_effort_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+                )
+            }
+
+            items(availableEffortFilters.size) { index ->
+                val effortFilter = availableEffortFilters[index]
+                ReviewFilterOptionRow(
+                    title = stringResource(
+                        id = R.string.review_filter_title_with_count,
+                        bidiWrap(
+                            text = reviewEffortLabel(effortLevel = effortFilter.effortLevel),
+                            locale = locale
+                        ),
+                        effortFilter.totalCount
+                    ),
+                    subtitle = stringResource(id = R.string.review_virtual_effort_filter_subtitle),
+                    selected = selectedFilter == ReviewFilter.Effort(effortLevel = effortFilter.effortLevel),
+                    onClick = {
+                        onSelectFilter(ReviewFilter.Effort(effortLevel = effortFilter.effortLevel))
+                    }
+                )
             }
 
             item {


### PR DESCRIPTION
## Summary
- Move Android review effort filters below the optional tags section in the Material 3 filter sheet.
- Preserve the existing filter rows, labels, bidi wrapping, selection behavior, divider, and manage decks action.

## Validation
- Freshness check passed before editing: git fetch origin main, git merge-base --is-ancestor origin/main HEAD, clean status.
- git --no-pager diff --check passed before commit.
- git --no-pager diff --check HEAD~1 HEAD passed after commit.
- Worker-owned review subagent found no P0-P4 issues and gave green light.
- Gradle was not run because explicit approval was not granted.