### PR TITLE
Suppress transient Android progress warnings

### DIFF
--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressReviewScheduleOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressReviewScheduleOrchestration.kt
@@ -20,6 +20,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.Progre
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressSyncBeforeRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressReviewScheduleRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.supportsServerRefresh
@@ -270,7 +271,7 @@ internal class ProgressReviewScheduleOrchestration(
             ) {
                 return
             }
-            logProgressRefreshWarning(
+            logProgressRemoteLoadFailure(
                 observability = observability,
                 observationVersions = observationVersions,
                 event = "progress_review_schedule_remote_load_failed",

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSeriesOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSeriesOrchestration.kt
@@ -21,7 +21,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.Progre
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRefreshReason
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressRemoteRefreshSyncMode
-import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressSyncBeforeRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSeriesRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.supportsServerRefresh
@@ -287,7 +287,7 @@ internal class ProgressSeriesOrchestration(
             ) {
                 return
             }
-            logProgressRefreshWarning(
+            logProgressRemoteLoadFailure(
                 observability = observability,
                 observationVersions = observationVersions,
                 event = "progress_series_remote_load_failed",

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSummaryOrchestration.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/orchestration/ProgressSummaryOrchestration.kt
@@ -22,7 +22,7 @@ import com.flashcardsopensourceapp.data.local.repository.progress.runtime.Progre
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRefreshReason
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.ProgressRemoteRefreshSyncMode
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.createProgressRemoteRefreshSyncMode
-import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRefreshWarning
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.logProgressSyncBeforeRemoteLoadFailure
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSummaryRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.supportsServerRefresh
@@ -286,7 +286,7 @@ internal class ProgressSummaryOrchestration(
             ) {
                 return
             }
-            logProgressRefreshWarning(
+            logProgressRemoteLoadFailure(
                 observability = observability,
                 observationVersions = observationVersions,
                 event = "progress_summary_remote_load_failed",

--- a/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
+++ b/apps/android/data/local/src/main/java/com/flashcardsopensourceapp/data/local/repository/progress/runtime/ProgressRepositoryRuntime.kt
@@ -125,7 +125,7 @@ internal fun logProgressSyncBeforeRemoteLoadFailure(
     fields: List<Pair<String, String?>>,
     error: Throwable
 ): Unit {
-    if (isExpectedTransientProgressSyncBeforeRemoteLoadError(error = error)) {
+    if (isExpectedTransientProgressRefreshError(error = error)) {
         logProgressRepositoryWarning(
             event = event,
             fields = fields + listOf(
@@ -148,7 +148,39 @@ internal fun logProgressSyncBeforeRemoteLoadFailure(
     )
 }
 
-internal fun isExpectedTransientProgressSyncBeforeRemoteLoadError(error: Throwable): Boolean {
+internal fun logProgressRemoteLoadFailure(
+    observability: AppObservability,
+    observationVersions: ProgressObservationVersions,
+    event: String,
+    scopeId: String,
+    source: String,
+    fields: List<Pair<String, String?>>,
+    error: Throwable
+): Unit {
+    if (isExpectedTransientProgressRefreshError(error = error)) {
+        logProgressRepositoryWarning(
+            event = event,
+            fields = fields + listOf(
+                "sentryWarningSuppressed" to "true",
+                "suppressionReason" to "transient_remote_load_failure"
+            ),
+            error = error
+        )
+        return
+    }
+
+    logProgressRefreshWarning(
+        observability = observability,
+        observationVersions = observationVersions,
+        event = event,
+        scopeId = scopeId,
+        source = source,
+        fields = fields,
+        error = error
+    )
+}
+
+internal fun isExpectedTransientProgressRefreshError(error: Throwable): Boolean {
     var currentError: Throwable? = error
     while (currentError != null) {
         if (

--- a/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
+++ b/apps/android/data/local/src/test/java/com/flashcardsopensourceapp/data/local/repository/progress/ProgressRemoteLoadWarningSuppressionTest.kt
@@ -10,7 +10,7 @@ import com.flashcardsopensourceapp.data.local.model.progress.ProgressSnapshotSou
 import com.flashcardsopensourceapp.data.local.model.progress.ProgressSummaryScopeKey
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatus
 import com.flashcardsopensourceapp.data.local.model.sync.SyncStatusSnapshot
-import com.flashcardsopensourceapp.data.local.repository.progress.runtime.isExpectedTransientProgressSyncBeforeRemoteLoadError
+import com.flashcardsopensourceapp.data.local.repository.progress.runtime.isExpectedTransientProgressRefreshError
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressReviewScheduleRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSeriesRemoteLoadWarning
 import com.flashcardsopensourceapp.data.local.repository.progress.runtime.shouldSuppressProgressSummaryRemoteLoadWarning
@@ -24,9 +24,9 @@ import org.junit.Test
 
 class ProgressRemoteLoadWarningSuppressionTest {
     @Test
-    fun syncBeforeRemoteLoadWarningIsSuppressedOnlyForExpectedTransientFailures(): Unit {
+    fun progressRefreshWarningIsSuppressedOnlyForExpectedTransientFailures(): Unit {
         assertTrue(
-            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+            isExpectedTransientProgressRefreshError(
                 error = CloudRemoteException(
                     message = "Gateway timeout",
                     statusCode = 504,
@@ -39,7 +39,7 @@ class ProgressRemoteLoadWarningSuppressionTest {
             )
         )
         assertTrue(
-            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+            isExpectedTransientProgressRefreshError(
                 error = IllegalStateException(
                     "Wrapped network error",
                     UnknownHostException("Unable to resolve host")
@@ -47,7 +47,7 @@ class ProgressRemoteLoadWarningSuppressionTest {
             )
         )
         assertFalse(
-            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+            isExpectedTransientProgressRefreshError(
                 error = CloudRemoteException(
                     message = "Invalid sync request",
                     statusCode = 400,
@@ -60,7 +60,7 @@ class ProgressRemoteLoadWarningSuppressionTest {
             )
         )
         assertFalse(
-            isExpectedTransientProgressSyncBeforeRemoteLoadError(
+            isExpectedTransientProgressRefreshError(
                 error = IllegalStateException("Progress sync invariant failed.")
             )
         )


### PR DESCRIPTION
## Summary
- suppress Sentry progress refresh warnings for expected transient remote-load failures
- reuse the shared progress transient classifier for sync-before-remote-load and remote-load paths
- keep local ProgressRepository warning logs and preserve non-transient Sentry warnings

## Validation
- git --no-pager diff --check
- review-kirill: no P0-P4 findings
- Gradle not run per repo policy / no explicit local Gradle approval