### PR TITLE
Move iOS cloud retry telemetry to breadcrumbs

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Guest/GuestCloudAuthService.swift
@@ -114,9 +114,9 @@ final class GuestCloudAuthService {
                 lastError = error
 
                 if attempt < guestSessionDeleteMaxAttempts {
-                    FlashcardsObservability.captureWarning(
+                    FlashcardsObservability.addBreadcrumb(
                         .cloudRetry(
-                            CloudRetryWarning(
+                            CloudRetryObservation(
                                 action: "guest_session_delete_retry",
                                 scope: IOSObservationScope(
                                     feature: .cloudAuth,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Session/CloudSessionRuntime.swift
@@ -463,9 +463,9 @@ final class CloudSessionRuntime {
                     self.clearActiveCloudSyncTaskIfCurrent(id: activeCloudSyncTask.id)
                     continue
                 }
-                FlashcardsObservability.captureWarning(
+                FlashcardsObservability.addBreadcrumb(
                     .cloudRetry(
-                        CloudRetryWarning(
+                        CloudRetryObservation(
                             action: "active_sync_settled_before_fresh_sync",
                             scope: IOSObservationScope(
                                 feature: .cloudSync,

--- a/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
+++ b/apps/ios/Flashcards/Flashcards/Cloud/Sync/CloudSyncTransport.swift
@@ -225,9 +225,9 @@ struct CloudSyncTransport {
                     throw error
                 }
 
-                FlashcardsObservability.captureWarning(
+                FlashcardsObservability.addBreadcrumb(
                     .cloudRetry(
-                        CloudRetryWarning(
+                        CloudRetryObservation(
                             action: "cloud_sync_transport_retry",
                             scope: IOSObservationScope(
                                 feature: cloudObservationFeature(phase: phase),

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -40,6 +40,7 @@ struct IOSObservationScope: Sendable, Hashable {
 
 enum IOSBreadcrumbEvent: Sendable {
     case cloudFlow(CloudFlowObservation)
+    case cloudRetry(CloudRetryObservation)
     case aiChatLifecycle(AIChatLifecycleObservation)
     case aiLiveLifecycle(AILiveLifecycleObservation)
     case notificationTap(NotificationTapObservation)
@@ -50,7 +51,6 @@ enum IOSWarningEvent: Sendable {
     case aiLiveUnknownEvent(AILiveUnknownEventWarning)
     case aiLiveLifecycle(AILiveLifecycleObservation)
     case cloudFlow(CloudFlowObservation)
-    case cloudRetry(CloudRetryWarning)
     case localDataRepair(LocalDataRepairWarning)
     case invalidCardDueAt(InvalidCardDueAtWarning)
     case notificationSchedulingFailed(NotificationSchedulingFailureWarning)
@@ -278,7 +278,7 @@ struct NotificationSchedulingFailureWarning: Sendable, Hashable {
     let diagnostics: NotificationSchedulingDiagnostics
 }
 
-struct CloudRetryWarning: Sendable, Hashable {
+struct CloudRetryObservation: Sendable, Hashable {
     let action: String
     let scope: IOSObservationScope
     let attempt: Int

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -44,6 +44,19 @@ extension SentryObservabilityAdapter {
                 message: "\(observation.phase.rawValue).\(observation.outcome.rawValue)",
                 data: self.cloudFlowContext(observation)
             )
+        case .cloudRetry(let observation):
+            self.writeLocalRecord(
+                kind: "breadcrumb",
+                feature: observation.scope.feature,
+                action: observation.action,
+                fields: self.cloudRetryFields(observation)
+            )
+            self.addSentryBreadcrumb(
+                category: "ios.cloud",
+                level: .info,
+                message: observation.action,
+                data: self.cloudRetryContext(observation)
+            )
         case .aiChatLifecycle(let observation):
             self.writeLocalRecord(
                 kind: "breadcrumb",
@@ -211,22 +224,6 @@ extension SentryObservabilityAdapter {
                 backendCode: observation.backendCode,
                 context: self.cloudFlowContext(observation),
                 localFields: self.cloudFlowFields(observation)
-            )
-        case .cloudRetry(let warning):
-            let context: [String: Any] = [
-                "attempt": warning.attempt,
-                "max_attempts": warning.maxAttempts,
-                "api_base_url": warning.apiBaseUrl ?? "",
-                "message_summary": warning.messageSummary ?? ""
-            ]
-            return ObservationPayload(
-                message: "iOS cloud retry: \(warning.action)",
-                action: warning.action,
-                scope: warning.scope,
-                statusCode: nil,
-                backendCode: nil,
-                context: context,
-                localFields: stringifyContext(context)
             )
         case .localDataRepair(let warning):
             let context: [String: Any] = [
@@ -597,6 +594,19 @@ extension SentryObservabilityAdapter {
 
     private static func cloudFlowFields(_ observation: CloudFlowObservation) -> [String: String] {
         stringifyContext(self.cloudFlowContext(observation))
+    }
+
+    private static func cloudRetryContext(_ observation: CloudRetryObservation) -> [String: Any] {
+        [
+            "attempt": observation.attempt,
+            "max_attempts": observation.maxAttempts,
+            "api_base_url": observation.apiBaseUrl ?? "",
+            "message_summary": observation.messageSummary ?? ""
+        ]
+    }
+
+    private static func cloudRetryFields(_ observation: CloudRetryObservation) -> [String: String] {
+        stringifyContext(self.cloudRetryContext(observation))
     }
 
     private static func aiChatLifecycleContext(_ observation: AIChatLifecycleObservation) -> [String: Any] {

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Support/LinkedSyncRunnerTestTransportSupport.swift
@@ -881,6 +881,7 @@ enum LinkedSyncRunnerTestTransportSupport {
 
 final class CloudSyncRunnerTestURLProtocol: URLProtocol, @unchecked Sendable {
     nonisolated(unsafe) static var requestHandler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requestCount: Int = 0
     nonisolated(unsafe) static var bootstrapPushCardIds: [String] = []
     nonisolated(unsafe) static var bootstrapPushEntryCounts: [Int] = []
     nonisolated(unsafe) static var pushEntityIds: [String] = []
@@ -919,6 +920,7 @@ final class CloudSyncRunnerTestURLProtocol: URLProtocol, @unchecked Sendable {
 
     static func reset() {
         self.requestHandler = nil
+        self.requestCount = 0
         self.bootstrapPushCardIds = []
         self.bootstrapPushEntryCounts = []
         self.pushEntityIds = []

--- a/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
+++ b/apps/ios/Flashcards/FlashcardsTests/Cloud/Sync/LinkedSync/LinkedSyncBootstrapAndRetryTests.swift
@@ -65,6 +65,67 @@ final class LinkedSyncBootstrapAndRetryTests: LocalWorkspaceSyncTestCase {
         }
     }
 
+    func testCloudSyncTransportRetriesRetryableNetworkFailure() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CloudSyncRunnerTestURLProtocol.self]
+        let transport = CloudSyncTransport(
+            session: URLSession(configuration: configuration),
+            decoder: makeFlashcardsRemoteJSONDecoder()
+        )
+        CloudSyncRunnerTestURLProtocol.requestHandler = { request in
+            CloudSyncRunnerTestURLProtocol.requestCount += 1
+            if CloudSyncRunnerTestURLProtocol.requestCount == 1 {
+                throw URLError(.networkConnectionLost)
+            }
+
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: [
+                        "Content-Type": "application/json",
+                        "X-Request-Id": "retry-success-request",
+                    ]
+                )
+            )
+            let responseBody = Data(
+                """
+                {
+                  "workspaces": [
+                    {
+                      "workspaceId": "workspace-1",
+                      "name": "Workspace",
+                      "createdAt": "2026-06-01T00:00:00.000Z",
+                      "isSelected": true
+                    }
+                  ],
+                  "nextCursor": null
+                }
+                """.utf8
+            )
+            return (response, responseBody)
+        }
+
+        let workspaces: [CloudWorkspaceSummary] = try await transport.listWorkspaces(
+            apiBaseUrl: "https://api.example.test/v1",
+            authorizationHeader: "Bearer id-token"
+        )
+
+        XCTAssertEqual(2, CloudSyncRunnerTestURLProtocol.requestCount)
+        XCTAssertEqual(
+            [
+                CloudWorkspaceSummary(
+                    workspaceId: "workspace-1",
+                    name: "Workspace",
+                    createdAt: "2026-06-01T00:00:00.000Z",
+                    isSelected: true
+                )
+            ],
+            workspaces
+        )
+    }
+
     func testLinkedSyncRetriesAfterPublicCardSyncConflictRecovery() async throws {
         let database = try self.makeDatabase()
         let workspace = try database.workspaceSettingsStore.loadWorkspace()


### PR DESCRIPTION
## Summary
- Move expected iOS cloud retry telemetry from Sentry warnings to info breadcrumbs
- Keep retry context in observability breadcrumbs and local records
- Add targeted CloudSyncTransport retry coverage

## Validation
- git --no-pager diff --check
- Static grep confirmed cloudRetry no longer uses IOSWarningEvent
- iOS simulator-backed tests not run per repo policy without explicit approval