### PR TITLE
Normalize legacy effort sync to tags

### DIFF
--- a/apps/backend/src/cards/mutations.ts
+++ b/apps/backend/src/cards/mutations.ts
@@ -17,6 +17,7 @@ import { assertConsistentFsrsState } from "./fsrs";
 import {
   CARD_COLUMNS,
   CARD_SELECT,
+  appendLegacyEffortTag,
   mapCard,
   normalizeCardMutationMetadata,
   recordCardSyncChange,
@@ -56,8 +57,8 @@ function normalizeCreateCardInput(input: CreateCardInput): CreateCardInput {
   return {
     frontText: normalizeRequiredCardText(input.frontText, "frontText"),
     backText: normalizeOptionalCardText(input.backText),
-    tags: input.tags,
-    effortLevel: input.effortLevel,
+    tags: appendLegacyEffortTag(input.tags, input.effortLevel),
+    effortLevel: "fast",
   };
 }
 
@@ -67,9 +68,13 @@ function normalizeUpdateCardInput(input: UpdateCardInput): UpdateCardInput {
       ? undefined
       : normalizeRequiredCardText(input.frontText, "frontText"),
     backText: input.backText === undefined ? undefined : normalizeOptionalCardText(input.backText),
-    tags: input.tags,
-    effortLevel: input.effortLevel,
+    tags: input.tags === undefined ? undefined : appendLegacyEffortTag(input.tags, input.effortLevel),
+    effortLevel: input.effortLevel === undefined ? undefined : "fast",
   };
+}
+
+function updateRequiresExistingTagsForLegacyEffort(input: UpdateCardInput): boolean {
+  return input.tags === undefined && (input.effortLevel === "medium" || input.effortLevel === "long");
 }
 
 function buildCardUpdateQueryParts(input: UpdateCardInput): UpdateQueryParts {
@@ -121,8 +126,8 @@ function normalizeCardSnapshotInput(input: CardSnapshotInput): CardSnapshotInput
     cardId: input.cardId,
     frontText: normalizeRequiredCardText(input.frontText, "frontText"),
     backText: normalizeOptionalCardText(input.backText),
-    tags: input.tags,
-    effortLevel: input.effortLevel,
+    tags: appendLegacyEffortTag(input.tags, input.effortLevel),
+    effortLevel: "fast",
     dueAt: input.dueAt === null ? null : normalizeIsoTimestamp(input.dueAt, "dueAt"),
     createdAt: normalizeIsoTimestamp(input.createdAt, "createdAt"),
     reps: input.reps,
@@ -438,9 +443,22 @@ export async function updateCardInExecutor(
   input: UpdateCardInput,
   metadata: CardMutationMetadata,
 ): Promise<Card> {
-  const normalizedInput = normalizeUpdateCardInput(input);
-  const updateParts = buildCardUpdateQueryParts(normalizedInput);
+  let normalizedInput = normalizeUpdateCardInput(input);
   const normalizedMetadata = normalizeCardMutationMetadata(metadata);
+
+  if (updateRequiresExistingTagsForLegacyEffort(input)) {
+    const existingRow = await loadCardRowForMutation(executor, workspaceId, cardId);
+    if (existingRow === undefined || existingRow.deleted_at !== null) {
+      throw new HttpError(404, "Card not found");
+    }
+
+    normalizedInput = {
+      ...normalizedInput,
+      tags: appendLegacyEffortTag(existingRow.tags, input.effortLevel),
+    };
+  }
+
+  const updateParts = buildCardUpdateQueryParts(normalizedInput);
 
   if (updateParts.assignments.length === 0) {
     throw new HttpError(400, "At least one editable field must be provided");

--- a/apps/backend/src/cards/shared.ts
+++ b/apps/backend/src/cards/shared.ts
@@ -7,6 +7,7 @@ import type {
   CardRow,
   DeckSummary,
   DeckSummaryRow,
+  EffortLevel,
   ReviewEvent,
   ReviewHistoryItem,
   ReviewHistoryRow,
@@ -58,6 +59,37 @@ export function normalizeCardMutationMetadata(
     lastModifiedByReplicaId: metadata.lastModifiedByReplicaId,
     lastOperationId: metadata.lastOperationId,
   };
+}
+
+// TODO(old-mobile-cutoff): Remove this legacy effort shim during final sync wire-drop cleanup.
+export function appendLegacyEffortTag(
+  tags: ReadonlyArray<string>,
+  legacyEffortLevel: EffortLevel | undefined,
+): ReadonlyArray<string> {
+  const dedupedTags: Array<string> = [];
+  const existingTags = new Set<string>();
+
+  for (const tag of tags) {
+    if (existingTags.has(tag)) {
+      continue;
+    }
+
+    existingTags.add(tag);
+    dedupedTags.push(tag);
+  }
+
+  if (
+    legacyEffortLevel !== "medium"
+    && legacyEffortLevel !== "long"
+  ) {
+    return dedupedTags;
+  }
+
+  if (!existingTags.has(legacyEffortLevel)) {
+    dedupedTags.push(legacyEffortLevel);
+  }
+
+  return dedupedTags;
 }
 
 export function mapCard(row: CardRow): Card {

--- a/apps/backend/src/decks/index.ts
+++ b/apps/backend/src/decks/index.ts
@@ -26,6 +26,7 @@ import {
   findSyncConflictWorkspaceIdInExecutor,
 } from "../sync/conflicts/fork";
 import type { EffortLevel } from "../cards";
+import { appendLegacyEffortTag } from "../cards/shared";
 
 type TimestampValue = Date | string;
 type ErrorFactory = (message: string) => Error;
@@ -228,6 +229,28 @@ function normalizeDeckTags(
   return [...uniqueTags];
 }
 
+function appendLegacyDeckEffortTags(
+  tags: ReadonlyArray<string>,
+  effortLevels: ReadonlyArray<EffortLevel>,
+): ReadonlyArray<string> {
+  return effortLevels.reduce<ReadonlyArray<string>>(
+    (dedupedTags, effortLevel) => appendLegacyEffortTag(dedupedTags, effortLevel),
+    tags,
+  );
+}
+
+function normalizeDeckFilterDefinitionValues(
+  tags: ReadonlyArray<string>,
+  effortLevels: ReadonlyArray<EffortLevel>,
+): DeckFilterDefinition {
+  return {
+    version: 2,
+    // TODO(old-mobile-cutoff): Remove legacy effortLevels output during final sync wire-drop cleanup.
+    effortLevels: [],
+    tags: appendLegacyDeckEffortTags(tags, effortLevels),
+  };
+}
+
 function parseDeckFilterDefinitionWithFactory(
   value: unknown,
   errorFactory: ErrorFactory,
@@ -239,11 +262,10 @@ function parseDeckFilterDefinitionWithFactory(
     throwError(errorFactory, "filterDefinition version must be 2");
   }
 
-  return {
-    version: 2,
-    effortLevels: normalizeDeckEffortLevels(record.effortLevels, "filterDefinition effortLevels", errorFactory),
-    tags: normalizeDeckTags(record.tags, "filterDefinition tags", errorFactory),
-  };
+  return normalizeDeckFilterDefinitionValues(
+    normalizeDeckTags(record.tags, "filterDefinition tags", errorFactory),
+    normalizeDeckEffortLevels(record.effortLevels, "filterDefinition effortLevels", errorFactory),
+  );
 }
 
 export function mapDeck(row: DeckRow): Deck {
@@ -319,7 +341,7 @@ function normalizeDeckSnapshotInput(input: DeckSnapshotInput): DeckSnapshotInput
   return {
     deckId: input.deckId,
     name: input.name,
-    filterDefinition: input.filterDefinition,
+    filterDefinition: normalizeTypedDeckFilterDefinition(input.filterDefinition),
     createdAt: normalizeIsoTimestamp(input.createdAt, "createdAt"),
     deletedAt: input.deletedAt === null ? null : normalizeIsoTimestamp(input.deletedAt, "deletedAt"),
   };
@@ -334,19 +356,18 @@ function normalizeDeckName(name: string): string {
 }
 
 function normalizeTypedDeckFilterDefinition(filterDefinition: DeckFilterDefinition): DeckFilterDefinition {
-  return {
-    version: 2,
-    effortLevels: normalizeDeckEffortLevels(
-      filterDefinition.effortLevels,
-      "filterDefinition effortLevels",
-      createRequestError,
-    ),
-    tags: normalizeDeckTags(
+  return normalizeDeckFilterDefinitionValues(
+    normalizeDeckTags(
       filterDefinition.tags,
       "filterDefinition tags",
       createRequestError,
     ),
-  };
+    normalizeDeckEffortLevels(
+      filterDefinition.effortLevels,
+      "filterDefinition effortLevels",
+      createRequestError,
+    ),
+  );
 }
 
 function normalizeCreateDeckInput(input: CreateDeckInput): CreateDeckInput {

--- a/apps/backend/src/guestAuth/store/cards.ts
+++ b/apps/backend/src/guestAuth/store/cards.ts
@@ -1,4 +1,5 @@
 import type { EffortLevel } from "../../cards";
+import { appendLegacyEffortTag } from "../../cards/shared";
 import {
   applyWorkspaceDatabaseScopeInExecutor,
   type DatabaseExecutor,
@@ -52,12 +53,14 @@ export type GuestCardRecord = Readonly<{
 }>;
 
 function mapGuestCardRecord(row: CardRow): GuestCardRecord {
+  const legacyEffortLevel = row.effort_level as EffortLevel;
+
   return {
     cardId: row.card_id,
     frontText: row.front_text,
     backText: row.back_text,
-    tags: row.tags,
-    effortLevel: row.effort_level as EffortLevel,
+    tags: appendLegacyEffortTag(row.tags, legacyEffortLevel),
+    effortLevel: "fast",
     dueAt: row.due_at,
     createdAt: row.created_at,
     reps: row.reps,

--- a/apps/backend/src/routes/sync/index.test.ts
+++ b/apps/backend/src/routes/sync/index.test.ts
@@ -109,6 +109,101 @@ async function retryTransientOnce<Result>(operation: () => Promise<Result>): Pro
   return operation();
 }
 
+test("POST /sync/push accepts card payloads without legacy effortLevel", async () => {
+  let processCalls = 0;
+  const routes = createSyncRoutes({
+    allowedOrigins: [],
+    loadRequestContextFromRequestFn: async () => ({
+      requestAuthInputs: {} as never,
+      requestContext: createRequestContext(),
+    }),
+    assertUserHasWorkspaceAccessFn: async (userId, requestedWorkspaceId) => {
+      assert.equal(userId, "user-1");
+      assert.equal(requestedWorkspaceId, workspaceId);
+    },
+    processSyncPushFn: async (requestedWorkspaceId, userId, input) => {
+      processCalls += 1;
+      assert.equal(requestedWorkspaceId, workspaceId);
+      assert.equal(userId, "user-1");
+      const operation = input.operations[0];
+      if (operation?.entityType !== "card") {
+        throw new Error("Expected card sync operation");
+      }
+
+      assert.equal(Object.prototype.hasOwnProperty.call(operation.payload, "effortLevel"), false);
+      return {
+        operations: [
+          {
+            operationId: operation.operationId,
+            entityType: operation.entityType,
+            entityId: operation.entityId,
+            status: "applied",
+            resultingHotChangeId: 1,
+            error: null,
+          },
+        ],
+      };
+    },
+    bindGuestSessionPlatformFn: async () => {
+      throw new Error("Signed-in web sync should not bind a guest session platform");
+    },
+  });
+  const app = createSyncTestApp(routes);
+
+  const response = await app.request(`http://localhost/workspaces/${workspaceId}/sync/push`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      installationId: "install-1",
+      platform: "web",
+      appVersion: "1.0.0",
+      operations: [
+        {
+          operationId: "operation-card-1",
+          entityType: "card",
+          action: "upsert",
+          entityId: "card-1",
+          clientUpdatedAt: "2026-02-28T09:30:00.000Z",
+          payload: {
+            cardId: "card-1",
+            frontText: "Question",
+            backText: "Answer",
+            tags: ["sync"],
+            dueAt: null,
+            createdAt: "2026-02-28T09:00:00.000Z",
+            reps: 0,
+            lapses: 0,
+            fsrsCardState: "new",
+            fsrsStepIndex: null,
+            fsrsStability: null,
+            fsrsDifficulty: null,
+            fsrsLastReviewedAt: null,
+            fsrsScheduledDays: null,
+            deletedAt: null,
+          },
+        },
+      ],
+    }),
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    operations: [
+      {
+        operationId: "operation-card-1",
+        entityType: "card",
+        entityId: "card-1",
+        status: "applied",
+        resultingHotChangeId: 1,
+        error: null,
+      },
+    ],
+  });
+  assert.equal(processCalls, 1);
+});
+
 test("sync routes reject guest web platform before creating a workspace replica", async () => {
   const routes = createSyncRoutes({
     allowedOrigins: [],

--- a/apps/backend/src/routes/sync/index.ts
+++ b/apps/backend/src/routes/sync/index.ts
@@ -53,6 +53,7 @@ type SyncRoutesOptions = Readonly<{
   loadRequestContextFromRequestFn?: typeof loadRequestContextFromRequest;
   assertUserHasWorkspaceAccessFn?: typeof assertUserHasWorkspaceAccess;
   processSyncBootstrapFn?: typeof processSyncBootstrap;
+  processSyncPushFn?: typeof processSyncPush;
   processSyncPullFn?: typeof processSyncPull;
   processSyncReviewHistoryPullFn?: typeof processSyncReviewHistoryPull;
   withTransientDatabaseRetryFn?: typeof withTransientDatabaseRetry;
@@ -78,6 +79,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
   const loadRequestContextFromRequestFn = options.loadRequestContextFromRequestFn ?? loadRequestContextFromRequest;
   const assertUserHasWorkspaceAccessFn = options.assertUserHasWorkspaceAccessFn ?? assertUserHasWorkspaceAccess;
   const processSyncBootstrapFn = options.processSyncBootstrapFn ?? processSyncBootstrap;
+  const processSyncPushFn = options.processSyncPushFn ?? processSyncPush;
   const processSyncPullFn = options.processSyncPullFn ?? processSyncPull;
   const processSyncReviewHistoryPullFn = options.processSyncReviewHistoryPullFn ?? processSyncReviewHistoryPull;
   const withTransientDatabaseRetryFn = options.withTransientDatabaseRetryFn ?? withTransientDatabaseRetry;
@@ -93,7 +95,7 @@ export function createSyncRoutes(options: SyncRoutesOptions): Hono<AppEnv> {
     const entityTypes = [...new Set(input.operations.map((operation) => operation.entityType))];
 
     try {
-      const result = await processSyncPush(workspaceId, requestContext.userId, input);
+      const result = await processSyncPushFn(workspaceId, requestContext.userId, input);
       addBackendBreadcrumb({
         action: "sync_push",
         scope: createSyncScope(requestId, context.req.path, context.req.method, requestContext.userId, workspaceId),

--- a/apps/backend/src/sync/contracts/input.test.ts
+++ b/apps/backend/src/sync/contracts/input.test.ts
@@ -1,9 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { CardSnapshotInput } from "../../cards";
+import type pg from "pg";
+import type { CardSnapshotInput, EffortLevel } from "../../cards";
+import type { CardRow } from "../../cards/types";
+import type { DatabaseExecutor, SqlValue } from "../../database";
+import {
+  parseDeckFilterDefinition,
+  upsertDeckSnapshotInExecutor,
+  type DeckRow,
+} from "../../decks";
 import { HttpError } from "../../shared/errors";
 import { parseBootstrapEntryRow } from "../replication/bootstrap";
+import { buildHotChangesFromRows } from "../replication/hotPull";
 import { parseSyncPushInput } from "./input";
+import { toCardSnapshotInput } from "./snapshots";
 import type { BootstrapProjectionRow } from "./types";
 
 type ReviewEventTimestampFixture = Readonly<{
@@ -16,13 +26,17 @@ type CardDueAtFixture = Readonly<{
   dueAt: string | null;
 }>;
 
+type CardSyncPushPayload = Omit<CardSnapshotInput, "effortLevel"> & Readonly<{
+  effortLevel?: EffortLevel;
+}>;
+
 type CardSyncPushOperation = Readonly<{
   operationId: string;
   entityType: "card";
   action: "upsert";
   entityId: string;
   clientUpdatedAt: string;
-  payload: CardSnapshotInput;
+  payload: CardSyncPushPayload;
 }>;
 
 type CardSyncPushInput = Readonly<{
@@ -106,6 +120,10 @@ function createCardSnapshotPayload(fixture: CardDueAtFixture): CardSnapshotInput
 }
 
 function createCardSyncPushInput(fixture: CardDueAtFixture): CardSyncPushInput {
+  return createCardSyncPushInputWithPayload(createCardSnapshotPayload(fixture));
+}
+
+function createCardSyncPushInputWithPayload(payload: CardSyncPushPayload): CardSyncPushInput {
   return {
     installationId: "installation-1",
     platform: "ios",
@@ -116,10 +134,16 @@ function createCardSyncPushInput(fixture: CardDueAtFixture): CardSyncPushInput {
         action: "upsert",
         entityId: "card-1",
         clientUpdatedAt: "2026-02-28T09:30:00.000Z",
-        payload: createCardSnapshotPayload(fixture),
+        payload,
       },
     ],
   };
+}
+
+function omitLegacyEffortLevel(payload: CardSnapshotInput): CardSyncPushPayload {
+  const { effortLevel, ...payloadWithoutEffortLevel } = payload;
+  assert.equal(effortLevel, "fast");
+  return payloadWithoutEffortLevel;
 }
 
 function createCardBootstrapPayload(fixture: CardDueAtFixture): CardBootstrapPayload {
@@ -138,6 +162,101 @@ function createCardBootstrapProjectionRow(fixture: CardDueAtFixture): BootstrapP
     entity_type: "card",
     entity_id: "card-1",
     payload: createCardBootstrapPayload(fixture),
+  };
+}
+
+function createQueryResult<Row extends pg.QueryResultRow>(rows: ReadonlyArray<Row>): pg.QueryResult<Row> {
+  return {
+    command: "SELECT",
+    rowCount: rows.length,
+    oid: 0,
+    fields: [],
+    rows: [...rows],
+  };
+}
+
+function createHotPullCardRow(effortLevel: EffortLevel): CardRow {
+  return {
+    card_id: "card-1",
+    front_text: "Question",
+    back_text: "Answer",
+    tags: ["sync"],
+    effort_level: effortLevel,
+    due_at: null,
+    created_at: "2026-02-28T09:00:00.000Z",
+    reps: 0,
+    lapses: 0,
+    fsrs_card_state: "new",
+    fsrs_step_index: null,
+    fsrs_stability: null,
+    fsrs_difficulty: null,
+    fsrs_last_reviewed_at: null,
+    fsrs_scheduled_days: null,
+    client_updated_at: "2026-02-28T09:30:00.000Z",
+    last_modified_by_replica_id: "replica-1",
+    last_operation_id: "operation-card-1",
+    updated_at: "2026-02-28T09:30:00.000Z",
+    deleted_at: null,
+  };
+}
+
+function createHotPullCardExecutor(effortLevel: EffortLevel): DatabaseExecutor {
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      assert.match(text, /FROM content\.cards/);
+      assert.deepEqual(params, ["workspace-1", ["card-1"]]);
+      return createQueryResult([createHotPullCardRow(effortLevel) as unknown as Row]);
+    },
+  };
+}
+
+function createDeckSnapshotExecutor(): DatabaseExecutor {
+  return {
+    query: async <Row extends pg.QueryResultRow>(
+      text: string,
+      params: ReadonlyArray<SqlValue>,
+    ): Promise<pg.QueryResult<Row>> => {
+      if (
+        text.includes("FROM content.decks")
+        && text.includes("WHERE workspace_id = $1 AND deck_id = $2")
+      ) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (
+        text.includes("INSERT INTO content.decks")
+        && text.includes("ON CONFLICT DO NOTHING")
+      ) {
+        const filterDefinition = JSON.parse(String(params[3])) as unknown;
+        return createQueryResult<Row>([{
+          deck_id: params[0],
+          workspace_id: params[1],
+          name: params[2],
+          filter_definition: filterDefinition,
+          created_at: params[4],
+          client_updated_at: params[5],
+          last_modified_by_replica_id: params[6],
+          last_operation_id: params[7],
+          updated_at: "2026-02-28T09:30:00.000Z",
+          deleted_at: params[8],
+        } as DeckRow as unknown as Row]);
+      }
+
+      if (text.includes("INSERT INTO sync.workspace_sync_metadata")) {
+        return createQueryResult<Row>([]);
+      }
+
+      if (text.includes("INSERT INTO sync.hot_changes")) {
+        return createQueryResult<Row>([{
+          change_id: 1,
+        } as unknown as Row]);
+      }
+
+      throw new Error(`Unexpected query: ${text}`);
+    },
   };
 }
 
@@ -255,6 +374,80 @@ test("parseSyncPushInput accepts dueAt as a string or null without numeric publi
   assert.equal(Object.prototype.hasOwnProperty.call(operationWithoutDueAt.payload, "dueAtMillis"), false);
 });
 
+test("parseSyncPushInput accepts card operations without legacy effortLevel", () => {
+  const payload = omitLegacyEffortLevel(createCardSnapshotPayload({
+    dueAt: null,
+  }));
+  const parsedInput = parseSyncPushInput(createCardSyncPushInputWithPayload(payload));
+  const operation = parsedInput.operations[0];
+  if (operation?.entityType !== "card") {
+    assert.fail("Expected the parsed sync operation to remain a card");
+  }
+
+  assert.equal(Object.prototype.hasOwnProperty.call(operation.payload, "effortLevel"), false);
+});
+
+test("toCardSnapshotInput converts legacy medium and long effort into tags", () => {
+  const mediumSnapshot = toCardSnapshotInput({
+    ...createCardSnapshotPayload({ dueAt: null }),
+    effortLevel: "medium",
+  });
+  const longSnapshot = toCardSnapshotInput({
+    ...createCardSnapshotPayload({ dueAt: null }),
+    tags: ["Long"],
+    effortLevel: "long",
+  });
+
+  assert.deepEqual(mediumSnapshot.tags, ["sync", "medium"]);
+  assert.equal(mediumSnapshot.effortLevel, "fast");
+  assert.deepEqual(longSnapshot.tags, ["Long", "long"]);
+  assert.equal(longSnapshot.effortLevel, "fast");
+});
+
+test("parseDeckFilterDefinition converts legacy effortLevels into canonical tags", () => {
+  const filterDefinition = parseDeckFilterDefinition({
+    version: 2,
+    effortLevels: ["medium", "long", "fast", "medium"],
+    tags: ["Study", "Long"],
+  });
+
+  assert.deepEqual(filterDefinition, {
+    version: 2,
+    effortLevels: [],
+    tags: ["Study", "Long", "medium", "long"],
+  });
+});
+
+test("upsertDeckSnapshotInExecutor normalizes legacy sync effortLevels before persistence", async () => {
+  const result = await upsertDeckSnapshotInExecutor(
+    createDeckSnapshotExecutor(),
+    "workspace-1",
+    {
+      deckId: "deck-1",
+      name: "Legacy deck",
+      filterDefinition: {
+        version: 2,
+        effortLevels: ["long"],
+        tags: ["Long"],
+      },
+      createdAt: "2026-02-28T09:00:00.000Z",
+      deletedAt: null,
+    },
+    {
+      clientUpdatedAt: "2026-02-28T09:30:00.000Z",
+      lastModifiedByReplicaId: "replica-1",
+      lastOperationId: "operation-deck-1",
+    },
+  );
+
+  assert.equal(result.applied, true);
+  assert.deepEqual(result.deck.filterDefinition, {
+    version: 2,
+    effortLevels: [],
+    tags: ["Long", "long"],
+  });
+});
+
 test("parseSyncPushInput rejects malformed non-null dueAt timestamps before ingest", () => {
   const malformedDueAtValues: ReadonlyArray<string> = [
     "2026-02-31T00:00:00.000Z",
@@ -298,6 +491,7 @@ test("parseBootstrapEntryRow keeps outbound card dueAt as a string or null witho
   }
 
   assert.equal(entryWithDueAt.payload.dueAt, validDueAt);
+  assert.equal(entryWithDueAt.payload.effortLevel, "fast");
   assert.equal(Object.prototype.hasOwnProperty.call(entryWithDueAt.payload, "dueAtMillis"), false);
 
   const entryWithoutDueAt = parseBootstrapEntryRow(createCardBootstrapProjectionRow({
@@ -308,5 +502,27 @@ test("parseBootstrapEntryRow keeps outbound card dueAt as a string or null witho
   }
 
   assert.equal(entryWithoutDueAt.payload.dueAt, null);
+  assert.equal(entryWithoutDueAt.payload.effortLevel, "fast");
   assert.equal(Object.prototype.hasOwnProperty.call(entryWithoutDueAt.payload, "dueAtMillis"), false);
+});
+
+test("buildHotChangesFromRows keeps outbound card effortLevel as fast", async () => {
+  const changes = await buildHotChangesFromRows(
+    createHotPullCardExecutor("long"),
+    "workspace-1",
+    [
+      {
+        change_id: 7,
+        entity_type: "card",
+        entity_id: "card-1",
+      },
+    ],
+  );
+
+  const change = changes[0];
+  if (change?.entityType !== "card") {
+    assert.fail("Expected the hot pull entry to remain a card");
+  }
+
+  assert.equal(change.payload.effortLevel, "fast");
 });

--- a/apps/backend/src/sync/contracts/input.ts
+++ b/apps/backend/src/sync/contracts/input.ts
@@ -158,6 +158,11 @@ const cardSnapshotSchema = z.object({
   deletedAt: z.string().datetime().nullable(),
 });
 
+const cardSnapshotInputSchema = cardSnapshotSchema.extend({
+  // TODO(old-mobile-cutoff): Remove legacy effort input during final sync wire-drop cleanup.
+  effortLevel: effortLevelSchema.optional(),
+});
+
 export const cardPayloadSchema = cardSnapshotSchema.extend({
   clientUpdatedAt: z.string().datetime(),
   lastModifiedByReplicaId: z.string().min(1),
@@ -211,7 +216,7 @@ const reviewEventImportPayloadSchema = reviewEventPushPayloadSchema.extend({
   reviewedAtServer: z.string().datetime(),
 });
 
-const cardBootstrapPushPayloadSchema = cardSnapshotSchema.extend({
+const cardBootstrapPushPayloadSchema = cardSnapshotInputSchema.extend({
   clientUpdatedAt: z.string().datetime(),
   lastOperationId: z.string().min(1),
   updatedAt: z.string().datetime(),
@@ -239,7 +244,7 @@ const baseOperationSchema = z.object({
 const cardOperationSchema = baseOperationSchema.extend({
   entityType: z.literal("card"),
   action: z.literal("upsert"),
-  payload: cardSnapshotSchema,
+  payload: cardSnapshotInputSchema,
 });
 
 const deckOperationSchema = baseOperationSchema.extend({

--- a/apps/backend/src/sync/contracts/snapshots.ts
+++ b/apps/backend/src/sync/contracts/snapshots.ts
@@ -1,7 +1,9 @@
 import type {
   CardMutationMetadata,
   CardSnapshotInput,
+  EffortLevel,
 } from "../../cards";
+import { appendLegacyEffortTag } from "../../cards/shared";
 import type {
   DeckMutationMetadata,
   DeckSnapshotInput,
@@ -17,13 +19,18 @@ type MutationMetadataInput = Readonly<{
   lastOperationId: string;
 }>;
 
-export function toCardSnapshotInput(payload: CardSnapshotInput): CardSnapshotInput {
+type CardSnapshotPayload = Omit<CardSnapshotInput, "effortLevel"> & Readonly<{
+  effortLevel?: EffortLevel;
+}>;
+
+export function toCardSnapshotInput(payload: CardSnapshotPayload): CardSnapshotInput {
   return {
     cardId: payload.cardId,
     frontText: payload.frontText,
     backText: payload.backText,
-    tags: payload.tags,
-    effortLevel: payload.effortLevel,
+    tags: appendLegacyEffortTag(payload.tags, payload.effortLevel),
+    // TODO(old-mobile-cutoff): Remove legacy effort defaulting during final sync wire-drop cleanup.
+    effortLevel: "fast",
     dueAt: payload.dueAt,
     createdAt: payload.createdAt,
     reps: payload.reps,

--- a/apps/backend/src/sync/replication/bootstrap.ts
+++ b/apps/backend/src/sync/replication/bootstrap.ts
@@ -242,6 +242,7 @@ export async function processSyncBootstrap(
       : decodeBootstrapCursor(input.cursor);
     const remoteIsEmpty = await loadRemoteEmptyState(executor, workspaceId);
 
+    // TODO(old-mobile-cutoff): Remove legacy effort fields during final sync wire-drop cleanup.
     const result = await executor.query<BootstrapProjectionRow>(
       [
         "WITH bootstrap_entries AS (",
@@ -273,7 +274,7 @@ export async function processSyncBootstrap(
         "      'frontText', cards.front_text,",
         "      'backText', cards.back_text,",
         "      'tags', cards.tags,",
-        "      'effortLevel', cards.effort_level,",
+        "      'effortLevel', 'fast',",
         "      'dueAt', CASE WHEN cards.due_at IS NULL THEN NULL ELSE to_char(date_trunc('milliseconds', cards.due_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"') END,",
         "      'createdAt', to_char(date_trunc('milliseconds', cards.created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),",
         "      'reps', cards.reps,",
@@ -301,7 +302,11 @@ export async function processSyncBootstrap(
         "      'deckId', decks.deck_id::text,",
         "      'workspaceId', decks.workspace_id::text,",
         "      'name', decks.name,",
-        "      'filterDefinition', decks.filter_definition,",
+        "      'filterDefinition', jsonb_build_object(",
+        "        'version', 2,",
+        "        'effortLevels', '[]'::jsonb,",
+        "        'tags', decks.filter_definition->'tags'",
+        "      ),",
         "      'createdAt', to_char(date_trunc('milliseconds', decks.created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),",
         "      'clientUpdatedAt', to_char(date_trunc('milliseconds', decks.client_updated_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD\"T\"HH24:MI:SS.MS\"Z\"'),",
         "      'lastModifiedByReplicaId', decks.last_modified_by_replica_id::text,",

--- a/apps/backend/src/sync/replication/hotPull.ts
+++ b/apps/backend/src/sync/replication/hotPull.ts
@@ -1,5 +1,6 @@
 import type { CardRow } from "../../cards/types";
 import { mapCard } from "../../cards/shared";
+import type { Card } from "../../cards";
 import {
   transactionWithWorkspaceScope,
   type DatabaseExecutor,
@@ -53,6 +54,14 @@ function toWorkspaceSchedulerSettings(row: WorkspaceSchedulerSettingsRow): Works
   };
 }
 
+// TODO(old-mobile-cutoff): Remove legacy effort output during final sync wire-drop cleanup.
+function toLegacySyncCardPayload(card: Card): Card {
+  return {
+    ...card,
+    effortLevel: "fast",
+  };
+}
+
 async function loadWorkspaceSchedulerSettingsInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
@@ -82,7 +91,7 @@ async function loadCardsByIdsInExecutor(
   executor: DatabaseExecutor,
   workspaceId: string,
   cardIds: ReadonlyArray<string>,
-): Promise<ReadonlyMap<string, import("../../cards").Card>> {
+): Promise<ReadonlyMap<string, Card>> {
   if (cardIds.length === 0) {
     return new Map();
   }
@@ -157,7 +166,7 @@ export async function buildHotChangesFromRows(
         entityType: "card" as const,
         entityId: row.entity_id,
         action: "upsert" as const,
-        payload: card,
+        payload: toLegacySyncCardPayload(card),
       };
     }
 

--- a/db/migrations/0073_card_effort_tag_backfill.sql
+++ b/db/migrations/0073_card_effort_tag_backfill.sql
@@ -1,0 +1,166 @@
+-- Migration status: Current / additive.
+-- Introduces: canonical tag storage for legacy medium/long card effort.
+-- Schemas touched/read explicitly: content, sync.
+
+CREATE OR REPLACE FUNCTION pg_temp.append_legacy_effort_tags(
+  p_existing_tags TEXT[],
+  p_legacy_efforts TEXT[]
+)
+RETURNS TEXT[]
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  WITH source_tags AS (
+    SELECT existing_tags.tag, existing_tags.ordinality
+    FROM unnest(coalesce(p_existing_tags, ARRAY[]::TEXT[])) WITH ORDINALITY AS existing_tags(tag, ordinality)
+  ),
+  source_effort_tags AS (
+    SELECT legacy_efforts.effort AS tag, 1000000 + legacy_efforts.ordinality AS ordinality
+    FROM unnest(coalesce(p_legacy_efforts, ARRAY[]::TEXT[])) WITH ORDINALITY AS legacy_efforts(effort, ordinality)
+    WHERE legacy_efforts.effort IN ('medium', 'long')
+  ),
+  ranked_tags AS (
+    SELECT DISTINCT ON (combined_tags.tag)
+      combined_tags.tag,
+      combined_tags.ordinality
+    FROM (
+      SELECT source_tags.tag, source_tags.ordinality
+      FROM source_tags
+      UNION ALL
+      SELECT source_effort_tags.tag, source_effort_tags.ordinality
+      FROM source_effort_tags
+    ) AS combined_tags
+    ORDER BY combined_tags.tag, combined_tags.ordinality
+  )
+  SELECT coalesce(array_agg(ranked_tags.tag ORDER BY ranked_tags.ordinality), ARRAY[]::TEXT[])
+  FROM ranked_tags;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.jsonb_text_array(p_value JSONB)
+RETURNS TEXT[]
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  SELECT coalesce(array_agg(item.value), ARRAY[]::TEXT[])
+  FROM jsonb_array_elements_text(p_value) AS item(value);
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM content.decks AS decks
+    WHERE decks.filter_definition->>'version' IS DISTINCT FROM '2'
+      OR jsonb_typeof(decks.filter_definition->'tags') IS DISTINCT FROM 'array'
+      OR jsonb_typeof(decks.filter_definition->'effortLevels') IS DISTINCT FROM 'array'
+  ) THEN
+    RAISE EXCEPTION '0073_card_effort_tag_backfill requires content.decks filter_definition version 2 with array tags and effortLevels';
+  END IF;
+END
+$$;
+
+CREATE TEMP TABLE migration_0073_changed_cards ON COMMIT DROP AS
+SELECT
+  cards.workspace_id,
+  cards.card_id,
+  cards.last_modified_by_replica_id,
+  cards.client_updated_at
+FROM content.cards AS cards
+WHERE cards.effort_level IN ('medium', 'long');
+
+CREATE TEMP TABLE migration_0073_changed_decks ON COMMIT DROP AS
+WITH normalized_decks AS (
+  SELECT
+    decks.workspace_id,
+    decks.deck_id,
+    decks.last_modified_by_replica_id,
+    decks.client_updated_at,
+    jsonb_build_object(
+      'version', 2,
+      'effortLevels', '[]'::jsonb,
+      'tags', to_jsonb(
+        pg_temp.append_legacy_effort_tags(
+          pg_temp.jsonb_text_array(decks.filter_definition->'tags'),
+          pg_temp.jsonb_text_array(decks.filter_definition->'effortLevels')
+        )
+      )
+    ) AS normalized_filter_definition
+  FROM content.decks AS decks
+)
+SELECT
+  normalized_decks.workspace_id,
+  normalized_decks.deck_id,
+  normalized_decks.last_modified_by_replica_id,
+  normalized_decks.client_updated_at,
+  normalized_decks.normalized_filter_definition
+FROM normalized_decks
+INNER JOIN content.decks AS decks
+  ON decks.workspace_id = normalized_decks.workspace_id
+  AND decks.deck_id = normalized_decks.deck_id
+WHERE decks.filter_definition IS DISTINCT FROM normalized_decks.normalized_filter_definition;
+
+UPDATE content.cards AS cards
+SET
+  tags = pg_temp.append_legacy_effort_tags(cards.tags, ARRAY[cards.effort_level]),
+  effort_level = 'fast',
+  updated_at = now()
+FROM migration_0073_changed_cards AS changed_cards
+WHERE cards.workspace_id = changed_cards.workspace_id
+  AND cards.card_id = changed_cards.card_id;
+
+UPDATE content.decks AS decks
+SET
+  filter_definition = changed_decks.normalized_filter_definition,
+  updated_at = now()
+FROM migration_0073_changed_decks AS changed_decks
+WHERE decks.workspace_id = changed_decks.workspace_id
+  AND decks.deck_id = changed_decks.deck_id;
+
+INSERT INTO sync.workspace_sync_metadata (workspace_id, min_available_hot_change_id, updated_at)
+SELECT changed_entities.workspace_id, 0, now()
+FROM (
+  SELECT changed_cards.workspace_id
+  FROM migration_0073_changed_cards AS changed_cards
+  UNION
+  SELECT changed_decks.workspace_id
+  FROM migration_0073_changed_decks AS changed_decks
+) AS changed_entities
+ON CONFLICT (workspace_id) DO NOTHING;
+
+INSERT INTO sync.hot_changes (
+  workspace_id,
+  entity_type,
+  entity_id,
+  action,
+  replica_id,
+  operation_id,
+  client_updated_at
+)
+SELECT
+  changed_cards.workspace_id,
+  'card',
+  changed_cards.card_id::text,
+  'upsert',
+  changed_cards.last_modified_by_replica_id,
+  'migration-0073-effort-tag-card-' || changed_cards.card_id::text,
+  changed_cards.client_updated_at
+FROM migration_0073_changed_cards AS changed_cards;
+
+INSERT INTO sync.hot_changes (
+  workspace_id,
+  entity_type,
+  entity_id,
+  action,
+  replica_id,
+  operation_id,
+  client_updated_at
+)
+SELECT
+  changed_decks.workspace_id,
+  'deck',
+  changed_decks.deck_id::text,
+  'upsert',
+  changed_decks.last_modified_by_replica_id,
+  'migration-0073-effort-tag-deck-' || changed_decks.deck_id::text,
+  changed_decks.client_updated_at
+FROM migration_0073_changed_decks AS changed_decks;


### PR DESCRIPTION
Summary:
- Normalize legacy card effort into canonical medium/long tags while preserving old sync compatibility.
- Backfill existing card/deck effort filters into tags and emit sync hot changes.
- Keep legacy sync payload fields present with fast effort/default empty effortLevels for old clients.

Validation:
- npm run lint --prefix apps/backend passed.
- npm run test --prefix apps/backend passed: 500 tests, 0 failures.
- node --import tsx --test src/sync/contracts/input.test.ts passed: 12 tests, 0 failures.
- git --no-pager diff --check passed.