### PR TITLE
Improve iOS AppHang telemetry

### DIFF
--- a/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
+++ b/apps/ios/Flashcards/Flashcards/App/FlashcardsApp.swift
@@ -72,6 +72,97 @@ private func nextProgressContextRolloverDate(now: Date) -> Date {
     return nextDay
 }
 
+private func appLifecycleTabName(tab: AppTab) -> String {
+    switch tab {
+    case .review:
+        return "review"
+    case .progress:
+        return "progress"
+    case .ai:
+        return "ai"
+    case .cards:
+        return "cards"
+    case .settings:
+        return "settings"
+    }
+}
+
+private func appLifecycleScenePhaseName(scenePhase: ScenePhase) -> String {
+    switch scenePhase {
+    case .active:
+        return "active"
+    case .inactive:
+        return "inactive"
+    case .background:
+        return "background"
+    @unknown default:
+        return "unknown"
+    }
+}
+
+@MainActor
+private func makeAppLifecycleScope(store: FlashcardsStore?) -> IOSObservationScope {
+    let configurationMode: CloudServiceConfigurationMode?
+    if let store {
+        configurationMode = try? store.currentCloudServiceConfiguration().mode
+    } else {
+        configurationMode = nil
+    }
+
+    return IOSObservationScope(
+        feature: .appStartup,
+        userId: store?.cloudSettings?.linkedUserId,
+        workspaceId: store?.workspace?.workspaceId,
+        requestId: nil,
+        clientRequestId: nil,
+        sessionId: nil,
+        runId: nil,
+        cloudState: store?.cloudSettings?.cloudState,
+        configurationMode: configurationMode
+    )
+}
+
+@MainActor
+private func logAppLifecycleBreadcrumb(
+    action: AppLifecycleAction,
+    store: FlashcardsStore?,
+    stage: String?,
+    scenePhase: ScenePhase?,
+    selectedTab: AppTab?,
+    isStartupReady: Bool?,
+    isRecoveryGateActive: Bool?,
+    messageSummary: String?
+) {
+    let scenePhaseName: String?
+    if let scenePhase {
+        scenePhaseName = appLifecycleScenePhaseName(scenePhase: scenePhase)
+    } else {
+        scenePhaseName = nil
+    }
+
+    let selectedTabName: String?
+    if let selectedTab {
+        selectedTabName = appLifecycleTabName(tab: selectedTab)
+    } else {
+        selectedTabName = nil
+    }
+
+    FlashcardsObservability.addBreadcrumb(
+        .appLifecycle(
+            AppLifecycleObservation(
+                action: action,
+                scope: makeAppLifecycleScope(store: store),
+                stage: stage,
+                scenePhase: scenePhaseName,
+                selectedTab: selectedTabName,
+                isStartupReady: isStartupReady,
+                isRecoveryGateActive: isRecoveryGateActive,
+                messageSummary: messageSummary
+            )
+        )
+    )
+}
+
 @MainActor
 private func consumeFlashcardsUITestAppNotificationTapRequest(processInfo: ProcessInfo) -> AppNotificationTapRequest? {
     guard hasConsumedFlashcardsUITestAppNotificationTapEnvironment == false else {
@@ -129,6 +220,16 @@ struct FlashcardsApp: App {
     @MainActor
     init() {
         FlashcardsObservability.configure(bundle: .main, processInfo: ProcessInfo.processInfo)
+        logAppLifecycleBreadcrumb(
+            action: .appInitConfigured,
+            store: nil,
+            stage: "app_init",
+            scenePhase: nil,
+            selectedTab: nil,
+            isStartupReady: false,
+            isRecoveryGateActive: nil,
+            messageSummary: nil
+        )
         let store = FlashcardsStore()
         let processInfo = ProcessInfo.processInfo
         let selectedTab = processInfo.environment[flashcardsUITestSelectedTabEnvironmentKey]
@@ -137,6 +238,16 @@ struct FlashcardsApp: App {
         let launchScenario = processInfo.environment[flashcardsUITestLaunchScenarioEnvironmentKey]
             .flatMap(FlashcardsUITestLaunchScenario.init(rawValue:))
         let aiHandoffCard = makeFlashcardsUITestAIHandoffCard(processInfo: processInfo)
+        logAppLifecycleBreadcrumb(
+            action: .appStoreInitialized,
+            store: store,
+            stage: "store_init",
+            scenePhase: nil,
+            selectedTab: selectedTab,
+            isStartupReady: false,
+            isRecoveryGateActive: store.cloudCredentialRecoveryState != nil,
+            messageSummary: nil
+        )
         if let launchScenario {
             store.uiTestLaunchPreparationStatus = .running(launchScenario: launchScenario)
         }
@@ -186,7 +297,27 @@ struct FlashcardsApp: App {
         }
 
         if store.cloudCredentialRecoveryState == nil {
+            logAppLifecycleBreadcrumb(
+                action: .visibleTabPrepareStart,
+                store: store,
+                stage: "visible_tab_prepare",
+                scenePhase: nil,
+                selectedTab: selectedTab,
+                isStartupReady: false,
+                isRecoveryGateActive: false,
+                messageSummary: nil
+            )
             store.prepareVisibleTabForPresentation(tab: selectedTab, now: Date())
+            logAppLifecycleBreadcrumb(
+                action: .visibleTabPrepareSuccess,
+                store: store,
+                stage: "visible_tab_prepare",
+                scenePhase: nil,
+                selectedTab: selectedTab,
+                isStartupReady: false,
+                isRecoveryGateActive: false,
+                messageSummary: nil
+            )
         }
 
         _store = State(initialValue: store)
@@ -215,6 +346,16 @@ struct FlashcardsApp: App {
                     await self.runInitialAppStartupIfNeeded()
                 }
                 .onChange(of: scenePhase) { _, nextPhase in
+                    logAppLifecycleBreadcrumb(
+                        action: .scenePhaseChanged,
+                        store: store,
+                        stage: "scene_phase",
+                        scenePhase: nextPhase,
+                        selectedTab: navigation.selectedTab,
+                        isStartupReady: self.isStartupReadyForBackgroundWork,
+                        isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                        messageSummary: nil
+                    )
                     guard self.isStartupReadyForBackgroundWork else {
                         return
                     }
@@ -306,6 +447,16 @@ struct FlashcardsApp: App {
             return
         }
 
+        logAppLifecycleBreadcrumb(
+            action: .initialStartupStart,
+            store: self.store,
+            stage: "initial_startup",
+            scenePhase: self.scenePhase,
+            selectedTab: self.navigation.selectedTab,
+            isStartupReady: self.isStartupReadyForBackgroundWork,
+            isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+            messageSummary: nil
+        )
         if self.isCloudCredentialRecoveryGateActive {
             if let launchScenario = self.uiTestLaunchScenario {
                 self.store.uiTestLaunchPreparationStatus = .failed(
@@ -329,8 +480,28 @@ struct FlashcardsApp: App {
             await self.store.resumePendingAccountDeletionIfNeeded()
 
             let now = Date()
+            logAppLifecycleBreadcrumb(
+                action: .progressContextRefresh,
+                store: self.store,
+                stage: "initial_startup",
+                scenePhase: self.scenePhase,
+                selectedTab: self.navigation.selectedTab,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                messageSummary: nil
+            )
             self.refreshProgressContext(now: now, restartWatcher: false)
             if self.uiTestLaunchScenario == nil {
+                logAppLifecycleBreadcrumb(
+                    action: .launchCloudSyncTriggered,
+                    store: self.store,
+                    stage: "initial_startup",
+                    scenePhase: self.scenePhase,
+                    selectedTab: self.navigation.selectedTab,
+                    isStartupReady: self.isStartupReadyForBackgroundWork,
+                    isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                    messageSummary: nil
+                )
                 self.store.triggerCloudSyncIfLinked(
                     trigger: CloudSyncTrigger(
                         source: .appLaunch,
@@ -343,6 +514,16 @@ struct FlashcardsApp: App {
                 )
                 self.store.triggerCloudAccountContextRefreshIfActive(surfacesGlobalErrorMessage: false)
             }
+            logAppLifecycleBreadcrumb(
+                action: .launchNotificationReconcileTriggered,
+                store: self.store,
+                stage: "initial_startup",
+                scenePhase: self.scenePhase,
+                selectedTab: self.navigation.selectedTab,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                messageSummary: nil
+            )
             self.store.reconcileReviewNotifications(trigger: .appActive, now: now)
             self.store.reconcileStrictReminders(trigger: .appActive, now: now)
 
@@ -350,8 +531,28 @@ struct FlashcardsApp: App {
                 self.store.uiTestLaunchPreparationStatus = .ready(launchScenario: launchScenario)
             }
             self.isStartupReadyForBackgroundWork = true
+            logAppLifecycleBreadcrumb(
+                action: .initialStartupReady,
+                store: self.store,
+                stage: "initial_startup",
+                scenePhase: self.scenePhase,
+                selectedTab: self.navigation.selectedTab,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                messageSummary: nil
+            )
         } catch {
             self.store.globalErrorMessage = Flashcards.errorMessage(error: error)
+            logAppLifecycleBreadcrumb(
+                action: .initialStartupFailed,
+                store: self.store,
+                stage: "initial_startup",
+                scenePhase: self.scenePhase,
+                selectedTab: self.navigation.selectedTab,
+                isStartupReady: self.isStartupReadyForBackgroundWork,
+                isRecoveryGateActive: self.isCloudCredentialRecoveryGateActive,
+                messageSummary: Flashcards.errorMessage(error: error)
+            )
             if let launchScenario = self.uiTestLaunchScenario {
                 self.store.uiTestLaunchPreparationStatus = .failed(
                     launchScenario: launchScenario,

--- a/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/ObservationEvents.swift
@@ -39,6 +39,7 @@ struct IOSObservationScope: Sendable, Hashable {
 }
 
 enum IOSBreadcrumbEvent: Sendable {
+    case appLifecycle(AppLifecycleObservation)
     case cloudFlow(CloudFlowObservation)
     case cloudRetry(CloudRetryObservation)
     case aiChatLifecycle(AIChatLifecycleObservation)
@@ -68,6 +69,31 @@ enum IOSExceptionEvent {
     case notificationSchedulingFailed(error: Error, scope: IOSObservationScope, details: NotificationFailureDetails)
     case localDataRepairFailed(error: Error, scope: IOSObservationScope, details: LocalDataRepairFailureDetails)
     case silentFailure(error: Error, scope: IOSObservationScope, details: SilentFailureDetails)
+}
+
+enum AppLifecycleAction: String, Sendable, Hashable {
+    case appInitConfigured = "app_init_configured"
+    case appStoreInitialized = "app_store_initialized"
+    case visibleTabPrepareStart = "visible_tab_prepare_start"
+    case visibleTabPrepareSuccess = "visible_tab_prepare_success"
+    case initialStartupStart = "initial_startup_start"
+    case initialStartupReady = "initial_startup_ready"
+    case initialStartupFailed = "initial_startup_failed"
+    case scenePhaseChanged = "scene_phase_changed"
+    case progressContextRefresh = "progress_context_refresh"
+    case launchCloudSyncTriggered = "launch_cloud_sync_triggered"
+    case launchNotificationReconcileTriggered = "launch_notification_reconcile_triggered"
+}
+
+struct AppLifecycleObservation: Sendable, Hashable {
+    let action: AppLifecycleAction
+    let scope: IOSObservationScope
+    let stage: String?
+    let scenePhase: String?
+    let selectedTab: String?
+    let isStartupReady: Bool?
+    let isRecoveryGateActive: Bool?
+    let messageSummary: String?
 }
 
 struct CloudFlowObservation: Sendable, Hashable {

--- a/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SanitizationHelpers.swift
@@ -36,7 +36,9 @@ func sanitizeSentryEvent(_ event: Event) -> Event? {
     if let exceptions: [Exception] = event.exceptions {
         for exception in exceptions {
             exception.value = exception.value.map(redactedString)
-            exception.type = exception.type.map(safeDiagnosticIdentifier)
+            exception.type = exception.type.map { type in
+                sanitizedExceptionType(type, mechanism: exception.mechanism)
+            }
             if let mechanism: Mechanism = exception.mechanism {
                 mechanism.desc = mechanism.desc.map(redactedString)
                 mechanism.data = sanitizedDictionary(mechanism.data)
@@ -44,6 +46,14 @@ func sanitizeSentryEvent(_ event: Event) -> Event? {
         }
     }
     return event
+}
+
+private func sanitizedExceptionType(_ value: String, mechanism: Mechanism?) -> String {
+    guard mechanism?.type == "AppHang" else {
+        return safeDiagnosticIdentifier(value)
+    }
+
+    return redactedString(value)
 }
 
 func sanitizeSentrySpan(_ span: any Span) -> (any Span)? {

--- a/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
+++ b/apps/ios/Flashcards/Flashcards/Observability/SentryCaptureMapping.swift
@@ -36,6 +36,19 @@ extension SentryObservabilityAdapter {
 
     static func addBreadcrumb(_ event: IOSBreadcrumbEvent) {
         switch event {
+        case .appLifecycle(let observation):
+            self.writeLocalRecord(
+                kind: "breadcrumb",
+                feature: .appStartup,
+                action: observation.action.rawValue,
+                fields: self.appLifecycleFields(observation)
+            )
+            self.addSentryBreadcrumb(
+                category: "ios.app_startup",
+                level: .info,
+                message: observation.action.rawValue,
+                data: self.appLifecycleContext(observation)
+            )
         case .cloudFlow(let observation):
             self.logCloudFlow(observation)
             self.addSentryBreadcrumb(
@@ -607,6 +620,21 @@ extension SentryObservabilityAdapter {
 
     private static func cloudRetryFields(_ observation: CloudRetryObservation) -> [String: String] {
         stringifyContext(self.cloudRetryContext(observation))
+    }
+
+    private static func appLifecycleContext(_ observation: AppLifecycleObservation) -> [String: Any] {
+        var context: [String: Any] = self.scopeContext(observation.scope)
+        context["stage"] = observation.stage ?? ""
+        context["scene_phase"] = observation.scenePhase ?? ""
+        context["selected_tab"] = observation.selectedTab ?? ""
+        context["is_startup_ready"] = observation.isStartupReady.map { isStartupReady in String(isStartupReady) } ?? ""
+        context["is_recovery_gate_active"] = observation.isRecoveryGateActive.map { isRecoveryGateActive in String(isRecoveryGateActive) } ?? ""
+        context["message_summary"] = observation.messageSummary ?? ""
+        return context
+    }
+
+    private static func appLifecycleFields(_ observation: AppLifecycleObservation) -> [String: String] {
+        stringifyContext(self.appLifecycleContext(observation))
     }
 
     private static func aiChatLifecycleContext(_ observation: AIChatLifecycleObservation) -> [String: Any] {


### PR DESCRIPTION
## Summary
- preserve Sentry AppHang exception types while keeping other exception type sanitization strict
- add typed iOS app lifecycle breadcrumbs for startup/AppHang diagnosis
- record startup, scene phase, progress refresh, launch sync, and notification reconcile lifecycle points

## Validation
- git --no-pager diff --check
- xcrun swiftc -parse on changed Swift files

## Notes
- no AppHang tracking flags changed
- no simulator-backed tests run