### PR TITLE
Fix stale iOS notification readback mismatches

### DIFF
--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/FlashcardsStore+ReviewNotifications.swift
@@ -516,6 +516,7 @@ extension FlashcardsStore {
         let appStateBeforeAdd: String = currentAppNotificationApplicationStateDiagnosticValue()
         var addFailure: Error?
         var failedRequestId: String?
+        var attemptedPayloads: [ScheduledReviewNotificationPayload] = []
 
         for payload in payloads {
             guard self.reviewNotificationsRescheduleGeneration == generation else {
@@ -523,6 +524,13 @@ extension FlashcardsStore {
             }
             guard Task.isCancelled == false else {
                 return
+            }
+            let addNow = Date()
+            guard isFutureNotificationPayload(
+                scheduledAtMillis: payload.scheduledAtMillis,
+                now: addNow
+            ) else {
+                continue
             }
             let content = UNMutableNotificationContent()
             content.title = appDisplayName()
@@ -533,13 +541,14 @@ extension FlashcardsStore {
                 content.badge = NSNumber(value: 1)
             }
 
-            let interval = max(1, TimeInterval(payload.scheduledAtMillis) / 1000 - now.timeIntervalSince1970)
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
+            let interval = max(1, TimeInterval(payload.scheduledAtMillis) / 1_000 - addNow.timeIntervalSince1970)
+            let notificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
             let request = UNNotificationRequest(
                 identifier: payload.requestId,
                 content: content,
-                trigger: trigger
+                trigger: notificationTrigger
             )
+            attemptedPayloads.append(payload)
             do {
                 try await center.add(request)
             } catch {
@@ -572,17 +581,26 @@ extension FlashcardsStore {
             return
         }
         let appStateAfterReadback: String = currentAppNotificationApplicationStateDiagnosticValue()
-        let acceptedPayloads: [ScheduledReviewNotificationPayload] = acceptedReviewNotificationPayloads(
-            payloads: payloads,
+        let readbackNow = Date()
+        let expectedPayloads: [ScheduledReviewNotificationPayload] = futureReviewNotificationPayloads(
+            payloads: attemptedPayloads,
+            now: readbackNow
+        )
+        let acceptedAttemptedPayloads: [ScheduledReviewNotificationPayload] = acceptedReviewNotificationPayloads(
+            payloads: attemptedPayloads,
             pendingRequestIdentifiers: pendingAfterRequestIdentifiers
         )
-        let hasReadbackMismatch: Bool = addFailure == nil && acceptedPayloads.count != payloads.count
+        let acceptedExpectedPayloads: [ScheduledReviewNotificationPayload] = acceptedReviewNotificationPayloads(
+            payloads: expectedPayloads,
+            pendingRequestIdentifiers: pendingAfterRequestIdentifiers
+        )
+        let hasReadbackMismatch: Bool = addFailure == nil && acceptedExpectedPayloads.count != expectedPayloads.count
         var delayedReadback: DelayedNotificationSchedulingReadback?
         if hasReadbackMismatch {
             do {
                 delayedReadback = try await delayedNotificationSchedulingReadback(
                     center: center,
-                    plannedRequestIdentifiers: payloads.map(\.requestId),
+                    plannedRequestIdentifiers: expectedPayloads.map(\.requestId),
                     delayNanoseconds: notificationSchedulingDelayedReadbackNanoseconds
                 )
             } catch is CancellationError {
@@ -605,12 +623,18 @@ extension FlashcardsStore {
                 return
             }
         }
+        let diagnosticPayloads: [ScheduledReviewNotificationPayload]
+        if addFailure == nil {
+            diagnosticPayloads = expectedPayloads
+        } else {
+            diagnosticPayloads = attemptedPayloads
+        }
         let diagnostics: NotificationSchedulingDiagnostics = makeNotificationSchedulingDiagnostics(
             trigger: trigger.diagnosticValue,
-            scheduledAtMillisRange: reviewNotificationScheduledAtMillisRange(payloads: payloads),
+            scheduledAtMillisRange: reviewNotificationScheduledAtMillisRange(payloads: diagnosticPayloads),
             delaySecondsRange: reviewNotificationSchedulingDelaySecondsRange(
-                payloads: payloads,
-                now: now
+                payloads: diagnosticPayloads,
+                now: readbackNow
             ),
             pendingBeforeRequestIdentifiers: pendingBeforeRequestIdentifiers,
             pendingAfterRequestIdentifiers: pendingAfterRequestIdentifiers,
@@ -640,8 +664,8 @@ extension FlashcardsStore {
                         workspaceId: workspaceId,
                         requestId: failedRequestId,
                         stage: "add",
-                        plannedCount: payloads.count,
-                        acceptedCount: acceptedPayloads.count,
+                        plannedCount: attemptedPayloads.count,
+                        acceptedCount: acceptedAttemptedPayloads.count,
                         diagnostics: diagnostics,
                         error: addFailure,
                         messageSummary: nil
@@ -668,8 +692,8 @@ extension FlashcardsStore {
                         workspaceId: workspaceId,
                         requestId: nil,
                         stage: "readback",
-                        plannedCount: payloads.count,
-                        acceptedCount: acceptedPayloads.count,
+                        plannedCount: expectedPayloads.count,
+                        acceptedCount: acceptedExpectedPayloads.count,
                         diagnostics: diagnostics,
                         error: nil,
                         messageSummary: "Notification Center accepted fewer review reminders than planned"
@@ -677,7 +701,7 @@ extension FlashcardsStore {
                 )
             )
         }
-        self.persistScheduledReviewNotifications(payloads: acceptedPayloads)
+        self.persistScheduledReviewNotifications(payloads: acceptedExpectedPayloads)
     }
 
     private func markReviewReminderAttentionFromDeliveredStates(

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationDiagnosticsSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationDiagnosticsSupport.swift
@@ -33,6 +33,13 @@ func notificationScheduledAtMillisRange(
     )
 }
 
+func isFutureNotificationPayload(
+    scheduledAtMillis: Int64,
+    now: Date
+) -> Bool {
+    TimeInterval(scheduledAtMillis) / 1_000 > now.timeIntervalSince1970
+}
+
 func reviewNotificationScheduledAtMillisRange(
     payloads: [ScheduledReviewNotificationPayload]
 ) -> NotificationScheduledAtMillisRange {

--- a/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPayloadSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Notifications/ReviewNotificationPayloadSupport.swift
@@ -260,3 +260,15 @@ func acceptedReviewNotificationPayloads(
         pendingRequestIdentifierSet.contains(payload.requestId)
     }
 }
+
+func futureReviewNotificationPayloads(
+    payloads: [ScheduledReviewNotificationPayload],
+    now: Date
+) -> [ScheduledReviewNotificationPayload] {
+    payloads.filter { payload in
+        isFutureNotificationPayload(
+            scheduledAtMillis: payload.scheduledAtMillis,
+            now: now
+        )
+    }
+}

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/FlashcardsStore+StrictReminders.swift
@@ -243,9 +243,17 @@ extension FlashcardsStore {
         let appStateBeforeAdd: String = currentAppNotificationApplicationStateDiagnosticValue()
         var addFailure: Error?
         var failedRequestId: String?
+        var attemptedPayloads: [ScheduledStrictReminderPayload] = []
         for payload in payloads {
             guard Task.isCancelled == false else {
                 return
+            }
+            let addNow = Date()
+            guard isFutureNotificationPayload(
+                scheduledAtMillis: payload.scheduledAtMillis,
+                now: addNow
+            ) else {
+                continue
             }
             let content = UNMutableNotificationContent()
             content.title = appDisplayName()
@@ -253,15 +261,16 @@ extension FlashcardsStore {
             content.sound = .default
             content.userInfo = buildStrictReminderNotificationUserInfo(scope: notificationScope)
 
-            let interval = max(1, TimeInterval(payload.scheduledAtMillis) / 1_000 - request.now.timeIntervalSince1970)
-            let request = UNNotificationRequest(
+            let interval = max(1, TimeInterval(payload.scheduledAtMillis) / 1_000 - addNow.timeIntervalSince1970)
+            let notificationRequest = UNNotificationRequest(
                 identifier: payload.requestId,
                 content: content,
                 trigger: UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
             )
 
+            attemptedPayloads.append(payload)
             do {
-                try await center.add(request)
+                try await center.add(notificationRequest)
             } catch {
                 addFailure = error
                 failedRequestId = payload.requestId
@@ -282,17 +291,26 @@ extension FlashcardsStore {
             return
         }
         let appStateAfterReadback: String = currentAppNotificationApplicationStateDiagnosticValue()
-        let acceptedPayloads: [ScheduledStrictReminderPayload] = acceptedStrictReminderPayloads(
-            payloads: payloads,
+        let readbackNow = Date()
+        let expectedPayloads: [ScheduledStrictReminderPayload] = futureStrictReminderPayloads(
+            payloads: attemptedPayloads,
+            now: readbackNow
+        )
+        let acceptedAttemptedPayloads: [ScheduledStrictReminderPayload] = acceptedStrictReminderPayloads(
+            payloads: attemptedPayloads,
             pendingRequestIdentifiers: pendingAfterRequestIdentifiers
         )
-        let hasReadbackMismatch: Bool = addFailure == nil && acceptedPayloads.count != payloads.count
+        let acceptedExpectedPayloads: [ScheduledStrictReminderPayload] = acceptedStrictReminderPayloads(
+            payloads: expectedPayloads,
+            pendingRequestIdentifiers: pendingAfterRequestIdentifiers
+        )
+        let hasReadbackMismatch: Bool = addFailure == nil && acceptedExpectedPayloads.count != expectedPayloads.count
         var delayedReadback: DelayedNotificationSchedulingReadback?
         if hasReadbackMismatch {
             do {
                 delayedReadback = try await delayedNotificationSchedulingReadback(
                     center: center,
-                    plannedRequestIdentifiers: payloads.map(\.requestId),
+                    plannedRequestIdentifiers: expectedPayloads.map(\.requestId),
                     delayNanoseconds: notificationSchedulingDelayedReadbackNanoseconds
                 )
             } catch is CancellationError {
@@ -312,12 +330,18 @@ extension FlashcardsStore {
                 return
             }
         }
+        let diagnosticPayloads: [ScheduledStrictReminderPayload]
+        if addFailure == nil {
+            diagnosticPayloads = expectedPayloads
+        } else {
+            diagnosticPayloads = attemptedPayloads
+        }
         let diagnostics: NotificationSchedulingDiagnostics = makeNotificationSchedulingDiagnostics(
             trigger: strictRemindersReconcileTriggerDiagnosticValue(triggers: request.triggers),
-            scheduledAtMillisRange: strictReminderScheduledAtMillisRange(payloads: payloads),
+            scheduledAtMillisRange: strictReminderScheduledAtMillisRange(payloads: diagnosticPayloads),
             delaySecondsRange: strictReminderSchedulingDelaySecondsRange(
-                payloads: payloads,
-                now: request.now
+                payloads: diagnosticPayloads,
+                now: readbackNow
             ),
             pendingBeforeRequestIdentifiers: pendingBeforeRequestIdentifiers,
             pendingAfterRequestIdentifiers: pendingAfterRequestIdentifiers,
@@ -347,8 +371,8 @@ extension FlashcardsStore {
                         workspaceId: self.workspace?.workspaceId,
                         requestId: failedRequestId,
                         stage: "add",
-                        plannedCount: payloads.count,
-                        acceptedCount: acceptedPayloads.count,
+                        plannedCount: attemptedPayloads.count,
+                        acceptedCount: acceptedAttemptedPayloads.count,
                         diagnostics: diagnostics,
                         error: addFailure,
                         messageSummary: nil
@@ -375,8 +399,8 @@ extension FlashcardsStore {
                         workspaceId: self.workspace?.workspaceId,
                         requestId: nil,
                         stage: "readback",
-                        plannedCount: payloads.count,
-                        acceptedCount: acceptedPayloads.count,
+                        plannedCount: expectedPayloads.count,
+                        acceptedCount: acceptedExpectedPayloads.count,
                         diagnostics: diagnostics,
                         error: nil,
                         messageSummary: "Notification Center accepted fewer strict reminders than planned"
@@ -384,6 +408,6 @@ extension FlashcardsStore {
                 )
             )
         }
-        self.persistScheduledStrictReminders(payloads: acceptedPayloads)
+        self.persistScheduledStrictReminders(payloads: acceptedExpectedPayloads)
     }
 }

--- a/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
+++ b/apps/ios/Flashcards/Flashcards/Review/Reminders/StrictRemindersSupport.swift
@@ -481,6 +481,18 @@ func acceptedStrictReminderPayloads(
     }
 }
 
+func futureStrictReminderPayloads(
+    payloads: [ScheduledStrictReminderPayload],
+    now: Date
+) -> [ScheduledStrictReminderPayload] {
+    payloads.filter { payload in
+        isFutureNotificationPayload(
+            scheduledAtMillis: payload.scheduledAtMillis,
+            now: now
+        )
+    }
+}
+
 func strictReminderScheduledAtMillisRange(
     payloads: [ScheduledStrictReminderPayload]
 ) -> NotificationScheduledAtMillisRange {


### PR DESCRIPTION
## Summary
- skip expired iOS notification payloads before scheduling
- compare review reminder readback against attempted future payloads only
- apply the same stale-readback handling to strict reminders

## Validation
- git --no-pager diff --check
- xcrun --sdk iphoneos swiftc -target arm64-apple-ios26.0 -parse changed Swift files

Full xcodebuild was blocked locally by destination/package resolution before app target compilation.