### PR TITLE
Add safe stale bundle telemetry

### DIFF
--- a/apps/web/src/observability/instrument.test.ts
+++ b/apps/web/src/observability/instrument.test.ts
@@ -148,6 +148,51 @@ describe("Sentry privacy sanitizer", () => {
     expect(sanitizedEvent.breadcrumbs?.[0]?.message).toBe("web.route_change");
   });
 
+  it("redacts arbitrary TypeError exception values", () => {
+    const event: SentryPrivacyEvent = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: `Cannot read private card text: ${sensitiveCardText}`,
+          },
+        ],
+      },
+    };
+
+    const sanitizedEvent = sanitizeSentryEventForPrivacy(event);
+
+    expect(sanitizedEvent.exception?.values?.[0]?.value).toBe("[Filtered exception value]");
+    expect(serializeEvent(sanitizedEvent)).not.toContain(sensitiveCardText);
+  });
+
+  it("keeps structured stale bundle breadcrumb diagnostics", () => {
+    const breadcrumb: SentryPrivacyBreadcrumb = {
+      category: "web.stale_bundle_reload",
+      level: "info",
+      message: "web.stale_bundle_preload_error",
+      data: {
+        app: "web",
+        feature: "app",
+        route: "/settings",
+        assetPath: "/assets/SettingsScreen-abc123.js",
+        reloadScheduled: true,
+        reloadSkipReason: null,
+      },
+    };
+
+    const sanitizedBreadcrumb = sanitizeSentryBreadcrumbForPrivacy(breadcrumb);
+
+    if (sanitizedBreadcrumb === null) {
+      throw new Error("Expected stale bundle breadcrumb to be kept after privacy sanitization");
+    }
+
+    expect(sanitizedBreadcrumb.message).toBe("web.stale_bundle_preload_error");
+    expect(sanitizedBreadcrumb.data?.assetPath).toBe("/assets/SettingsScreen-abc123.js");
+    expect(sanitizedBreadcrumb.data?.reloadScheduled).toBe(true);
+    expect(sanitizedBreadcrumb.data?.reloadSkipReason).toBe(null);
+  });
+
   it("redacts normalized query and search key variants without redacting route names", () => {
     const event: SentryPrivacyEvent = {
       extra: {

--- a/apps/web/src/observability/webObservability.ts
+++ b/apps/web/src/observability/webObservability.ts
@@ -152,10 +152,23 @@ export type IndexedDbOpenLifecycleBreadcrumbDetails = Readonly<{
   indexedDbDatabaseUpgraded: boolean;
 }>;
 
-export type StaleBundleReloadBreadcrumbDetails = Readonly<{
+export type StaleBundleReloadSkipReason = "storage_unavailable" | "rate_limited" | "storage_write_failed";
+
+export type StaleBundlePreloadErrorBreadcrumbDetails = Readonly<{
+  eventName: "stale_bundle_preload_error";
+  assetPath: string | null;
+  reloadScheduled: boolean;
+  reloadSkipReason: StaleBundleReloadSkipReason | null;
+}>;
+
+export type StaleBundleReloadRecoveredBreadcrumbDetails = Readonly<{
   eventName: "stale_bundle_reload_recovered";
   reloadAgeMs: number | null;
 }>;
+
+export type StaleBundleReloadBreadcrumbDetails =
+  | StaleBundlePreloadErrorBreadcrumbDetails
+  | StaleBundleReloadRecoveredBreadcrumbDetails;
 
 export type IndexedDbDeleteLifecycleBreadcrumbDetails = Readonly<{
   eventName: "indexed_db_delete_lifecycle";

--- a/apps/web/src/staleBundleReload.ts
+++ b/apps/web/src/staleBundleReload.ts
@@ -1,11 +1,13 @@
 import {
   addWebBreadcrumb,
+  type StaleBundleReloadSkipReason,
   type WebObservationScope,
 } from "./observability/webObservability";
 
 const PRELOAD_ERROR_RELOADED_AT_STORAGE_KEY = "flashcards-preload-error-reloaded-at";
 const PRELOAD_ERROR_REPORT_PENDING_STORAGE_KEY = "flashcards-preload-error-report-pending";
 const PRELOAD_ERROR_RELOAD_MIN_INTERVAL_MS = 60_000;
+const ASSET_PATH_PATTERN = /(?:https?:\/\/[^\s"'<>]+|(?:\/|\.\.?\/)assets\/[^\s"'<>]+)/u;
 
 function getSessionStorage(): Storage | null {
   try {
@@ -44,6 +46,41 @@ function buildReloadObservationScope(): WebObservationScope {
   };
 }
 
+function stripTrailingPunctuation(value: string): string {
+  return value.replace(/[),.;:!?]+$/u, "");
+}
+
+function extractPreloadAssetPath(error: Error): string | null {
+  const match = error.message.match(ASSET_PATH_PATTERN);
+  if (match === null) {
+    return null;
+  }
+
+  try {
+    const url = new URL(stripTrailingPunctuation(match[0]), window.location.origin);
+    return url.pathname.startsWith("/assets/") ? url.pathname : null;
+  } catch {
+    return null;
+  }
+}
+
+function reportPreloadError(
+  assetPath: string | null,
+  reloadScheduled: boolean,
+  reloadSkipReason: StaleBundleReloadSkipReason | null,
+): void {
+  addWebBreadcrumb({
+    action: "stale_bundle_reload",
+    scope: buildReloadObservationScope(),
+    details: {
+      eventName: "stale_bundle_preload_error",
+      assetPath,
+      reloadScheduled,
+      reloadSkipReason,
+    },
+  });
+}
+
 function reportRecoveredReload(sessionStorage: Storage): void {
   if (sessionStorage.getItem(PRELOAD_ERROR_REPORT_PENDING_STORAGE_KEY) !== "1") {
     return;
@@ -79,13 +116,16 @@ export function installStaleBundleReloadGuard(): void {
   }
 
   window.addEventListener("vite:preloadError", (event) => {
+    const assetPath = extractPreloadAssetPath(event.payload);
     const sessionStorage = getSessionStorage();
     if (sessionStorage === null) {
+      reportPreloadError(assetPath, false, "storage_unavailable");
       return;
     }
 
     const lastReloadAtMs = Number(sessionStorage.getItem(PRELOAD_ERROR_RELOADED_AT_STORAGE_KEY) ?? "0");
     if (Number.isFinite(lastReloadAtMs) && Date.now() - lastReloadAtMs < PRELOAD_ERROR_RELOAD_MIN_INTERVAL_MS) {
+      reportPreloadError(assetPath, false, "rate_limited");
       return;
     }
 
@@ -95,9 +135,11 @@ export function installStaleBundleReloadGuard(): void {
     } catch {
       // Without a persisted rate-limit marker a reload could loop, so let the
       // preload error surface instead of healing.
+      reportPreloadError(assetPath, false, "storage_write_failed");
       return;
     }
 
+    reportPreloadError(assetPath, true, null);
     event.preventDefault();
     window.location.reload();
   });


### PR DESCRIPTION
## Summary
- keep raw exception values redacted while recording structured stale-bundle preload diagnostics
- include safe asset path and reload scheduling status for preload failures
- cover sanitizer behavior for arbitrary TypeError values and structured stale-bundle breadcrumbs

## Validation
- npx vitest run src/observability/instrument.test.ts
- npm run build